### PR TITLE
feat(peers): filter acked requests from render output and auto-ack on display

### DIFF
--- a/crates/edda-bridge-claude/src/peers/render_coord.rs
+++ b/crates/edda-bridge-claude/src/peers/render_coord.rs
@@ -23,7 +23,43 @@ pub fn render_coordination_protocol(
 ) -> Option<String> {
     let peers = discover_active_peers(project_id, session_id);
     let board = compute_board_state(project_id);
-    render_coordination_protocol_with(&peers, &board, project_id, session_id)
+
+    // Resolve my label to identify which requests are "to me"
+    let my_label: String = board
+        .claims
+        .iter()
+        .find(|c| c.session_id == session_id)
+        .map(|c| c.label.clone())
+        .or_else(|| read_heartbeat(project_id, session_id).map(|hb| hb.label))
+        .unwrap_or_default();
+
+    // Collect unacked requests addressed to me (before rendering)
+    let unacked_from_labels: Vec<String> = if !my_label.is_empty() {
+        board
+            .requests
+            .iter()
+            .filter(|r| r.to_label == my_label)
+            .filter(|r| {
+                !board
+                    .request_acks
+                    .iter()
+                    .any(|a| a.from_label == r.from_label && a.acker_session == session_id)
+            })
+            .map(|r| r.from_label.clone())
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    let result = render_coordination_protocol_with(&peers, &board, project_id, session_id);
+
+    // Auto-ack: the agent has now "seen" these requests at SessionStart.
+    // Write ack events so they won't appear in subsequent renders.
+    for from_label in &unacked_from_labels {
+        super::heartbeat::write_request_ack(project_id, session_id, from_label);
+    }
+
+    result
 }
 
 /// Generate a suggested `edda claim` command based on available session context.
@@ -212,10 +248,17 @@ pub fn render_coordination_protocol_with(
     }
 
     // Requests to me (using resolved my_label from claim or heartbeat fallback)
+    // Filter out already-acked requests so stale entries don't accumulate.
     let my_requests: Vec<&RequestEntry> = board
         .requests
         .iter()
         .filter(|r| r.to_label == my_label && !my_label.is_empty())
+        .filter(|r| {
+            !board
+                .request_acks
+                .iter()
+                .any(|a| a.from_label == r.from_label && a.acker_session == session_id)
+        })
         .collect();
     if !my_requests.is_empty() {
         lines.push("### Requests to you".to_string());
@@ -320,10 +363,17 @@ pub(crate) fn render_peer_updates_with(
     } else {
         ""
     };
+    // Filter out acked requests so stale entries don't appear in peer updates.
     let my_requests: Vec<&RequestEntry> = board
         .requests
         .iter()
         .filter(|r| r.to_label == my_label && !my_label.is_empty())
+        .filter(|r| {
+            !board
+                .request_acks
+                .iter()
+                .any(|a| a.from_label == r.from_label && a.acker_session == session_id)
+        })
         .collect();
     if !my_requests.is_empty() {
         for r in my_requests.iter().take(2) {

--- a/crates/edda-bridge-claude/src/peers/tests.rs
+++ b/crates/edda-bridge-claude/src/peers/tests.rs
@@ -258,14 +258,22 @@ fn full_lifecycle_multi_session() {
     assert!(proto.contains("4")); // 3 peers + self = 4 agents
     assert!(proto.contains("JWT RS256"));
 
-    // Verify s2 sees the request
-    let proto_s2 = render_coordination_protocol(pid, "s2", ".").unwrap();
-    assert!(proto_s2.contains("Export BillingPlan type"));
-
-    // s2 sees peer updates (lightweight)
+    // s2 sees peer updates (lightweight) — check BEFORE render_coordination_protocol
+    // because render_coordination_protocol auto-acks displayed requests.
     let updates = render_peer_updates(pid, "s2").unwrap();
     assert!(updates.contains("Peers"));
     assert!(updates.contains("Export BillingPlan"));
+
+    // Verify s2 sees the request at SessionStart (auto-acks it)
+    let proto_s2 = render_coordination_protocol(pid, "s2", ".").unwrap();
+    assert!(proto_s2.contains("Export BillingPlan type"));
+
+    // After auto-ack, peer updates should no longer show the request
+    let updates_after = render_peer_updates(pid, "s2").unwrap();
+    assert!(
+        !updates_after.contains("Export BillingPlan"),
+        "acked request should be filtered from subsequent peer updates"
+    );
 
     // Solo session should still see bindings (but not peer sections)
     remove_heartbeat(pid, "s1");
@@ -2225,4 +2233,88 @@ mod derive_scope_tests {
             Some(("server".to_string(), vec!["server/*".to_string()]))
         );
     }
+}
+
+// ── Request ack render filtering tests ──
+
+#[test]
+fn render_coordination_filters_acked_requests() {
+    let pid = "test_render_coord_ack_filter";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    // Set up two peers: s1 (auth) and s2 (billing)
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"));
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"));
+    write_claim(pid, "s1", "auth", &["src/auth/*".into()]);
+
+    // billing sends a request to auth
+    write_request(pid, "s2", "billing", "auth", "Need AuthToken export");
+
+    // Before ack: request should appear in render for s1 (auth)
+    let peers = discover_active_peers(pid, "s1");
+    let board = compute_board_state(pid);
+    let result = render_coordination_protocol_with(&peers, &board, pid, "s1");
+    assert!(result.is_some());
+    let text = result.unwrap();
+    assert!(
+        text.contains("Need AuthToken export"),
+        "unacked request should appear: {text}"
+    );
+
+    // s1 acks the request from billing
+    write_request_ack(pid, "s1", "billing");
+
+    // After ack: request should NOT appear for s1
+    let board = compute_board_state(pid);
+    let result = render_coordination_protocol_with(&peers, &board, pid, "s1");
+    assert!(result.is_some());
+    let text = result.unwrap();
+    assert!(
+        !text.contains("Need AuthToken export"),
+        "acked request should be filtered out: {text}"
+    );
+
+    remove_heartbeat(pid, "s1");
+    remove_heartbeat(pid, "s2");
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn peer_updates_filters_acked_requests() {
+    let pid = "test_peer_updates_ack_filter";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"));
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"));
+    write_claim(pid, "s1", "auth", &["src/auth/*".into()]);
+
+    // billing sends a request to auth
+    write_request(pid, "s2", "billing", "auth", "Export BillingPlan");
+
+    // Before ack: request should appear in peer updates for s1
+    let result = render_peer_updates(pid, "s1");
+    assert!(result.is_some());
+    let text = result.unwrap();
+    assert!(
+        text.contains("Export BillingPlan"),
+        "unacked request should appear in peer updates: {text}"
+    );
+
+    // s1 acks the request
+    write_request_ack(pid, "s1", "billing");
+
+    // After ack: request should NOT appear for s1
+    let result = render_peer_updates(pid, "s1");
+    assert!(result.is_some());
+    let text = result.unwrap();
+    assert!(
+        !text.contains("Export BillingPlan"),
+        "acked request should be filtered from peer updates: {text}"
+    );
+
+    remove_heartbeat(pid, "s1");
+    remove_heartbeat(pid, "s2");
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }

--- a/crates/edda-cli/src/tui/ui.rs
+++ b/crates/edda-cli/src/tui/ui.rs
@@ -270,9 +270,23 @@ fn render_requests(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         .requests
         .iter()
         .map(|r| {
+            let is_acked = app
+                .board
+                .request_acks
+                .iter()
+                .any(|a| a.from_label == r.from_label);
             let msg = truncate_str(&r.message, 40);
-            let line = format!(" {} → {}: {msg}", r.from_label, r.to_label);
-            ListItem::new(Line::from(line))
+            let line = if is_acked {
+                format!(" [ack] {} → {}: {msg}", r.from_label, r.to_label)
+            } else {
+                format!(" {} → {}: {msg}", r.from_label, r.to_label)
+            };
+            let style = if is_acked {
+                Style::default().fg(Color::DarkGray)
+            } else {
+                Style::default()
+            };
+            ListItem::new(Line::from(line)).style(style)
         })
         .collect();
     let block = Block::default().title(" Requests ").borders(Borders::TOP);


### PR DESCRIPTION
## Summary

Closes #49

- Filter acked requests in `render_coordination_protocol_with()` and `render_peer_updates_with()` so stale requests don't accumulate in rendered output
- Auto-ack unacked requests when `render_coordination_protocol()` is called at SessionStart — the agent "sees" the request once, then it disappears from subsequent renders
- Show acked requests with `[ack]` prefix and dimmed (DarkGray) style in `edda watch` TUI, preserving audit trail visibility
- Add 2 new tests: `render_coordination_filters_acked_requests` and `peer_updates_filters_acked_requests`

## Design

Implements **Option B (Auto-Ack on Display)** from the approved plan. The existing infrastructure (`RequestAck` event type, `write_request_ack()`, `pending_requests_for_session()` helper) was already ~80% complete. This PR wires the ack filtering into the remaining render paths and adds auto-ack at SessionStart.

Auto-ack is placed in `render_coordination_protocol()` (the wrapper), not in `render_coordination_protocol_with()` (the pure function), keeping the `_with` variant side-effect-free for tests.

## Files Changed

| File | Change |
|------|--------|
| `crates/edda-bridge-claude/src/peers/render_coord.rs` | Filter acked requests in both render functions + auto-ack in wrapper |
| `crates/edda-cli/src/tui/ui.rs` | Dim acked requests with `[ack]` prefix in TUI |
| `crates/edda-bridge-claude/src/peers/tests.rs` | 2 new tests + update existing lifecycle test for auto-ack behavior |

## Test plan

- [x] `cargo clippy -- -D warnings` passes (zero warnings)
- [x] All 89 peers tests pass including 2 new ones
- [x] `full_lifecycle_multi_session` updated to verify auto-ack behavior
- [x] Pre-existing `post_tool_use_increments_nudge_counter` failure unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)