### PR TITLE
feat(logging): adopt tracing crate for structured logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,6 +702,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-util",
+ "tracing-subscriber",
  "ulid",
 ]
 
@@ -755,6 +756,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "time",
+ "tracing",
  "ulid",
  "ureq",
 ]
@@ -795,6 +797,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -895,6 +898,7 @@ dependencies = [
  "edda-ledger",
  "serde",
  "serde_json",
+ "tracing",
  "ureq",
 ]
 
@@ -941,6 +945,7 @@ dependencies = [
  "tantivy",
  "tempfile",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -965,6 +970,7 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
+ "tracing",
 ]
 
 [[package]]
@@ -1704,6 +1710,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,6 +1817,15 @@ name = "lz4_flex"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matchit"
@@ -1913,6 +1934,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2704,6 +2734,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3054,6 +3093,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3230,6 +3278,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3384,6 +3462,12 @@ dependencies = [
  "sha1_smol",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ tempfile = "3"
 globset = "0.4"
 regex = "1"
 uuid = { version = "1", features = ["v5"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [profile.release]
 lto = true

--- a/crates/edda-bridge-claude/Cargo.toml
+++ b/crates/edda-bridge-claude/Cargo.toml
@@ -30,6 +30,7 @@ dirs.workspace = true
 regex.workspace = true
 blake3.workspace = true
 ureq = "3"
+tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/edda-bridge-claude/src/admin.rs
+++ b/crates/edda-bridge-claude/src/admin.rs
@@ -126,8 +126,8 @@ pub fn install(repo_root: &Path, no_claude_md: bool) -> anyhow::Result<()> {
     let output = serde_json::to_string_pretty(&settings)?;
     fs::write(&path, output.as_bytes())?;
 
-    tracing::info!(path = %path.display(), "installed edda hooks");
-    tracing::info!("configured MCP server (edda mcp serve)");
+    println!("Installed edda hooks into {}", path.display());
+    println!("Configured MCP server (edda mcp serve)");
 
     // Onboard CLAUDE.md with edda decision-tracking instructions.
     // B1.5 testing showed CLAUDE.md is the decisive factor for agent compliance:
@@ -145,7 +145,7 @@ pub fn uninstall(repo_root: &Path) -> anyhow::Result<()> {
     let path = settings_path(repo_root);
 
     if !path.exists() {
-        tracing::info!(path = %path.display(), "no settings file found");
+        println!("No settings file found at {}", path.display());
         return Ok(());
     }
 
@@ -195,7 +195,7 @@ pub fn uninstall(repo_root: &Path) -> anyhow::Result<()> {
     let output = serde_json::to_string_pretty(&settings)?;
     fs::write(&path, output.as_bytes())?;
 
-    tracing::info!(path = %path.display(), "uninstalled edda hooks");
+    println!("Uninstalled edda hooks from {}", path.display());
     Ok(())
 }
 
@@ -332,11 +332,11 @@ fn ensure_claude_md_edda_section(repo_root: &Path) -> anyhow::Result<()> {
         }
         appended.push_str(EDDA_CLAUDE_MD_APPEND);
         fs::write(&claude_md, appended)?;
-        tracing::info!(path = %claude_md.display(), "appended edda section");
+        println!("Appended edda section to {}", claude_md.display());
     } else {
         // Create new file with full onboarding template
         fs::write(&claude_md, EDDA_CLAUDE_MD_CREATE.trim_start())?;
-        tracing::info!(path = %claude_md.display(), "created CLAUDE.md with edda decision tracking");
+        println!("Created {} with edda decision tracking", claude_md.display());
     }
     Ok(())
 }
@@ -360,7 +360,7 @@ fn ensure_claude_md_coordination_section(repo_root: &Path) -> anyhow::Result<()>
     }
     appended.push_str(EDDA_COORDINATION_SECTION);
     fs::write(&claude_md, appended)?;
-    tracing::info!(path = %claude_md.display(), "appended coordination rules");
+    println!("Appended coordination rules to {}", claude_md.display());
     Ok(())
 }
 

--- a/crates/edda-bridge-claude/src/admin.rs
+++ b/crates/edda-bridge-claude/src/admin.rs
@@ -126,8 +126,8 @@ pub fn install(repo_root: &Path, no_claude_md: bool) -> anyhow::Result<()> {
     let output = serde_json::to_string_pretty(&settings)?;
     fs::write(&path, output.as_bytes())?;
 
-    println!("Installed edda hooks into {}", path.display());
-    println!("Configured MCP server (edda mcp serve)");
+    tracing::info!(path = %path.display(), "installed edda hooks");
+    tracing::info!("configured MCP server (edda mcp serve)");
 
     // Onboard CLAUDE.md with edda decision-tracking instructions.
     // B1.5 testing showed CLAUDE.md is the decisive factor for agent compliance:
@@ -145,7 +145,7 @@ pub fn uninstall(repo_root: &Path) -> anyhow::Result<()> {
     let path = settings_path(repo_root);
 
     if !path.exists() {
-        println!("No settings file found at {}", path.display());
+        tracing::info!(path = %path.display(), "no settings file found");
         return Ok(());
     }
 
@@ -195,7 +195,7 @@ pub fn uninstall(repo_root: &Path) -> anyhow::Result<()> {
     let output = serde_json::to_string_pretty(&settings)?;
     fs::write(&path, output.as_bytes())?;
 
-    println!("Uninstalled edda hooks from {}", path.display());
+    tracing::info!(path = %path.display(), "uninstalled edda hooks");
     Ok(())
 }
 
@@ -332,14 +332,11 @@ fn ensure_claude_md_edda_section(repo_root: &Path) -> anyhow::Result<()> {
         }
         appended.push_str(EDDA_CLAUDE_MD_APPEND);
         fs::write(&claude_md, appended)?;
-        println!("Appended edda section to {}", claude_md.display());
+        tracing::info!(path = %claude_md.display(), "appended edda section");
     } else {
         // Create new file with full onboarding template
         fs::write(&claude_md, EDDA_CLAUDE_MD_CREATE.trim_start())?;
-        println!(
-            "Created {} with edda decision tracking",
-            claude_md.display()
-        );
+        tracing::info!(path = %claude_md.display(), "created CLAUDE.md with edda decision tracking");
     }
     Ok(())
 }
@@ -363,7 +360,7 @@ fn ensure_claude_md_coordination_section(repo_root: &Path) -> anyhow::Result<()>
     }
     appended.push_str(EDDA_COORDINATION_SECTION);
     fs::write(&claude_md, appended)?;
-    println!("Appended coordination rules to {}", claude_md.display());
+    tracing::info!(path = %claude_md.display(), "appended coordination rules");
     Ok(())
 }
 

--- a/crates/edda-bridge-claude/src/bg_digest.rs
+++ b/crates/edda-bridge-claude/src/bg_digest.rs
@@ -231,7 +231,7 @@ fn write_session_note(cwd: &str, summary: &str) -> Result<()> {
     edda_core::event::finalize_event(&mut event);
     ledger.append_event(&event)?;
 
-    eprintln!("[edda-bg] session digest written → {}", event.event_id);
+    tracing::info!(event_id = %event.event_id, "session digest written");
     Ok(())
 }
 

--- a/crates/edda-bridge-claude/src/bg_scan.rs
+++ b/crates/edda-bridge-claude/src/bg_scan.rs
@@ -195,10 +195,10 @@ pub fn run_scan(project_id: &str, cwd: &str) -> Result<ScanResult> {
         },
     )?;
 
-    eprintln!(
-        "[edda-bg] capability scan complete: {} gaps found (cost: ${:.4})",
-        result.gaps.len(),
-        cost_usd
+    tracing::info!(
+        gaps = result.gaps.len(),
+        cost_usd = format_args!("{:.4}", cost_usd),
+        "capability scan complete",
     );
 
     Ok(result)

--- a/crates/edda-bridge-claude/src/dispatch/events.rs
+++ b/crates/edda-bridge-claude/src/dispatch/events.rs
@@ -150,7 +150,7 @@ pub(super) fn try_post_karvi_signal(
         .header("Content-Type", "application/json")
         .send(payload.to_string())
     {
-        eprintln!("[edda-bridge-claude] karvi write-back failed: {}", e);
+        tracing::warn!(error = %e, "karvi write-back failed");
     }
 }
 

--- a/crates/edda-bridge-claude/src/dispatch/helpers.rs
+++ b/crates/edda-bridge-claude/src/dispatch/helpers.rs
@@ -163,7 +163,7 @@ pub(super) fn run_auto_digest(
         digest_failed_cmds,
     ) {
         crate::digest::DigestResult::Written { event_id } => {
-            eprintln!("[edda] digested previous session → {event_id}");
+            tracing::info!(%event_id, "digested previous session");
             None
         }
         crate::digest::DigestResult::PermanentFailure(warning) => Some(warning),

--- a/crates/edda-bridge-claude/src/dispatch/session.rs
+++ b/crates/edda-bridge-claude/src/dispatch/session.rs
@@ -278,7 +278,7 @@ pub(super) fn dispatch_session_end(
         let sid = session_id.to_string();
         std::thread::spawn(move || {
             if let Err(e) = crate::bg_extract::run_extraction(&pid, &sid) {
-                eprintln!("[edda-bg] decision extraction failed: {e}");
+                tracing::warn!(error = %e, "decision extraction failed");
             }
         });
     }
@@ -290,7 +290,7 @@ pub(super) fn dispatch_session_end(
         let cwd_str = cwd.to_string();
         std::thread::spawn(move || {
             if let Err(e) = crate::bg_digest::run_digest(&pid, &sid, &cwd_str) {
-                eprintln!("[edda-bg] session digest failed: {e}");
+                tracing::warn!(error = %e, "session digest failed");
             }
         });
     }
@@ -303,7 +303,7 @@ pub(super) fn dispatch_session_end(
         let cwd_owned = cwd.to_string();
         std::thread::spawn(move || {
             if let Err(e) = crate::bg_scan::run_scan(&pid, &cwd_owned) {
-                eprintln!("[edda-bg] capability scan failed: {e}");
+                tracing::warn!(error = %e, "capability scan failed");
             }
         });
     }
@@ -445,11 +445,11 @@ pub(super) fn run_postmortem(project_id: &str, session_id: &str, cwd: &str) {
         let _ = lessons_store.sync_to_claude_md(&claude_md_path, 10);
     }
 
-    eprintln!(
-        "[edda L3] post-mortem: {} triggers, {} lessons, {} rule proposals",
-        result.triggers.len(),
-        result.lessons.len(),
-        result.rule_proposals.len(),
+    tracing::info!(
+        triggers = result.triggers.len(),
+        lessons = result.lessons.len(),
+        rule_proposals = result.rule_proposals.len(),
+        "post-mortem complete",
     );
 }
 

--- a/crates/edda-chronicle/Cargo.toml
+++ b/crates/edda-chronicle/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = { workspace = true }
 reqwest = { version = "0.12", features = ["json"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }
+tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/edda-chronicle/src/relate.rs
+++ b/crates/edda-chronicle/src/relate.rs
@@ -34,10 +34,7 @@ pub fn build_search_index_if_needed(project_root: &std::path::Path) -> Result<()
     if !search_dir.exists() {
         // Index doesn't exist - would need to trigger index build
         // For now, just log a warning
-        eprintln!(
-            "Warning: FTS index not found at {:?}. BM25 relations will be skipped.",
-            search_dir
-        );
+        tracing::warn!(path = ?search_dir, "FTS index not found, BM25 relations will be skipped");
     }
 
     Ok(())

--- a/crates/edda-chronicle/src/synthesize.rs
+++ b/crates/edda-chronicle/src/synthesize.rs
@@ -80,7 +80,7 @@ async fn synthesize_with_llm(api_key: &str, input: SynthesisInput) -> Result<cra
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
-        eprintln!("Warning: LLM API failed ({}): {}", status, body);
+        tracing::warn!(%status, %body, "LLM API failed");
         return synthesize_with_template(input);
     }
 

--- a/crates/edda-cli/Cargo.toml
+++ b/crates/edda-cli/Cargo.toml
@@ -47,6 +47,7 @@ hex.workspace = true
 ulid.workspace = true
 time.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
+tracing-subscriber = { workspace = true }
 
 [features]
 default = ["tui"]

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -836,6 +836,14 @@ enum McpCommand {
 }
 
 fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "warn".into()),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
     let cli = Cli::parse();
     let cwd = std::env::current_dir()?;
     let repo_root = edda_ledger::EddaPaths::find_root(&cwd).unwrap_or(cwd);

--- a/crates/edda-notify/Cargo.toml
+++ b/crates/edda-notify/Cargo.toml
@@ -15,3 +15,4 @@ ureq = "3"
 serde.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true
+tracing = { workspace = true }

--- a/crates/edda-notify/src/lib.rs
+++ b/crates/edda-notify/src/lib.rs
@@ -182,7 +182,7 @@ pub fn dispatch(config: &NotifyConfig, event: &NotifyEvent) {
         }
         let name = channel.display_name();
         if let Err(e) = send(&agent, channel, event) {
-            eprintln!("[edda-notify] failed to send to {name}: {e}");
+            tracing::warn!(channel = %name, error = %e, "notification send failed");
         }
     }
 }

--- a/crates/edda-search-fts/Cargo.toml
+++ b/crates/edda-search-fts/Cargo.toml
@@ -19,6 +19,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
+tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/edda-search-fts/src/indexer.rs
+++ b/crates/edda-search-fts/src/indexer.rs
@@ -344,7 +344,7 @@ pub fn index_project(
             ) {
                 Ok(n) => total += n,
                 Err(e) => {
-                    eprintln!("warn: indexing session {session_id}: {e}");
+                    tracing::warn!(%session_id, error = %e, "indexing session failed");
                 }
             }
         }

--- a/crates/edda-serve/Cargo.toml
+++ b/crates/edda-serve/Cargo.toml
@@ -18,6 +18,7 @@ edda-aggregate = { path = "../edda-aggregate", version = "0.1.1" }
 edda-store = { path = "../edda-store", version = "0.1.1" }
 edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.1.1" }
 axum = "0.8"
+tracing = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread", "net"] }
 tower-http = { version = "0.6", features = ["cors"] }
 anyhow.workspace = true

--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -107,7 +107,7 @@ pub async fn serve(repo_root: &Path, config: ServeConfig) -> anyhow::Result<()> 
 
     let addr = format!("{}:{}", config.bind, config.port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;
-    tracing::info!(%addr, "HTTP server listening");
+    eprintln!("edda HTTP server listening on http://{addr}");
     axum::serve(listener, app).await?;
     Ok(())
 }

--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -107,7 +107,7 @@ pub async fn serve(repo_root: &Path, config: ServeConfig) -> anyhow::Result<()> 
 
     let addr = format!("{}:{}", config.bind, config.port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;
-    eprintln!("edda HTTP server listening on http://{addr}");
+    tracing::info!(%addr, "HTTP server listening");
     axum::serve(listener, app).await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

Closes #211

- Add `tracing` + `tracing-subscriber` to workspace dependencies
- Initialize subscriber in `edda-cli/src/main.rs` with `RUST_LOG` env var (default: `warn`, stderr output)
- Migrate diagnostic `eprintln!`/`println!` to `tracing` macros in 6 crates: `edda-bridge-claude`, `edda-serve`, `edda-chronicle`, `edda-notify`, `edda-search-fts`
- User-facing CLI output (`cmd_*.rs` println) is intentionally preserved

## Files changed (20)

| Step | Scope | Files |
|---|---|---|
| 1 | Workspace deps | `Cargo.toml`, `Cargo.lock` |
| 2 | Subscriber init | `edda-cli/Cargo.toml`, `edda-cli/src/main.rs` |
| 3 | bridge-claude | `Cargo.toml`, `admin.rs`, `bg_digest.rs`, `bg_scan.rs`, `dispatch/{session,helpers,events}.rs` |
| 4 | serve | `Cargo.toml`, `lib.rs` |
| 5 | chronicle/notify/fts | 3x `Cargo.toml`, `synthesize.rs`, `relate.rs`, `lib.rs`, `indexer.rs` |

## Test plan

- [x] `cargo clippy -- -D warnings` passes clean
- [x] `cargo test --workspace` — 439 pass, 1 pre-existing failure (`post_tool_use_increments_nudge_counter`)
- [ ] Manual: `RUST_LOG=debug cargo run -- --help` shows no log noise by default
- [ ] Manual: `RUST_LOG=info edda serve` shows structured startup log on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)