### PR TITLE
feat(ledger): decisions table with auto-extraction and supersede tracking

### DIFF
--- a/crates/edda-ledger/src/ledger.rs
+++ b/crates/edda-ledger/src/ledger.rs
@@ -1,5 +1,5 @@
 use crate::paths::EddaPaths;
-use crate::sqlite_store::SqliteStore;
+use crate::sqlite_store::{DecisionRow, SqliteStore};
 use edda_core::Event;
 use std::io::{BufRead, Write};
 use std::path::Path;
@@ -151,6 +151,42 @@ impl Ledger {
             serde_json::to_string_pretty(value)?,
         )?;
         Ok(())
+    }
+
+    // ── Decisions ───────────────────────────────────────────────────
+
+    /// Query active decisions, optionally filtered by domain or key pattern.
+    ///
+    /// For JSONL backend, returns empty (decisions table not available).
+    pub fn active_decisions(
+        &self,
+        domain: Option<&str>,
+        key_pattern: Option<&str>,
+    ) -> anyhow::Result<Vec<DecisionRow>> {
+        if let Some(store) = &self.sqlite {
+            return store.active_decisions(domain, key_pattern);
+        }
+        Ok(Vec::new())
+    }
+
+    /// All decisions for a key (active + superseded), ordered by time.
+    pub fn decision_timeline(&self, key: &str) -> anyhow::Result<Vec<DecisionRow>> {
+        if let Some(store) = &self.sqlite {
+            return store.decision_timeline(key);
+        }
+        Ok(Vec::new())
+    }
+
+    /// Find the active decision for a specific key on a branch.
+    pub fn find_active_decision(
+        &self,
+        branch: &str,
+        key: &str,
+    ) -> anyhow::Result<Option<DecisionRow>> {
+        if let Some(store) = &self.sqlite {
+            return store.find_active_decision(branch, key);
+        }
+        Ok(None)
     }
 }
 

--- a/crates/edda-ledger/src/lib.rs
+++ b/crates/edda-ledger/src/lib.rs
@@ -12,6 +12,7 @@ pub use blob_store::{
     blob_put_classified, blob_remove, blob_size, BlobInfo,
 };
 pub use ledger::Ledger;
+pub use sqlite_store::DecisionRow;
 pub use lock::WorkspaceLock;
 pub use paths::EddaPaths;
 pub use tombstone::{append_tombstone, list_tombstones, make_tombstone, DeleteReason, Tombstone};


### PR DESCRIPTION
## Summary

Closes #28

- Add `decisions` table (schema v2) with append-time materialization — decision events are extracted and indexed in the same transaction as event insert
- Auto-extract domain from dotted keys (`"db.engine"` → domain `"db"`), support both structured `payload.decision` and legacy text-parse formats
- Branch-scoped supersession: same key on different branches stays active independently
- Schema migration v1→v2 backfills existing decision events
- Replace O(n) `find_prior_decision` scan in `cmd_bridge` with indexed SQL query
- Restructure `cmd_query` with SQLite fast path using `active_decisions` API

## Changes

| File | What |
|------|------|
| `sqlite_store.rs` | +633 — schema v2 DDL, migration, materialization in `append_event`, query methods, 10 new tests |
| `cmd_bridge.rs` | -79 — removed `find_prior_decision`, use `ledger.find_active_decision()` |
| `cmd_query.rs` | restructured — `query_decisions_sqlite()` fast path + `query_decisions_jsonl()` legacy path |
| `ledger.rs` | +38 — decision wrapper methods delegating to SqliteStore |
| `lib.rs` | +1 — re-export `DecisionRow` |

## Test plan

- [x] 10 new unit tests: materialization, supersession, domain extraction, migration, branch scoping
- [x] Full workspace: 676 tests pass, 0 failures
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)