### PR TITLE
feat(serve): real-time event subscription via SSE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +975,7 @@ name = "edda-serve"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "async-stream",
  "axum",
  "edda-aggregate",
  "edda-ask",
@@ -962,12 +985,14 @@ dependencies = [
  "edda-ledger",
  "edda-store",
  "globset",
+ "http-body-util",
  "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
  "time",
  "tokio",
+ "tokio-stream",
  "tower",
  "tower-http",
  "tracing",
@@ -3186,6 +3211,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/crates/edda-ledger/src/ledger.rs
+++ b/crates/edda-ledger/src/ledger.rs
@@ -106,6 +106,19 @@ impl Ledger {
         self.sqlite.iter_events_by_type(event_type)
     }
 
+    /// Get all events with rowid strictly greater than `after_rowid`.
+    ///
+    /// Returns `(rowid, Event)` pairs ordered by rowid, useful for cursor-based
+    /// polling (e.g. SSE streaming).
+    pub fn events_after_rowid(&self, after_rowid: i64) -> anyhow::Result<Vec<(i64, Event)>> {
+        self.sqlite.events_after_rowid(after_rowid)
+    }
+
+    /// Look up the rowid for a given `event_id`.
+    pub fn rowid_for_event_id(&self, event_id: &str) -> anyhow::Result<Option<i64>> {
+        self.sqlite.rowid_for_event_id(event_id)
+    }
+
     // ── Branches JSON ───────────────────────────────────────────────
 
     /// Read branches.json content.

--- a/crates/edda-ledger/src/sqlite_store.rs
+++ b/crates/edda-ledger/src/sqlite_store.rs
@@ -655,6 +655,69 @@ impl SqliteStore {
         }
     }
 
+    /// Get all events with rowid strictly greater than `after_rowid`.
+    ///
+    /// Returns `(rowid, Event)` pairs ordered by rowid, useful for cursor-based
+    /// polling (e.g. SSE streaming).
+    pub fn events_after_rowid(&self, after_rowid: i64) -> anyhow::Result<Vec<(i64, Event)>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT rowid, event_id, ts, event_type, branch, parent_hash, hash,
+                    payload, refs_blobs, refs_events, refs_provenance,
+                    schema_version, digests, event_family, event_level
+             FROM events WHERE rowid > ?1 ORDER BY rowid",
+        )?;
+
+        let rows = stmt
+            .query_map(params![after_rowid], |row| {
+                let rowid: i64 = row.get(0)?;
+                let payload_str: String = row.get(7)?;
+                let refs_blobs_str: String = row.get(8)?;
+                let refs_events_str: String = row.get(9)?;
+                let refs_prov_str: String = row.get(10)?;
+                let digests_str: String = row.get(12)?;
+
+                Ok((
+                    rowid,
+                    EventRow {
+                        event_id: row.get(1)?,
+                        ts: row.get(2)?,
+                        event_type: row.get(3)?,
+                        branch: row.get(4)?,
+                        parent_hash: row.get(5)?,
+                        hash: row.get(6)?,
+                        payload_str,
+                        refs_blobs_str,
+                        refs_events_str,
+                        refs_prov_str,
+                        schema_version: row.get(11)?,
+                        digests_str,
+                        event_family: row.get(13)?,
+                        event_level: row.get(14)?,
+                    },
+                ))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        rows.into_iter()
+            .map(|(rid, er)| Ok((rid, row_to_event(er)?)))
+            .collect()
+    }
+
+    /// Look up the rowid for a given `event_id`.
+    ///
+    /// Returns `None` if the event does not exist.
+    pub fn rowid_for_event_id(&self, event_id: &str) -> anyhow::Result<Option<i64>> {
+        let result: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT rowid FROM events WHERE event_id = ?1",
+                params![event_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(result)
+    }
+
     /// Get the hash of the last event.
     pub fn last_event_hash(&self) -> anyhow::Result<Option<String>> {
         let result: Option<String> = self

--- a/crates/edda-serve/Cargo.toml
+++ b/crates/edda-serve/Cargo.toml
@@ -19,7 +19,9 @@ edda-store = { path = "../edda-store", version = "0.1.1" }
 edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.1.1" }
 axum = "0.8"
 tracing = { workspace = true }
-tokio = { version = "1", features = ["rt-multi-thread", "net"] }
+tokio = { version = "1", features = ["rt-multi-thread", "net", "time"] }
+tokio-stream = "0.1"
+async-stream = "0.3"
 tower-http = { version = "0.6", features = ["cors"] }
 anyhow.workspace = true
 serde.workspace = true
@@ -32,3 +34,4 @@ globset = { workspace = true }
 tempfile.workspace = true
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"

--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -1,9 +1,12 @@
+use std::convert::Infallible;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::extract::{Path as AxumPath, Query, State};
-use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::sse::{Event as SseEvent, KeepAlive};
+use axum::response::{IntoResponse, Response, Sse};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
@@ -109,6 +112,7 @@ pub async fn serve(repo_root: &Path, config: ServeConfig) -> anyhow::Result<()> 
         .route("/dashboard", get(serve_dashboard))
         .route("/api/actors", get(get_actors))
         .route("/api/actors/{name}", get(get_actor))
+        .route("/api/events/stream", get(get_event_stream))
         .layer(CorsLayer::permissive())
         .with_state(state);
 
@@ -158,6 +162,7 @@ pub fn router(repo_root: &Path) -> Router {
         .route("/api/metrics/quality", get(get_quality_metrics))
         .route("/api/dashboard", get(get_dashboard))
         .route("/dashboard", get(serve_dashboard))
+        .route("/api/events/stream", get(get_event_stream))
         .layer(CorsLayer::permissive())
         .with_state(state)
 }
@@ -1419,7 +1424,12 @@ fn compute_attention(
         if r.risk_level == "high" {
             red.push(OverviewRedItem {
                 project: r.project.clone(),
-                summary: format!("{} = {} (risk {:.0}%)", r.key, r.value, r.risk_score * 100.0),
+                summary: format!(
+                    "{} = {} (risk {:.0}%)",
+                    r.key,
+                    r.value,
+                    r.risk_score * 100.0
+                ),
                 action: "Review before overriding".to_string(),
                 blocked_count: 0,
             });
@@ -1431,7 +1441,12 @@ fn compute_attention(
         if r.risk_level == "medium" {
             yellow.push(OverviewYellowItem {
                 project: r.project.clone(),
-                summary: format!("{} = {} (risk {:.0}%)", r.key, r.value, r.risk_score * 100.0),
+                summary: format!(
+                    "{} = {} (risk {:.0}%)",
+                    r.key,
+                    r.value,
+                    r.risk_score * 100.0
+                ),
                 eta: String::new(),
             });
         }
@@ -1480,6 +1495,130 @@ fn compute_attention(
         green,
         updated_at,
     }
+}
+
+// ── SSE Event Stream ──
+
+/// Query parameters for the SSE event stream endpoint.
+#[derive(Deserialize)]
+struct StreamParams {
+    /// Comma-separated event types to subscribe to (e.g. "decision,phase_change").
+    /// If omitted, all event types are streamed.
+    types: Option<String>,
+    /// Resume from this event_id (alternative to `Last-Event-ID` header).
+    since: Option<String>,
+}
+
+/// Map a ledger event to the SSE event name sent to clients.
+///
+/// Decisions are stored as `note` events with a `decision` key in the payload,
+/// so we check the payload in addition to the `event_type` field.
+fn sse_event_name(event: &edda_core::Event) -> &'static str {
+    match event.event_type.as_str() {
+        "agent_phase_change" => "phase_change",
+        "approval_request" => "approval_pending",
+        "note" if event.payload.get("decision").is_some() => "decision",
+        _ => "new_event",
+    }
+}
+
+/// `GET /api/events/stream` — Server-Sent Events endpoint.
+///
+/// Streams new ledger events in real time using a poll-based approach
+/// (queries SQLite rowid cursor every 2 seconds).
+///
+/// Supports:
+/// - `?types=decision,phase_change` — filter by SSE event type
+/// - `?since=evt_xxx` or `Last-Event-ID` header — resume after disconnect
+/// - 30-second keep-alive heartbeat
+async fn get_event_stream(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<StreamParams>,
+    headers: HeaderMap,
+) -> Result<Sse<impl tokio_stream::Stream<Item = Result<SseEvent, Infallible>>>, AppError> {
+    // Determine the resume cursor: query param takes precedence over header.
+    let since = params.since.or_else(|| {
+        headers
+            .get("Last-Event-ID")
+            .and_then(|v| v.to_str().ok())
+            .map(String::from)
+    });
+
+    // Parse type filter into a set for O(1) lookups.
+    let type_filter: Option<Vec<String>> = params.types.map(|t| {
+        t.split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect()
+    });
+
+    // Resolve the initial cursor (rowid) from `since` event_id.
+    let mut cursor: i64 = if let Some(ref event_id) = since {
+        let ledger = state.open_ledger()?;
+        ledger.rowid_for_event_id(event_id)?.unwrap_or(0)
+    } else {
+        0
+    };
+
+    let repo_root = state.repo_root.clone();
+
+    let stream = async_stream::stream! {
+        let mut interval = tokio::time::interval(Duration::from_secs(2));
+        loop {
+            interval.tick().await;
+
+            let ledger = match edda_ledger::Ledger::open(&repo_root) {
+                Ok(l) => l,
+                Err(_) => continue,
+            };
+
+            let new_events = match ledger.events_after_rowid(cursor) {
+                Ok(evts) => evts,
+                Err(_) => continue,
+            };
+
+            if new_events.is_empty() {
+                continue;
+            }
+
+            // Update cursor to the latest rowid.
+            if let Some((last_rowid, _)) = new_events.last() {
+                cursor = *last_rowid;
+            }
+
+            for (_rowid, event) in new_events {
+                let sse_name = sse_event_name(&event);
+
+                // Apply type filter if specified.
+                if let Some(ref filters) = type_filter {
+                    if !filters.iter().any(|f| f == sse_name) {
+                        continue;
+                    }
+                }
+
+                let event_id = event.event_id.clone();
+                let data = serde_json::json!({
+                    "event_type": sse_name,
+                    "data": serde_json::to_value(&event).unwrap_or_default(),
+                    "ts": &event.ts,
+                });
+
+                let sse_event = SseEvent::default()
+                    .event(sse_name)
+                    .id(event_id)
+                    .json_data(data)
+                    .unwrap_or_else(|_| SseEvent::default().comment("serialization error"));
+
+                yield Ok::<_, Infallible>(sse_event);
+            }
+        }
+    };
+
+    Ok(Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(30))
+            .text("ping"),
+    ))
 }
 
 // ── Tests ──
@@ -2941,5 +3080,238 @@ actors:
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert!(json["error"].as_str().unwrap().contains("not found"));
+    }
+
+    // ── SSE tests ──
+
+    #[tokio::test]
+    async fn test_sse_stream_content_type() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/events/stream")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            ct.contains("text/event-stream"),
+            "expected text/event-stream, got: {ct}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sse_stream_new_events() {
+        use http_body_util::BodyExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+
+        // Append an event BEFORE connecting (so it's immediately available).
+        let ledger = edda_ledger::Ledger::open(tmp.path()).unwrap();
+        let note =
+            edda_core::event::new_note_event("main", None, "system", "sse test note", &[]).unwrap();
+        ledger.append_event(&note).unwrap();
+        drop(ledger);
+
+        let app = router(tmp.path());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/events/stream")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Read the first frame from the SSE stream (with timeout).
+        let mut body = resp.into_body();
+        let frame = tokio::time::timeout(Duration::from_secs(5), body.frame())
+            .await
+            .expect("timed out waiting for SSE frame")
+            .expect("stream ended unexpectedly")
+            .expect("frame error");
+
+        let data = frame.into_data().expect("expected data frame");
+        let text = String::from_utf8(data.to_vec()).unwrap();
+
+        // SSE format: "event: new_event\ndata: ...\nid: evt_...\n\n"
+        assert!(text.contains("event: new_event"), "got: {text}");
+        assert!(text.contains(&note.event_id), "got: {text}");
+    }
+
+    #[tokio::test]
+    async fn test_sse_stream_type_filter() {
+        use http_body_util::BodyExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+
+        // Append a decision event.
+        let ledger = edda_ledger::Ledger::open(tmp.path()).unwrap();
+        let dp = edda_core::types::DecisionPayload {
+            key: "test.key".into(),
+            value: "test_val".into(),
+            reason: Some("testing".into()),
+        };
+        let decision = edda_core::event::new_decision_event("main", None, "system", &dp).unwrap();
+        ledger.append_event(&decision).unwrap();
+
+        // Append a note event (should be filtered out).
+        let note = edda_core::event::new_note_event(
+            "main",
+            Some(&decision.hash),
+            "system",
+            "filtered out",
+            &[],
+        )
+        .unwrap();
+        ledger.append_event(&note).unwrap();
+        drop(ledger);
+
+        let app = router(tmp.path());
+
+        // Subscribe only to "decision" type.
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/events/stream?types=decision")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let mut body = resp.into_body();
+        let frame = tokio::time::timeout(Duration::from_secs(5), body.frame())
+            .await
+            .expect("timed out waiting for SSE frame")
+            .expect("stream ended unexpectedly")
+            .expect("frame error");
+
+        let data = frame.into_data().expect("expected data frame");
+        let text = String::from_utf8(data.to_vec()).unwrap();
+
+        // Should contain the decision but NOT the note.
+        assert!(text.contains("event: decision"), "got: {text}");
+        assert!(text.contains(&decision.event_id), "got: {text}");
+        assert!(
+            !text.contains(&note.event_id),
+            "note should be filtered out: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sse_stream_since_replay() {
+        use http_body_util::BodyExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+
+        // Append two events.
+        let ledger = edda_ledger::Ledger::open(tmp.path()).unwrap();
+        let e1 =
+            edda_core::event::new_note_event("main", None, "system", "first event", &[]).unwrap();
+        ledger.append_event(&e1).unwrap();
+
+        let e2 =
+            edda_core::event::new_note_event("main", Some(&e1.hash), "system", "second event", &[])
+                .unwrap();
+        ledger.append_event(&e2).unwrap();
+        drop(ledger);
+
+        let app = router(tmp.path());
+
+        // Connect with ?since=<e1.event_id>, should only get e2.
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/events/stream?since={}", e1.event_id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let mut body = resp.into_body();
+        let frame = tokio::time::timeout(Duration::from_secs(5), body.frame())
+            .await
+            .expect("timed out waiting for SSE frame")
+            .expect("stream ended unexpectedly")
+            .expect("frame error");
+
+        let data = frame.into_data().expect("expected data frame");
+        let text = String::from_utf8(data.to_vec()).unwrap();
+
+        // Should contain e2 but NOT e1.
+        assert!(text.contains(&e2.event_id), "expected e2: {text}");
+        assert!(!text.contains(&e1.event_id), "e1 should be skipped: {text}");
+    }
+
+    #[tokio::test]
+    async fn test_sse_stream_last_event_id_header() {
+        use http_body_util::BodyExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+
+        let ledger = edda_ledger::Ledger::open(tmp.path()).unwrap();
+        let e1 = edda_core::event::new_note_event("main", None, "system", "first", &[]).unwrap();
+        ledger.append_event(&e1).unwrap();
+
+        let e2 = edda_core::event::new_note_event("main", Some(&e1.hash), "system", "second", &[])
+            .unwrap();
+        ledger.append_event(&e2).unwrap();
+        drop(ledger);
+
+        let app = router(tmp.path());
+
+        // Use Last-Event-ID header instead of query param.
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/events/stream")
+                    .header("Last-Event-ID", &e1.event_id)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let mut body = resp.into_body();
+        let frame = tokio::time::timeout(Duration::from_secs(5), body.frame())
+            .await
+            .expect("timed out waiting for SSE frame")
+            .expect("stream ended unexpectedly")
+            .expect("frame error");
+
+        let data = frame.into_data().expect("expected data frame");
+        let text = String::from_utf8(data.to_vec()).unwrap();
+
+        assert!(text.contains(&e2.event_id), "expected e2: {text}");
+        assert!(!text.contains(&e1.event_id), "e1 should be skipped: {text}");
     }
 }


### PR DESCRIPTION
## Summary

- Add `GET /api/events/stream` SSE endpoint to `edda-serve` for real-time ledger event streaming
- Poll-based approach using SQLite `rowid` cursor (2-second interval), minimal disruption to existing architecture
- Add `events_after_rowid()` and `rowid_for_event_id()` cursor methods to `edda-ledger`
- Support `?types=decision,phase_change` filtering and `?since=` / `Last-Event-ID` reconnection
- 30-second keep-alive heartbeat via axum's built-in `KeepAlive`

## Changed files

| File | Change |
|------|--------|
| `crates/edda-serve/Cargo.toml` | Add `tokio-stream`, `async-stream`, `http-body-util` deps |
| `crates/edda-ledger/src/sqlite_store.rs` | Add `events_after_rowid()`, `rowid_for_event_id()` |
| `crates/edda-ledger/src/ledger.rs` | Expose new cursor methods |
| `crates/edda-serve/src/lib.rs` | SSE handler, route registration, event type mapping, 5 tests |

## SSE event types

| SSE `event:` | Source |
|---|---|
| `decision` | `note` events with `decision` payload key |
| `phase_change` | `agent_phase_change` ledger events |
| `approval_pending` | `approval_request` ledger events |
| `new_event` | All other ledger events |

## Test plan

- [x] `test_sse_stream_content_type` — response has `text/event-stream` content type
- [x] `test_sse_stream_new_events` — appended event appears in SSE stream
- [x] `test_sse_stream_type_filter` — `?types=decision` filters non-decision events
- [x] `test_sse_stream_since_replay` — `?since=evt_xxx` replays only subsequent events
- [x] `test_sse_stream_last_event_id_header` — `Last-Event-ID` header works same as `?since`

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)