### PR TITLE
refactor(cli): co-locate clap sub-enums and dispatch in cmd_* modules

### DIFF
--- a/crates/edda-cli/src/cmd_branch.rs
+++ b/crates/edda-cli/src/cmd_branch.rs
@@ -1,8 +1,33 @@
+use clap::Subcommand;
 use edda_core::event::{new_branch_create_event, new_note_event};
 use edda_derive::{rebuild_all, rebuild_branch};
 use edda_ledger::lock::WorkspaceLock;
 use edda_ledger::Ledger;
 use std::path::Path;
+
+// ── CLI Schema ──
+
+#[derive(Subcommand)]
+pub enum BranchCmd {
+    /// Create a new branch
+    Create {
+        /// Branch name
+        name: String,
+        /// Purpose of this branch
+        #[arg(short = 'm', long = "purpose")]
+        purpose: String,
+    },
+}
+
+// ── Dispatch ──
+
+pub fn run(cmd: BranchCmd, repo_root: &Path) -> anyhow::Result<()> {
+    match cmd {
+        BranchCmd::Create { name, purpose } => create(repo_root, &name, &purpose),
+    }
+}
+
+// ── Command Implementations ──
 
 fn validate_branch_name(name: &str) -> anyhow::Result<()> {
     if name.is_empty() || name.len() > 64 {

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -4,6 +4,12 @@ use edda_conductor::agent::budget::BudgetTracker;
 use edda_conductor::agent::launcher::{phase_session_id, ClaudeCodeLauncher};
 use edda_conductor::check::engine::CheckEngine;
 use edda_conductor::plan::parser::load_plan;
+use edda_conductor::runner::notify::StdoutNotifier;
+use edda_conductor::runner::sequential::run_plan;
+use edda_conductor::state::machine::{PhaseStatus, PlanState, PlanStatus};
+use edda_conductor::state::persist::{load_state, save_state};
+use std::path::Path;
+use tokio_util::sync::CancellationToken;
 
 // ── CLI Schema ──
 
@@ -59,7 +65,7 @@ pub enum ConductCmd {
 
 // ── Dispatch ──
 
-pub fn run_cmd(cmd: ConductCmd, repo_root: &std::path::Path) -> Result<()> {
+pub fn run_cmd(cmd: ConductCmd, repo_root: &Path) -> Result<()> {
     match cmd {
         ConductCmd::Run {
             plan_file,
@@ -67,8 +73,8 @@ pub fn run_cmd(cmd: ConductCmd, repo_root: &std::path::Path) -> Result<()> {
             dry_run,
             quiet,
         } => run(
-            std::path::Path::new(&plan_file),
-            cwd.as_deref().map(std::path::Path::new),
+            Path::new(&plan_file),
+            cwd.as_deref().map(Path::new),
             dry_run,
             !quiet,
         ),
@@ -84,12 +90,6 @@ pub fn run_cmd(cmd: ConductCmd, repo_root: &std::path::Path) -> Result<()> {
 }
 
 // ── Command Implementations ──
-use edda_conductor::runner::notify::StdoutNotifier;
-use edda_conductor::runner::sequential::run_plan;
-use edda_conductor::state::machine::{PhaseStatus, PlanState, PlanStatus};
-use edda_conductor::state::persist::{load_state, save_state};
-use std::path::Path;
-use tokio_util::sync::CancellationToken;
 
 /// Execute `edda conduct run <plan.yaml>`
 pub fn run(

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -1,8 +1,89 @@
 use anyhow::{bail, Result};
+use clap::Subcommand;
 use edda_conductor::agent::budget::BudgetTracker;
 use edda_conductor::agent::launcher::{phase_session_id, ClaudeCodeLauncher};
 use edda_conductor::check::engine::CheckEngine;
 use edda_conductor::plan::parser::load_plan;
+
+// ── CLI Schema ──
+
+#[derive(Subcommand)]
+pub enum ConductCmd {
+    /// Run a plan from a YAML file
+    Run {
+        /// Path to plan.yaml
+        plan_file: String,
+        /// Override working directory
+        #[arg(long)]
+        cwd: Option<String>,
+        /// Preview plan without executing
+        #[arg(long)]
+        dry_run: bool,
+        /// Suppress live agent activity output
+        #[arg(short, long)]
+        quiet: bool,
+    },
+    /// Show status of running/completed plans
+    Status {
+        /// Plan name (auto-detects if only one)
+        plan_name: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Reset a failed/stale phase to Pending
+    Retry {
+        /// Phase ID to retry
+        phase_id: String,
+        /// Plan name (auto-detects if only one)
+        #[arg(long)]
+        plan: Option<String>,
+    },
+    /// Skip a failed/stale/pending phase
+    Skip {
+        /// Phase ID to skip
+        phase_id: String,
+        /// Reason for skipping
+        #[arg(long)]
+        reason: Option<String>,
+        /// Plan name (auto-detects if only one)
+        #[arg(long)]
+        plan: Option<String>,
+    },
+    /// Abort a running plan
+    Abort {
+        /// Plan name (auto-detects if only one)
+        plan_name: Option<String>,
+    },
+}
+
+// ── Dispatch ──
+
+pub fn run_cmd(cmd: ConductCmd, repo_root: &std::path::Path) -> Result<()> {
+    match cmd {
+        ConductCmd::Run {
+            plan_file,
+            cwd,
+            dry_run,
+            quiet,
+        } => run(
+            std::path::Path::new(&plan_file),
+            cwd.as_deref().map(std::path::Path::new),
+            dry_run,
+            !quiet,
+        ),
+        ConductCmd::Status { plan_name, json } => status(repo_root, plan_name.as_deref(), json),
+        ConductCmd::Retry { phase_id, plan } => retry(repo_root, &phase_id, plan.as_deref()),
+        ConductCmd::Skip {
+            phase_id,
+            reason,
+            plan,
+        } => skip(repo_root, &phase_id, reason.as_deref(), plan.as_deref()),
+        ConductCmd::Abort { plan_name } => abort(repo_root, plan_name.as_deref()),
+    }
+}
+
+// ── Command Implementations ──
 use edda_conductor::runner::notify::StdoutNotifier;
 use edda_conductor::runner::sequential::run_plan;
 use edda_conductor::state::machine::{PhaseStatus, PlanState, PlanStatus};

--- a/crates/edda-cli/src/cmd_config.rs
+++ b/crates/edda-cli/src/cmd_config.rs
@@ -1,4 +1,37 @@
+use clap::Subcommand;
 use std::path::Path;
+
+// ── CLI Schema ──
+
+#[derive(Subcommand)]
+pub enum ConfigCmd {
+    /// Set a config value
+    Set {
+        /// Config key (e.g. skill_guide)
+        key: String,
+        /// Config value (true/false/number/string)
+        value: String,
+    },
+    /// Get a config value
+    Get {
+        /// Config key
+        key: String,
+    },
+    /// List all config values
+    List,
+}
+
+// ── Dispatch ──
+
+pub fn run(cmd: ConfigCmd, repo_root: &Path) -> anyhow::Result<()> {
+    match cmd {
+        ConfigCmd::Set { key, value } => set(repo_root, &key, &value),
+        ConfigCmd::Get { key } => get(repo_root, &key),
+        ConfigCmd::List => list(repo_root),
+    }
+}
+
+// ── Command Implementations ──
 
 /// Read config from `.edda/config.json`. Returns empty map if file doesn't exist.
 fn read_config(path: &Path) -> anyhow::Result<serde_json::Map<String, serde_json::Value>> {

--- a/crates/edda-cli/src/cmd_pattern.rs
+++ b/crates/edda-cli/src/cmd_pattern.rs
@@ -1,4 +1,56 @@
+use clap::Subcommand;
 use std::path::Path;
+
+// ── CLI Schema ──
+
+#[derive(Subcommand)]
+pub enum PatternCmd {
+    /// Add a new pattern
+    Add {
+        /// Pattern ID (e.g. test-no-db)
+        #[arg(long)]
+        id: String,
+        /// File glob patterns (repeatable)
+        #[arg(long = "glob")]
+        globs: Vec<String>,
+        /// Rule description
+        #[arg(long)]
+        rule: String,
+        /// Source reference (e.g. "PR #2587")
+        #[arg(long, default_value = "")]
+        source: String,
+    },
+    /// Remove a pattern
+    Remove {
+        /// Pattern ID
+        id: String,
+    },
+    /// List all patterns
+    List,
+    /// Test which patterns match a file path
+    Test {
+        /// File path to test
+        file_path: String,
+    },
+}
+
+// ── Dispatch ──
+
+pub fn run(cmd: PatternCmd, repo_root: &Path) -> anyhow::Result<()> {
+    match cmd {
+        PatternCmd::Add {
+            id,
+            globs,
+            rule,
+            source,
+        } => add(repo_root, &id, &globs, &rule, &source),
+        PatternCmd::Remove { id } => remove(repo_root, &id),
+        PatternCmd::List => list(repo_root),
+        PatternCmd::Test { file_path } => test(repo_root, &file_path),
+    }
+}
+
+// ── Command Implementations ──
 
 pub fn add(
     repo_root: &Path,

--- a/crates/edda-cli/src/cmd_plan.rs
+++ b/crates/edda-cli/src/cmd_plan.rs
@@ -1,5 +1,35 @@
+use clap::Subcommand;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::Path;
+
+// ── CLI Schema ──
+
+#[derive(Subcommand)]
+pub enum PlanCmd {
+    /// Scan codebase and suggest a plan
+    Scan {
+        /// High-level intent for the plan (injected into purpose field)
+        #[arg(long)]
+        purpose: Option<String>,
+    },
+    /// Generate plan.yaml from built-in template
+    Init {
+        /// Template name (rust-cli, rust-lib, python-api, node-app, fullstack, minimal)
+        template: Option<String>,
+        /// Output file path
+        #[arg(short, long, default_value = "plan.yaml")]
+        output: String,
+    },
+}
+
+// ── Dispatch ──
+
+pub fn run(cmd: PlanCmd, repo_root: &Path) -> anyhow::Result<()> {
+    match cmd {
+        PlanCmd::Scan { purpose } => scan(repo_root, purpose.as_deref()),
+        PlanCmd::Init { template, output } => init(repo_root, template.as_deref(), &output),
+    }
+}
 
 // ── Scan ──
 

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -189,7 +189,7 @@ enum Command {
     /// Branch operations
     Branch {
         #[command(subcommand)]
-        cmd: BranchCmd,
+        cmd: cmd_branch::BranchCmd,
     },
     /// Switch to another branch
     Switch {
@@ -209,37 +209,37 @@ enum Command {
     /// Draft commit operations (propose, show, list, apply, delete)
     Draft {
         #[command(subcommand)]
-        cmd: DraftCmd,
+        cmd: cmd_draft::DraftCmd,
     },
     /// Bridge operations (install/uninstall hooks for Claude Code)
     Bridge {
         #[command(subcommand)]
-        cmd: BridgeCmd,
+        cmd: cmd_bridge::BridgeCmd,
     },
     /// Hook entrypoint (called by Claude Code hooks)
     Hook {
         #[command(subcommand)]
-        cmd: HookCmd,
+        cmd: cmd_bridge::HookCmd,
     },
     /// Health check for bridge integration
     Doctor {
         #[command(subcommand)]
-        cmd: DoctorCmd,
+        cmd: cmd_bridge::DoctorCmd,
     },
     /// Index operations
     Index {
         #[command(subcommand)]
-        cmd: IndexCmd,
+        cmd: cmd_bridge::IndexCmd,
     },
     /// Read or write workspace config (.edda/config.json)
     Config {
         #[command(subcommand)]
-        cmd: ConfigCmd,
+        cmd: cmd_config::ConfigCmd,
     },
     /// Manage pattern store (.edda/patterns/)
     Pattern {
         #[command(subcommand)]
-        cmd: PatternCmd,
+        cmd: cmd_pattern::PatternCmd,
     },
     /// MCP server operations
     Mcp {
@@ -249,22 +249,22 @@ enum Command {
     /// Full-text search (Tantivy)
     Search {
         #[command(subcommand)]
-        cmd: SearchCmd,
+        cmd: cmd_search::SearchCmd,
     },
     /// Manage blob metadata (classify, pin, unpin, info, stats)
     Blob {
         #[command(subcommand)]
-        cmd: BlobCmd,
+        cmd: cmd_blob::BlobCmd,
     },
     /// Plan scaffolding and templates
     Plan {
         #[command(subcommand)]
-        cmd: PlanCmd,
+        cmd: cmd_plan::PlanCmd,
     },
     /// Multi-phase AI plan conductor
     Conduct {
         #[command(subcommand)]
-        cmd: ConductCmd,
+        cmd: cmd_conduct::ConductCmd,
     },
     /// Launch the real-time peer status and event TUI
     Watch,
@@ -298,477 +298,9 @@ enum Command {
 }
 
 #[derive(Subcommand)]
-enum BranchCmd {
-    /// Create a new branch
-    Create {
-        /// Branch name
-        name: String,
-        /// Purpose of this branch
-        #[arg(short = 'm', long = "purpose")]
-        purpose: String,
-    },
-}
-
-#[derive(Subcommand)]
-enum PlanCmd {
-    /// Scan codebase and suggest a plan
-    Scan {
-        /// High-level intent for the plan (injected into purpose field)
-        #[arg(long)]
-        purpose: Option<String>,
-    },
-    /// Generate plan.yaml from built-in template
-    Init {
-        /// Template name (rust-cli, rust-lib, python-api, node-app, fullstack, minimal)
-        template: Option<String>,
-        /// Output file path
-        #[arg(short, long, default_value = "plan.yaml")]
-        output: String,
-    },
-}
-
-#[derive(Subcommand)]
-enum BridgeCmd {
-    /// Claude Code bridge operations
-    Claude {
-        #[command(subcommand)]
-        cmd: BridgeClaudeCmd,
-    },
-    /// OpenClaw bridge operations
-    Openclaw {
-        #[command(subcommand)]
-        cmd: BridgeOpenclawCmd,
-    },
-}
-
-#[derive(Subcommand)]
-enum BridgeClaudeCmd {
-    /// Install edda hooks into .claude/settings.local.json
-    Install {
-        /// Skip writing edda section to .claude/CLAUDE.md
-        #[arg(long)]
-        no_claude_md: bool,
-    },
-    /// Uninstall edda hooks from .claude/settings.local.json
-    Uninstall,
-    /// Manually digest a session into workspace ledger
-    Digest {
-        /// Session ID to digest
-        #[arg(long)]
-        session: Option<String>,
-        /// Digest all pending sessions
-        #[arg(long)]
-        all: bool,
-    },
-    /// Show active peer sessions for current project
-    Peers,
-    /// Claim a scope for coordination (e.g. "auth", "billing")
-    Claim {
-        /// Short label for this session's scope
-        label: String,
-        /// File path patterns this scope covers (e.g. "src/auth/*")
-        #[arg(long)]
-        paths: Vec<String>,
-        /// Session ID (auto-inferred from active heartbeats if omitted)
-        #[arg(long)]
-        session: Option<String>,
-    },
-    /// Record a binding decision for all sessions
-    Decide {
-        /// Decision in key=value format (e.g. "auth.method=JWT RS256")
-        decision: String,
-        /// Reason for the decision
-        #[arg(long)]
-        reason: Option<String>,
-        /// Session ID (auto-inferred from active heartbeats if omitted)
-        #[arg(long)]
-        session: Option<String>,
-    },
-    /// Send a request to another session
-    Request {
-        /// Target session label
-        to: String,
-        /// Request message
-        message: String,
-        /// Session ID (auto-inferred from active heartbeats if omitted)
-        #[arg(long)]
-        session: Option<String>,
-    },
-    /// Render write-back protocol (static teaching text)
-    RenderWriteback,
-    /// Render workspace context from .edda/ ledger
-    RenderWorkspace {
-        /// Max chars budget
-        #[arg(long, default_value = "2500")]
-        budget: usize,
-    },
-    /// Render L2 coordination protocol
-    RenderCoordination {
-        /// Session ID (auto-inferred if omitted)
-        #[arg(long)]
-        session: Option<String>,
-    },
-    /// Render hot pack (recent turns summary, reads last-built pack)
-    RenderPack,
-    /// Render active plan excerpt
-    RenderPlan,
-    /// Write session heartbeat for peer discovery
-    HeartbeatWrite {
-        /// Session label (e.g. "auth", "billing")
-        #[arg(long)]
-        label: String,
-        /// Session ID (auto-inferred if omitted)
-        #[arg(long)]
-        session: Option<String>,
-    },
-    /// Touch heartbeat timestamp (liveness ping)
-    HeartbeatTouch {
-        /// Session ID (auto-inferred if omitted)
-        #[arg(long)]
-        session: Option<String>,
-    },
-    /// Remove session heartbeat
-    HeartbeatRemove {
-        /// Session ID (auto-inferred if omitted)
-        #[arg(long)]
-        session: Option<String>,
-    },
-}
-
-#[derive(Subcommand)]
-enum BridgeOpenclawCmd {
-    /// Install edda OpenClaw plugin
-    Install {
-        /// Custom target directory (default: ~/.openclaw/extensions/edda-bridge/)
-        #[arg(long)]
-        target: Option<String>,
-    },
-    /// Uninstall edda OpenClaw plugin
-    Uninstall {
-        /// Custom target directory
-        #[arg(long)]
-        target: Option<String>,
-    },
-    /// Manually digest a session into workspace ledger
-    Digest {
-        /// Session ID to digest
-        #[arg(long)]
-        session: Option<String>,
-        /// Digest all pending sessions
-        #[arg(long)]
-        all: bool,
-    },
-}
-
-#[derive(Subcommand)]
-enum HookCmd {
-    /// Claude Code hook entrypoint (reads stdin JSON)
-    Claude,
-    /// OpenClaw hook entrypoint (reads stdin JSON)
-    Openclaw,
-}
-
-#[derive(Subcommand)]
-enum DoctorCmd {
-    /// Check Claude Code bridge health
-    Claude,
-    /// Check OpenClaw bridge health
-    Openclaw,
-}
-
-#[derive(Subcommand)]
-enum IndexCmd {
-    /// Verify index entries match store records
-    Verify {
-        /// Project ID
-        #[arg(long)]
-        project: String,
-        /// Session ID
-        #[arg(long)]
-        session: String,
-        /// Number of records to sample
-        #[arg(long, default_value_t = 50)]
-        sample: usize,
-        /// Check all records
-        #[arg(long)]
-        all: bool,
-    },
-}
-
-#[derive(Subcommand)]
-enum ConfigCmd {
-    /// Set a config value
-    Set {
-        /// Config key (e.g. skill_guide)
-        key: String,
-        /// Config value (true/false/number/string)
-        value: String,
-    },
-    /// Get a config value
-    Get {
-        /// Config key
-        key: String,
-    },
-    /// List all config values
-    List,
-}
-
-#[derive(Subcommand)]
-enum PatternCmd {
-    /// Add a new pattern
-    Add {
-        /// Pattern ID (e.g. test-no-db)
-        #[arg(long)]
-        id: String,
-        /// File glob patterns (repeatable)
-        #[arg(long = "glob")]
-        globs: Vec<String>,
-        /// Rule description
-        #[arg(long)]
-        rule: String,
-        /// Source reference (e.g. "PR #2587")
-        #[arg(long, default_value = "")]
-        source: String,
-    },
-    /// Remove a pattern
-    Remove {
-        /// Pattern ID
-        id: String,
-    },
-    /// List all patterns
-    List,
-    /// Test which patterns match a file path
-    Test {
-        /// File path to test
-        file_path: String,
-    },
-}
-
-#[derive(Subcommand)]
-enum DraftCmd {
-    /// Create a draft commit (does not write to ledger)
-    Propose {
-        /// Draft title
-        #[arg(short, long)]
-        title: String,
-        /// Purpose of this commit
-        #[arg(long)]
-        purpose: Option<String>,
-        /// Contribution description (defaults to title)
-        #[arg(long)]
-        contrib: Option<String>,
-        /// Evidence refs: evt_* or blob:sha256:* (repeatable)
-        #[arg(long = "evidence")]
-        evidence: Vec<String>,
-        /// Labels (repeatable)
-        #[arg(long = "label")]
-        labels: Vec<String>,
-        /// Enable auto-evidence collection (also auto-enabled when no --evidence given)
-        #[arg(long)]
-        auto: bool,
-        /// Maximum number of auto-evidence items
-        #[arg(long, default_value_t = 20)]
-        max_evidence: usize,
-    },
-    /// Show a draft by ID
-    Show {
-        /// Draft ID (drf_*)
-        id: String,
-    },
-    /// List all drafts
-    List {
-        /// Output as JSON lines (one object per draft)
-        #[arg(long)]
-        json: bool,
-    },
-    /// Apply a draft commit to the ledger (with rebase)
-    Apply {
-        /// Draft ID (drf_*)
-        id: String,
-        /// Preview without writing to ledger
-        #[arg(long)]
-        dry_run: bool,
-        /// Delete draft after successful apply
-        #[arg(long)]
-        delete: bool,
-    },
-    /// Delete a draft
-    Delete {
-        /// Draft ID (drf_*)
-        id: String,
-    },
-    /// Approve a draft
-    Approve {
-        /// Draft ID (drf_*)
-        id: String,
-        /// Actor name
-        #[arg(long, default_value = "human")]
-        by: String,
-        /// Approval note
-        #[arg(long, default_value = "")]
-        note: String,
-        /// Stage ID (required for multi-stage drafts)
-        #[arg(long)]
-        stage: Option<String>,
-    },
-    /// Reject a draft
-    Reject {
-        /// Draft ID (drf_*)
-        id: String,
-        /// Actor name
-        #[arg(long, default_value = "human")]
-        by: String,
-        /// Rejection note
-        #[arg(long, default_value = "")]
-        note: String,
-        /// Stage ID (required for multi-stage drafts)
-        #[arg(long)]
-        stage: Option<String>,
-    },
-    /// Show pending approval items
-    Inbox {
-        /// Filter by actor name
-        #[arg(long)]
-        by: Option<String>,
-        /// Filter by role
-        #[arg(long)]
-        role: Option<String>,
-        /// Output as JSON lines (one object per item)
-        #[arg(long)]
-        json: bool,
-    },
-}
-
-#[derive(Subcommand)]
 enum McpCommand {
     /// Start MCP server (stdio transport, JSON-RPC 2.0)
     Serve,
-}
-
-#[derive(Subcommand)]
-enum BlobCmd {
-    /// Classify a blob (artifact, decision_evidence, trace_noise)
-    Classify {
-        /// Blob hash or prefix
-        hash: String,
-        /// Classification: artifact, decision_evidence, trace_noise
-        #[arg(long)]
-        class: String,
-    },
-    /// Pin a blob (prevent GC from removing it)
-    Pin {
-        /// Blob hash or prefix
-        hash: String,
-    },
-    /// Unpin a blob (allow GC to remove it)
-    Unpin {
-        /// Blob hash or prefix
-        hash: String,
-    },
-    /// Show blob info (hash, size, class, pinned, location)
-    Info {
-        /// Blob hash or prefix
-        hash: String,
-    },
-    /// Show blob store statistics
-    Stats,
-    /// List tombstones (deleted blob records)
-    Tombstones,
-}
-
-#[derive(Subcommand)]
-enum SearchCmd {
-    /// Build or update search index (Tantivy)
-    Index {
-        /// Project ID (defaults to current repo)
-        #[arg(long)]
-        project: Option<String>,
-        /// Session ID (index single session instead of all)
-        #[arg(long)]
-        session: Option<String>,
-    },
-    /// Search for events and transcript turns
-    Query {
-        /// Search query (supports fuzzy, "exact", /regex/)
-        query: String,
-        /// Project ID (defaults to current repo)
-        #[arg(long)]
-        project: Option<String>,
-        /// Session ID filter
-        #[arg(long)]
-        session: Option<String>,
-        /// Filter by document type: event or turn
-        #[arg(long, name = "type")]
-        doc_type: Option<String>,
-        /// Filter by event type: note, commit, merge, etc.
-        #[arg(long)]
-        event_type: Option<String>,
-        /// Exact match (disable fuzzy)
-        #[arg(long)]
-        exact: bool,
-        /// Maximum results (default: 20)
-        #[arg(long, default_value_t = 20)]
-        limit: usize,
-    },
-    /// Show full content of a specific turn
-    Show {
-        /// Turn ID (from search results)
-        #[arg(long)]
-        turn: String,
-        /// Project ID (defaults to current repo)
-        #[arg(long)]
-        project: Option<String>,
-    },
-}
-
-#[derive(Subcommand)]
-enum ConductCmd {
-    /// Run a plan from a YAML file
-    Run {
-        /// Path to plan.yaml
-        plan_file: String,
-        /// Override working directory
-        #[arg(long)]
-        cwd: Option<String>,
-        /// Preview plan without executing
-        #[arg(long)]
-        dry_run: bool,
-        /// Suppress live agent activity output
-        #[arg(short, long)]
-        quiet: bool,
-    },
-    /// Show status of running/completed plans
-    Status {
-        /// Plan name (auto-detects if only one)
-        plan_name: Option<String>,
-        /// Output as JSON
-        #[arg(long)]
-        json: bool,
-    },
-    /// Reset a failed/stale phase to Pending
-    Retry {
-        /// Phase ID to retry
-        phase_id: String,
-        /// Plan name (auto-detects if only one)
-        #[arg(long)]
-        plan: Option<String>,
-    },
-    /// Skip a failed/stale/pending phase
-    Skip {
-        /// Phase ID to skip
-        phase_id: String,
-        /// Reason for skipping
-        #[arg(long)]
-        reason: Option<String>,
-        /// Plan name (auto-detects if only one)
-        #[arg(long)]
-        plan: Option<String>,
-    },
-    /// Abort a running plan
-    Abort {
-        /// Plan name (auto-detects if only one)
-        plan_name: Option<String>,
-    },
 }
 
 fn main() -> anyhow::Result<()> {
@@ -859,190 +391,27 @@ fn main() -> anyhow::Result<()> {
             all,
             reason,
         } => cmd_rebuild::execute(&repo_root, branch.as_deref(), all, &reason),
-        Command::Branch { cmd } => match cmd {
-            BranchCmd::Create { name, purpose } => cmd_branch::create(&repo_root, &name, &purpose),
-        },
+        Command::Branch { cmd } => cmd_branch::run(cmd, &repo_root),
         Command::Switch { name } => cmd_switch::execute(&repo_root, &name),
         Command::Merge { src, dst, reason } => cmd_merge::execute(&repo_root, &src, &dst, &reason),
-        Command::Draft { cmd } => match cmd {
-            DraftCmd::Propose {
-                title,
-                purpose,
-                contrib,
-                evidence,
-                labels,
-                auto,
-                max_evidence,
-            } => cmd_draft::propose(cmd_draft::ProposeParams {
-                repo_root: &repo_root,
-                title: &title,
-                purpose: purpose.as_deref(),
-                contrib: contrib.as_deref(),
-                evidence_args: &evidence,
-                labels,
-                auto,
-                max_evidence,
-            }),
-            DraftCmd::Show { id } => cmd_draft::show(&repo_root, &id),
-            DraftCmd::List { json } => cmd_draft::list(&repo_root, json),
-            DraftCmd::Apply {
-                id,
-                dry_run,
-                delete,
-            } => cmd_draft::apply(&repo_root, &id, dry_run, delete),
-            DraftCmd::Delete { id } => cmd_draft::delete(&repo_root, &id),
-            DraftCmd::Approve {
-                id,
-                by,
-                note,
-                stage,
-            } => cmd_draft::approve(&repo_root, &id, &by, &note, stage.as_deref()),
-            DraftCmd::Reject {
-                id,
-                by,
-                note,
-                stage,
-            } => cmd_draft::reject(&repo_root, &id, &by, &note, stage.as_deref()),
-            DraftCmd::Inbox { by, role, json } => {
-                cmd_draft::inbox(&repo_root, by.as_deref(), role.as_deref(), json)
-            }
-        },
-        Command::Bridge { cmd } => match cmd {
-            BridgeCmd::Claude { cmd } => match cmd {
-                BridgeClaudeCmd::Install { no_claude_md } => {
-                    cmd_bridge::install(&repo_root, no_claude_md)
-                }
-                BridgeClaudeCmd::Uninstall => cmd_bridge::uninstall(&repo_root),
-                BridgeClaudeCmd::Digest { session, all } => {
-                    cmd_bridge::digest(&repo_root, session.as_deref(), all)
-                }
-                BridgeClaudeCmd::Peers => cmd_bridge::peers(&repo_root),
-                BridgeClaudeCmd::Claim {
-                    label,
-                    paths,
-                    session,
-                } => cmd_bridge::claim(&repo_root, &label, &paths, session.as_deref()),
-                BridgeClaudeCmd::Decide {
-                    decision,
-                    reason,
-                    session,
-                } => {
-                    cmd_bridge::decide(&repo_root, &decision, reason.as_deref(), session.as_deref())
-                }
-                BridgeClaudeCmd::Request {
-                    to,
-                    message,
-                    session,
-                } => cmd_bridge::request(&repo_root, &to, &message, session.as_deref()),
-                BridgeClaudeCmd::RenderWriteback => cmd_bridge::render_writeback(),
-                BridgeClaudeCmd::RenderWorkspace { budget } => {
-                    cmd_bridge::render_workspace(&repo_root, budget)
-                }
-                BridgeClaudeCmd::RenderCoordination { session } => {
-                    cmd_bridge::render_coordination(&repo_root, session.as_deref())
-                }
-                BridgeClaudeCmd::RenderPack => cmd_bridge::render_pack(&repo_root),
-                BridgeClaudeCmd::RenderPlan => cmd_bridge::render_plan(&repo_root),
-                BridgeClaudeCmd::HeartbeatWrite { label, session } => {
-                    cmd_bridge::heartbeat_write(&repo_root, &label, session.as_deref())
-                }
-                BridgeClaudeCmd::HeartbeatTouch { session } => {
-                    cmd_bridge::heartbeat_touch(&repo_root, session.as_deref())
-                }
-                BridgeClaudeCmd::HeartbeatRemove { session } => {
-                    cmd_bridge::heartbeat_remove(&repo_root, session.as_deref())
-                }
-            },
-            BridgeCmd::Openclaw { cmd } => match cmd {
-                BridgeOpenclawCmd::Install { target } => {
-                    cmd_bridge::install_openclaw(target.as_deref().map(std::path::Path::new))
-                }
-                BridgeOpenclawCmd::Uninstall { target } => {
-                    cmd_bridge::uninstall_openclaw(target.as_deref().map(std::path::Path::new))
-                }
-                BridgeOpenclawCmd::Digest { session, all } => {
-                    cmd_bridge::digest(&repo_root, session.as_deref(), all)
-                }
-            },
-        },
-        Command::Hook { cmd } => match cmd {
-            HookCmd::Claude => cmd_bridge::hook_claude(),
-            HookCmd::Openclaw => cmd_bridge::hook_openclaw(),
-        },
-        Command::Doctor { cmd } => match cmd {
-            DoctorCmd::Claude => cmd_bridge::doctor(&repo_root),
-            DoctorCmd::Openclaw => cmd_bridge::doctor_openclaw(),
-        },
-        Command::Config { cmd } => match cmd {
-            ConfigCmd::Set { key, value } => cmd_config::set(&repo_root, &key, &value),
-            ConfigCmd::Get { key } => cmd_config::get(&repo_root, &key),
-            ConfigCmd::List => cmd_config::list(&repo_root),
-        },
-        Command::Pattern { cmd } => match cmd {
-            PatternCmd::Add {
-                id,
-                globs,
-                rule,
-                source,
-            } => cmd_pattern::add(&repo_root, &id, &globs, &rule, &source),
-            PatternCmd::Remove { id } => cmd_pattern::remove(&repo_root, &id),
-            PatternCmd::List => cmd_pattern::list(&repo_root),
-            PatternCmd::Test { file_path } => cmd_pattern::test(&repo_root, &file_path),
-        },
-        Command::Index { cmd } => match cmd {
-            IndexCmd::Verify {
-                project,
-                session,
-                sample,
-                all,
-            } => cmd_bridge::index_verify(&project, &session, sample, all),
-        },
+        Command::Draft { cmd } => cmd_draft::run(cmd, &repo_root),
+        Command::Bridge { cmd } => cmd_bridge::run_bridge(cmd, &repo_root),
+        Command::Hook { cmd } => cmd_bridge::run_hook(cmd),
+        Command::Doctor { cmd } => cmd_bridge::run_doctor(cmd, &repo_root),
+        Command::Index { cmd } => cmd_bridge::run_index(cmd),
+        Command::Config { cmd } => cmd_config::run(cmd, &repo_root),
+        Command::Pattern { cmd } => cmd_pattern::run(cmd, &repo_root),
         Command::Mcp { cmd } => match cmd {
             McpCommand::Serve => {
                 tokio::runtime::Runtime::new()?.block_on(edda_mcp::serve(&repo_root))?;
                 Ok(())
             }
         },
-        Command::Plan { cmd } => match cmd {
-            PlanCmd::Scan { purpose } => cmd_plan::scan(&repo_root, purpose.as_deref()),
-            PlanCmd::Init { template, output } => {
-                cmd_plan::init(&repo_root, template.as_deref(), &output)
-            }
-        },
-        Command::Conduct { cmd } => match cmd {
-            ConductCmd::Run {
-                plan_file,
-                cwd,
-                dry_run,
-                quiet,
-            } => cmd_conduct::run(
-                std::path::Path::new(&plan_file),
-                cwd.as_deref().map(std::path::Path::new),
-                dry_run,
-                !quiet,
-            ),
-            ConductCmd::Status { plan_name, json } => {
-                cmd_conduct::status(&repo_root, plan_name.as_deref(), json)
-            }
-            ConductCmd::Retry { phase_id, plan } => {
-                cmd_conduct::retry(&repo_root, &phase_id, plan.as_deref())
-            }
-            ConductCmd::Skip {
-                phase_id,
-                reason,
-                plan,
-            } => cmd_conduct::skip(&repo_root, &phase_id, reason.as_deref(), plan.as_deref()),
-            ConductCmd::Abort { plan_name } => cmd_conduct::abort(&repo_root, plan_name.as_deref()),
-        },
+        Command::Search { cmd } => cmd_search::run_cmd(cmd, &repo_root),
+        Command::Blob { cmd } => cmd_blob::run(cmd, &repo_root),
+        Command::Plan { cmd } => cmd_plan::run(cmd, &repo_root),
+        Command::Conduct { cmd } => cmd_conduct::run_cmd(cmd, &repo_root),
         Command::Watch => cmd_watch::execute(&repo_root),
-        Command::Blob { cmd } => match cmd {
-            BlobCmd::Classify { hash, class } => cmd_blob::classify(&repo_root, &hash, &class),
-            BlobCmd::Pin { hash } => cmd_blob::pin(&repo_root, &hash),
-            BlobCmd::Unpin { hash } => cmd_blob::unpin(&repo_root, &hash),
-            BlobCmd::Info { hash } => cmd_blob::info(&repo_root, &hash),
-            BlobCmd::Stats => cmd_blob::stats(&repo_root),
-            BlobCmd::Tombstones => cmd_blob::tombstones(&repo_root),
-        },
         Command::Gc {
             dry_run,
             keep_days,
@@ -1063,38 +432,5 @@ fn main() -> anyhow::Result<()> {
             archive_keep_days,
             include_sessions,
         }),
-        Command::Search { cmd } => {
-            let default_pid = cmd_search::resolve_project_id(&repo_root);
-            match cmd {
-                SearchCmd::Index { project, session } => {
-                    let pid = project.as_deref().unwrap_or(&default_pid);
-                    cmd_search::index(&repo_root, pid, session.as_deref())
-                }
-                SearchCmd::Query {
-                    query,
-                    project,
-                    session,
-                    doc_type,
-                    event_type,
-                    exact,
-                    limit,
-                } => {
-                    let pid = project.as_deref().unwrap_or(&default_pid);
-                    cmd_search::query(
-                        pid,
-                        &query,
-                        session.as_deref(),
-                        doc_type.as_deref(),
-                        event_type.as_deref(),
-                        exact,
-                        limit,
-                    )
-                }
-                SearchCmd::Show { turn, project } => {
-                    let pid = project.as_deref().unwrap_or(&default_pid);
-                    cmd_search::show(pid, &turn)
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Move all `Subcommand`-derived enums and dispatch `match` arms from `main.rs` into their respective `cmd_*` modules
- `main.rs` reduced from ~1,100 lines to ~370 lines — now a thin router that parses CLI args and delegates to module-level `run()` functions
- 10 modules updated: `cmd_bridge`, `cmd_draft`, `cmd_conduct`, `cmd_search`, `cmd_blob`, `cmd_config`, `cmd_pattern`, `cmd_plan`, `cmd_branch`

## Test plan
- [x] All 95 CLI tests pass (`cargo test -p edda`)
- [x] `cargo clippy -p edda -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] Pure mechanical refactor — no behavior changes

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)