### PR TITLE
feat(infra): Homebrew tap and update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ Your coding agent forgets every decision when the session ends. Edda makes them 
 ## Install
 
 ```bash
-# Download a prebuilt binary
+# macOS / Linux (Homebrew)
+brew install fagemx/tap/edda
+
+# Or download a prebuilt binary
 # → https://github.com/fagemx/edda/releases
 
 # Or build from source

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -26,7 +26,7 @@ mod tui;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(name = "edda", about = "Git-style Context Controller")]
+#[command(name = "edda", version, about = "Decision memory for coding agents")]
 struct Cli {
     #[command(subcommand)]
     cmd: Command,

--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Update the Homebrew formula in fagemx/homebrew-tap with SHA256 hashes
+# from a GitHub Release.
+#
+# Usage:
+#   ./scripts/update-homebrew.sh 0.1.0
+#   ./scripts/update-homebrew.sh 0.1.0 /path/to/homebrew-tap
+
+set -euo pipefail
+
+VERSION="${1:?Usage: update-homebrew.sh <version> [tap-dir]}"
+TAG="v${VERSION}"
+REPO="fagemx/edda"
+TAP_DIR="${2:-}"
+FORMULA_OUT=""
+
+# Fetch SHA256 for a given target
+fetch_hash() {
+  local target="$1"
+  local asset="edda-${TAG}-${target}.tar.gz.sha256"
+  gh release download "$TAG" --repo "$REPO" --pattern "$asset" --output - | awk '{print $1}'
+}
+
+echo "Fetching SHA256 hashes for ${TAG}..."
+
+HASH_MACOS_ARM=$(fetch_hash "aarch64-apple-darwin")
+HASH_MACOS_X86=$(fetch_hash "x86_64-apple-darwin")
+HASH_LINUX_ARM=$(fetch_hash "aarch64-unknown-linux-gnu")
+HASH_LINUX_X86=$(fetch_hash "x86_64-unknown-linux-gnu")
+
+echo "  macOS arm64:  ${HASH_MACOS_ARM}"
+echo "  macOS x86_64: ${HASH_MACOS_X86}"
+echo "  Linux arm64:  ${HASH_LINUX_ARM}"
+echo "  Linux x86_64: ${HASH_LINUX_X86}"
+
+# Generate formula
+generate_formula() {
+cat <<RUBY
+class Edda < Formula
+  desc "Decision memory for coding agents"
+  homepage "https://github.com/fagemx/edda"
+  version "${VERSION}"
+  license any_of: ["MIT", "Apache-2.0"]
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/fagemx/edda/releases/download/v#{version}/edda-v#{version}-aarch64-apple-darwin.tar.gz"
+      sha256 "${HASH_MACOS_ARM}"
+    else
+      url "https://github.com/fagemx/edda/releases/download/v#{version}/edda-v#{version}-x86_64-apple-darwin.tar.gz"
+      sha256 "${HASH_MACOS_X86}"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/fagemx/edda/releases/download/v#{version}/edda-v#{version}-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "${HASH_LINUX_ARM}"
+    else
+      url "https://github.com/fagemx/edda/releases/download/v#{version}/edda-v#{version}-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "${HASH_LINUX_X86}"
+    end
+  end
+
+  def install
+    bin.install "edda"
+  end
+
+  test do
+    assert_match "edda #{version}", shell_output("#{bin}/edda --version")
+  end
+end
+RUBY
+}
+
+if [ -n "$TAP_DIR" ]; then
+  FORMULA_OUT="${TAP_DIR}/Formula/edda.rb"
+  generate_formula > "$FORMULA_OUT"
+  echo ""
+  echo "Formula written to: ${FORMULA_OUT}"
+else
+  echo ""
+  echo "--- Formula/edda.rb ---"
+  generate_formula
+fi


### PR DESCRIPTION
## Summary
- Add `--version` flag to edda CLI (`edda --version` → `edda 0.1.0`)
- Create `scripts/update-homebrew.sh` to generate Homebrew formula from release SHA256 files
- Add `brew install fagemx/tap/edda` to README install section
- Homebrew tap repo created at [fagemx/homebrew-tap](https://github.com/fagemx/homebrew-tap) with formula for v0.1.0

## Test plan
- [ ] `cargo run -p edda-cli -- --version` outputs `edda 0.1.0`
- [ ] `bash scripts/update-homebrew.sh 0.1.0` fetches correct hashes and generates valid formula
- [ ] `brew install fagemx/tap/edda` installs successfully on macOS
- [ ] `brew test edda` passes

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)