### PR TITLE
feat(bridge): actionable claim nudge in coordination protocol

### DIFF
--- a/crates/edda-bridge-claude/src/peers.rs
+++ b/crates/edda-bridge-claude/src/peers.rs
@@ -928,19 +928,16 @@ pub fn render_coordination_protocol_with(
             claim.label,
             claim.paths.join(", ")
         ));
-        lines.push(
-            "Message a peer: `edda request \"peer-label\" \"your message\"`".to_string(),
-        );
     } else {
         // No claim yet — provide actionable nudge with specific suggestion
         let suggested = suggest_claim_command(my_label, &my_heartbeat);
         lines.push(format!(
             "**Claim your scope** so peers know what you're working on:\n{suggested}",
         ));
-        lines.push(
-            "Message a peer: `edda request \"peer-label\" \"your message\"`".to_string(),
-        );
     }
+    lines.push(
+        "Message a peer: `edda request \"peer-label\" \"your message\"`".to_string(),
+    );
 
     // Peer activity (tasks + focus files)
     let active_peers: Vec<&PeerSummary> = peers


### PR DESCRIPTION
## Summary
- When an agent has no explicit claim in a multi-agent session, the coordination protocol now generates a **specific** `edda claim` command suggestion instead of a generic placeholder
- Suggestion priority: focus files → branch name → heartbeat label → generic template
- When claim exists, shows "Your scope" as before (no nudge)

Closes #131

## Test plan
- [x] 328 tests pass (7 new: suggest_claim_command variants + protocol_no_claim/with_claim/branch_context)
- [x] 0 clippy warnings
- [ ] Smoke test: start multi-agent session, verify unclaimed agent sees actionable nudge


🤖 Generated with [Claude Code](https://claude.com/claude-code)