### PR TITLE
refactor(bridge): extract shared render and state modules

### DIFF
--- a/crates/edda-bridge-claude/src/lib.rs
+++ b/crates/edda-bridge-claude/src/lib.rs
@@ -3,6 +3,7 @@ pub mod pattern;
 pub mod peers;
 pub mod redact;
 pub mod render;
+pub mod state;
 
 mod admin;
 mod dispatch;

--- a/crates/edda-bridge-claude/src/render.rs
+++ b/crates/edda-bridge-claude/src/render.rs
@@ -1,19 +1,187 @@
-//! Public render API for external integrations (CLI consumers).
+//! Public render API for external integrations (CLI consumers, other bridges).
 //!
-//! Thin wrappers around internal dispatch/peers render functions,
-//! providing a stable public interface for `edda bridge claude render-*` commands.
+//! Contains shared context rendering utilities used by both Claude and OpenClaw
+//! bridges, plus thin wrappers for CLI commands.
+
+use std::fs;
+use std::path::Path;
+
+// ── Context Boundary ──
+
+/// Edda context boundary start marker.
+pub const BOUNDARY_START: &str = "<!-- edda:start -->";
+
+/// Edda context boundary end marker.
+pub const BOUNDARY_END: &str = "<!-- edda:end -->";
+
+/// Default max context chars (~2000 tokens). Overridable via
+/// `EDDA_MAX_CONTEXT_CHARS` env var or `bridge.max_context_chars` in config.
+pub const DEFAULT_MAX_CONTEXT_CHARS: usize = 8000;
+
+/// Wrap context content with edda boundary markers for multi-plugin coexistence.
+pub fn wrap_boundary(content: &str) -> String {
+    format!("{BOUNDARY_START}\n{content}\n{BOUNDARY_END}")
+}
+
+/// Resolve the context char budget from env or config.
+pub fn context_budget(cwd: &str) -> usize {
+    std::env::var("EDDA_MAX_CONTEXT_CHARS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .or_else(|| config_usize(cwd, "bridge.max_context_chars"))
+        .unwrap_or(DEFAULT_MAX_CONTEXT_CHARS)
+}
+
+/// Truncate content to fit within the char budget, preserving UTF-8 boundaries.
+pub fn apply_budget(content: &str, budget: usize) -> String {
+    if content.len() <= budget {
+        return content.to_string();
+    }
+    let cut = content.len().min(budget.saturating_sub(50));
+    let safe = content.floor_char_boundary(cut);
+    format!(
+        "{}\n\n... (truncated to {} char budget)",
+        &content[..safe],
+        budget
+    )
+}
+
+// ── Write-Back Protocol ──
 
 /// Static write-back protocol text that teaches agents to use `edda decide` and `edda note`.
 pub fn writeback() -> String {
-    crate::dispatch::render_write_back_protocol("").unwrap_or_default()
+    "## Write-Back Protocol\n\
+     Record architectural decisions with: `edda decide \"domain.aspect=value\" --reason \"justification\"`\n\
+     \n\
+     Examples:\n  \
+     `edda decide \"db.engine=postgres\" --reason \"need JSONB for flexible metadata\"`\n  \
+     `edda decide \"auth.method=JWT\" --reason \"stateless, scales horizontally\"`\n  \
+     `edda decide \"api.style=REST\" --reason \"client SDK compatibility\"`\n\
+     \n\
+     Do NOT record: formatting changes, test fixes, minor refactors, dependency bumps.\n\
+     \n\
+     Before ending a session, summarize open context:\n  \
+     `edda note \"completed X; decided Y; next: Z\" --tag session`"
+        .to_string()
 }
+
+// ── Workspace Context ──
 
 /// Workspace context rendered from the `.edda/` ledger in `cwd`.
 ///
 /// Returns `None` if no workspace exists at `cwd`.
 pub fn workspace(cwd: &str, budget: usize) -> Option<String> {
-    crate::dispatch::render_workspace_section(cwd, budget)
+    if cwd.is_empty() {
+        return None;
+    }
+    let cwd_path = Path::new(cwd);
+    let root = edda_ledger::EddaPaths::find_root(cwd_path)?;
+    let ledger = edda_ledger::Ledger::open(&root).ok()?;
+    let branch = ledger.head_branch().unwrap_or_else(|_| "main".to_string());
+
+    let max_depth: usize = std::env::var("EDDA_WORKSPACE_DEPTH")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(3);
+
+    // Try with requested depth, reduce if over budget
+    for d in (1..=max_depth).rev() {
+        let opt = edda_derive::DeriveOptions { depth: d };
+        if let Ok(raw) = edda_derive::render_context(&ledger, &branch, opt) {
+            let mut section = transform_context_to_section(&raw);
+            // If edda ledger has no commit events, fall back to `git log`
+            supplement_git_commits(&mut section, cwd_path, d);
+            if section.len() <= budget {
+                return Some(section);
+            }
+        }
+    }
+    None
 }
+
+/// Transform `render_context` output into a pack-embeddable section.
+/// Replaces `# CONTEXT SNAPSHOT` header with `## Workspace Context`
+/// and removes the `## How to cite evidence` footer.
+fn transform_context_to_section(raw: &str) -> String {
+    let mut out = String::new();
+    out.push_str("## Workspace Context\n\n");
+    let mut skip_header = true;
+    let mut skip_cite = false;
+    for line in raw.lines() {
+        if skip_header && line.starts_with("# CONTEXT SNAPSHOT") {
+            skip_header = false;
+            continue;
+        }
+        if line.starts_with("## How to cite evidence") {
+            skip_cite = true;
+            continue;
+        }
+        if skip_cite {
+            continue;
+        }
+        skip_header = false;
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
+}
+
+/// If the workspace section has empty "Recent Commits", supplement with `git log --oneline`.
+fn supplement_git_commits(section: &mut String, cwd: &Path, depth: usize) {
+    let empty_marker = format!("## Recent Commits (last {depth})\n- (none)\n");
+    if !section.contains(&empty_marker) {
+        return;
+    }
+    let Ok(output) = std::process::Command::new("git")
+        .args(["log", "--oneline", &format!("-{depth}")])
+        .current_dir(cwd)
+        .output()
+    else {
+        return;
+    };
+    if !output.status.success() {
+        return;
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    let text = text.trim();
+    if text.is_empty() {
+        return;
+    }
+    let formatted: String = text.lines().map(|l| format!("- {l}\n")).collect();
+    let replacement = format!("## Recent Commits (last {depth})\n{formatted}");
+    *section = section.replace(&empty_marker, &replacement);
+}
+
+// ── Workspace Config ──
+
+/// Read a boolean value from `.edda/config.json` in the workspace.
+/// Supports dot-notation keys (e.g. "bridge.auto_digest").
+pub fn config_bool(cwd: &str, key: &str) -> Option<bool> {
+    config_value(cwd, key)?.as_bool()
+}
+
+/// Read a usize value from `.edda/config.json` in the workspace.
+pub fn config_usize(cwd: &str, key: &str) -> Option<usize> {
+    config_value(cwd, key)?.as_u64().map(|v| v as usize)
+}
+
+/// Read a raw JSON value from `.edda/config.json` using dot-notation keys.
+pub fn config_value(cwd: &str, key: &str) -> Option<serde_json::Value> {
+    if cwd.is_empty() {
+        return None;
+    }
+    let root = edda_ledger::EddaPaths::find_root(Path::new(cwd))?;
+    let config_path = root.join(".edda").join("config.json");
+    let content = fs::read_to_string(&config_path).ok()?;
+    let val: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let mut current = val;
+    for part in key.split('.') {
+        current = current.get(part)?.clone();
+    }
+    Some(current)
+}
+
+// ── High-Level Wrappers (CLI Commands) ──
 
 /// Full L2 coordination protocol (peers, claims, bindings, requests).
 ///
@@ -35,4 +203,66 @@ pub fn pack(project_id: &str) -> Option<String> {
 /// Returns `None` if no plan file exists.
 pub fn plan(project_id: Option<&str>) -> Option<String> {
     crate::dispatch::render_active_plan(project_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrap_boundary_adds_markers() {
+        let content = "hello world";
+        let wrapped = wrap_boundary(content);
+        assert!(wrapped.starts_with(BOUNDARY_START));
+        assert!(wrapped.ends_with(BOUNDARY_END));
+        assert!(wrapped.contains("hello world"));
+    }
+
+    #[test]
+    fn apply_budget_no_truncation() {
+        let content = "short content";
+        let result = apply_budget(content, 8000);
+        assert_eq!(result, content);
+    }
+
+    #[test]
+    fn apply_budget_truncates_long_content() {
+        let content = "x".repeat(10000);
+        let result = apply_budget(&content, 500);
+        assert!(result.len() <= 550);
+        assert!(result.contains("truncated"));
+    }
+
+    #[test]
+    fn context_budget_uses_env_var() {
+        std::env::set_var("EDDA_MAX_CONTEXT_CHARS", "1234");
+        let budget = context_budget("");
+        assert_eq!(budget, 1234);
+        std::env::remove_var("EDDA_MAX_CONTEXT_CHARS");
+    }
+
+    #[test]
+    fn context_budget_default_without_config() {
+        std::env::remove_var("EDDA_MAX_CONTEXT_CHARS");
+        let budget = context_budget("/nonexistent/dir");
+        assert_eq!(budget, DEFAULT_MAX_CONTEXT_CHARS);
+    }
+
+    #[test]
+    fn writeback_contains_decide_command() {
+        let text = writeback();
+        assert!(text.contains("edda decide"));
+        assert!(text.contains("edda note"));
+    }
+
+    #[test]
+    fn transform_context_strips_header_and_cite() {
+        let raw = "# CONTEXT SNAPSHOT\n\n## Project (main)\n- head: main\n\n## How to cite evidence\n- Use event_id\n";
+        let section = transform_context_to_section(raw);
+        assert!(section.starts_with("## Workspace Context\n"));
+        assert!(section.contains("## Project (main)"));
+        assert!(!section.contains("# CONTEXT SNAPSHOT"));
+        assert!(!section.contains("How to cite evidence"));
+        assert!(!section.contains("Use event_id"));
+    }
 }

--- a/crates/edda-bridge-claude/src/state.rs
+++ b/crates/edda-bridge-claude/src/state.rs
@@ -1,0 +1,235 @@
+//! Session-scoped state file management.
+//!
+//! Shared utilities for managing per-session state files (counters, dedup hashes,
+//! nudge cooldown, compact recovery flags). Used by both Claude and OpenClaw bridges.
+
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
+
+// ── Recall Rate Counters ──
+
+/// Increment a per-session counter file (e.g. `nudge_count`, `decide_count`).
+pub fn increment_counter(project_id: &str, session_id: &str, name: &str) {
+    let path = edda_store::project_dir(project_id)
+        .join("state")
+        .join(format!("{name}.{session_id}"));
+    let current: u64 = fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(0);
+    let _ = fs::write(&path, (current + 1).to_string());
+}
+
+/// Read a per-session counter file; returns 0 if missing.
+pub fn read_counter(project_id: &str, session_id: &str, name: &str) -> u64 {
+    let path = edda_store::project_dir(project_id)
+        .join("state")
+        .join(format!("{name}.{session_id}"));
+    fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(0)
+}
+
+// ── Injection Dedup ──
+
+/// Path to the inject hash state file for a given session.
+fn inject_hash_path(project_id: &str, session_id: &str) -> PathBuf {
+    edda_store::project_dir(project_id)
+        .join("state")
+        .join(format!("inject_hash.{session_id}"))
+}
+
+/// Compute a 64-bit hash of a string (for dedup comparison).
+fn content_hash(s: &str) -> u64 {
+    let mut hasher = std::hash::DefaultHasher::new();
+    s.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Check if the given content matches the last injected content for this session.
+pub fn is_same_as_last_inject(project_id: &str, session_id: &str, content: &str) -> bool {
+    let path = inject_hash_path(project_id, session_id);
+    let current = format!("{:016x}", content_hash(content));
+    match fs::read_to_string(&path) {
+        Ok(stored) => stored.trim() == current,
+        Err(_) => false,
+    }
+}
+
+/// Write the content hash for the current injection.
+pub fn write_inject_hash(project_id: &str, session_id: &str, content: &str) {
+    let path = inject_hash_path(project_id, session_id);
+    let hash = format!("{:016x}", content_hash(content));
+    let _ = fs::write(&path, hash);
+}
+
+// ── Nudge Cooldown ──
+
+/// Default cooldown between nudges (seconds).
+const NUDGE_COOLDOWN_SECS: i64 = 180; // 3 minutes
+
+/// Read the effective cooldown, allowing `EDDA_NUDGE_COOLDOWN_SECS` env override.
+fn nudge_cooldown_secs() -> i64 {
+    std::env::var("EDDA_NUDGE_COOLDOWN_SECS")
+        .ok()
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(NUDGE_COOLDOWN_SECS)
+}
+
+/// Check if we should send a nudge (cooldown expired).
+pub fn should_nudge(project_id: &str, session_id: &str) -> bool {
+    let path = edda_store::project_dir(project_id)
+        .join("state")
+        .join(format!("nudge_ts.{session_id}"));
+    match fs::read_to_string(&path) {
+        Ok(ts) => {
+            let last = time::OffsetDateTime::parse(
+                ts.trim(),
+                &time::format_description::well_known::Rfc3339,
+            )
+            .unwrap_or(time::OffsetDateTime::UNIX_EPOCH);
+            let elapsed = time::OffsetDateTime::now_utc() - last;
+            elapsed.whole_seconds() >= nudge_cooldown_secs()
+        }
+        Err(_) => true, // no previous nudge → allow
+    }
+}
+
+/// Record that a nudge was sent.
+pub fn mark_nudge_sent(project_id: &str, session_id: &str) {
+    let path = edda_store::project_dir(project_id)
+        .join("state")
+        .join(format!("nudge_ts.{session_id}"));
+    let _ = fs::write(&path, now_rfc3339());
+}
+
+// ── Compact Recovery ──
+
+/// Path to the compact_pending flag file.
+fn compact_pending_path(project_id: &str) -> PathBuf {
+    edda_store::project_dir(project_id)
+        .join("state")
+        .join("compact_pending")
+}
+
+/// Set the compact_pending flag (called before compaction).
+pub fn set_compact_pending(project_id: &str) {
+    let path = compact_pending_path(project_id);
+    let _ = fs::write(&path, b"1");
+}
+
+/// Take (read + clear) the compact_pending flag. Returns true if it was set.
+pub fn take_compact_pending(project_id: &str) -> bool {
+    let path = compact_pending_path(project_id);
+    if path.exists() {
+        let _ = fs::remove_file(&path);
+        true
+    } else {
+        false
+    }
+}
+
+// ── Peer Count Tracking (Late Peer Detection) ──
+
+/// Read the previously recorded peer count for this session (defaults to 0).
+pub fn read_peer_count(project_id: &str, session_id: &str) -> usize {
+    let path = edda_store::project_dir(project_id)
+        .join("state")
+        .join(format!("peer_count.{session_id}"));
+    fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(0)
+}
+
+/// Write the current peer count for this session.
+pub fn write_peer_count(project_id: &str, session_id: &str, count: usize) {
+    let path = edda_store::project_dir(project_id)
+        .join("state")
+        .join(format!("peer_count.{session_id}"));
+    let _ = fs::write(&path, count.to_string());
+}
+
+// ── Utility ──
+
+fn now_rfc3339() -> String {
+    let now = time::OffsetDateTime::now_utc();
+    now.format(&time::format_description::well_known::Rfc3339)
+        .expect("RFC3339 formatting should not fail")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counter_round_trip() {
+        let pid = "test_state_counter_rt";
+        let sid = "s1";
+        let _ = edda_store::ensure_dirs(pid);
+
+        assert_eq!(read_counter(pid, sid, "test_count"), 0);
+        increment_counter(pid, sid, "test_count");
+        assert_eq!(read_counter(pid, sid, "test_count"), 1);
+        increment_counter(pid, sid, "test_count");
+        assert_eq!(read_counter(pid, sid, "test_count"), 2);
+
+        let _ = std::fs::remove_dir_all(edda_store::project_dir(pid));
+    }
+
+    #[test]
+    fn dedup_hash_round_trip() {
+        let pid = "test_state_dedup_rt";
+        let sid = "s1";
+        let _ = edda_store::ensure_dirs(pid);
+
+        let content = "test dedup content";
+        assert!(!is_same_as_last_inject(pid, sid, content));
+        write_inject_hash(pid, sid, content);
+        assert!(is_same_as_last_inject(pid, sid, content));
+        assert!(!is_same_as_last_inject(pid, sid, "different"));
+
+        let _ = std::fs::remove_dir_all(edda_store::project_dir(pid));
+    }
+
+    #[test]
+    fn compact_pending_lifecycle() {
+        let pid = "test_state_compact_lc";
+        let _ = edda_store::ensure_dirs(pid);
+
+        assert!(!take_compact_pending(pid));
+        set_compact_pending(pid);
+        assert!(take_compact_pending(pid));
+        assert!(!take_compact_pending(pid)); // cleared
+
+        let _ = std::fs::remove_dir_all(edda_store::project_dir(pid));
+    }
+
+    #[test]
+    fn nudge_cooldown_env_var_override() {
+        assert_eq!(nudge_cooldown_secs(), 180);
+
+        std::env::set_var("EDDA_NUDGE_COOLDOWN_SECS", "60");
+        assert_eq!(nudge_cooldown_secs(), 60);
+
+        std::env::set_var("EDDA_NUDGE_COOLDOWN_SECS", "not_a_number");
+        assert_eq!(nudge_cooldown_secs(), 180);
+
+        std::env::remove_var("EDDA_NUDGE_COOLDOWN_SECS");
+    }
+
+    #[test]
+    fn peer_count_round_trip() {
+        let pid = "test_state_peer_ct";
+        let sid = "s1";
+        let _ = edda_store::ensure_dirs(pid);
+
+        assert_eq!(read_peer_count(pid, sid), 0);
+        write_peer_count(pid, sid, 3);
+        assert_eq!(read_peer_count(pid, sid), 3);
+
+        let _ = std::fs::remove_dir_all(edda_store::project_dir(pid));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract ~290 lines of duplicated code from both bridge `dispatch.rs` into shared public modules in `edda-bridge-claude`
- New `state.rs` module: session counters, injection dedup, nudge cooldown, compact recovery flags, peer count tracking
- Expanded `render.rs`: context boundary markers, budget management, workspace rendering, write-back protocol, config helpers
- OpenClaw bridge now imports `edda_bridge_claude::{render, state}` instead of maintaining its own copies

Net: 619 deletions, 564 insertions (including new `state.rs` with 5 test cases). All 290 tests pass.

Closes #17

## Test plan
- [x] `cargo test -p edda-bridge-claude` — 259 passed
- [x] `cargo test -p edda-bridge-openclaw` — 31 passed
- [x] `cargo clippy` — clean, no warnings
- [x] Full workspace tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)