### PR TITLE
feat: add HTTP API server with edda serve command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,10 +127,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -776,6 +834,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "edda-serve"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "edda-ask",
+ "edda-core",
+ "edda-derive",
+ "edda-ledger",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tower",
+ "tower-http",
+]
+
+[[package]]
 name = "edda-store"
 version = "0.1.0"
 dependencies = [
@@ -865,6 +941,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs2"
@@ -1087,6 +1172,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyperloglogplus"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,6 +1469,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "measure_time"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,6 +1497,12 @@ checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -1472,10 +1650,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1907,6 +2097,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2010,6 +2223,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,6 +2282,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tantivy"
@@ -2280,6 +2509,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2309,11 +2539,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2639,7 +2912,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2657,14 +2939,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2674,10 +2973,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2686,10 +2997,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2698,10 +3021,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2710,10 +3045,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/edda-ask",
     "crates/edda-search-fts",
     "crates/edda-conductor",
+    "crates/edda-serve",
     "crates/edda-cli",  # crate name: "edda"
 ]
 

--- a/crates/edda-bridge-claude/src/peers.rs
+++ b/crates/edda-bridge-claude/src/peers.rs
@@ -3054,7 +3054,10 @@ mod tests {
         let board_before = compute_board_state(pid);
         assert_eq!(board_before.request_acks.len(), 1);
         let pending_before = pending_requests_for_session(pid, "s1");
-        assert!(pending_before.is_empty(), "acked request should not be pending");
+        assert!(
+            pending_before.is_empty(),
+            "acked request should not be pending"
+        );
 
         // Compact
         let lines = compute_board_state_for_compaction(pid);

--- a/crates/edda-cli/Cargo.toml
+++ b/crates/edda-cli/Cargo.toml
@@ -25,6 +25,7 @@ edda-transcript = { path = "../edda-transcript", version = "0.1.0" }
 edda-index = { path = "../edda-index", version = "0.1.0" }
 edda-pack = { path = "../edda-pack", version = "0.1.0" }
 edda-mcp = { path = "../edda-mcp", version = "0.1.0" }
+edda-serve = { path = "../edda-serve", version = "0.1.0" }
 edda-search-fts = { path = "../edda-search-fts", version = "0.1.0" }
 edda-conductor = { path = "../edda-conductor", version = "0.1.0" }
 ratatui = { version = "0.29", optional = true }

--- a/crates/edda-cli/src/cmd_serve.rs
+++ b/crates/edda-cli/src/cmd_serve.rs
@@ -1,0 +1,11 @@
+use std::path::Path;
+
+use edda_serve::ServeConfig;
+
+pub fn execute(repo_root: &Path, bind: &str, port: u16) -> anyhow::Result<()> {
+    let config = ServeConfig {
+        bind: bind.to_string(),
+        port,
+    };
+    tokio::runtime::Runtime::new()?.block_on(edda_serve::serve(repo_root, config))
+}

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -18,6 +18,7 @@ mod cmd_plan;
 mod cmd_rebuild;
 mod cmd_run;
 mod cmd_search;
+mod cmd_serve;
 mod cmd_status;
 mod cmd_switch;
 mod cmd_watch;
@@ -288,6 +289,15 @@ enum Command {
     },
     /// Launch the real-time peer status and event TUI
     Watch,
+    /// Start HTTP API server
+    Serve {
+        /// Bind address
+        #[arg(long, default_value = "127.0.0.1")]
+        bind: String,
+        /// Port number
+        #[arg(long, default_value_t = 7433)]
+        port: u16,
+    },
     /// Garbage collect expired blobs and transcripts
     Gc {
         /// Preview without deleting
@@ -813,6 +823,7 @@ fn main() -> anyhow::Result<()> {
             IntakeCmd::Github { issue_id } => cmd_intake::execute_github(&repo_root, issue_id),
         },
         Command::Watch => cmd_watch::execute(&repo_root),
+        Command::Serve { bind, port } => cmd_serve::execute(&repo_root, &bind, port),
         Command::Gc {
             dry_run,
             keep_days,

--- a/crates/edda-serve/Cargo.toml
+++ b/crates/edda-serve/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "edda-serve"
+description = "HTTP API server for edda workspace"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+categories.workspace = true
+keywords.workspace = true
+
+[dependencies]
+edda-ask = { path = "../edda-ask", version = "0.1.0" }
+edda-core = { path = "../edda-core", version = "0.1.0" }
+edda-derive = { path = "../edda-derive", version = "0.1.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.1.0" }
+axum = "0.8"
+tokio = { version = "1", features = ["rt-multi-thread", "net"] }
+tower-http = { version = "0.6", features = ["cors"] }
+anyhow.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tower = { version = "0.5", features = ["util"] }

--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -1,0 +1,706 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use tower_http::cors::CorsLayer;
+
+use edda_core::event::{finalize_event, new_decision_event, new_note_event};
+use edda_core::types::{rel, DecisionPayload, Provenance};
+use edda_derive::{rebuild_branch, render_context, DeriveOptions};
+use edda_ledger::lock::WorkspaceLock;
+use edda_ledger::Ledger;
+
+// ── Config ──
+
+pub struct ServeConfig {
+    pub bind: String,
+    pub port: u16,
+}
+
+// ── App State ──
+
+struct AppState {
+    repo_root: PathBuf,
+}
+
+impl AppState {
+    fn open_ledger(&self) -> anyhow::Result<Ledger> {
+        Ledger::open(&self.repo_root)
+    }
+}
+
+// ── Error Handling ──
+
+struct AppError(anyhow::Error);
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let body = serde_json::json!({ "error": self.0.to_string() });
+        (StatusCode::INTERNAL_SERVER_ERROR, Json(body)).into_response()
+    }
+}
+
+impl<E: Into<anyhow::Error>> From<E> for AppError {
+    fn from(err: E) -> Self {
+        Self(err.into())
+    }
+}
+
+// ── Entrypoint ──
+
+pub async fn serve(repo_root: &Path, config: ServeConfig) -> anyhow::Result<()> {
+    let paths = edda_ledger::EddaPaths::discover(repo_root);
+    if !paths.is_initialized() {
+        anyhow::bail!("not a edda workspace (run `edda init` first)");
+    }
+
+    let state = Arc::new(AppState {
+        repo_root: repo_root.to_path_buf(),
+    });
+
+    let app = Router::new()
+        .route("/api/health", get(health))
+        .route("/api/status", get(get_status))
+        .route("/api/context", get(get_context))
+        .route("/api/decisions", get(get_decisions))
+        .route("/api/log", get(get_log))
+        .route("/api/drafts", get(get_drafts))
+        .route("/api/note", post(post_note))
+        .route("/api/decide", post(post_decide))
+        .layer(CorsLayer::permissive())
+        .with_state(state);
+
+    let addr = format!("{}:{}", config.bind, config.port);
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    eprintln!("edda HTTP server listening on http://{addr}");
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+/// Build the router (for testing without binding to a port).
+pub fn router(repo_root: &Path) -> Router {
+    let state = Arc::new(AppState {
+        repo_root: repo_root.to_path_buf(),
+    });
+    Router::new()
+        .route("/api/health", get(health))
+        .route("/api/status", get(get_status))
+        .route("/api/context", get(get_context))
+        .route("/api/decisions", get(get_decisions))
+        .route("/api/log", get(get_log))
+        .route("/api/drafts", get(get_drafts))
+        .route("/api/note", post(post_note))
+        .route("/api/decide", post(post_decide))
+        .layer(CorsLayer::permissive())
+        .with_state(state)
+}
+
+// ── Health ──
+
+async fn health() -> Json<serde_json::Value> {
+    Json(serde_json::json!({ "ok": true }))
+}
+
+// ── GET /api/status ──
+
+#[derive(Serialize)]
+struct StatusResponse {
+    branch: String,
+    last_commit: Option<LastCommit>,
+    uncommitted_events: usize,
+}
+
+#[derive(Serialize)]
+struct LastCommit {
+    ts: String,
+    event_id: String,
+    title: String,
+}
+
+async fn get_status(State(state): State<Arc<AppState>>) -> Result<Json<StatusResponse>, AppError> {
+    let ledger = state.open_ledger()?;
+    let head = ledger.head_branch()?;
+    let snap = rebuild_branch(&ledger, &head)?;
+
+    let last_commit = snap.last_commit.as_ref().map(|c| LastCommit {
+        ts: c.ts.clone(),
+        event_id: c.event_id.clone(),
+        title: c.title.clone(),
+    });
+
+    Ok(Json(StatusResponse {
+        branch: head,
+        last_commit,
+        uncommitted_events: snap.uncommitted_events,
+    }))
+}
+
+// ── GET /api/context ──
+
+#[derive(Deserialize)]
+struct ContextQuery {
+    depth: Option<usize>,
+}
+
+#[derive(Serialize)]
+struct ContextResponse {
+    context: String,
+}
+
+async fn get_context(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<ContextQuery>,
+) -> Result<Json<ContextResponse>, AppError> {
+    let ledger = state.open_ledger()?;
+    let head = ledger.head_branch()?;
+    let depth = params.depth.unwrap_or(5);
+    let text = render_context(&ledger, &head, DeriveOptions { depth })?;
+    Ok(Json(ContextResponse { context: text }))
+}
+
+// ── GET /api/decisions ──
+
+#[derive(Deserialize)]
+struct DecisionsQuery {
+    q: Option<String>,
+    limit: Option<usize>,
+    all: Option<bool>,
+    branch: Option<String>,
+}
+
+async fn get_decisions(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<DecisionsQuery>,
+) -> Result<Json<edda_ask::AskResult>, AppError> {
+    let ledger = state.open_ledger()?;
+    let q = params.q.as_deref().unwrap_or("");
+    let opts = edda_ask::AskOptions {
+        limit: params.limit.unwrap_or(20),
+        include_superseded: params.all.unwrap_or(false),
+        branch: params.branch,
+    };
+    let result = edda_ask::ask(&ledger, q, &opts, None)?;
+    Ok(Json(result))
+}
+
+// ── GET /api/log ──
+
+#[derive(Deserialize)]
+struct LogQuery {
+    r#type: Option<String>,
+    keyword: Option<String>,
+    after: Option<String>,
+    before: Option<String>,
+    limit: Option<usize>,
+}
+
+#[derive(Serialize)]
+struct LogEntry {
+    ts: String,
+    event_type: String,
+    event_id: String,
+    branch: String,
+    detail: String,
+}
+
+#[derive(Serialize)]
+struct LogResponse {
+    events: Vec<LogEntry>,
+}
+
+async fn get_log(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<LogQuery>,
+) -> Result<Json<LogResponse>, AppError> {
+    let ledger = state.open_ledger()?;
+    let head = ledger.head_branch()?;
+    let events = ledger.iter_events()?;
+    let limit = params.limit.unwrap_or(50);
+
+    let results: Vec<LogEntry> = events
+        .iter()
+        .rev()
+        .filter(|e| e.branch == head)
+        .filter(|e| {
+            if let Some(ref et) = params.r#type {
+                if e.event_type != *et {
+                    return false;
+                }
+            }
+            if let Some(ref kw) = params.keyword {
+                let payload_str = e.payload.to_string().to_lowercase();
+                if !payload_str.contains(&kw.to_lowercase()) {
+                    return false;
+                }
+            }
+            if let Some(ref after) = params.after {
+                if e.ts.as_str() < after.as_str() {
+                    return false;
+                }
+            }
+            if let Some(ref before) = params.before {
+                if e.ts.as_str() > before.as_str() {
+                    return false;
+                }
+            }
+            true
+        })
+        .take(limit)
+        .map(|e| {
+            let detail = e
+                .payload
+                .get("text")
+                .and_then(|v| v.as_str())
+                .or_else(|| e.payload.get("title").and_then(|v| v.as_str()))
+                .unwrap_or("")
+                .to_string();
+            LogEntry {
+                ts: e.ts.clone(),
+                event_type: e.event_type.clone(),
+                event_id: e.event_id.clone(),
+                branch: e.branch.clone(),
+                detail,
+            }
+        })
+        .collect();
+
+    Ok(Json(LogResponse { events: results }))
+}
+
+// ── GET /api/drafts ──
+
+#[derive(Serialize)]
+struct DraftItem {
+    draft_id: String,
+    title: String,
+    stage_id: String,
+    role: String,
+    approved: usize,
+    min_approvals: usize,
+}
+
+#[derive(Serialize)]
+struct DraftsResponse {
+    drafts: Vec<DraftItem>,
+}
+
+#[derive(Deserialize)]
+struct MinimalDraft {
+    #[serde(default)]
+    draft_id: String,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    stages: Vec<MinimalStage>,
+}
+
+#[derive(Deserialize)]
+struct MinimalStage {
+    #[serde(default)]
+    stage_id: String,
+    #[serde(default)]
+    role: String,
+    #[serde(default)]
+    min_approvals: usize,
+    #[serde(default)]
+    approved_by: Vec<String>,
+    #[serde(default)]
+    status: String,
+}
+
+async fn get_drafts(State(state): State<Arc<AppState>>) -> Result<Json<DraftsResponse>, AppError> {
+    let ledger = state.open_ledger()?;
+    let drafts_dir = &ledger.paths.drafts_dir;
+
+    if !drafts_dir.exists() {
+        return Ok(Json(DraftsResponse { drafts: vec![] }));
+    }
+
+    let mut items = Vec::new();
+    for entry in std::fs::read_dir(drafts_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        if path.file_stem().and_then(|s| s.to_str()) == Some("latest") {
+            continue;
+        }
+
+        let content = std::fs::read_to_string(&path)?;
+        let draft: MinimalDraft = match serde_json::from_str(&content) {
+            Ok(d) => d,
+            Err(_) => continue,
+        };
+
+        if draft.status == "applied" {
+            continue;
+        }
+
+        for stage in &draft.stages {
+            if stage.status != "pending" {
+                continue;
+            }
+            items.push(DraftItem {
+                draft_id: draft.draft_id.clone(),
+                title: draft.title.clone(),
+                stage_id: stage.stage_id.clone(),
+                role: stage.role.clone(),
+                approved: stage.approved_by.len(),
+                min_approvals: stage.min_approvals,
+            });
+        }
+    }
+
+    Ok(Json(DraftsResponse { drafts: items }))
+}
+
+// ── POST /api/note ──
+
+#[derive(Deserialize)]
+struct NoteBody {
+    text: String,
+    role: Option<String>,
+    tags: Option<Vec<String>>,
+}
+
+#[derive(Serialize)]
+struct EventResponse {
+    event_id: String,
+}
+
+async fn post_note(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<NoteBody>,
+) -> Result<Json<EventResponse>, AppError> {
+    let ledger = state.open_ledger()?;
+    let _lock = WorkspaceLock::acquire(&ledger.paths)?;
+
+    let branch = ledger.head_branch()?;
+    let parent_hash = ledger.last_event_hash()?;
+    let role = body.role.as_deref().unwrap_or("user");
+    let tags = body.tags.unwrap_or_default();
+
+    let event = new_note_event(&branch, parent_hash.as_deref(), role, &body.text, &tags)?;
+    ledger.append_event(&event)?;
+
+    Ok(Json(EventResponse {
+        event_id: event.event_id,
+    }))
+}
+
+// ── POST /api/decide ──
+
+#[derive(Deserialize)]
+struct DecideBody {
+    decision: String,
+    reason: Option<String>,
+}
+
+#[derive(Serialize)]
+struct DecideResponse {
+    event_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    superseded: Option<String>,
+}
+
+async fn post_decide(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<DecideBody>,
+) -> Result<Json<DecideResponse>, AppError> {
+    let (key, value) = body.decision.split_once('=').ok_or_else(|| {
+        anyhow::anyhow!("decision must be in key=value format (e.g. \"db.engine=postgres\")")
+    })?;
+    let key = key.trim();
+    let value = value.trim();
+
+    let ledger = state.open_ledger()?;
+    let _lock = WorkspaceLock::acquire(&ledger.paths)?;
+
+    let branch = ledger.head_branch()?;
+    let parent_hash = ledger.last_event_hash()?;
+
+    let dp = DecisionPayload {
+        key: key.to_string(),
+        value: value.to_string(),
+        reason: body.reason,
+    };
+    let mut event = new_decision_event(&branch, parent_hash.as_deref(), "system", &dp)?;
+
+    // Auto-supersede: find prior decision with same key
+    let prior = find_prior_decision(&ledger, &branch, key);
+    let mut superseded = None;
+    if let Some((prior_id, prior_value)) = &prior {
+        if prior_value.as_deref() != Some(value) {
+            superseded = Some(prior_id.clone());
+            event.refs.provenance.push(Provenance {
+                target: prior_id.clone(),
+                rel: rel::SUPERSEDES.to_string(),
+                note: Some(format!("key '{}' re-decided", key)),
+            });
+        }
+    }
+
+    finalize_event(&mut event);
+    ledger.append_event(&event)?;
+
+    Ok(Json(DecideResponse {
+        event_id: event.event_id,
+        superseded,
+    }))
+}
+
+/// Find the most recent decision event with the same key on the given branch.
+fn find_prior_decision(
+    ledger: &Ledger,
+    branch: &str,
+    key: &str,
+) -> Option<(String, Option<String>)> {
+    let events = ledger.iter_events().ok()?;
+    events
+        .iter()
+        .rev()
+        .filter(|e| e.branch == branch && e.event_type == "note")
+        .filter(|e| edda_core::decision::is_decision(&e.payload))
+        .find_map(|e| {
+            let dp = edda_core::decision::extract_decision(&e.payload)?;
+            if dp.key == key {
+                Some((e.event_id.clone(), Some(dp.value)))
+            } else {
+                None
+            }
+        })
+}
+
+// ── Tests ──
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    fn setup_workspace(dir: &Path) {
+        let paths = edda_ledger::EddaPaths::discover(dir);
+        paths.ensure_layout().unwrap();
+        edda_ledger::ledger::init_workspace(&paths).unwrap();
+        edda_ledger::ledger::init_head(&paths, "main").unwrap();
+        edda_ledger::ledger::init_branches_json(&paths, "main").unwrap();
+    }
+
+    #[tokio::test]
+    async fn health_returns_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["ok"], true);
+    }
+
+    #[tokio::test]
+    async fn status_returns_branch() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/status")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["branch"], "main");
+    }
+
+    #[tokio::test]
+    async fn context_returns_markdown() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/context")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["context"].as_str().unwrap().contains("main"));
+    }
+
+    #[tokio::test]
+    async fn post_note_creates_event() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/note")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"text": "hello from HTTP"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["event_id"].as_str().unwrap().starts_with("evt_"));
+    }
+
+    #[tokio::test]
+    async fn post_decide_creates_event() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/decide")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"decision": "db.engine=sqlite", "reason": "embedded"})
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["event_id"].as_str().unwrap().starts_with("evt_"));
+        assert!(json.get("superseded").is_none() || json["superseded"].is_null());
+    }
+
+    #[tokio::test]
+    async fn log_returns_events() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+
+        // Seed an event
+        let ledger = Ledger::open(tmp.path()).unwrap();
+        let parent_hash = ledger.last_event_hash().unwrap();
+        let event =
+            new_note_event("main", parent_hash.as_deref(), "user", "test note", &[]).unwrap();
+        ledger.append_event(&event).unwrap();
+        drop(ledger);
+
+        let app = router(tmp.path());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/log")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let events = json["events"].as_array().unwrap();
+        assert!(!events.is_empty());
+        assert_eq!(events[0]["event_type"], "note");
+    }
+
+    #[tokio::test]
+    async fn decisions_returns_results() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/decisions")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn drafts_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/drafts")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["drafts"].as_array().unwrap().len(), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- New `edda-serve` crate with axum HTTP server exposing 8 REST endpoints
- `edda serve [--bind] [--port]` CLI command (default: 127.0.0.1:7433)

### Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/health` | Health check |
| GET | `/api/status` | Workspace status (branch, last commit, uncommitted) |
| GET | `/api/context?depth=` | Context snapshot as markdown |
| GET | `/api/decisions?q=&limit=&all=&branch=` | Query decisions |
| GET | `/api/log?type=&keyword=&after=&before=&limit=` | Event log with filters |
| GET | `/api/drafts` | Pending draft approvals |
| POST | `/api/note` | Record a note event |
| POST | `/api/decide` | Record a decision (with auto-supersede) |

### Design
- Per-request `Ledger::open()` (same pattern as MCP handlers)
- `WorkspaceLock` for write endpoints
- CORS middleware for local dev (browser access)
- `AppError` maps anyhow errors to JSON responses

Closes #106

## Test plan
- [x] 8 integration tests using axum oneshot (all passing)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)