### PR TITLE
feat(cli): add edda peers and edda coord shortcuts

### DIFF
--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -100,11 +100,7 @@ enum Command {
         session: Option<String>,
     },
     /// Show active peer sessions (shortcut for `bridge claude peers`)
-    Peers {
-        /// Session ID (auto-inferred from active heartbeats if omitted)
-        #[arg(long)]
-        session: Option<String>,
-    },
+    Peers,
     /// Show coordination state (shortcut for `bridge claude render-coordination`)
     Coord {
         /// Session ID (auto-inferred from active heartbeats if omitted)


### PR DESCRIPTION
## Summary

- Add `edda peers` as top-level shortcut for `edda bridge claude peers`
- Add `edda coord` as top-level shortcut for `edda bridge claude render-coordination`
- Fix `edda bridge-claude` → `edda bridge claude` typo in local coord-sync skill (not tracked in git — #134 will address embedding skills in the binary)

Follows the existing shortcut pattern: `decide`, `claim`, `request`, `request-ack`.

Fixes #133
Ref: #134 (skill scaffolding follow-up)

## Test plan

- [x] `cargo build` — compiles
- [x] `cargo clippy` — no warnings
- [x] `cargo test` — all pass
- [x] `edda peers` — shows active sessions
- [x] `edda coord` — shows coordination state

🤖 Generated with [Claude Code](https://claude.com/claude-code)