### PR TITLE
feat(store): user-level aggregation layer (~/.edda/)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,6 +642,7 @@ dependencies = [
  "clap",
  "crossterm",
  "ctrlc",
+ "edda-aggregate",
  "edda-ask",
  "edda-bridge-claude",
  "edda-bridge-openclaw",
@@ -668,6 +669,20 @@ dependencies = [
  "tokio",
  "tokio-util",
  "ulid",
+]
+
+[[package]]
+name = "edda-aggregate"
+version = "0.1.1"
+dependencies = [
+ "anyhow",
+ "edda-core",
+ "edda-ledger",
+ "edda-store",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "time",
 ]
 
 [[package]]
@@ -859,10 +874,12 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",
+ "edda-aggregate",
  "edda-ask",
  "edda-core",
  "edda-derive",
  "edda-ledger",
+ "edda-store",
  "serde",
  "serde_json",
  "tempfile",
@@ -883,6 +900,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/edda-conductor",
     "crates/edda-serve",
     "crates/edda-notify",
+    "crates/edda-aggregate",
     "crates/edda-cli",  # crate name: "edda"
 ]
 

--- a/crates/edda-aggregate/Cargo.toml
+++ b/crates/edda-aggregate/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "edda-aggregate"
+description = "Cross-repo aggregation queries and rollup statistics for Edda"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+categories.workspace = true
+keywords.workspace = true
+
+[dependencies]
+edda-core = { path = "../edda-core", version = "0.1.1" }
+edda-ledger = { path = "../edda-ledger", version = "0.1.1" }
+edda-store = { path = "../edda-store", version = "0.1.1" }
+anyhow.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+time.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/edda-aggregate/src/aggregate.rs
+++ b/crates/edda-aggregate/src/aggregate.rs
@@ -1,0 +1,368 @@
+//! Cross-repo aggregation queries.
+//!
+//! Lazy aggregation: reads each project's ledger on demand, no persistent DB.
+
+use edda_core::Event;
+use edda_ledger::Ledger;
+use edda_store::registry::ProjectEntry;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Inclusive date range filter using ISO 8601 prefix comparison.
+#[derive(Debug, Clone, Default)]
+pub struct DateRange {
+    pub after: Option<String>,
+    pub before: Option<String>,
+}
+
+impl DateRange {
+    pub fn matches(&self, ts: &str) -> bool {
+        if let Some(ref after) = self.after {
+            if ts < after.as_str() {
+                return false;
+            }
+        }
+        if let Some(ref before) = self.before {
+            if ts > before.as_str() {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// Per-project summary within an aggregation result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectSummary {
+    pub project_id: String,
+    pub name: String,
+    pub path: String,
+    pub event_count: usize,
+    pub commit_count: usize,
+    pub decision_count: usize,
+    pub session_count: usize,
+}
+
+/// A commit record from any project.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitRecord {
+    pub project_id: String,
+    pub project_name: String,
+    pub event_id: String,
+    pub ts: String,
+    pub title: String,
+    pub branch: String,
+}
+
+/// A decision record from any project.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DecisionRecord {
+    pub project_id: String,
+    pub project_name: String,
+    pub event_id: String,
+    pub key: String,
+    pub value: String,
+    pub reason: String,
+    pub domain: String,
+    pub branch: String,
+    pub ts: Option<String>,
+}
+
+/// Full cross-repo aggregation result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AggregateResult {
+    pub projects: Vec<ProjectSummary>,
+    pub total_events: usize,
+    pub total_commits: usize,
+    pub total_decisions: usize,
+}
+
+/// Aggregate overview across all given projects.
+pub fn aggregate_overview(projects: &[ProjectEntry], range: &DateRange) -> AggregateResult {
+    let mut summaries = Vec::new();
+    let mut total_events = 0usize;
+    let mut total_commits = 0usize;
+    let mut total_decisions = 0usize;
+
+    for entry in projects {
+        let root = Path::new(&entry.path);
+        let ledger = match Ledger::open(root) {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        let events = match ledger.iter_events() {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        let filtered: Vec<&Event> = events.iter().filter(|e| range.matches(&e.ts)).collect();
+        let commit_count = filtered.iter().filter(|e| e.event_type == "commit").count();
+        let decision_count = ledger
+            .active_decisions(None, None)
+            .map(|d| d.len())
+            .unwrap_or(0);
+        let session_count = count_unique_sessions(&filtered);
+
+        summaries.push(ProjectSummary {
+            project_id: entry.project_id.clone(),
+            name: entry.name.clone(),
+            path: entry.path.clone(),
+            event_count: filtered.len(),
+            commit_count,
+            decision_count,
+            session_count,
+        });
+
+        total_events += filtered.len();
+        total_commits += commit_count;
+        total_decisions += decision_count;
+    }
+
+    AggregateResult {
+        projects: summaries,
+        total_events,
+        total_commits,
+        total_decisions,
+    }
+}
+
+/// Collect commits across all projects, sorted by timestamp descending.
+pub fn aggregate_commits(
+    projects: &[ProjectEntry],
+    range: &DateRange,
+    limit: usize,
+) -> Vec<CommitRecord> {
+    let mut records = Vec::new();
+
+    for entry in projects {
+        let root = Path::new(&entry.path);
+        let ledger = match Ledger::open(root) {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        let events = match ledger.iter_events() {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        for event in &events {
+            if event.event_type != "commit" {
+                continue;
+            }
+            if !range.matches(&event.ts) {
+                continue;
+            }
+
+            let title = event
+                .payload
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+
+            records.push(CommitRecord {
+                project_id: entry.project_id.clone(),
+                project_name: entry.name.clone(),
+                event_id: event.event_id.clone(),
+                ts: event.ts.clone(),
+                title,
+                branch: event.branch.clone(),
+            });
+        }
+    }
+
+    records.sort_by(|a, b| b.ts.cmp(&a.ts));
+    records.truncate(limit);
+    records
+}
+
+/// Collect active decisions across all projects.
+pub fn aggregate_decisions(projects: &[ProjectEntry]) -> Vec<DecisionRecord> {
+    let mut records = Vec::new();
+
+    for entry in projects {
+        let root = Path::new(&entry.path);
+        let ledger = match Ledger::open(root) {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        let decisions = match ledger.active_decisions(None, None) {
+            Ok(d) => d,
+            Err(_) => continue,
+        };
+
+        for d in decisions {
+            records.push(DecisionRecord {
+                project_id: entry.project_id.clone(),
+                project_name: entry.name.clone(),
+                event_id: d.event_id,
+                key: d.key,
+                value: d.value,
+                reason: d.reason,
+                domain: d.domain,
+                branch: d.branch,
+                ts: d.ts,
+            });
+        }
+    }
+
+    records
+}
+
+/// Count events by date (YYYY-MM-DD) across all projects.
+pub fn events_by_date(
+    projects: &[ProjectEntry],
+    range: &DateRange,
+) -> BTreeMap<String, usize> {
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+
+    for entry in projects {
+        let root = Path::new(&entry.path);
+        let ledger = match Ledger::open(root) {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        let events = match ledger.iter_events() {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        for event in &events {
+            if !range.matches(&event.ts) {
+                continue;
+            }
+            let date = &event.ts[..10.min(event.ts.len())];
+            *counts.entry(date.to_string()).or_insert(0) += 1;
+        }
+    }
+
+    counts
+}
+
+/// Count commits by date (YYYY-MM-DD) across all projects.
+pub fn commits_by_date(
+    projects: &[ProjectEntry],
+    range: &DateRange,
+) -> BTreeMap<String, usize> {
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+
+    for entry in projects {
+        let root = Path::new(&entry.path);
+        let ledger = match Ledger::open(root) {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        let events = match ledger.iter_events() {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        for event in &events {
+            if event.event_type != "commit" {
+                continue;
+            }
+            if !range.matches(&event.ts) {
+                continue;
+            }
+            let date = &event.ts[..10.min(event.ts.len())];
+            *counts.entry(date.to_string()).or_insert(0) += 1;
+        }
+    }
+
+    counts
+}
+
+/// Count unique session IDs from events.
+fn count_unique_sessions(events: &[&Event]) -> usize {
+    let mut sessions = std::collections::HashSet::new();
+    for event in events {
+        if let Some(sid) = event.payload.get("session_id").and_then(|v| v.as_str()) {
+            sessions.insert(sid.to_string());
+        }
+    }
+    sessions.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn date_range_matches_open() {
+        let range = DateRange::default();
+        assert!(range.matches("2026-03-01T00:00:00Z"));
+    }
+
+    #[test]
+    fn date_range_matches_after() {
+        let range = DateRange {
+            after: Some("2026-03-01".to_string()),
+            before: None,
+        };
+        assert!(range.matches("2026-03-02T00:00:00Z"));
+        assert!(!range.matches("2026-02-28T23:59:59Z"));
+    }
+
+    #[test]
+    fn date_range_matches_before() {
+        let range = DateRange {
+            after: None,
+            before: Some("2026-03-01".to_string()),
+        };
+        assert!(range.matches("2026-02-28T23:59:59Z"));
+        assert!(!range.matches("2026-03-02T00:00:00Z"));
+    }
+
+    #[test]
+    fn date_range_matches_bounded() {
+        let range = DateRange {
+            after: Some("2026-03-01".to_string()),
+            before: Some("2026-03-31".to_string()),
+        };
+        assert!(range.matches("2026-03-15T12:00:00Z"));
+        assert!(!range.matches("2026-02-28T00:00:00Z"));
+        assert!(!range.matches("2026-04-01T00:00:00Z"));
+    }
+
+    #[test]
+    fn aggregate_overview_empty_projects() {
+        let result = aggregate_overview(&[], &DateRange::default());
+        assert_eq!(result.total_events, 0);
+        assert_eq!(result.total_commits, 0);
+        assert!(result.projects.is_empty());
+    }
+
+    #[test]
+    fn aggregate_overview_with_real_ledger() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        // Initialize a workspace
+        let paths = edda_ledger::EddaPaths::discover(root);
+        edda_ledger::ledger::init_workspace(&paths).unwrap();
+        edda_ledger::ledger::init_head(&paths, "main").unwrap();
+
+        let ledger = Ledger::open(root).unwrap();
+        let event = edda_core::event::new_note_event("main", None, "system", "test note", &[]).unwrap();
+        ledger.append_event(&event).unwrap();
+
+        let entry = ProjectEntry {
+            project_id: "test".to_string(),
+            path: root.to_string_lossy().to_string(),
+            name: "test-project".to_string(),
+            registered_at: "2026-03-01T00:00:00Z".to_string(),
+            last_seen: "2026-03-01T00:00:00Z".to_string(),
+        };
+
+        let result = aggregate_overview(&[entry], &DateRange::default());
+        assert_eq!(result.total_events, 1);
+        assert_eq!(result.projects.len(), 1);
+        assert_eq!(result.projects[0].event_count, 1);
+    }
+}

--- a/crates/edda-aggregate/src/aggregate.rs
+++ b/crates/edda-aggregate/src/aggregate.rs
@@ -99,10 +99,10 @@ pub fn aggregate_overview(projects: &[ProjectEntry], range: &DateRange) -> Aggre
 
         let filtered: Vec<&Event> = events.iter().filter(|e| range.matches(&e.ts)).collect();
         let commit_count = filtered.iter().filter(|e| e.event_type == "commit").count();
-        let decision_count = ledger
-            .active_decisions(None, None)
-            .map(|d| d.len())
-            .unwrap_or(0);
+        let decision_count = filtered
+            .iter()
+            .filter(|e| e.event_type == "decision")
+            .count();
         let session_count = count_unique_sessions(&filtered);
 
         summaries.push(ProjectSummary {
@@ -214,10 +214,7 @@ pub fn aggregate_decisions(projects: &[ProjectEntry]) -> Vec<DecisionRecord> {
 }
 
 /// Count events by date (YYYY-MM-DD) across all projects.
-pub fn events_by_date(
-    projects: &[ProjectEntry],
-    range: &DateRange,
-) -> BTreeMap<String, usize> {
+pub fn events_by_date(projects: &[ProjectEntry], range: &DateRange) -> BTreeMap<String, usize> {
     let mut counts: BTreeMap<String, usize> = BTreeMap::new();
 
     for entry in projects {
@@ -245,10 +242,7 @@ pub fn events_by_date(
 }
 
 /// Count commits by date (YYYY-MM-DD) across all projects.
-pub fn commits_by_date(
-    projects: &[ProjectEntry],
-    range: &DateRange,
-) -> BTreeMap<String, usize> {
+pub fn commits_by_date(projects: &[ProjectEntry], range: &DateRange) -> BTreeMap<String, usize> {
     let mut counts: BTreeMap<String, usize> = BTreeMap::new();
 
     for entry in projects {
@@ -349,7 +343,8 @@ mod tests {
         edda_ledger::ledger::init_head(&paths, "main").unwrap();
 
         let ledger = Ledger::open(root).unwrap();
-        let event = edda_core::event::new_note_event("main", None, "system", "test note", &[]).unwrap();
+        let event =
+            edda_core::event::new_note_event("main", None, "system", "test note", &[]).unwrap();
         ledger.append_event(&event).unwrap();
 
         let entry = ProjectEntry {

--- a/crates/edda-aggregate/src/lib.rs
+++ b/crates/edda-aggregate/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod aggregate;
+pub mod rollup;

--- a/crates/edda-aggregate/src/rollup.rs
+++ b/crates/edda-aggregate/src/rollup.rs
@@ -57,7 +57,7 @@ pub fn rollup_path(tool: &str) -> PathBuf {
 /// Ensure the collabs directory structure exists.
 pub fn ensure_collabs_dir(tool: &str) -> anyhow::Result<()> {
     let dir = collabs_dir(tool);
-    std::fs::create_dir_all(dir.join("writings"))?;
+    std::fs::create_dir_all(&dir)?;
     Ok(())
 }
 
@@ -99,24 +99,19 @@ pub fn compute_rollup(projects: &[ProjectEntry], range: &DateRange, tool: &str) 
 }
 
 /// Incremental rollup: compute only new data since last update, then merge.
-pub fn compute_rollup_incremental(
-    projects: &[ProjectEntry],
-    tool: &str,
-) -> anyhow::Result<Rollup> {
+pub fn compute_rollup_incremental(projects: &[ProjectEntry], tool: &str) -> anyhow::Result<Rollup> {
     let existing = load_rollup(tool);
 
     let range = if let Some(ref existing) = existing {
-        // Only fetch events since last update date
-        let last_date = existing
-            .daily
-            .last()
-            .map(|d| d.date.clone())
-            .unwrap_or_default();
+        // Only fetch events since last_updated (not last daily entry date).
+        let cutoff = &existing.last_updated;
         DateRange {
-            after: if last_date.is_empty() {
+            after: if cutoff.is_empty() {
                 None
             } else {
-                Some(last_date)
+                // Use the date portion (YYYY-MM-DD) of last_updated as the
+                // "after" boundary so we re-scan the partial day.
+                Some(cutoff.chars().take(10).collect())
             },
             before: None,
         }
@@ -230,13 +225,12 @@ fn build_monthly_stats(daily: &[DayStat]) -> Vec<MonthStat> {
 
 /// Given a date string "YYYY-MM-DD", return the ISO Monday of that week as "YYYY-MM-DD".
 fn iso_week_start(date_str: &str) -> Option<String> {
-    let format =
-        time::format_description::parse("[year]-[month]-[day]").ok()?;
+    let format = time::format_description::parse("[year]-[month]-[day]").ok()?;
     let date = time::Date::parse(date_str, &format).ok()?;
     let weekday = date.weekday();
     let days_since_monday = weekday.number_days_from_monday();
     let monday = date - time::Duration::days(i64::from(days_since_monday));
-    Some(monday.format(&format).ok()?)
+    monday.format(&format).ok()
 }
 
 #[cfg(test)]
@@ -267,8 +261,18 @@ mod tests {
             tool: "test".to_string(),
             last_updated: "old".to_string(),
             daily: vec![
-                DayStat { date: "2026-03-01".into(), events: 5, commits: 1, sessions: 0 },
-                DayStat { date: "2026-03-02".into(), events: 3, commits: 0, sessions: 0 },
+                DayStat {
+                    date: "2026-03-01".into(),
+                    events: 5,
+                    commits: 1,
+                    sessions: 0,
+                },
+                DayStat {
+                    date: "2026-03-02".into(),
+                    events: 3,
+                    commits: 0,
+                    sessions: 0,
+                },
             ],
             weekly: vec![],
             monthly: vec![],
@@ -277,8 +281,18 @@ mod tests {
             tool: "test".to_string(),
             last_updated: "new".to_string(),
             daily: vec![
-                DayStat { date: "2026-03-02".into(), events: 10, commits: 2, sessions: 0 },
-                DayStat { date: "2026-03-03".into(), events: 7, commits: 3, sessions: 0 },
+                DayStat {
+                    date: "2026-03-02".into(),
+                    events: 10,
+                    commits: 2,
+                    sessions: 0,
+                },
+                DayStat {
+                    date: "2026-03-03".into(),
+                    events: 7,
+                    commits: 3,
+                    sessions: 0,
+                },
             ],
             weekly: vec![],
             monthly: vec![],
@@ -289,7 +303,11 @@ mod tests {
         assert_eq!(merged.last_updated, "new");
 
         // March 2 should have new data (10 events, not 3)
-        let mar2 = merged.daily.iter().find(|d| d.date == "2026-03-02").unwrap();
+        let mar2 = merged
+            .daily
+            .iter()
+            .find(|d| d.date == "2026-03-02")
+            .unwrap();
         assert_eq!(mar2.events, 10);
     }
 

--- a/crates/edda-aggregate/src/rollup.rs
+++ b/crates/edda-aggregate/src/rollup.rs
@@ -1,0 +1,314 @@
+//! Pre-computed rollup statistics cached at `~/.edda/collabs/<tool>/rollup.json`.
+//!
+//! Supports daily, weekly, and monthly granularity with incremental updates.
+
+use crate::aggregate::{self, DateRange};
+use edda_store::registry::ProjectEntry;
+use edda_store::{store_root, write_atomic};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+/// Daily statistics.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DayStat {
+    pub date: String,
+    pub events: usize,
+    pub commits: usize,
+    pub sessions: usize,
+}
+
+/// Weekly statistics.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct WeekStat {
+    pub week_start: String,
+    pub events: usize,
+    pub commits: usize,
+}
+
+/// Monthly statistics.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct MonthStat {
+    pub month: String,
+    pub events: usize,
+    pub commits: usize,
+}
+
+/// The full rollup cache.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Rollup {
+    pub tool: String,
+    pub last_updated: String,
+    pub daily: Vec<DayStat>,
+    pub weekly: Vec<WeekStat>,
+    pub monthly: Vec<MonthStat>,
+}
+
+/// Path to the collabs directory for a tool.
+pub fn collabs_dir(tool: &str) -> PathBuf {
+    store_root().join("collabs").join(tool)
+}
+
+/// Path to the rollup cache file for a tool.
+pub fn rollup_path(tool: &str) -> PathBuf {
+    collabs_dir(tool).join("rollup.json")
+}
+
+/// Ensure the collabs directory structure exists.
+pub fn ensure_collabs_dir(tool: &str) -> anyhow::Result<()> {
+    let dir = collabs_dir(tool);
+    std::fs::create_dir_all(dir.join("writings"))?;
+    Ok(())
+}
+
+/// Load an existing rollup from disk.
+pub fn load_rollup(tool: &str) -> Option<Rollup> {
+    let path = rollup_path(tool);
+    let content = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// Save a rollup to disk.
+pub fn save_rollup(rollup: &Rollup) -> anyhow::Result<()> {
+    ensure_collabs_dir(&rollup.tool)?;
+    let json = serde_json::to_string_pretty(rollup)?;
+    write_atomic(&rollup_path(&rollup.tool), json.as_bytes())
+}
+
+/// Compute a full rollup from scratch.
+pub fn compute_rollup(projects: &[ProjectEntry], range: &DateRange, tool: &str) -> Rollup {
+    let events_map = aggregate::events_by_date(projects, range);
+    let commits_map = aggregate::commits_by_date(projects, range);
+
+    let daily = build_daily_stats(&events_map, &commits_map);
+    let weekly = build_weekly_stats(&daily);
+    let monthly = build_monthly_stats(&daily);
+
+    let now = time::OffsetDateTime::now_utc();
+    let last_updated = now
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "unknown".to_string());
+
+    Rollup {
+        tool: tool.to_string(),
+        last_updated,
+        daily,
+        weekly,
+        monthly,
+    }
+}
+
+/// Incremental rollup: compute only new data since last update, then merge.
+pub fn compute_rollup_incremental(
+    projects: &[ProjectEntry],
+    tool: &str,
+) -> anyhow::Result<Rollup> {
+    let existing = load_rollup(tool);
+
+    let range = if let Some(ref existing) = existing {
+        // Only fetch events since last update date
+        let last_date = existing
+            .daily
+            .last()
+            .map(|d| d.date.clone())
+            .unwrap_or_default();
+        DateRange {
+            after: if last_date.is_empty() {
+                None
+            } else {
+                Some(last_date)
+            },
+            before: None,
+        }
+    } else {
+        DateRange::default()
+    };
+
+    let new_rollup = compute_rollup(projects, &range, tool);
+
+    let merged = if let Some(existing) = existing {
+        merge_rollups(&existing, &new_rollup)
+    } else {
+        new_rollup
+    };
+
+    save_rollup(&merged)?;
+    Ok(merged)
+}
+
+/// Merge two rollups: new data replaces overlapping days in base.
+pub fn merge_rollups(base: &Rollup, new: &Rollup) -> Rollup {
+    let mut daily_map: BTreeMap<String, DayStat> = BTreeMap::new();
+
+    for d in &base.daily {
+        daily_map.insert(d.date.clone(), d.clone());
+    }
+    for d in &new.daily {
+        daily_map.insert(d.date.clone(), d.clone());
+    }
+
+    let daily: Vec<DayStat> = daily_map.into_values().collect();
+    let weekly = build_weekly_stats(&daily);
+    let monthly = build_monthly_stats(&daily);
+
+    Rollup {
+        tool: new.tool.clone(),
+        last_updated: new.last_updated.clone(),
+        daily,
+        weekly,
+        monthly,
+    }
+}
+
+/// Build daily stats from event and commit counts by date.
+fn build_daily_stats(
+    events_map: &BTreeMap<String, usize>,
+    commits_map: &BTreeMap<String, usize>,
+) -> Vec<DayStat> {
+    let mut all_dates: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+    for key in events_map.keys() {
+        all_dates.insert(key.as_str());
+    }
+    for key in commits_map.keys() {
+        all_dates.insert(key.as_str());
+    }
+
+    all_dates
+        .into_iter()
+        .map(|date| DayStat {
+            date: date.to_string(),
+            events: events_map.get(date).copied().unwrap_or(0),
+            commits: commits_map.get(date).copied().unwrap_or(0),
+            sessions: 0, // sessions don't have a natural daily granularity
+        })
+        .collect()
+}
+
+/// Build weekly stats from daily stats.
+fn build_weekly_stats(daily: &[DayStat]) -> Vec<WeekStat> {
+    let mut weekly_map: BTreeMap<String, (usize, usize)> = BTreeMap::new();
+
+    for d in daily {
+        // Parse the date to find the Monday of its ISO week
+        if let Some(week_start) = iso_week_start(&d.date) {
+            let entry = weekly_map.entry(week_start).or_insert((0, 0));
+            entry.0 += d.events;
+            entry.1 += d.commits;
+        }
+    }
+
+    weekly_map
+        .into_iter()
+        .map(|(week_start, (events, commits))| WeekStat {
+            week_start,
+            events,
+            commits,
+        })
+        .collect()
+}
+
+/// Build monthly stats from daily stats.
+fn build_monthly_stats(daily: &[DayStat]) -> Vec<MonthStat> {
+    let mut monthly_map: BTreeMap<String, (usize, usize)> = BTreeMap::new();
+
+    for d in daily {
+        let month = &d.date[..7.min(d.date.len())]; // "YYYY-MM"
+        let entry = monthly_map.entry(month.to_string()).or_insert((0, 0));
+        entry.0 += d.events;
+        entry.1 += d.commits;
+    }
+
+    monthly_map
+        .into_iter()
+        .map(|(month, (events, commits))| MonthStat {
+            month,
+            events,
+            commits,
+        })
+        .collect()
+}
+
+/// Given a date string "YYYY-MM-DD", return the ISO Monday of that week as "YYYY-MM-DD".
+fn iso_week_start(date_str: &str) -> Option<String> {
+    let format =
+        time::format_description::parse("[year]-[month]-[day]").ok()?;
+    let date = time::Date::parse(date_str, &format).ok()?;
+    let weekday = date.weekday();
+    let days_since_monday = weekday.number_days_from_monday();
+    let monday = date - time::Duration::days(i64::from(days_since_monday));
+    Some(monday.format(&format).ok()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iso_week_start_monday() {
+        // 2026-03-02 is a Monday
+        assert_eq!(iso_week_start("2026-03-02"), Some("2026-03-02".to_string()));
+    }
+
+    #[test]
+    fn iso_week_start_wednesday() {
+        // 2026-03-04 is a Wednesday
+        assert_eq!(iso_week_start("2026-03-04"), Some("2026-03-02".to_string()));
+    }
+
+    #[test]
+    fn iso_week_start_sunday() {
+        // 2026-03-08 is a Sunday
+        assert_eq!(iso_week_start("2026-03-08"), Some("2026-03-02".to_string()));
+    }
+
+    #[test]
+    fn merge_rollups_replaces_overlapping() {
+        let base = Rollup {
+            tool: "test".to_string(),
+            last_updated: "old".to_string(),
+            daily: vec![
+                DayStat { date: "2026-03-01".into(), events: 5, commits: 1, sessions: 0 },
+                DayStat { date: "2026-03-02".into(), events: 3, commits: 0, sessions: 0 },
+            ],
+            weekly: vec![],
+            monthly: vec![],
+        };
+        let new = Rollup {
+            tool: "test".to_string(),
+            last_updated: "new".to_string(),
+            daily: vec![
+                DayStat { date: "2026-03-02".into(), events: 10, commits: 2, sessions: 0 },
+                DayStat { date: "2026-03-03".into(), events: 7, commits: 3, sessions: 0 },
+            ],
+            weekly: vec![],
+            monthly: vec![],
+        };
+
+        let merged = merge_rollups(&base, &new);
+        assert_eq!(merged.daily.len(), 3);
+        assert_eq!(merged.last_updated, "new");
+
+        // March 2 should have new data (10 events, not 3)
+        let mar2 = merged.daily.iter().find(|d| d.date == "2026-03-02").unwrap();
+        assert_eq!(mar2.events, 10);
+    }
+
+    #[test]
+    fn build_daily_stats_combines_maps() {
+        let mut events = BTreeMap::new();
+        events.insert("2026-03-01".to_string(), 5);
+        events.insert("2026-03-02".to_string(), 3);
+
+        let mut commits = BTreeMap::new();
+        commits.insert("2026-03-01".to_string(), 2);
+        commits.insert("2026-03-03".to_string(), 1);
+
+        let daily = build_daily_stats(&events, &commits);
+        assert_eq!(daily.len(), 3);
+        assert_eq!(daily[0].date, "2026-03-01");
+        assert_eq!(daily[0].events, 5);
+        assert_eq!(daily[0].commits, 2);
+        assert_eq!(daily[2].date, "2026-03-03");
+        assert_eq!(daily[2].commits, 1);
+    }
+}

--- a/crates/edda-cli/Cargo.toml
+++ b/crates/edda-cli/Cargo.toml
@@ -14,6 +14,7 @@ name = "edda"
 path = "src/main.rs"
 
 [dependencies]
+edda-aggregate = { path = "../edda-aggregate", version = "0.1.1" }
 edda-ask = { path = "../edda-ask", version = "0.1.1" }
 edda-core = { path = "../edda-core", version = "0.1.1" }
 edda-ledger = { path = "../edda-ledger", version = "0.1.1" }

--- a/crates/edda-cli/src/cmd_gc.rs
+++ b/crates/edda-cli/src/cmd_gc.rs
@@ -288,6 +288,23 @@ pub fn execute(params: &GcParams) -> anyhow::Result<()> {
         }
     }
 
+    // Phase 4d: Registry cleanup (prune stale project entries)
+    if params.global {
+        let (_valid, stale) = edda_store::registry::validate_projects();
+        if !stale.is_empty() {
+            for entry in &stale {
+                if !params.dry_run {
+                    let _ = edda_store::registry::unregister_project(&entry.project_id);
+                }
+            }
+            println!(
+                "  {} stale project(s) {} from registry",
+                stale.len(),
+                if params.dry_run { "found" } else { "removed" }
+            );
+        }
+    }
+
     // Phase 5: Execute or dry-run
     let total_items = candidates.len() + transcript_candidates.len() + session_candidates.len();
     if total_items == 0 {

--- a/crates/edda-cli/src/cmd_init.rs
+++ b/crates/edda-cli/src/cmd_init.rs
@@ -85,6 +85,11 @@ actors: {}
         println!("  {}", event.event_id);
     }
 
+    // Register in user-level project registry (~/.edda/registry.json)
+    if let Err(e) = edda_store::registry::register_project(repo_root) {
+        eprintln!("Warning: failed to register project: {e}");
+    }
+
     // Auto-detect and install bridge hooks (unless --no-hooks)
     if !no_hooks {
         auto_install_bridges(repo_root);

--- a/crates/edda-cli/src/cmd_user.rs
+++ b/crates/edda-cli/src/cmd_user.rs
@@ -89,7 +89,11 @@ pub enum UserConfigCmd {
 pub fn execute(cmd: UserCmd) -> anyhow::Result<()> {
     match cmd {
         UserCmd::Projects { prune, json } => execute_projects(prune, json),
-        UserCmd::Overview { after, before, json } => execute_overview(after, before, json),
+        UserCmd::Overview {
+            after,
+            before,
+            json,
+        } => execute_overview(after, before, json),
         UserCmd::Commits {
             after,
             before,
@@ -97,7 +101,11 @@ pub fn execute(cmd: UserCmd) -> anyhow::Result<()> {
             json,
         } => execute_commits(after, before, limit, json),
         UserCmd::Decisions { json } => execute_decisions(json),
-        UserCmd::Rollup { tool, refresh, json } => execute_rollup(&tool, refresh, json),
+        UserCmd::Rollup {
+            tool,
+            refresh,
+            json,
+        } => execute_rollup(&tool, refresh, json),
         UserCmd::Config { cmd } => execute_config(cmd),
     }
 }
@@ -129,8 +137,8 @@ fn execute_projects(prune: bool, json: bool) -> anyhow::Result<()> {
     }
 
     println!("Registered projects ({}):\n", projects.len());
+    let (valid, _) = registry::validate_projects();
     for p in &projects {
-        let (valid, _) = registry::validate_projects();
         let status = if valid.iter().any(|v| v.project_id == p.project_id) {
             "ok"
         } else {
@@ -145,7 +153,11 @@ fn execute_projects(prune: bool, json: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn execute_overview(after: Option<String>, before: Option<String>, json: bool) -> anyhow::Result<()> {
+fn execute_overview(
+    after: Option<String>,
+    before: Option<String>,
+    json: bool,
+) -> anyhow::Result<()> {
     let projects = registry::list_projects();
     let range = DateRange { after, before };
     let result = aggregate::aggregate_overview(&projects, &range);
@@ -275,8 +287,8 @@ fn execute_config(cmd: UserConfigCmd) -> anyhow::Result<()> {
             Ok(())
         }
         UserConfigCmd::Set { key, value } => {
-            let parsed: serde_json::Value = serde_json::from_str(&value)
-                .unwrap_or_else(|_| serde_json::Value::String(value));
+            let parsed: serde_json::Value =
+                serde_json::from_str(&value).unwrap_or_else(|_| serde_json::Value::String(value));
             user_config::set_user_config(&key, parsed)?;
             println!("Set {key}");
             Ok(())

--- a/crates/edda-cli/src/cmd_user.rs
+++ b/crates/edda-cli/src/cmd_user.rs
@@ -1,0 +1,297 @@
+//! `edda user` subcommand group — user-level aggregation commands.
+
+use clap::Subcommand;
+use edda_aggregate::aggregate::{self, DateRange};
+use edda_aggregate::rollup;
+use edda_store::registry;
+
+#[derive(Subcommand)]
+pub enum UserCmd {
+    /// List all registered projects
+    Projects {
+        /// Remove stale entries (projects whose .edda/ no longer exists)
+        #[arg(long)]
+        prune: bool,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Cross-repo overview (event/commit/decision counts)
+    Overview {
+        /// Only include events after this date (ISO 8601 prefix)
+        #[arg(long)]
+        after: Option<String>,
+        /// Only include events before this date
+        #[arg(long)]
+        before: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// List recent commits across all projects
+    Commits {
+        /// Only include commits after this date
+        #[arg(long)]
+        after: Option<String>,
+        /// Only include commits before this date
+        #[arg(long)]
+        before: Option<String>,
+        /// Maximum number of commits to show
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// List active decisions across all projects
+    Decisions {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Compute/show rollup statistics
+    Rollup {
+        /// Tool name (default: claude-code)
+        #[arg(long, default_value = "claude-code")]
+        tool: String,
+        /// Recompute from scratch instead of incremental
+        #[arg(long)]
+        refresh: bool,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// User-level config operations
+    Config {
+        #[command(subcommand)]
+        cmd: UserConfigCmd,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum UserConfigCmd {
+    /// Get a config value
+    Get {
+        /// Config key
+        key: String,
+    },
+    /// Set a config value
+    Set {
+        /// Config key
+        key: String,
+        /// Config value (JSON-compatible)
+        value: String,
+    },
+    /// List all config values
+    List,
+}
+
+pub fn execute(cmd: UserCmd) -> anyhow::Result<()> {
+    match cmd {
+        UserCmd::Projects { prune, json } => execute_projects(prune, json),
+        UserCmd::Overview { after, before, json } => execute_overview(after, before, json),
+        UserCmd::Commits {
+            after,
+            before,
+            limit,
+            json,
+        } => execute_commits(after, before, limit, json),
+        UserCmd::Decisions { json } => execute_decisions(json),
+        UserCmd::Rollup { tool, refresh, json } => execute_rollup(&tool, refresh, json),
+        UserCmd::Config { cmd } => execute_config(cmd),
+    }
+}
+
+fn execute_projects(prune: bool, json: bool) -> anyhow::Result<()> {
+    if prune {
+        let (_valid, stale) = registry::validate_projects();
+        if stale.is_empty() {
+            println!("No stale projects found.");
+        } else {
+            for entry in &stale {
+                registry::unregister_project(&entry.project_id)?;
+                println!("  Removed: {} ({})", entry.name, entry.path);
+            }
+            println!("{} stale project(s) removed.", stale.len());
+        }
+        return Ok(());
+    }
+
+    let projects = registry::list_projects();
+    if json {
+        println!("{}", serde_json::to_string_pretty(&projects)?);
+        return Ok(());
+    }
+
+    if projects.is_empty() {
+        println!("No registered projects. Run `edda init` in a repository to register it.");
+        return Ok(());
+    }
+
+    println!("Registered projects ({}):\n", projects.len());
+    for p in &projects {
+        let (valid, _) = registry::validate_projects();
+        let status = if valid.iter().any(|v| v.project_id == p.project_id) {
+            "ok"
+        } else {
+            "stale"
+        };
+        println!(
+            "  {} [{}] {}\n    path: {}\n    registered: {}\n    last_seen: {}\n",
+            p.name, status, p.project_id, p.path, p.registered_at, p.last_seen
+        );
+    }
+
+    Ok(())
+}
+
+fn execute_overview(after: Option<String>, before: Option<String>, json: bool) -> anyhow::Result<()> {
+    let projects = registry::list_projects();
+    let range = DateRange { after, before };
+    let result = aggregate::aggregate_overview(&projects, &range);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+
+    println!("Cross-repo overview:");
+    println!("  Projects:  {}", result.projects.len());
+    println!("  Events:    {}", result.total_events);
+    println!("  Commits:   {}", result.total_commits);
+    println!("  Decisions: {}", result.total_decisions);
+
+    if !result.projects.is_empty() {
+        println!("\nPer-project breakdown:");
+        for p in &result.projects {
+            println!(
+                "  {} — {} events, {} commits, {} decisions",
+                p.name, p.event_count, p.commit_count, p.decision_count
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn execute_commits(
+    after: Option<String>,
+    before: Option<String>,
+    limit: usize,
+    json: bool,
+) -> anyhow::Result<()> {
+    let projects = registry::list_projects();
+    let range = DateRange { after, before };
+    let commits = aggregate::aggregate_commits(&projects, &range, limit);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&commits)?);
+        return Ok(());
+    }
+
+    if commits.is_empty() {
+        println!("No commits found.");
+        return Ok(());
+    }
+
+    println!("Recent commits across all projects:\n");
+    for c in &commits {
+        println!(
+            "  [{}] {} — {} ({})",
+            c.ts, c.project_name, c.title, c.branch
+        );
+    }
+
+    Ok(())
+}
+
+fn execute_decisions(json: bool) -> anyhow::Result<()> {
+    let projects = registry::list_projects();
+    let decisions = aggregate::aggregate_decisions(&projects);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&decisions)?);
+        return Ok(());
+    }
+
+    if decisions.is_empty() {
+        println!("No active decisions found.");
+        return Ok(());
+    }
+
+    println!("Active decisions across all projects:\n");
+    for d in &decisions {
+        println!(
+            "  [{}] {}.{}={} — {}",
+            d.project_name, d.domain, d.key, d.value, d.reason
+        );
+    }
+
+    Ok(())
+}
+
+fn execute_rollup(tool: &str, refresh: bool, json: bool) -> anyhow::Result<()> {
+    let projects = registry::list_projects();
+
+    let rollup_data = if refresh {
+        let range = DateRange::default();
+        let r = rollup::compute_rollup(&projects, &range, tool);
+        rollup::save_rollup(&r)?;
+        r
+    } else {
+        rollup::compute_rollup_incremental(&projects, tool)?
+    };
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&rollup_data)?);
+        return Ok(());
+    }
+
+    println!("Rollup for '{}':", tool);
+    println!("  Last updated: {}", rollup_data.last_updated);
+    println!("  Daily entries: {}", rollup_data.daily.len());
+    println!("  Weekly entries: {}", rollup_data.weekly.len());
+    println!("  Monthly entries: {}", rollup_data.monthly.len());
+
+    if !rollup_data.monthly.is_empty() {
+        println!("\nMonthly summary:");
+        for m in &rollup_data.monthly {
+            println!("  {} — {} events, {} commits", m.month, m.events, m.commits);
+        }
+    }
+
+    Ok(())
+}
+
+fn execute_config(cmd: UserConfigCmd) -> anyhow::Result<()> {
+    use edda_store::user_config;
+
+    match cmd {
+        UserConfigCmd::Get { key } => {
+            match user_config::get_user_config(&key) {
+                Some(val) => println!("{}", serde_json::to_string_pretty(&val)?),
+                None => println!("(not set)"),
+            }
+            Ok(())
+        }
+        UserConfigCmd::Set { key, value } => {
+            let parsed: serde_json::Value = serde_json::from_str(&value)
+                .unwrap_or_else(|_| serde_json::Value::String(value));
+            user_config::set_user_config(&key, parsed)?;
+            println!("Set {key}");
+            Ok(())
+        }
+        UserConfigCmd::List => {
+            let config = user_config::load_user_config();
+            if config.is_empty() {
+                println!("(no user-level config set)");
+            } else {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::Value::Object(config))?
+                );
+            }
+            Ok(())
+        }
+    }
+}

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -25,6 +25,7 @@ mod cmd_search;
 mod cmd_serve;
 mod cmd_status;
 mod cmd_switch;
+mod cmd_user;
 mod cmd_watch;
 mod pipeline_templates;
 #[cfg(feature = "tui")]
@@ -364,6 +365,11 @@ enum Command {
         /// Also clean session ledgers, index files, and stale state files
         #[arg(long)]
         include_sessions: bool,
+    },
+    /// User-level aggregation (cross-repo queries, rollup, config)
+    User {
+        #[command(subcommand)]
+        cmd: cmd_user::UserCmd,
     },
 }
 
@@ -959,5 +965,6 @@ fn main() -> anyhow::Result<()> {
             archive_keep_days,
             include_sessions,
         }),
+        Command::User { cmd } => cmd_user::execute(cmd),
     }
 }

--- a/crates/edda-serve/Cargo.toml
+++ b/crates/edda-serve/Cargo.toml
@@ -10,10 +10,8 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-aggregate = { path = "../edda-aggregate", version = "0.1.1" }
 edda-ask = { path = "../edda-ask", version = "0.1.1" }
 edda-core = { path = "../edda-core", version = "0.1.1" }
-edda-store = { path = "../edda-store", version = "0.1.1" }
 edda-derive = { path = "../edda-derive", version = "0.1.1" }
 edda-ledger = { path = "../edda-ledger", version = "0.1.1" }
 axum = "0.8"

--- a/crates/edda-serve/Cargo.toml
+++ b/crates/edda-serve/Cargo.toml
@@ -10,8 +10,10 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
+edda-aggregate = { path = "../edda-aggregate", version = "0.1.1" }
 edda-ask = { path = "../edda-ask", version = "0.1.1" }
 edda-core = { path = "../edda-core", version = "0.1.1" }
+edda-store = { path = "../edda-store", version = "0.1.1" }
 edda-derive = { path = "../edda-derive", version = "0.1.1" }
 edda-ledger = { path = "../edda-ledger", version = "0.1.1" }
 axum = "0.8"

--- a/crates/edda-store/Cargo.toml
+++ b/crates/edda-store/Cargo.toml
@@ -18,3 +18,4 @@ blake3.workspace = true
 dirs.workspace = true
 tempfile.workspace = true
 fs2.workspace = true
+time.workspace = true

--- a/crates/edda-store/src/lib.rs
+++ b/crates/edda-store/src/lib.rs
@@ -1,3 +1,6 @@
+pub mod registry;
+pub mod user_config;
+
 use fs2::FileExt;
 use std::fs;
 use std::io::Write;

--- a/crates/edda-store/src/lib.rs
+++ b/crates/edda-store/src/lib.rs
@@ -72,7 +72,12 @@ fn normalize_path(p: &Path) -> String {
 
 /// Return the per-user store root: `~/.edda/`
 /// Windows: `%APPDATA%\edda\` (falls back to `%USERPROFILE%\.edda\`)
+///
+/// Override with `EDDA_STORE_ROOT` env var (useful for testing).
 pub fn store_root() -> PathBuf {
+    if let Ok(custom) = std::env::var("EDDA_STORE_ROOT") {
+        return PathBuf::from(custom);
+    }
     if let Some(data_dir) = dirs::data_dir() {
         data_dir.join("edda")
     } else if let Some(home) = dirs::home_dir() {

--- a/crates/edda-store/src/registry.rs
+++ b/crates/edda-store/src/registry.rs
@@ -147,66 +147,81 @@ pub fn validate_projects() -> (Vec<ProjectEntry>, Vec<ProjectEntry>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Serialize registry tests so EDDA_STORE_ROOT env var doesn't conflict.
+    static REGISTRY_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Run a closure with `EDDA_STORE_ROOT` pointing to an isolated tempdir.
+    fn with_isolated_store(f: impl FnOnce()) {
+        let _guard = REGISTRY_LOCK.lock().unwrap();
+        let store = tempfile::tempdir().unwrap();
+        std::env::set_var("EDDA_STORE_ROOT", store.path());
+        f();
+        std::env::remove_var("EDDA_STORE_ROOT");
+    }
 
     #[test]
     fn register_and_list_roundtrip() {
-        let tmp = tempfile::tempdir().unwrap();
-        // Create a fake .edda/ so validate_projects considers it valid
-        std::fs::create_dir_all(tmp.path().join(".edda")).unwrap();
+        with_isolated_store(|| {
+            let tmp = tempfile::tempdir().unwrap();
+            std::fs::create_dir_all(tmp.path().join(".edda")).unwrap();
 
-        register_project(tmp.path()).unwrap();
-        let projects = list_projects();
-        let pid = project_id(tmp.path());
+            register_project(tmp.path()).unwrap();
+            let projects = list_projects();
+            let pid = project_id(tmp.path());
 
-        assert!(projects.iter().any(|p| p.project_id == pid));
-
-        // Cleanup
-        unregister_project(&pid).unwrap();
+            assert!(projects.iter().any(|p| p.project_id == pid));
+        });
     }
 
     #[test]
     fn register_is_idempotent() {
-        let tmp = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(tmp.path().join(".edda")).unwrap();
+        with_isolated_store(|| {
+            let tmp = tempfile::tempdir().unwrap();
+            std::fs::create_dir_all(tmp.path().join(".edda")).unwrap();
 
-        register_project(tmp.path()).unwrap();
-        register_project(tmp.path()).unwrap();
+            register_project(tmp.path()).unwrap();
+            register_project(tmp.path()).unwrap();
 
-        let pid = project_id(tmp.path());
-        let reg = load_registry();
-        let count = reg.projects.values().filter(|p| p.project_id == pid).count();
-        assert_eq!(count, 1, "should not create duplicates");
-
-        unregister_project(&pid).unwrap();
+            let pid = project_id(tmp.path());
+            let reg = load_registry();
+            let count = reg
+                .projects
+                .values()
+                .filter(|p| p.project_id == pid)
+                .count();
+            assert_eq!(count, 1, "should not create duplicates");
+        });
     }
 
     #[test]
     fn unregister_removes_entry() {
-        let tmp = tempfile::tempdir().unwrap();
-        let pid = project_id(tmp.path());
+        with_isolated_store(|| {
+            let tmp = tempfile::tempdir().unwrap();
+            let pid = project_id(tmp.path());
 
-        register_project(tmp.path()).unwrap();
-        assert!(get_project(&pid).is_some());
+            register_project(tmp.path()).unwrap();
+            assert!(get_project(&pid).is_some());
 
-        unregister_project(&pid).unwrap();
-        assert!(get_project(&pid).is_none());
+            unregister_project(&pid).unwrap();
+            assert!(get_project(&pid).is_none());
+        });
     }
 
     #[test]
     fn validate_detects_stale() {
-        let tmp = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(tmp.path().join(".edda")).unwrap();
-        register_project(tmp.path()).unwrap();
+        with_isolated_store(|| {
+            let tmp = tempfile::tempdir().unwrap();
+            std::fs::create_dir_all(tmp.path().join(".edda")).unwrap();
+            register_project(tmp.path()).unwrap();
 
-        let pid = project_id(tmp.path());
+            let pid = project_id(tmp.path());
+            std::fs::remove_dir_all(tmp.path().join(".edda")).unwrap();
 
-        // Remove .edda/ to make it stale
-        std::fs::remove_dir_all(tmp.path().join(".edda")).unwrap();
-
-        let (valid, stale) = validate_projects();
-        assert!(stale.iter().any(|p| p.project_id == pid));
-        assert!(!valid.iter().any(|p| p.project_id == pid));
-
-        unregister_project(&pid).unwrap();
+            let (valid, stale) = validate_projects();
+            assert!(stale.iter().any(|p| p.project_id == pid));
+            assert!(!valid.iter().any(|p| p.project_id == pid));
+        });
     }
 }

--- a/crates/edda-store/src/registry.rs
+++ b/crates/edda-store/src/registry.rs
@@ -1,0 +1,212 @@
+//! Project registry: `~/.edda/registry.json`
+//!
+//! Maps project_id (BLAKE3 hash) to repo path. Used for cross-repo aggregation.
+
+use crate::{lock_file, project_id, store_root, write_atomic};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use time::OffsetDateTime;
+
+/// A registered project entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectEntry {
+    pub project_id: String,
+    pub path: String,
+    pub name: String,
+    pub registered_at: String,
+    pub last_seen: String,
+}
+
+/// The full registry: a map of project_id → ProjectEntry.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Registry {
+    pub projects: BTreeMap<String, ProjectEntry>,
+}
+
+/// Path to the registry JSON file.
+pub fn registry_path() -> PathBuf {
+    store_root().join("registry.json")
+}
+
+/// Path to the registry lock file.
+fn registry_lock_path() -> PathBuf {
+    store_root().join("registry.lock")
+}
+
+/// Load the registry from disk. Returns empty registry if file doesn't exist.
+fn load_registry() -> Registry {
+    let path = registry_path();
+    match std::fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+        Err(_) => Registry::default(),
+    }
+}
+
+/// Save the registry to disk atomically.
+fn save_registry(reg: &Registry) -> anyhow::Result<()> {
+    let json = serde_json::to_string_pretty(reg)?;
+    write_atomic(&registry_path(), json.as_bytes())
+}
+
+/// Get current timestamp as RFC 3339 string.
+fn now_rfc3339() -> String {
+    let now = OffsetDateTime::now_utc();
+    now.format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+/// Extract project name from the repo path (last component).
+fn project_name_from_path(repo_root: &Path) -> String {
+    repo_root
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Register a project in the user-level registry. Idempotent.
+pub fn register_project(repo_root: &Path) -> anyhow::Result<()> {
+    let _lock = lock_file(&registry_lock_path())?;
+    let pid = project_id(repo_root);
+    let mut reg = load_registry();
+    let now = now_rfc3339();
+
+    if let Some(entry) = reg.projects.get_mut(&pid) {
+        // Update last_seen and path (in case repo was moved)
+        entry.last_seen = now;
+        entry.path = repo_root.to_string_lossy().to_string();
+    } else {
+        reg.projects.insert(
+            pid.clone(),
+            ProjectEntry {
+                project_id: pid,
+                path: repo_root.to_string_lossy().to_string(),
+                name: project_name_from_path(repo_root),
+                registered_at: now.clone(),
+                last_seen: now,
+            },
+        );
+    }
+
+    save_registry(&reg)
+}
+
+/// Unregister a project by project_id.
+pub fn unregister_project(pid: &str) -> anyhow::Result<()> {
+    let _lock = lock_file(&registry_lock_path())?;
+    let mut reg = load_registry();
+    reg.projects.remove(pid);
+    save_registry(&reg)
+}
+
+/// List all registered projects.
+pub fn list_projects() -> Vec<ProjectEntry> {
+    let reg = load_registry();
+    reg.projects.into_values().collect()
+}
+
+/// Get a specific project by project_id.
+pub fn get_project(pid: &str) -> Option<ProjectEntry> {
+    let reg = load_registry();
+    reg.projects.get(pid).cloned()
+}
+
+/// Update last_seen timestamp for a project.
+pub fn touch_project(repo_root: &Path) -> anyhow::Result<()> {
+    let _lock = lock_file(&registry_lock_path())?;
+    let pid = project_id(repo_root);
+    let mut reg = load_registry();
+
+    if let Some(entry) = reg.projects.get_mut(&pid) {
+        entry.last_seen = now_rfc3339();
+        save_registry(&reg)?;
+    }
+
+    Ok(())
+}
+
+/// Validate all registered projects. Returns (valid, stale) entries.
+/// A project is stale if its path no longer contains a `.edda/` directory.
+pub fn validate_projects() -> (Vec<ProjectEntry>, Vec<ProjectEntry>) {
+    let reg = load_registry();
+    let mut valid = Vec::new();
+    let mut stale = Vec::new();
+
+    for entry in reg.projects.into_values() {
+        let edda_dir = Path::new(&entry.path).join(".edda");
+        if edda_dir.is_dir() {
+            valid.push(entry);
+        } else {
+            stale.push(entry);
+        }
+    }
+
+    (valid, stale)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_and_list_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Create a fake .edda/ so validate_projects considers it valid
+        std::fs::create_dir_all(tmp.path().join(".edda")).unwrap();
+
+        register_project(tmp.path()).unwrap();
+        let projects = list_projects();
+        let pid = project_id(tmp.path());
+
+        assert!(projects.iter().any(|p| p.project_id == pid));
+
+        // Cleanup
+        unregister_project(&pid).unwrap();
+    }
+
+    #[test]
+    fn register_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".edda")).unwrap();
+
+        register_project(tmp.path()).unwrap();
+        register_project(tmp.path()).unwrap();
+
+        let pid = project_id(tmp.path());
+        let reg = load_registry();
+        let count = reg.projects.values().filter(|p| p.project_id == pid).count();
+        assert_eq!(count, 1, "should not create duplicates");
+
+        unregister_project(&pid).unwrap();
+    }
+
+    #[test]
+    fn unregister_removes_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pid = project_id(tmp.path());
+
+        register_project(tmp.path()).unwrap();
+        assert!(get_project(&pid).is_some());
+
+        unregister_project(&pid).unwrap();
+        assert!(get_project(&pid).is_none());
+    }
+
+    #[test]
+    fn validate_detects_stale() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".edda")).unwrap();
+        register_project(tmp.path()).unwrap();
+
+        let pid = project_id(tmp.path());
+
+        // Remove .edda/ to make it stale
+        std::fs::remove_dir_all(tmp.path().join(".edda")).unwrap();
+
+        let (valid, stale) = validate_projects();
+        assert!(stale.iter().any(|p| p.project_id == pid));
+        assert!(!valid.iter().any(|p| p.project_id == pid));
+
+        unregister_project(&pid).unwrap();
+    }
+}

--- a/crates/edda-store/src/user_config.rs
+++ b/crates/edda-store/src/user_config.rs
@@ -1,0 +1,77 @@
+//! User-level config at `~/.edda/config.json`.
+//!
+//! Provides get/set access to a simple JSON key-value store.
+
+use crate::{store_root, write_atomic};
+use serde_json::{Map, Value};
+use std::path::PathBuf;
+
+/// Path to the user-level config file.
+pub fn user_config_path() -> PathBuf {
+    store_root().join("config.json")
+}
+
+/// Load user config from disk. Returns empty map if file doesn't exist.
+pub fn load_user_config() -> Map<String, Value> {
+    let path = user_config_path();
+    match std::fs::read_to_string(&path) {
+        Ok(content) => match serde_json::from_str::<Value>(&content) {
+            Ok(Value::Object(map)) => map,
+            _ => Map::new(),
+        },
+        Err(_) => Map::new(),
+    }
+}
+
+/// Save user config to disk atomically.
+pub fn save_user_config(config: &Map<String, Value>) -> anyhow::Result<()> {
+    let json = serde_json::to_string_pretty(&Value::Object(config.clone()))?;
+    write_atomic(&user_config_path(), json.as_bytes())
+}
+
+/// Get a single config value by key.
+pub fn get_user_config(key: &str) -> Option<Value> {
+    let config = load_user_config();
+    config.get(key).cloned()
+}
+
+/// Set a single config value. Creates the file if it doesn't exist.
+pub fn set_user_config(key: &str, value: Value) -> anyhow::Result<()> {
+    let mut config = load_user_config();
+    config.insert(key.to_string(), value);
+    save_user_config(&config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_returns_empty_when_no_file() {
+        // This test relies on the default store_root; just verify it doesn't panic
+        let _ = load_user_config();
+    }
+
+    // Note: set/get tests use the global ~/.edda/config.json and must be run
+    // sequentially to avoid Windows file-locking races. We combine them into
+    // a single test to avoid concurrency issues.
+    #[test]
+    fn set_get_and_overwrite_roundtrip() {
+        let key = &format!("test_key_{}", std::process::id());
+
+        // Initial set
+        set_user_config(key, Value::String("hello".into())).unwrap();
+        let val = get_user_config(key);
+        assert_eq!(val, Some(Value::String("hello".into())));
+
+        // Overwrite
+        set_user_config(key, Value::Number(42.into())).unwrap();
+        let val = get_user_config(key);
+        assert_eq!(val, Some(Value::Number(42.into())));
+
+        // Cleanup
+        let mut config = load_user_config();
+        config.remove(key);
+        let _ = save_user_config(&config);
+    }
+}

--- a/crates/edda-store/src/user_config.rs
+++ b/crates/edda-store/src/user_config.rs
@@ -46,32 +46,34 @@ pub fn set_user_config(key: &str, value: Value) -> anyhow::Result<()> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn load_returns_empty_when_no_file() {
-        // This test relies on the default store_root; just verify it doesn't panic
-        let _ = load_user_config();
+    /// Run a closure with `EDDA_STORE_ROOT` pointing to an isolated tempdir.
+    fn with_isolated_store(f: impl FnOnce()) {
+        let store = tempfile::tempdir().unwrap();
+        // Safety: these tests are independent since each gets its own tempdir
+        std::env::set_var("EDDA_STORE_ROOT", store.path());
+        f();
+        std::env::remove_var("EDDA_STORE_ROOT");
     }
 
-    // Note: set/get tests use the global ~/.edda/config.json and must be run
-    // sequentially to avoid Windows file-locking races. We combine them into
-    // a single test to avoid concurrency issues.
+    #[test]
+    fn load_returns_empty_when_no_file() {
+        with_isolated_store(|| {
+            let config = load_user_config();
+            assert!(config.is_empty());
+        });
+    }
+
     #[test]
     fn set_get_and_overwrite_roundtrip() {
-        let key = &format!("test_key_{}", std::process::id());
+        with_isolated_store(|| {
+            set_user_config("test_key", Value::String("hello".into())).unwrap();
+            let val = get_user_config("test_key");
+            assert_eq!(val, Some(Value::String("hello".into())));
 
-        // Initial set
-        set_user_config(key, Value::String("hello".into())).unwrap();
-        let val = get_user_config(key);
-        assert_eq!(val, Some(Value::String("hello".into())));
-
-        // Overwrite
-        set_user_config(key, Value::Number(42.into())).unwrap();
-        let val = get_user_config(key);
-        assert_eq!(val, Some(Value::Number(42.into())));
-
-        // Cleanup
-        let mut config = load_user_config();
-        config.remove(key);
-        let _ = save_user_config(&config);
+            // Overwrite
+            set_user_config("test_key", Value::Number(42.into())).unwrap();
+            let val = get_user_config("test_key");
+            assert_eq!(val, Some(Value::Number(42.into())));
+        });
     }
 }


### PR DESCRIPTION
## Summary

Implements the user-level aggregation layer at `~/.edda/` for cross-repo queries and rollup statistics, providing the data foundation for Chronicle (#152).

**Architecture: Hybrid approach** — registry stays in `edda-store` (no new deps besides `time`), aggregation + rollup move to new `edda-aggregate` crate (avoids circular dependency with `edda-ledger`).

### What's included

- **`edda-store::registry`** — project registry at `~/.edda/registry.json` with register, unregister, list, validate, touch operations and file locking
- **`edda-store::user_config`** — user-level config at `~/.edda/config.json` with get/set/load/save
- **`edda-aggregate` crate** (new) — cross-repo aggregation queries (`aggregate_overview`, `aggregate_commits`, `aggregate_decisions`, `events_by_date`, `commits_by_date`) and rollup statistics (`compute_rollup`, `compute_rollup_incremental`, `merge_rollups`) with daily/weekly/monthly granularity
- **`edda user` CLI subcommand group** — `projects`, `overview`, `commits`, `decisions`, `rollup`, `config get/set/list` (all with `--json` support)
- **`edda init` integration** — auto-registers project in user-level registry
- **`edda gc --global` extension** — prunes stale registry entries
- **`edda-serve` dependency wiring** — ready for #152 API endpoints

### File changes

| File | Action | Description |
|------|--------|-------------|
| `crates/edda-store/src/lib.rs` | Edit | Add `pub mod registry; pub mod user_config;` |
| `crates/edda-store/Cargo.toml` | Edit | Add `time.workspace = true` |
| `crates/edda-store/src/registry.rs` | New | Project registry (~/.edda/registry.json) |
| `crates/edda-store/src/user_config.rs` | New | User-level config (~/.edda/config.json) |
| `crates/edda-aggregate/` | New crate | Cross-repo aggregation + rollup |
| `Cargo.toml` | Edit | Add `edda-aggregate` to workspace members |
| `crates/edda-cli/Cargo.toml` | Edit | Add `edda-aggregate` dependency |
| `crates/edda-cli/src/main.rs` | Edit | Add `mod cmd_user;` + `User` command variant |
| `crates/edda-cli/src/cmd_user.rs` | New | User-level CLI subcommands |
| `crates/edda-cli/src/cmd_init.rs` | Edit | Add `register_project()` call |
| `crates/edda-cli/src/cmd_gc.rs` | Edit | Add registry cleanup to `--global` |
| `crates/edda-serve/Cargo.toml` | Edit | Add `edda-aggregate`, `edda-store` deps |

### Design decisions

- **Lazy aggregation** — queries read each repo's ledger on demand, no persistent cross-repo DB
- **Incremental rollup** — `compute_rollup_incremental` merges new data into existing cache
- **No circular deps** — `edda-aggregate` depends on both `edda-store` and `edda-ledger`; `edda-ledger` depends on `edda-store` only
- **Best-effort registration** — `register_project()` failure in `edda init` prints warning, doesn't block init

## Test plan

- [x] `cargo check --workspace` passes (zero errors, zero warnings)
- [x] `cargo test --workspace` passes (965+ tests, 0 failures)
- [x] `cargo test -p edda-store` — 16 tests (registry: 4, user_config: 2, existing: 10)
- [x] `cargo test -p edda-aggregate` — 11 tests (aggregate: 6, rollup: 5)
- [ ] Manual: `edda init` registers project in `~/.edda/registry.json`
- [ ] Manual: `edda user projects` shows registered projects
- [ ] Manual: `edda user overview` shows cross-repo summary
- [ ] Manual: `edda gc --global` cleans stale entries

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)