### PR TITLE
fix: UTF-8 byte-level truncate panic (#233)

### DIFF
--- a/crates/edda-cli/src/cmd_log.rs
+++ b/crates/edda-cli/src/cmd_log.rs
@@ -182,7 +182,7 @@ fn format_event_detail(event: &Event) -> String {
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
             let truncated = if text.len() > 60 {
-                format!("{}...", &text[..57])
+                format!("{}...", &text[..text.floor_char_boundary(57)])
             } else {
                 text.to_string()
             };
@@ -206,7 +206,7 @@ fn format_event_detail(event: &Event) -> String {
                 })
                 .unwrap_or_default();
             let argv_short = if argv.len() > 40 {
-                format!("{}...", &argv[..37])
+                format!("{}...", &argv[..argv.floor_char_boundary(37)])
             } else {
                 argv
             };

--- a/crates/edda-conductor/src/agent/stream.rs
+++ b/crates/edda-conductor/src/agent/stream.rs
@@ -261,7 +261,7 @@ fn truncate(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
         s
     } else {
-        format!("{}...", &s[..max_len])
+        format!("{}...", &s[..s.floor_char_boundary(max_len)])
     }
 }
 

--- a/crates/edda-derive/src/evidence.rs
+++ b/crates/edda-derive/src/evidence.rs
@@ -13,7 +13,7 @@ fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
         s.to_string()
     } else {
-        format!("{}...", &s[..max])
+        format!("{}...", &s[..s.floor_char_boundary(max)])
     }
 }
 
@@ -166,6 +166,18 @@ mod tests {
     use edda_core::event::{
         new_cmd_event, new_commit_event, new_note_event, CmdEventParams, CommitEventParams,
     };
+
+    #[test]
+    fn truncate_handles_multibyte_chars() {
+        // "café" is 5 chars but 6 bytes (é = 2 bytes)
+        let s = "café hello world";
+        let result = truncate(s, 4);
+        // Should not panic; boundary lands inside 'é', floor_char_boundary rounds down
+        assert!(result.ends_with("..."));
+        // With max=5 we should get the full "café " prefix
+        let result2 = truncate(s, 5);
+        assert!(result2.starts_with("café"));
+    }
 
     #[test]
     fn build_auto_evidence_collects_todos_and_fails() {


### PR DESCRIPTION
## Summary
- Replace `&s[..N]` with `&s[..s.floor_char_boundary(N)]` in three truncate sites to prevent panics when slicing lands inside a multi-byte UTF-8 character
- Affected files: `edda-derive/src/evidence.rs`, `edda-cli/src/cmd_log.rs`, `edda-conductor/src/agent/stream.rs`
- Added unit test `truncate_handles_multibyte_chars` in `evidence.rs`

Closes #233

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (2 pre-existing flaky failures in `edda-bridge-claude` unrelated)
- [x] New test `truncate_handles_multibyte_chars` verifies multi-byte strings don't panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)