### PR TITLE
docs(architecture): formalize L1-L4 layer model (#238)

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -4,41 +4,89 @@ title: Architecture
 
 # Architecture
 
-Edda is a Rust workspace with 14 crates, organized in three layers: core storage, bridge integrations, and user-facing interfaces.
+Edda is a Rust workspace organized in four layers. Each layer may depend on layers
+below it, never above.
+
+## Layer model
+
+| Layer | Purpose | Crates |
+|-------|---------|--------|
+| **L1 Foundation** | Event model, schema, hashing | `edda-core` |
+| **L2 Persistence** | Storage, ledger, blobs | `edda-ledger`, `edda-store` |
+| **L3 Processing** | View building, indexing, orchestration, analysis | `edda-derive`, `edda-transcript`, `edda-index`, `edda-conductor`, `edda-aggregate`, `edda-chronicle`, `edda-postmortem` |
+| **L3 Bridge** | External system integration | `edda-bridge-claude`, `edda-bridge-openclaw` |
+| **L3 Query** | Cross-source queries, context generation | `edda-ask`, `edda-pack`, `edda-search-fts` |
+| **L4 Interface** | User-facing CLI, MCP, HTTP, notifications | `edda-cli`, `edda-mcp`, `edda-serve`, `edda-notify` |
+
+### Dependency rules
+
+```
+L4 Interface  ──▶  L3 Processing / Bridge / Query  ──▶  L2 Persistence  ──▶  L1 Foundation
+```
+
+- **L1** has no workspace dependencies (only `std` and external crates).
+- **L2** may depend on L1.
+- **L3** may depend on L1 and L2.
+- **L4** may depend on any layer.
+
+Same-layer dependencies are allowed (e.g. an L3 crate may depend on another L3 crate).
+
+### Dependency matrix
+
+| Depends on →  | L1 | L2 | L3 | L4 |
+|---------------|----|----|----|----|
+| **L1**        | —  | no | no | no |
+| **L2**        | yes | — | no | no |
+| **L3**        | yes | yes | yes | no |
+| **L4**        | yes | yes | yes | yes |
+
+> **Note**: `edda-derive` is classified as L3 Processing. Its dependency on
+> `edda-ledger` (L2) is valid under the layer rules — derive builds derived
+> views *from* the ledger, making it a consumer of persistence, not a
+> foundation crate.
 
 ## Crate map
 
 ```
-User-facing          Bridge                    Core
-─────────────        ──────────────────        ──────────────
-edda-cli             edda-bridge-claude        edda-core
-edda-mcp             edda-bridge-openclaw      edda-ledger
-                                               edda-store
+L4 Interface         L3 Bridge                 L2 Persistence     L1 Foundation
+─────────────        ──────────────────        ──────────────     ──────────────
+edda-cli             edda-bridge-claude        edda-ledger        edda-core
+edda-mcp             edda-bridge-openclaw      edda-store
+edda-serve
+edda-notify
 
-Query & context      Processing
+L3 Query             L3 Processing
 ──────────────       ──────────────
 edda-ask             edda-transcript
 edda-pack            edda-derive
 edda-search-fts      edda-index
                      edda-conductor
+                     edda-aggregate
+                     edda-chronicle
+                     edda-postmortem
 ```
 
 | Crate | Layer | What it does |
 |-------|-------|-------------|
-| `edda-core` | Core | Event model, hash chain, schema, provenance |
-| `edda-ledger` | Core | Append-only ledger (SQLite), blob store, locking |
-| `edda-store` | Core | Per-user store, atomic writes |
-| `edda-bridge-claude` | Bridge | Claude Code hooks, transcript ingest, context injection, peer coordination |
-| `edda-bridge-openclaw` | Bridge | OpenClaw hooks and plugin |
-| `edda-transcript` | Processing | Transcript delta ingest, classification |
-| `edda-derive` | Processing | View rebuilding, tiered history |
-| `edda-index` | Processing | Transcript index |
-| `edda-conductor` | Processing | Multi-phase plan orchestration |
-| `edda-ask` | Query | Cross-source decision query engine |
-| `edda-pack` | Query | Context generation, budget controls |
-| `edda-search-fts` | Query | Full-text search (Tantivy) |
-| `edda-cli` | Interface | All commands + TUI (`tui` feature) |
-| `edda-mcp` | Interface | MCP server (7 tools, stdio JSON-RPC 2.0) |
+| `edda-core` | L1 Foundation | Event model, hash chain, schema, provenance |
+| `edda-ledger` | L2 Persistence | Append-only ledger (SQLite), blob store, locking |
+| `edda-store` | L2 Persistence | Per-user store, atomic writes |
+| `edda-bridge-claude` | L3 Bridge | Claude Code hooks, transcript ingest, context injection, peer coordination |
+| `edda-bridge-openclaw` | L3 Bridge | OpenClaw hooks and plugin |
+| `edda-transcript` | L3 Processing | Transcript delta ingest, classification |
+| `edda-derive` | L3 Processing | View rebuilding, tiered history |
+| `edda-index` | L3 Processing | Transcript index |
+| `edda-conductor` | L3 Processing | Multi-phase plan orchestration |
+| `edda-aggregate` | L3 Processing | Cross-session aggregation |
+| `edda-chronicle` | L3 Processing | Timeline and chronicle generation |
+| `edda-postmortem` | L3 Processing | Post-session analysis and rule lifecycle |
+| `edda-ask` | L3 Query | Cross-source decision query engine |
+| `edda-pack` | L3 Query | Context generation, budget controls |
+| `edda-search-fts` | L3 Query | Full-text search (Tantivy) |
+| `edda-cli` | L4 Interface | All commands + TUI (`tui` feature) |
+| `edda-mcp` | L4 Interface | MCP server (7 tools, stdio JSON-RPC 2.0) |
+| `edda-serve` | L4 Interface | HTTP API server |
+| `edda-notify` | L4 Interface | Notification dispatch |
 
 ## Data flow
 


### PR DESCRIPTION
## Summary

- Formally define the L1/L2/L3/L4 layer model with dependency rules in `docs/architecture/overview.md`
- Reclassify `edda-derive` as L3 Processing, making its dependency on `edda-ledger` (L2) valid
- Add dependency matrix showing which layers can depend on which
- Update crate map to cover all 19 workspace crates (was missing `edda-aggregate`, `edda-chronicle`, `edda-postmortem`, `edda-serve`, `edda-notify`)

Closes #238

## Test plan

- [ ] No code changes — docs only
- [ ] CI passes (cargo fmt, clippy, test unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)