### PR TITLE
fix(core): replace .expect() with Result in serialization path

### DIFF
--- a/crates/edda-aggregate/src/graph.rs
+++ b/crates/edda-aggregate/src/graph.rs
@@ -166,7 +166,7 @@ mod tests {
             rel: edda_core::types::rel::SUPERSEDES.to_string(),
             note: Some("key 'db.engine' re-decided".to_string()),
         });
-        edda_core::event::finalize_event(&mut event2);
+        edda_core::event::finalize_event(&mut event2).unwrap();
         ledger.append_event(&event2).unwrap();
 
         let entry = ProjectEntry {

--- a/crates/edda-ask/src/lib.rs
+++ b/crates/edda-ask/src/lib.rs
@@ -704,7 +704,7 @@ mod tests {
                 note: Some(format!("key '{key}' re-decided")),
             });
         }
-        finalize_event(&mut event);
+        finalize_event(&mut event).unwrap();
         event
     }
 
@@ -732,7 +732,7 @@ mod tests {
             event_family: None,
             event_level: None,
         };
-        finalize_event(&mut event);
+        finalize_event(&mut event).unwrap();
         event
     }
 
@@ -1090,7 +1090,7 @@ mod tests {
             "tool_calls": 10,
             "tasks_snapshot": [{"subject": "Fix postgres pool", "status": "completed"}],
         });
-        finalize_event(&mut digest);
+        finalize_event(&mut digest).unwrap();
         ledger.append_event(&digest).unwrap();
 
         let result = ask(&ledger, "postgres", &AskOptions::default(), None).unwrap();

--- a/crates/edda-bridge-claude/src/bg_detect.rs
+++ b/crates/edda-bridge-claude/src/bg_detect.rs
@@ -702,7 +702,7 @@ fn write_detect_note(_project_id: &str, cwd: &str, result: &DetectResult) -> Res
 
     event.payload["source"] = serde_json::json!("bridge:pattern-detect");
 
-    edda_core::event::finalize_event(&mut event);
+    edda_core::event::finalize_event(&mut event)?;
     ledger.append_event(&event)?;
 
     eprintln!("[edda-bg] pattern detect note written → {}", event.event_id);

--- a/crates/edda-bridge-claude/src/bg_digest.rs
+++ b/crates/edda-bridge-claude/src/bg_digest.rs
@@ -228,7 +228,7 @@ fn write_session_note(cwd: &str, summary: &str) -> Result<()> {
     // Mark source so collect_session_ledger_extras filters it out
     event.payload["source"] = serde_json::json!("bridge:session-digest");
 
-    edda_core::event::finalize_event(&mut event);
+    edda_core::event::finalize_event(&mut event)?;
     ledger.append_event(&event)?;
 
     tracing::info!(event_id = %event.event_id, "session digest written");

--- a/crates/edda-bridge-claude/src/digest/orchestrate.rs
+++ b/crates/edda-bridge-claude/src/digest/orchestrate.rs
@@ -293,7 +293,9 @@ pub(super) fn harvest_inferred_decisions(
             )),
         });
 
-        finalize_event(&mut event);
+        if finalize_event(&mut event).is_err() {
+            break;
+        }
         let event_id = event.event_id.clone();
 
         if ledger.append_event(&event).is_ok() {

--- a/crates/edda-bridge-claude/src/digest/orchestrate.rs
+++ b/crates/edda-bridge-claude/src/digest/orchestrate.rs
@@ -293,7 +293,8 @@ pub(super) fn harvest_inferred_decisions(
             )),
         });
 
-        if finalize_event(&mut event).is_err() {
+        if let Err(e) = finalize_event(&mut event) {
+            tracing::warn!(event_id = %event.event_id, error = %e, "finalize failed for inferred decision, stopping harvest");
             break;
         }
         let event_id = event.event_id.clone();

--- a/crates/edda-bridge-claude/src/digest/render.rs
+++ b/crates/edda-bridge-claude/src/digest/render.rs
@@ -82,7 +82,7 @@ pub fn build_digest_event(
         event_level: None,
     };
 
-    finalize_event(&mut event);
+    finalize_event(&mut event)?;
     Ok(event)
 }
 
@@ -145,6 +145,6 @@ pub fn build_cmd_milestone_event(
         event_level: None,
     };
 
-    finalize_event(&mut event);
+    finalize_event(&mut event)?;
     Ok(event)
 }

--- a/crates/edda-bridge-claude/src/digest/tests.rs
+++ b/crates/edda-bridge-claude/src/digest/tests.rs
@@ -1094,7 +1094,7 @@ fn collect_session_ledger_extras_excludes_digest_notes() {
     )
     .unwrap();
     evt.payload["source"] = serde_json::json!("bridge:session_digest");
-    edda_core::event::finalize_event(&mut evt);
+    edda_core::event::finalize_event(&mut evt).unwrap();
     let ts = evt.ts.clone();
     ledger.append_event(&evt).unwrap();
 

--- a/crates/edda-cli/src/cmd_bridge.rs
+++ b/crates/edda-cli/src/cmd_bridge.rs
@@ -569,7 +569,7 @@ pub fn decide(
     }
 
     // Re-finalize after payload/refs mutation
-    edda_core::event::finalize_event(&mut event);
+    edda_core::event::finalize_event(&mut event)?;
     ledger.append_event(&event)?;
 
     // Insert dependency edges
@@ -1077,7 +1077,7 @@ mod tests {
         )
         .unwrap();
         event.payload["decision"] = serde_json::json!({"key": "db.engine", "value": "postgres"});
-        edda_core::event::finalize_event(&mut event);
+        edda_core::event::finalize_event(&mut event).unwrap();
         ledger.append_event(&event).unwrap();
 
         let result = ledger.find_active_decision(&branch, "db.engine").unwrap();

--- a/crates/edda-core/src/canon.rs
+++ b/crates/edda-core/src/canon.rs
@@ -2,9 +2,9 @@ use serde_json::Value;
 
 /// Produce canonical JSON bytes: object keys sorted lexicographically (recursive),
 /// arrays preserve order, no extra whitespace.
-pub fn canonical_json_bytes(value: &Value) -> Vec<u8> {
+pub fn canonical_json_bytes(value: &Value) -> Result<Vec<u8>, serde_json::Error> {
     let sorted = sort_value(value);
-    serde_json::to_vec(&sorted).expect("canonical JSON serialization should not fail")
+    serde_json::to_vec(&sorted)
 }
 
 fn sort_value(value: &Value) -> Value {
@@ -29,7 +29,7 @@ mod tests {
     #[test]
     fn keys_sorted_lexicographically() {
         let input: Value = serde_json::from_str(r#"{"z":1,"a":2,"m":3}"#).unwrap();
-        let bytes = canonical_json_bytes(&input);
+        let bytes = canonical_json_bytes(&input).unwrap();
         let output = String::from_utf8(bytes).unwrap();
         assert_eq!(output, r#"{"a":2,"m":3,"z":1}"#);
     }
@@ -37,7 +37,7 @@ mod tests {
     #[test]
     fn nested_objects_sorted() {
         let input: Value = serde_json::from_str(r#"{"b":{"z":1,"a":2},"a":1}"#).unwrap();
-        let bytes = canonical_json_bytes(&input);
+        let bytes = canonical_json_bytes(&input).unwrap();
         let output = String::from_utf8(bytes).unwrap();
         assert_eq!(output, r#"{"a":1,"b":{"a":2,"z":1}}"#);
     }
@@ -45,7 +45,7 @@ mod tests {
     #[test]
     fn arrays_preserve_order() {
         let input: Value = serde_json::from_str(r#"{"a":[3,1,2]}"#).unwrap();
-        let bytes = canonical_json_bytes(&input);
+        let bytes = canonical_json_bytes(&input).unwrap();
         let output = String::from_utf8(bytes).unwrap();
         assert_eq!(output, r#"{"a":[3,1,2]}"#);
     }
@@ -53,7 +53,7 @@ mod tests {
     #[test]
     fn scalars_unchanged() {
         let input: Value = serde_json::from_str(r#""hello""#).unwrap();
-        let bytes = canonical_json_bytes(&input);
+        let bytes = canonical_json_bytes(&input).unwrap();
         let output = String::from_utf8(bytes).unwrap();
         assert_eq!(output, r#""hello""#);
     }

--- a/crates/edda-core/src/event.rs
+++ b/crates/edda-core/src/event.rs
@@ -6,9 +6,9 @@ use crate::types::{
 
 /// Compute the hash for an event: serialize without the `hash` field,
 /// canonical JSON sort, then SHA-256.
-pub fn compute_event_hash(event_without_hash: &serde_json::Value) -> String {
-    let bytes = canonical_json_bytes(event_without_hash);
-    sha256_hex(&bytes)
+pub fn compute_event_hash(event_without_hash: &serde_json::Value) -> anyhow::Result<String> {
+    let bytes = canonical_json_bytes(event_without_hash)?;
+    Ok(sha256_hex(&bytes))
 }
 
 fn new_event_id() -> String {
@@ -28,18 +28,18 @@ fn set_taxonomy(event: &mut Event) {
     event.event_level = level.map(|s| s.to_string());
 }
 
-fn finalize(event: &mut Event) {
+fn finalize(event: &mut Event) -> anyhow::Result<()> {
     // Auto-populate taxonomy fields before hashing
     set_taxonomy(event);
 
     // Serialize the event, remove hash/digests/schema_version, compute canonical hash
-    let mut val = serde_json::to_value(&*event).expect("event serialization should not fail");
+    let mut val = serde_json::to_value(&*event)?;
     if let Some(obj) = val.as_object_mut() {
         obj.remove("hash");
         obj.remove("digests");
         obj.remove("schema_version");
     }
-    let hash_value = compute_event_hash(&val);
+    let hash_value = compute_event_hash(&val)?;
 
     event.hash = hash_value.clone();
     event.digests = vec![Digest {
@@ -47,12 +47,13 @@ fn finalize(event: &mut Event) {
         canon: CANON_EDDA_V1.to_string(),
         value: hash_value,
     }];
+    Ok(())
 }
 
 /// Re-finalize an event after post-construction modification.
 /// Recomputes hash and digests based on current event state.
-pub fn finalize_event(event: &mut Event) {
-    finalize(event);
+pub fn finalize_event(event: &mut Event) -> anyhow::Result<()> {
+    finalize(event)
 }
 
 /// Create a new `note` event.
@@ -84,7 +85,7 @@ pub fn new_note_event(
         event_level: None,
     };
 
-    finalize(&mut event);
+    finalize(&mut event)?;
     Ok(event)
 }
 
@@ -102,8 +103,8 @@ pub fn new_decision_event(
     let tags = vec!["decision".to_string()];
     let mut event = new_note_event(branch, parent_hash, role, &text, &tags)?;
     event.payload["decision"] =
-        serde_json::to_value(decision).expect("DecisionPayload serialization should not fail");
-    finalize(&mut event);
+        serde_json::to_value(decision)?;
+    finalize(&mut event)?;
     Ok(event)
 }
 
@@ -156,7 +157,7 @@ pub fn new_cmd_event(params: &CmdEventParams<'_>) -> anyhow::Result<Event> {
         event_level: None,
     };
 
-    finalize(&mut event);
+    finalize(&mut event)?;
     Ok(event)
 }
 
@@ -215,7 +216,7 @@ pub fn new_commit_event(params: &mut CommitEventParams<'_>) -> anyhow::Result<Ev
         event_level: None,
     };
 
-    finalize(&mut event);
+    finalize(&mut event)?;
     Ok(event)
 }
 
@@ -248,7 +249,7 @@ pub fn new_rebuild_event(
         event_level: None,
     };
 
-    finalize(&mut event);
+    finalize(&mut event)?;
     Ok(event)
 }
 
@@ -283,7 +284,7 @@ pub fn new_branch_create_event(
         event_level: None,
     };
 
-    finalize(&mut event);
+    finalize(&mut event)?;
     Ok(event)
 }
 
@@ -314,7 +315,7 @@ pub fn new_branch_switch_event(
         event_level: None,
     };
 
-    finalize(&mut event);
+    finalize(&mut event)?;
     Ok(event)
 }
 
@@ -349,7 +350,7 @@ pub fn new_merge_event(
         event_level: None,
     };
 
-    finalize(&mut event);
+    finalize(&mut event)?;
     Ok(event)
 }
 
@@ -393,7 +394,7 @@ pub fn new_approval_event(p: &ApprovalEventParams<'_>) -> anyhow::Result<Event> 
         event_level: None,
     };
 
-    finalize(&mut event);
+    finalize(&mut event)?;
     Ok(event)
 }
 
@@ -437,7 +438,7 @@ pub fn new_approval_request_event(p: &ApprovalRequestParams<'_>) -> anyhow::Resu
         event_level: None,
     };
 
-    finalize(&mut event);
+    finalize(&mut event)?;
     Ok(event)
 }
 
@@ -483,7 +484,7 @@ pub fn new_task_intake_event(params: &TaskIntakeParams) -> anyhow::Result<Event>
         event_level: None,
     };
 
-    finalize(&mut event);
+    finalize(&mut event)?;
     Ok(event)
 }
 
@@ -531,7 +532,7 @@ pub fn new_agent_phase_change_event(p: &AgentPhaseChangeParams<'_>) -> anyhow::R
         event_level: None,
     };
 
-    finalize(&mut event);
+    finalize(&mut event)?;
     Ok(event)
 }
 
@@ -561,7 +562,7 @@ pub fn new_review_bundle_event(params: &ReviewBundleParams) -> anyhow::Result<Ev
         event_level: None,
     };
 
-    finalize(&mut event);
+    finalize(&mut event)?;
     Ok(event)
 }
 
@@ -610,7 +611,7 @@ pub fn new_pr_event(params: &PrEventParams) -> anyhow::Result<Event> {
         event_level: None,
     };
 
-    finalize(&mut event);
+    finalize(&mut event)?;
     Ok(event)
 }
 
@@ -658,7 +659,7 @@ pub fn new_execution_event(
         event_level: None,
     };
 
-    finalize(&mut event);
+    finalize(&mut event)?;
     Ok(event)
 }
 
@@ -712,7 +713,7 @@ pub fn new_approval_policy_match_event(
         event_level: None,
     };
 
-    finalize(&mut event);
+    finalize(&mut event)?;
     Ok(event)
 }
 
@@ -823,7 +824,7 @@ mod tests {
         obj.remove("hash");
         obj.remove("digests");
         obj.remove("schema_version");
-        let recomputed = compute_event_hash(&val);
+        let recomputed = compute_event_hash(&val).unwrap();
         assert_eq!(recomputed, event.hash);
     }
 
@@ -1017,7 +1018,7 @@ mod tests {
         obj.remove("hash");
         obj.remove("digests");
         obj.remove("schema_version");
-        let recomputed = compute_event_hash(&val);
+        let recomputed = compute_event_hash(&val).unwrap();
         assert_eq!(recomputed, e1.hash);
     }
 
@@ -1032,7 +1033,7 @@ mod tests {
         obj.remove("hash");
         obj.remove("digests");
         obj.remove("schema_version");
-        let recomputed = compute_event_hash(&e2_val);
+        let recomputed = compute_event_hash(&e2_val).unwrap();
         assert_eq!(recomputed, e1.hash);
     }
 
@@ -1062,7 +1063,7 @@ mod tests {
         // Force same event_id and ts so we can compare hashes
         e2.event_id = e1.event_id.clone();
         e2.ts = e1.ts.clone();
-        finalize_event(&mut e2);
+        finalize_event(&mut e2).unwrap();
         assert_eq!(e1.hash, e2.hash);
 
         // Add provenance and re-finalize
@@ -1071,7 +1072,7 @@ mod tests {
             rel: rel::BASED_ON.to_string(),
             note: None,
         });
-        finalize_event(&mut e2);
+        finalize_event(&mut e2).unwrap();
         assert_ne!(e1.hash, e2.hash);
     }
 
@@ -1085,7 +1086,7 @@ mod tests {
             rel: rel::REVIEWS.to_string(),
             note: Some("review note".to_string()),
         });
-        finalize_event(&mut event);
+        finalize_event(&mut event).unwrap();
 
         let json = serde_json::to_string(&event).unwrap();
         let deserialized: Event = serde_json::from_str(&json).unwrap();
@@ -1388,5 +1389,25 @@ mod tests {
         .unwrap();
         assert_eq!(event.event_family.as_deref(), Some("signal"));
         assert_eq!(event.event_level.as_deref(), Some("info"));
+    }
+
+    #[test]
+    fn finalize_returns_error_on_non_finite_float() {
+        let mut event = Event {
+            event_id: "test".into(),
+            ts: "2026-01-01T00:00:00Z".into(),
+            event_type: "note".into(),
+            branch: "main".into(),
+            parent_hash: None,
+            hash: String::new(),
+            payload: serde_json::json!({"value": f64::NAN}),
+            refs: Refs::default(),
+            schema_version: 1,
+            digests: Vec::new(),
+            event_family: None,
+            event_level: None,
+        };
+        let result = finalize_event(&mut event);
+        assert!(result.is_err(), "finalize should return Err for NaN payload");
     }
 }

--- a/crates/edda-derive/src/context.rs
+++ b/crates/edda-derive/src/context.rs
@@ -637,7 +637,7 @@ mod tests {
             event_family: None,
             event_level: None,
         };
-        finalize_event(&mut event);
+        finalize_event(&mut event).unwrap();
         event
     }
 
@@ -686,7 +686,7 @@ mod tests {
             event_family: None,
             event_level: None,
         };
-        finalize_event(&mut event);
+        finalize_event(&mut event).unwrap();
         event
     }
 
@@ -1118,7 +1118,7 @@ mod tests {
             event_family: None,
             event_level: None,
         };
-        finalize_event(&mut event);
+        finalize_event(&mut event).unwrap();
         ledger.append_event(&event).unwrap();
 
         let ctx = render_context(&ledger, "main", DeriveOptions::default()).unwrap();
@@ -1196,7 +1196,7 @@ mod tests {
             event_family: None,
             event_level: None,
         };
-        finalize_event(&mut d2);
+        finalize_event(&mut d2).unwrap();
         ledger.append_event(&d2).unwrap();
 
         let ctx = render_context(&ledger, "main", DeriveOptions::default()).unwrap();
@@ -1235,7 +1235,7 @@ mod tests {
             rel: "supersedes".to_string(),
             note: None,
         });
-        finalize_event(&mut b);
+        finalize_event(&mut b).unwrap();
         ledger.append_event(&b).unwrap();
 
         // C: db = postgres, supersedes B
@@ -1245,7 +1245,7 @@ mod tests {
             rel: "supersedes".to_string(),
             note: None,
         });
-        finalize_event(&mut c);
+        finalize_event(&mut c).unwrap();
         ledger.append_event(&c).unwrap();
 
         let ctx = render_context(&ledger, "main", DeriveOptions::default()).unwrap();
@@ -1439,7 +1439,7 @@ mod tests {
             event_family: None,
             event_level: None,
         };
-        finalize_event(&mut event);
+        finalize_event(&mut event).unwrap();
         event
     }
 

--- a/crates/edda-derive/src/snapshot.rs
+++ b/crates/edda-derive/src/snapshot.rs
@@ -457,7 +457,7 @@ mod tests {
             event_family: None,
             event_level: None,
         };
-        finalize_event(&mut event);
+        finalize_event(&mut event).unwrap();
         ledger.append_event(&event).unwrap();
 
         let snap = build_branch_snapshot(&ledger, "main").unwrap();

--- a/crates/edda-ledger/src/ledger.rs
+++ b/crates/edda-ledger/src/ledger.rs
@@ -398,7 +398,7 @@ mod tests {
         let tags = vec!["decision".to_string()];
         let mut event = new_note_event(branch, None, "system", &text, &tags).unwrap();
         event.payload["decision"] = serde_json::json!({"key": key, "value": value});
-        finalize_event(&mut event);
+        finalize_event(&mut event).unwrap();
         event
     }
 

--- a/crates/edda-ledger/src/sqlite_store.rs
+++ b/crates/edda-ledger/src/sqlite_store.rs
@@ -1643,7 +1643,7 @@ mod tests {
             });
         }
 
-        finalize_event(&mut event);
+        finalize_event(&mut event).unwrap();
         event
     }
 
@@ -1752,7 +1752,7 @@ mod tests {
         // Do NOT add payload.decision — simulate legacy format
         // Remove it if new_note_event somehow adds it (it doesn't)
         event.payload.as_object_mut().unwrap().remove("decision");
-        finalize_event(&mut event);
+        finalize_event(&mut event).unwrap();
         store.append_event(&event).unwrap();
 
         let active = store.active_decisions(None, None).unwrap();
@@ -2348,7 +2348,7 @@ mod tests {
             event_family: None,
             event_level: None,
         };
-        edda_core::event::finalize_event(&mut event);
+        edda_core::event::finalize_event(&mut event).unwrap();
         event
     }
 

--- a/crates/edda-mcp/src/lib.rs
+++ b/crates/edda-mcp/src/lib.rs
@@ -233,7 +233,7 @@ impl EddaServer {
         }
 
         // Re-finalize after payload/refs mutation
-        finalize_event(&mut event);
+        finalize_event(&mut event).map_err(to_mcp_err)?;
         ledger.append_event(&event).map_err(to_mcp_err)?;
 
         Ok(CallToolResult::success(vec![Content::text(format!(

--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -540,7 +540,7 @@ async fn post_decide(
         }
     }
 
-    finalize_event(&mut event);
+    finalize_event(&mut event)?;
     ledger.append_event(&event)?;
 
     Ok(Json(DecideResponse {


### PR DESCRIPTION
## Summary
- `canon.rs`: `canonical_json_bytes()` returns `Result<Vec<u8>, serde_json::Error>` instead of panicking
- `event.rs`: `finalize()` and `compute_event_hash()` return `anyhow::Result` instead of panicking
- Only retained `.expect()` is `now_rfc3339()` where UTC + RFC3339 format cannot fail

Closes #237

## Test plan
- [ ] `cargo test` passes (1 pre-existing failure in `post_tool_use_increments_nudge_counter` unrelated to this PR)
- [ ] All callers updated to propagate errors
- [ ] No new `.expect()` in production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)