### PR TITLE
feat(governance): issue proposal workflow

### DIFF
--- a/crates/edda-bridge-claude/src/issue_proposal.rs
+++ b/crates/edda-bridge-claude/src/issue_proposal.rs
@@ -167,6 +167,12 @@ pub fn record_issue_created(
     issue_number: u64,
 ) -> Result<()> {
     let mut proposal = load_proposal(project_id, proposal_id)?;
+    if proposal.status != ProposalStatus::Approved {
+        anyhow::bail!(
+            "Proposal {proposal_id} is not approved (status: {:?})",
+            proposal.status
+        );
+    }
     proposal.issue_url = Some(issue_url.to_string());
     proposal.issue_number = Some(issue_number);
 
@@ -510,6 +516,46 @@ mod tests {
             Some("https://github.com/test/repo/issues/42")
         );
         assert_eq!(loaded.issue_number, Some(42));
+
+        // Cleanup
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    }
+
+    #[test]
+    fn record_issue_created_rejects_non_approved() {
+        let pid = "test_proposal_reject_non_approved";
+        let _ = edda_store::ensure_dirs(pid);
+
+        let proposal = IssueProposal {
+            proposal_id: "prop_reject1".to_string(),
+            created_at: "2026-03-12T10:00:00Z".to_string(),
+            source: ProposalSource::Manual,
+            source_ref: None,
+            title: "Not approved".to_string(),
+            body: "body".to_string(),
+            labels: vec![],
+            status: ProposalStatus::Pending,
+            approved_by: None,
+            approved_at: None,
+            issue_url: None,
+            issue_number: None,
+            dismiss_reason: None,
+        };
+        save_proposal(pid, &proposal).unwrap();
+
+        // Should fail because proposal is Pending, not Approved
+        let result = record_issue_created(
+            pid,
+            "prop_reject1",
+            "https://github.com/test/repo/issues/99",
+            99,
+        );
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("not approved"),
+            "Expected 'not approved' in error, got: {err_msg}"
+        );
 
         // Cleanup
         let _ = fs::remove_dir_all(edda_store::project_dir(pid));

--- a/crates/edda-bridge-claude/src/issue_proposal.rs
+++ b/crates/edda-bridge-claude/src/issue_proposal.rs
@@ -1,0 +1,585 @@
+//! Issue proposal workflow — drafts issue proposals for human approval before
+//! calling `gh issue create`.
+//!
+//! Storage pattern mirrors `bg_scan`: JSON files in `state/issue_proposals/`,
+//! audit log in `state/issue_proposal_audit.jsonl`.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+// ── Data Structures ──
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ProposalSource {
+    Scan,
+    Postmortem,
+    Manual,
+    Bridge,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ProposalStatus {
+    #[default]
+    Pending,
+    Approved,
+    Dismissed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueProposal {
+    pub proposal_id: String,
+    pub created_at: String,
+    pub source: ProposalSource,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_ref: Option<String>,
+    pub title: String,
+    pub body: String,
+    pub labels: Vec<String>,
+    pub status: ProposalStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approved_by: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approved_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issue_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issue_number: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dismiss_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AuditEntry {
+    ts: String,
+    proposal_id: String,
+    action: String,
+    actor: Option<String>,
+    detail: Option<String>,
+}
+
+// ── Public API ──
+
+/// Generate a new proposal ID.
+pub fn new_proposal_id() -> String {
+    format!(
+        "prop_{}",
+        &ulid::Ulid::new().to_string()[..12].to_lowercase()
+    )
+}
+
+/// Save an issue proposal to disk.
+pub fn save_proposal(project_id: &str, proposal: &IssueProposal) -> Result<()> {
+    let path = proposal_path(project_id, &proposal.proposal_id);
+    fs::create_dir_all(path.parent().unwrap())?;
+    let json = serde_json::to_string_pretty(proposal)?;
+    fs::write(&path, json)?;
+
+    append_audit(
+        project_id,
+        &proposal.proposal_id,
+        "created",
+        None,
+        Some(&proposal.title),
+    )?;
+
+    Ok(())
+}
+
+/// Load a single proposal by ID.
+pub fn load_proposal(project_id: &str, proposal_id: &str) -> Result<IssueProposal> {
+    let path = proposal_path(project_id, proposal_id);
+    let content =
+        fs::read_to_string(&path).with_context(|| format!("Proposal not found: {proposal_id}"))?;
+    let proposal: IssueProposal = serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse proposal: {}", path.display()))?;
+    Ok(proposal)
+}
+
+/// List all proposals, optionally filtered by status.
+pub fn list_proposals(
+    project_id: &str,
+    status_filter: Option<&ProposalStatus>,
+) -> Result<Vec<IssueProposal>> {
+    let dir = proposals_dir(project_id);
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut results = Vec::new();
+    for entry in fs::read_dir(&dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let content = fs::read_to_string(&path)?;
+        let proposal: IssueProposal = serde_json::from_str(&content)
+            .with_context(|| format!("Failed to parse proposal: {}", path.display()))?;
+
+        if let Some(filter) = status_filter {
+            if &proposal.status != filter {
+                continue;
+            }
+        }
+        results.push(proposal);
+    }
+
+    results.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    Ok(results)
+}
+
+/// Approve a proposal: mark as approved and return it.
+pub fn approve_proposal(
+    project_id: &str,
+    proposal_id: &str,
+    by: &str,
+) -> Result<IssueProposal> {
+    let mut proposal = load_proposal(project_id, proposal_id)?;
+    if proposal.status != ProposalStatus::Pending {
+        anyhow::bail!(
+            "Proposal {proposal_id} is not pending (status: {:?})",
+            proposal.status
+        );
+    }
+
+    proposal.status = ProposalStatus::Approved;
+    proposal.approved_by = Some(by.to_string());
+    proposal.approved_at = Some(now_rfc3339());
+
+    let path = proposal_path(project_id, proposal_id);
+    let json = serde_json::to_string_pretty(&proposal)?;
+    fs::write(&path, json)?;
+
+    append_audit(project_id, proposal_id, "approved", Some(by), None)?;
+
+    Ok(proposal)
+}
+
+/// Record issue creation result on an approved proposal.
+pub fn record_issue_created(
+    project_id: &str,
+    proposal_id: &str,
+    issue_url: &str,
+    issue_number: u64,
+) -> Result<()> {
+    let mut proposal = load_proposal(project_id, proposal_id)?;
+    proposal.issue_url = Some(issue_url.to_string());
+    proposal.issue_number = Some(issue_number);
+
+    let path = proposal_path(project_id, proposal_id);
+    let json = serde_json::to_string_pretty(&proposal)?;
+    fs::write(&path, json)?;
+
+    append_audit(
+        project_id,
+        proposal_id,
+        "issue_created",
+        None,
+        Some(issue_url),
+    )?;
+
+    Ok(())
+}
+
+/// Dismiss a proposal with optional reason.
+pub fn dismiss_proposal(
+    project_id: &str,
+    proposal_id: &str,
+    reason: Option<&str>,
+) -> Result<()> {
+    let mut proposal = load_proposal(project_id, proposal_id)?;
+    if proposal.status != ProposalStatus::Pending {
+        anyhow::bail!(
+            "Proposal {proposal_id} is not pending (status: {:?})",
+            proposal.status
+        );
+    }
+
+    proposal.status = ProposalStatus::Dismissed;
+    proposal.dismiss_reason = reason.map(String::from);
+
+    let path = proposal_path(project_id, proposal_id);
+    let json = serde_json::to_string_pretty(&proposal)?;
+    fs::write(&path, json)?;
+
+    append_audit(project_id, proposal_id, "dismissed", None, reason)?;
+
+    Ok(())
+}
+
+/// Create a proposal from a scan gap.
+pub fn create_proposal_from_scan_gap(
+    project_id: &str,
+    scan_id: &str,
+    index: usize,
+) -> Result<IssueProposal> {
+    let scan = crate::bg_scan::load_scan(project_id, scan_id)?;
+    if index >= scan.gaps.len() {
+        anyhow::bail!(
+            "Gap index {index} out of range (scan has {} gaps)",
+            scan.gaps.len()
+        );
+    }
+
+    let gap = &scan.gaps[index];
+    let mut body_parts = vec![gap.description.clone()];
+
+    if !gap.evidence.is_empty() {
+        body_parts.push(String::new());
+        body_parts.push("## Evidence".to_string());
+        for ev in &gap.evidence {
+            body_parts.push(format!("- {ev}"));
+        }
+    }
+
+    body_parts.push(String::new());
+    body_parts.push(format!(
+        "_Generated by `edda scan` (confidence: {:.0}%, scan: {})_",
+        gap.confidence * 100.0,
+        scan_id
+    ));
+
+    let proposal = IssueProposal {
+        proposal_id: new_proposal_id(),
+        created_at: now_rfc3339(),
+        source: ProposalSource::Scan,
+        source_ref: Some(format!("{scan_id}:{index}")),
+        title: gap.title.clone(),
+        body: body_parts.join("\n"),
+        labels: gap.suggested_labels.clone(),
+        status: ProposalStatus::Pending,
+        approved_by: None,
+        approved_at: None,
+        issue_url: None,
+        issue_number: None,
+        dismiss_reason: None,
+    };
+
+    save_proposal(project_id, &proposal)?;
+    Ok(proposal)
+}
+
+// ── Storage Helpers ──
+
+fn proposals_dir(project_id: &str) -> PathBuf {
+    edda_store::project_dir(project_id)
+        .join("state")
+        .join("issue_proposals")
+}
+
+fn proposal_path(project_id: &str, proposal_id: &str) -> PathBuf {
+    proposals_dir(project_id).join(format!("{proposal_id}.json"))
+}
+
+fn audit_log_path(project_id: &str) -> PathBuf {
+    edda_store::project_dir(project_id)
+        .join("state")
+        .join("issue_proposal_audit.jsonl")
+}
+
+fn append_audit(
+    project_id: &str,
+    proposal_id: &str,
+    action: &str,
+    actor: Option<&str>,
+    detail: Option<&str>,
+) -> Result<()> {
+    use std::io::Write;
+    let path = audit_log_path(project_id);
+    fs::create_dir_all(path.parent().unwrap())?;
+    let entry = AuditEntry {
+        ts: now_rfc3339(),
+        proposal_id: proposal_id.to_string(),
+        action: action.to_string(),
+        actor: actor.map(String::from),
+        detail: detail.map(String::from),
+    };
+    let line = serde_json::to_string(&entry)?;
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)?;
+    writeln!(file, "{}", line)?;
+    Ok(())
+}
+
+fn now_rfc3339() -> String {
+    time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_default()
+}
+
+// ── Tests ──
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proposal_serde_roundtrip() {
+        let proposal = IssueProposal {
+            proposal_id: "prop_test123".to_string(),
+            created_at: "2026-03-12T10:00:00Z".to_string(),
+            source: ProposalSource::Manual,
+            source_ref: None,
+            title: "Test issue".to_string(),
+            body: "This is a test".to_string(),
+            labels: vec!["enhancement".to_string()],
+            status: ProposalStatus::Pending,
+            approved_by: None,
+            approved_at: None,
+            issue_url: None,
+            issue_number: None,
+            dismiss_reason: None,
+        };
+        let json = serde_json::to_string(&proposal).unwrap();
+        let parsed: IssueProposal = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.proposal_id, "prop_test123");
+        assert_eq!(parsed.title, "Test issue");
+        assert_eq!(parsed.status, ProposalStatus::Pending);
+        assert_eq!(parsed.source, ProposalSource::Manual);
+    }
+
+    #[test]
+    fn proposal_status_transitions() {
+        let pid = "test_proposal_status";
+        let _ = edda_store::ensure_dirs(pid);
+
+        // Create a pending proposal
+        let proposal = IssueProposal {
+            proposal_id: "prop_status1".to_string(),
+            created_at: "2026-03-12T10:00:00Z".to_string(),
+            source: ProposalSource::Manual,
+            source_ref: None,
+            title: "Approve me".to_string(),
+            body: "body".to_string(),
+            labels: vec![],
+            status: ProposalStatus::Pending,
+            approved_by: None,
+            approved_at: None,
+            issue_url: None,
+            issue_number: None,
+            dismiss_reason: None,
+        };
+        save_proposal(pid, &proposal).unwrap();
+
+        // Approve
+        let approved = approve_proposal(pid, "prop_status1", "alice").unwrap();
+        assert_eq!(approved.status, ProposalStatus::Approved);
+        assert_eq!(approved.approved_by.as_deref(), Some("alice"));
+        assert!(approved.approved_at.is_some());
+
+        // Cannot approve again
+        assert!(approve_proposal(pid, "prop_status1", "bob").is_err());
+
+        // Create another proposal to test dismiss
+        let proposal2 = IssueProposal {
+            proposal_id: "prop_status2".to_string(),
+            created_at: "2026-03-12T10:01:00Z".to_string(),
+            source: ProposalSource::Scan,
+            source_ref: Some("scan_abc:0".to_string()),
+            title: "Dismiss me".to_string(),
+            body: "body".to_string(),
+            labels: vec![],
+            status: ProposalStatus::Pending,
+            approved_by: None,
+            approved_at: None,
+            issue_url: None,
+            issue_number: None,
+            dismiss_reason: None,
+        };
+        save_proposal(pid, &proposal2).unwrap();
+
+        // Dismiss
+        dismiss_proposal(pid, "prop_status2", Some("not relevant")).unwrap();
+        let dismissed = load_proposal(pid, "prop_status2").unwrap();
+        assert_eq!(dismissed.status, ProposalStatus::Dismissed);
+        assert_eq!(dismissed.dismiss_reason.as_deref(), Some("not relevant"));
+
+        // Cannot dismiss again
+        assert!(dismiss_proposal(pid, "prop_status2", None).is_err());
+
+        // Cleanup
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    }
+
+    #[test]
+    fn storage_save_load_list_roundtrip() {
+        let pid = "test_proposal_storage";
+        let _ = edda_store::ensure_dirs(pid);
+
+        let p1 = IssueProposal {
+            proposal_id: "prop_store1".to_string(),
+            created_at: "2026-03-12T10:00:00Z".to_string(),
+            source: ProposalSource::Manual,
+            source_ref: None,
+            title: "First".to_string(),
+            body: "body1".to_string(),
+            labels: vec!["bug".to_string()],
+            status: ProposalStatus::Pending,
+            approved_by: None,
+            approved_at: None,
+            issue_url: None,
+            issue_number: None,
+            dismiss_reason: None,
+        };
+        let p2 = IssueProposal {
+            proposal_id: "prop_store2".to_string(),
+            created_at: "2026-03-12T11:00:00Z".to_string(),
+            source: ProposalSource::Bridge,
+            source_ref: None,
+            title: "Second".to_string(),
+            body: "body2".to_string(),
+            labels: vec![],
+            status: ProposalStatus::Pending,
+            approved_by: None,
+            approved_at: None,
+            issue_url: None,
+            issue_number: None,
+            dismiss_reason: None,
+        };
+
+        save_proposal(pid, &p1).unwrap();
+        save_proposal(pid, &p2).unwrap();
+
+        // Load single
+        let loaded = load_proposal(pid, "prop_store1").unwrap();
+        assert_eq!(loaded.title, "First");
+
+        // List all
+        let all = list_proposals(pid, None).unwrap();
+        assert_eq!(all.len(), 2);
+
+        // List pending only
+        let pending = list_proposals(pid, Some(&ProposalStatus::Pending)).unwrap();
+        assert_eq!(pending.len(), 2);
+
+        // Approve one, list pending
+        approve_proposal(pid, "prop_store1", "human").unwrap();
+        let pending = list_proposals(pid, Some(&ProposalStatus::Pending)).unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].proposal_id, "prop_store2");
+
+        // List approved
+        let approved = list_proposals(pid, Some(&ProposalStatus::Approved)).unwrap();
+        assert_eq!(approved.len(), 1);
+        assert_eq!(approved[0].proposal_id, "prop_store1");
+
+        // Cleanup
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    }
+
+    #[test]
+    fn record_issue_created_updates_proposal() {
+        let pid = "test_proposal_issue_created";
+        let _ = edda_store::ensure_dirs(pid);
+
+        let proposal = IssueProposal {
+            proposal_id: "prop_issue1".to_string(),
+            created_at: "2026-03-12T10:00:00Z".to_string(),
+            source: ProposalSource::Manual,
+            source_ref: None,
+            title: "Create me".to_string(),
+            body: "body".to_string(),
+            labels: vec![],
+            status: ProposalStatus::Pending,
+            approved_by: None,
+            approved_at: None,
+            issue_url: None,
+            issue_number: None,
+            dismiss_reason: None,
+        };
+        save_proposal(pid, &proposal).unwrap();
+        approve_proposal(pid, "prop_issue1", "human").unwrap();
+
+        record_issue_created(
+            pid,
+            "prop_issue1",
+            "https://github.com/test/repo/issues/42",
+            42,
+        )
+        .unwrap();
+
+        let loaded = load_proposal(pid, "prop_issue1").unwrap();
+        assert_eq!(
+            loaded.issue_url.as_deref(),
+            Some("https://github.com/test/repo/issues/42")
+        );
+        assert_eq!(loaded.issue_number, Some(42));
+
+        // Cleanup
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    }
+
+    #[test]
+    fn audit_log_records_actions() {
+        let pid = "test_proposal_audit";
+        let _ = edda_store::ensure_dirs(pid);
+
+        let proposal = IssueProposal {
+            proposal_id: "prop_audit1".to_string(),
+            created_at: "2026-03-12T10:00:00Z".to_string(),
+            source: ProposalSource::Manual,
+            source_ref: None,
+            title: "Audit test".to_string(),
+            body: "body".to_string(),
+            labels: vec![],
+            status: ProposalStatus::Pending,
+            approved_by: None,
+            approved_at: None,
+            issue_url: None,
+            issue_number: None,
+            dismiss_reason: None,
+        };
+        save_proposal(pid, &proposal).unwrap(); // creates 1 audit entry
+
+        approve_proposal(pid, "prop_audit1", "human").unwrap(); // creates 1 more
+
+        let path = audit_log_path(pid);
+        let content = fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("created"));
+        assert!(lines[1].contains("approved"));
+
+        // Cleanup
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    }
+
+    #[test]
+    fn new_proposal_id_format() {
+        let id = new_proposal_id();
+        assert!(id.starts_with("prop_"));
+        assert_eq!(id.len(), 17); // "prop_" (5) + 12 chars
+    }
+
+    #[test]
+    fn load_nonexistent_proposal_returns_error() {
+        let pid = "test_proposal_missing";
+        let _ = edda_store::ensure_dirs(pid);
+
+        let result = load_proposal(pid, "prop_nonexistent");
+        assert!(result.is_err());
+
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    }
+
+    #[test]
+    fn proposal_source_serde() {
+        for (source, expected) in [
+            (ProposalSource::Scan, "\"scan\""),
+            (ProposalSource::Postmortem, "\"postmortem\""),
+            (ProposalSource::Manual, "\"manual\""),
+            (ProposalSource::Bridge, "\"bridge\""),
+        ] {
+            let json = serde_json::to_string(&source).unwrap();
+            assert_eq!(json, expected);
+            let parsed: ProposalSource = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, source);
+        }
+    }
+}

--- a/crates/edda-bridge-claude/src/lib.rs
+++ b/crates/edda-bridge-claude/src/lib.rs
@@ -3,6 +3,7 @@ pub mod bg_detect;
 pub mod bg_digest;
 pub mod bg_extract;
 pub mod bg_scan;
+pub mod issue_proposal;
 pub mod digest;
 pub mod pattern;
 pub mod peers;

--- a/crates/edda-cli/src/cmd_propose.rs
+++ b/crates/edda-cli/src/cmd_propose.rs
@@ -1,0 +1,406 @@
+use clap::Subcommand;
+use edda_bridge_claude::issue_proposal::{
+    self, IssueProposal, ProposalSource, ProposalStatus,
+};
+use std::path::Path;
+
+#[derive(Subcommand)]
+pub enum ProposeCmd {
+    /// Create a new issue proposal
+    Create {
+        /// Issue title
+        #[arg(long)]
+        title: String,
+        /// Issue body
+        #[arg(long)]
+        body: String,
+        /// Labels (repeatable)
+        #[arg(long = "label")]
+        labels: Vec<String>,
+        /// Source: scan, postmortem, manual, bridge
+        #[arg(long, default_value = "manual")]
+        source: String,
+        /// Source reference (e.g. "scan_abc:0")
+        #[arg(long)]
+        source_ref: Option<String>,
+    },
+    /// Create a proposal from a scan gap
+    FromScan {
+        /// Scan ID (scan_...)
+        scan_id: String,
+        /// Gap index (0-based)
+        index: usize,
+    },
+    /// List proposals
+    List {
+        /// Filter by status: pending, approved, dismissed
+        #[arg(long)]
+        status: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show a proposal
+    Show {
+        /// Proposal ID (prop_...)
+        prop_id: String,
+    },
+    /// Approve a proposal and create GitHub issue
+    Approve {
+        /// Proposal ID (prop_...)
+        prop_id: String,
+        /// Actor name
+        #[arg(long, default_value = "human")]
+        by: String,
+        /// Preview without creating the issue
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Dismiss a proposal
+    Dismiss {
+        /// Proposal ID (prop_...)
+        prop_id: String,
+        /// Reason for dismissal
+        #[arg(long)]
+        reason: Option<String>,
+    },
+}
+
+pub fn execute(cmd: ProposeCmd, repo_root: &Path) -> anyhow::Result<()> {
+    let project_id = edda_store::project_id(repo_root);
+
+    match cmd {
+        ProposeCmd::Create {
+            title,
+            body,
+            labels,
+            source,
+            source_ref,
+        } => execute_create(
+            &project_id,
+            &title,
+            &body,
+            &labels,
+            &source,
+            source_ref.as_deref(),
+        ),
+        ProposeCmd::FromScan { scan_id, index } => {
+            execute_from_scan(&project_id, &scan_id, index)
+        }
+        ProposeCmd::List { status, json } => execute_list(&project_id, status.as_deref(), json),
+        ProposeCmd::Show { prop_id } => execute_show(&project_id, &prop_id),
+        ProposeCmd::Approve {
+            prop_id,
+            by,
+            dry_run,
+        } => execute_approve(&project_id, &prop_id, &by, dry_run, repo_root),
+        ProposeCmd::Dismiss { prop_id, reason } => {
+            execute_dismiss(&project_id, &prop_id, reason.as_deref())
+        }
+    }
+}
+
+fn parse_source(s: &str) -> anyhow::Result<ProposalSource> {
+    match s {
+        "scan" => Ok(ProposalSource::Scan),
+        "postmortem" => Ok(ProposalSource::Postmortem),
+        "manual" => Ok(ProposalSource::Manual),
+        "bridge" => Ok(ProposalSource::Bridge),
+        _ => anyhow::bail!("Unknown source: {s} (expected: scan, postmortem, manual, bridge)"),
+    }
+}
+
+fn execute_create(
+    project_id: &str,
+    title: &str,
+    body: &str,
+    labels: &[String],
+    source: &str,
+    source_ref: Option<&str>,
+) -> anyhow::Result<()> {
+    let source = parse_source(source)?;
+    let proposal = IssueProposal {
+        proposal_id: issue_proposal::new_proposal_id(),
+        created_at: now_rfc3339(),
+        source,
+        source_ref: source_ref.map(String::from),
+        title: title.to_string(),
+        body: body.to_string(),
+        labels: labels.to_vec(),
+        status: ProposalStatus::Pending,
+        approved_by: None,
+        approved_at: None,
+        issue_url: None,
+        issue_number: None,
+        dismiss_reason: None,
+    };
+
+    issue_proposal::save_proposal(project_id, &proposal)?;
+    println!("Proposal created: {}", proposal.proposal_id);
+    println!("  Title: {}", proposal.title);
+    println!();
+    println!(
+        "Use `edda propose-issue approve {}` to create the GitHub issue.",
+        proposal.proposal_id
+    );
+    Ok(())
+}
+
+fn execute_from_scan(project_id: &str, scan_id: &str, index: usize) -> anyhow::Result<()> {
+    let proposal = issue_proposal::create_proposal_from_scan_gap(project_id, scan_id, index)?;
+    println!("Proposal created from scan gap: {}", proposal.proposal_id);
+    println!("  Title: {}", proposal.title);
+    println!("  Source: {}:{}", scan_id, index);
+    println!();
+    println!(
+        "Use `edda propose-issue approve {}` to create the GitHub issue.",
+        proposal.proposal_id
+    );
+    Ok(())
+}
+
+fn execute_list(
+    project_id: &str,
+    status: Option<&str>,
+    json: bool,
+) -> anyhow::Result<()> {
+    let status_filter = match status {
+        Some("pending") => Some(ProposalStatus::Pending),
+        Some("approved") => Some(ProposalStatus::Approved),
+        Some("dismissed") => Some(ProposalStatus::Dismissed),
+        Some(s) => anyhow::bail!(
+            "Unknown status filter: {s} (expected: pending, approved, dismissed)"
+        ),
+        None => None,
+    };
+
+    let proposals = issue_proposal::list_proposals(project_id, status_filter.as_ref())?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&proposals)?);
+        return Ok(());
+    }
+
+    if proposals.is_empty() {
+        let qualifier = status.unwrap_or("any");
+        println!("No {qualifier} issue proposals found.");
+        println!("Use `edda propose-issue create --title \"...\" --body \"...\"` to create one.");
+        return Ok(());
+    }
+
+    for p in &proposals {
+        let status_str = match p.status {
+            ProposalStatus::Pending => "PENDING",
+            ProposalStatus::Approved => "approved",
+            ProposalStatus::Dismissed => "dismissed",
+        };
+        let labels_str = if p.labels.is_empty() {
+            String::new()
+        } else {
+            format!(" [{}]", p.labels.join(", "))
+        };
+        let issue_str = p
+            .issue_url
+            .as_deref()
+            .map(|u| format!(" -> {u}"))
+            .unwrap_or_default();
+        println!(
+            "  {} [{}] {}{}{} ({})",
+            p.proposal_id, status_str, p.title, labels_str, issue_str, p.created_at
+        );
+    }
+
+    Ok(())
+}
+
+fn execute_show(project_id: &str, prop_id: &str) -> anyhow::Result<()> {
+    let p = issue_proposal::load_proposal(project_id, prop_id)?;
+
+    println!("Proposal:  {}", p.proposal_id);
+    println!("Status:    {:?}", p.status);
+    println!("Created:   {}", p.created_at);
+    println!("Source:    {:?}", p.source);
+    if let Some(ref sr) = p.source_ref {
+        println!("Source ref: {sr}");
+    }
+    println!("Title:     {}", p.title);
+    if !p.labels.is_empty() {
+        println!("Labels:    {}", p.labels.join(", "));
+    }
+    println!();
+    println!("Body:");
+    println!("{}", p.body);
+
+    if let Some(ref by) = p.approved_by {
+        println!();
+        println!("Approved by: {by}");
+        if let Some(ref at) = p.approved_at {
+            println!("Approved at: {at}");
+        }
+    }
+    if let Some(ref url) = p.issue_url {
+        println!("Issue URL:   {url}");
+    }
+    if let Some(num) = p.issue_number {
+        println!("Issue #:     {num}");
+    }
+    if let Some(ref reason) = p.dismiss_reason {
+        println!();
+        println!("Dismiss reason: {reason}");
+    }
+
+    Ok(())
+}
+
+fn execute_approve(
+    project_id: &str,
+    prop_id: &str,
+    by: &str,
+    dry_run: bool,
+    repo_root: &Path,
+) -> anyhow::Result<()> {
+    // Optional RBAC check
+    check_rbac_if_configured(repo_root, by, "approve_issue_proposal")?;
+
+    let proposal = if dry_run {
+        issue_proposal::load_proposal(project_id, prop_id)?
+    } else {
+        issue_proposal::approve_proposal(project_id, prop_id, by)?
+    };
+
+    if dry_run {
+        println!("=== DRY RUN ===");
+        println!("Would create GitHub issue:");
+        println!("  Title:  {}", proposal.title);
+        println!("  Labels: {}", proposal.labels.join(", "));
+        println!();
+        println!("Body:");
+        println!("{}", proposal.body);
+        return Ok(());
+    }
+
+    // Call gh issue create
+    let cwd = repo_root.to_string_lossy().to_string();
+    match create_github_issue(&proposal, &cwd) {
+        Ok((url, number)) => {
+            issue_proposal::record_issue_created(project_id, prop_id, &url, number)?;
+            println!("Issue created: {url}");
+        }
+        Err(e) => {
+            // Issue creation failed, but approval is already recorded.
+            // The user can retry by running `gh issue create` manually.
+            eprintln!("Warning: Proposal approved but issue creation failed: {e}");
+            eprintln!("The proposal is marked as approved. Create the issue manually:");
+            eprintln!(
+                "  gh issue create --title {:?} --body {:?}",
+                proposal.title, proposal.body
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn execute_dismiss(
+    project_id: &str,
+    prop_id: &str,
+    reason: Option<&str>,
+) -> anyhow::Result<()> {
+    issue_proposal::dismiss_proposal(project_id, prop_id, reason)?;
+    println!("Proposal {prop_id} dismissed.");
+    if let Some(r) = reason {
+        println!("  Reason: {r}");
+    }
+    Ok(())
+}
+
+/// Create a GitHub issue via `gh` CLI. Returns (url, issue_number).
+fn create_github_issue(proposal: &IssueProposal, cwd: &str) -> anyhow::Result<(String, u64)> {
+    let mut args = vec![
+        "issue".to_string(),
+        "create".to_string(),
+        "--title".to_string(),
+        proposal.title.clone(),
+        "--body".to_string(),
+        proposal.body.clone(),
+    ];
+
+    for label in &proposal.labels {
+        args.push("--label".to_string());
+        args.push(label.clone());
+    }
+
+    let output = std::process::Command::new("gh")
+        .args(&args)
+        .current_dir(cwd)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("gh issue create failed: {stderr}");
+    }
+
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    // Parse issue number from URL (e.g. https://github.com/owner/repo/issues/42)
+    let number = url
+        .rsplit('/')
+        .next()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(0);
+
+    Ok((url, number))
+}
+
+/// Check RBAC if policy.yaml has permissions configured. Permissive default.
+fn check_rbac_if_configured(repo_root: &Path, actor: &str, action: &str) -> anyhow::Result<()> {
+    let edda_dir = repo_root.join(".edda");
+    let policy = edda_core::policy::load_policy_from_dir(&edda_dir)?;
+
+    // No permissions section = permissive
+    if policy.permissions.is_none() {
+        return Ok(());
+    }
+
+    let actors = edda_core::policy::load_actors_from_dir(&edda_dir)?;
+    let req = edda_core::policy::AuthzRequest {
+        actor: actor.to_string(),
+        action: action.to_string(),
+        resource: None,
+    };
+    let result = edda_core::policy::evaluate_authz(&req, &policy, &actors);
+    if !result.allowed {
+        let reason = result.reason.unwrap_or_default();
+        anyhow::bail!(
+            "RBAC denied: actor '{actor}' lacks '{action}' permission. {reason}"
+        );
+    }
+    Ok(())
+}
+
+fn now_rfc3339() -> String {
+    time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_source_valid() {
+        assert_eq!(parse_source("scan").unwrap(), ProposalSource::Scan);
+        assert_eq!(
+            parse_source("postmortem").unwrap(),
+            ProposalSource::Postmortem
+        );
+        assert_eq!(parse_source("manual").unwrap(), ProposalSource::Manual);
+        assert_eq!(parse_source("bridge").unwrap(), ProposalSource::Bridge);
+    }
+
+    #[test]
+    fn parse_source_invalid() {
+        assert!(parse_source("unknown").is_err());
+    }
+}

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -20,6 +20,7 @@ mod cmd_pattern;
 mod cmd_phase;
 mod cmd_pipeline;
 mod cmd_plan;
+mod cmd_propose;
 mod cmd_prs;
 mod cmd_rebuild;
 mod cmd_recap;
@@ -422,6 +423,12 @@ enum Command {
     Scan {
         #[command(subcommand)]
         cmd: cmd_scan::ScanCmd,
+    },
+    /// Issue proposal workflow — draft, review, and create GitHub issues
+    #[command(name = "propose-issue")]
+    ProposeIssue {
+        #[command(subcommand)]
+        cmd: cmd_propose::ProposeCmd,
     },
     /// Manage skill registry (scan, list, show, search)
     Skill {
@@ -1063,6 +1070,7 @@ fn main() -> anyhow::Result<()> {
         Command::User { cmd } => cmd_user::execute(cmd),
         Command::Rules { cmd } => cmd_rules::execute(cmd, &repo_root),
         Command::Scan { cmd } => cmd_scan::execute(cmd, &repo_root),
+        Command::ProposeIssue { cmd } => cmd_propose::execute(cmd, &repo_root),
         Command::Skill { cmd } => cmd_skill::execute(cmd, &repo_root),
     }
 }


### PR DESCRIPTION
## Summary
- Add `edda propose-issue` command with create, from-scan, list, show, approve, dismiss subcommands
- New `issue_proposal.rs` in edda-bridge-claude: data model (`IssueProposal`, `ProposalSource`, `ProposalStatus`), JSON storage in `state/issue_proposals/`, JSONL audit log
- New `cmd_propose.rs` in edda-cli: CLI with RBAC integration via `evaluate_authz()` (permissive when no policy.yaml)
- Approve flow calls `gh issue create` and records issue URL/number back on proposal
- 10 unit tests covering serde roundtrip, status transitions, storage CRUD, audit log

Closes #204

## Test plan
- [x] `cargo clippy -p edda-bridge-claude -p edda -- -D warnings` passes clean
- [x] `cargo test -p edda-bridge-claude -- issue_proposal` (8 tests pass)
- [x] `cargo test -p edda -- cmd_propose` (2 tests pass)
- [ ] CI pipeline (fmt, clippy, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)