### PR TITLE
feat(tool-tier): add tool tier governance policy (T0-T4)

### DIFF
--- a/crates/edda-cli/src/cmd_init.rs
+++ b/crates/edda-cli/src/cmd_init.rs
@@ -80,6 +80,13 @@ actors: {}
             std::fs::write(&actors_path, default_actors.as_bytes())?;
         }
 
+        // Generate default tool_tiers.yaml
+        let tier_path = paths.edda_dir.join("tool_tiers.yaml");
+        if !tier_path.exists() {
+            let default_tiers = edda_core::tool_tier::default_tool_tier_config();
+            edda_core::tool_tier::save_tool_tiers_to_dir(&paths.edda_dir, &default_tiers)?;
+        }
+
         // Open ledger and write the init event
         let ledger = Ledger::open(repo_root)?;
         let _lock = WorkspaceLock::acquire(&ledger.paths)?;

--- a/crates/edda-cli/src/cmd_tool_tier.rs
+++ b/crates/edda-cli/src/cmd_tool_tier.rs
@@ -1,0 +1,112 @@
+use clap::Subcommand;
+use edda_core::tool_tier::{
+    default_tool_tier_config, load_tool_tiers_from_dir, resolve_tool_tier, save_tool_tiers_to_dir,
+    ToolTier, ToolTierEntry,
+};
+use std::path::Path;
+
+// ── CLI Schema ──
+
+#[derive(Subcommand)]
+pub enum ToolTierCmd {
+    /// Query a tool's tier and approval requirement
+    Get {
+        /// Tool name (e.g. "bash", "Write", "rm")
+        tool: String,
+    },
+    /// Set a tool's tier (also records a decision event)
+    Set {
+        /// Tool name
+        tool: String,
+        /// Tier level (T0..T4)
+        tier: ToolTier,
+        /// Reason for this classification
+        #[arg(long)]
+        reason: Option<String>,
+    },
+    /// List all tool-to-tier mappings
+    List {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Generate default tool_tiers.yaml
+    Init,
+}
+
+pub fn run(cmd: ToolTierCmd, repo_root: &Path) -> anyhow::Result<()> {
+    let edda_dir = repo_root.join(".edda");
+
+    match cmd {
+        ToolTierCmd::Get { tool } => {
+            let config = load_tool_tiers_from_dir(&edda_dir)?;
+            let result = resolve_tool_tier(&config, &tool);
+            let json = serde_json::to_string_pretty(&result)?;
+            println!("{json}");
+        }
+        ToolTierCmd::Set {
+            tool,
+            tier,
+            reason,
+        } => {
+            // Load, update, save
+            let mut config = load_tool_tiers_from_dir(&edda_dir)?;
+            config.tools.insert(tool.clone(), tier);
+            save_tool_tiers_to_dir(&edda_dir, &config)?;
+
+            // Record as decision event for audit trail
+            let decision_str = format!("tool_governance.{tool}={tier}");
+            let reason_str = reason.unwrap_or_else(|| format!("set tool tier: {tool} -> {tier}"));
+
+            // Use the same decide path as `edda decide`
+            super::cmd_bridge::decide(repo_root, &decision_str, Some(&reason_str), &[], None)?;
+
+            println!("Set {tool} = {tier}");
+        }
+        ToolTierCmd::List { json } => {
+            let config = load_tool_tiers_from_dir(&edda_dir)?;
+            let entries: Vec<ToolTierEntry> = config
+                .tools
+                .iter()
+                .map(|(tool, &tier)| {
+                    let result = resolve_tool_tier(&config, tool);
+                    ToolTierEntry {
+                        tool: tool.clone(),
+                        tier,
+                        approval: result.approval,
+                    }
+                })
+                .collect();
+
+            if json {
+                println!("{}", serde_json::to_string_pretty(&entries)?);
+            } else if entries.is_empty() {
+                println!("No tool tier mappings configured.");
+                println!(
+                    "Default tier: {} (applied to all unmapped tools)",
+                    config.default_tier
+                );
+            } else {
+                println!("{:<20} {:<6} APPROVAL", "TOOL", "TIER");
+                println!("{}", "-".repeat(44));
+                for entry in &entries {
+                    println!("{:<20} {:<6} {}", entry.tool, entry.tier, entry.approval);
+                }
+                println!();
+                println!("Default tier: {}", config.default_tier);
+            }
+        }
+        ToolTierCmd::Init => {
+            let path = edda_dir.join("tool_tiers.yaml");
+            if path.exists() {
+                println!("tool_tiers.yaml already exists at {}", path.display());
+            } else {
+                let config = default_tool_tier_config();
+                save_tool_tiers_to_dir(&edda_dir, &config)?;
+                println!("Generated {}", path.display());
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -33,6 +33,7 @@ mod cmd_serve;
 mod cmd_skill;
 mod cmd_status;
 mod cmd_switch;
+mod cmd_tool_tier;
 mod cmd_user;
 mod cmd_watch;
 mod pipeline_templates;
@@ -440,6 +441,12 @@ enum Command {
     Skill {
         #[command(subcommand)]
         cmd: cmd_skill::SkillCmd,
+    },
+    /// Tool tier governance (get, set, list, init)
+    #[command(name = "tool-tier")]
+    ToolTier {
+        #[command(subcommand)]
+        cmd: cmd_tool_tier::ToolTierCmd,
     },
 }
 
@@ -1079,5 +1086,6 @@ fn main() -> anyhow::Result<()> {
         Command::Scan { cmd } => cmd_scan::execute(cmd, &repo_root),
         Command::ProposeIssue { cmd } => cmd_propose::execute(cmd, &repo_root),
         Command::Skill { cmd } => cmd_skill::execute(cmd, &repo_root),
+        Command::ToolTier { cmd } => cmd_tool_tier::run(cmd, &repo_root),
     }
 }

--- a/crates/edda-core/src/lib.rs
+++ b/crates/edda-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod event;
 pub mod git;
 pub mod hash;
 pub mod policy;
+pub mod tool_tier;
 pub mod types;
 
 pub use types::*;

--- a/crates/edda-core/src/tool_tier.rs
+++ b/crates/edda-core/src/tool_tier.rs
@@ -1,0 +1,350 @@
+//! Tool tier governance policy — T0..T4 classification and query.
+//!
+//! Defines tool risk tiers and approval requirements. The runtime source of
+//! truth is `tool_tiers.yaml` in the `.edda/` directory; changes are also
+//! recorded as decision events in the ledger for audit.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt;
+use std::path::Path;
+use std::str::FromStr;
+
+// ── ToolTier enum ──
+
+/// Risk tier for a tool (T0 = safest, T4 = forbidden).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum ToolTier {
+    T0,
+    T1,
+    T2,
+    T3,
+    T4,
+}
+
+impl fmt::Display for ToolTier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ToolTier::T0 => write!(f, "T0"),
+            ToolTier::T1 => write!(f, "T1"),
+            ToolTier::T2 => write!(f, "T2"),
+            ToolTier::T3 => write!(f, "T3"),
+            ToolTier::T4 => write!(f, "T4"),
+        }
+    }
+}
+
+impl FromStr for ToolTier {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_uppercase().as_str() {
+            "T0" => Ok(ToolTier::T0),
+            "T1" => Ok(ToolTier::T1),
+            "T2" => Ok(ToolTier::T2),
+            "T3" => Ok(ToolTier::T3),
+            "T4" => Ok(ToolTier::T4),
+            other => anyhow::bail!("invalid tool tier: '{other}' (expected T0..T4)"),
+        }
+    }
+}
+
+// ── Approval requirement ──
+
+/// What approval is needed before executing a tool at this tier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ApprovalRequirement {
+    /// No approval needed.
+    None,
+    /// Execute immediately but log for post-review.
+    Lazy,
+    /// Must get explicit approval before execution.
+    Required,
+    /// Cannot execute under any circumstance.
+    Blocked,
+}
+
+impl fmt::Display for ApprovalRequirement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ApprovalRequirement::None => write!(f, "none"),
+            ApprovalRequirement::Lazy => write!(f, "lazy"),
+            ApprovalRequirement::Required => write!(f, "required"),
+            ApprovalRequirement::Blocked => write!(f, "blocked"),
+        }
+    }
+}
+
+// ── Tier definition ──
+
+/// Metadata for a single tier level (stored in YAML).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TierDef {
+    pub description: String,
+    pub approval: ApprovalRequirement,
+}
+
+// ── Config (loaded from tool_tiers.yaml) ──
+
+/// Full tool-tier policy loaded from `.edda/tool_tiers.yaml`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolTierConfig {
+    pub version: u32,
+    pub default_tier: ToolTier,
+    pub tiers: BTreeMap<ToolTier, TierDef>,
+    #[serde(default)]
+    pub tools: BTreeMap<String, ToolTier>,
+}
+
+// ── Query result ──
+
+/// Result of resolving a tool's tier — returned by the API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolTierResult {
+    pub tool: String,
+    pub tier: ToolTier,
+    pub approval: ApprovalRequirement,
+    pub description: String,
+}
+
+// ── Entry for list output ──
+
+/// A single tool → tier entry for list display.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolTierEntry {
+    pub tool: String,
+    pub tier: ToolTier,
+    pub approval: ApprovalRequirement,
+}
+
+// ── Default config ──
+
+/// Build a sensible default `ToolTierConfig` (no tools mapped yet).
+pub fn default_tool_tier_config() -> ToolTierConfig {
+    let mut tiers = BTreeMap::new();
+    tiers.insert(
+        ToolTier::T0,
+        TierDef {
+            description: "Safe \u{2014} read-only, no side effects".to_string(),
+            approval: ApprovalRequirement::None,
+        },
+    );
+    tiers.insert(
+        ToolTier::T1,
+        TierDef {
+            description: "Standard \u{2014} normal operations".to_string(),
+            approval: ApprovalRequirement::None,
+        },
+    );
+    tiers.insert(
+        ToolTier::T2,
+        TierDef {
+            description: "Elevated \u{2014} significant changes".to_string(),
+            approval: ApprovalRequirement::Lazy,
+        },
+    );
+    tiers.insert(
+        ToolTier::T3,
+        TierDef {
+            description: "Dangerous \u{2014} destructive or irreversible".to_string(),
+            approval: ApprovalRequirement::Required,
+        },
+    );
+    tiers.insert(
+        ToolTier::T4,
+        TierDef {
+            description: "Forbidden \u{2014} never allowed".to_string(),
+            approval: ApprovalRequirement::Blocked,
+        },
+    );
+
+    ToolTierConfig {
+        version: 1,
+        default_tier: ToolTier::T1,
+        tiers,
+        tools: BTreeMap::new(),
+    }
+}
+
+// ── Query logic ──
+
+/// Resolve a tool's tier from the config, falling back to `default_tier`.
+pub fn resolve_tool_tier(config: &ToolTierConfig, tool_name: &str) -> ToolTierResult {
+    let tier = config
+        .tools
+        .get(tool_name)
+        .copied()
+        .unwrap_or(config.default_tier);
+
+    let tier_def = config.tiers.get(&tier);
+    let (approval, description) = match tier_def {
+        Some(def) => (def.approval, def.description.clone()),
+        // Fallback for missing tier definition (shouldn't happen with defaults)
+        None => (approval_for_tier(tier), format!("Tier {tier}")),
+    };
+
+    ToolTierResult {
+        tool: tool_name.to_string(),
+        tier,
+        approval,
+        description,
+    }
+}
+
+/// Derive the canonical approval requirement from a tier level.
+pub fn approval_for_tier(tier: ToolTier) -> ApprovalRequirement {
+    match tier {
+        ToolTier::T0 | ToolTier::T1 => ApprovalRequirement::None,
+        ToolTier::T2 => ApprovalRequirement::Lazy,
+        ToolTier::T3 => ApprovalRequirement::Required,
+        ToolTier::T4 => ApprovalRequirement::Blocked,
+    }
+}
+
+// ── YAML file I/O ──
+
+const TOOL_TIERS_FILE: &str = "tool_tiers.yaml";
+
+/// Load `tool_tiers.yaml` from the `.edda/` directory.
+/// Returns a default config if the file doesn't exist.
+pub fn load_tool_tiers_from_dir(edda_dir: &Path) -> anyhow::Result<ToolTierConfig> {
+    let path = edda_dir.join(TOOL_TIERS_FILE);
+    if !path.exists() {
+        return Ok(default_tool_tier_config());
+    }
+    let content = std::fs::read(&path)?;
+    let config: ToolTierConfig = serde_yaml::from_slice(&content)?;
+    Ok(config)
+}
+
+/// Save `tool_tiers.yaml` to the `.edda/` directory.
+pub fn save_tool_tiers_to_dir(edda_dir: &Path, config: &ToolTierConfig) -> anyhow::Result<()> {
+    let path = edda_dir.join(TOOL_TIERS_FILE);
+    let yaml = serde_yaml::to_string(config)?;
+    std::fs::write(&path, yaml.as_bytes())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_known_tool() {
+        let mut config = default_tool_tier_config();
+        config.tools.insert("bash".to_string(), ToolTier::T1);
+        config.tools.insert("rm".to_string(), ToolTier::T3);
+
+        let result = resolve_tool_tier(&config, "bash");
+        assert_eq!(result.tier, ToolTier::T1);
+        assert_eq!(result.approval, ApprovalRequirement::None);
+
+        let result = resolve_tool_tier(&config, "rm");
+        assert_eq!(result.tier, ToolTier::T3);
+        assert_eq!(result.approval, ApprovalRequirement::Required);
+    }
+
+    #[test]
+    fn resolve_unknown_tool_uses_default() {
+        let config = default_tool_tier_config();
+        let result = resolve_tool_tier(&config, "unknown_tool");
+        assert_eq!(result.tier, ToolTier::T1); // default_tier
+        assert_eq!(result.approval, ApprovalRequirement::None);
+        assert_eq!(result.tool, "unknown_tool");
+    }
+
+    #[test]
+    fn all_tiers_have_correct_approval() {
+        assert_eq!(approval_for_tier(ToolTier::T0), ApprovalRequirement::None);
+        assert_eq!(approval_for_tier(ToolTier::T1), ApprovalRequirement::None);
+        assert_eq!(approval_for_tier(ToolTier::T2), ApprovalRequirement::Lazy);
+        assert_eq!(
+            approval_for_tier(ToolTier::T3),
+            ApprovalRequirement::Required
+        );
+        assert_eq!(
+            approval_for_tier(ToolTier::T4),
+            ApprovalRequirement::Blocked
+        );
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let mut config = default_tool_tier_config();
+        config.tools.insert("bash".to_string(), ToolTier::T1);
+        config.tools.insert("Write".to_string(), ToolTier::T2);
+
+        let yaml = serde_yaml::to_string(&config).unwrap();
+        let parsed: ToolTierConfig = serde_yaml::from_str(&yaml).unwrap();
+
+        assert_eq!(parsed.version, 1);
+        assert_eq!(parsed.default_tier, ToolTier::T1);
+        assert_eq!(parsed.tools.get("bash"), Some(&ToolTier::T1));
+        assert_eq!(parsed.tools.get("Write"), Some(&ToolTier::T2));
+        assert_eq!(parsed.tiers.len(), 5);
+    }
+
+    #[test]
+    fn load_missing_file_returns_default() {
+        let tmp = std::env::temp_dir().join("edda_tool_tier_missing_test");
+        let _ = std::fs::create_dir_all(&tmp);
+        let config = load_tool_tiers_from_dir(&tmp).unwrap();
+        assert_eq!(config.default_tier, ToolTier::T1);
+        assert!(config.tools.is_empty());
+        assert_eq!(config.tiers.len(), 5);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let tmp = std::env::temp_dir().join(format!(
+            "edda_tool_tier_io_test_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let mut config = default_tool_tier_config();
+        config.tools.insert("curl".to_string(), ToolTier::T2);
+
+        save_tool_tiers_to_dir(&tmp, &config).unwrap();
+        let loaded = load_tool_tiers_from_dir(&tmp).unwrap();
+
+        assert_eq!(loaded.tools.get("curl"), Some(&ToolTier::T2));
+        assert_eq!(loaded.default_tier, ToolTier::T1);
+        assert_eq!(loaded.tiers.len(), 5);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn tool_tier_display_and_parse() {
+        for tier in [
+            ToolTier::T0,
+            ToolTier::T1,
+            ToolTier::T2,
+            ToolTier::T3,
+            ToolTier::T4,
+        ] {
+            let s = tier.to_string();
+            let parsed: ToolTier = s.parse().unwrap();
+            assert_eq!(parsed, tier);
+        }
+        // case-insensitive
+        assert_eq!("t2".parse::<ToolTier>().unwrap(), ToolTier::T2);
+        // invalid
+        assert!("T5".parse::<ToolTier>().is_err());
+    }
+
+    #[test]
+    fn resolve_with_t4_forbidden() {
+        let mut config = default_tool_tier_config();
+        config
+            .tools
+            .insert("git_push_force".to_string(), ToolTier::T4);
+
+        let result = resolve_tool_tier(&config, "git_push_force");
+        assert_eq!(result.tier, ToolTier::T4);
+        assert_eq!(result.approval, ApprovalRequirement::Blocked);
+    }
+}

--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -113,6 +113,7 @@ pub async fn serve(repo_root: &Path, config: ServeConfig) -> anyhow::Result<()> 
         .route("/dashboard", get(serve_dashboard))
         .route("/api/actors", get(get_actors))
         .route("/api/actors/{name}", get(get_actor))
+        .route("/api/tool-tier/{tool_name}", get(get_tool_tier))
         .route("/api/events/stream", get(get_event_stream))
         .layer(CorsLayer::permissive())
         .with_state(state);
@@ -161,6 +162,7 @@ pub fn router(repo_root: &Path) -> Router {
         .route("/api/projects", get(get_projects))
         .route("/api/actors", get(get_actors))
         .route("/api/actors/{name}", get(get_actor))
+        .route("/api/tool-tier/{tool_name}", get(get_tool_tier))
         .route("/api/metrics/quality", get(get_quality_metrics))
         .route("/api/dashboard", get(get_dashboard))
         .route("/dashboard", get(serve_dashboard))
@@ -1046,6 +1048,18 @@ async fn get_actor(
             (StatusCode::NOT_FOUND, Json(body)).into_response()
         }
     }
+}
+
+// ── GET /api/tool-tier/:tool_name ──
+
+async fn get_tool_tier(
+    State(state): State<Arc<AppState>>,
+    AxumPath(tool_name): AxumPath<String>,
+) -> Result<Json<edda_core::tool_tier::ToolTierResult>, AppError> {
+    let edda_dir = state.repo_root.join(".edda");
+    let config = edda_core::tool_tier::load_tool_tiers_from_dir(&edda_dir)?;
+    let result = edda_core::tool_tier::resolve_tool_tier(&config, &tool_name);
+    Ok(Json(result))
 }
 
 // ── GET /api/metrics/quality ──
@@ -3416,5 +3430,64 @@ actors:
 
         assert!(text.contains(&e2.event_id), "expected e2: {text}");
         assert!(!text.contains(&e1.event_id), "e1 should be skipped: {text}");
+    }
+
+    #[tokio::test]
+    async fn tool_tier_known_tool() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+
+        let edda_dir = tmp.path().join(".edda");
+        let mut config = edda_core::tool_tier::default_tool_tier_config();
+        config
+            .tools
+            .insert("bash".to_string(), edda_core::tool_tier::ToolTier::T0);
+        edda_core::tool_tier::save_tool_tiers_to_dir(&edda_dir, &config).unwrap();
+
+        let app = router(tmp.path());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/tool-tier/bash")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["tool"], "bash");
+        assert_eq!(json["tier"], "T0");
+        assert_eq!(json["approval"], "none");
+    }
+
+    #[tokio::test]
+    async fn tool_tier_unknown_tool_returns_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+
+        let app = router(tmp.path());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/tool-tier/nonexistent")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["tool"], "nonexistent");
+        assert_eq!(json["tier"], "T1"); // default tier
+        assert_eq!(json["approval"], "none");
     }
 }


### PR DESCRIPTION
## Summary

- Add **ToolTier enum** (T0 safe -> T4 forbidden) with `ApprovalRequirement` in `edda-core/src/tool_tier.rs`
- Add **YAML config** (`tool_tiers.yaml`) loader/saver with default config generation
- Add **CLI subcommand** `edda tool-tier {get,set,list,init}` in `edda-cli/src/cmd_tool_tier.rs`
- Add **REST endpoint** `GET /api/tool-tier/:tool_name` in `edda-serve` for Karvi integration
- Auto-generate `tool_tiers.yaml` during `edda init`
- Hybrid approach: YAML for runtime queries + decision events for audit trail

## Design

| Tier | Approval | Description |
|------|----------|-------------|
| T0 | none | Safe -- read-only, no side effects |
| T1 | none | Standard -- normal operations (default) |
| T2 | lazy | Elevated -- significant changes |
| T3 | required | Dangerous -- destructive or irreversible |
| T4 | blocked | Forbidden -- never allowed |

## Test plan

- [x] 8 unit tests in `edda-core::tool_tier` (resolve, defaults, serde, parse, I/O)
- [x] 2 integration tests in `edda-serve` (known tool, unknown tool default)
- [x] `cargo clippy -p edda-core -p edda-serve -p edda -- -D warnings` passes clean

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)