### PR TITLE
feat(bridge): add coordination rules to CLAUDE.md onboarding

### DIFF
--- a/crates/edda-bridge-claude/src/admin.rs
+++ b/crates/edda-bridge-claude/src/admin.rs
@@ -413,14 +413,8 @@ mod tests {
             md_content.contains("edda:coordination"),
             "coordination marker"
         );
-        assert!(
-            md_content.contains("edda claim"),
-            "claim instruction"
-        );
-        assert!(
-            md_content.contains("edda request"),
-            "request instruction"
-        );
+        assert!(md_content.contains("edda claim"), "claim instruction");
+        assert!(md_content.contains("edda request"), "request instruction");
 
         uninstall(tmp.path()).unwrap();
         let content = fs::read_to_string(&path).unwrap();
@@ -458,10 +452,7 @@ mod tests {
             content.contains("edda:coordination"),
             "coordination section appended"
         );
-        assert!(
-            content.contains("edda claim"),
-            "claim instruction present"
-        );
+        assert!(content.contains("edda claim"), "claim instruction present");
     }
 
     #[test]
@@ -531,14 +522,8 @@ mod tests {
             content.contains("edda:coordination"),
             "coordination section appended"
         );
-        assert!(
-            content.contains("edda claim"),
-            "claim instruction present"
-        );
-        assert!(
-            content.contains("Off-limits"),
-            "off-limits rule present"
-        );
+        assert!(content.contains("edda claim"), "claim instruction present");
+        assert!(content.contains("Off-limits"), "off-limits rule present");
         assert_eq!(
             content.matches("edda:decision-tracking").count(),
             1,


### PR DESCRIPTION
## Summary

- Adds "Multi-Agent Coordination" section to CLAUDE.md templates in `admin.rs`
- Uses imperative "You MUST" language to instruct agents to check off-limits, claim scope, and request before crossing boundaries
- Separate `<!-- edda:coordination -->` marker for idempotent management
- Existing installs get coordination appended on next `edda init`

Closes #79

## Test plan

- [x] `cargo test -p edda-bridge-claude -- admin` — 6/6 pass
- [x] `cargo clippy -p edda-bridge-claude -- -D warnings` — clean
- [ ] CI passes (fmt, clippy, test on 3 OS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)