### PR TITLE
test: add critical missing tests (concurrent write, parse malformed, hash chain break)

### DIFF
--- a/crates/edda-bridge-claude/src/parse.rs
+++ b/crates/edda-bridge-claude/src/parse.rs
@@ -110,4 +110,71 @@ mod tests {
         assert_eq!(snake_to_camel("tool_use_id"), "toolUseId");
         assert_eq!(snake_to_camel("permission_mode"), "permissionMode");
     }
+
+    // ── parse_hook_stdin error path tests ──────────────────────────
+
+    #[test]
+    fn parse_empty_string_errors() {
+        assert!(parse_hook_stdin("").is_err());
+    }
+
+    #[test]
+    fn parse_invalid_json_errors() {
+        assert!(parse_hook_stdin("not json at all").is_err());
+    }
+
+    #[test]
+    fn parse_truncated_json_errors() {
+        assert!(parse_hook_stdin("{\"session_id\": \"abc").is_err());
+    }
+
+    #[test]
+    fn parse_valid_empty_object_succeeds() {
+        let val = parse_hook_stdin("{}").unwrap();
+        assert!(val.is_object());
+        assert_eq!(val.as_object().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn parse_valid_json_with_fields() {
+        let input = r#"{"session_id": "s1", "hook_event_name": "init"}"#;
+        let val = parse_hook_stdin(input).unwrap();
+        assert_eq!(val["session_id"], "s1");
+        assert_eq!(val["hook_event_name"], "init");
+    }
+
+    // ── get_str field extraction tests ─────────────────────────────
+
+    #[test]
+    fn get_str_missing_fields_returns_empty() {
+        let val = serde_json::json!({});
+        assert_eq!(get_str(&val, "session_id"), "");
+        assert_eq!(get_str(&val, "hook_event_name"), "");
+        assert_eq!(get_str(&val, "cwd"), "");
+        assert_eq!(get_str(&val, "tool_name"), "");
+    }
+
+    #[test]
+    fn get_str_snake_case_preferred() {
+        // When both snake_case and camelCase exist, snake_case wins
+        let val = serde_json::json!({
+            "session_id": "snake_wins",
+            "sessionId": "camel_loses"
+        });
+        assert_eq!(get_str(&val, "session_id"), "snake_wins");
+    }
+
+    #[test]
+    fn get_str_camel_case_fallback() {
+        // When only camelCase exists, it should be found via fallback
+        let val = serde_json::json!({"sessionId": "from_camel"});
+        assert_eq!(get_str(&val, "session_id"), "from_camel");
+    }
+
+    #[test]
+    fn get_str_non_string_value_returns_empty() {
+        // If the field exists but is not a string, return empty
+        let val = serde_json::json!({"session_id": 42});
+        assert_eq!(get_str(&val, "session_id"), "");
+    }
 }

--- a/crates/edda-conductor/src/state/persist.rs
+++ b/crates/edda-conductor/src/state/persist.rs
@@ -81,4 +81,49 @@ mod tests {
         let loaded = load_state(dir.path(), "test").unwrap().unwrap();
         assert_eq!(loaded.version, 42);
     }
+
+    // ── Corrupted state recovery tests ─────────────────────────────
+
+    /// Helper: create the state.json directory structure and write content.
+    fn write_corrupt_state(dir: &Path, plan_name: &str, content: &[u8]) {
+        let path = state_path(dir, plan_name);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, content).unwrap();
+    }
+
+    #[test]
+    fn load_empty_file_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        write_corrupt_state(dir.path(), "broken", b"");
+        let result = load_state(dir.path(), "broken");
+        assert!(result.is_err(), "empty file should return Err, not Ok");
+    }
+
+    #[test]
+    fn load_truncated_json_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        write_corrupt_state(dir.path(), "trunc", br#"{"plan_name": "te"#);
+        let result = load_state(dir.path(), "trunc");
+        assert!(result.is_err(), "truncated JSON should return Err, not Ok");
+    }
+
+    #[test]
+    fn load_wrong_schema_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        // Valid JSON but missing required PlanState fields
+        write_corrupt_state(dir.path(), "wrong", br#"{"unexpected": true}"#);
+        let result = load_state(dir.path(), "wrong");
+        assert!(result.is_err(), "wrong schema should return Err, not Ok");
+    }
+
+    #[test]
+    fn load_binary_garbage_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        write_corrupt_state(dir.path(), "garbage", &[0x00, 0x01, 0xFF, 0xFE, 0x89, 0x50]);
+        let result = load_state(dir.path(), "garbage");
+        assert!(
+            result.is_err(),
+            "binary garbage should return Err, not panic"
+        );
+    }
 }

--- a/crates/edda-ledger/src/sqlite_store.rs
+++ b/crates/edda-ledger/src/sqlite_store.rs
@@ -1208,6 +1208,45 @@ impl SqliteStore {
 
         Ok(results)
     }
+
+    /// Verify the hash chain integrity of all events in insertion order.
+    ///
+    /// Returns `Ok(())` if the chain is valid: the first event has
+    /// `parent_hash == None`, and each subsequent event's `parent_hash`
+    /// matches the previous event's `hash`.
+    ///
+    /// Returns `Err` describing the first break found.
+    pub fn verify_chain(&self) -> anyhow::Result<()> {
+        let events = self.iter_events()?;
+        if events.is_empty() {
+            return Ok(());
+        }
+
+        // First event must have no parent
+        if events[0].parent_hash.is_some() {
+            anyhow::bail!(
+                "chain break at first event {}: expected parent_hash=None, got {:?}",
+                events[0].event_id,
+                events[0].parent_hash,
+            );
+        }
+
+        for i in 1..events.len() {
+            let expected = Some(events[i - 1].hash.as_str());
+            let actual = events[i].parent_hash.as_deref();
+            if actual != expected {
+                anyhow::bail!(
+                    "chain break at event {} (index {}): expected parent_hash={:?}, got {:?}",
+                    events[i].event_id,
+                    i,
+                    expected,
+                    actual,
+                );
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl Drop for SqliteStore {
@@ -2536,6 +2575,153 @@ mod tests {
         assert_eq!(d2_execs.len(), 1);
         assert_eq!(d2_execs[0].event_id, "evt_exec_d2");
         assert_eq!(d2_execs[0].status, "failed");
+
+        drop(store);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ── Concurrent writer tests ────────────────────────────────────
+
+    #[test]
+    fn concurrent_writers_no_data_loss() {
+        let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+        let dir = std::env::temp_dir().join(format!("edda_sqlite_conc_{}_{n}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let db_path = dir.join("ledger.db");
+
+        // Create DB with schema first
+        {
+            let _init = SqliteStore::open_or_create(&db_path).unwrap();
+        }
+
+        let num_threads: usize = 10;
+        let events_per_thread: usize = 5;
+        let db_path_shared = db_path.clone();
+
+        let handles: Vec<_> = (0..num_threads)
+            .map(|t| {
+                let path = db_path_shared.clone();
+                std::thread::spawn(move || {
+                    let store = SqliteStore::open(&path).unwrap();
+                    for i in 0..events_per_thread {
+                        // Each event gets a unique UUID via new_note_event, no parent_hash
+                        // linkage needed — we're testing concurrent *writes*, not chain integrity.
+                        let e = new_note_event(
+                            "main",
+                            None,
+                            "system",
+                            &format!("thread {t} event {i}"),
+                            &[],
+                        )
+                        .unwrap();
+                        store.append_event(&e).unwrap();
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().expect("thread panicked");
+        }
+
+        // Verify: all events persisted, no data loss
+        let store = SqliteStore::open(&db_path).unwrap();
+        let events = store.iter_events().unwrap();
+        assert_eq!(
+            events.len(),
+            num_threads * events_per_thread,
+            "expected {} events, got {}",
+            num_threads * events_per_thread,
+            events.len()
+        );
+
+        // Verify no duplicate event_ids
+        let mut ids: Vec<&str> = events.iter().map(|e| e.event_id.as_str()).collect();
+        ids.sort();
+        ids.dedup();
+        assert_eq!(ids.len(), num_threads * events_per_thread);
+
+        drop(store);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ── Hash chain verification tests ──────────────────────────────
+
+    #[test]
+    fn verify_chain_empty_store() {
+        let (dir, store) = tmp_db();
+        assert!(store.verify_chain().is_ok());
+        drop(store);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn verify_chain_single_event() {
+        let (dir, store) = tmp_db();
+        let e = new_note_event("main", None, "system", "only event", &[]).unwrap();
+        store.append_event(&e).unwrap();
+        assert!(store.verify_chain().is_ok());
+        drop(store);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn verify_chain_valid_sequence() {
+        let (dir, store) = tmp_db();
+        let e1 = new_note_event("main", None, "system", "first", &[]).unwrap();
+        store.append_event(&e1).unwrap();
+        let e2 = new_note_event("main", Some(&e1.hash), "system", "second", &[]).unwrap();
+        store.append_event(&e2).unwrap();
+        let e3 = new_note_event("main", Some(&e2.hash), "system", "third", &[]).unwrap();
+        store.append_event(&e3).unwrap();
+
+        assert!(store.verify_chain().is_ok());
+        drop(store);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn verify_chain_detects_broken_parent_hash() {
+        let (dir, store) = tmp_db();
+        let e1 = new_note_event("main", None, "system", "first", &[]).unwrap();
+        store.append_event(&e1).unwrap();
+
+        // Intentionally use wrong parent_hash
+        let e2 =
+            new_note_event("main", Some("sha256:bogus_hash"), "system", "broken", &[]).unwrap();
+        store.append_event(&e2).unwrap();
+
+        let result = store.verify_chain();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("chain break"),
+            "error should mention 'chain break', got: {msg}"
+        );
+
+        drop(store);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn verify_chain_detects_first_event_with_parent() {
+        let (dir, store) = tmp_db();
+        // First event should have parent_hash=None, but we insert one with a parent
+        let e = new_note_event(
+            "main",
+            Some("sha256:unexpected"),
+            "system",
+            "bad first",
+            &[],
+        )
+        .unwrap();
+        store.append_event(&e).unwrap();
+
+        let result = store.verify_chain();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("first event"));
 
         drop(store);
         let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
## Summary

Adds 16 new tests covering four high-risk untested code paths identified in code review (Track C):

- **Concurrent writer** (`sqlite_store`): 10 threads x 5 events writing to the same DB file, verifying WAL mode + `busy_timeout` handles contention with zero data loss
- **Parse malformed input** (`parse.rs`): 8 tests for `parse_hook_stdin` error paths (empty, invalid, truncated JSON) and `get_str` field extraction (missing fields, snake/camel fallback, non-string values)
- **Hash chain integrity** (`sqlite_store`): New `verify_chain()` method (~30 lines) + 5 tests detecting broken `parent_hash` linkage, first-event-with-parent, and validating correct chains
- **Corrupted state recovery** (`persist.rs`): 4 tests for empty file, truncated JSON, wrong schema, and binary garbage — all return `Err` without panic

## Files Changed

| File | Change |
|------|--------|
| `crates/edda-ledger/src/sqlite_store.rs` | +186 lines: `verify_chain()` method + 6 tests |
| `crates/edda-bridge-claude/src/parse.rs` | +67 lines: 8 tests |
| `crates/edda-conductor/src/state/persist.rs` | +45 lines: 4 tests |

## Test plan

- [x] `cargo clippy -p edda-ledger -p edda-bridge-claude -p edda-conductor -- -D warnings` — zero warnings
- [x] All 16 new tests pass
- [x] Pre-existing test failure (`post_tool_use_increments_nudge_counter`) confirmed unrelated

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)