### PR TITLE
fix(bridge): resolve session identity via heartbeat inference

### DIFF
--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -51,6 +51,9 @@ enum Command {
         /// Reason for the decision
         #[arg(long)]
         reason: Option<String>,
+        /// Session ID (auto-inferred from active heartbeats if omitted)
+        #[arg(long)]
+        session: Option<String>,
     },
     /// Query workspace decisions by keyword
     Query {
@@ -333,6 +336,9 @@ enum BridgeClaudeCmd {
         /// File path patterns this scope covers (e.g. "src/auth/*")
         #[arg(long)]
         paths: Vec<String>,
+        /// Session ID (auto-inferred from active heartbeats if omitted)
+        #[arg(long)]
+        session: Option<String>,
     },
     /// Record a binding decision for all sessions
     Decide {
@@ -341,6 +347,9 @@ enum BridgeClaudeCmd {
         /// Reason for the decision
         #[arg(long)]
         reason: Option<String>,
+        /// Session ID (auto-inferred from active heartbeats if omitted)
+        #[arg(long)]
+        session: Option<String>,
     },
     /// Send a request to another session
     Request {
@@ -348,6 +357,9 @@ enum BridgeClaudeCmd {
         to: String,
         /// Request message
         message: String,
+        /// Session ID (auto-inferred from active heartbeats if omitted)
+        #[arg(long)]
+        session: Option<String>,
     },
 }
 
@@ -682,7 +694,7 @@ fn main() -> anyhow::Result<()> {
     match cli.cmd {
         Command::Init => cmd_init::execute(&repo_root),
         Command::Note { text, role, tags } => cmd_note::execute(&repo_root, &text, &role, &tags),
-        Command::Decide { decision, reason } => cmd_bridge::decide(&repo_root, &decision, reason.as_deref()),
+        Command::Decide { decision, reason, session } => cmd_bridge::decide(&repo_root, &decision, reason.as_deref(), session.as_deref()),
         Command::Query { query, limit, json, all } => cmd_query::execute(&repo_root, &query, limit, json, all),
         Command::Run { argv } => cmd_run::execute(&repo_root, &argv),
         Command::Status => cmd_status::execute(&repo_root),
@@ -796,14 +808,14 @@ fn main() -> anyhow::Result<()> {
                     cmd_bridge::digest(&repo_root, session.as_deref(), all)
                 }
                 BridgeClaudeCmd::Peers => cmd_bridge::peers(&repo_root),
-                BridgeClaudeCmd::Claim { label, paths } => {
-                    cmd_bridge::claim(&repo_root, &label, &paths)
+                BridgeClaudeCmd::Claim { label, paths, session } => {
+                    cmd_bridge::claim(&repo_root, &label, &paths, session.as_deref())
                 }
-                BridgeClaudeCmd::Decide { decision, reason } => {
-                    cmd_bridge::decide(&repo_root, &decision, reason.as_deref())
+                BridgeClaudeCmd::Decide { decision, reason, session } => {
+                    cmd_bridge::decide(&repo_root, &decision, reason.as_deref(), session.as_deref())
                 }
-                BridgeClaudeCmd::Request { to, message } => {
-                    cmd_bridge::request(&repo_root, &to, &message)
+                BridgeClaudeCmd::Request { to, message, session } => {
+                    cmd_bridge::request(&repo_root, &to, &message, session.as_deref())
                 }
             },
             BridgeCmd::Openclaw { cmd } => match cmd {

--- a/crates/edda-conductor/src/agent/launcher.rs
+++ b/crates/edda-conductor/src/agent/launcher.rs
@@ -133,7 +133,9 @@ impl AgentLauncher for ClaudeCodeLauncher {
             .env_remove("CLAUDE_CODE")
             .env_remove("CLAUDECODE")
             // Tell edda hooks to use conductor-optimized injection
-            .env("EDDA_CONDUCTOR_MODE", "1");
+            .env("EDDA_CONDUCTOR_MODE", "1")
+            // Propagate session_id so agent-spawned `edda decide` etc. can resolve identity
+            .env("EDDA_SESSION_ID", session_id);
 
         // Optional: per-phase budget
         if let Some(budget) = phase.budget_usd {


### PR DESCRIPTION
## Summary

- `edda decide`, `edda claim`, `edda request` were always attributed to `"cli-cli"` because `EDDA_SESSION_ID` was never set in the agent's shell environment
- Introduces a 4-tier fallback chain for session identity resolution:
  1. `--session` CLI flag (explicit override)
  2. `EDDA_SESSION_ID` env var (conductor path)
  3. Heartbeat inference (auto-detect sole active session)
  4. `"cli-{label}"` (genuine CLI usage)
- Conductor now sets `EDDA_SESSION_ID` env var when launching agents
- L1 ledger event actor uses resolved label instead of hardcoded `"system"`

## Test plan

- [x] `cargo test -p edda-bridge-claude` — 217 tests pass (5 new for `infer_session_id`)
- [x] `cargo test -p edda-bridge-openclaw` — 18 tests pass (no regressions)
- [x] `cargo clippy` — no new warnings
- [ ] Manual: `edda decide "db=postgres"` with one active session → correct session_id
- [ ] Manual: `edda decide "db=postgres" --session abc` → uses "abc"

Fixes fagemx/gctx#145

🤖 Generated with [Claude Code](https://claude.com/claude-code)