### PR TITLE
feat(bridge): auto-write commit/merge events to workspace ledger

### DIFF
--- a/crates/edda-bridge-claude/src/dispatch.rs
+++ b/crates/edda-bridge-claude/src/dispatch.rs
@@ -2502,10 +2502,7 @@ mod tests {
         // Verify event was written
         let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
         let events = ledger.iter_events().unwrap();
-        let commit_events: Vec<_> = events
-            .iter()
-            .filter(|e| e.event_type == "commit")
-            .collect();
+        let commit_events: Vec<_> = events.iter().filter(|e| e.event_type == "commit").collect();
         assert_eq!(commit_events.len(), 1);
         assert_eq!(
             commit_events[0].payload["title"].as_str().unwrap(),
@@ -2538,10 +2535,7 @@ mod tests {
         // Verify event was written
         let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
         let events = ledger.iter_events().unwrap();
-        let merge_events: Vec<_> = events
-            .iter()
-            .filter(|e| e.event_type == "merge")
-            .collect();
+        let merge_events: Vec<_> = events.iter().filter(|e| e.event_type == "merge").collect();
         assert_eq!(merge_events.len(), 1);
         assert_eq!(merge_events[0].payload["src"].as_str().unwrap(), "PR#42");
         assert_eq!(

--- a/crates/edda-bridge-claude/src/nudge.rs
+++ b/crates/edda-bridge-claude/src/nudge.rs
@@ -626,7 +626,10 @@ mod tests {
 
     #[test]
     fn format_nudge_merge_gentle() {
-        let nudge = format_nudge(&NudgeSignal::Merge("feature/auth".into(), "merge".into()), 1);
+        let nudge = format_nudge(
+            &NudgeSignal::Merge("feature/auth".into(), "merge".into()),
+            1,
+        );
         assert!(nudge.contains("feature/auth"));
         assert!(nudge.contains("edda decide"));
         assert!(!nudge.contains("\u{26a0}\u{fe0f}"));


### PR DESCRIPTION
## Summary

Closes #85.

- When PostToolUse detects `git commit` or `git merge`/`gh pr merge`, writes a standalone `commit` or `merge` event to the workspace ledger immediately
- This populates the "Recent Commits" and "Recent Merges" sections in `edda context`, which were previously always empty
- Uses try-lock (non-blocking): silently skips if workspace is locked by another agent
- Auto-detected commits get `auto_detect` label to distinguish from manual `edda commit`

## Changes

| File | Change |
|------|--------|
| `nudge.rs` | Add `Merge(src, strategy)` signal variant, `extract_merge_branch()`, `extract_gh_pr_merge()`, 7 new tests |
| `dispatch.rs` | Add `try_write_commit_event()`, `try_write_merge_event()`, integrate into `dispatch_post_tool_use()`, 4 new tests |

## Test plan

- [x] 7 new merge detection unit tests (git merge, gh pr merge variants, nudge formatting)
- [x] 4 new integration tests (commit/merge event write, no-workspace skip, empty-cwd skip)
- [x] All 780+ workspace tests pass
- [x] Clippy clean (zero warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)