### PR TITLE
feat(bg): session digester background agent (#193)

### DIFF
--- a/crates/edda-bridge-claude/src/bg_digest.rs
+++ b/crates/edda-bridge-claude/src/bg_digest.rs
@@ -1,0 +1,470 @@
+//! Background session digester — generates an LLM-powered summary of the
+//! session and writes it as an `edda note` event to the workspace ledger.
+//!
+//! Design: non-blocking, idempotent, cost-controlled.  Triggered at SessionEnd
+//! via `std::thread::spawn` so the hook returns immediately.
+//!
+//! Reuses shared infrastructure from `bg_extract` (API call, budget tracking,
+//! transcript reading).
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::bg_extract::{
+    call_anthropic_sync, check_daily_budget, compute_file_hash, now_rfc3339, read_transcript_turns,
+    truncate_text, update_daily_cost, DEFAULT_MAX_TRANSCRIPT_CHARS, DEFAULT_MODEL,
+    HAIKU_INPUT_COST_PER_TOKEN, HAIKU_OUTPUT_COST_PER_TOKEN,
+};
+
+// ── Data Structures ──
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DigestState {
+    status: String, // "completed" | "failed"
+    digested_at: String,
+    transcript_hash: String,
+    summary_len: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AuditEntry {
+    ts: String,
+    session_id: String,
+    summary_len: usize,
+    cost_usd: f64,
+    model: String,
+    status: String,
+}
+
+// ── Public API ──
+
+/// Check whether background session digest should run for this session.
+///
+/// Returns `false` (skip) if any of these hold:
+/// - `EDDA_BG_ENABLED` is `"0"`
+/// - `EDDA_LLM_API_KEY` is missing or empty
+/// - Transcript doesn't exist for this session
+/// - Daily budget is exhausted
+/// - Session was already digested (idempotent guard)
+pub fn should_run(project_id: &str, session_id: &str) -> bool {
+    if std::env::var("EDDA_BG_ENABLED").unwrap_or_else(|_| "1".into()) == "0" {
+        return false;
+    }
+    if std::env::var("EDDA_LLM_API_KEY")
+        .unwrap_or_default()
+        .is_empty()
+    {
+        return false;
+    }
+
+    let transcript_path = transcript_path(project_id, session_id);
+    if !transcript_path.exists() {
+        return false;
+    }
+
+    if already_digested(project_id, session_id) {
+        return false;
+    }
+
+    check_daily_budget(project_id).unwrap_or(true)
+}
+
+/// Main digest entry point — called from a background thread.
+///
+/// Reads the stored transcript, calls the LLM for a summary, writes an
+/// `edda note` event to the workspace ledger, and updates state tracking.
+pub fn run_digest(project_id: &str, session_id: &str, cwd: &str) -> Result<()> {
+    let api_key = std::env::var("EDDA_LLM_API_KEY").with_context(|| "EDDA_LLM_API_KEY not set")?;
+    if api_key.is_empty() {
+        anyhow::bail!("EDDA_LLM_API_KEY is empty");
+    }
+
+    let tp = transcript_path(project_id, session_id);
+    if !tp.exists() {
+        anyhow::bail!("Transcript not found: {}", tp.display());
+    }
+
+    // Idempotency check by hash
+    let transcript_hash = compute_file_hash(&tp)?;
+    if let Some(state) = load_digest_state(project_id, session_id) {
+        if state.transcript_hash == transcript_hash && state.status == "completed" {
+            return Ok(());
+        }
+    }
+
+    // Read and truncate transcript
+    let transcript_text = read_transcript_turns(&tp)?;
+    let max_chars = crate::bg_extract::env_f64(
+        "EDDA_BG_MAX_TRANSCRIPT_CHARS",
+        DEFAULT_MAX_TRANSCRIPT_CHARS as f64,
+    ) as usize;
+    let truncated = truncate_text(&transcript_text, max_chars);
+
+    // Read prev_digest for structured stats context
+    let stats_context = build_stats_context(project_id);
+
+    // Build prompt and call LLM
+    let prompt = build_digest_prompt(&truncated, &stats_context);
+    let model = std::env::var("EDDA_BG_MODEL").unwrap_or_else(|_| DEFAULT_MODEL.to_string());
+    let (summary, input_tokens, output_tokens) = call_anthropic_sync(&api_key, &model, &prompt)?;
+
+    let summary = summary.trim().to_string();
+    if summary.is_empty() {
+        anyhow::bail!("LLM returned empty summary");
+    }
+
+    let cost_usd = (input_tokens as f64 * HAIKU_INPUT_COST_PER_TOKEN)
+        + (output_tokens as f64 * HAIKU_OUTPUT_COST_PER_TOKEN);
+
+    // Write note event to workspace ledger
+    write_session_note(cwd, &summary)?;
+
+    // Save digest state (idempotency marker)
+    save_digest_state(project_id, session_id, &transcript_hash, summary.len())?;
+
+    // Update daily cost (shared with bg_extract)
+    update_daily_cost(project_id, cost_usd)?;
+
+    // Append audit log
+    append_audit_log(
+        project_id,
+        &AuditEntry {
+            ts: now_rfc3339(),
+            session_id: session_id.to_string(),
+            summary_len: summary.len(),
+            cost_usd,
+            model,
+            status: "completed".to_string(),
+        },
+    )?;
+
+    Ok(())
+}
+
+// ── Internal Helpers ──
+
+fn transcript_path(project_id: &str, session_id: &str) -> PathBuf {
+    edda_store::project_dir(project_id)
+        .join("transcripts")
+        .join(format!("{session_id}.jsonl"))
+}
+
+fn state_dir(project_id: &str) -> PathBuf {
+    edda_store::project_dir(project_id).join("state")
+}
+
+fn digest_state_path(project_id: &str, session_id: &str) -> PathBuf {
+    state_dir(project_id).join(format!("bg_digest.{session_id}.json"))
+}
+
+fn audit_log_path(project_id: &str) -> PathBuf {
+    state_dir(project_id).join("bg_digest_audit.jsonl")
+}
+
+fn already_digested(project_id: &str, session_id: &str) -> bool {
+    load_digest_state(project_id, session_id).is_some_and(|s| s.status == "completed")
+}
+
+fn load_digest_state(project_id: &str, session_id: &str) -> Option<DigestState> {
+    let path = digest_state_path(project_id, session_id);
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+fn save_digest_state(
+    project_id: &str,
+    session_id: &str,
+    transcript_hash: &str,
+    summary_len: usize,
+) -> Result<()> {
+    let state = DigestState {
+        status: "completed".to_string(),
+        digested_at: now_rfc3339(),
+        transcript_hash: transcript_hash.to_string(),
+        summary_len,
+    };
+    let path = digest_state_path(project_id, session_id);
+    fs::create_dir_all(path.parent().unwrap())?;
+    let json = serde_json::to_string_pretty(&state)?;
+    fs::write(&path, json)?;
+    Ok(())
+}
+
+fn append_audit_log(project_id: &str, entry: &AuditEntry) -> Result<()> {
+    use std::io::Write;
+    let path = audit_log_path(project_id);
+    fs::create_dir_all(path.parent().unwrap())?;
+    let line = serde_json::to_string(entry)?;
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)?;
+    writeln!(file, "{}", line)?;
+    Ok(())
+}
+
+/// Write the LLM-generated summary as an `edda note` event to the workspace ledger.
+fn write_session_note(cwd: &str, summary: &str) -> Result<()> {
+    let cwd_path = Path::new(cwd);
+    let root = edda_ledger::EddaPaths::find_root(cwd_path)
+        .ok_or_else(|| anyhow::anyhow!("No edda workspace found from {cwd}"))?;
+    let ledger = edda_ledger::Ledger::open(&root)?;
+    let _lock = edda_ledger::lock::WorkspaceLock::acquire(&ledger.paths)?;
+
+    let branch = ledger.head_branch()?;
+    let parent_hash = ledger.last_event_hash()?;
+
+    let tags = vec!["session".to_string(), "auto-digest".to_string()];
+    let mut event = edda_core::event::new_note_event(
+        &branch,
+        parent_hash.as_deref(),
+        "bridge",
+        summary,
+        &tags,
+    )?;
+
+    // Mark source so collect_session_ledger_extras filters it out
+    event.payload["source"] = serde_json::json!("bridge:session-digest");
+
+    edda_core::event::finalize_event(&mut event);
+    ledger.append_event(&event)?;
+
+    eprintln!("[edda-bg] session digest written → {}", event.event_id);
+    Ok(())
+}
+
+/// Build structured stats context from prev_digest.json.
+fn build_stats_context(project_id: &str) -> String {
+    let Some(digest) = crate::digest::read_prev_digest(project_id) else {
+        return String::new();
+    };
+
+    let mut parts = Vec::new();
+    parts.push(format!("Session outcome: {}", digest.outcome));
+    parts.push(format!("Duration: {} minutes", digest.duration_minutes));
+    if !digest.activity.is_empty() {
+        parts.push(format!("Activity type: {}", digest.activity));
+    }
+    if digest.files_modified_count > 0 {
+        parts.push(format!("Files modified: {}", digest.files_modified_count));
+    }
+    if !digest.commits.is_empty() {
+        parts.push(format!("Commits: {}", digest.commits.join("; ")));
+    }
+    if !digest.completed_tasks.is_empty() {
+        parts.push(format!(
+            "Completed tasks: {}",
+            digest.completed_tasks.join("; ")
+        ));
+    }
+    if !digest.pending_tasks.is_empty() {
+        parts.push(format!(
+            "Pending tasks: {}",
+            digest.pending_tasks.join("; ")
+        ));
+    }
+    if !digest.decisions.is_empty() {
+        parts.push(format!("Decisions: {}", digest.decisions.join("; ")));
+    }
+    if !digest.notes.is_empty() {
+        parts.push(format!("Notes: {}", digest.notes.join("; ")));
+    }
+
+    parts.join("\n")
+}
+
+/// Build the LLM prompt for session digest.
+pub(crate) fn build_digest_prompt(transcript: &str, stats_context: &str) -> String {
+    let stats_section = if stats_context.is_empty() {
+        String::new()
+    } else {
+        format!(
+            r#"
+## Session Stats
+
+{stats_context}
+
+"#
+        )
+    };
+
+    format!(
+        r#"你是 session 摘要器。根據以下開發對話 transcript 和統計數據，生成簡潔的 session 摘要。
+
+要求：
+- 2-4 句話，概述 session 做了什麼、達成了什麼、遇到什麼問題
+- 用自然語言，像是寫給同事的交接備忘
+- 如果有未完成的工作，提到 next steps
+- 直接輸出摘要文字，不要加標題或格式化標記
+- 使用英文撰寫
+{stats_section}
+## Transcript
+
+{transcript}"#
+    )
+}
+
+// ── Tests ──
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_run_returns_false_when_disabled() {
+        std::env::set_var("EDDA_BG_ENABLED", "0");
+        std::env::set_var("EDDA_LLM_API_KEY", "test-key");
+        assert!(!should_run("test_proj", "test_sess"));
+        std::env::remove_var("EDDA_BG_ENABLED");
+        std::env::remove_var("EDDA_LLM_API_KEY");
+    }
+
+    #[test]
+    fn should_run_returns_false_without_api_key() {
+        std::env::set_var("EDDA_BG_ENABLED", "1");
+        std::env::remove_var("EDDA_LLM_API_KEY");
+        assert!(!should_run("test_proj", "test_sess"));
+    }
+
+    #[test]
+    fn should_run_returns_false_without_transcript() {
+        std::env::set_var("EDDA_BG_ENABLED", "1");
+        std::env::set_var("EDDA_LLM_API_KEY", "test-key");
+        // No transcript file exists for a random project/session
+        assert!(!should_run("nonexistent_proj_digest", "nonexistent_sess"));
+        std::env::remove_var("EDDA_LLM_API_KEY");
+    }
+
+    #[test]
+    fn should_run_returns_false_when_already_digested() {
+        let pid = "test_digest_idempotent";
+        let sid = "sess-digest-1";
+        let _ = edda_store::ensure_dirs(pid);
+
+        // Create a transcript so that check passes
+        let transcript_dir = edda_store::project_dir(pid).join("transcripts");
+        let _ = fs::create_dir_all(&transcript_dir);
+        let _ = fs::write(transcript_dir.join(format!("{sid}.jsonl")), "{}");
+
+        // Write completed digest state
+        let state = DigestState {
+            status: "completed".to_string(),
+            digested_at: "2026-01-01T00:00:00Z".to_string(),
+            transcript_hash: "test-hash".to_string(),
+            summary_len: 100,
+        };
+        let state_path = digest_state_path(pid, sid);
+        let _ = fs::create_dir_all(state_path.parent().unwrap());
+        let _ = fs::write(&state_path, serde_json::to_string_pretty(&state).unwrap());
+
+        std::env::set_var("EDDA_BG_ENABLED", "1");
+        std::env::set_var("EDDA_LLM_API_KEY", "test-key");
+
+        assert!(!should_run(pid, sid));
+
+        // Cleanup
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+        std::env::remove_var("EDDA_LLM_API_KEY");
+    }
+
+    #[test]
+    fn build_digest_prompt_includes_transcript() {
+        let prompt = build_digest_prompt("hello world transcript", "");
+        assert!(prompt.contains("hello world transcript"));
+        assert!(prompt.contains("session 摘要器"));
+    }
+
+    #[test]
+    fn build_digest_prompt_includes_stats() {
+        let stats = "Duration: 30 minutes\nFiles modified: 5";
+        let prompt = build_digest_prompt("transcript text", stats);
+        assert!(prompt.contains("Duration: 30 minutes"));
+        assert!(prompt.contains("Files modified: 5"));
+        assert!(prompt.contains("## Session Stats"));
+    }
+
+    #[test]
+    fn build_digest_prompt_omits_stats_section_when_empty() {
+        let prompt = build_digest_prompt("transcript text", "");
+        assert!(!prompt.contains("## Session Stats"));
+    }
+
+    #[test]
+    fn digest_state_roundtrip() {
+        let state = DigestState {
+            status: "completed".to_string(),
+            digested_at: "2026-03-12T10:00:00Z".to_string(),
+            transcript_hash: "blake3:abc123".to_string(),
+            summary_len: 250,
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        let parsed: DigestState = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.status, "completed");
+        assert_eq!(parsed.transcript_hash, "blake3:abc123");
+        assert_eq!(parsed.summary_len, 250);
+    }
+
+    #[test]
+    fn idempotency_guard_works() {
+        let pid = "test_digest_guard";
+        let sid = "sess-guard-1";
+        let _ = edda_store::ensure_dirs(pid);
+
+        // Initially not digested
+        assert!(!already_digested(pid, sid));
+
+        // Save completed state
+        let _ = save_digest_state(pid, sid, "hash-1", 100);
+        assert!(already_digested(pid, sid));
+
+        // Cleanup
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    }
+
+    #[test]
+    fn build_stats_context_handles_missing_digest() {
+        // No prev_digest.json for a nonexistent project
+        let ctx = build_stats_context("nonexistent_proj_ctx");
+        assert!(ctx.is_empty());
+    }
+
+    #[test]
+    fn audit_log_appends() {
+        let pid = "test_digest_audit";
+        let _ = edda_store::ensure_dirs(pid);
+
+        let entry = AuditEntry {
+            ts: "2026-03-12T10:00:00Z".to_string(),
+            session_id: "sess-1".to_string(),
+            summary_len: 200,
+            cost_usd: 0.01,
+            model: "test-model".to_string(),
+            status: "completed".to_string(),
+        };
+        append_audit_log(pid, &entry).unwrap();
+
+        let path = audit_log_path(pid);
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("sess-1"));
+        assert!(content.contains("test-model"));
+
+        // Append another
+        let entry2 = AuditEntry {
+            ts: "2026-03-12T11:00:00Z".to_string(),
+            session_id: "sess-2".to_string(),
+            summary_len: 300,
+            cost_usd: 0.02,
+            model: "test-model".to_string(),
+            status: "completed".to_string(),
+        };
+        append_audit_log(pid, &entry2).unwrap();
+
+        let content2 = fs::read_to_string(&path).unwrap();
+        assert_eq!(content2.lines().count(), 2);
+
+        // Cleanup
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    }
+}

--- a/crates/edda-bridge-claude/src/bg_extract.rs
+++ b/crates/edda-bridge-claude/src/bg_extract.rs
@@ -11,15 +11,15 @@ use std::path::{Path, PathBuf};
 
 // ── Configuration ──
 
-const DEFAULT_MODEL: &str = "claude-3-5-haiku-20241022";
-const DEFAULT_MAX_TRANSCRIPT_CHARS: usize = 30_000;
+pub(crate) const DEFAULT_MODEL: &str = "claude-3-5-haiku-20241022";
+pub(crate) const DEFAULT_MAX_TRANSCRIPT_CHARS: usize = 30_000;
 const DEFAULT_DAILY_BUDGET_USD: f64 = 0.50;
 const DEFAULT_CONFIDENCE_THRESHOLD: f64 = 0.7;
-const API_TIMEOUT_SECS: u64 = 30;
+pub(crate) const API_TIMEOUT_SECS: u64 = 30;
 
 // Haiku pricing (per token)
-const HAIKU_INPUT_COST_PER_TOKEN: f64 = 0.000_001; // $1 / 1M input tokens
-const HAIKU_OUTPUT_COST_PER_TOKEN: f64 = 0.000_005; // $5 / 1M output tokens
+pub(crate) const HAIKU_INPUT_COST_PER_TOKEN: f64 = 0.000_001; // $1 / 1M input tokens
+pub(crate) const HAIKU_OUTPUT_COST_PER_TOKEN: f64 = 0.000_005; // $5 / 1M output tokens
 
 // ── Data Structures ──
 
@@ -109,36 +109,36 @@ struct AuditEntry {
 
 // Anthropic API types (sync, ureq-based)
 #[derive(Debug, Serialize)]
-struct AnthropicRequest {
-    model: String,
-    max_tokens: u32,
-    messages: Vec<ApiMessage>,
+pub(crate) struct AnthropicRequest {
+    pub model: String,
+    pub max_tokens: u32,
+    pub messages: Vec<ApiMessage>,
 }
 
 #[derive(Debug, Serialize)]
-struct ApiMessage {
-    role: String,
-    content: String,
+pub(crate) struct ApiMessage {
+    pub role: String,
+    pub content: String,
 }
 
 #[derive(Debug, Deserialize)]
-struct AnthropicResponse {
-    content: Vec<ContentBlock>,
+pub(crate) struct AnthropicResponse {
+    pub content: Vec<ContentBlock>,
     #[serde(default)]
-    usage: Option<Usage>,
+    pub usage: Option<Usage>,
 }
 
 #[derive(Debug, Deserialize)]
-struct ContentBlock {
-    text: String,
+pub(crate) struct ContentBlock {
+    pub text: String,
 }
 
 #[derive(Debug, Deserialize)]
-struct Usage {
+pub(crate) struct Usage {
     #[serde(default)]
-    input_tokens: u64,
+    pub input_tokens: u64,
     #[serde(default)]
-    output_tokens: u64,
+    pub output_tokens: u64,
 }
 
 // ── Public API ──
@@ -450,7 +450,7 @@ fn save_extraction_state(project_id: &str, result: &ExtractionResult) -> Result<
     Ok(())
 }
 
-fn check_daily_budget(project_id: &str) -> Result<bool> {
+pub(crate) fn check_daily_budget(project_id: &str) -> Result<bool> {
     let budget = env_f64("EDDA_BG_DAILY_BUDGET_USD", DEFAULT_DAILY_BUDGET_USD);
     let path = daily_cost_path(project_id);
 
@@ -470,7 +470,7 @@ fn check_daily_budget(project_id: &str) -> Result<bool> {
     Ok(cost.total_usd < budget)
 }
 
-fn update_daily_cost(project_id: &str, cost_usd: f64) -> Result<()> {
+pub(crate) fn update_daily_cost(project_id: &str, cost_usd: f64) -> Result<()> {
     let path = daily_cost_path(project_id);
     let today = today_date();
 
@@ -541,7 +541,7 @@ fn append_audit_log(project_id: &str, entry: &AuditEntry) -> Result<()> {
 }
 
 /// Read a stored transcript JSONL and assemble user/assistant turns into text.
-fn read_transcript_turns(transcript_path: &Path) -> Result<String> {
+pub(crate) fn read_transcript_turns(transcript_path: &Path) -> Result<String> {
     let content = fs::read_to_string(transcript_path)
         .with_context(|| format!("Failed to read transcript: {}", transcript_path.display()))?;
 
@@ -598,13 +598,13 @@ fn extract_text_from_content(content: &serde_json::Value) -> String {
     String::new()
 }
 
-fn compute_file_hash(path: &Path) -> Result<String> {
+pub(crate) fn compute_file_hash(path: &Path) -> Result<String> {
     let content = fs::read(path)?;
     let hash = blake3::hash(&content);
     Ok(format!("blake3:{}", hash.to_hex()))
 }
 
-fn truncate_text(text: &str, max_chars: usize) -> String {
+pub(crate) fn truncate_text(text: &str, max_chars: usize) -> String {
     if text.len() <= max_chars {
         return text.to_string();
     }
@@ -830,7 +830,11 @@ Enhancement 項目格式：
 }
 
 /// Synchronous Anthropic API call via ureq.
-fn call_anthropic_sync(api_key: &str, model: &str, prompt: &str) -> Result<(String, u64, u64)> {
+pub(crate) fn call_anthropic_sync(
+    api_key: &str,
+    model: &str,
+    prompt: &str,
+) -> Result<(String, u64, u64)> {
     let request = AnthropicRequest {
         model: model.to_string(),
         max_tokens: 2048,
@@ -971,7 +975,7 @@ fn extract_json_array(text: &str) -> String {
     trimmed.to_string()
 }
 
-fn now_rfc3339() -> String {
+pub(crate) fn now_rfc3339() -> String {
     let now = time::OffsetDateTime::now_utc();
     now.format(&time::format_description::well_known::Rfc3339)
         .unwrap_or_else(|_| "unknown".to_string())
@@ -987,7 +991,7 @@ fn today_date() -> String {
     )
 }
 
-fn env_f64(name: &str, default: f64) -> f64 {
+pub(crate) fn env_f64(name: &str, default: f64) -> f64 {
     std::env::var(name)
         .ok()
         .and_then(|v| v.parse().ok())

--- a/crates/edda-bridge-claude/src/dispatch.rs
+++ b/crates/edda-bridge-claude/src/dispatch.rs
@@ -676,6 +676,18 @@ fn dispatch_session_end(
         });
     }
 
+    // 2g. Background session digest (non-blocking, best-effort)
+    if crate::bg_digest::should_run(project_id, session_id) {
+        let pid = project_id.to_string();
+        let sid = session_id.to_string();
+        let cwd_str = cwd.to_string();
+        std::thread::spawn(move || {
+            if let Err(e) = crate::bg_digest::run_digest(&pid, &sid, &cwd_str) {
+                eprintln!("[edda-bg] session digest failed: {e}");
+            }
+        });
+    }
+
     // 2d. Push notification (best-effort, fire-and-forget)
     notify_session_end(project_id, cwd, session_id);
 

--- a/crates/edda-bridge-claude/src/lib.rs
+++ b/crates/edda-bridge-claude/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod agent_phase;
+pub mod bg_digest;
 pub mod bg_extract;
 pub mod digest;
 pub mod pattern;


### PR DESCRIPTION
## Summary

- Add `bg_digest` module that generates LLM-powered session summaries at `SessionEnd` and writes them as `edda note` events to the workspace ledger
- Promote shared helpers in `bg_extract` to `pub(crate)` for reuse (API call, budget tracking, transcript reading)
- Integrate into `dispatch_session_end()` as a non-blocking background thread

Closes #193

## Design

- **Non-blocking**: spawns a thread so the hook returns immediately
- **Idempotent**: `DigestState` marker prevents re-digesting the same session
- **Cost-controlled**: shares daily budget with `bg_extract` via `bg_daily_cost.json`
- **Filterable**: note events tagged with `source: "bridge:session-digest"` so `collect_session_ledger_extras` excludes them from duplication

## Test plan

- [x] `should_run` gate logic: disabled, no API key, no transcript, already digested (4 tests)
- [x] Prompt construction: includes transcript, includes stats, omits empty stats (3 tests)
- [x] State management: roundtrip serialization, idempotency guard, audit log append (3 tests)
- [x] Stats context handles missing `prev_digest.json` gracefully (1 test)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] Pre-existing test failure (`post_tool_use_increments_nudge_counter`) confirmed unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)