### PR TITLE
fix(paths): resolve edda workspace in git worktrees

### DIFF
--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -665,7 +665,8 @@ enum McpCommand {
 
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
-    let repo_root = std::env::current_dir()?;
+    let cwd = std::env::current_dir()?;
+    let repo_root = edda_ledger::EddaPaths::find_root(&cwd).unwrap_or(cwd);
 
     match cli.cmd {
         Command::Init { no_hooks } => cmd_init::execute(&repo_root, no_hooks),

--- a/crates/edda-ledger/src/paths.rs
+++ b/crates/edda-ledger/src/paths.rs
@@ -71,17 +71,62 @@ impl EddaPaths {
 
 impl EddaPaths {
     /// Walk up from `start` looking for a directory containing `.edda/`.
-    /// Returns `None` if not found.
+    ///
+    /// If the walk-up fails, falls back to git worktree resolution:
+    /// reads the `.git` file to find the main repo root, then checks
+    /// whether `.edda/` exists there.
+    ///
+    /// Returns `None` if not found by either method.
     pub fn find_root(start: &Path) -> Option<PathBuf> {
+        // Phase 1: Walk up looking for .edda/ (fast path)
         let mut cur = start.to_path_buf();
         loop {
             if cur.join(".edda").is_dir() {
                 return Some(cur);
             }
             if !cur.pop() {
-                return None;
+                break;
             }
         }
+
+        // Phase 2: Git worktree fallback — resolve to main repo, check .edda/ there
+        resolve_git_repo_root(start).filter(|root| root.join(".edda").is_dir())
+    }
+}
+
+/// Resolve git worktree to main repo root.
+///
+/// Walks up from `start` looking for `.git`:
+/// - **Directory** → parent is the repo root (normal repo)
+/// - **File** with `gitdir: .../worktrees/{name}` → resolve to main repo root
+/// - **File** without `/worktrees/` (e.g. submodule) → use that directory
+/// - **Not found** → `None`
+fn resolve_git_repo_root(start: &Path) -> Option<PathBuf> {
+    let abs = start.canonicalize().unwrap_or_else(|_| start.to_path_buf());
+    let mut cur = abs.as_path();
+    loop {
+        let dot_git = cur.join(".git");
+        if dot_git.is_dir() {
+            return Some(cur.to_path_buf());
+        }
+        if dot_git.is_file() {
+            if let Ok(content) = std::fs::read_to_string(&dot_git) {
+                let content = content.trim();
+                if let Some(gitdir) = content.strip_prefix("gitdir:") {
+                    let gitdir = gitdir.trim().replace('\\', "/");
+                    if let Some(pos) = gitdir.find("/worktrees/") {
+                        // Worktree: gitdir points to .git/worktrees/{name}
+                        // Strip /worktrees/{name} to get the common .git dir,
+                        // then take its parent as the repo root.
+                        let common_git = &gitdir[..pos];
+                        return Path::new(common_git).parent().map(|p| p.to_path_buf());
+                    }
+                }
+            }
+            // .git file but not a worktree (e.g. submodule) → use this dir
+            return Some(cur.to_path_buf());
+        }
+        cur = cur.parent()?;
     }
 }
 
@@ -122,6 +167,134 @@ mod tests {
         assert!(p.branches_dir.is_dir());
         assert!(p.drafts_dir.is_dir());
         assert!(p.patterns_dir.is_dir());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static PATH_TEST_CTR: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_tmp(label: &str) -> PathBuf {
+        let n = PATH_TEST_CTR.fetch_add(1, Ordering::SeqCst);
+        std::env::temp_dir().join(format!("edda_path_{label}_{}_{n}", std::process::id()))
+    }
+
+    #[test]
+    fn find_root_walks_up_to_edda_dir() {
+        let tmp = unique_tmp("walkup");
+        let _ = std::fs::remove_dir_all(&tmp);
+        // repo/.edda/ exists, start from repo/sub/deep/
+        std::fs::create_dir_all(tmp.join(".edda")).unwrap();
+        let deep = tmp.join("sub").join("deep");
+        std::fs::create_dir_all(&deep).unwrap();
+
+        let found = EddaPaths::find_root(&deep);
+        assert_eq!(found.unwrap(), tmp);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn find_root_worktree_outside_repo() {
+        // Simulate: main repo at repo/ with .edda/ and .git/
+        // Worktree at wt/ with .git file pointing back
+        let tmp = unique_tmp("wt_outside");
+        let _ = std::fs::remove_dir_all(&tmp);
+        let repo = tmp.join("repo");
+        let wt = tmp.join("wt");
+
+        // Main repo: .git/ directory + .edda/ workspace
+        std::fs::create_dir_all(repo.join(".git").join("worktrees").join("feat-x")).unwrap();
+        std::fs::create_dir_all(repo.join(".edda")).unwrap();
+
+        // Worktree: .git file pointing to main repo's worktree gitdir
+        std::fs::create_dir_all(&wt).unwrap();
+        let gitdir = repo.join(".git").join("worktrees").join("feat-x");
+        let gitdir_str = gitdir
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .replace('\\', "/");
+        std::fs::write(wt.join(".git"), format!("gitdir: {gitdir_str}")).unwrap();
+
+        let found = EddaPaths::find_root(&wt);
+        assert!(found.is_some(), "should resolve worktree to main repo");
+        // Resolved root should contain .edda/
+        assert!(found.unwrap().join(".edda").is_dir());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn find_root_non_git_no_edda_returns_none() {
+        let tmp = unique_tmp("no_git");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        assert!(EddaPaths::find_root(&tmp).is_none());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn resolve_git_repo_root_normal_repo() {
+        let tmp = unique_tmp("git_normal");
+        let _ = std::fs::remove_dir_all(&tmp);
+        let repo = tmp.join("my-repo");
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+
+        let result = resolve_git_repo_root(&repo);
+        assert_eq!(result.unwrap(), repo.canonicalize().unwrap());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn resolve_git_repo_root_worktree() {
+        let tmp = unique_tmp("git_wt");
+        let _ = std::fs::remove_dir_all(&tmp);
+        let repo = tmp.join("repo");
+
+        std::fs::create_dir_all(repo.join(".git").join("worktrees").join("feat-x")).unwrap();
+        let wt = tmp.join("wt");
+        std::fs::create_dir_all(&wt).unwrap();
+
+        let gitdir = repo.join(".git").join("worktrees").join("feat-x");
+        let gitdir_str = gitdir
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .replace('\\', "/");
+        std::fs::write(wt.join(".git"), format!("gitdir: {gitdir_str}")).unwrap();
+
+        let resolved = resolve_git_repo_root(&wt).unwrap();
+        let repo_canon = repo.canonicalize().unwrap();
+        // Normalize for comparison
+        let norm = |p: &Path| p.to_string_lossy().replace('\\', "/").to_lowercase();
+        assert_eq!(
+            norm(&resolved),
+            norm(&repo_canon),
+            "worktree should resolve to main repo root"
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn resolve_git_repo_root_submodule() {
+        let tmp = unique_tmp("git_sub");
+        let _ = std::fs::remove_dir_all(&tmp);
+        let sub = tmp.join("parent").join("submodule");
+        std::fs::create_dir_all(&sub).unwrap();
+        // Submodule .git file has /modules/ not /worktrees/
+        std::fs::write(sub.join(".git"), "gitdir: ../../.git/modules/submodule").unwrap();
+
+        let resolved = resolve_git_repo_root(&sub).unwrap();
+        assert_eq!(resolved, sub.canonicalize().unwrap());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn resolve_git_repo_root_non_git() {
+        let tmp = unique_tmp("git_none");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        assert!(resolve_git_repo_root(&tmp).is_none());
         let _ = std::fs::remove_dir_all(&tmp);
     }
 }


### PR DESCRIPTION
## Summary

- Add git worktree resolution fallback to `EddaPaths::find_root()` — when walking up fails to find `.edda/`, reads `.git` file to resolve worktree → main repo root
- Update CLI `main()` to use `find_root()` instead of raw `cwd`, fixing all 30+ CLI commands in worktree context
- Add 7 unit tests covering: walk-up, worktree outside repo, non-git dirs, normal repos, worktrees, submodules

## Test plan

- [x] `cargo test -p edda-ledger -- paths` — 9 tests pass (2 existing + 7 new)
- [x] `cargo clippy -p edda-ledger -p edda --all-targets` — zero warnings
- [ ] Manual: build edda, create worktree, run `edda status` from inside it

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)