### PR TITLE
feat(bridge): register TaskCompleted hook for milestone extraction

### DIFF
--- a/crates/edda-bridge-claude/src/admin.rs
+++ b/crates/edda-bridge-claude/src/admin.rs
@@ -18,6 +18,7 @@ const HOOK_EVENTS: &[&str] = &[
     "SessionEnd",
     "SubagentStart",
     "SubagentStop",
+    "TaskCompleted",
 ];
 
 /// Check if a matcher group (Claude Code hook format) contains a edda hook.

--- a/crates/edda-bridge-claude/src/dispatch/events.rs
+++ b/crates/edda-bridge-claude/src/dispatch/events.rs
@@ -154,6 +154,47 @@ pub(super) fn try_post_karvi_signal(
     }
 }
 
+/// Best-effort write of a task-completed `note` event to workspace ledger.
+/// Uses try-lock: silently skips if workspace is locked by another process.
+pub(super) fn try_write_task_completed_note_event(
+    cwd: &str,
+    task_id: &str,
+    task_subject: &str,
+) {
+    if cwd.is_empty() || task_id.is_empty() {
+        return;
+    }
+
+    let Some(root) = edda_ledger::EddaPaths::find_root(Path::new(cwd)) else {
+        return;
+    };
+    let Ok(ledger) = edda_ledger::Ledger::open(&root) else {
+        return;
+    };
+    let Ok(_lock) = edda_ledger::WorkspaceLock::acquire(&ledger.paths) else {
+        return;
+    };
+    let Ok(branch) = ledger.head_branch() else {
+        return;
+    };
+    let Ok(parent_hash) = ledger.last_event_hash() else {
+        return;
+    };
+
+    let text = if task_subject.is_empty() {
+        format!("Task completed: {task_id}")
+    } else {
+        format!("Task completed: {task_subject} ({task_id})")
+    };
+
+    let tags = vec!["session".to_string(), "task".to_string()];
+    if let Ok(event) =
+        edda_core::event::new_note_event(&branch, parent_hash.as_deref(), "agent", &text, &tags)
+    {
+        let _ = ledger.append_event(&event);
+    }
+}
+
 /// Best-effort write of a sub-agent completion `note` event to workspace ledger.
 /// Uses try-lock: silently skips if workspace is locked by another process.
 pub(super) fn try_write_subagent_completed_note_event(

--- a/crates/edda-bridge-claude/src/dispatch/mod.rs
+++ b/crates/edda-bridge-claude/src/dispatch/mod.rs
@@ -14,7 +14,7 @@ mod tools;
 pub(crate) use helpers::render_active_plan;
 
 // Sub-module function imports used in hook_entrypoint_from_stdin
-use events::try_write_subagent_completed_note_event;
+use events::{try_write_subagent_completed_note_event, try_write_task_completed_note_event};
 use helpers::run_auto_digest;
 use session::{
     dispatch_session_end, dispatch_session_start, dispatch_subagent_context,
@@ -276,6 +276,25 @@ pub fn hook_entrypoint_from_stdin(stdin: &str) -> anyhow::Result<HookResult> {
                 try_write_subagent_completed_note_event(&cwd, &agent_id, &agent_type, &summary);
                 crate::peers::remove_heartbeat(&project_id, &agent_id);
             }
+            Ok(HookResult::empty())
+        }
+        "TaskCompleted" => {
+            let task_id = get_str(&raw, "task_id");
+            let task_subject = get_str(&raw, "task_subject");
+            let task_description = get_str(&raw, "task_description");
+
+            if !task_id.is_empty() {
+                crate::peers::write_task_completed(
+                    &project_id,
+                    &session_id,
+                    &task_id,
+                    &task_subject,
+                    &task_description,
+                );
+
+                try_write_task_completed_note_event(&cwd, &task_id, &task_subject);
+            }
+
             Ok(HookResult::empty())
         }
         _ => Ok(HookResult::empty()),

--- a/crates/edda-bridge-claude/src/dispatch/tests.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tests.rs
@@ -2244,3 +2244,80 @@ fn is_karvi_project_detection() {
     // Now it's a karvi project
     assert!(is_karvi_project(path.to_str().unwrap()));
 }
+
+#[test]
+fn task_completed_writes_coordination_event() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace = tmp.path().to_path_buf();
+    let paths = edda_ledger::EddaPaths::discover(&workspace);
+    edda_ledger::ledger::init_workspace(&paths).unwrap();
+    edda_ledger::ledger::init_head(&paths, "main").unwrap();
+    edda_ledger::ledger::init_branches_json(&paths, "main").unwrap();
+
+    let project_id = resolve_project_id(workspace.to_str().unwrap());
+    let _ = edda_store::ensure_dirs(&project_id);
+
+    let stdin = serde_json::json!({
+        "session_id": "sess-tc1",
+        "hook_event_name": "TaskCompleted",
+        "cwd": workspace.to_str().unwrap(),
+        "task_id": "task-abc",
+        "task_subject": "Implement auth module",
+        "task_description": "Add JWT-based authentication"
+    })
+    .to_string();
+
+    let result = hook_entrypoint_from_stdin(&stdin).unwrap();
+    // TaskCompleted does not support hookSpecificOutput
+    assert!(result.stdout.is_none());
+    assert!(result.stderr.is_none());
+
+    // Verify coordination.jsonl contains the task_completed event
+    let coord_path = edda_store::project_dir(&project_id)
+        .join("state")
+        .join("coordination.jsonl");
+    let content = fs::read_to_string(&coord_path).unwrap();
+    assert!(
+        content.contains("task_completed"),
+        "coordination.jsonl should contain task_completed event type"
+    );
+    assert!(
+        content.contains("task-abc"),
+        "coordination.jsonl should contain task_id"
+    );
+    assert!(
+        content.contains("Implement auth module"),
+        "coordination.jsonl should contain task_subject"
+    );
+}
+
+#[test]
+fn task_completed_skips_when_task_id_empty() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace = tmp.path().to_path_buf();
+
+    let project_id = resolve_project_id(workspace.to_str().unwrap());
+    let _ = edda_store::ensure_dirs(&project_id);
+
+    let stdin = serde_json::json!({
+        "session_id": "sess-tc2",
+        "hook_event_name": "TaskCompleted",
+        "cwd": workspace.to_str().unwrap(),
+        "task_id": "",
+        "task_subject": "Should be skipped"
+    })
+    .to_string();
+
+    let result = hook_entrypoint_from_stdin(&stdin).unwrap();
+    assert!(result.stdout.is_none());
+    assert!(result.stderr.is_none());
+
+    // No coordination.jsonl should be created (no events written)
+    let coord_path = edda_store::project_dir(&project_id)
+        .join("state")
+        .join("coordination.jsonl");
+    assert!(
+        !coord_path.exists() || fs::read_to_string(&coord_path).unwrap().is_empty(),
+        "no coordination event should be written when task_id is empty"
+    );
+}

--- a/crates/edda-bridge-claude/src/peers/board.rs
+++ b/crates/edda-bridge-claude/src/peers/board.rs
@@ -92,6 +92,10 @@ pub fn compute_board_state(project_id: &str) -> BoardState {
                     ts: event.ts,
                 });
             }
+            CoordEventType::TaskCompleted => {
+                // TaskCompleted events are informational milestones;
+                // no board-level state aggregation needed yet.
+            }
             CoordEventType::SubagentCompleted => {
                 let parent_session_id = event.payload["parent_session_id"]
                     .as_str()

--- a/crates/edda-bridge-claude/src/peers/heartbeat.rs
+++ b/crates/edda-bridge-claude/src/peers/heartbeat.rs
@@ -332,6 +332,27 @@ pub(crate) fn write_subagent_completed(
     append_coord_event(project_id, &event);
 }
 
+/// Write a task completion event to coordination.jsonl.
+pub(crate) fn write_task_completed(
+    project_id: &str,
+    session_id: &str,
+    task_id: &str,
+    task_subject: &str,
+    task_description: &str,
+) {
+    let event = CoordEvent {
+        ts: now_rfc3339(),
+        session_id: session_id.to_string(),
+        event_type: CoordEventType::TaskCompleted,
+        payload: serde_json::json!({
+            "task_id": task_id,
+            "task_subject": task_subject,
+            "task_description": task_description,
+        }),
+    };
+    append_coord_event(project_id, &event);
+}
+
 /// Check if a binding conflict exists for the given key in coordination.jsonl.
 ///
 /// Returns `Some(BindingConflict)` if a binding with the same key but a

--- a/crates/edda-bridge-claude/src/peers/mod.rs
+++ b/crates/edda-bridge-claude/src/peers/mod.rs
@@ -96,6 +96,7 @@ pub(crate) enum CoordEventType {
     Request,
     RequestAck,
     SubagentCompleted,
+    TaskCompleted,
 }
 
 /// A scope claim by a session.
@@ -234,7 +235,8 @@ pub use board::{compute_board_state, compute_board_state_for_compaction};
 pub use discovery::{discover_active_peers, discover_all_sessions, infer_session_id};
 pub(crate) use heartbeat::{
     cleanup_subagent_heartbeats, ensure_heartbeat_exists, read_heartbeat, update_heartbeat_branch,
-    write_heartbeat, write_subagent_completed, write_subagent_heartbeat, SubagentReport,
+    write_heartbeat, write_subagent_completed, write_subagent_heartbeat, write_task_completed,
+    SubagentReport,
 };
 pub use heartbeat::{
     find_binding_conflict, remove_heartbeat, touch_heartbeat, write_binding, write_claim,


### PR DESCRIPTION
## Summary

- Register `TaskCompleted` in `HOOK_EVENTS` so `edda init` includes it in `.claude/settings.local.json`
- Add `TaskCompleted` variant to `CoordEventType` enum
- Dispatch handler writes coordination event to `coordination.jsonl` and a note event to the workspace ledger
- Skip processing when `task_id` is empty (graceful handling of incomplete payloads)

Closes #143

## Changes

| File | Change |
|------|--------|
| `admin.rs` | Add `"TaskCompleted"` to `HOOK_EVENTS` |
| `peers/mod.rs` | Add `TaskCompleted` variant to `CoordEventType`, export `write_task_completed` |
| `peers/heartbeat.rs` | New `write_task_completed()` function |
| `peers/board.rs` | Handle `TaskCompleted` in match (no-op for board state) |
| `dispatch/mod.rs` | Add `"TaskCompleted"` match arm |
| `dispatch/events.rs` | New `try_write_task_completed_note_event()` helper |
| `dispatch/tests.rs` | Two tests: happy path + empty task_id skip |

## Test plan

- [x] `cargo clippy -- -D warnings` passes (zero warnings)
- [x] `task_completed_writes_coordination_event` — verifies coordination.jsonl contains event
- [x] `task_completed_skips_when_task_id_empty` — verifies no event on empty task_id
- [ ] Users must re-run `edda init` after upgrading to register the new hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)