### PR TITLE
feat(tui): improve edda watch readability and layout

### DIFF
--- a/crates/edda-cli/src/tui/app.rs
+++ b/crates/edda-cli/src/tui/app.rs
@@ -296,10 +296,10 @@ mod tests {
     fn active_peers_hides_stale_unlabeled() {
         let mut app = App::new("test".into(), PathBuf::from("/tmp"));
         app.peers = vec![
-            make_peer("worker-1", 30),   // active, labeled → show
-            make_peer("", 200),          // stale, no label → hide
-            make_peer("worker-2", 200),  // stale, labeled → show
-            make_peer("", 50),           // active, no label → show
+            make_peer("worker-1", 30),  // active, labeled → show
+            make_peer("", 200),         // stale, no label → hide
+            make_peer("worker-2", 200), // stale, labeled → show
+            make_peer("", 50),          // active, no label → show
         ];
         let active = app.active_peers();
         assert_eq!(active.len(), 3);

--- a/crates/edda-cli/src/tui/ui.rs
+++ b/crates/edda-cli/src/tui/ui.rs
@@ -21,8 +21,7 @@ pub fn render(f: &mut Frame, app: &App) {
 
     let active_peers = app.active_peers();
     let has_peers = !active_peers.is_empty();
-    let has_claims_or_requests =
-        !app.board.claims.is_empty() || !app.board.requests.is_empty();
+    let has_claims_or_requests = !app.board.claims.is_empty() || !app.board.requests.is_empty();
 
     if has_peers || has_claims_or_requests {
         // 3-column layout
@@ -172,8 +171,7 @@ fn render_events(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
 }
 
 fn render_decisions(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
-    let has_claims_or_requests =
-        !app.board.claims.is_empty() || !app.board.requests.is_empty();
+    let has_claims_or_requests = !app.board.claims.is_empty() || !app.board.requests.is_empty();
 
     let title = format!(" Decisions ({}) ", app.board.bindings.len());
     let block = Block::default()
@@ -221,7 +219,10 @@ fn render_bindings_grouped(f: &mut Frame, app: &App, area: ratatui::layout::Rect
         } else {
             Style::default().add_modifier(Modifier::BOLD)
         };
-        items.push(ListItem::new(Line::from(Span::styled(header, header_style))));
+        items.push(ListItem::new(Line::from(Span::styled(
+            header,
+            header_style,
+        ))));
 
         if expanded {
             for b in bindings {


### PR DESCRIPTION
## Summary

Closes #89

- **Filter noise by default**: cmd events (40%+ of events) hidden, stale unlabeled peers hidden
- **Group decisions by domain**: user-facing domains expanded, internal domains collapsed with ▸/▾ toggle
- **Adaptive layout**: 2-column when no active peers, 3-column otherwise
- **Better event formatting**: digest shows ✓/✗ with duration, commits green ●, merges cyan ◆, shorter HH:MM timestamps
- **Toggle keybinds**: `c` for cmd events, `p` for stale peers, `Enter` to expand/collapse domain groups

## Test plan

- [x] `cargo check -p edda` — compiles clean
- [x] `cargo clippy -p edda -- -D warnings` — zero warnings
- [x] `cargo test -p edda -- tui` — all 26 tests pass (17 existing + 9 new)
- [ ] Manual: run `edda watch` and verify panels render correctly
- [ ] Manual: press `c` to toggle cmd events, `p` to toggle stale peers
- [ ] Manual: press `Enter` on collapsed domain to expand/collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)