### PR TITLE
feat(bridge): optional hard off-limits enforcement in PreToolUse hook

### DIFF
--- a/crates/edda-bridge-claude/src/dispatch/tests.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tests.rs
@@ -17,7 +17,9 @@ use super::session::{
     cleanup_session_state, collect_session_end_warnings, dispatch_session_end,
     dispatch_session_start, dispatch_user_prompt_submit, dispatch_with_workspace_only,
 };
-use super::tools::{check_pending_requests, dispatch_post_tool_use, dispatch_pre_tool_use};
+use super::tools::{
+    check_offlimits, check_pending_requests, dispatch_post_tool_use, dispatch_pre_tool_use,
+};
 // Imports from crate
 use crate::parse::resolve_project_id;
 use crate::render;
@@ -2320,4 +2322,199 @@ fn task_completed_skips_when_task_id_empty() {
         !coord_path.exists() || fs::read_to_string(&coord_path).unwrap().is_empty(),
         "no coordination event should be written when task_id is empty"
     );
+}
+
+// ── Off-limits enforcement tests ──
+
+#[test]
+fn offlimits_disabled_by_default() {
+    let pid = "test-offlimits-disabled";
+    let sid = "s-self";
+    let _ = edda_store::ensure_dirs(pid);
+
+    // Even with a peer claim, check_offlimits returns None when peer_count == 0
+    crate::peers::write_claim(pid, "s-peer", "peer-agent", &["src/auth/*".into()]);
+    let result = check_offlimits(pid, sid, "src/auth/login.rs");
+    assert!(result.is_none(), "should not block when peer_count == 0");
+
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn offlimits_blocks_peer_claimed_file() {
+    let pid = "test-offlimits-blocks";
+    let sid = "s-self-blocks";
+    let peer_sid = "s-peer-blocks";
+    let _ = edda_store::ensure_dirs(pid);
+
+    // Create peer heartbeat so it's discovered as active
+    crate::peers::write_heartbeat_minimal(pid, peer_sid, "store-refactor");
+    // Create peer claim
+    crate::peers::write_claim(
+        pid,
+        peer_sid,
+        "store-refactor",
+        &["crates/edda-store/*".into()],
+    );
+    // Set peer count > 0
+    write_peer_count(pid, sid, 1);
+
+    let result = check_offlimits(pid, sid, "crates/edda-store/src/lib.rs");
+    assert!(result.is_some(), "should block file claimed by active peer");
+    let (label, glob) = result.unwrap();
+    assert_eq!(label, "store-refactor");
+    assert_eq!(glob, "crates/edda-store/*");
+
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn offlimits_allows_own_claimed_file() {
+    let pid = "test-offlimits-self";
+    let sid = "s-self-own";
+    let _ = edda_store::ensure_dirs(pid);
+
+    // Create own heartbeat and claim
+    crate::peers::write_heartbeat_minimal(pid, sid, "my-agent");
+    crate::peers::write_claim(pid, sid, "my-agent", &["src/auth/*".into()]);
+    write_peer_count(pid, sid, 1);
+
+    let result = check_offlimits(pid, sid, "src/auth/login.rs");
+    assert!(result.is_none(), "should not block own claimed files");
+
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn offlimits_allows_unclaimed_file() {
+    let pid = "test-offlimits-unclaimed";
+    let sid = "s-self-unclaimed";
+    let peer_sid = "s-peer-unclaimed";
+    let _ = edda_store::ensure_dirs(pid);
+
+    // Create peer with claims on different paths
+    crate::peers::write_heartbeat_minimal(pid, peer_sid, "db-agent");
+    crate::peers::write_claim(pid, peer_sid, "db-agent", &["crates/edda-store/*".into()]);
+    write_peer_count(pid, sid, 1);
+
+    let result = check_offlimits(pid, sid, "crates/edda-bridge-claude/src/lib.rs");
+    assert!(
+        result.is_none(),
+        "should allow files not claimed by any peer"
+    );
+
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn offlimits_skips_stale_claims() {
+    let pid = "test-offlimits-stale";
+    let sid = "s-self-stale";
+    let stale_sid = "s-stale-peer";
+    let _ = edda_store::ensure_dirs(pid);
+
+    // Write a claim but NO heartbeat for the peer -> peer won't be discovered as active
+    crate::peers::write_claim(
+        pid,
+        stale_sid,
+        "stale-agent",
+        &["crates/edda-store/*".into()],
+    );
+    write_peer_count(pid, sid, 1);
+
+    let result = check_offlimits(pid, sid, "crates/edda-store/src/lib.rs");
+    assert!(
+        result.is_none(),
+        "should not block on claims from stale/missing peers"
+    );
+
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn offlimits_env_var_enables_enforcement() {
+    let pid = "test-offlimits-env";
+    let sid = "s-self-env";
+    let peer_sid = "s-peer-env";
+    let _ = edda_store::ensure_dirs(pid);
+
+    // Set up peer
+    crate::peers::write_heartbeat_minimal(pid, peer_sid, "env-agent");
+    crate::peers::write_claim(pid, peer_sid, "env-agent", &["src/core/*".into()]);
+    write_peer_count(pid, sid, 1);
+
+    // Enable enforcement via env var
+    std::env::set_var("EDDA_ENFORCE_OFFLIMITS", "1");
+
+    let raw = serde_json::json!({
+        "session_id": sid,
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": "src/core/engine.rs",
+            "old_string": "fn old()",
+            "new_string": "fn new()"
+        },
+        "cwd": "."
+    });
+    let result = dispatch_pre_tool_use(&raw, ".", pid, sid).unwrap();
+    let output_str = result.stdout.expect("should produce output");
+    let output: serde_json::Value = serde_json::from_str(&output_str).unwrap();
+    assert_eq!(
+        output["hookSpecificOutput"]["permissionDecision"], "block",
+        "should block Edit on peer-claimed file"
+    );
+    let reason = output["hookSpecificOutput"]["permissionDecisionReason"]
+        .as_str()
+        .unwrap();
+    assert!(
+        reason.contains("Off-limits"),
+        "reason should mention Off-limits"
+    );
+    assert!(
+        reason.contains("env-agent"),
+        "reason should mention peer label"
+    );
+
+    std::env::remove_var("EDDA_ENFORCE_OFFLIMITS");
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn offlimits_skips_non_edit_tools() {
+    let pid = "test-offlimits-bash";
+    let sid = "s-self-bash";
+    let peer_sid = "s-peer-bash";
+    let _ = edda_store::ensure_dirs(pid);
+
+    // Set up peer with claim
+    crate::peers::write_heartbeat_minimal(pid, peer_sid, "bash-agent");
+    crate::peers::write_claim(pid, peer_sid, "bash-agent", &["src/*".into()]);
+    write_peer_count(pid, sid, 1);
+
+    // Enable enforcement
+    std::env::set_var("EDDA_ENFORCE_OFFLIMITS", "1");
+    std::env::set_var("EDDA_CLAUDE_AUTO_APPROVE", "1");
+
+    let raw = serde_json::json!({
+        "session_id": sid,
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": "cat src/main.rs"
+        },
+        "cwd": "."
+    });
+    let result = dispatch_pre_tool_use(&raw, ".", pid, sid).unwrap();
+    let output_str = result.stdout.expect("should have output");
+    let output: serde_json::Value = serde_json::from_str(&output_str).unwrap();
+    // Should be "allow" (auto-approve), not "block"
+    assert_eq!(
+        output["hookSpecificOutput"]["permissionDecision"], "allow",
+        "Bash tool should not be blocked by off-limits"
+    );
+
+    std::env::remove_var("EDDA_ENFORCE_OFFLIMITS");
+    std::env::remove_var("EDDA_CLAUDE_AUTO_APPROVE");
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }

--- a/crates/edda-bridge-claude/src/dispatch/tools.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tools.rs
@@ -1,6 +1,8 @@
 use std::fs;
 use std::path::Path;
 
+use globset::Glob;
+
 use crate::parse::*;
 
 use super::events::{
@@ -49,6 +51,41 @@ pub(super) fn dispatch_pre_tool_use(
                             }
                         }
                     }
+                }
+            }
+        }
+    }
+
+    // ── Off-limits enforcement: block Edit/Write on peer-claimed files ──
+    let enforce_offlimits = match std::env::var("EDDA_ENFORCE_OFFLIMITS") {
+        Ok(val) => val == "1",
+        Err(_) => read_workspace_config_bool(cwd, "bridge.enforce_offlimits").unwrap_or(false),
+    };
+    if enforce_offlimits {
+        let tool_name_ol = get_str(raw, "tool_name");
+        if tool_name_ol == "Edit" || tool_name_ol == "Write" {
+            let file_path = raw
+                .pointer("/tool_input/file_path")
+                .or_else(|| raw.pointer("/input/file_path"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if !file_path.is_empty() {
+                if let Some((peer_label, matched_glob)) =
+                    check_offlimits(project_id, session_id, file_path)
+                {
+                    let reason = format!(
+                        "Off-limits: file '{}' is claimed by agent '{}' (paths: {}). \
+                         Use `edda request \"{}\" \"need to edit {}\"` to coordinate.",
+                        file_path, peer_label, matched_glob, peer_label, file_path
+                    );
+                    let output = serde_json::json!({
+                        "hookSpecificOutput": {
+                            "hookEventName": "PreToolUse",
+                            "permissionDecision": "block",
+                            "permissionDecisionReason": reason
+                        }
+                    });
+                    return Ok(HookResult::output(serde_json::to_string(&output)?));
                 }
             }
         }
@@ -126,6 +163,67 @@ pub(super) fn check_pending_requests(project_id: &str, session_id: &str) -> Opti
         lines.push(format!("  - From **{}**: {}", r.from_label, r.message));
     }
     Some(lines.join("\n"))
+}
+
+/// Check if a file path is claimed by an active peer (off-limits enforcement).
+///
+/// Returns `Some((peer_label, matched_glob))` if the file is claimed by another
+/// active session, `None` otherwise. Self-claims and stale peer claims are excluded.
+pub(super) fn check_offlimits(
+    project_id: &str,
+    session_id: &str,
+    file_path: &str,
+) -> Option<(String, String)> {
+    // Solo gate: skip when no peers are active.
+    if read_peer_count(project_id, session_id) == 0 {
+        return None;
+    }
+
+    // Get active peers (excludes self and stale sessions).
+    let active_peers = crate::peers::discover_active_peers(project_id, session_id);
+    if active_peers.is_empty() {
+        return None;
+    }
+
+    // Collect active peer session IDs for cross-referencing.
+    let active_sids: std::collections::HashSet<&str> =
+        active_peers.iter().map(|p| p.session_id.as_str()).collect();
+
+    // Get board state (cached per #83).
+    let board = crate::peers::compute_board_state(project_id);
+
+    // Normalize path separators for cross-platform matching.
+    let normalized = file_path.replace('\\', "/");
+
+    for claim in &board.claims {
+        // Skip self-claims.
+        if claim.session_id == session_id {
+            continue;
+        }
+        // Skip claims from stale/inactive peers.
+        if !active_sids.contains(claim.session_id.as_str()) {
+            continue;
+        }
+
+        for glob_pattern in &claim.paths {
+            if let Ok(glob) = Glob::new(glob_pattern) {
+                let matcher = glob.compile_matcher();
+                if matcher.is_match(&normalized) {
+                    return Some((claim.label.clone(), glob_pattern.clone()));
+                }
+                // Also try matching against just the file name.
+                if let Some(file_name) =
+                    Path::new(&normalized).file_name().and_then(|n| n.to_str())
+                {
+                    if matcher.is_match(file_name) {
+                        return Some((claim.label.clone(), glob_pattern.clone()));
+                    }
+                }
+            }
+        }
+    }
+
+    None
 }
 
 /// L3: evaluate learned rules against the current PreToolUse hook context.


### PR DESCRIPTION
## Summary

- Add opt-in hard enforcement for off-limits file claims in `PreToolUse` hook
- When enabled, Edit/Write operations on files claimed by active peer agents return `permissionDecision: "block"` with a descriptive reason including the peer label and suggested `edda request` command
- Disabled by default; enable via `EDDA_ENFORCE_OFFLIMITS=1` env var or `bridge.enforce_offlimits` config key
- Solo gate optimization: skips all checks when no peers are active
- Self-claims never trigger blocking; stale peer claims are ignored via active peer cross-referencing

## Details

- Guard inserted in `dispatch_pre_tool_use` after branch guard, before auto-approve
- New `check_offlimits` helper uses `discover_active_peers` + `compute_board_state` + `globset::Glob` matching
- Cross-platform path normalization (backslash -> forward slash)
- 7 test cases covering: disabled-by-default, peer blocking, self-exclusion, unclaimed files, stale claims, env var override, non-Edit/Write tools

Closes #84

## Test plan

- [x] `cargo clippy -p edda-bridge-claude -- -D warnings` passes
- [x] All 7 new off-limits tests pass
- [x] Pre-existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)