### PR TITLE
feat(L3): post-mortem analysis with learned rules and TTL decay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,6 +653,7 @@ dependencies = [
  "edda-mcp",
  "edda-notify",
  "edda-pack",
+ "edda-postmortem",
  "edda-search-fts",
  "edda-serve",
  "edda-store",
@@ -695,6 +696,7 @@ dependencies = [
  "edda-ledger",
  "edda-notify",
  "edda-pack",
+ "edda-postmortem",
  "edda-store",
  "edda-transcript",
  "globset",
@@ -835,6 +837,22 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+]
+
+[[package]]
+name = "edda-postmortem"
+version = "0.1.1"
+dependencies = [
+ "anyhow",
+ "edda-core",
+ "edda-store",
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "time",
+ "ulid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/edda-conductor",
     "crates/edda-serve",
     "crates/edda-notify",
+    "crates/edda-postmortem",
     "crates/edda-cli",  # crate name: "edda"
 ]
 

--- a/crates/edda-bridge-claude/Cargo.toml
+++ b/crates/edda-bridge-claude/Cargo.toml
@@ -17,6 +17,7 @@ edda-index = { path = "../edda-index", version = "0.1.1" }
 edda-pack = { path = "../edda-pack", version = "0.1.1" }
 edda-ledger = { path = "../edda-ledger", version = "0.1.1" }
 edda-notify = { path = "../edda-notify", version = "0.1.1" }
+edda-postmortem = { path = "../edda-postmortem", version = "0.1.1" }
 edda-derive = { path = "../edda-derive", version = "0.1.1" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/edda-bridge-claude/src/digest.rs
+++ b/crates/edda-bridge-claude/src/digest.rs
@@ -4,7 +4,7 @@
 //! `edda_core::Event` milestone summarizing the session — without LLM,
 //! without touching the workspace ledger.
 
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 use std::io::BufRead;
 use std::path::Path;
 
@@ -77,12 +77,29 @@ pub struct SessionStats {
     pub signal_count: u64,
     /// Dependency packages added during this session (for passive harvest).
     pub deps_added: Vec<String>,
+    /// Per-file edit counts: (file_path, count).
+    /// Used by L3 post-mortem trigger to detect file churn.
+    pub file_edit_counts: Vec<(String, u64)>,
+    /// Per-tool call counts (e.g. "Read" -> 15, "Edit" -> 8).
+    pub tool_call_breakdown: BTreeMap<String, u64>,
+    /// Model name used in this session.
+    pub model: String,
+    /// Total input tokens consumed.
+    pub input_tokens: u64,
+    /// Total output tokens consumed.
+    pub output_tokens: u64,
+    /// Total cache-read input tokens.
+    pub cache_read_tokens: u64,
+    /// Total cache-creation input tokens.
+    pub cache_creation_tokens: u64,
+    /// Estimated cost in USD.
+    pub estimated_cost_usd: f64,
 }
 
 /// Extract statistics from a session ledger file.
 pub fn extract_stats(session_ledger_path: &Path) -> anyhow::Result<SessionStats> {
     let mut stats = SessionStats::default();
-    let mut files_set: BTreeSet<String> = BTreeSet::new();
+    let mut file_edit_map: BTreeMap<String, u64> = BTreeMap::new();
 
     // Track session outcome: last event type + trailing failure count
     let mut last_event_name = String::new();
@@ -142,10 +159,13 @@ pub fn extract_stats(session_ledger_path: &Path) -> anyhow::Result<SessionStats>
                     })
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
+                if !tool_name.is_empty() {
+                    *stats.tool_call_breakdown.entry(tool_name.to_string()).or_insert(0) += 1;
+                }
                 if tool_name == "Edit" || tool_name == "Write" {
                     if let Some(fp) = extract_file_path(&envelope) {
                         if !crate::signals::is_noise_file(&fp) {
-                            files_set.insert(fp);
+                            *file_edit_map.entry(fp).or_insert(0) += 1;
                         }
                     }
                 }
@@ -197,7 +217,8 @@ pub fn extract_stats(session_ledger_path: &Path) -> anyhow::Result<SessionStats>
         }
     }
 
-    stats.files_modified = files_set.into_iter().collect();
+    stats.file_edit_counts = file_edit_map.iter().map(|(k, v)| (k.clone(), *v)).collect();
+    stats.files_modified = file_edit_map.into_keys().collect();
     stats.duration_minutes = compute_duration_minutes(&stats.first_ts, &stats.last_ts);
 
     // Determine session outcome
@@ -254,6 +275,18 @@ pub fn render_digest_text(session_id: &str, stats: &SessionStats) -> String {
         stats.duration_minutes,
     ));
 
+    if !stats.tool_call_breakdown.is_empty() {
+        let breakdown: Vec<String> = stats
+            .tool_call_breakdown
+            .iter()
+            .map(|(name, count)| format!("{name}:{count}"))
+            .collect();
+        lines.push(format!("Tools: {}", breakdown.join(" ")));
+        let edit_ratio = compute_edit_ratio(&stats.tool_call_breakdown, stats.tool_calls);
+        let search_ratio = compute_search_ratio(&stats.tool_call_breakdown, stats.tool_calls);
+        lines.push(format!("edit_ratio: {edit_ratio:.2}, search_ratio: {search_ratio:.2}"));
+    }
+
     if !stats.files_modified.is_empty() {
         lines.push(format!(
             "Files modified: {}",
@@ -309,7 +342,47 @@ pub fn render_digest_text(session_id: &str, stats: &SessionStats) -> String {
         }
     }
 
+    // Usage summary
+    if stats.input_tokens > 0 || stats.output_tokens > 0 {
+        let model_label = if stats.model.is_empty() {
+            "unknown".to_string()
+        } else {
+            stats.model.clone()
+        };
+        let total = stats.input_tokens + stats.output_tokens;
+        let cost_str = if stats.estimated_cost_usd > 0.0 {
+            format!(", ${:.4}", stats.estimated_cost_usd)
+        } else {
+            String::new()
+        };
+        lines.push(format!(
+            "Usage: {model_label} -- {total} tokens (in:{} out:{}){cost_str}",
+            stats.input_tokens, stats.output_tokens
+        ));
+    }
+
     lines.join("\n")
+}
+
+/// Compute edit ratio: fraction of tool calls that are Edit/Write.
+fn compute_edit_ratio(breakdown: &BTreeMap<String, u64>, total: u64) -> f64 {
+    if total == 0 {
+        return 0.0;
+    }
+    let edit_count = breakdown.get("Edit").copied().unwrap_or(0)
+        + breakdown.get("Write").copied().unwrap_or(0);
+    edit_count as f64 / total as f64
+}
+
+/// Compute search ratio: fraction of tool calls that are Read/Grep/Glob.
+fn compute_search_ratio(breakdown: &BTreeMap<String, u64>, total: u64) -> f64 {
+    if total == 0 {
+        return 0.0;
+    }
+    let search_count = breakdown.get("Read").copied().unwrap_or(0)
+        + breakdown.get("Grep").copied().unwrap_or(0)
+        + breakdown.get("Glob").copied().unwrap_or(0);
+    search_count as f64 / total as f64
 }
 
 /// Build a milestone `Event` from session stats.
@@ -346,6 +419,15 @@ pub fn build_digest_event(
             "decide_count": stats.decide_count,
             "signal_count": stats.signal_count,
             "notes": notes,
+            "tool_call_breakdown": stats.tool_call_breakdown,
+            "edit_ratio": compute_edit_ratio(&stats.tool_call_breakdown, stats.tool_calls),
+            "search_ratio": compute_search_ratio(&stats.tool_call_breakdown, stats.tool_calls),
+            "model": stats.model,
+            "input_tokens": stats.input_tokens,
+            "output_tokens": stats.output_tokens,
+            "cache_read_tokens": stats.cache_read_tokens,
+            "cache_creation_tokens": stats.cache_creation_tokens,
+            "estimated_cost_usd": stats.estimated_cost_usd,
         }
     });
 
@@ -834,6 +916,19 @@ fn digest_one_session(
     // Enrich with tasks snapshot from state file
     stats.tasks_snapshot = load_tasks_for_digest(project_id);
 
+    // Enrich with usage data (model, tokens, cost) from transcript signals
+    {
+        let usage = crate::signals::read_usage_state(project_id);
+        if !usage.model.is_empty() {
+            stats.model = usage.model.clone();
+        }
+        stats.input_tokens = usage.input_tokens;
+        stats.output_tokens = usage.output_tokens;
+        stats.cache_read_tokens = usage.cache_read_tokens;
+        stats.cache_creation_tokens = usage.cache_creation_tokens;
+        stats.estimated_cost_usd = crate::signals::estimate_cost(&usage);
+    }
+
     // Collect session notes and decisions from workspace ledger
     let (decisions, notes) = collect_session_ledger_extras(cwd, stats.first_ts.as_deref());
 
@@ -1189,6 +1284,18 @@ pub struct PrevDigest {
     /// Total decision-worthy signals detected (including suppressed ones).
     #[serde(default)]
     pub signal_count: u64,
+    /// Model name used in this session.
+    #[serde(default)]
+    pub model: String,
+    /// Total input tokens.
+    #[serde(default)]
+    pub input_tokens: u64,
+    /// Total output tokens.
+    #[serde(default)]
+    pub output_tokens: u64,
+    /// Estimated cost in USD.
+    #[serde(default)]
+    pub estimated_cost_usd: f64,
 }
 
 /// Write prev_digest.json from SessionStats + optional ledger extras.
@@ -1231,6 +1338,10 @@ pub fn write_prev_digest(
         nudge_count: stats.nudge_count,
         decide_count: stats.decide_count,
         signal_count: stats.signal_count,
+        model: stats.model.clone(),
+        input_tokens: stats.input_tokens,
+        output_tokens: stats.output_tokens,
+        estimated_cost_usd: stats.estimated_cost_usd,
     };
 
     let path = edda_store::project_dir(project_id)
@@ -1382,6 +1493,18 @@ pub fn write_prev_digest_from_store(
     stats.nudge_count = nudge_count;
     stats.decide_count = decide_count;
     stats.signal_count = signal_count;
+    // Supplement usage data from transcript signals
+    {
+        let usage = crate::signals::read_usage_state(project_id);
+        if !usage.model.is_empty() {
+            stats.model = usage.model.clone();
+        }
+        stats.input_tokens = usage.input_tokens;
+        stats.output_tokens = usage.output_tokens;
+        stats.cache_read_tokens = usage.cache_read_tokens;
+        stats.cache_creation_tokens = usage.cache_creation_tokens;
+        stats.estimated_cost_usd = crate::signals::estimate_cost(&usage);
+    }
     // Collect decisions + notes from workspace ledger before writing
     let (decisions, notes) = collect_session_ledger_extras(cwd, stats.first_ts.as_deref());
     write_prev_digest(project_id, session_id, &stats, decisions, notes);

--- a/crates/edda-bridge-claude/src/dispatch.rs
+++ b/crates/edda-bridge-claude/src/dispatch.rs
@@ -641,6 +641,9 @@ fn dispatch_session_end(
         signal_count,
     );
 
+    // 2e. L3 post-mortem analysis (best-effort, fire-and-forget)
+    run_postmortem(project_id, session_id, cwd);
+
     // 2d. Push notification (best-effort, fire-and-forget)
     notify_session_end(project_id, cwd, session_id);
 
@@ -687,6 +690,114 @@ fn notify_session_end(project_id: &str, cwd: &str, session_id: &str) {
             duration_minutes,
             summary,
         },
+    );
+}
+
+/// L3 post-mortem analysis: evaluate triggers, propose rules, store lessons.
+///
+/// Best-effort — all errors are silently swallowed. The session-end hook must
+/// never fail because of post-mortem logic.
+fn run_postmortem(project_id: &str, session_id: &str, cwd: &str) {
+    // Skip if explicitly disabled
+    if std::env::var("EDDA_POSTMORTEM").unwrap_or_else(|_| "1".into()) == "0" {
+        return;
+    }
+
+    // Extract stats from the session ledger
+    let store_path = edda_store::project_dir(project_id)
+        .join("ledger")
+        .join(format!("{session_id}.jsonl"));
+    if !store_path.exists() {
+        return;
+    }
+    let stats = match crate::digest::extract_stats(&store_path) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    // Build SessionSummary from SessionStats
+    let summary = edda_postmortem::trigger::SessionSummary {
+        session_id: session_id.to_string(),
+        user_prompts: stats.user_prompts,
+        tool_failures: stats.tool_failures,
+        failed_commands: stats.failed_commands.clone(),
+        file_edit_counts: stats.file_edit_counts.clone(),
+        decisions_superseded: 0, // TODO: count from workspace ledger
+        had_conflict: false,     // TODO: detect from coordination state
+        outcome: stats.outcome.to_string(),
+    };
+
+    // Evaluate triggers
+    let trigger = edda_postmortem::trigger::evaluate_triggers(&summary);
+    if !trigger.should_analyze {
+        return;
+    }
+
+    // Build analysis input
+    let input = edda_postmortem::analyzer::AnalysisInput {
+        session_id: session_id.to_string(),
+        user_prompts: stats.user_prompts,
+        tool_failures: stats.tool_failures,
+        failed_commands: stats.failed_commands.clone(),
+        files_modified: stats.files_modified.clone(),
+        file_edit_counts: stats.file_edit_counts.clone(),
+        commits_made: stats.commits_made.clone(),
+        decisions_superseded: 0,
+        had_conflict: false,
+        outcome: stats.outcome.to_string(),
+        duration_minutes: stats.duration_minutes,
+    };
+
+    // Run analysis
+    let result = edda_postmortem::analyzer::analyze(&trigger, &input);
+
+    // Load rules store, propose rules, run decay
+    let mut rules_store = edda_postmortem::RulesStore::load_project(project_id);
+
+    for proposal in &result.rule_proposals {
+        rules_store.propose_rule(
+            proposal.trigger.clone(),
+            proposal.action.clone(),
+            proposal.anchor_file.clone(),
+            proposal.category.clone(),
+            session_id.to_string(),
+            None,
+        );
+    }
+
+    // Rate-limited decay: only run once per day
+    let should_decay = match &rules_store.last_decay_run {
+        Some(last) => {
+            let today = time::OffsetDateTime::now_utc()
+                .date()
+                .to_string();
+            !last.starts_with(&today)
+        }
+        None => true,
+    };
+    if should_decay {
+        rules_store.run_decay_cycle();
+    }
+
+    let _ = rules_store.save_project(project_id);
+
+    // Store lessons
+    let mut lessons_store =
+        edda_postmortem::lessons::LessonsStore::load_project(project_id);
+    lessons_store.add_lessons(&result.lessons, session_id);
+    let _ = lessons_store.save_project(project_id);
+
+    // Sync top lessons to CLAUDE.md (best-effort)
+    let claude_md_path = Path::new(cwd).join("CLAUDE.md");
+    if claude_md_path.exists() {
+        let _ = lessons_store.sync_to_claude_md(&claude_md_path, 10);
+    }
+
+    eprintln!(
+        "[edda L3] post-mortem: {} triggers, {} lessons, {} rule proposals",
+        result.triggers.len(),
+        result.lessons.len(),
+        result.rule_proposals.len(),
     );
 }
 
@@ -1061,12 +1172,18 @@ fn dispatch_pre_tool_use(
     // Check for pending requests (with cooldown: once per 3 tool calls)
     let request_nudge = check_pending_requests(project_id, session_id);
 
-    // Combine pattern context and request nudge
-    let combined_ctx = match (pattern_ctx, request_nudge) {
-        (Some(p), Some(r)) => Some(format!("{p}\n\n{r}")),
-        (Some(p), None) => Some(p),
-        (None, Some(r)) => Some(r),
-        (None, None) => None,
+    // L3: evaluate learned rules (warn-only, via additionalContext)
+    let rules_warning = evaluate_learned_rules(raw, project_id, cwd);
+
+    // Combine pattern context, request nudge, and rules warning
+    let combined_ctx = [pattern_ctx, request_nudge, rules_warning]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    let combined_ctx = if combined_ctx.is_empty() {
+        None
+    } else {
+        Some(combined_ctx.join("\n\n"))
     };
 
     if auto_approve == "1" {
@@ -1119,6 +1236,47 @@ fn check_pending_requests(project_id: &str, session_id: &str) -> Option<String> 
         lines.push(format!("  - From **{}**: {}", r.from_label, r.message));
     }
     Some(lines.join("\n"))
+}
+
+/// L3: evaluate learned rules against the current PreToolUse hook context.
+/// Returns a warning string if any rules triggered, None otherwise.
+/// Best-effort — all errors silently return None.
+fn evaluate_learned_rules(
+    raw: &serde_json::Value,
+    project_id: &str,
+    cwd: &str,
+) -> Option<String> {
+    if std::env::var("EDDA_POSTMORTEM").unwrap_or_else(|_| "1".into()) == "0" {
+        return None;
+    }
+
+    let rules_store = edda_postmortem::RulesStore::load_project(project_id);
+    if rules_store.active_rules().is_empty() {
+        return None;
+    }
+
+    let tool_name = get_str(raw, "tool_name");
+    let file_path = raw
+        .pointer("/tool_input/file_path")
+        .or_else(|| raw.pointer("/input/file_path"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let files_touched = if file_path.is_empty() {
+        vec![]
+    } else {
+        vec![file_path]
+    };
+
+    let hook_ctx = edda_postmortem::hooks::HookContext {
+        hook_event: "PreToolUse".to_string(),
+        tool_name,
+        files_touched,
+        cwd: cwd.to_string(),
+    };
+
+    let result = edda_postmortem::hooks::evaluate_rules(&rules_store, &hook_ctx);
+    edda_postmortem::hooks::format_warnings(&result)
 }
 
 /// Best-effort write of a `commit` event to the workspace ledger.
@@ -1672,7 +1830,7 @@ mod tests {
                 hash: "abc1234".into(),
                 message: "fix: the bug".into(),
             }],
-            failed_commands: vec![],
+            ..Default::default()
         };
         save_session_signals(pid, "test-session", &signals);
 

--- a/crates/edda-bridge-claude/src/narrative.rs
+++ b/crates/edda-bridge-claude/src/narrative.rs
@@ -182,7 +182,7 @@ mod tests {
                 hash: "abc1234".into(),
                 message: "fix: bug".into(),
             }],
-            failed_commands: vec![],
+            ..Default::default()
         };
         save_session_signals(pid, "test-session", &signals);
 
@@ -256,6 +256,7 @@ mod tests {
                 stderr_snippet: "thread 'test' panicked".into(),
                 count: 2,
             }],
+            ..Default::default()
         };
         save_session_signals(pid, "test-session", &signals);
 
@@ -326,7 +327,7 @@ mod tests {
                     message: "second commit".into(),
                 },
             ],
-            failed_commands: vec![],
+            ..Default::default()
         };
         save_session_signals(pid, "test-session", &signals);
 
@@ -354,8 +355,7 @@ mod tests {
                     count: 30,
                 },
             ],
-            commits: vec![],
-            failed_commands: vec![],
+            ..Default::default()
         };
         save_session_signals(pid, "test-session", &signals);
 

--- a/crates/edda-bridge-claude/src/peers.rs
+++ b/crates/edda-bridge-claude/src/peers.rs
@@ -1589,7 +1589,7 @@ mod tests {
                 hash: "abc1234".into(),
                 message: "feat: add JWT auth".into(),
             }],
-            failed_commands: vec![],
+            ..Default::default()
         };
 
         write_heartbeat(pid, sid, &signals, Some("auth"));

--- a/crates/edda-bridge-claude/src/signals.rs
+++ b/crates/edda-bridge-claude/src/signals.rs
@@ -32,6 +32,27 @@ pub(crate) struct FailedBashCmd {
     pub count: usize,
 }
 
+/// Accumulated token usage from assistant messages in a transcript.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct UsageSnapshot {
+    #[serde(default)]
+    pub model: String,
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+    #[serde(default)]
+    pub cache_read_tokens: u64,
+    #[serde(default)]
+    pub cache_creation_tokens: u64,
+}
+
+impl UsageSnapshot {
+    pub fn total_tokens(&self) -> u64 {
+        self.input_tokens + self.output_tokens
+    }
+}
+
 /// All signals extracted from a single transcript scan.
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub(crate) struct SessionSignals {
@@ -40,6 +61,8 @@ pub(crate) struct SessionSignals {
     pub commits: Vec<CommitInfo>,
     #[serde(default)]
     pub failed_commands: Vec<FailedBashCmd>,
+    #[serde(default)]
+    pub usage: UsageSnapshot,
 }
 
 /// One-pass transcript scan: extract tasks, files modified, and commits.
@@ -50,6 +73,8 @@ pub(crate) fn extract_session_signals(transcript_store_path: &Path) -> SessionSi
         Ok(f) => f,
         Err(_) => return SessionSignals::default(),
     };
+
+    let mut usage = UsageSnapshot::default();
 
     let mut tasks: std::collections::HashMap<String, TaskSnapshot> =
         std::collections::HashMap::new();
@@ -80,7 +105,40 @@ pub(crate) fn extract_session_signals(transcript_store_path: &Path) -> SessionSi
         let record_type = record.get("type").and_then(|t| t.as_str()).unwrap_or("");
 
         match record_type {
+            "system" => {
+                // Extract model from system record
+                if let Some(model) = record.get("model").and_then(|m| m.as_str()) {
+                    if !model.is_empty() {
+                        usage.model = model.to_string();
+                    }
+                }
+            }
             "assistant" => {
+                // Accumulate usage from assistant messages
+                if let Some(u) = record.get("message").and_then(|m| m.get("usage")) {
+                    usage.input_tokens +=
+                        u.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+                    usage.output_tokens +=
+                        u.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+                    usage.cache_read_tokens += u
+                        .get("cache_read_input_tokens")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                    usage.cache_creation_tokens += u
+                        .get("cache_creation_input_tokens")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                }
+                // Also try model from assistant message
+                if usage.model.is_empty() {
+                    if let Some(model) = record
+                        .get("message")
+                        .and_then(|m| m.get("model"))
+                        .and_then(|m| m.as_str())
+                    {
+                        usage.model = model.to_string();
+                    }
+                }
                 let content = match record
                     .get("message")
                     .and_then(|m| m.get("content"))
@@ -256,6 +314,7 @@ pub(crate) fn extract_session_signals(transcript_store_path: &Path) -> SessionSi
         files_modified: sorted_files,
         commits,
         failed_commands,
+        usage,
     }
 }
 
@@ -354,6 +413,18 @@ pub(crate) fn save_session_signals(project_id: &str, session_id: &str, signals: 
         // Clean up stale file if no failures
         let _ = fs::remove_file(state_dir.join("failed_commands.json"));
     }
+    // Usage
+    {
+        let mut p = serde_json::json!({
+            "session_id": session_id,
+            "updated_at": now_rfc3339(),
+        });
+        p["usage"] = serde_json::to_value(&signals.usage).unwrap_or_default();
+        let _ = fs::write(
+            state_dir.join("usage.json"),
+            serde_json::to_string_pretty(&p).unwrap_or_default(),
+        );
+    }
 }
 
 pub(crate) fn load_state_vec<T: serde::de::DeserializeOwned>(
@@ -375,6 +446,87 @@ pub(crate) fn load_state_vec<T: serde::de::DeserializeOwned>(
     val.get(key)
         .and_then(|t| serde_json::from_value::<Vec<T>>(t.clone()).ok())
         .unwrap_or_default()
+}
+
+/// Read the usage state from the state directory.
+pub fn read_usage_state(project_id: &str) -> UsageSnapshot {
+    let path = edda_store::project_dir(project_id)
+        .join("state")
+        .join("usage.json");
+    let content = match fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return UsageSnapshot::default(),
+    };
+    let val: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return UsageSnapshot::default(),
+    };
+    val.get("usage")
+        .and_then(|u| serde_json::from_value::<UsageSnapshot>(u.clone()).ok())
+        .unwrap_or_default()
+}
+
+/// Per-model pricing (USD per million tokens).
+struct ModelPricing {
+    input_per_m: f64,
+    output_per_m: f64,
+}
+
+/// Look up pricing for a model name. Returns None for unknown models.
+fn lookup_pricing(model: &str) -> Option<ModelPricing> {
+    // Check env override first: EDDA_MODEL_PRICING="model:in:out,model2:in:out"
+    if let Some(p) = lookup_pricing_from_env(model) {
+        return Some(p);
+    }
+    // Built-in pricing (Anthropic API rates as of 2025-05)
+    let lower = model.to_lowercase();
+    if lower.contains("opus") {
+        Some(ModelPricing {
+            input_per_m: 15.0,
+            output_per_m: 75.0,
+        })
+    } else if lower.contains("sonnet") {
+        Some(ModelPricing {
+            input_per_m: 3.0,
+            output_per_m: 15.0,
+        })
+    } else if lower.contains("haiku") {
+        Some(ModelPricing {
+            input_per_m: 0.25,
+            output_per_m: 1.25,
+        })
+    } else {
+        None
+    }
+}
+
+/// Parse EDDA_MODEL_PRICING env var for custom pricing.
+fn lookup_pricing_from_env(model: &str) -> Option<ModelPricing> {
+    let env_val = std::env::var("EDDA_MODEL_PRICING").ok()?;
+    let lower_model = model.to_lowercase();
+    for entry in env_val.split(',') {
+        let parts: Vec<&str> = entry.trim().split(':').collect();
+        if parts.len() == 3 && lower_model.contains(&parts[0].to_lowercase()) {
+            let input: f64 = parts[1].parse().ok()?;
+            let output: f64 = parts[2].parse().ok()?;
+            return Some(ModelPricing {
+                input_per_m: input,
+                output_per_m: output,
+            });
+        }
+    }
+    None
+}
+
+/// Estimate cost in USD from a UsageSnapshot.
+pub fn estimate_cost(usage: &UsageSnapshot) -> f64 {
+    let pricing = match lookup_pricing(&usage.model) {
+        Some(p) => p,
+        None => return 0.0,
+    };
+    let input_cost = (usage.input_tokens as f64 / 1_000_000.0) * pricing.input_per_m;
+    let output_cost = (usage.output_tokens as f64 / 1_000_000.0) * pricing.output_per_m;
+    input_cost + output_cost
 }
 
 pub(crate) fn render_blocking_section(project_id: &str) -> Option<String> {
@@ -797,6 +949,7 @@ mod tests {
                 message: "fix".into(),
             }],
             failed_commands: vec![],
+            ..Default::default()
         };
         save_session_signals(pid, "test-session", &signals);
 
@@ -1005,6 +1158,7 @@ mod tests {
             ],
             commits: vec![],
             failed_commands: vec![],
+            ..Default::default()
         };
         save_session_signals(pid, "test-session", &signals);
 
@@ -1049,6 +1203,7 @@ mod tests {
             ],
             commits: vec![],
             failed_commands: vec![],
+            ..Default::default()
         };
         save_session_signals(pid, "test-session", &signals);
 
@@ -1325,5 +1480,118 @@ mod tests {
         let signals = extract_session_signals(&path);
         assert!(signals.failed_commands.is_empty());
         let _ = fs::remove_file(&path);
+    }
+
+    // ── Usage / Cost tests ──
+
+    #[test]
+    fn estimate_cost_sonnet() {
+        let usage = UsageSnapshot {
+            model: "claude-sonnet-4-20250514".into(),
+            input_tokens: 1_000_000,
+            output_tokens: 100_000,
+            ..Default::default()
+        };
+        let cost = estimate_cost(&usage);
+        // input: 1M * $3/M = $3.00, output: 0.1M * $15/M = $1.50 → $4.50
+        assert!((cost - 4.50).abs() < 0.01, "cost={cost}");
+    }
+
+    #[test]
+    fn estimate_cost_opus() {
+        let usage = UsageSnapshot {
+            model: "claude-opus-4-20250514".into(),
+            input_tokens: 500_000,
+            output_tokens: 50_000,
+            ..Default::default()
+        };
+        let cost = estimate_cost(&usage);
+        // input: 0.5M * $15/M = $7.50, output: 0.05M * $75/M = $3.75 → $11.25
+        assert!((cost - 11.25).abs() < 0.01, "cost={cost}");
+    }
+
+    #[test]
+    fn estimate_cost_unknown_model() {
+        let usage = UsageSnapshot {
+            model: "gpt-4o".into(),
+            input_tokens: 1_000_000,
+            output_tokens: 100_000,
+            ..Default::default()
+        };
+        let cost = estimate_cost(&usage);
+        assert_eq!(cost, 0.0, "unknown model should return 0");
+    }
+
+    #[test]
+    fn signals_extract_usage_from_transcript() {
+        let records = vec![
+            serde_json::json!({
+                "type": "system",
+                "model": "claude-sonnet-4-20250514"
+            }),
+            serde_json::json!({
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "model": "claude-sonnet-4-20250514",
+                    "usage": {
+                        "input_tokens": 1000,
+                        "output_tokens": 500,
+                        "cache_read_input_tokens": 200,
+                        "cache_creation_input_tokens": 50
+                    },
+                    "content": [{ "type": "text", "text": "Hello" }]
+                }
+            }),
+            serde_json::json!({
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "usage": {
+                        "input_tokens": 2000,
+                        "output_tokens": 800,
+                        "cache_read_input_tokens": 100,
+                        "cache_creation_input_tokens": 0
+                    },
+                    "content": [{ "type": "text", "text": "World" }]
+                }
+            }),
+        ];
+        let path = make_transcript(&records);
+        let signals = extract_session_signals(&path);
+        assert_eq!(signals.usage.model, "claude-sonnet-4-20250514");
+        assert_eq!(signals.usage.input_tokens, 3000);
+        assert_eq!(signals.usage.output_tokens, 1300);
+        assert_eq!(signals.usage.cache_read_tokens, 300);
+        assert_eq!(signals.usage.cache_creation_tokens, 50);
+        assert_eq!(signals.usage.total_tokens(), 4300);
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn usage_save_and_read_round_trip() {
+        let pid = "test_usage_rt_00";
+        let _ = edda_store::ensure_dirs(pid);
+
+        let signals = SessionSignals {
+            usage: UsageSnapshot {
+                model: "claude-sonnet-4-20250514".into(),
+                input_tokens: 5000,
+                output_tokens: 2000,
+                cache_read_tokens: 100,
+                cache_creation_tokens: 50,
+            },
+            ..Default::default()
+        };
+        save_session_signals(pid, "test-session", &signals);
+
+        let loaded = read_usage_state(pid);
+        assert_eq!(loaded.model, "claude-sonnet-4-20250514");
+        assert_eq!(loaded.input_tokens, 5000);
+        assert_eq!(loaded.output_tokens, 2000);
+        assert_eq!(loaded.cache_read_tokens, 100);
+        assert_eq!(loaded.cache_creation_tokens, 50);
+
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     }
 }

--- a/crates/edda-cli/Cargo.toml
+++ b/crates/edda-cli/Cargo.toml
@@ -27,6 +27,7 @@ edda-pack = { path = "../edda-pack", version = "0.1.1" }
 edda-mcp = { path = "../edda-mcp", version = "0.1.1" }
 edda-serve = { path = "../edda-serve", version = "0.1.1" }
 edda-notify = { path = "../edda-notify", version = "0.1.1" }
+edda-postmortem = { path = "../edda-postmortem", version = "0.1.1" }
 edda-search-fts = { path = "../edda-search-fts", version = "0.1.1" }
 edda-conductor = { path = "../edda-conductor", version = "0.1.1" }
 ratatui = { version = "0.29", optional = true }

--- a/crates/edda-cli/src/cmd_log.rs
+++ b/crates/edda-cli/src/cmd_log.rs
@@ -11,6 +11,7 @@ pub struct LogParams<'a> {
     pub after: Option<&'a str>,
     pub before: Option<&'a str>,
     pub branch: Option<&'a str>,
+    pub tool: Option<&'a str>,
     pub limit: usize,
     pub json: bool,
 }
@@ -49,9 +50,19 @@ pub fn execute(params: &LogParams<'_>) -> anyhow::Result<()> {
 }
 
 fn matches_filter(event: &Event, params: &LogParams<'_>) -> bool {
-    // --type filter
+    // --type filter (with "session" alias for session_digest tagged events)
     if let Some(t) = params.event_type {
-        if event.event_type != t {
+        if t == "session" {
+            let is_session_digest = event
+                .payload
+                .get("tags")
+                .and_then(|v| v.as_array())
+                .map(|arr| arr.iter().any(|t| t.as_str() == Some("session_digest")))
+                .unwrap_or(false);
+            if !is_session_digest {
+                return false;
+            }
+        } else if event.event_type != t {
             return false;
         }
     }
@@ -106,6 +117,21 @@ fn matches_filter(event: &Event, params: &LogParams<'_>) -> bool {
         }
     }
 
+    // --tool filter (check session_stats.tool_call_breakdown for a specific tool)
+    if let Some(tool) = params.tool {
+        let has_tool = event
+            .payload
+            .get("session_stats")
+            .and_then(|ss| ss.get("tool_call_breakdown"))
+            .and_then(|tb| tb.get(tool))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0)
+            > 0;
+        if !has_tool {
+            return false;
+        }
+    }
+
     true
 }
 
@@ -133,7 +159,21 @@ fn print_event_line(event: &Event) {
     );
 }
 
+fn is_session_digest(event: &Event) -> bool {
+    event
+        .payload
+        .get("tags")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().any(|t| t.as_str() == Some("session_digest")))
+        .unwrap_or(false)
+}
+
 fn format_event_detail(event: &Event) -> String {
+    // Session digest events get special formatting regardless of event_type
+    if is_session_digest(event) {
+        return format_session_digest_detail(event);
+    }
+
     match event.event_type.as_str() {
         "note" => {
             let text = event
@@ -238,6 +278,129 @@ fn format_event_detail(event: &Event) -> String {
     }
 }
 
+fn format_session_digest_detail(event: &Event) -> String {
+    let ss = event.payload.get("session_stats");
+    let tool_calls = ss
+        .and_then(|s| s.get("tool_calls"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let duration = ss
+        .and_then(|s| s.get("duration_minutes"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let outcome = ss
+        .and_then(|s| s.get("outcome"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+
+    let mut parts = vec![format!("{tool_calls} calls, {duration}m, {outcome}")];
+
+    // Tool breakdown
+    if let Some(tb) = ss.and_then(|s| s.get("tool_call_breakdown")).and_then(|v| v.as_object()) {
+        let breakdown: Vec<String> = tb
+            .iter()
+            .filter(|(_, v)| v.as_u64().unwrap_or(0) > 0)
+            .map(|(k, v)| format!("{}:{}", k, v.as_u64().unwrap_or(0)))
+            .collect();
+        if !breakdown.is_empty() {
+            parts.push(format!("[{}]", breakdown.join(" ")));
+        }
+    }
+
+    // Edit/search ratios
+    if let Some(edit_ratio) = ss.and_then(|s| s.get("edit_ratio")).and_then(|v| v.as_f64()) {
+        if edit_ratio > 0.0 {
+            parts.push(format!("edit:{:.0}%", edit_ratio * 100.0));
+        }
+    }
+    if let Some(search_ratio) = ss.and_then(|s| s.get("search_ratio")).and_then(|v| v.as_f64()) {
+        if search_ratio > 0.0 {
+            parts.push(format!("search:{:.0}%", search_ratio * 100.0));
+        }
+    }
+
+    // Model/tokens/cost
+    let model = ss
+        .and_then(|s| s.get("model"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let input_tokens = ss
+        .and_then(|s| s.get("input_tokens"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let output_tokens = ss
+        .and_then(|s| s.get("output_tokens"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let cost = ss
+        .and_then(|s| s.get("estimated_cost_usd"))
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+
+    if input_tokens > 0 || output_tokens > 0 {
+        let model_short = if model.is_empty() {
+            "unknown".to_string()
+        } else {
+            shorten_model_name(model)
+        };
+        let total = format_token_count(input_tokens + output_tokens);
+        let cost_str = if cost > 0.0 {
+            format!(" ${:.4}", cost)
+        } else {
+            String::new()
+        };
+        parts.push(format!("{model_short} {total}{cost_str}"));
+    }
+
+    parts.join("  ")
+}
+
+/// Shorten Claude model names for display.
+/// "claude-sonnet-4-20250514" -> "sonnet-4"
+/// "claude-opus-4-20250514" -> "opus-4"
+fn shorten_model_name(model: &str) -> String {
+    let lower = model.to_lowercase();
+    // Match patterns like "claude-{family}-{version}-{date}"
+    if lower.starts_with("claude-") {
+        let without_prefix = &model[7..]; // skip "claude-"
+        // Remove trailing date (YYYYMMDD)
+        let trimmed = if without_prefix.len() > 9 {
+            let last_dash = without_prefix.rfind('-').unwrap_or(without_prefix.len());
+            let after_dash = &without_prefix[last_dash + 1..];
+            // Check if it looks like a date (8 digits)
+            if after_dash.len() == 8 && after_dash.chars().all(|c| c.is_ascii_digit()) {
+                &without_prefix[..last_dash]
+            } else {
+                without_prefix
+            }
+        } else {
+            without_prefix
+        };
+        return trimmed.to_string();
+    }
+    model.to_string()
+}
+
+/// Format a token count for human-readable display.
+/// <1000 -> exact, 1k-999k -> "X.Xk", >=1M -> "X.XM"
+fn format_token_count(tokens: u64) -> String {
+    if tokens < 1_000 {
+        format!("{tokens}")
+    } else if tokens < 1_000_000 {
+        let k = tokens as f64 / 1_000.0;
+        if k >= 100.0 {
+            format!("{:.0}k", k)
+        } else if k >= 10.0 {
+            format!("{:.0}k", k)
+        } else {
+            format!("{:.1}k", k)
+        }
+    } else {
+        let m = tokens as f64 / 1_000_000.0;
+        format!("{:.1}M", m)
+    }
+}
+
 fn format_tags(event: &Event) -> String {
     event
         .payload
@@ -252,4 +415,157 @@ fn format_tags(event: &Event) -> String {
             tags.join("")
         })
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_token_count() {
+        assert_eq!(format_token_count(0), "0");
+        assert_eq!(format_token_count(999), "999");
+        assert_eq!(format_token_count(1_000), "1.0k");
+        assert_eq!(format_token_count(1_500), "1.5k");
+        assert_eq!(format_token_count(10_000), "10k");
+        assert_eq!(format_token_count(150_000), "150k");
+        assert_eq!(format_token_count(1_000_000), "1.0M");
+        assert_eq!(format_token_count(2_500_000), "2.5M");
+    }
+
+    #[test]
+    fn test_shorten_model_name() {
+        assert_eq!(
+            shorten_model_name("claude-sonnet-4-20250514"),
+            "sonnet-4"
+        );
+        assert_eq!(
+            shorten_model_name("claude-opus-4-20250514"),
+            "opus-4"
+        );
+        assert_eq!(
+            shorten_model_name("claude-haiku-3-5-20250514"),
+            "haiku-3-5"
+        );
+        assert_eq!(shorten_model_name("gpt-4o"), "gpt-4o");
+        assert_eq!(
+            shorten_model_name("claude-sonnet-4"),
+            "sonnet-4"
+        );
+    }
+
+    #[test]
+    fn test_session_digest_with_usage() {
+        let event = Event {
+            event_id: "evt_test123456789".into(),
+            event_type: "note".into(),
+            ts: "2026-03-01T10:00:00Z".into(),
+            branch: "main".into(),
+            event_family: Some("milestone".into()),
+            payload: serde_json::json!({
+                "tags": ["session_digest"],
+                "session_stats": {
+                    "tool_calls": 42,
+                    "duration_minutes": 15,
+                    "outcome": "completed",
+                    "tool_call_breakdown": {
+                        "Read": 10,
+                        "Edit": 8,
+                        "Bash": 6,
+                        "Grep": 5
+                    },
+                    "edit_ratio": 0.19,
+                    "search_ratio": 0.12,
+                    "model": "claude-sonnet-4-20250514",
+                    "input_tokens": 150000,
+                    "output_tokens": 30000,
+                    "estimated_cost_usd": 0.9
+                }
+            }),
+
+            refs: edda_core::types::Refs::default(),
+            hash: String::new(),
+            parent_hash: None,
+            digests: vec![],
+            event_level: None,
+            schema_version: 1,
+        };
+        assert!(is_session_digest(&event));
+        let detail = format_event_detail(&event);
+        assert!(detail.contains("42 calls"), "detail: {detail}");
+        assert!(detail.contains("15m"), "detail: {detail}");
+        assert!(detail.contains("completed"), "detail: {detail}");
+        assert!(detail.contains("sonnet-4"), "detail: {detail}");
+        assert!(detail.contains("180k"), "detail: {detail}"); // 150k+30k
+        assert!(detail.contains("$0.9000"), "detail: {detail}");
+    }
+
+    #[test]
+    fn test_session_digest_without_usage() {
+        let event = Event {
+            event_id: "evt_test123456789".into(),
+            event_type: "note".into(),
+            ts: "2026-03-01T10:00:00Z".into(),
+            branch: "main".into(),
+            event_family: Some("milestone".into()),
+            payload: serde_json::json!({
+                "tags": ["session_digest"],
+                "session_stats": {
+                    "tool_calls": 10,
+                    "duration_minutes": 5,
+                    "outcome": "completed",
+                    "model": "",
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "estimated_cost_usd": 0.0
+                }
+            }),
+
+            refs: edda_core::types::Refs::default(),
+            hash: String::new(),
+            parent_hash: None,
+            digests: vec![],
+            event_level: None,
+            schema_version: 1,
+        };
+        let detail = format_event_detail(&event);
+        assert!(detail.contains("10 calls"), "detail: {detail}");
+        // Should NOT contain model/token info when tokens are 0
+        assert!(!detail.contains("unknown"), "detail: {detail}");
+    }
+
+    #[test]
+    fn test_session_digest_with_usage_no_cost() {
+        let event = Event {
+            event_id: "evt_test123456789".into(),
+            event_type: "note".into(),
+            ts: "2026-03-01T10:00:00Z".into(),
+            branch: "main".into(),
+            event_family: Some("milestone".into()),
+            payload: serde_json::json!({
+                "tags": ["session_digest"],
+                "session_stats": {
+                    "tool_calls": 20,
+                    "duration_minutes": 8,
+                    "outcome": "completed",
+                    "model": "gpt-4o",
+                    "input_tokens": 50000,
+                    "output_tokens": 10000,
+                    "estimated_cost_usd": 0.0
+                }
+            }),
+
+            refs: edda_core::types::Refs::default(),
+            hash: String::new(),
+            parent_hash: None,
+            digests: vec![],
+            event_level: None,
+            schema_version: 1,
+        };
+        let detail = format_event_detail(&event);
+        assert!(detail.contains("gpt-4o"), "detail: {detail}");
+        assert!(detail.contains("60k"), "detail: {detail}"); // 50k+10k
+        // Should NOT contain $ when cost is 0
+        assert!(!detail.contains("$"), "detail: {detail}");
+    }
 }

--- a/crates/edda-cli/src/cmd_rules.rs
+++ b/crates/edda-cli/src/cmd_rules.rs
@@ -1,0 +1,132 @@
+//! CLI subcommand: `edda rules` — manage learned rules from L3 post-mortem.
+
+use clap::Subcommand;
+use std::path::Path;
+
+#[derive(Subcommand)]
+pub enum RulesCmd {
+    /// List all rules (default: alive only)
+    List {
+        /// Show all rules including dead/superseded
+        #[arg(long)]
+        all: bool,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show a specific rule by ID
+    Show {
+        /// Rule ID (rule_*)
+        id: String,
+    },
+    /// Run decay cycle on all rules
+    Decay,
+    /// Show rules store statistics
+    Stats,
+    /// Garbage-collect dead rules
+    Gc,
+}
+
+pub fn run(cmd: RulesCmd, repo_root: &Path) -> anyhow::Result<()> {
+    let project_id = edda_store::project_id(repo_root);
+
+    match cmd {
+        RulesCmd::List { all, json } => {
+            let store = edda_postmortem::RulesStore::load_project(&project_id);
+            let rules: Vec<_> = if all {
+                store.rules.iter().collect()
+            } else {
+                store.alive_rules()
+            };
+
+            if rules.is_empty() {
+                if !json {
+                    println!("No rules found.");
+                }
+                return Ok(());
+            }
+
+            if json {
+                for rule in &rules {
+                    println!("{}", serde_json::to_string(rule)?);
+                }
+            } else {
+                println!(
+                    "{:<12} {:<10} {:<12} {:<5} {}",
+                    "STATUS", "CATEGORY", "HITS", "TTL", "TRIGGER → ACTION"
+                );
+                println!("{}", "-".repeat(70));
+                for rule in &rules {
+                    println!(
+                        "{:<12} {:<10} {:<12} {:<5} {} → {}",
+                        rule.status,
+                        rule.category,
+                        rule.hits,
+                        rule.ttl_days,
+                        rule.trigger,
+                        rule.action,
+                    );
+                }
+                println!("\n{} rules shown.", rules.len());
+            }
+        }
+
+        RulesCmd::Show { id } => {
+            let store = edda_postmortem::RulesStore::load_project(&project_id);
+            match store.get(&id) {
+                Some(rule) => {
+                    println!("{}", serde_json::to_string_pretty(rule)?);
+                }
+                None => {
+                    anyhow::bail!("Rule not found: {id}");
+                }
+            }
+        }
+
+        RulesCmd::Decay => {
+            let mut store = edda_postmortem::RulesStore::load_project(&project_id);
+            let before = store.stats();
+            store.run_decay_cycle();
+            let after = store.stats();
+            store.save_project(&project_id)?;
+            println!("Decay cycle complete.");
+            println!(
+                "  Active: {} → {}",
+                before.active, after.active
+            );
+            println!(
+                "  Dormant: {} → {}",
+                before.dormant, after.dormant
+            );
+            println!(
+                "  Dead: {} → {}",
+                before.dead, after.dead
+            );
+        }
+
+        RulesCmd::Stats => {
+            let store = edda_postmortem::RulesStore::load_project(&project_id);
+            let stats = store.stats();
+            println!("Rules store statistics:");
+            println!("  Total:      {}", stats.total);
+            println!("  Proposed:   {}", stats.proposed);
+            println!("  Active:     {}", stats.active);
+            println!("  Dormant:    {}", stats.dormant);
+            println!("  Settled:    {}", stats.settled);
+            println!("  Dead:       {}", stats.dead);
+            println!("  Superseded: {}", stats.superseded);
+            if let Some(ref last) = store.last_decay_run {
+                println!("  Last decay: {}", last);
+            }
+        }
+
+        RulesCmd::Gc => {
+            let mut store = edda_postmortem::RulesStore::load_project(&project_id);
+            let removed = store.gc_dead_rules();
+            store.save_project(&project_id)?;
+            println!("Removed {removed} dead rules.");
+        }
+    }
+
+    Ok(())
+}

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -20,6 +20,7 @@ mod cmd_phase;
 mod cmd_pipeline;
 mod cmd_plan;
 mod cmd_rebuild;
+mod cmd_rules;
 mod cmd_run;
 mod cmd_search;
 mod cmd_serve;
@@ -169,7 +170,7 @@ enum Command {
     },
     /// Query events from the ledger with filters
     Log {
-        /// Filter by event type (note, cmd, commit, merge, etc.)
+        /// Filter by event type (note, cmd, commit, merge, session, etc.)
         #[arg(long = "type")]
         event_type: Option<String>,
         /// Filter by event family (signal, milestone, admin, governance)
@@ -190,6 +191,9 @@ enum Command {
         /// Filter by branch name
         #[arg(long)]
         branch: Option<String>,
+        /// Filter session digests by tool name (e.g. Edit, Read, Bash)
+        #[arg(long)]
+        tool: Option<String>,
         /// Maximum number of events to show (0 = unlimited)
         #[arg(long, default_value_t = 50)]
         limit: usize,
@@ -272,6 +276,11 @@ enum Command {
     Pattern {
         #[command(subcommand)]
         cmd: cmd_pattern::PatternCmd,
+    },
+    /// Manage learned rules from L3 post-mortem analysis
+    Rules {
+        #[command(subcommand)]
+        cmd: cmd_rules::RulesCmd,
     },
     /// MCP server operations
     Mcp {
@@ -865,6 +874,7 @@ fn main() -> anyhow::Result<()> {
             after,
             before,
             branch,
+            tool,
             limit,
             json,
         } => cmd_log::execute(&cmd_log::LogParams {
@@ -876,6 +886,7 @@ fn main() -> anyhow::Result<()> {
             after: after.as_deref(),
             before: before.as_deref(),
             branch: branch.as_deref(),
+            tool: tool.as_deref(),
             limit,
             json,
         }),
@@ -897,6 +908,7 @@ fn main() -> anyhow::Result<()> {
         Command::Index { cmd } => cmd_bridge::run_index(cmd),
         Command::Config { cmd } => cmd_config::run(cmd, &repo_root),
         Command::Pattern { cmd } => cmd_pattern::run(cmd, &repo_root),
+        Command::Rules { cmd } => cmd_rules::run(cmd, &repo_root),
         Command::Mcp { cmd } => match cmd {
             McpCommand::Serve => {
                 tokio::runtime::Runtime::new()?.block_on(edda_mcp::serve(&repo_root))?;

--- a/crates/edda-postmortem/Cargo.toml
+++ b/crates/edda-postmortem/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "edda-postmortem"
+description = "L3 post-mortem analysis and learned rules with TTL decay for Edda"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+categories.workspace = true
+keywords.workspace = true
+
+[dependencies]
+edda-core = { path = "../edda-core", version = "0.1.1" }
+edda-store = { path = "../edda-store", version = "0.1.1" }
+anyhow.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+time.workspace = true
+ulid.workspace = true
+sha2.workspace = true
+hex.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/edda-postmortem/src/analyzer.rs
+++ b/crates/edda-postmortem/src/analyzer.rs
@@ -1,0 +1,357 @@
+//! Post-mortem analysis: produce lessons and rule proposals from session data.
+//!
+//! The analyzer takes session statistics and trigger reasons, then produces
+//! structured findings. The current implementation uses deterministic heuristics;
+//! future versions can delegate to LLM (Sonnet) for deeper analysis.
+//!
+//! Output hierarchy (from GH-157 spec):
+//!   - **Rules**: Hook-enforced (block/auto-run), 100% compliance
+//!   - **Lessons**: CLAUDE.md auto-maintained paragraph, ~90% compliance
+//!   - **Observations**: `edda ask` on-demand, no enforcement
+
+use serde::{Deserialize, Serialize};
+
+use crate::rules::RuleCategory;
+use crate::trigger::{PostMortemTrigger, TriggerReason};
+
+/// Severity of a lesson.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LessonSeverity {
+    /// Minor observation, useful context.
+    Low,
+    /// Actionable insight, should influence future work.
+    Medium,
+    /// Critical lesson, likely produces a rule proposal.
+    High,
+}
+
+/// A lesson extracted from post-mortem analysis (descriptive, not prescriptive).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Lesson {
+    pub id: String,
+    pub text: String,
+    pub severity: LessonSeverity,
+    pub tags: Vec<String>,
+    pub source_trigger: String,
+}
+
+/// A rule proposal from post-mortem analysis (prescriptive).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuleProposal {
+    pub trigger: String,
+    pub action: String,
+    pub anchor_file: Option<String>,
+    pub category: RuleCategory,
+    pub confidence: f64,
+    pub evidence: Vec<String>,
+}
+
+/// Complete result of a post-mortem analysis.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PostMortemResult {
+    pub session_id: String,
+    pub triggers: Vec<TriggerReason>,
+    pub lessons: Vec<Lesson>,
+    pub rule_proposals: Vec<RuleProposal>,
+    pub analyzed_at: String,
+}
+
+/// Session data available for analysis.
+#[derive(Debug, Clone, Default)]
+pub struct AnalysisInput {
+    pub session_id: String,
+    pub user_prompts: u64,
+    pub tool_failures: u64,
+    pub failed_commands: Vec<String>,
+    pub files_modified: Vec<String>,
+    pub file_edit_counts: Vec<(String, u64)>,
+    pub commits_made: Vec<String>,
+    pub decisions_superseded: u64,
+    pub had_conflict: bool,
+    pub outcome: String,
+    pub duration_minutes: u64,
+}
+
+/// Run deterministic post-mortem analysis on a triggered session.
+///
+/// Produces lessons and rule proposals based on trigger reasons and session data.
+/// This is the heuristic analyzer — no LLM calls. Future: `analyze_with_llm()`.
+pub fn analyze(trigger: &PostMortemTrigger, input: &AnalysisInput) -> PostMortemResult {
+    let mut lessons = Vec::new();
+    let mut rule_proposals = Vec::new();
+
+    for reason in &trigger.reasons {
+        match reason {
+            TriggerReason::SessionFailures => {
+                analyze_failures(input, &mut lessons, &mut rule_proposals);
+            }
+            TriggerReason::AbnormallyLong => {
+                analyze_long_session(input, &mut lessons);
+            }
+            TriggerReason::ExcessiveFileEdits => {
+                analyze_file_churn(input, &mut lessons, &mut rule_proposals);
+            }
+            TriggerReason::DecisionSuperseded => {
+                analyze_decision_reversal(input, &mut lessons);
+            }
+            TriggerReason::MultiAgentConflict => {
+                analyze_conflict(input, &mut lessons, &mut rule_proposals);
+            }
+        }
+    }
+
+    PostMortemResult {
+        session_id: input.session_id.clone(),
+        triggers: trigger.reasons.clone(),
+        lessons,
+        rule_proposals,
+        analyzed_at: now_rfc3339(),
+    }
+}
+
+// -- Per-trigger analyzers --
+
+fn analyze_failures(
+    input: &AnalysisInput,
+    lessons: &mut Vec<Lesson>,
+    rule_proposals: &mut Vec<RuleProposal>,
+) {
+    // Lesson: session had failures
+    if input.outcome == "error_stuck" {
+        lessons.push(Lesson {
+            id: new_lesson_id(),
+            text: format!(
+                "Session got stuck after {} consecutive failures. \
+                 Consider breaking the task into smaller steps.",
+                input.tool_failures
+            ),
+            severity: LessonSeverity::High,
+            tags: vec!["failure".into(), "stuck".into()],
+            source_trigger: "session_failures".into(),
+        });
+    }
+
+    // Rule proposal: if specific commands keep failing, suggest a pre-check
+    for cmd in &input.failed_commands {
+        let short_cmd = cmd.split_whitespace().next().unwrap_or(cmd);
+        rule_proposals.push(RuleProposal {
+            trigger: format!("command_failure:{short_cmd}"),
+            action: format!("Verify {short_cmd} is available and configured before running"),
+            anchor_file: None,
+            category: RuleCategory::Workflow,
+            confidence: 0.6,
+            evidence: vec![format!("Failed command: {cmd}")],
+        });
+    }
+
+    if input.tool_failures > 3 {
+        lessons.push(Lesson {
+            id: new_lesson_id(),
+            text: format!(
+                "{} tool failures in session. Pattern suggests environment or dependency issue.",
+                input.tool_failures
+            ),
+            severity: LessonSeverity::Medium,
+            tags: vec!["failure".into(), "tools".into()],
+            source_trigger: "session_failures".into(),
+        });
+    }
+}
+
+fn analyze_long_session(input: &AnalysisInput, lessons: &mut Vec<Lesson>) {
+    lessons.push(Lesson {
+        id: new_lesson_id(),
+        text: format!(
+            "Session ran for {} user prompts ({} minutes). \
+             Long sessions reduce focus — consider splitting into sub-tasks.",
+            input.user_prompts, input.duration_minutes
+        ),
+        severity: LessonSeverity::Medium,
+        tags: vec!["long_session".into(), "productivity".into()],
+        source_trigger: "abnormally_long".into(),
+    });
+}
+
+fn analyze_file_churn(
+    input: &AnalysisInput,
+    lessons: &mut Vec<Lesson>,
+    rule_proposals: &mut Vec<RuleProposal>,
+) {
+    let churned: Vec<&(String, u64)> = input
+        .file_edit_counts
+        .iter()
+        .filter(|(_, count)| *count >= 3)
+        .collect();
+
+    for (file, count) in &churned {
+        lessons.push(Lesson {
+            id: new_lesson_id(),
+            text: format!(
+                "File '{file}' was edited {count} times. \
+                 Frequent edits to the same file suggest unclear requirements or iterative debugging.",
+            ),
+            severity: LessonSeverity::Medium,
+            tags: vec!["churn".into(), "file_edits".into()],
+            source_trigger: "excessive_file_edits".into(),
+        });
+
+        // Propose a rule: if a file is frequently edited, add a pre-commit check
+        rule_proposals.push(RuleProposal {
+            trigger: format!("file_churn:{file}"),
+            action: format!("Review '{file}' carefully before committing — historically unstable"),
+            anchor_file: Some(file.clone()),
+            category: RuleCategory::PreCommit,
+            confidence: 0.5,
+            evidence: vec![format!("Edited {count} times in session {}", input.session_id)],
+        });
+    }
+}
+
+fn analyze_decision_reversal(input: &AnalysisInput, lessons: &mut Vec<Lesson>) {
+    lessons.push(Lesson {
+        id: new_lesson_id(),
+        text: format!(
+            "{} decision(s) were superseded during this session. \
+             Consider spending more time on upfront design before committing to an approach.",
+            input.decisions_superseded
+        ),
+        severity: LessonSeverity::High,
+        tags: vec!["decision".into(), "reversal".into()],
+        source_trigger: "decision_superseded".into(),
+    });
+}
+
+fn analyze_conflict(
+    input: &AnalysisInput,
+    lessons: &mut Vec<Lesson>,
+    rule_proposals: &mut Vec<RuleProposal>,
+) {
+    lessons.push(Lesson {
+        id: new_lesson_id(),
+        text: "Multi-agent conflict detected. \
+               Ensure agents claim non-overlapping scopes before starting work."
+            .to_string(),
+        severity: LessonSeverity::High,
+        tags: vec!["conflict".into(), "multi_agent".into()],
+        source_trigger: "multi_agent_conflict".into(),
+    });
+
+    rule_proposals.push(RuleProposal {
+        trigger: "multi_agent_start".to_string(),
+        action: "Run `edda claim` to claim scope before starting multi-agent work".to_string(),
+        anchor_file: None,
+        category: RuleCategory::Workflow,
+        confidence: 0.8,
+        evidence: vec![format!(
+            "Conflict detected in session {}",
+            input.session_id
+        )],
+    });
+}
+
+// -- Helpers --
+
+fn new_lesson_id() -> String {
+    format!("lesson_{}", ulid::Ulid::new().to_string().to_lowercase())
+}
+
+fn now_rfc3339() -> String {
+    let now = time::OffsetDateTime::now_utc();
+    now.format(&time::format_description::well_known::Rfc3339)
+        .expect("RFC3339 formatting should not fail")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::trigger::PostMortemTrigger;
+
+    fn trigger_with(reasons: Vec<TriggerReason>) -> PostMortemTrigger {
+        PostMortemTrigger {
+            should_analyze: true,
+            reasons,
+            session_id: "test-session".to_string(),
+        }
+    }
+
+    fn base_input() -> AnalysisInput {
+        AnalysisInput {
+            session_id: "test-session".to_string(),
+            outcome: "completed".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn analyze_session_failures_produces_lessons() {
+        let trigger = trigger_with(vec![TriggerReason::SessionFailures]);
+        let mut input = base_input();
+        input.outcome = "error_stuck".to_string();
+        input.tool_failures = 5;
+        input.failed_commands = vec!["npm test".to_string()];
+
+        let result = analyze(&trigger, &input);
+        assert!(!result.lessons.is_empty());
+        assert!(!result.rule_proposals.is_empty());
+        assert!(result
+            .lessons
+            .iter()
+            .any(|l| l.tags.contains(&"stuck".to_string())));
+    }
+
+    #[test]
+    fn analyze_long_session_produces_lesson() {
+        let trigger = trigger_with(vec![TriggerReason::AbnormallyLong]);
+        let mut input = base_input();
+        input.user_prompts = 30;
+        input.duration_minutes = 45;
+
+        let result = analyze(&trigger, &input);
+        assert_eq!(result.lessons.len(), 1);
+        assert!(result.lessons[0].text.contains("30 user prompts"));
+    }
+
+    #[test]
+    fn analyze_file_churn_produces_rule_proposal() {
+        let trigger = trigger_with(vec![TriggerReason::ExcessiveFileEdits]);
+        let mut input = base_input();
+        input.file_edit_counts = vec![("src/main.rs".to_string(), 5)];
+
+        let result = analyze(&trigger, &input);
+        assert!(!result.lessons.is_empty());
+        assert!(!result.rule_proposals.is_empty());
+        assert!(result.rule_proposals[0].trigger.contains("file_churn"));
+    }
+
+    #[test]
+    fn analyze_conflict_produces_high_severity() {
+        let trigger = trigger_with(vec![TriggerReason::MultiAgentConflict]);
+        let input = base_input();
+
+        let result = analyze(&trigger, &input);
+        assert!(result
+            .lessons
+            .iter()
+            .any(|l| l.severity == LessonSeverity::High));
+        assert!(!result.rule_proposals.is_empty());
+    }
+
+    #[test]
+    fn multiple_triggers_produce_combined_results() {
+        let trigger = trigger_with(vec![
+            TriggerReason::SessionFailures,
+            TriggerReason::AbnormallyLong,
+            TriggerReason::ExcessiveFileEdits,
+        ]);
+        let mut input = base_input();
+        input.tool_failures = 5;
+        input.user_prompts = 30;
+        input.duration_minutes = 45;
+        input.file_edit_counts = vec![("a.rs".to_string(), 4)];
+
+        let result = analyze(&trigger, &input);
+        // Should have lessons from multiple triggers
+        assert!(result.lessons.len() >= 3);
+    }
+}

--- a/crates/edda-postmortem/src/hooks.rs
+++ b/crates/edda-postmortem/src/hooks.rs
@@ -1,0 +1,273 @@
+//! Rule execution via hooks.
+//!
+//! Rules are NOT context injections (50-70% compliance). They are hooks
+//! that block or warn (100% compliance). This module provides the
+//! enforcement interface for the bridge hook system.
+//!
+//! Execution model:
+//! - PreCommit hook reads rules store -> executes matching checks
+//! - Each active rule's trigger is matched against the current context
+//! - Matching rules produce either a block (exit 1) or warn (stderr)
+
+use crate::rules::{RuleCategory, RulesStore};
+use serde::{Deserialize, Serialize};
+
+/// Action to take when a rule matches.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Enforcement {
+    /// Block the operation with a message.
+    Block(String),
+    /// Warn but allow the operation.
+    Warn(String),
+}
+
+/// Context for evaluating rules against current operation.
+#[derive(Debug, Clone, Default)]
+pub struct HookContext {
+    /// Which hook event is firing (e.g., "PreToolUse", "PostToolUse").
+    pub hook_event: String,
+    /// Tool being used (e.g., "Bash", "Write", "Edit").
+    pub tool_name: String,
+    /// Files being modified in this operation.
+    pub files_touched: Vec<String>,
+    /// Current working directory.
+    pub cwd: String,
+}
+
+/// Result of evaluating all active rules against a hook context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluationResult {
+    pub rules_checked: usize,
+    pub rules_matched: usize,
+    pub matched_rule_ids: Vec<String>,
+    pub enforcements: Vec<EnforcementRecord>,
+}
+
+/// Record of a single rule enforcement.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnforcementRecord {
+    pub rule_id: String,
+    pub trigger: String,
+    pub action: String,
+    pub category: String,
+}
+
+/// Map hook event to the relevant rule categories.
+fn relevant_categories(hook_event: &str) -> Vec<RuleCategory> {
+    match hook_event {
+        "PreToolUse" => vec![
+            RuleCategory::PreCommit,
+            RuleCategory::CodePattern,
+            RuleCategory::Workflow,
+        ],
+        "PostToolUse" => vec![RuleCategory::CodePattern, RuleCategory::Workflow],
+        _ => vec![RuleCategory::Workflow],
+    }
+}
+
+/// Evaluate all active rules against the current hook context.
+///
+/// Returns matched rules and their enforcement actions. The caller
+/// (bridge dispatch) decides whether to block or warn based on results.
+pub fn evaluate_rules(store: &RulesStore, ctx: &HookContext) -> EvaluationResult {
+    let active = store.active_rules();
+    let categories = relevant_categories(&ctx.hook_event);
+    let mut matched_ids = Vec::new();
+    let mut enforcements = Vec::new();
+
+    for rule in &active {
+        // Filter by category relevance
+        if !categories.contains(&rule.category) {
+            continue;
+        }
+
+        // Match trigger against context
+        if matches_trigger(&rule.trigger, ctx) {
+            matched_ids.push(rule.id.clone());
+            enforcements.push(EnforcementRecord {
+                rule_id: rule.id.clone(),
+                trigger: rule.trigger.clone(),
+                action: rule.action.clone(),
+                category: rule.category.to_string(),
+            });
+        }
+    }
+
+    EvaluationResult {
+        rules_checked: active.len(),
+        rules_matched: matched_ids.len(),
+        matched_rule_ids: matched_ids,
+        enforcements,
+    }
+}
+
+/// Record hits for all matched rules (updates last_hit and hit count).
+pub fn record_matched_hits(store: &mut RulesStore, matched_ids: &[String]) {
+    for id in matched_ids {
+        if let Some(rule) = store.get_mut(id) {
+            rule.record_hit();
+        }
+    }
+}
+
+/// Format enforcement results as a warning message for the user.
+pub fn format_warnings(result: &EvaluationResult) -> Option<String> {
+    if result.enforcements.is_empty() {
+        return None;
+    }
+
+    let mut lines = vec!["[edda L3] Learned rules triggered:".to_string()];
+    for e in &result.enforcements {
+        lines.push(format!("  - {} -> {}", e.trigger, e.action));
+    }
+    Some(lines.join("\n"))
+}
+
+// -- Trigger matching --
+
+/// Check if a rule trigger matches the current hook context.
+///
+/// Trigger format:
+///   - `file_churn:<path>` -- matches if the path is in files_touched
+///   - `command_failure:<cmd>` -- matches if tool_name is "Bash"
+///   - `multi_agent_start` -- matches on SessionStart-like events
+///   - Plain text -- substring match against tool_name or files_touched
+fn matches_trigger(trigger: &str, ctx: &HookContext) -> bool {
+    if let Some(path) = trigger.strip_prefix("file_churn:") {
+        return ctx.files_touched.iter().any(|f| f.contains(path));
+    }
+
+    if let Some(cmd) = trigger.strip_prefix("command_failure:") {
+        return ctx.tool_name == "Bash" && ctx.cwd.contains(cmd);
+    }
+
+    if trigger == "multi_agent_start" {
+        return ctx.hook_event == "SessionStart";
+    }
+
+    // Fallback: substring match on tool name or files
+    if ctx.tool_name.contains(trigger) {
+        return true;
+    }
+    ctx.files_touched.iter().any(|f| f.contains(trigger))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rules::{Rule, RuleCategory, RuleStatus, RulesStore};
+
+    fn active_rule(trigger: &str, action: &str, category: RuleCategory) -> Rule {
+        Rule {
+            id: format!("rule_test_{}", trigger.replace(':', "_")),
+            trigger: trigger.to_string(),
+            action: action.to_string(),
+            anchor_file: None,
+            anchor_hash: None,
+            created: "2026-01-01T00:00:00Z".to_string(),
+            last_hit: "2026-01-01T00:00:00Z".to_string(),
+            hits: 2,
+            ttl_days: 30,
+            superseded_by: None,
+            status: RuleStatus::Active,
+            source_session: "test".to_string(),
+            source_event: None,
+            category,
+        }
+    }
+
+    fn make_store(rules: Vec<Rule>) -> RulesStore {
+        RulesStore {
+            rules,
+            last_decay_run: None,
+        }
+    }
+
+    #[test]
+    fn file_churn_trigger_matches_touched_files() {
+        let store = make_store(vec![active_rule(
+            "file_churn:src/main.rs",
+            "Review carefully",
+            RuleCategory::PreCommit,
+        )]);
+
+        let ctx = HookContext {
+            hook_event: "PreToolUse".to_string(),
+            tool_name: "Write".to_string(),
+            files_touched: vec!["src/main.rs".to_string()],
+            cwd: "/project".to_string(),
+        };
+
+        let result = evaluate_rules(&store, &ctx);
+        assert_eq!(result.rules_matched, 1);
+    }
+
+    #[test]
+    fn no_match_when_file_not_touched() {
+        let store = make_store(vec![active_rule(
+            "file_churn:src/main.rs",
+            "Review carefully",
+            RuleCategory::PreCommit,
+        )]);
+
+        let ctx = HookContext {
+            hook_event: "PreToolUse".to_string(),
+            tool_name: "Write".to_string(),
+            files_touched: vec!["src/lib.rs".to_string()],
+            cwd: "/project".to_string(),
+        };
+
+        let result = evaluate_rules(&store, &ctx);
+        assert_eq!(result.rules_matched, 0);
+    }
+
+    #[test]
+    fn dormant_rules_not_evaluated() {
+        let mut rule = active_rule(
+            "file_churn:src/main.rs",
+            "Review carefully",
+            RuleCategory::PreCommit,
+        );
+        rule.status = RuleStatus::Dormant;
+        let store = make_store(vec![rule]);
+
+        let ctx = HookContext {
+            hook_event: "PreToolUse".to_string(),
+            tool_name: "Write".to_string(),
+            files_touched: vec!["src/main.rs".to_string()],
+            cwd: "/project".to_string(),
+        };
+
+        let result = evaluate_rules(&store, &ctx);
+        assert_eq!(result.rules_matched, 0);
+    }
+
+    #[test]
+    fn format_warnings_empty_when_no_matches() {
+        let result = EvaluationResult {
+            rules_checked: 5,
+            rules_matched: 0,
+            matched_rule_ids: vec![],
+            enforcements: vec![],
+        };
+        assert!(format_warnings(&result).is_none());
+    }
+
+    #[test]
+    fn format_warnings_produces_output() {
+        let result = EvaluationResult {
+            rules_checked: 5,
+            rules_matched: 1,
+            matched_rule_ids: vec!["rule_1".to_string()],
+            enforcements: vec![EnforcementRecord {
+                rule_id: "rule_1".to_string(),
+                trigger: "file_churn:main.rs".to_string(),
+                action: "Review carefully".to_string(),
+                category: "pre_commit".to_string(),
+            }],
+        };
+        let warning = format_warnings(&result).unwrap();
+        assert!(warning.contains("Learned rules triggered"));
+        assert!(warning.contains("file_churn:main.rs"));
+    }
+}

--- a/crates/edda-postmortem/src/lessons.rs
+++ b/crates/edda-postmortem/src/lessons.rs
@@ -1,0 +1,372 @@
+//! Lesson management: persist lessons and maintain CLAUDE.md integration.
+//!
+//! Output hierarchy:
+//!   - Rules: Hook (block/auto-run), 100% compliance
+//!   - **Lessons**: CLAUDE.md auto-maintained paragraph, ~90% compliance
+//!   - Observations: `edda ask` on-demand, no enforcement
+//!
+//! Lessons are stored per-project in state/lessons.json and optionally
+//! synced to a managed section in the project's CLAUDE.md.
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::analyzer::Lesson;
+
+/// Persistent store for lessons.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LessonsStore {
+    pub lessons: Vec<StoredLesson>,
+    #[serde(default)]
+    pub last_updated: Option<String>,
+}
+
+/// A lesson with persistence metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredLesson {
+    pub id: String,
+    pub text: String,
+    pub severity: String,
+    pub tags: Vec<String>,
+    pub source_session: String,
+    pub source_trigger: String,
+    pub created_at: String,
+    /// Number of times this lesson pattern was seen.
+    pub occurrences: u64,
+}
+
+/// CLAUDE.md managed section markers.
+const CLAUDE_MD_SECTION_START: &str = "<!-- edda:lessons:start -->";
+const CLAUDE_MD_SECTION_END: &str = "<!-- edda:lessons:end -->";
+
+impl LessonsStore {
+    /// Load from disk, returning default if not found.
+    pub fn load(path: &Path) -> Self {
+        match fs::read_to_string(path) {
+            Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+            Err(_) => Self::default(),
+        }
+    }
+
+    /// Persist to disk atomically.
+    pub fn save(&self, path: &Path) -> anyhow::Result<()> {
+        let json = serde_json::to_string_pretty(self)?;
+        edda_store::write_atomic(path, json.as_bytes())
+    }
+
+    /// Resolve the lessons path for a project.
+    pub fn project_path(project_id: &str) -> PathBuf {
+        edda_store::project_dir(project_id)
+            .join("state")
+            .join("lessons.json")
+    }
+
+    /// Load project-scoped lessons.
+    pub fn load_project(project_id: &str) -> Self {
+        Self::load(&Self::project_path(project_id))
+    }
+
+    /// Save project-scoped lessons.
+    pub fn save_project(&self, project_id: &str) -> anyhow::Result<()> {
+        self.save(&Self::project_path(project_id))
+    }
+
+    /// Add lessons from a post-mortem analysis.
+    /// Deduplicates by checking if a similar lesson already exists (same tags + trigger).
+    pub fn add_lessons(&mut self, lessons: &[Lesson], session_id: &str) {
+        let now = now_rfc3339();
+        for lesson in lessons {
+            // Check for duplicate: same trigger + similar tags
+            if let Some(existing) = self
+                .lessons
+                .iter_mut()
+                .find(|l| l.source_trigger == lesson.source_trigger && l.tags == lesson.tags)
+            {
+                existing.occurrences += 1;
+                existing.text = lesson.text.clone(); // Update text with latest
+                continue;
+            }
+
+            self.lessons.push(StoredLesson {
+                id: lesson.id.clone(),
+                text: lesson.text.clone(),
+                severity: format!("{:?}", lesson.severity).to_lowercase(),
+                tags: lesson.tags.clone(),
+                source_session: session_id.to_string(),
+                source_trigger: lesson.source_trigger.clone(),
+                created_at: now.clone(),
+                occurrences: 1,
+            });
+        }
+        self.last_updated = Some(now);
+    }
+
+    /// Get the top N lessons by occurrence count, for CLAUDE.md sync.
+    pub fn top_lessons(&self, n: usize) -> Vec<&StoredLesson> {
+        let mut sorted: Vec<&StoredLesson> = self.lessons.iter().collect();
+        sorted.sort_by(|a, b| b.occurrences.cmp(&a.occurrences));
+        sorted.truncate(n);
+        sorted
+    }
+
+    /// Render lessons as a markdown section for CLAUDE.md.
+    pub fn render_claude_md_section(&self, max_lessons: usize) -> String {
+        let top = self.top_lessons(max_lessons);
+        if top.is_empty() {
+            return String::new();
+        }
+
+        let mut lines = vec![
+            CLAUDE_MD_SECTION_START.to_string(),
+            "## Learned Lessons (edda L3)".to_string(),
+            String::new(),
+        ];
+
+        for lesson in &top {
+            let severity_marker = match lesson.severity.as_str() {
+                "high" => "!",
+                "medium" => "*",
+                _ => "-",
+            };
+            lines.push(format!(
+                "{severity_marker} {} (seen {}x)",
+                lesson.text, lesson.occurrences
+            ));
+        }
+
+        lines.push(String::new());
+        lines.push(CLAUDE_MD_SECTION_END.to_string());
+        lines.join("\n")
+    }
+
+    /// Sync lessons to a CLAUDE.md file, replacing the managed section.
+    ///
+    /// If the file doesn't have the managed section markers, appends them.
+    /// Returns true if the file was modified.
+    pub fn sync_to_claude_md(
+        &self,
+        claude_md_path: &Path,
+        max_lessons: usize,
+    ) -> anyhow::Result<bool> {
+        let section = self.render_claude_md_section(max_lessons);
+        if section.is_empty() {
+            return Ok(false);
+        }
+
+        let content = fs::read_to_string(claude_md_path).unwrap_or_default();
+
+        let new_content = if let (Some(start_pos), Some(end_pos)) = (
+            content.find(CLAUDE_MD_SECTION_START),
+            content.find(CLAUDE_MD_SECTION_END),
+        ) {
+            // Replace existing section
+            let end_pos = end_pos + CLAUDE_MD_SECTION_END.len();
+            format!(
+                "{}{}{}",
+                &content[..start_pos],
+                section,
+                &content[end_pos..]
+            )
+        } else {
+            // Append new section
+            if content.is_empty() {
+                section
+            } else {
+                format!("{}\n\n{}", content.trim_end(), section)
+            }
+        };
+
+        if new_content == content {
+            return Ok(false);
+        }
+
+        edda_store::write_atomic(claude_md_path, new_content.as_bytes())?;
+        Ok(true)
+    }
+}
+
+fn now_rfc3339() -> String {
+    let now = time::OffsetDateTime::now_utc();
+    now.format(&time::format_description::well_known::Rfc3339)
+        .expect("RFC3339 formatting should not fail")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analyzer::{Lesson, LessonSeverity};
+
+    fn make_lesson(text: &str, trigger: &str, tags: &[&str]) -> Lesson {
+        Lesson {
+            id: format!("lesson_{}", text.len()),
+            text: text.to_string(),
+            severity: LessonSeverity::Medium,
+            tags: tags.iter().map(|t| t.to_string()).collect(),
+            source_trigger: trigger.to_string(),
+        }
+    }
+
+    #[test]
+    fn add_lessons_deduplicates() {
+        let mut store = LessonsStore::default();
+        let lessons = vec![make_lesson(
+            "Test lesson",
+            "session_failures",
+            &["failure"],
+        )];
+
+        store.add_lessons(&lessons, "s1");
+        assert_eq!(store.lessons.len(), 1);
+        assert_eq!(store.lessons[0].occurrences, 1);
+
+        // Add same lesson again -> increment occurrences
+        store.add_lessons(&lessons, "s2");
+        assert_eq!(store.lessons.len(), 1);
+        assert_eq!(store.lessons[0].occurrences, 2);
+    }
+
+    #[test]
+    fn different_lessons_not_deduplicated() {
+        let mut store = LessonsStore::default();
+        store.add_lessons(
+            &[make_lesson("Lesson A", "trigger_a", &["tag_a"])],
+            "s1",
+        );
+        store.add_lessons(
+            &[make_lesson("Lesson B", "trigger_b", &["tag_b"])],
+            "s2",
+        );
+        assert_eq!(store.lessons.len(), 2);
+    }
+
+    #[test]
+    fn top_lessons_sorted_by_occurrence() {
+        let mut store = LessonsStore::default();
+        store.lessons.push(StoredLesson {
+            id: "l1".into(),
+            text: "Low".into(),
+            severity: "low".into(),
+            tags: vec![],
+            source_session: "s1".into(),
+            source_trigger: "t1".into(),
+            created_at: "2026-01-01T00:00:00Z".into(),
+            occurrences: 1,
+        });
+        store.lessons.push(StoredLesson {
+            id: "l2".into(),
+            text: "High".into(),
+            severity: "high".into(),
+            tags: vec![],
+            source_session: "s2".into(),
+            source_trigger: "t2".into(),
+            created_at: "2026-01-01T00:00:00Z".into(),
+            occurrences: 5,
+        });
+
+        let top = store.top_lessons(1);
+        assert_eq!(top.len(), 1);
+        assert_eq!(top[0].text, "High");
+    }
+
+    #[test]
+    fn render_claude_md_section_empty_when_no_lessons() {
+        let store = LessonsStore::default();
+        assert!(store.render_claude_md_section(5).is_empty());
+    }
+
+    #[test]
+    fn render_claude_md_section_with_lessons() {
+        let mut store = LessonsStore::default();
+        store.lessons.push(StoredLesson {
+            id: "l1".into(),
+            text: "Always run tests".into(),
+            severity: "high".into(),
+            tags: vec![],
+            source_session: "s1".into(),
+            source_trigger: "t1".into(),
+            created_at: "2026-01-01T00:00:00Z".into(),
+            occurrences: 3,
+        });
+
+        let section = store.render_claude_md_section(5);
+        assert!(section.contains(CLAUDE_MD_SECTION_START));
+        assert!(section.contains(CLAUDE_MD_SECTION_END));
+        assert!(section.contains("Always run tests"));
+        assert!(section.contains("3x"));
+    }
+
+    #[test]
+    fn sync_to_claude_md_appends_if_no_section() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("CLAUDE.md");
+        fs::write(&path, "# My Project\n\nSome content.\n").unwrap();
+
+        let mut store = LessonsStore::default();
+        store.lessons.push(StoredLesson {
+            id: "l1".into(),
+            text: "Test lesson".into(),
+            severity: "medium".into(),
+            tags: vec![],
+            source_session: "s1".into(),
+            source_trigger: "t1".into(),
+            created_at: "2026-01-01T00:00:00Z".into(),
+            occurrences: 1,
+        });
+
+        let modified = store.sync_to_claude_md(&path, 5).unwrap();
+        assert!(modified);
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("# My Project"));
+        assert!(content.contains(CLAUDE_MD_SECTION_START));
+        assert!(content.contains("Test lesson"));
+    }
+
+    #[test]
+    fn sync_to_claude_md_replaces_existing_section() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("CLAUDE.md");
+        let initial = format!(
+            "# Project\n\n{}\nOld lessons\n{}\n\nMore content.",
+            CLAUDE_MD_SECTION_START, CLAUDE_MD_SECTION_END
+        );
+        fs::write(&path, &initial).unwrap();
+
+        let mut store = LessonsStore::default();
+        store.lessons.push(StoredLesson {
+            id: "l1".into(),
+            text: "New lesson".into(),
+            severity: "medium".into(),
+            tags: vec![],
+            source_session: "s1".into(),
+            source_trigger: "t1".into(),
+            created_at: "2026-01-01T00:00:00Z".into(),
+            occurrences: 2,
+        });
+
+        let modified = store.sync_to_claude_md(&path, 5).unwrap();
+        assert!(modified);
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(!content.contains("Old lessons"));
+        assert!(content.contains("New lesson"));
+        assert!(content.contains("More content."));
+    }
+
+    #[test]
+    fn store_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("lessons.json");
+
+        let mut store = LessonsStore::default();
+        store.add_lessons(
+            &[make_lesson("Test", "trigger", &["tag"])],
+            "s1",
+        );
+        store.save(&path).unwrap();
+
+        let loaded = LessonsStore::load(&path);
+        assert_eq!(loaded.lessons.len(), 1);
+    }
+}

--- a/crates/edda-postmortem/src/lib.rs
+++ b/crates/edda-postmortem/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod analyzer;
+pub mod hooks;
+pub mod lessons;
+pub mod rules;
+pub mod trigger;
+
+pub use rules::{Rule, RuleCategory, RuleStatus, RulesStore};
+pub use trigger::{PostMortemTrigger, TriggerReason};

--- a/crates/edda-postmortem/src/rules.rs
+++ b/crates/edda-postmortem/src/rules.rs
@@ -1,0 +1,634 @@
+//! Rules store with immune-system lifecycle and TTL decay.
+//!
+//! Rules are learned from post-mortem analysis and enforced via hooks.
+//! Each rule follows an immune-system lifecycle:
+//!
+//!   Proposed -> Active -> Dormant -> Settled -> Dead
+//!                                           |
+//!                              Superseded --+
+//!
+//! Three decay mechanisms:
+//! - **Time decay**: TTL (default 30 days), reset on each trigger hit
+//! - **Anchor decay**: Rule anchored to file; file changes -> stale
+//! - **Contradiction detection**: Same trigger, different action -> supersede
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as Sha2Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+use time::OffsetDateTime;
+
+/// Default TTL in days for new rules.
+const DEFAULT_TTL_DAYS: u32 = 30;
+
+/// Maximum number of active rules enforced simultaneously.
+const MAX_ACTIVE_RULES: usize = 15;
+
+/// Days after last_hit before a rule transitions from Active -> Dormant.
+const DORMANT_THRESHOLD_DAYS: i64 = 30;
+
+/// Days after last_hit before Dormant -> Settled.
+const SETTLED_THRESHOLD_DAYS: i64 = 60;
+
+/// Days after last_hit before Settled -> Dead.
+const DEAD_THRESHOLD_DAYS: i64 = 90;
+
+/// Minimum confirmations to promote Proposed -> Active.
+const MIN_CONFIRMATIONS: u64 = 2;
+
+/// Rule lifecycle status (immune system model).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuleStatus {
+    /// First observation, needs confirmation (pattern repeated 2x to activate).
+    Proposed,
+    /// Pattern confirmed, rule is enforced.
+    Active,
+    /// TTL window passed without trigger; rule is suspended.
+    Dormant,
+    /// Long dormant, near death.
+    Settled,
+    /// TTL expired completely; rule is archived.
+    Dead,
+    /// Contradicted by a newer rule with the same trigger.
+    Superseded,
+}
+
+impl std::fmt::Display for RuleStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Proposed => write!(f, "proposed"),
+            Self::Active => write!(f, "active"),
+            Self::Dormant => write!(f, "dormant"),
+            Self::Settled => write!(f, "settled"),
+            Self::Dead => write!(f, "dead"),
+            Self::Superseded => write!(f, "superseded"),
+        }
+    }
+}
+
+/// What kind of rule this is — determines enforcement mechanism.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuleCategory {
+    /// Check before commit (PreCommit hook).
+    PreCommit,
+    /// Check before push (PrePush hook).
+    PrePush,
+    /// Code pattern to avoid/enforce.
+    CodePattern,
+    /// Workflow pattern to follow.
+    Workflow,
+}
+
+impl std::fmt::Display for RuleCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PreCommit => write!(f, "pre_commit"),
+            Self::PrePush => write!(f, "pre_push"),
+            Self::CodePattern => write!(f, "code_pattern"),
+            Self::Workflow => write!(f, "workflow"),
+        }
+    }
+}
+
+/// A learned rule with TTL decay.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Rule {
+    pub id: String,
+    pub trigger: String,
+    pub action: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub anchor_file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub anchor_hash: Option<String>,
+    pub created: String,
+    pub last_hit: String,
+    pub hits: u64,
+    pub ttl_days: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub superseded_by: Option<String>,
+    pub status: RuleStatus,
+    pub source_session: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_event: Option<String>,
+    pub category: RuleCategory,
+}
+
+impl Rule {
+    /// Check if this rule is enforceable (Active status).
+    pub fn is_enforceable(&self) -> bool {
+        self.status == RuleStatus::Active
+    }
+
+    /// Check if this rule is alive (not Dead or Superseded).
+    pub fn is_alive(&self) -> bool {
+        !matches!(self.status, RuleStatus::Dead | RuleStatus::Superseded)
+    }
+
+    /// Record a trigger hit: increment counter and reset TTL.
+    pub fn record_hit(&mut self) {
+        self.hits += 1;
+        self.last_hit = now_rfc3339();
+        // If proposed and enough hits, promote to active
+        if self.status == RuleStatus::Proposed && self.hits >= MIN_CONFIRMATIONS {
+            self.status = RuleStatus::Active;
+        }
+        // If dormant/settled, reactivate on hit
+        if matches!(self.status, RuleStatus::Dormant | RuleStatus::Settled) {
+            self.status = RuleStatus::Active;
+        }
+    }
+
+    /// Compute days since last hit.
+    pub fn days_since_last_hit(&self) -> Option<i64> {
+        let last = parse_rfc3339(&self.last_hit)?;
+        let now = OffsetDateTime::now_utc();
+        Some((now - last).whole_days())
+    }
+
+    /// Apply time-based decay to this rule's status.
+    pub fn apply_time_decay(&mut self) {
+        if matches!(
+            self.status,
+            RuleStatus::Dead | RuleStatus::Superseded | RuleStatus::Proposed
+        ) {
+            return;
+        }
+
+        let days = match self.days_since_last_hit() {
+            Some(d) => d,
+            None => return,
+        };
+
+        if days >= DEAD_THRESHOLD_DAYS {
+            self.status = RuleStatus::Dead;
+        } else if days >= SETTLED_THRESHOLD_DAYS {
+            self.status = RuleStatus::Settled;
+        } else if days >= DORMANT_THRESHOLD_DAYS {
+            self.status = RuleStatus::Dormant;
+        }
+        // else: still Active, no change
+    }
+}
+
+/// The rules store: manages rules.json persistence and lifecycle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RulesStore {
+    pub rules: Vec<Rule>,
+    #[serde(default)]
+    pub last_decay_run: Option<String>,
+}
+
+impl Default for RulesStore {
+    fn default() -> Self {
+        Self {
+            rules: Vec::new(),
+            last_decay_run: None,
+        }
+    }
+}
+
+impl RulesStore {
+    /// Load rules store from disk. Returns default if file doesn't exist.
+    pub fn load(path: &Path) -> Self {
+        match fs::read_to_string(path) {
+            Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+            Err(_) => Self::default(),
+        }
+    }
+
+    /// Persist rules store to disk atomically.
+    pub fn save(&self, path: &Path) -> anyhow::Result<()> {
+        let json = serde_json::to_string_pretty(self)?;
+        edda_store::write_atomic(path, json.as_bytes())
+    }
+
+    /// Resolve the rules.json path for a project.
+    pub fn project_rules_path(project_id: &str) -> PathBuf {
+        edda_store::project_dir(project_id)
+            .join("state")
+            .join("rules.json")
+    }
+
+    /// Resolve the global rules.json path (~/.edda/rules.json).
+    pub fn global_rules_path() -> PathBuf {
+        edda_store::store_root().join("rules.json")
+    }
+
+    /// Load project-scoped rules.
+    pub fn load_project(project_id: &str) -> Self {
+        Self::load(&Self::project_rules_path(project_id))
+    }
+
+    /// Save project-scoped rules.
+    pub fn save_project(&self, project_id: &str) -> anyhow::Result<()> {
+        self.save(&Self::project_rules_path(project_id))
+    }
+
+    /// Get all active (enforceable) rules.
+    pub fn active_rules(&self) -> Vec<&Rule> {
+        self.rules.iter().filter(|r| r.is_enforceable()).collect()
+    }
+
+    /// Get all alive rules (not dead/superseded).
+    pub fn alive_rules(&self) -> Vec<&Rule> {
+        self.rules.iter().filter(|r| r.is_alive()).collect()
+    }
+
+    /// Add a new rule proposal. If a rule with the same trigger already exists
+    /// and is alive, increment its hits instead (confirmation).
+    pub fn propose_rule(
+        &mut self,
+        trigger: String,
+        action: String,
+        anchor_file: Option<String>,
+        category: RuleCategory,
+        source_session: String,
+        source_event: Option<String>,
+    ) -> String {
+        // Check for contradiction: same trigger, different action -> supersede old
+        let mut superseded_ids = Vec::new();
+        for rule in &self.rules {
+            if rule.trigger == trigger && rule.is_alive() {
+                if rule.action == action {
+                    // Same trigger + same action: confirmation, not new rule.
+                    // Find the mutable reference and record hit.
+                    let rule_id = rule.id.clone();
+                    if let Some(existing) = self.rules.iter_mut().find(|r| r.id == rule_id) {
+                        existing.record_hit();
+                    }
+                    return rule_id;
+                }
+                // Same trigger, different action -> contradiction
+                superseded_ids.push(rule.id.clone());
+            }
+        }
+
+        // Supersede contradicting rules
+        let new_id = new_rule_id();
+        for sid in &superseded_ids {
+            if let Some(old_rule) = self.rules.iter_mut().find(|r| r.id == *sid) {
+                old_rule.status = RuleStatus::Superseded;
+                old_rule.superseded_by = Some(new_id.clone());
+            }
+        }
+
+        // Compute anchor hash if anchor file provided
+        let anchor_hash = anchor_file.as_ref().and_then(|f| file_sha256(f));
+
+        let now = now_rfc3339();
+        let rule = Rule {
+            id: new_id.clone(),
+            trigger,
+            action,
+            anchor_file,
+            anchor_hash,
+            created: now.clone(),
+            last_hit: now,
+            hits: 1,
+            ttl_days: DEFAULT_TTL_DAYS,
+            superseded_by: None,
+            status: RuleStatus::Proposed,
+            source_session,
+            source_event,
+            category,
+        };
+
+        self.rules.push(rule);
+        new_id
+    }
+
+    /// Run the full decay cycle on all rules.
+    ///
+    /// 1. Time decay: check TTL against last_hit
+    /// 2. Anchor decay: check if anchored file changed
+    /// 3. Enforce active window cap (~15)
+    pub fn run_decay_cycle(&mut self) {
+        // 1. Time decay
+        for rule in &mut self.rules {
+            rule.apply_time_decay();
+        }
+
+        // 2. Anchor decay: mark rules stale if anchored file changed
+        for rule in &mut self.rules {
+            if !rule.is_alive() {
+                continue;
+            }
+            if let (Some(ref anchor_file), Some(ref stored_hash)) =
+                (&rule.anchor_file, &rule.anchor_hash)
+            {
+                if let Some(current_hash) = file_sha256(anchor_file) {
+                    if current_hash != *stored_hash {
+                        // File changed significantly -> mark dormant
+                        if rule.status == RuleStatus::Active {
+                            rule.status = RuleStatus::Dormant;
+                        }
+                    }
+                }
+                // If file was deleted, also mark dormant
+                else if !Path::new(anchor_file).exists() {
+                    if rule.status == RuleStatus::Active {
+                        rule.status = RuleStatus::Dormant;
+                    }
+                }
+            }
+        }
+
+        // 3. Enforce active window cap: keep top N by hits, demote rest
+        let mut active_ids: Vec<(String, u64)> = self
+            .rules
+            .iter()
+            .filter(|r| r.status == RuleStatus::Active)
+            .map(|r| (r.id.clone(), r.hits))
+            .collect();
+        active_ids.sort_by(|a, b| b.1.cmp(&a.1)); // Sort by hits descending
+        if active_ids.len() > MAX_ACTIVE_RULES {
+            let demote_ids: Vec<String> = active_ids[MAX_ACTIVE_RULES..]
+                .iter()
+                .map(|(id, _)| id.clone())
+                .collect();
+            for rule in &mut self.rules {
+                if demote_ids.contains(&rule.id) {
+                    rule.status = RuleStatus::Dormant;
+                }
+            }
+        }
+
+        self.last_decay_run = Some(now_rfc3339());
+    }
+
+    /// Garbage-collect dead rules (remove from store entirely).
+    pub fn gc_dead_rules(&mut self) -> usize {
+        let before = self.rules.len();
+        self.rules
+            .retain(|r| !matches!(r.status, RuleStatus::Dead));
+        before - self.rules.len()
+    }
+
+    /// Find rules matching a given trigger pattern (substring match).
+    pub fn find_by_trigger(&self, trigger_pattern: &str) -> Vec<&Rule> {
+        self.rules
+            .iter()
+            .filter(|r| r.trigger.contains(trigger_pattern))
+            .collect()
+    }
+
+    /// Get a rule by ID.
+    pub fn get(&self, id: &str) -> Option<&Rule> {
+        self.rules.iter().find(|r| r.id == id)
+    }
+
+    /// Get a mutable rule by ID.
+    pub fn get_mut(&mut self, id: &str) -> Option<&mut Rule> {
+        self.rules.iter_mut().find(|r| r.id == id)
+    }
+
+    /// Summary statistics.
+    pub fn stats(&self) -> StoreStats {
+        let mut stats = StoreStats::default();
+        for rule in &self.rules {
+            match rule.status {
+                RuleStatus::Proposed => stats.proposed += 1,
+                RuleStatus::Active => stats.active += 1,
+                RuleStatus::Dormant => stats.dormant += 1,
+                RuleStatus::Settled => stats.settled += 1,
+                RuleStatus::Dead => stats.dead += 1,
+                RuleStatus::Superseded => stats.superseded += 1,
+            }
+        }
+        stats.total = self.rules.len();
+        stats
+    }
+}
+
+/// Summary statistics for the rules store.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct StoreStats {
+    pub total: usize,
+    pub proposed: usize,
+    pub active: usize,
+    pub dormant: usize,
+    pub settled: usize,
+    pub dead: usize,
+    pub superseded: usize,
+}
+
+// -- Helpers --
+
+fn new_rule_id() -> String {
+    format!("rule_{}", ulid::Ulid::new().to_string().to_lowercase())
+}
+
+fn now_rfc3339() -> String {
+    let now = OffsetDateTime::now_utc();
+    now.format(&time::format_description::well_known::Rfc3339)
+        .expect("RFC3339 formatting should not fail")
+}
+
+fn parse_rfc3339(s: &str) -> Option<OffsetDateTime> {
+    OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339).ok()
+}
+
+/// Compute SHA-256 of a file's contents. Returns None if file unreadable.
+fn file_sha256(path: &str) -> Option<String> {
+    let data = fs::read(path).ok()?;
+    let hash = Sha256::digest(&data);
+    Some(hex::encode(hash))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_rule(trigger: &str, action: &str, status: RuleStatus) -> Rule {
+        Rule {
+            id: new_rule_id(),
+            trigger: trigger.to_string(),
+            action: action.to_string(),
+            anchor_file: None,
+            anchor_hash: None,
+            created: now_rfc3339(),
+            last_hit: now_rfc3339(),
+            hits: 2,
+            ttl_days: DEFAULT_TTL_DAYS,
+            superseded_by: None,
+            status,
+            source_session: "test-session".to_string(),
+            source_event: None,
+            category: RuleCategory::PreCommit,
+        }
+    }
+
+    #[test]
+    fn new_store_is_empty() {
+        let store = RulesStore::default();
+        assert!(store.rules.is_empty());
+        assert!(store.active_rules().is_empty());
+    }
+
+    #[test]
+    fn propose_creates_proposed_rule() {
+        let mut store = RulesStore::default();
+        let id = store.propose_rule(
+            "test failure".into(),
+            "run tests before commit".into(),
+            None,
+            RuleCategory::PreCommit,
+            "s1".into(),
+            None,
+        );
+        assert!(!id.is_empty());
+        let rule = store.get(&id).unwrap();
+        assert_eq!(rule.status, RuleStatus::Proposed);
+        assert_eq!(rule.hits, 1);
+    }
+
+    #[test]
+    fn duplicate_proposal_confirms_existing() {
+        let mut store = RulesStore::default();
+        let id1 = store.propose_rule(
+            "test failure".into(),
+            "run tests before commit".into(),
+            None,
+            RuleCategory::PreCommit,
+            "s1".into(),
+            None,
+        );
+        let id2 = store.propose_rule(
+            "test failure".into(),
+            "run tests before commit".into(),
+            None,
+            RuleCategory::PreCommit,
+            "s2".into(),
+            None,
+        );
+        // Same rule ID returned (confirmation, not new rule)
+        assert_eq!(id1, id2);
+        let rule = store.get(&id1).unwrap();
+        assert_eq!(rule.hits, 2);
+        // 2 hits -> promoted to Active
+        assert_eq!(rule.status, RuleStatus::Active);
+    }
+
+    #[test]
+    fn contradiction_supersedes_old_rule() {
+        let mut store = RulesStore::default();
+        let id1 = store.propose_rule(
+            "test failure".into(),
+            "run tests before commit".into(),
+            None,
+            RuleCategory::PreCommit,
+            "s1".into(),
+            None,
+        );
+        // Same trigger, different action
+        let id2 = store.propose_rule(
+            "test failure".into(),
+            "run linter before commit".into(),
+            None,
+            RuleCategory::PreCommit,
+            "s2".into(),
+            None,
+        );
+        assert_ne!(id1, id2);
+        let old = store.get(&id1).unwrap();
+        assert_eq!(old.status, RuleStatus::Superseded);
+        assert_eq!(old.superseded_by.as_deref(), Some(id2.as_str()));
+    }
+
+    #[test]
+    fn record_hit_resets_ttl() {
+        let mut rule = make_rule("trigger", "action", RuleStatus::Active);
+        let before = rule.last_hit.clone();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        rule.record_hit();
+        assert_ne!(rule.last_hit, before);
+        assert_eq!(rule.hits, 3);
+    }
+
+    #[test]
+    fn dormant_reactivates_on_hit() {
+        let mut rule = make_rule("trigger", "action", RuleStatus::Dormant);
+        rule.record_hit();
+        assert_eq!(rule.status, RuleStatus::Active);
+    }
+
+    #[test]
+    fn active_window_cap_enforced() {
+        let mut store = RulesStore::default();
+        // Create 20 active rules
+        for i in 0..20 {
+            let mut rule = make_rule(
+                &format!("trigger_{i}"),
+                &format!("action_{i}"),
+                RuleStatus::Active,
+            );
+            rule.hits = 20 - i;
+            store.rules.push(rule);
+        }
+        store.run_decay_cycle();
+        let active_count = store.active_rules().len();
+        assert!(
+            active_count <= MAX_ACTIVE_RULES,
+            "active_count={active_count} exceeds cap={MAX_ACTIVE_RULES}"
+        );
+    }
+
+    #[test]
+    fn gc_removes_dead_rules() {
+        let mut store = RulesStore::default();
+        store
+            .rules
+            .push(make_rule("a", "b", RuleStatus::Active));
+        store.rules.push(make_rule("c", "d", RuleStatus::Dead));
+        store
+            .rules
+            .push(make_rule("e", "f", RuleStatus::Superseded));
+        let removed = store.gc_dead_rules();
+        assert_eq!(removed, 1);
+        assert_eq!(store.rules.len(), 2);
+    }
+
+    #[test]
+    fn store_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("rules.json");
+
+        let mut store = RulesStore::default();
+        store.propose_rule(
+            "trigger".into(),
+            "action".into(),
+            None,
+            RuleCategory::Workflow,
+            "s1".into(),
+            None,
+        );
+        store.save(&path).unwrap();
+
+        let loaded = RulesStore::load(&path);
+        assert_eq!(loaded.rules.len(), 1);
+        assert_eq!(loaded.rules[0].trigger, "trigger");
+    }
+
+    #[test]
+    fn stats_counts_correctly() {
+        let mut store = RulesStore::default();
+        store
+            .rules
+            .push(make_rule("a", "b", RuleStatus::Active));
+        store
+            .rules
+            .push(make_rule("c", "d", RuleStatus::Proposed));
+        store
+            .rules
+            .push(make_rule("e", "f", RuleStatus::Dormant));
+        store.rules.push(make_rule("g", "h", RuleStatus::Dead));
+        let stats = store.stats();
+        assert_eq!(stats.total, 4);
+        assert_eq!(stats.active, 1);
+        assert_eq!(stats.proposed, 1);
+        assert_eq!(stats.dormant, 1);
+        assert_eq!(stats.dead, 1);
+    }
+}

--- a/crates/edda-postmortem/src/trigger.rs
+++ b/crates/edda-postmortem/src/trigger.rs
@@ -1,0 +1,256 @@
+//! Deterministic trigger detection for post-mortem analysis.
+//!
+//! Checks session statistics against thresholds to decide whether a
+//! post-mortem analysis should run. No LLM calls — pure deterministic logic.
+
+use serde::{Deserialize, Serialize};
+
+/// Default threshold: sessions longer than this many user prompts are "abnormally long".
+const DEFAULT_LONG_SESSION_THRESHOLD: u64 = 20;
+
+/// Default threshold: a file edited this many times signals churn.
+const DEFAULT_FILE_EDIT_THRESHOLD: u64 = 3;
+
+/// Reason why a post-mortem was triggered.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TriggerReason {
+    /// Session had command failures (tests broken, PR blocked, etc.)
+    SessionFailures,
+    /// Abnormally long session (> threshold user prompts)
+    AbnormallyLong,
+    /// Same file edited 3+ times (churn indicator)
+    ExcessiveFileEdits,
+    /// A decision was superseded during this session
+    DecisionSuperseded,
+    /// Multi-agent conflict detected
+    MultiAgentConflict,
+}
+
+impl std::fmt::Display for TriggerReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SessionFailures => write!(f, "session_failures"),
+            Self::AbnormallyLong => write!(f, "abnormally_long"),
+            Self::ExcessiveFileEdits => write!(f, "excessive_file_edits"),
+            Self::DecisionSuperseded => write!(f, "decision_superseded"),
+            Self::MultiAgentConflict => write!(f, "multi_agent_conflict"),
+        }
+    }
+}
+
+/// Input data for trigger evaluation. Mirrors fields available from
+/// `PrevDigest` / `SessionStats` without coupling to those types.
+#[derive(Debug, Clone, Default)]
+pub struct SessionSummary {
+    pub session_id: String,
+    pub user_prompts: u64,
+    pub tool_failures: u64,
+    pub failed_commands: Vec<String>,
+    /// Map of file path -> edit count during session.
+    pub file_edit_counts: Vec<(String, u64)>,
+    /// Number of decisions superseded during this session.
+    pub decisions_superseded: u64,
+    /// Whether multi-agent conflicts were detected.
+    pub had_conflict: bool,
+    /// Session outcome: "completed", "interrupted", "error_stuck".
+    pub outcome: String,
+}
+
+/// Result of trigger evaluation.
+#[derive(Debug, Clone)]
+pub struct PostMortemTrigger {
+    pub should_analyze: bool,
+    pub reasons: Vec<TriggerReason>,
+    pub session_id: String,
+}
+
+/// Configuration for trigger thresholds. Overridable via environment variables.
+#[derive(Debug, Clone)]
+pub struct TriggerConfig {
+    pub long_session_threshold: u64,
+    pub file_edit_threshold: u64,
+}
+
+impl Default for TriggerConfig {
+    fn default() -> Self {
+        Self {
+            long_session_threshold: std::env::var("EDDA_PM_LONG_SESSION")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(DEFAULT_LONG_SESSION_THRESHOLD),
+            file_edit_threshold: std::env::var("EDDA_PM_FILE_EDIT_THRESHOLD")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(DEFAULT_FILE_EDIT_THRESHOLD),
+        }
+    }
+}
+
+/// Evaluate whether a session warrants post-mortem analysis.
+///
+/// Returns a `PostMortemTrigger` with the decision and reasons.
+/// All checks are deterministic — no LLM calls.
+pub fn evaluate_triggers(summary: &SessionSummary) -> PostMortemTrigger {
+    evaluate_triggers_with_config(summary, &TriggerConfig::default())
+}
+
+/// Evaluate with explicit config (useful for testing).
+pub fn evaluate_triggers_with_config(
+    summary: &SessionSummary,
+    config: &TriggerConfig,
+) -> PostMortemTrigger {
+    let mut reasons = Vec::new();
+
+    // 1. Session had failures
+    if summary.tool_failures > 0
+        || !summary.failed_commands.is_empty()
+        || summary.outcome == "error_stuck"
+    {
+        reasons.push(TriggerReason::SessionFailures);
+    }
+
+    // 2. Abnormally long session
+    if summary.user_prompts > config.long_session_threshold {
+        reasons.push(TriggerReason::AbnormallyLong);
+    }
+
+    // 3. Excessive file edits (same file modified 3+ times)
+    for (_, count) in &summary.file_edit_counts {
+        if *count >= config.file_edit_threshold {
+            reasons.push(TriggerReason::ExcessiveFileEdits);
+            break; // one trigger is enough
+        }
+    }
+
+    // 4. Decision superseded
+    if summary.decisions_superseded > 0 {
+        reasons.push(TriggerReason::DecisionSuperseded);
+    }
+
+    // 5. Multi-agent conflict
+    if summary.had_conflict {
+        reasons.push(TriggerReason::MultiAgentConflict);
+    }
+
+    let should_analyze = !reasons.is_empty();
+
+    PostMortemTrigger {
+        should_analyze,
+        reasons,
+        session_id: summary.session_id.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_summary() -> SessionSummary {
+        SessionSummary {
+            session_id: "test-session-1".to_string(),
+            outcome: "completed".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn no_triggers_for_clean_session() {
+        let summary = base_summary();
+        let result = evaluate_triggers(&summary);
+        assert!(!result.should_analyze);
+        assert!(result.reasons.is_empty());
+    }
+
+    #[test]
+    fn triggers_on_failures() {
+        let mut summary = base_summary();
+        summary.tool_failures = 3;
+        let result = evaluate_triggers(&summary);
+        assert!(result.should_analyze);
+        assert!(result.reasons.contains(&TriggerReason::SessionFailures));
+    }
+
+    #[test]
+    fn triggers_on_failed_commands() {
+        let mut summary = base_summary();
+        summary.failed_commands = vec!["npm test".to_string()];
+        let result = evaluate_triggers(&summary);
+        assert!(result.should_analyze);
+        assert!(result.reasons.contains(&TriggerReason::SessionFailures));
+    }
+
+    #[test]
+    fn triggers_on_error_stuck_outcome() {
+        let mut summary = base_summary();
+        summary.outcome = "error_stuck".to_string();
+        let result = evaluate_triggers(&summary);
+        assert!(result.should_analyze);
+        assert!(result.reasons.contains(&TriggerReason::SessionFailures));
+    }
+
+    #[test]
+    fn triggers_on_long_session() {
+        let mut summary = base_summary();
+        summary.user_prompts = 25;
+        let result = evaluate_triggers(&summary);
+        assert!(result.should_analyze);
+        assert!(result.reasons.contains(&TriggerReason::AbnormallyLong));
+    }
+
+    #[test]
+    fn triggers_on_file_churn() {
+        let mut summary = base_summary();
+        summary.file_edit_counts = vec![
+            ("src/main.rs".to_string(), 5),
+            ("src/lib.rs".to_string(), 1),
+        ];
+        let result = evaluate_triggers(&summary);
+        assert!(result.should_analyze);
+        assert!(result.reasons.contains(&TriggerReason::ExcessiveFileEdits));
+    }
+
+    #[test]
+    fn triggers_on_decision_superseded() {
+        let mut summary = base_summary();
+        summary.decisions_superseded = 1;
+        let result = evaluate_triggers(&summary);
+        assert!(result.should_analyze);
+        assert!(result.reasons.contains(&TriggerReason::DecisionSuperseded));
+    }
+
+    #[test]
+    fn triggers_on_conflict() {
+        let mut summary = base_summary();
+        summary.had_conflict = true;
+        let result = evaluate_triggers(&summary);
+        assert!(result.should_analyze);
+        assert!(result.reasons.contains(&TriggerReason::MultiAgentConflict));
+    }
+
+    #[test]
+    fn multiple_triggers_accumulate() {
+        let mut summary = base_summary();
+        summary.tool_failures = 2;
+        summary.user_prompts = 30;
+        summary.had_conflict = true;
+        let result = evaluate_triggers(&summary);
+        assert!(result.should_analyze);
+        assert_eq!(result.reasons.len(), 3);
+    }
+
+    #[test]
+    fn custom_config_thresholds() {
+        let mut summary = base_summary();
+        summary.user_prompts = 10; // Below default 20, above custom 5
+        summary.file_edit_counts = vec![("a.rs".to_string(), 2)]; // Below default 3, at custom 2
+
+        let config = TriggerConfig {
+            long_session_threshold: 5,
+            file_edit_threshold: 2,
+        };
+        let result = evaluate_triggers_with_config(&summary, &config);
+        assert!(result.should_analyze);
+        assert_eq!(result.reasons.len(), 2);
+    }
+}


### PR DESCRIPTION
## Summary

Implements #157: L3 post-mortem analysis system with immune-system lifecycle for learned rules.

- **New crate `edda-postmortem`** (6 modules, 38 tests): deterministic trigger detection, heuristic analysis, rules store with TTL decay (time/anchor/contradiction), lessons store with CLAUDE.md sync
- **Bridge integration**: `run_postmortem()` wired into SessionEnd (best-effort); `evaluate_learned_rules()` wired into PreToolUse (warn-only via additionalContext)
- **CLI integration**: `edda rules list/show/decay/stats/gc` subcommands
- **Rate-limited decay**: only runs once per calendar day

## Architecture

Rule lifecycle: `Proposed → Active → Dormant → Settled → Dead` (+ `Superseded` for contradictions)

Three decay mechanisms:
1. **Time decay**: TTL (30 days default), reset on each trigger hit
2. **Anchor decay**: rule anchored to file hash; file changes → dormant
3. **Contradiction detection**: same trigger, different action → supersede old rule

Five trigger reasons: session failures, abnormally long sessions, excessive file edits, decision superseded, multi-agent conflict.

## Test plan

- [x] `cargo test -p edda-postmortem` — 38 tests pass (triggers, analyzer, rules lifecycle, lessons store, hooks evaluation)
- [x] `cargo test --workspace` — all 967 tests pass, 0 failures
- [x] Workspace compiles cleanly (`cargo check --workspace`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)