### PR TITLE
feat(init): auto-detect and install bridge hooks on edda init

### DIFF
--- a/crates/edda-cli/src/cmd_draft.rs
+++ b/crates/edda-cli/src/cmd_draft.rs
@@ -1283,7 +1283,7 @@ mod tests {
 
     /// Initialize a temp edda workspace for testing.
     fn init_workspace(root: &Path) {
-        crate::cmd_init::execute(root).expect("init should succeed");
+        crate::cmd_init::execute(root, true).expect("init should succeed");
     }
 
     /// Write a minimal draft file directly (bypasses propose logic).

--- a/crates/edda-cli/src/cmd_init.rs
+++ b/crates/edda-cli/src/cmd_init.rs
@@ -5,7 +5,7 @@ use edda_ledger::paths::EddaPaths;
 use edda_ledger::{ledger, Ledger};
 use std::path::Path;
 
-pub fn execute(repo_root: &Path) -> anyhow::Result<()> {
+pub fn execute(repo_root: &Path, no_hooks: bool) -> anyhow::Result<()> {
     let paths = EddaPaths::discover(repo_root);
 
     if paths.is_initialized() {
@@ -13,18 +13,16 @@ pub fn execute(repo_root: &Path) -> anyhow::Result<()> {
         ledger::init_workspace(&paths)?;
         ledger::init_head(&paths, "main")?;
         println!("Already initialized at {}", paths.edda_dir.display());
-        return Ok(());
-    }
+    } else {
+        // Create directory layout
+        ledger::init_workspace(&paths)?;
+        ledger::init_head(&paths, "main")?;
+        ledger::init_branches_json(&paths, "main")?;
 
-    // Create directory layout
-    ledger::init_workspace(&paths)?;
-    ledger::init_head(&paths, "main")?;
-    ledger::init_branches_json(&paths, "main")?;
-
-    // Generate default policy.yaml (v2)
-    let policy_path = paths.edda_dir.join("policy.yaml");
-    if !policy_path.exists() {
-        let default_policy = "\
+        // Generate default policy.yaml (v2)
+        let policy_path = paths.edda_dir.join("policy.yaml");
+        if !policy_path.exists() {
+            let default_policy = "\
 version: 2
 roles:
   - lead
@@ -45,37 +43,157 @@ rules:
       default: true
     stages: []
 ";
-        std::fs::write(&policy_path, default_policy.as_bytes())?;
-    }
+            std::fs::write(&policy_path, default_policy.as_bytes())?;
+        }
 
-    // Generate default actors.yaml
-    let actors_path = paths.edda_dir.join("actors.yaml");
-    if !actors_path.exists() {
-        let default_actors = "\
+        // Generate default actors.yaml
+        let actors_path = paths.edda_dir.join("actors.yaml");
+        if !actors_path.exists() {
+            let default_actors = "\
 version: 1
 actors: {}
 ";
-        std::fs::write(&actors_path, default_actors.as_bytes())?;
+            std::fs::write(&actors_path, default_actors.as_bytes())?;
+        }
+
+        // Open ledger and write the init event
+        let ledger = Ledger::open(repo_root)?;
+        let _lock = WorkspaceLock::acquire(&ledger.paths)?;
+
+        let parent_hash = ledger.last_event_hash()?;
+        let event = new_note_event(
+            "main",
+            parent_hash.as_deref(),
+            "system",
+            "init edda workspace",
+            &[],
+        )?;
+        ledger.append_event(&event)?;
+
+        // Build derived views immediately so they're available right after init
+        rebuild_all(&ledger)?;
+
+        println!("Initialized .edda/ (HEAD=main)");
+        println!("  {}", event.event_id);
     }
 
-    // Open ledger and write the init event
-    let ledger = Ledger::open(repo_root)?;
-    let _lock = WorkspaceLock::acquire(&ledger.paths)?;
+    // Auto-detect and install bridge hooks (unless --no-hooks)
+    if !no_hooks {
+        auto_install_bridges(repo_root);
+    }
 
-    let parent_hash = ledger.last_event_hash()?;
-    let event = new_note_event(
-        "main",
-        parent_hash.as_deref(),
-        "system",
-        "init edda workspace",
-        &[],
-    )?;
-    ledger.append_event(&event)?;
-
-    // Build derived views immediately so they're available right after init
-    rebuild_all(&ledger)?;
-
-    println!("Initialized .edda/ (HEAD=main)");
-    println!("  {}", event.event_id);
     Ok(())
+}
+
+/// Detect known agent platforms and install repo-local hooks automatically.
+fn auto_install_bridges(repo_root: &Path) {
+    // Claude Code: repo-local hooks — safe to auto-install
+    if repo_root.join(".claude").is_dir() {
+        println!("Detected Claude Code project, installing hooks...");
+        match edda_bridge_claude::install(repo_root, false) {
+            Ok(()) => {} // install() already prints its own success messages
+            Err(e) => eprintln!("Warning: Claude hook install failed: {e}"),
+        }
+    }
+
+    // OpenClaw: global plugin (~/.openclaw/extensions/) — hint only, don't auto-install
+    if repo_root.join(".openclaw").is_dir() {
+        println!(
+            "Detected OpenClaw project. Run 'edda bridge openclaw install' to enable edda hooks."
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_dir() -> std::path::PathBuf {
+        let n = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let tmp =
+            std::env::temp_dir().join(format!("edda_init_test_{}_{n}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        tmp
+    }
+
+    #[test]
+    fn init_detects_claude_and_installs_hooks() {
+        let tmp = temp_dir();
+        std::fs::create_dir_all(tmp.join(".claude")).unwrap();
+
+        execute(&tmp, false).unwrap();
+
+        // Workspace created
+        assert!(tmp.join(".edda").is_dir());
+        // Claude hooks installed
+        let settings = tmp.join(".claude").join("settings.local.json");
+        assert!(settings.exists(), "settings.local.json should exist");
+        let content = std::fs::read_to_string(&settings).unwrap();
+        assert!(
+            content.contains("edda hook claude"),
+            "should contain edda hook"
+        );
+        // CLAUDE.md created
+        assert!(tmp.join(".claude").join("CLAUDE.md").exists());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn init_no_hooks_skips_bridge() {
+        let tmp = temp_dir();
+        std::fs::create_dir_all(tmp.join(".claude")).unwrap();
+
+        execute(&tmp, true).unwrap();
+
+        // Workspace created
+        assert!(tmp.join(".edda").is_dir());
+        // Hooks NOT installed
+        assert!(
+            !tmp.join(".claude").join("settings.local.json").exists(),
+            "settings.local.json should not exist with --no-hooks"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn init_without_claude_dir_no_error() {
+        let tmp = temp_dir();
+
+        execute(&tmp, false).unwrap();
+
+        // Workspace created
+        assert!(tmp.join(".edda").is_dir());
+        // No Claude artifacts
+        assert!(!tmp.join(".claude").join("settings.local.json").exists());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn reinit_also_installs_hooks() {
+        let tmp = temp_dir();
+
+        // First init — no .claude/ dir
+        execute(&tmp, false).unwrap();
+        assert!(tmp.join(".edda").is_dir());
+        assert!(!tmp.join(".claude").join("settings.local.json").exists());
+
+        // Now add .claude/ and re-init
+        std::fs::create_dir_all(tmp.join(".claude")).unwrap();
+        execute(&tmp, false).unwrap();
+
+        // Hooks should now be installed
+        let settings = tmp.join(".claude").join("settings.local.json");
+        assert!(settings.exists(), "hooks should be installed on re-init");
+        let content = std::fs::read_to_string(&settings).unwrap();
+        assert!(content.contains("edda hook claude"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
 }

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -33,7 +33,11 @@ struct Cli {
 #[derive(Subcommand)]
 enum Command {
     /// Initialize a new .edda/ workspace
-    Init,
+    Init {
+        /// Skip auto-detection and installation of bridge hooks
+        #[arg(long)]
+        no_hooks: bool,
+    },
     /// Record a note event
     Note {
         /// Note text
@@ -746,7 +750,7 @@ fn main() -> anyhow::Result<()> {
     let repo_root = std::env::current_dir()?;
 
     match cli.cmd {
-        Command::Init => cmd_init::execute(&repo_root),
+        Command::Init { no_hooks } => cmd_init::execute(&repo_root, no_hooks),
         Command::Note { text, role, tags } => cmd_note::execute(&repo_root, &text, &role, &tags),
         Command::Decide {
             decision,


### PR DESCRIPTION
## Summary
- `edda init` now auto-detects `.claude/` and installs Claude Code hooks (settings.local.json + CLAUDE.md)
- `.openclaw/` detected → prints hint to run manual install (global plugin, not auto-installed)
- `--no-hooks` flag for CI/scripting opt-out
- Re-init also triggers hook install (useful after edda upgrade)
- Hook install failure → warning only, workspace init always succeeds

## Test plan
- [x] 4 unit tests: detects_claude, no_hooks_skips, no_claude_no_error, reinit_installs
- [x] 73 total tests pass (`cargo test -p edda-cli`)
- [x] clippy clean
- [ ] Manual: `mkdir /tmp/t && mkdir /tmp/t/.claude && cd /tmp/t && edda init`

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)