### PR TITLE
feat(governance): unified actor management (Phase 1)

### DIFF
--- a/crates/edda-cli/src/cmd_actor.rs
+++ b/crates/edda-cli/src/cmd_actor.rs
@@ -1,5 +1,5 @@
 use clap::Subcommand;
-use edda_core::policy::{load_actors_from_dir, save_actors_to_dir, ActorDef, ActorsConfig};
+use edda_core::policy::{load_actors_from_dir, save_actors_to_dir, ActorDef, ActorKind, ActorsConfig};
 use std::path::Path;
 
 // ── CLI Schema ──
@@ -15,7 +15,7 @@ pub enum ActorCmd {
         roles: Vec<String>,
         /// Actor kind: user or agent
         #[arg(long, default_value = "user")]
-        kind: String,
+        kind: ActorKind,
         /// Email address (optional)
         #[arg(long)]
         email: Option<String>,
@@ -81,7 +81,7 @@ pub fn run(cmd: ActorCmd, repo_root: &Path) -> anyhow::Result<()> {
             repo_root,
             &name,
             &roles,
-            &kind,
+            kind,
             email,
             display_name,
             runtime,
@@ -111,13 +111,6 @@ fn validate_actor_name(name: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn validate_kind(kind: &str) -> anyhow::Result<()> {
-    if kind != "user" && kind != "agent" {
-        anyhow::bail!("Actor kind must be 'user' or 'agent', got: {kind}");
-    }
-    Ok(())
-}
-
 fn load_and_check(
     repo_root: &Path,
 ) -> anyhow::Result<(edda_ledger::paths::EddaPaths, ActorsConfig)> {
@@ -135,13 +128,12 @@ fn add(
     repo_root: &Path,
     name: &str,
     roles: &[String],
-    kind: &str,
+    kind: ActorKind,
     email: Option<String>,
     display_name: Option<String>,
     runtime: Option<String>,
 ) -> anyhow::Result<()> {
     validate_actor_name(name)?;
-    validate_kind(kind)?;
 
     let (paths, mut cfg) = load_and_check(repo_root)?;
 
@@ -151,9 +143,15 @@ fn add(
         );
     }
 
+    println!("Added actor: {name}");
+    println!("  kind: {kind}");
+    if !roles.is_empty() {
+        println!("  roles: {}", roles.join(", "));
+    }
+
     let actor = ActorDef {
         roles: roles.to_vec(),
-        kind: kind.to_string(),
+        kind,
         email,
         display_name,
         runtime,
@@ -163,11 +161,6 @@ fn add(
     cfg.version = 2;
     save_actors_to_dir(&paths.edda_dir, &cfg)?;
 
-    println!("Added actor: {name}");
-    println!("  kind: {kind}");
-    if !roles.is_empty() {
-        println!("  roles: {}", roles.join(", "));
-    }
     Ok(())
 }
 
@@ -339,7 +332,7 @@ mod tests {
             &tmp,
             "alice",
             &["lead".into(), "reviewer".into()],
-            "user",
+            ActorKind::User,
             Some("a@b.com".into()),
             None,
             None,
@@ -350,7 +343,7 @@ mod tests {
         assert!(cfg.actors.contains_key("alice"));
         let alice = cfg.actors.get("alice").unwrap();
         assert_eq!(alice.roles, vec!["lead", "reviewer"]);
-        assert_eq!(alice.kind, "user");
+        assert_eq!(alice.kind, ActorKind::User);
         assert_eq!(alice.email.as_deref(), Some("a@b.com"));
 
         let _ = std::fs::remove_dir_all(&tmp);
@@ -363,7 +356,7 @@ mod tests {
             &tmp,
             "bob",
             &["operator".into()],
-            "agent",
+            ActorKind::Agent,
             None,
             None,
             Some("claude".into()),
@@ -387,7 +380,7 @@ mod tests {
             &tmp,
             "carol",
             &["reviewer".into()],
-            "user",
+            ActorKind::User,
             None,
             None,
             None,
@@ -412,8 +405,8 @@ mod tests {
     #[test]
     fn test_actor_add_duplicate_errors() {
         let tmp = setup_workspace();
-        add(&tmp, "dave", &[], "user", None, None, None).unwrap();
-        let result = add(&tmp, "dave", &[], "user", None, None, None);
+        add(&tmp, "dave", &[], ActorKind::User, None, None, None).unwrap();
+        let result = add(&tmp, "dave", &[], ActorKind::User, None, None, None);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("already exists"));
 
@@ -434,10 +427,10 @@ mod tests {
     fn test_actor_kind_default() {
         let tmp = setup_workspace();
         // When kind defaults to "user"
-        add(&tmp, "eve", &[], "user", None, None, None).unwrap();
+        add(&tmp, "eve", &[], ActorKind::User, None, None, None).unwrap();
         let (_, cfg) = load_and_check(&tmp).unwrap();
         let eve = cfg.actors.get("eve").unwrap();
-        assert_eq!(eve.kind, "user");
+        assert_eq!(eve.kind, ActorKind::User);
 
         let _ = std::fs::remove_dir_all(&tmp);
     }
@@ -454,14 +447,12 @@ mod tests {
 
     #[test]
     fn test_actor_invalid_kind_errors() {
-        let tmp = setup_workspace();
-        let result = add(&tmp, "frank", &[], "robot", None, None, None);
+        // ActorKind::from_str rejects invalid values at parse time
+        let result: Result<ActorKind, _> = "robot".parse();
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
             .to_string()
             .contains("must be 'user' or 'agent'"));
-
-        let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/crates/edda-cli/src/cmd_actor.rs
+++ b/crates/edda-cli/src/cmd_actor.rs
@@ -1,0 +1,467 @@
+use clap::Subcommand;
+use edda_core::policy::{load_actors_from_dir, save_actors_to_dir, ActorDef, ActorsConfig};
+use std::path::Path;
+
+// ── CLI Schema ──
+
+#[derive(Subcommand)]
+pub enum ActorCmd {
+    /// Add an actor to the project
+    Add {
+        /// Actor name (alphanumeric, hyphens, underscores)
+        name: String,
+        /// Role to assign (repeatable)
+        #[arg(long = "role")]
+        roles: Vec<String>,
+        /// Actor kind: user or agent
+        #[arg(long, default_value = "user")]
+        kind: String,
+        /// Email address (optional)
+        #[arg(long)]
+        email: Option<String>,
+        /// Display name (optional)
+        #[arg(long)]
+        display_name: Option<String>,
+        /// Runtime platform for agents (e.g. "claude", "opencode")
+        #[arg(long)]
+        runtime: Option<String>,
+    },
+    /// Remove an actor from the project
+    Remove {
+        /// Actor name
+        name: String,
+    },
+    /// List all project actors
+    List {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+        /// Filter by role
+        #[arg(long)]
+        role: Option<String>,
+    },
+    /// Show details of a single actor
+    Show {
+        /// Actor name
+        name: String,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Grant a role to an existing actor
+    Grant {
+        /// Actor name
+        name: String,
+        /// Role to add
+        #[arg(long)]
+        role: String,
+    },
+    /// Revoke a role from an existing actor
+    Revoke {
+        /// Actor name
+        name: String,
+        /// Role to remove
+        #[arg(long)]
+        role: String,
+    },
+}
+
+// ── Dispatch ──
+
+pub fn run(cmd: ActorCmd, repo_root: &Path) -> anyhow::Result<()> {
+    match cmd {
+        ActorCmd::Add {
+            name,
+            roles,
+            kind,
+            email,
+            display_name,
+            runtime,
+        } => add(
+            repo_root,
+            &name,
+            &roles,
+            &kind,
+            email,
+            display_name,
+            runtime,
+        ),
+        ActorCmd::Remove { name } => remove(repo_root, &name),
+        ActorCmd::List { json, role } => list(repo_root, json, role.as_deref()),
+        ActorCmd::Show { name, json } => show(repo_root, &name, json),
+        ActorCmd::Grant { name, role } => grant(repo_root, &name, &role),
+        ActorCmd::Revoke { name, role } => revoke(repo_root, &name, &role),
+    }
+}
+
+// ── Helpers ──
+
+fn validate_actor_name(name: &str) -> anyhow::Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("Actor name cannot be empty");
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    {
+        anyhow::bail!(
+            "Actor name must contain only alphanumeric characters, hyphens, or underscores: {name}"
+        );
+    }
+    Ok(())
+}
+
+fn validate_kind(kind: &str) -> anyhow::Result<()> {
+    if kind != "user" && kind != "agent" {
+        anyhow::bail!("Actor kind must be 'user' or 'agent', got: {kind}");
+    }
+    Ok(())
+}
+
+fn load_and_check(
+    repo_root: &Path,
+) -> anyhow::Result<(edda_ledger::paths::EddaPaths, ActorsConfig)> {
+    let paths = edda_ledger::EddaPaths::discover(repo_root);
+    if !paths.is_initialized() {
+        anyhow::bail!("No .edda/ workspace found. Run `edda init` first.");
+    }
+    let cfg = load_actors_from_dir(&paths.edda_dir)?;
+    Ok((paths, cfg))
+}
+
+// ── Commands ──
+
+fn add(
+    repo_root: &Path,
+    name: &str,
+    roles: &[String],
+    kind: &str,
+    email: Option<String>,
+    display_name: Option<String>,
+    runtime: Option<String>,
+) -> anyhow::Result<()> {
+    validate_actor_name(name)?;
+    validate_kind(kind)?;
+
+    let (paths, mut cfg) = load_and_check(repo_root)?;
+
+    if cfg.actors.contains_key(name) {
+        anyhow::bail!(
+            "Actor '{name}' already exists. Remove it first or use grant/revoke to modify roles."
+        );
+    }
+
+    let actor = ActorDef {
+        roles: roles.to_vec(),
+        kind: kind.to_string(),
+        email,
+        display_name,
+        runtime,
+    };
+
+    cfg.actors.insert(name.to_string(), actor);
+    cfg.version = 2;
+    save_actors_to_dir(&paths.edda_dir, &cfg)?;
+
+    println!("Added actor: {name}");
+    println!("  kind: {kind}");
+    if !roles.is_empty() {
+        println!("  roles: {}", roles.join(", "));
+    }
+    Ok(())
+}
+
+fn remove(repo_root: &Path, name: &str) -> anyhow::Result<()> {
+    let (paths, mut cfg) = load_and_check(repo_root)?;
+
+    if cfg.actors.remove(name).is_none() {
+        anyhow::bail!("Actor '{name}' not found.");
+    }
+
+    save_actors_to_dir(&paths.edda_dir, &cfg)?;
+    println!("Removed actor: {name}");
+    Ok(())
+}
+
+fn list(repo_root: &Path, json: bool, role_filter: Option<&str>) -> anyhow::Result<()> {
+    let (_paths, cfg) = load_and_check(repo_root)?;
+
+    let actors: Vec<_> = cfg
+        .actors
+        .iter()
+        .filter(|(_, def)| {
+            role_filter
+                .map(|r| def.roles.contains(&r.to_string()))
+                .unwrap_or(true)
+        })
+        .collect();
+
+    if json {
+        for (name, def) in &actors {
+            let obj = serde_json::json!({
+                "name": name,
+                "kind": def.kind,
+                "roles": def.roles,
+                "email": def.email,
+                "display_name": def.display_name,
+                "runtime": def.runtime,
+            });
+            println!("{}", serde_json::to_string(&obj)?);
+        }
+    } else if actors.is_empty() {
+        println!("(no actors)");
+    } else {
+        for (name, def) in &actors {
+            println!(
+                "{} [{}] roles={}",
+                name,
+                def.kind,
+                if def.roles.is_empty() {
+                    "(none)".to_string()
+                } else {
+                    def.roles.join(", ")
+                }
+            );
+        }
+    }
+    Ok(())
+}
+
+fn show(repo_root: &Path, name: &str, json: bool) -> anyhow::Result<()> {
+    let (_paths, cfg) = load_and_check(repo_root)?;
+
+    let def = cfg
+        .actors
+        .get(name)
+        .ok_or_else(|| anyhow::anyhow!("Actor '{name}' not found."))?;
+
+    if json {
+        let obj = serde_json::json!({
+            "name": name,
+            "kind": def.kind,
+            "roles": def.roles,
+            "email": def.email,
+            "display_name": def.display_name,
+            "runtime": def.runtime,
+        });
+        println!("{}", serde_json::to_string_pretty(&obj)?);
+    } else {
+        println!("Actor: {name}");
+        println!("  kind: {}", def.kind);
+        println!(
+            "  roles: {}",
+            if def.roles.is_empty() {
+                "(none)".to_string()
+            } else {
+                def.roles.join(", ")
+            }
+        );
+        if let Some(email) = &def.email {
+            println!("  email: {email}");
+        }
+        if let Some(dn) = &def.display_name {
+            println!("  display_name: {dn}");
+        }
+        if let Some(rt) = &def.runtime {
+            println!("  runtime: {rt}");
+        }
+    }
+    Ok(())
+}
+
+fn grant(repo_root: &Path, name: &str, role: &str) -> anyhow::Result<()> {
+    let (paths, mut cfg) = load_and_check(repo_root)?;
+
+    let def = cfg
+        .actors
+        .get_mut(name)
+        .ok_or_else(|| anyhow::anyhow!("Actor '{name}' not found."))?;
+
+    if def.roles.contains(&role.to_string()) {
+        println!("Actor '{name}' already has role '{role}'.");
+        return Ok(());
+    }
+
+    def.roles.push(role.to_string());
+    save_actors_to_dir(&paths.edda_dir, &cfg)?;
+    println!("Granted role '{role}' to actor '{name}'.");
+    Ok(())
+}
+
+fn revoke(repo_root: &Path, name: &str, role: &str) -> anyhow::Result<()> {
+    let (paths, mut cfg) = load_and_check(repo_root)?;
+
+    let def = cfg
+        .actors
+        .get_mut(name)
+        .ok_or_else(|| anyhow::anyhow!("Actor '{name}' not found."))?;
+
+    let before_len = def.roles.len();
+    def.roles.retain(|r| r != role);
+    if def.roles.len() == before_len {
+        anyhow::bail!("Actor '{name}' does not have role '{role}'.");
+    }
+
+    save_actors_to_dir(&paths.edda_dir, &cfg)?;
+    println!("Revoked role '{role}' from actor '{name}'.");
+    Ok(())
+}
+
+// ── Tests ──
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn setup_workspace() -> std::path::PathBuf {
+        let n = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let tmp = std::env::temp_dir().join(format!("edda_actor_test_{}_{n}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        // Minimal init: create .edda/ dir with actors.yaml
+        let edda_dir = tmp.join(".edda");
+        std::fs::create_dir_all(&edda_dir).unwrap();
+        std::fs::write(edda_dir.join("actors.yaml"), "version: 2\nactors: {}\n").unwrap();
+        // Also need schema.json and HEAD for EddaPaths::is_initialized()
+        std::fs::write(edda_dir.join("schema.json"), r#"{"version":4}"#).unwrap();
+        std::fs::write(edda_dir.join("HEAD"), "main").unwrap();
+        tmp
+    }
+
+    #[test]
+    fn test_actor_add_and_list() {
+        let tmp = setup_workspace();
+        add(
+            &tmp,
+            "alice",
+            &["lead".into(), "reviewer".into()],
+            "user",
+            Some("a@b.com".into()),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let (_, cfg) = load_and_check(&tmp).unwrap();
+        assert!(cfg.actors.contains_key("alice"));
+        let alice = cfg.actors.get("alice").unwrap();
+        assert_eq!(alice.roles, vec!["lead", "reviewer"]);
+        assert_eq!(alice.kind, "user");
+        assert_eq!(alice.email.as_deref(), Some("a@b.com"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_actor_remove() {
+        let tmp = setup_workspace();
+        add(
+            &tmp,
+            "bob",
+            &["operator".into()],
+            "agent",
+            None,
+            None,
+            Some("claude".into()),
+        )
+        .unwrap();
+
+        let (_, cfg) = load_and_check(&tmp).unwrap();
+        assert!(cfg.actors.contains_key("bob"));
+
+        remove(&tmp, "bob").unwrap();
+        let (_, cfg) = load_and_check(&tmp).unwrap();
+        assert!(!cfg.actors.contains_key("bob"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_actor_grant_revoke() {
+        let tmp = setup_workspace();
+        add(
+            &tmp,
+            "carol",
+            &["reviewer".into()],
+            "user",
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        grant(&tmp, "carol", "lead").unwrap();
+        let (_, cfg) = load_and_check(&tmp).unwrap();
+        let carol = cfg.actors.get("carol").unwrap();
+        assert!(carol.roles.contains(&"lead".to_string()));
+        assert!(carol.roles.contains(&"reviewer".to_string()));
+
+        revoke(&tmp, "carol", "reviewer").unwrap();
+        let (_, cfg) = load_and_check(&tmp).unwrap();
+        let carol = cfg.actors.get("carol").unwrap();
+        assert!(!carol.roles.contains(&"reviewer".to_string()));
+        assert!(carol.roles.contains(&"lead".to_string()));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_actor_add_duplicate_errors() {
+        let tmp = setup_workspace();
+        add(&tmp, "dave", &[], "user", None, None, None).unwrap();
+        let result = add(&tmp, "dave", &[], "user", None, None, None);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("already exists"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_actor_remove_nonexistent_errors() {
+        let tmp = setup_workspace();
+        let result = remove(&tmp, "nobody");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not found"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_actor_kind_default() {
+        let tmp = setup_workspace();
+        // When kind defaults to "user"
+        add(&tmp, "eve", &[], "user", None, None, None).unwrap();
+        let (_, cfg) = load_and_check(&tmp).unwrap();
+        let eve = cfg.actors.get("eve").unwrap();
+        assert_eq!(eve.kind, "user");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_actor_name_validation() {
+        assert!(validate_actor_name("alice").is_ok());
+        assert!(validate_actor_name("claude-agent-1").is_ok());
+        assert!(validate_actor_name("my_bot").is_ok());
+        assert!(validate_actor_name("").is_err());
+        assert!(validate_actor_name("a b").is_err());
+        assert!(validate_actor_name("a@b").is_err());
+    }
+
+    #[test]
+    fn test_actor_invalid_kind_errors() {
+        let tmp = setup_workspace();
+        let result = add(&tmp, "frank", &[], "robot", None, None, None);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("must be 'user' or 'agent'"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/crates/edda-cli/src/cmd_draft.rs
+++ b/crates/edda-cli/src/cmd_draft.rs
@@ -4,7 +4,9 @@ use edda_core::event::{
     new_approval_event, new_approval_request_event, new_commit_event, ApprovalEventParams,
     ApprovalRequestParams, CommitEventParams,
 };
-use edda_core::policy::{ActorsConfig, PolicyRule, PolicyStageDef, PolicyV2Config, PolicyWhen};
+use edda_core::policy::{
+    load_actors_from_dir, ActorsConfig, PolicyRule, PolicyStageDef, PolicyV2Config, PolicyWhen,
+};
 use edda_derive::{build_auto_evidence, last_commit_contribution, rebuild_all};
 use std::path::Path;
 
@@ -290,13 +292,7 @@ fn load_policy_v2(ledger: &Ledger) -> anyhow::Result<PolicyV2Config> {
 }
 
 fn load_actors(ledger: &Ledger) -> anyhow::Result<ActorsConfig> {
-    let path = ledger.paths.edda_dir.join("actors.yaml");
-    if !path.exists() {
-        return Ok(ActorsConfig::default());
-    }
-    let content = std::fs::read(&path)?;
-    let cfg: ActorsConfig = serde_yaml::from_slice(&content)?;
-    Ok(cfg)
+    load_actors_from_dir(&ledger.paths.edda_dir)
 }
 
 // ── Route selection ──

--- a/crates/edda-cli/src/cmd_init.rs
+++ b/crates/edda-cli/src/cmd_init.rs
@@ -65,8 +65,17 @@ rules:
         let actors_path = paths.edda_dir.join("actors.yaml");
         if !actors_path.exists() {
             let default_actors = "\
-version: 1
+version: 2
 actors: {}
+# Example:
+#   alice:
+#     kind: user
+#     roles: [lead, reviewer]
+#     email: alice@example.com
+#   claude-agent:
+#     kind: agent
+#     roles: [operator]
+#     runtime: claude
 ";
             std::fs::write(&actors_path, default_actors.as_bytes())?;
         }

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod cmd_actor;
 mod cmd_ask;
 mod cmd_blob;
 mod cmd_branch;
@@ -55,6 +56,11 @@ enum Command {
         /// Overwrite existing coordination skills with latest embedded versions
         #[arg(long)]
         force_skills: bool,
+    },
+    /// Manage project actors (add, remove, list, grant, revoke)
+    Actor {
+        #[command(subcommand)]
+        cmd: cmd_actor::ActorCmd,
     },
     /// Record a note event
     Note {
@@ -859,6 +865,7 @@ fn main() -> anyhow::Result<()> {
             no_hooks,
             force_skills,
         } => cmd_init::execute(&repo_root, no_hooks, force_skills),
+        Command::Actor { cmd } => cmd_actor::run(cmd, &repo_root),
         Command::Note { text, role, tags } => cmd_note::execute(&repo_root, &text, &role, &tags),
         Command::Decide {
             decision,

--- a/crates/edda-core/src/policy.rs
+++ b/crates/edda-core/src/policy.rs
@@ -67,13 +67,42 @@ pub struct ActorsConfig {
     pub actors: BTreeMap<String, ActorDef>,
 }
 
+/// Actor kind: distinguishes human users from automated agents.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ActorKind {
+    #[default]
+    User,
+    Agent,
+}
+
+impl std::fmt::Display for ActorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ActorKind::User => write!(f, "user"),
+            ActorKind::Agent => write!(f, "agent"),
+        }
+    }
+}
+
+impl std::str::FromStr for ActorKind {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "user" => Ok(ActorKind::User),
+            "agent" => Ok(ActorKind::Agent),
+            other => anyhow::bail!("Actor kind must be 'user' or 'agent', got: {other}"),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ActorDef {
     #[serde(default)]
     pub roles: Vec<String>,
-    /// Actor kind: "user" or "agent". Defaults to "user" for v1 compat.
-    #[serde(default = "default_user_kind")]
-    pub kind: String,
+    /// Actor kind: "user" or "agent". Defaults to User for v1 compat.
+    #[serde(default)]
+    pub kind: ActorKind,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -81,10 +110,6 @@ pub struct ActorDef {
     /// For agent actors: runtime platform (e.g. "claude", "opencode").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime: Option<String>,
-}
-
-fn default_user_kind() -> String {
-    "user".into()
 }
 
 impl Default for ActorsConfig {
@@ -293,7 +318,7 @@ mod tests {
             name.to_string(),
             ActorDef {
                 roles: roles.iter().map(|s| s.to_string()).collect(),
-                kind: "user".into(),
+                kind: ActorKind::User,
                 email: None,
                 display_name: None,
                 runtime: None,
@@ -455,7 +480,7 @@ actors:
         assert_eq!(cfg.version, 1);
         let alice = cfg.actors.get("alice").unwrap();
         assert_eq!(alice.roles, vec!["lead", "reviewer"]);
-        assert_eq!(alice.kind, "user"); // default
+        assert_eq!(alice.kind, ActorKind::User); // default
         assert!(alice.email.is_none());
         assert!(alice.display_name.is_none());
         assert!(alice.runtime.is_none());
@@ -480,13 +505,13 @@ actors:
         assert_eq!(cfg.version, 2);
 
         let alice = cfg.actors.get("alice").unwrap();
-        assert_eq!(alice.kind, "user");
+        assert_eq!(alice.kind, ActorKind::User);
         assert_eq!(alice.email.as_deref(), Some("alice@example.com"));
         assert_eq!(alice.display_name.as_deref(), Some("Alice Chen"));
         assert!(alice.runtime.is_none());
 
         let agent = cfg.actors.get("claude-agent-1").unwrap();
-        assert_eq!(agent.kind, "agent");
+        assert_eq!(agent.kind, ActorKind::Agent);
         assert_eq!(agent.roles, vec!["operator"]);
         assert_eq!(agent.runtime.as_deref(), Some("claude"));
         assert!(agent.email.is_none());

--- a/crates/edda-core/src/policy.rs
+++ b/crates/edda-core/src/policy.rs
@@ -71,6 +71,20 @@ pub struct ActorsConfig {
 pub struct ActorDef {
     #[serde(default)]
     pub roles: Vec<String>,
+    /// Actor kind: "user" or "agent". Defaults to "user" for v1 compat.
+    #[serde(default = "default_user_kind")]
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    /// For agent actors: runtime platform (e.g. "claude", "opencode").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<String>,
+}
+
+fn default_user_kind() -> String {
+    "user".into()
 }
 
 impl Default for ActorsConfig {
@@ -236,6 +250,14 @@ pub fn load_actors_from_dir(edda_dir: &Path) -> anyhow::Result<ActorsConfig> {
     Ok(cfg)
 }
 
+/// Save actors.yaml to the `.edda/` directory.
+pub fn save_actors_to_dir(edda_dir: &Path, cfg: &ActorsConfig) -> anyhow::Result<()> {
+    let path = edda_dir.join("actors.yaml");
+    let yaml = serde_yaml::to_string(cfg)?;
+    std::fs::write(&path, yaml.as_bytes())?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -271,6 +293,10 @@ mod tests {
             name.to_string(),
             ActorDef {
                 roles: roles.iter().map(|s| s.to_string()).collect(),
+                kind: "user".into(),
+                email: None,
+                display_name: None,
+                runtime: None,
             },
         );
         ActorsConfig { version: 1, actors }
@@ -415,6 +441,55 @@ permissions:
         assert_eq!(perms.default, "deny");
         assert_eq!(perms.grants.len(), 2);
         assert_eq!(perms.grants[0].actions, vec!["deploy"]);
+    }
+
+    #[test]
+    fn test_actors_v1_backward_compat() {
+        let yaml = r#"
+version: 1
+actors:
+  alice:
+    roles: [lead, reviewer]
+"#;
+        let cfg: ActorsConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.version, 1);
+        let alice = cfg.actors.get("alice").unwrap();
+        assert_eq!(alice.roles, vec!["lead", "reviewer"]);
+        assert_eq!(alice.kind, "user"); // default
+        assert!(alice.email.is_none());
+        assert!(alice.display_name.is_none());
+        assert!(alice.runtime.is_none());
+    }
+
+    #[test]
+    fn test_actors_v2_full_fields() {
+        let yaml = r#"
+version: 2
+actors:
+  alice:
+    kind: user
+    roles: [lead, reviewer]
+    email: alice@example.com
+    display_name: Alice Chen
+  claude-agent-1:
+    kind: agent
+    roles: [operator]
+    runtime: claude
+"#;
+        let cfg: ActorsConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.version, 2);
+
+        let alice = cfg.actors.get("alice").unwrap();
+        assert_eq!(alice.kind, "user");
+        assert_eq!(alice.email.as_deref(), Some("alice@example.com"));
+        assert_eq!(alice.display_name.as_deref(), Some("Alice Chen"));
+        assert!(alice.runtime.is_none());
+
+        let agent = cfg.actors.get("claude-agent-1").unwrap();
+        assert_eq!(agent.kind, "agent");
+        assert_eq!(agent.roles, vec!["operator"]);
+        assert_eq!(agent.runtime.as_deref(), Some("claude"));
+        assert!(agent.email.is_none());
     }
 
     #[test]

--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -14,7 +14,7 @@ use edda_aggregate::graph::build_dependency_graph;
 use edda_aggregate::quality::{model_quality_from_events, QualityReport};
 use edda_aggregate::risk::{compute_decision_risks, DecisionInput, DecisionRisk};
 use edda_core::event::{finalize_event, new_decision_event, new_execution_event, new_note_event};
-use edda_core::policy;
+use edda_core::policy::{self, ActorKind};
 use edda_core::types::{rel, DecisionPayload, Provenance};
 use edda_derive::{rebuild_branch, render_context, DeriveOptions};
 use edda_ledger::lock::WorkspaceLock;
@@ -975,7 +975,7 @@ async fn get_projects(
 #[derive(Serialize)]
 struct ActorResponse {
     name: String,
-    kind: String,
+    kind: ActorKind,
     roles: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     email: Option<String>,
@@ -1015,21 +1015,30 @@ async fn get_actors(
 async fn get_actor(
     State(state): State<Arc<AppState>>,
     AxumPath(name): AxumPath<String>,
-) -> Result<Json<ActorResponse>, AppError> {
-    let ledger = state.open_ledger()?;
-    let cfg = policy::load_actors_from_dir(&ledger.paths.edda_dir)?;
-    let def = cfg
-        .actors
-        .get(&name)
-        .ok_or_else(|| anyhow::anyhow!("Actor '{name}' not found"))?;
-    Ok(Json(ActorResponse {
-        name,
-        kind: def.kind.clone(),
-        roles: def.roles.clone(),
-        email: def.email.clone(),
-        display_name: def.display_name.clone(),
-        runtime: def.runtime.clone(),
-    }))
+) -> Response {
+    let ledger = match state.open_ledger() {
+        Ok(l) => l,
+        Err(e) => return AppError(e).into_response(),
+    };
+    let cfg = match policy::load_actors_from_dir(&ledger.paths.edda_dir) {
+        Ok(c) => c,
+        Err(e) => return AppError(e).into_response(),
+    };
+    match cfg.actors.get(&name) {
+        Some(def) => Json(ActorResponse {
+            name,
+            kind: def.kind.clone(),
+            roles: def.roles.clone(),
+            email: def.email.clone(),
+            display_name: def.display_name.clone(),
+            runtime: def.runtime.clone(),
+        })
+        .into_response(),
+        None => {
+            let body = serde_json::json!({ "error": format!("Actor '{name}' not found") });
+            (StatusCode::NOT_FOUND, Json(body)).into_response()
+        }
+    }
 }
 
 // ── GET /api/metrics/quality ──
@@ -2881,5 +2890,56 @@ actors:
         let html = String::from_utf8(body.to_vec()).unwrap();
         assert!(html.contains("Edda Dashboard"));
         assert!(html.contains("/api/dashboard"));
+    }
+
+    // ── Actor endpoint tests ──
+
+    #[tokio::test]
+    async fn test_get_actors_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/actors")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let actors = json["actors"].as_array().unwrap();
+        assert!(actors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_actor_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/actors/nonexistent")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["error"].as_str().unwrap().contains("not found"));
     }
 }

--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -107,6 +107,8 @@ pub async fn serve(repo_root: &Path, config: ServeConfig) -> anyhow::Result<()> 
         .route("/api/metrics/quality", get(get_quality_metrics))
         .route("/api/dashboard", get(get_dashboard))
         .route("/dashboard", get(serve_dashboard))
+        .route("/api/actors", get(get_actors))
+        .route("/api/actors/{name}", get(get_actor))
         .layer(CorsLayer::permissive())
         .with_state(state);
 
@@ -151,6 +153,8 @@ pub fn router(repo_root: &Path) -> Router {
         .route("/api/recap/cached", get(get_recap_cached))
         .route("/api/overview", get(get_overview))
         .route("/api/projects", get(get_projects))
+        .route("/api/actors", get(get_actors))
+        .route("/api/actors/{name}", get(get_actor))
         .route("/api/metrics/quality", get(get_quality_metrics))
         .route("/api/dashboard", get(get_dashboard))
         .route("/dashboard", get(serve_dashboard))
@@ -963,6 +967,68 @@ async fn get_projects(
 
     Ok(Json(ProjectsResponse {
         projects: project_statuses,
+    }))
+}
+
+// ── GET /api/actors ──
+
+#[derive(Serialize)]
+struct ActorResponse {
+    name: String,
+    kind: String,
+    roles: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    email: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    runtime: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ActorsListResponse {
+    actors: Vec<ActorResponse>,
+}
+
+async fn get_actors(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<ActorsListResponse>, AppError> {
+    let ledger = state.open_ledger()?;
+    let cfg = policy::load_actors_from_dir(&ledger.paths.edda_dir)?;
+    let actors = cfg
+        .actors
+        .into_iter()
+        .map(|(name, def)| ActorResponse {
+            name,
+            kind: def.kind,
+            roles: def.roles,
+            email: def.email,
+            display_name: def.display_name,
+            runtime: def.runtime,
+        })
+        .collect();
+    Ok(Json(ActorsListResponse { actors }))
+}
+
+// ── GET /api/actors/:name ──
+
+async fn get_actor(
+    State(state): State<Arc<AppState>>,
+    AxumPath(name): AxumPath<String>,
+) -> Result<Json<ActorResponse>, AppError> {
+    let ledger = state.open_ledger()?;
+    let cfg = policy::load_actors_from_dir(&ledger.paths.edda_dir)?;
+    let def = cfg
+        .actors
+        .get(&name)
+        .ok_or_else(|| anyhow::anyhow!("Actor '{name}' not found"))?;
+    Ok(Json(ActorResponse {
+        name,
+        kind: def.kind.clone(),
+        roles: def.roles.clone(),
+        email: def.email.clone(),
+        display_name: def.display_name.clone(),
+        runtime: def.runtime.clone(),
     }))
 }
 


### PR DESCRIPTION
## Summary

- Extends `ActorDef` schema with `kind` (user/agent), `email`, `display_name`, `runtime` fields — backward compatible with v1
- Adds `edda actor add/remove/list/show/grant/revoke` CLI commands in new `cmd_actor.rs`
- Deduplicates legacy `ActorsConfig` from `cmd_draft.rs`, delegates to `edda_core::policy`
- Updates `edda init` default `actors.yaml` template to v2 with commented examples
- Adds `GET /api/actors` and `GET /api/actors/:name` REST endpoints in `edda-serve`

Closes #206 (Phase 1 only — Phase 2 global registry is a follow-up)

## Test plan

- [x] 12 edda-core policy tests pass (including 2 new: v1 backward compat, v2 full fields)
- [x] 8 new cmd_actor tests: add/remove, grant/revoke, duplicate errors, name validation, kind validation
- [x] 11 existing cmd_draft tests pass unchanged after deduplication
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)