### PR TITLE
feat(serve): 30-second dashboard with risk scoring (#195)

### DIFF
--- a/crates/edda-aggregate/src/graph.rs
+++ b/crates/edda-aggregate/src/graph.rs
@@ -1,0 +1,188 @@
+//! Decision dependency graph extraction from provenance references.
+
+use edda_ledger::Ledger;
+use edda_store::registry::ProjectEntry;
+use serde::Serialize;
+use std::collections::HashSet;
+use std::path::Path;
+
+/// A node in the dependency graph representing a decision event.
+#[derive(Debug, Clone, Serialize)]
+pub struct GraphNode {
+    pub event_id: String,
+    pub key: String,
+    pub value: String,
+    pub project: String,
+    pub ts: String,
+}
+
+/// An edge in the dependency graph representing a provenance relationship.
+#[derive(Debug, Clone, Serialize)]
+pub struct GraphEdge {
+    pub source: String,
+    pub target: String,
+    pub rel: String,
+}
+
+/// The full dependency graph: nodes (decisions) + edges (provenance links).
+#[derive(Debug, Clone, Serialize)]
+pub struct DependencyGraph {
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<GraphEdge>,
+}
+
+/// Build a dependency graph from all decision events across registered projects.
+///
+/// Nodes are decision events; edges are provenance links between them.
+pub fn build_dependency_graph(projects: &[ProjectEntry]) -> DependencyGraph {
+    let mut nodes = Vec::new();
+    let mut edges = Vec::new();
+    let mut decision_ids: HashSet<String> = HashSet::new();
+
+    for entry in projects {
+        let root = Path::new(&entry.path);
+        let ledger = match Ledger::open(root) {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        let events = match ledger.iter_events() {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        for event in &events {
+            if edda_core::decision::is_decision(&event.payload) {
+                let dec = edda_core::decision::extract_decision(&event.payload);
+                let key = dec.as_ref().map(|d| d.key.clone()).unwrap_or_default();
+                let value = dec.as_ref().map(|d| d.value.clone()).unwrap_or_default();
+
+                nodes.push(GraphNode {
+                    event_id: event.event_id.clone(),
+                    key,
+                    value,
+                    project: entry.name.clone(),
+                    ts: event.ts.clone(),
+                });
+                decision_ids.insert(event.event_id.clone());
+            }
+
+            // Extract provenance edges
+            for prov in &event.refs.provenance {
+                edges.push(GraphEdge {
+                    source: event.event_id.clone(),
+                    target: prov.target.clone(),
+                    rel: prov.rel.clone(),
+                });
+            }
+        }
+    }
+
+    // Filter edges to only include those between known decision nodes
+    let edges = edges
+        .into_iter()
+        .filter(|e| decision_ids.contains(&e.source) || decision_ids.contains(&e.target))
+        .collect();
+
+    DependencyGraph { nodes, edges }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_decision_payload(
+        key: &str,
+        value: &str,
+        reason: Option<&str>,
+    ) -> edda_core::types::DecisionPayload {
+        edda_core::types::DecisionPayload {
+            key: key.to_string(),
+            value: value.to_string(),
+            reason: reason.map(|r| r.to_string()),
+        }
+    }
+
+    #[test]
+    fn empty_projects_returns_empty_graph() {
+        let graph = build_dependency_graph(&[]);
+        assert!(graph.nodes.is_empty());
+        assert!(graph.edges.is_empty());
+    }
+
+    #[test]
+    fn single_decision_produces_node_no_edges() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        let paths = edda_ledger::EddaPaths::discover(root);
+        edda_ledger::ledger::init_workspace(&paths).unwrap();
+        edda_ledger::ledger::init_head(&paths, "main").unwrap();
+
+        let ledger = Ledger::open(root).unwrap();
+        let payload = make_decision_payload("db.engine", "sqlite", Some("embedded"));
+        let event = edda_core::event::new_decision_event("main", None, "user", &payload).unwrap();
+        ledger.append_event(&event).unwrap();
+
+        let entry = ProjectEntry {
+            project_id: "test".to_string(),
+            path: root.to_string_lossy().to_string(),
+            name: "test-project".to_string(),
+            registered_at: "2026-03-01T00:00:00Z".to_string(),
+            last_seen: "2026-03-01T00:00:00Z".to_string(),
+        };
+
+        let graph = build_dependency_graph(&[entry]);
+        assert_eq!(graph.nodes.len(), 1);
+        assert_eq!(graph.nodes[0].key, "db.engine");
+        assert_eq!(graph.nodes[0].value, "sqlite");
+        assert!(graph.edges.is_empty());
+    }
+
+    #[test]
+    fn superseded_decision_produces_edge() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        let paths = edda_ledger::EddaPaths::discover(root);
+        edda_ledger::ledger::init_workspace(&paths).unwrap();
+        edda_ledger::ledger::init_head(&paths, "main").unwrap();
+
+        let ledger = Ledger::open(root).unwrap();
+
+        // First decision
+        let payload1 = make_decision_payload("db.engine", "sqlite", Some("mvp"));
+        let event1 =
+            edda_core::event::new_decision_event("main", None, "user", &payload1).unwrap();
+        ledger.append_event(&event1).unwrap();
+        let event1_id = event1.event_id.clone();
+
+        // Second decision that supersedes the first
+        let payload2 = make_decision_payload("db.engine", "postgres", Some("scale"));
+        let mut event2 =
+            edda_core::event::new_decision_event("main", None, "user", &payload2).unwrap();
+        event2.refs.provenance.push(edda_core::types::Provenance {
+            target: event1_id,
+            rel: edda_core::types::rel::SUPERSEDES.to_string(),
+            note: Some("key 'db.engine' re-decided".to_string()),
+        });
+        edda_core::event::finalize_event(&mut event2);
+        ledger.append_event(&event2).unwrap();
+
+        let entry = ProjectEntry {
+            project_id: "test".to_string(),
+            path: root.to_string_lossy().to_string(),
+            name: "test-project".to_string(),
+            registered_at: "2026-03-01T00:00:00Z".to_string(),
+            last_seen: "2026-03-01T00:00:00Z".to_string(),
+        };
+
+        let graph = build_dependency_graph(&[entry]);
+        assert_eq!(graph.nodes.len(), 2);
+        // The superseding decision should create a provenance edge
+        assert!(
+            !graph.edges.is_empty(),
+            "Expected at least one edge from supersession"
+        );
+    }
+}

--- a/crates/edda-aggregate/src/lib.rs
+++ b/crates/edda-aggregate/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod aggregate;
+pub mod graph;
 pub mod quality;
+pub mod risk;
 pub mod rollup;

--- a/crates/edda-aggregate/src/risk.rs
+++ b/crates/edda-aggregate/src/risk.rs
@@ -1,0 +1,290 @@
+//! Override risk scoring for active decisions.
+//!
+//! Each decision receives a `risk_score` (0.0..1.0) computed from five weighted
+//! factors: downstream dependents, age, execution references, cross-project
+//! usage, and approval status.
+
+use edda_core::Event;
+use serde::Serialize;
+use std::collections::{HashMap, HashSet};
+
+/// Risk assessment for a single decision.
+#[derive(Debug, Clone, Serialize)]
+pub struct DecisionRisk {
+    pub event_id: String,
+    pub key: String,
+    pub value: String,
+    pub project: String,
+    pub risk_score: f64,
+    pub risk_level: String,
+    pub factors: RiskFactors,
+}
+
+/// Individual risk factor values used to compute the overall score.
+#[derive(Debug, Clone, Serialize)]
+pub struct RiskFactors {
+    pub downstream_count: usize,
+    pub age_days: u32,
+    pub execution_refs: usize,
+    pub cross_project: bool,
+    pub has_approval: bool,
+}
+
+/// Input describing one active decision for risk computation.
+pub struct DecisionInput {
+    pub event_id: String,
+    pub key: String,
+    pub value: String,
+    pub project: String,
+    pub ts: Option<String>,
+}
+
+/// Compute risk scores for a set of decisions given all events across projects.
+///
+/// `now_iso` should be an ISO 8601 timestamp used as the reference point for
+/// age calculations (e.g. `"2026-03-12T00:00:00Z"`).
+pub fn compute_decision_risks(
+    decisions: &[DecisionInput],
+    all_events: &[Event],
+    now_iso: &str,
+    cross_project_ids: &HashSet<String>,
+) -> Vec<DecisionRisk> {
+    // Pre-compute: how many provenance refs target each event_id
+    let mut downstream_counts: HashMap<&str, usize> = HashMap::new();
+    let mut execution_counts: HashMap<&str, usize> = HashMap::new();
+    let mut approval_set: HashSet<&str> = HashSet::new();
+
+    for event in all_events {
+        // Count provenance links targeting decision events
+        for prov in &event.refs.provenance {
+            *downstream_counts.entry(prov.target.as_str()).or_insert(0) += 1;
+        }
+
+        // Count execution events referencing decisions
+        if event.event_type == "execution_event" {
+            for prov in &event.refs.provenance {
+                *execution_counts.entry(prov.target.as_str()).or_insert(0) += 1;
+            }
+        }
+
+        // Track approved decisions (approval events referencing a decision)
+        if event.event_type == "approval" {
+            for prov in &event.refs.provenance {
+                approval_set.insert(prov.target.as_str());
+            }
+            for eid in &event.refs.events {
+                approval_set.insert(eid.as_str());
+            }
+        }
+    }
+
+    decisions
+        .iter()
+        .map(|d| {
+            let downstream_count =
+                downstream_counts.get(d.event_id.as_str()).copied().unwrap_or(0);
+            let execution_refs =
+                execution_counts.get(d.event_id.as_str()).copied().unwrap_or(0);
+            let cross_project = cross_project_ids.contains(&d.event_id);
+            let has_approval = approval_set.contains(d.event_id.as_str());
+            let age_days = compute_age_days(d.ts.as_deref(), now_iso);
+
+            let factors = RiskFactors {
+                downstream_count,
+                age_days,
+                execution_refs,
+                cross_project,
+                has_approval,
+            };
+
+            let risk_score = score_from_factors(&factors);
+            let risk_level = level_from_score(risk_score).to_string();
+
+            DecisionRisk {
+                event_id: d.event_id.clone(),
+                key: d.key.clone(),
+                value: d.value.clone(),
+                project: d.project.clone(),
+                risk_score,
+                risk_level,
+                factors,
+            }
+        })
+        .collect()
+}
+
+/// Weighted risk formula.
+fn score_from_factors(f: &RiskFactors) -> f64 {
+    let downstream = (f.downstream_count as f64 / 5.0).min(1.0) * 0.3;
+    let age = (f.age_days as f64 / 30.0).min(1.0) * 0.15;
+    let exec = (f.execution_refs as f64 / 10.0).min(1.0) * 0.25;
+    let cross = if f.cross_project { 0.2 } else { 0.0 };
+    let approval = if f.has_approval { 0.1 } else { 0.0 };
+    downstream + age + exec + cross + approval
+}
+
+/// Map score to human-readable level.
+fn level_from_score(score: f64) -> &'static str {
+    if score > 0.6 {
+        "high"
+    } else if score >= 0.3 {
+        "medium"
+    } else {
+        "low"
+    }
+}
+
+/// Compute age in days from an ISO 8601 timestamp to `now_iso`.
+fn compute_age_days(ts: Option<&str>, now_iso: &str) -> u32 {
+    let Some(ts) = ts else { return 0 };
+    // Simple date-only comparison using the first 10 chars (YYYY-MM-DD)
+    let ts_date = &ts[..10.min(ts.len())];
+    let now_date = &now_iso[..10.min(now_iso.len())];
+
+    let parse = |d: &str| -> Option<(i32, u32, u32)> {
+        let parts: Vec<&str> = d.split('-').collect();
+        if parts.len() < 3 {
+            return None;
+        }
+        Some((
+            parts[0].parse().ok()?,
+            parts[1].parse().ok()?,
+            parts[2].parse().ok()?,
+        ))
+    };
+
+    let Some((y1, m1, d1)) = parse(ts_date) else {
+        return 0;
+    };
+    let Some((y2, m2, d2)) = parse(now_date) else {
+        return 0;
+    };
+
+    // Rough day calculation (good enough for risk scoring)
+    let days1 = y1 * 365 + m1 as i32 * 30 + d1 as i32;
+    let days2 = y2 * 365 + m2 as i32 * 30 + d2 as i32;
+    (days2 - days1).max(0) as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use edda_core::types::Refs;
+
+    fn make_decision(event_id: &str, key: &str, value: &str, ts: &str) -> DecisionInput {
+        DecisionInput {
+            event_id: event_id.to_string(),
+            key: key.to_string(),
+            value: value.to_string(),
+            project: "test-project".to_string(),
+            ts: Some(ts.to_string()),
+        }
+    }
+
+    fn make_event(event_type: &str, refs: Refs) -> Event {
+        Event {
+            event_id: format!("evt_{}", uuid_stub()),
+            ts: "2026-03-12T00:00:00Z".to_string(),
+            event_type: event_type.to_string(),
+            branch: "main".to_string(),
+            parent_hash: None,
+            hash: String::new(),
+            payload: serde_json::json!({}),
+            refs,
+            schema_version: 1,
+            digests: vec![],
+            event_family: None,
+            event_level: None,
+        }
+    }
+
+    static COUNTER: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+    fn uuid_stub() -> u32 {
+        COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
+
+    #[test]
+    fn risk_score_zero_for_isolated_new_decision() {
+        let decisions = vec![make_decision("evt_1", "db.engine", "sqlite", "2026-03-12")];
+        let risks =
+            compute_decision_risks(&decisions, &[], "2026-03-12T00:00:00Z", &HashSet::new());
+        assert_eq!(risks.len(), 1);
+        assert_eq!(risks[0].risk_score, 0.0);
+        assert_eq!(risks[0].risk_level, "low");
+    }
+
+    #[test]
+    fn risk_score_high_for_old_decision_with_many_refs() {
+        let decisions = vec![make_decision(
+            "evt_old",
+            "auth.strategy",
+            "JWT",
+            "2025-01-01",
+        )];
+
+        // Create many downstream refs and execution events
+        let mut events = Vec::new();
+        for _ in 0..6 {
+            events.push(make_event(
+                "decision",
+                Refs {
+                    provenance: vec![edda_core::types::Provenance {
+                        target: "evt_old".to_string(),
+                        rel: "supersedes".to_string(),
+                        note: None,
+                    }],
+                    ..Default::default()
+                },
+            ));
+        }
+        for _ in 0..12 {
+            events.push(make_event(
+                "execution_event",
+                Refs {
+                    provenance: vec![edda_core::types::Provenance {
+                        target: "evt_old".to_string(),
+                        rel: "based_on".to_string(),
+                        note: None,
+                    }],
+                    ..Default::default()
+                },
+            ));
+        }
+
+        let mut cross = HashSet::new();
+        cross.insert("evt_old".to_string());
+
+        let risks = compute_decision_risks(&decisions, &events, "2026-03-12T00:00:00Z", &cross);
+        assert_eq!(risks[0].risk_level, "high");
+        assert!(risks[0].risk_score > 0.6);
+    }
+
+    #[test]
+    fn risk_level_thresholds() {
+        assert_eq!(level_from_score(0.0), "low");
+        assert_eq!(level_from_score(0.29), "low");
+        assert_eq!(level_from_score(0.3), "medium");
+        assert_eq!(level_from_score(0.6), "medium");
+        assert_eq!(level_from_score(0.61), "high");
+        assert_eq!(level_from_score(1.0), "high");
+    }
+
+    #[test]
+    fn cross_project_flag_increases_risk() {
+        let decisions = vec![make_decision("evt_cp", "api.version", "v2", "2026-03-12")];
+
+        let risks_no_cross =
+            compute_decision_risks(&decisions, &[], "2026-03-12T00:00:00Z", &HashSet::new());
+
+        let mut cross = HashSet::new();
+        cross.insert("evt_cp".to_string());
+        let risks_cross =
+            compute_decision_risks(&decisions, &[], "2026-03-12T00:00:00Z", &cross);
+
+        assert!(risks_cross[0].risk_score > risks_no_cross[0].risk_score);
+        assert_eq!(
+            risks_cross[0].risk_score - risks_no_cross[0].risk_score,
+            0.2
+        );
+    }
+}

--- a/crates/edda-aggregate/src/risk.rs
+++ b/crates/edda-aggregate/src/risk.rs
@@ -119,6 +119,8 @@ fn score_from_factors(f: &RiskFactors) -> f64 {
     let age = (f.age_days as f64 / 30.0).min(1.0) * 0.15;
     let exec = (f.execution_refs as f64 / 10.0).min(1.0) * 0.25;
     let cross = if f.cross_project { 0.2 } else { 0.0 };
+    // Approved decisions carry higher override risk because they have
+    // organizational backing — overriding them has greater organizational impact.
     let approval = if f.has_approval { 0.1 } else { 0.0 };
     downstream + age + exec + cross + approval
 }

--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -9,8 +9,10 @@ use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 use tower_http::cors::CorsLayer;
 
-use edda_aggregate::aggregate::{aggregate_overview, DateRange};
+use edda_aggregate::aggregate::{aggregate_decisions, aggregate_overview, DateRange};
+use edda_aggregate::graph::build_dependency_graph;
 use edda_aggregate::quality::{model_quality_from_events, QualityReport};
+use edda_aggregate::risk::{compute_decision_risks, DecisionInput, DecisionRisk};
 use edda_core::event::{finalize_event, new_decision_event, new_execution_event, new_note_event};
 use edda_core::policy;
 use edda_core::types::{rel, DecisionPayload, Provenance};
@@ -102,6 +104,9 @@ pub async fn serve(repo_root: &Path, config: ServeConfig) -> anyhow::Result<()> 
         .route("/api/recap/cached", get(get_recap_cached))
         .route("/api/overview", get(get_overview))
         .route("/api/projects", get(get_projects))
+        .route("/api/metrics/quality", get(get_quality_metrics))
+        .route("/api/dashboard", get(get_dashboard))
+        .route("/dashboard", get(serve_dashboard))
         .layer(CorsLayer::permissive())
         .with_state(state);
 
@@ -147,6 +152,8 @@ pub fn router(repo_root: &Path) -> Router {
         .route("/api/overview", get(get_overview))
         .route("/api/projects", get(get_projects))
         .route("/api/metrics/quality", get(get_quality_metrics))
+        .route("/api/dashboard", get(get_dashboard))
+        .route("/dashboard", get(serve_dashboard))
         .layer(CorsLayer::permissive())
         .with_state(state)
 }
@@ -872,23 +879,51 @@ async fn get_overview(
     }
 
     let projects = list_projects();
-    let range = DateRange::default();
-    let _aggregate = aggregate_overview(&projects, &range);
-
-    // TODO: Implement actual attention routing logic
-    // For now, return empty lists
-    let now = time::OffsetDateTime::now_utc();
-    let updated_at = now
-        .format(&time::format_description::well_known::Rfc3339)
-        .unwrap_or_else(|_| "unknown".to_string());
-
-    let response = OverviewResponse {
-        red: vec![],
-        yellow: vec![],
-        green: vec![],
-        updated_at,
+    let range = DateRange {
+        after: Some({
+            let now = time::OffsetDateTime::now_utc();
+            let from = now - time::Duration::days(7);
+            from.format(&time::format_description::well_known::Rfc3339)
+                .unwrap_or_default()[..10]
+                .to_string()
+        }),
+        before: None,
     };
 
+    // Compute decisions + risks for attention routing
+    let decisions = aggregate_decisions(&projects);
+    let now_iso = time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_default();
+    let decision_inputs: Vec<DecisionInput> = decisions
+        .iter()
+        .map(|d| DecisionInput {
+            event_id: d.event_id.clone(),
+            key: d.key.clone(),
+            value: d.value.clone(),
+            project: d.project_name.clone(),
+            ts: d.ts.clone(),
+        })
+        .collect();
+
+    let mut all_events = Vec::new();
+    for entry in &projects {
+        let root = std::path::Path::new(&entry.path);
+        if let Ok(ledger) = Ledger::open(root) {
+            if let Ok(events) = ledger.iter_events() {
+                all_events.extend(events);
+            }
+        }
+    }
+
+    let risks = compute_decision_risks(
+        &decision_inputs,
+        &all_events,
+        &now_iso,
+        &std::collections::HashSet::new(),
+    );
+
+    let response = compute_attention(&risks, &projects, &range);
     Ok(Json(response))
 }
 
@@ -1102,6 +1137,272 @@ async fn post_authz_check(
     let actors = policy::load_actors_from_dir(&edda_dir)?;
     let result = policy::evaluate_authz(&body, &pol, &actors);
     Ok(Json(result))
+}
+
+// ── GET /dashboard (HTML) ──
+
+async fn serve_dashboard() -> impl IntoResponse {
+    axum::response::Html(include_str!("../static/dashboard.html"))
+}
+
+// ── GET /api/dashboard ──
+
+#[derive(Deserialize)]
+struct DashboardQuery {
+    #[serde(default = "default_days")]
+    days: usize,
+}
+
+fn default_days() -> usize {
+    7
+}
+
+#[derive(Serialize)]
+struct DashboardResponse {
+    period: DashboardPeriod,
+    summary: DashboardSummary,
+    attention: OverviewResponse,
+    timeline: Vec<TimelineEntry>,
+    graph: edda_aggregate::graph::DependencyGraph,
+    risks: Vec<DecisionRisk>,
+}
+
+#[derive(Serialize)]
+struct DashboardPeriod {
+    from: String,
+    to: String,
+    days: usize,
+}
+
+#[derive(Serialize)]
+struct DashboardSummary {
+    total_projects: usize,
+    total_decisions: usize,
+    total_events: usize,
+    total_commits: usize,
+}
+
+#[derive(Serialize)]
+struct TimelineEntry {
+    ts: String,
+    event_type: String,
+    key: String,
+    value: String,
+    reason: String,
+    project: String,
+    risk_level: String,
+    supersedes: Option<String>,
+}
+
+async fn get_dashboard(
+    State(_state): State<Arc<AppState>>,
+    Query(params): Query<DashboardQuery>,
+) -> Result<Json<DashboardResponse>, AppError> {
+    let projects = list_projects();
+
+    let now = time::OffsetDateTime::now_utc();
+    let from_date = now - time::Duration::days(params.days as i64);
+    let to_str = now
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_default();
+    let from_str = from_date
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_default();
+
+    let range = DateRange {
+        after: Some(from_str[..10].to_string()),
+        before: None,
+    };
+
+    // Summary
+    let agg = aggregate_overview(&projects, &range);
+
+    // Decisions + risk scoring
+    let decisions = aggregate_decisions(&projects);
+    let now_iso = &to_str;
+
+    let decision_inputs: Vec<DecisionInput> = decisions
+        .iter()
+        .map(|d| DecisionInput {
+            event_id: d.event_id.clone(),
+            key: d.key.clone(),
+            value: d.value.clone(),
+            project: d.project_name.clone(),
+            ts: d.ts.clone(),
+        })
+        .collect();
+
+    // Collect all events for risk computation
+    let mut all_events = Vec::new();
+    for entry in &projects {
+        let root = std::path::Path::new(&entry.path);
+        if let Ok(ledger) = Ledger::open(root) {
+            if let Ok(events) = ledger.iter_events() {
+                all_events.extend(events);
+            }
+        }
+    }
+
+    // Cross-project: decision IDs that appear in provenance of events from OTHER projects
+    let mut cross_project_ids = std::collections::HashSet::new();
+    for entry in &projects {
+        let root = std::path::Path::new(&entry.path);
+        if let Ok(ledger) = Ledger::open(root) {
+            if let Ok(events) = ledger.iter_events() {
+                for event in &events {
+                    for prov in &event.refs.provenance {
+                        // If this event references a decision from another project
+                        for d in &decisions {
+                            if d.event_id == prov.target && d.project_name != entry.name {
+                                cross_project_ids.insert(d.event_id.clone());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let risks = compute_decision_risks(&decision_inputs, &all_events, now_iso, &cross_project_ids);
+
+    // Build risk lookup for timeline entries
+    let risk_map: std::collections::HashMap<&str, &str> = risks
+        .iter()
+        .map(|r| (r.event_id.as_str(), r.risk_level.as_str()))
+        .collect();
+
+    // Timeline: decisions sorted by timestamp descending
+    let mut timeline: Vec<TimelineEntry> = decisions
+        .iter()
+        .map(|d| {
+            let risk_level = risk_map
+                .get(d.event_id.as_str())
+                .unwrap_or(&"low")
+                .to_string();
+            TimelineEntry {
+                ts: d.ts.clone().unwrap_or_default(),
+                event_type: "decision".to_string(),
+                key: d.key.clone(),
+                value: d.value.clone(),
+                reason: d.reason.clone(),
+                project: d.project_name.clone(),
+                risk_level,
+                supersedes: None, // Would need provenance walk
+            }
+        })
+        .collect();
+    timeline.sort_by(|a, b| b.ts.cmp(&a.ts));
+
+    // Dependency graph
+    let graph = build_dependency_graph(&projects);
+
+    // Attention routing
+    let attention = compute_attention(&risks, &projects, &range);
+
+    let period = DashboardPeriod {
+        from: from_str[..10].to_string(),
+        to: to_str[..10].to_string(),
+        days: params.days,
+    };
+
+    let summary = DashboardSummary {
+        total_projects: agg.projects.len(),
+        total_decisions: agg.total_decisions,
+        total_events: agg.total_events,
+        total_commits: agg.total_commits,
+    };
+
+    Ok(Json(DashboardResponse {
+        period,
+        summary,
+        attention,
+        timeline,
+        graph,
+        risks,
+    }))
+}
+
+/// Compute attention routing: red / yellow / green classification.
+fn compute_attention(
+    risks: &[DecisionRisk],
+    projects: &[edda_store::registry::ProjectEntry],
+    range: &DateRange,
+) -> OverviewResponse {
+    let mut red = Vec::new();
+    let mut yellow = Vec::new();
+    let mut green = Vec::new();
+
+    let now = time::OffsetDateTime::now_utc();
+    let updated_at = now
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "unknown".to_string());
+
+    // Red: high-risk decisions
+    for r in risks {
+        if r.risk_level == "high" {
+            red.push(OverviewRedItem {
+                project: r.project.clone(),
+                summary: format!("{} = {} (risk {:.0}%)", r.key, r.value, r.risk_score * 100.0),
+                action: "Review before overriding".to_string(),
+                blocked_count: 0,
+            });
+        }
+    }
+
+    // Yellow: medium-risk decisions
+    for r in risks {
+        if r.risk_level == "medium" {
+            yellow.push(OverviewYellowItem {
+                project: r.project.clone(),
+                summary: format!("{} = {} (risk {:.0}%)", r.key, r.value, r.risk_score * 100.0),
+                eta: String::new(),
+            });
+        }
+    }
+
+    // Red: stale projects (no events in range)
+    for entry in projects {
+        let root = std::path::Path::new(&entry.path);
+        let has_events = Ledger::open(root)
+            .and_then(|l| l.iter_events())
+            .map(|events| events.iter().any(|e| range.matches(&e.ts)))
+            .unwrap_or(false);
+        if !has_events {
+            red.push(OverviewRedItem {
+                project: entry.name.clone(),
+                summary: "No activity in period".to_string(),
+                action: "Check project status".to_string(),
+                blocked_count: 0,
+            });
+        }
+    }
+
+    // Green: projects with normal activity
+    for entry in projects {
+        let root = std::path::Path::new(&entry.path);
+        let has_events = Ledger::open(root)
+            .and_then(|l| l.iter_events())
+            .map(|events| events.iter().any(|e| range.matches(&e.ts)))
+            .unwrap_or(false);
+        if has_events {
+            let high_risk = risks
+                .iter()
+                .any(|r| r.project == entry.name && r.risk_level == "high");
+            if !high_risk {
+                green.push(OverviewGreenItem {
+                    project: entry.name.clone(),
+                    summary: "Normal activity".to_string(),
+                });
+            }
+        }
+    }
+
+    OverviewResponse {
+        red,
+        yellow,
+        green,
+        updated_at,
+    }
 }
 
 // ── Tests ──
@@ -1356,7 +1657,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn overview_returns_empty_structure() {
+    async fn overview_returns_structure() {
         let tmp = tempfile::tempdir().unwrap();
         setup_workspace(tmp.path());
         let app = router(tmp.path());
@@ -1376,9 +1677,9 @@ mod tests {
             .await
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert!(json["red"].as_array().unwrap().is_empty());
-        assert!(json["yellow"].as_array().unwrap().is_empty());
-        assert!(json["green"].as_array().unwrap().is_empty());
+        assert!(json["red"].is_array());
+        assert!(json["yellow"].is_array());
+        assert!(json["green"].is_array());
         assert!(json["updated_at"].is_string());
     }
 
@@ -2434,5 +2735,83 @@ actors:
         let j3: serde_json::Value = serde_json::from_slice(&b3).unwrap();
         assert_eq!(j3["allowed"], false);
         assert!(j3["actor_roles"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn dashboard_returns_all_sections() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/dashboard")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["period"].is_object());
+        assert!(json["summary"].is_object());
+        assert!(json["attention"].is_object());
+        assert!(json["timeline"].is_array());
+        assert!(json["graph"].is_object());
+        assert!(json["risks"].is_array());
+    }
+
+    #[tokio::test]
+    async fn dashboard_respects_days_param() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/dashboard?days=1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["period"]["days"], 1);
+    }
+
+    #[tokio::test]
+    async fn dashboard_html_returns_html() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/dashboard")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(html.contains("Edda Dashboard"));
+        assert!(html.contains("/api/dashboard"));
     }
 }

--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -906,6 +906,7 @@ async fn get_overview(
         })
         .collect();
 
+    // TODO: This event-loading block is duplicated in get_dashboard; extract into a shared helper in a follow-up.
     let mut all_events = Vec::new();
     for entry in &projects {
         let root = std::path::Path::new(&entry.path);
@@ -1233,6 +1234,7 @@ async fn get_dashboard(
         .collect();
 
     // Collect all events for risk computation
+    // TODO: This event-loading block is duplicated in get_overview; extract into a shared helper in a follow-up.
     let mut all_events = Vec::new();
     for entry in &projects {
         let root = std::path::Path::new(&entry.path);
@@ -1677,9 +1679,9 @@ mod tests {
             .await
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert!(json["red"].is_array());
-        assert!(json["yellow"].is_array());
-        assert!(json["green"].is_array());
+        assert!(json["red"].as_array().unwrap().is_empty());
+        assert!(json["yellow"].as_array().unwrap().is_empty());
+        assert!(json["green"].as_array().unwrap().is_empty());
         assert!(json["updated_at"].is_string());
     }
 

--- a/crates/edda-serve/static/dashboard.html
+++ b/crates/edda-serve/static/dashboard.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Edda Dashboard</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#f5f6fa;color:#2d3436}
+header{background:#2d3436;color:#fff;padding:1rem 2rem;display:flex;justify-content:space-between;align-items:center}
+header h1{font-size:1.4rem;font-weight:600}
+header .period{font-size:.85rem;opacity:.7}
+header select{background:#444;color:#fff;border:1px solid #666;border-radius:4px;padding:4px 8px;font-size:.85rem}
+.grid{display:grid;grid-template-columns:1fr 1fr;gap:1rem;padding:1.5rem 2rem;max-width:1400px;margin:0 auto}
+.card{background:#fff;border-radius:8px;padding:1.25rem;box-shadow:0 1px 3px rgba(0,0,0,.08)}
+.card h2{font-size:1rem;font-weight:600;margin-bottom:.75rem;color:#636e72}
+.attention-list{list-style:none}
+.attention-list li{padding:.5rem .75rem;border-radius:4px;margin-bottom:.5rem;font-size:.9rem}
+.att-red{background:#ffeaea;border-left:4px solid #e74c3c}
+.att-yellow{background:#fff8e1;border-left:4px solid #f39c12}
+.att-green{background:#e8f5e9;border-left:4px solid #27ae60}
+.timeline-list{list-style:none;max-height:340px;overflow-y:auto}
+.timeline-list li{padding:.5rem 0;border-bottom:1px solid #eee;font-size:.88rem;display:flex;align-items:center;gap:.5rem}
+.timeline-list li:last-child{border-bottom:none}
+.badge{display:inline-block;padding:2px 8px;border-radius:10px;font-size:.72rem;font-weight:600;text-transform:uppercase}
+.badge-low{background:#e8f5e9;color:#27ae60}
+.badge-medium{background:#fff8e1;color:#f39c12}
+.badge-high{background:#ffeaea;color:#e74c3c}
+.risk-table{width:100%;border-collapse:collapse;font-size:.88rem}
+.risk-table th{text-align:left;padding:.5rem;border-bottom:2px solid #ddd;color:#636e72;font-size:.8rem;text-transform:uppercase}
+.risk-table td{padding:.5rem;border-bottom:1px solid #eee}
+.risk-table tr:hover{background:#f8f9fa}
+.stats{display:flex;gap:2rem;justify-content:center;padding:1rem 2rem}
+.stat{text-align:center}
+.stat .num{font-size:2rem;font-weight:700;color:#2d3436}
+.stat .label{font-size:.8rem;color:#636e72;text-transform:uppercase}
+.graph-container{min-height:280px;position:relative}
+.graph-placeholder{display:flex;align-items:center;justify-content:center;height:280px;color:#b2bec3;font-size:.9rem}
+.no-data{color:#b2bec3;font-size:.9rem;text-align:center;padding:2rem}
+.refresh-info{text-align:center;padding:.5rem;font-size:.75rem;color:#b2bec3}
+</style>
+</head>
+<body>
+<header>
+  <h1>Edda Dashboard</h1>
+  <div style="display:flex;align-items:center;gap:1rem">
+    <label>
+      <select id="days-select">
+        <option value="1">Last 24h</option>
+        <option value="7" selected>Last 7 days</option>
+        <option value="14">Last 14 days</option>
+        <option value="30">Last 30 days</option>
+      </select>
+    </label>
+    <span class="period" id="period-label"></span>
+  </div>
+</header>
+
+<div class="stats" id="stats-bar">
+  <div class="stat"><span class="num" id="s-projects">-</span><span class="label">Projects</span></div>
+  <div class="stat"><span class="num" id="s-decisions">-</span><span class="label">Decisions</span></div>
+  <div class="stat"><span class="num" id="s-events">-</span><span class="label">Events</span></div>
+  <div class="stat"><span class="num" id="s-commits">-</span><span class="label">Commits</span></div>
+</div>
+
+<div class="grid">
+  <div class="card">
+    <h2>Attention</h2>
+    <ul class="attention-list" id="attention-list">
+      <li class="no-data">Loading...</li>
+    </ul>
+  </div>
+
+  <div class="card">
+    <h2>Decision Timeline</h2>
+    <ul class="timeline-list" id="timeline-list">
+      <li class="no-data">Loading...</li>
+    </ul>
+  </div>
+
+  <div class="card">
+    <h2>Dependency Graph</h2>
+    <div class="graph-container" id="graph-container">
+      <div class="graph-placeholder">Loading graph...</div>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Override Risk</h2>
+    <table class="risk-table" id="risk-table">
+      <thead><tr><th>Decision</th><th>Value</th><th>Project</th><th>Risk</th></tr></thead>
+      <tbody id="risk-tbody"><tr><td colspan="4" class="no-data">Loading...</td></tr></tbody>
+    </table>
+  </div>
+</div>
+
+<div class="refresh-info">Auto-refreshes every 60s</div>
+
+<script>
+(function(){
+  const $ = (s) => document.getElementById(s);
+
+  let refreshTimer = null;
+
+  function fetchDashboard() {
+    const days = $('days-select').value;
+    fetch('/api/dashboard?days=' + days)
+      .then(r => r.json())
+      .then(render)
+      .catch(err => {
+        console.error('Dashboard fetch failed:', err);
+        $('attention-list').innerHTML = '<li class="no-data">Failed to load data</li>';
+      });
+  }
+
+  function render(data) {
+    // Period label
+    if (data.period) {
+      $('period-label').textContent = data.period.from + ' to ' + data.period.to;
+    }
+
+    // Summary stats
+    if (data.summary) {
+      $('s-projects').textContent = data.summary.total_projects;
+      $('s-decisions').textContent = data.summary.total_decisions;
+      $('s-events').textContent = data.summary.total_events;
+      $('s-commits').textContent = data.summary.total_commits;
+    }
+
+    // Attention panel
+    renderAttention(data.attention || {red:[], yellow:[], green:[]});
+
+    // Timeline
+    renderTimeline(data.timeline || []);
+
+    // Risk table
+    renderRisks(data.risks || []);
+
+    // Dependency graph
+    renderGraph(data.graph || {nodes:[], edges:[]});
+  }
+
+  function renderAttention(att) {
+    const list = $('attention-list');
+    const items = [];
+    (att.red || []).forEach(r => items.push('<li class="att-red"><strong>' + esc(r.project) + ':</strong> ' + esc(r.summary) + ' <em>(' + esc(r.action) + ')</em></li>'));
+    (att.yellow || []).forEach(y => items.push('<li class="att-yellow"><strong>' + esc(y.project) + ':</strong> ' + esc(y.summary) + '</li>'));
+    (att.green || []).forEach(g => items.push('<li class="att-green"><strong>' + esc(g.project) + ':</strong> ' + esc(g.summary) + '</li>'));
+    list.innerHTML = items.length ? items.join('') : '<li class="att-green">All clear - no items needing attention</li>';
+  }
+
+  function renderTimeline(timeline) {
+    const list = $('timeline-list');
+    if (!timeline.length) {
+      list.innerHTML = '<li class="no-data">No decisions in this period</li>';
+      return;
+    }
+    list.innerHTML = timeline.map(t => {
+      const badge = '<span class="badge badge-' + (t.risk_level || 'low') + '">' + (t.risk_level || 'low') + '</span>';
+      const supersedes = t.supersedes ? ' <span style="color:#b2bec3;font-size:.75rem">(supersedes)</span>' : '';
+      const ts = t.ts ? t.ts.substring(0, 10) : '';
+      return '<li>' + badge + ' <strong>' + esc(t.key) + '</strong>=' + esc(t.value) + supersedes +
+        ' <span style="color:#636e72;margin-left:auto;white-space:nowrap">' + esc(t.project) + ' ' + ts + '</span></li>';
+    }).join('');
+  }
+
+  function renderRisks(risks) {
+    const tbody = $('risk-tbody');
+    if (!risks.length) {
+      tbody.innerHTML = '<tr><td colspan="4" class="no-data">No active decisions</td></tr>';
+      return;
+    }
+    const sorted = risks.slice().sort((a, b) => b.risk_score - a.risk_score);
+    tbody.innerHTML = sorted.map(r => {
+      const badge = '<span class="badge badge-' + r.risk_level + '">' + r.risk_level + ' (' + (r.risk_score * 100).toFixed(0) + '%)</span>';
+      return '<tr><td>' + esc(r.key) + '</td><td>' + esc(r.value) + '</td><td>' + esc(r.project) + '</td><td>' + badge + '</td></tr>';
+    }).join('');
+  }
+
+  function renderGraph(graph) {
+    const container = $('graph-container');
+    if (!graph.nodes.length) {
+      container.innerHTML = '<div class="graph-placeholder">No decisions with dependencies</div>';
+      return;
+    }
+    // Simple SVG-based graph rendering
+    const w = container.clientWidth || 600;
+    const h = 280;
+    const nodes = graph.nodes.map((n, i) => ({
+      ...n,
+      x: 60 + (i % 4) * ((w - 120) / Math.min(graph.nodes.length, 4)),
+      y: 40 + Math.floor(i / 4) * 70
+    }));
+    const nodeMap = {};
+    nodes.forEach(n => { nodeMap[n.event_id] = n; });
+
+    let svg = '<svg width="' + w + '" height="' + h + '" style="font-family:sans-serif;font-size:11px">';
+
+    // Edges
+    graph.edges.forEach(e => {
+      const src = nodeMap[e.source];
+      const tgt = nodeMap[e.target];
+      if (src && tgt) {
+        svg += '<line x1="' + src.x + '" y1="' + src.y + '" x2="' + tgt.x + '" y2="' + tgt.y +
+          '" stroke="#b2bec3" stroke-width="1.5" marker-end="url(#arrow)"/>';
+      }
+    });
+
+    svg += '<defs><marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">' +
+      '<path d="M0,0 L8,3 L0,6" fill="#b2bec3"/></marker></defs>';
+
+    // Nodes
+    nodes.forEach(n => {
+      svg += '<g transform="translate(' + n.x + ',' + n.y + ')">' +
+        '<rect x="-50" y="-15" width="100" height="30" rx="4" fill="#dfe6e9" stroke="#b2bec3"/>' +
+        '<text text-anchor="middle" dy="4" fill="#2d3436">' + esc(n.key) + '</text></g>';
+    });
+
+    svg += '</svg>';
+    container.innerHTML = svg;
+  }
+
+  function esc(s) {
+    if (!s) return '';
+    const d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  $('days-select').addEventListener('change', function() {
+    fetchDashboard();
+    clearInterval(refreshTimer);
+    refreshTimer = setInterval(fetchDashboard, 60000);
+  });
+
+  fetchDashboard();
+  refreshTimer = setInterval(fetchDashboard, 60000);
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Closes #195

- **New `risk.rs` module** in `edda-aggregate`: 5-factor weighted risk scoring for override safety assessment (downstream dependents, age, execution refs, cross-project usage, approval status)
- **New `graph.rs` module** in `edda-aggregate`: dependency graph extraction from provenance references across projects
- **`GET /api/dashboard`** consolidated JSON endpoint returning period, summary stats, attention routing, decision timeline, dependency graph, and risk scores
- **`GET /dashboard`** embedded HTML dashboard via `include_str!` (no build step, single binary)
- **Enhanced `GET /api/overview`** with real red/yellow/green attention routing (was previously stubbed)
- **Fix**: added missing `/api/metrics/quality` route to `serve()` function (was only in `router()`)

## Files changed (5 files, ~1118 lines)

| File | Change |
|---|---|
| `crates/edda-aggregate/src/risk.rs` | New: risk scoring module with 4 unit tests |
| `crates/edda-aggregate/src/graph.rs` | New: dependency graph module with 3 unit tests |
| `crates/edda-aggregate/src/lib.rs` | Register new modules |
| `crates/edda-serve/src/lib.rs` | Dashboard API + HTML endpoints, attention routing, route fix |
| `crates/edda-serve/static/dashboard.html` | Single-page HTML dashboard (inline CSS/JS, SVG graph, 60s auto-refresh) |

## Test plan

- [x] 25 edda-aggregate tests pass (including 7 new: risk scoring + graph extraction)
- [x] 38 edda-serve tests pass (including 3 new: dashboard JSON, days param, HTML response)
- [x] `cargo clippy -- -D warnings` clean
- [ ] Manual: `edda serve` then open `http://localhost:PORT/dashboard` to verify 4-panel layout

Generated with [Claude Code](https://claude.com/claude-code)