### PR TITLE
feat(bridge): hook-level automation for coordination

### DIFF
--- a/crates/edda-bridge-claude/src/dispatch.rs
+++ b/crates/edda-bridge-claude/src/dispatch.rs
@@ -970,9 +970,7 @@ fn check_pending_requests(project_id: &str, session_id: &str) -> Option<String> 
         return None;
     }
 
-    let mut lines = vec![
-        "**Pending requests** (ack with `edda request-ack <from>`):".to_string(),
-    ];
+    let mut lines = vec!["**Pending requests** (ack with `edda request-ack <from>`):".to_string()];
     for r in &pending {
         lines.push(format!("  - From **{}**: {}", r.from_label, r.message));
     }

--- a/crates/edda-bridge-claude/src/peers.rs
+++ b/crates/edda-bridge-claude/src/peers.rs
@@ -2923,7 +2923,10 @@ mod tests {
         // Claim should still be "auth" (manual), not "edda-store" (auto)
         let board = compute_board_state(pid);
         let claim = board.claims.iter().find(|c| c.session_id == "s1").unwrap();
-        assert_eq!(claim.label, "auth", "manual claim should not be overwritten");
+        assert_eq!(
+            claim.label, "auth",
+            "manual claim should not be overwritten"
+        );
 
         let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     }

--- a/crates/edda-cli/src/cmd_bridge.rs
+++ b/crates/edda-cli/src/cmd_bridge.rs
@@ -545,6 +545,20 @@ pub fn request(
     Ok(())
 }
 
+/// `edda request-ack <from>` — acknowledge a pending request
+pub fn request_ack(
+    repo_root: &Path,
+    from_label: &str,
+    cli_session: Option<&str>,
+) -> anyhow::Result<()> {
+    let project_id = edda_store::project_id(repo_root);
+    let (session_id, _label) = resolve_session_id(cli_session, &project_id, "cli");
+
+    edda_bridge_claude::peers::write_request_ack(&project_id, &session_id, from_label);
+    println!("Acknowledged request from [{from_label}]");
+    Ok(())
+}
+
 /// Resolve session identity via 4-tier fallback:
 ///
 /// 1. `--session` CLI flag (explicit override)

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -84,6 +84,15 @@ enum Command {
         #[arg(long)]
         session: Option<String>,
     },
+    /// Acknowledge a pending request from another session
+    #[command(name = "request-ack")]
+    RequestAck {
+        /// Label of the session whose request to acknowledge
+        from: String,
+        /// Session ID (auto-inferred from active heartbeats if omitted)
+        #[arg(long)]
+        session: Option<String>,
+    },
     /// Setup a bridge integration (shortcut for `bridge <platform> install`)
     Setup {
         #[command(subcommand)]
@@ -701,6 +710,9 @@ fn main() -> anyhow::Result<()> {
             message,
             session,
         } => cmd_bridge::request(&repo_root, &to, &message, session.as_deref()),
+        Command::RequestAck { from, session } => {
+            cmd_bridge::request_ack(&repo_root, &from, session.as_deref())
+        }
         Command::Setup { cmd } => match cmd {
             SetupCmd::Openclaw { target, uninstall } => {
                 let path = target.as_deref().map(std::path::Path::new);


### PR DESCRIPTION
## Summary

Closes #56

- **Real-time auto-claim**: PostToolUse(Edit/Write) tracks edited files incrementally, derives scope via `derive_scope_from_files()`, writes claim when scope changes (dedup, skips if manual claim exists)
- **Request persistent nudge**: PreToolUse checks pending requests every 3rd tool call (counter-based cooldown), injects reminder into `additionalContext`
- **Request ack**: New `RequestAck` CoordEventType, `write_request_ack()`, CLI command `edda request-ack <from>`, filters acked requests from pending list

Decision pre-commit gate and phase-guided request sending deferred (needs #55).

## Files Changed

| File | Change |
|---|---|
| `peers.rs` | `RequestAck` type, `write_request_ack()`, `maybe_auto_claim_file()`, `pending_requests_for_session()`, `AutoClaimState.files` |
| `dispatch.rs` | Auto-claim in PostToolUse, request nudge in PreToolUse with `check_pending_requests()` |
| `cmd_bridge.rs` | `request_ack()` CLI handler |
| `main.rs` | `RequestAck` command variant + routing |

## Test plan

- [x] `auto_claim_file_incremental_same_crate` — 3 files in same crate → single claim
- [x] `auto_claim_file_scope_change` — files in different crates → claim updated
- [x] `auto_claim_file_skips_manual_claim` — manual claim exists → auto-claim skipped
- [x] `auto_claim_file_dedup_no_extra_writes` — same file twice → no duplicate claim
- [x] `request_ack_filters_pending` — write request + ack → pending list empty
- [x] `request_ack_only_for_acker_session` — ack from session A doesn't affect session B
- [x] `request_ack_in_board_state` — RequestAck appears in BoardState
- [x] `pending_requests_no_label_returns_empty` — no label → no pending
- [x] `post_tool_use_edit_triggers_auto_claim` — Edit → auto-claim written
- [x] `post_tool_use_write_triggers_auto_claim` — Write → auto-claim written
- [x] `post_tool_use_bash_does_not_auto_claim` — Bash → no auto-claim
- [x] `pre_tool_use_request_nudge_cooldown` — cooldown fires at 0, 3, 6...
- [x] `pre_tool_use_no_pending_no_nudge` — no requests → no nudge
- [x] 302 tests pass, 0 clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)