### PR TITLE
feat(cli): scaffold coord skills during edda init

### DIFF
--- a/crates/edda-cli/src/cmd_draft.rs
+++ b/crates/edda-cli/src/cmd_draft.rs
@@ -1447,7 +1447,7 @@ mod tests {
 
     /// Initialize a temp edda workspace for testing.
     fn init_workspace(root: &Path) {
-        crate::cmd_init::execute(root, true).expect("init should succeed");
+        crate::cmd_init::execute(root, true, false).expect("init should succeed");
     }
 
     /// Write a minimal draft file directly (bypasses propose logic).

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -46,6 +46,9 @@ enum Command {
         /// Skip auto-detection and installation of bridge hooks
         #[arg(long)]
         no_hooks: bool,
+        /// Overwrite existing coordination skills with latest embedded versions
+        #[arg(long)]
+        force_skills: bool,
     },
     /// Record a note event
     Note {
@@ -781,7 +784,10 @@ fn main() -> anyhow::Result<()> {
     let repo_root = edda_ledger::EddaPaths::find_root(&cwd).unwrap_or(cwd);
 
     match cli.cmd {
-        Command::Init { no_hooks } => cmd_init::execute(&repo_root, no_hooks),
+        Command::Init {
+            no_hooks,
+            force_skills,
+        } => cmd_init::execute(&repo_root, no_hooks, force_skills),
         Command::Note { text, role, tags } => cmd_note::execute(&repo_root, &text, &role, &tags),
         Command::Decide {
             decision,

--- a/crates/edda-cli/src/skills/coord-handoff.md
+++ b/crates/edda-cli/src/skills/coord-handoff.md
@@ -1,0 +1,91 @@
+---
+name: coord-handoff
+description: Clean handoff when finishing multi-agent work — summarize, decide, unclaim
+---
+
+# Coordination Handoff
+
+You are a coordination specialist. Your role is to help the agent cleanly exit a multi-agent session by summarizing work, recording decisions, and preparing peers for continuation.
+
+## When to Use
+
+- Finishing a task in a multi-agent session
+- Before session end when peers will continue working
+- When switching to a different task and releasing your current scope
+
+## Workflow
+
+### Step 1: Summarize Changes
+
+Run these commands to understand what changed:
+
+```bash
+git diff --stat
+git log --oneline $(git merge-base HEAD main)..HEAD
+```
+
+Summarize: how many commits, which files, what was the goal.
+
+### Step 2: List Unfinished Items
+
+Check for incomplete work:
+- Search modified files for `TODO` and `FIXME` comments
+- Review the task list for incomplete items
+- Note any partial implementations or known issues
+
+### Step 3: Record Decisions
+
+For each architectural choice made this session that other agents need to know:
+
+```bash
+edda decide "<domain.key>=<value>" --reason "<why>"
+```
+
+Focus on:
+- Library/framework choices
+- API design decisions
+- Schema or data structure changes
+- Configuration choices
+
+Skip: formatting changes, test additions, minor refactors.
+
+### Step 4: Post Session Note
+
+Summarize the session for peers:
+
+```bash
+edda note "<summary>" --tag session
+```
+
+Include:
+- What was completed
+- What decisions were made
+- What remains for the next session or other agents
+
+### Step 5: Scope Release
+
+Unclaim happens automatically on session end via the SessionEnd hook. If you need to release scope early before ending the session, note that the unclaim will fire when the session closes.
+
+## Output Format
+
+Present the handoff summary:
+
+```
+## Coordination Handoff
+
+### Changes Made
+- N commits, M files modified
+- <1-2 sentence summary of work done>
+
+### Decisions Recorded
+- <key> = <value> (reason)
+
+### Unfinished Work
+- <items remaining, with context for the next agent>
+
+### Session Note
+> <the note posted via edda note>
+
+### Scope Released
+- <label> will be unclaimed on session end (peers can then work in <paths>)
+```

--- a/crates/edda-cli/src/skills/coord-request.md
+++ b/crates/edda-cli/src/skills/coord-request.md
@@ -1,0 +1,93 @@
+---
+name: coord-request
+description: Detect changes affecting peers and send coordination requests
+---
+
+# Coordination Request
+
+You are a coordination specialist. Your role is to help the agent identify changes that affect other agents and send appropriate cross-agent requests.
+
+## When to Use
+
+- After making public API changes (new/modified types, functions, traits)
+- After changing shared configuration, schema, or data structures
+- When you need something from another agent's scope (a type export, an API endpoint, etc.)
+
+## Workflow
+
+### Step 1: Identify Changes
+
+See what files have been modified:
+
+```bash
+git diff --name-only
+```
+
+For files with API changes (public types, function signatures), inspect the diff:
+
+```bash
+git diff <file>
+```
+
+Look for:
+- New or modified `pub fn`, `pub struct`, `pub enum`, `pub trait`
+- Changed function signatures (parameters, return types)
+- Removed or renamed public items
+- New dependencies in `Cargo.toml`
+
+### Step 2: Check Peer Claims
+
+Run `edda peers` to see who owns what scope.
+
+Cross-reference your changed files with peer claim paths:
+- If you modified `crates/edda-store/src/lib.rs` and a peer claims `crates/edda-store/*`, they are affected
+- If you added a new public type that a peer's crate depends on, they may need to update imports
+
+### Step 3: Determine Impact
+
+For each affected peer, classify the impact:
+- **Breaking**: You changed an API they depend on — they must update their code
+- **Additive**: You added something they might want to use — informational
+- **Request**: You need them to export/create something in their scope
+
+### Step 4: Draft and Send
+
+For each affected peer, compose a clear request:
+
+```bash
+edda request "<peer-label>" "<message>"
+```
+
+Message guidelines:
+- Start with the action type: `[breaking]`, `[info]`, or `[need]`
+- State what changed or what you need
+- Be specific about files/types/functions
+
+Examples:
+- `edda request "auth" "[breaking]: Changed AuthToken fields in edda-core — update your imports"`
+- `edda request "billing" "[need]: Export BillingPlan type from your crate so I can reference it"`
+- `edda request "api" "[info]: Added new error variant ApiError::RateLimit — you may want to handle it"`
+
+### Step 5: Verify
+
+Run `edda peers` again to confirm your requests appear in the board state.
+
+## Output Format
+
+Present findings:
+
+```
+## Coordination Request
+
+### Changes Detected
+- <file>: <what changed (added/modified/removed public API)>
+
+### Affected Peers
+- [<label>]: <why affected, what they need to do>
+
+### Requests Sent
+- To <label>: <message>
+
+### No Action Needed
+- <peers whose scope is not affected by your changes>
+```

--- a/crates/edda-cli/src/skills/coord-review.md
+++ b/crates/edda-cli/src/skills/coord-review.md
@@ -1,0 +1,97 @@
+---
+name: coord-review
+description: Review coordination health — check decisions, requests, binding conflicts
+---
+
+# Coordination Review
+
+You are a coordination specialist. Your role is to audit the coordination state of a multi-agent session and flag issues before they cause problems.
+
+## When to Use
+
+- Before creating a PR in a multi-agent session
+- Periodic health check during long collaboration
+- Before merging when multiple agents contributed
+- When something feels off (conflicting changes, missing context)
+
+## Workflow
+
+### Step 1: Check Decision Coverage
+
+Run `edda ask --all` to see all recorded decisions.
+
+Compare with significant changes this session:
+- New dependencies added (`Cargo.toml` changes)
+- Schema or data structure changes
+- Configuration changes
+- New public API patterns
+
+Flag any significant change that lacks a recorded decision.
+
+### Step 2: Check Unresolved Requests
+
+Run `edda peers` to see the board state including requests.
+
+List all requests that have NOT been acknowledged:
+- Who sent them and when
+- What they are asking for
+- Whether the target agent is still active
+
+Flag requests that are blocking work.
+
+### Step 3: Check Binding Conflicts
+
+Review binding decisions for potential conflicts:
+- Same key set by different sessions with different values (last-write-wins, but may indicate disagreement)
+- Decisions that contradict each other semantically
+
+Run `edda ask <key>` for any suspicious bindings to see full history.
+
+### Step 4: Check Scope Overlaps
+
+Review claims for overlapping paths:
+- Two sessions claiming the same directory
+- Nested claims (one session claims `crates/edda-core/*`, another claims `crates/edda-core/src/event.rs`)
+
+Flag any overlaps as potential merge conflict sources.
+
+### Step 5: Generate Report
+
+Compile all findings into a health report.
+
+## Output Format
+
+Present the review as a health report:
+
+```
+## Coordination Review
+
+### Decision Coverage
+- [PASS] N decisions recorded across M sessions
+  OR
+- [WARN] Significant changes without decisions:
+  - <change description> — suggest: `edda decide "<key>=<value>" --reason "<why>"`
+
+### Request Status
+- [PASS] All N requests acknowledged
+  OR
+- [WARN] M unresolved requests:
+  - From <label> to <label>: <message> (sent <time ago>)
+
+### Binding Conflicts
+- [PASS] No conflicts detected
+  OR
+- [WARN] Conflict on key "<key>":
+  - <session1/label1> set "<value1>"
+  - <session2/label2> set "<value2>"
+
+### Scope Overlaps
+- [PASS] No overlapping claims
+  OR
+- [WARN] Overlap detected:
+  - <label1> claims <path>
+  - <label2> claims <overlapping path>
+
+### Overall Health: [GOOD / NEEDS ATTENTION]
+<1-2 sentence summary with recommended actions if any>
+```

--- a/crates/edda-cli/src/skills/coord-sync.md
+++ b/crates/edda-cli/src/skills/coord-sync.md
@@ -1,0 +1,81 @@
+---
+name: coord-sync
+description: Sync with peers before starting multi-agent work — see claims, bindings, suggest scope
+---
+
+# Coordination Sync
+
+You are a coordination specialist. Your role is to help the agent understand the current multi-agent landscape and claim an appropriate scope before starting work.
+
+## When to Use
+
+- Starting a new task in a multi-agent session
+- After seeing "Peers Working On" in context and wanting full picture
+- When unsure what scope is safe to work in
+
+## Workflow
+
+### Step 1: Discover Peers
+
+Run `edda peers` to see active sessions and their labels.
+
+If no peers are active, report "Solo session — no coordination needed" and exit.
+
+### Step 2: Read Board State
+
+Run `edda coord` to get the full coordination protocol view including:
+- Peer claims (scope ownership)
+- Binding decisions (architecture constraints)
+- Pending requests
+
+### Step 3: Analyze Scope
+
+From the board state, identify:
+- **Off-limits areas**: Paths claimed by other agents — do NOT edit these
+- **Binding decisions**: Architecture constraints all agents must follow
+- **Pending requests for you**: Messages from peers requiring your attention
+- **Unclaimed areas**: Safe zones related to your current task
+
+### Step 4: Claim Scope
+
+Based on your current task/issue, suggest a claim:
+
+```bash
+edda claim "<label>" --paths "<path1>" --paths "<path2>"
+```
+
+Guidelines:
+- Use a descriptive label (crate name, module name, or feature area)
+- Paths should use glob patterns (e.g., `crates/edda-store/*`)
+- If auto-claim already set a scope from your edits, show it and ask if manual override is needed
+
+### Step 5: Acknowledge Requests
+
+For each pending request addressed to your label:
+- Read the message and assess if you can handle it
+- If yes: `edda request-ack <from-label>`
+- If not now: note it as deferred
+
+## Output Format
+
+Present findings in this structure:
+
+```
+## Coordination Sync
+
+### Active Peers (N)
+- [label] (Xs ago): working on <tasks>, branch: <branch>
+
+### My Scope
+- Claimed: <label> → <paths>
+- Off-limits: <peer claims listed>
+
+### Binding Decisions to Follow
+- <key> = <value> (by <label>)
+
+### Pending Requests for Me
+- From <label>: <message> → [acknowledged / deferred]
+
+### Ready to Start
+<summary of what you can safely work on without conflicting with peers>
+```


### PR DESCRIPTION
## Summary

- Embed 4 coordination skill templates in the binary via `include_str!`
- `edda init` writes them to `.claude/skills/coord-*/SKILL.md`
- Skip-if-exists by default — don't overwrite user modifications
- `--force-skills` flag to opt-in overwrite with latest embedded versions

Prevents version drift from manually copying skills between projects (#133 root cause).

Closes #134

## Files changed

- `crates/edda-cli/src/skills/*.md` — 4 canonical skill templates
- `crates/edda-cli/src/cmd_init.rs` — scaffold logic + 3 new tests
- `crates/edda-cli/src/main.rs` — `--force-skills` flag on `Init`
- `crates/edda-cli/src/cmd_draft.rs` — fix call site for new signature

## Test plan

- [x] `cargo build` — compiles
- [x] `cargo clippy` — no warnings
- [x] `cargo test` — 7/7 init tests pass (including 3 new)
- [x] New: `init_scaffolds_coord_skills` — verifies all 4 skills created
- [x] New: `init_skips_existing_skills` — verifies skip-if-exists
- [x] New: `init_force_skills_overwrites` — verifies `--force-skills`

🤖 Generated with [Claude Code](https://claude.com/claude-code)