### PR TITLE
feat(conductor): add --tmux flag for multi-agent pane management

### DIFF
--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -8,6 +8,7 @@ use edda_conductor::runner::notify::StdoutNotifier;
 use edda_conductor::runner::sequential::{run_plan, RunContext};
 use edda_conductor::state::machine::{PhaseStatus, PlanState, PlanStatus};
 use edda_conductor::state::persist::{load_state, save_state};
+use edda_conductor::tmux::TmuxSession;
 use std::path::Path;
 use tokio_util::sync::CancellationToken;
 
@@ -31,6 +32,9 @@ pub enum ConductCmd {
         /// Output events as JSONL to stdout (for machine consumption)
         #[arg(long)]
         json: bool,
+        /// Create a tmux session with per-phase transcript panes + dashboard
+        #[arg(long)]
+        tmux: bool,
     },
     /// Show status of running/completed plans
     Status {
@@ -76,12 +80,14 @@ pub fn run_cmd(cmd: ConductCmd, repo_root: &Path) -> Result<()> {
             dry_run,
             quiet,
             json,
+            tmux,
         } => run(
             Path::new(&plan_file),
             cwd.as_deref().map(Path::new),
             dry_run,
             !quiet,
             json,
+            tmux,
         ),
         ConductCmd::Status { plan_name, json } => status(repo_root, plan_name.as_deref(), json),
         ConductCmd::Retry { phase_id, plan } => retry(repo_root, &phase_id, plan.as_deref()),
@@ -103,6 +109,7 @@ pub fn run(
     dry_run: bool,
     verbose: bool,
     json_events: bool,
+    tmux: bool,
 ) -> Result<()> {
     let plan = load_plan(plan_file)?;
     let cwd = cwd_override
@@ -121,6 +128,21 @@ pub fn run(
 
     // When --json, suppress human-readable output (verbose/TUI)
     let verbose = if json_events { false } else { verbose };
+
+    // Resolve tmux availability
+    let use_tmux = if tmux {
+        if TmuxSession::is_available() {
+            true
+        } else {
+            eprintln!(
+                "Warning: --tmux requested but tmux is not installed. \
+                 Falling back to normal mode."
+            );
+            false
+        }
+    } else {
+        false
+    };
 
     // Load or create state
     let mut state = match load_state(&cwd, &plan.name)? {
@@ -142,6 +164,8 @@ pub fn run(
         }
     };
 
+    let order = edda_conductor::plan::topo::topo_sort(&plan)?;
+
     if dry_run {
         println!("\n[dry-run] Plan: {}", plan.name);
         println!("  Phases: {}", plan.phases.len());
@@ -153,7 +177,6 @@ pub fn run(
         println!("  Max attempts: {}", plan.max_attempts);
         println!("  On fail: {:?}", plan.on_fail);
         println!("\n  Phase order:");
-        let order = edda_conductor::plan::topo::topo_sort(&plan)?;
         for (i, id) in order.iter().enumerate() {
             let phase = plan
                 .phases
@@ -169,18 +192,22 @@ pub fn run(
         }
         println!("\n  Session IDs:");
         for id in &order {
-            println!("    {} → {}", id, phase_session_id(&plan.name, id));
+            println!("    {} \u{2192} {}", id, phase_session_id(&plan.name, id));
+        }
+        if use_tmux {
+            TmuxSession::print_layout_preview(&plan.name, &order);
         }
         return Ok(());
     }
 
+    let transcript_dir = cwd
+        .join(".edda")
+        .join("conductor")
+        .join(&plan.name)
+        .join("transcripts");
+
     let mut launcher = ClaudeCodeLauncher::new().with_verbose(verbose);
-    launcher.transcript_dir = Some(
-        cwd.join(".edda")
-            .join("conductor")
-            .join(&plan.name)
-            .join("transcripts"),
-    );
+    launcher.transcript_dir = Some(transcript_dir.clone());
     launcher.verify_available()?;
     let engine = CheckEngine::new(cwd.clone());
     let notifier = StdoutNotifier;
@@ -193,8 +220,28 @@ pub fn run(
 
     let interactive = std::io::IsTerminal::is_terminal(&std::io::stdin());
 
+    // Create tmux session if requested
+    let tmux_session = if use_tmux {
+        match TmuxSession::create(&plan.name, &order, &transcript_dir) {
+            Ok(session) => {
+                println!("Tmux session created: {}", session.session_name);
+                println!("  Attach: tmux attach -t {}", session.session_name);
+                Some(session)
+            }
+            Err(e) => {
+                eprintln!(
+                    "Warning: failed to create tmux session: {e}. \
+                     Continuing without tmux."
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     let rt = tokio::runtime::Runtime::new()?;
-    rt.block_on(run_plan(
+    let result = rt.block_on(run_plan(
         &plan,
         &mut state,
         RunContext {
@@ -206,10 +253,23 @@ pub fn run(
             cwd: &cwd,
             interactive,
             json_events,
+            tmux_session: tmux_session.as_ref(),
         },
-    ))?;
+    ));
 
-    Ok(())
+    // Print tmux session info after run completes
+    if let Some(ref session) = tmux_session {
+        println!(
+            "\nTmux session still active: tmux attach -t {}",
+            session.session_name
+        );
+        println!(
+            "  Destroy: tmux kill-session -t {}",
+            session.session_name
+        );
+    }
+
+    result
 }
 
 /// Execute `edda conduct status [plan-name]`

--- a/crates/edda-cli/src/cmd_pipeline.rs
+++ b/crates/edda-cli/src/cmd_pipeline.rs
@@ -66,7 +66,7 @@ pub fn execute_run(repo_root: &Path, issue_id: u64, dry_run: bool) -> Result<()>
     println!("Plan written to {}", plan_file.display());
 
     // 6. Delegate to conductor
-    crate::cmd_conduct::run(&plan_file, Some(repo_root), false, true, false)
+    crate::cmd_conduct::run(&plan_file, Some(repo_root), false, true, false, false)
 }
 
 /// Execute `edda pipeline status [issue-id]`.

--- a/crates/edda-conductor/src/lib.rs
+++ b/crates/edda-conductor/src/lib.rs
@@ -3,3 +3,4 @@ pub mod check;
 pub mod plan;
 pub mod runner;
 pub mod state;
+pub mod tmux;

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -15,6 +15,7 @@ use crate::state::machine::{
     PlanState, PlanStatus,
 };
 use crate::state::persist::save_state;
+use crate::tmux::TmuxSession;
 use anyhow::Context;
 use anyhow::Result;
 use std::path::Path;
@@ -31,6 +32,8 @@ pub struct RunContext<'a> {
     pub cwd: &'a Path,
     pub interactive: bool,
     pub json_events: bool,
+    /// Optional tmux session for updating pane status during execution.
+    pub tmux_session: Option<&'a TmuxSession>,
 }
 
 /// Run a plan sequentially. The main conductor loop.
@@ -44,6 +47,7 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
         cwd,
         interactive,
         json_events,
+        tmux_session,
     } = ctx;
     let order = topo_sort(plan)?;
     let total_phases = order.len();
@@ -195,6 +199,9 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
         save_state(cwd, state)?;
 
         println!("\n▶ [{phase_num}/{total_phases}] Phase \"{phase_id}\" (attempt {attempt})");
+        if let Some(tmux) = tmux_session {
+            let _ = tmux.update_phase_status(&phase_id, "Running");
+        }
         let phase_start = Instant::now();
         event_log.record(Event::PhaseStart {
             phase_id: phase_id.clone(),
@@ -268,6 +275,9 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                         "  ✓ Phase \"{phase_id}\" passed ({})",
                         format_elapsed(phase_start.elapsed())
                     );
+                    if let Some(tmux) = tmux_session {
+                        let _ = tmux.update_phase_status(&phase_id, "Passed");
+                    }
 
                     // Record to edda ledger
                     edda::record_phase_done(cwd, &phase_id, result_text.as_deref(), cost_usd);
@@ -299,6 +309,9 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                         "  ✗ Phase \"{phase_id}\" failed ({}): {err_msg}",
                         format_elapsed(phase_start.elapsed()),
                     );
+                    if let Some(tmux) = tmux_session {
+                        let _ = tmux.update_phase_status(&phase_id, "Failed");
+                    }
                     edda::record_phase_failed(cwd, &phase_id, err_msg);
                     event_log.record(Event::PhaseFailed {
                         phase_id: phase_id.clone(),
@@ -340,6 +353,9 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                     "  ⏰ Phase \"{phase_id}\" timed out ({})",
                     format_elapsed(phase_start.elapsed())
                 );
+                if let Some(tmux) = tmux_session {
+                    let _ = tmux.update_phase_status(&phase_id, "Stale");
+                }
                 edda::record_phase_failed(cwd, &phase_id, "timed out");
                 event_log.record(Event::PhaseFailed {
                     phase_id: phase_id.clone(),
@@ -370,6 +386,9 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                     "  ✗ Phase \"{phase_id}\" crashed ({}): {error}",
                     format_elapsed(phase_start.elapsed())
                 );
+                if let Some(tmux) = tmux_session {
+                    let _ = tmux.update_phase_status(&phase_id, "Failed");
+                }
                 edda::record_phase_failed(cwd, &phase_id, &error);
                 event_log.record(Event::PhaseFailed {
                     phase_id: phase_id.clone(),
@@ -752,6 +771,7 @@ mod tests {
                 cwd: dir.path(),
                 interactive: false,
                 json_events: false,
+                tmux_session: None,
             },
         )
         .await
@@ -994,6 +1014,7 @@ phases:
                 cwd: dir.path(),
                 interactive: false,
                 json_events: false,
+                tmux_session: None,
             },
         )
         .await
@@ -1143,6 +1164,7 @@ phases:
                 cwd: dir.path(),
                 interactive: false,
                 json_events: false,
+                tmux_session: None,
             },
         )
         .await

--- a/crates/edda-conductor/src/tmux.rs
+++ b/crates/edda-conductor/src/tmux.rs
@@ -1,0 +1,267 @@
+//! Tmux session and pane management for multi-agent visibility.
+//!
+//! Creates a tmux session with one pane per phase (showing `tail -f` of
+//! transcript files) plus a dashboard pane running `edda watch`.
+//! All tmux interaction is via `std::process::Command` — no crate dependency.
+
+use anyhow::{bail, Result};
+use std::path::Path;
+use std::process::Command;
+
+/// Information about a single tmux pane.
+#[derive(Debug, Clone)]
+pub struct PaneInfo {
+    pub phase_id: String,
+    pub pane_id: String,
+}
+
+/// A tmux session managing panes for a conductor plan.
+#[derive(Debug)]
+pub struct TmuxSession {
+    pub session_name: String,
+    pub panes: Vec<PaneInfo>,
+    pub dashboard_pane: Option<String>,
+}
+
+impl TmuxSession {
+    /// Check if `tmux` is available on this system.
+    pub fn is_available() -> bool {
+        Command::new("tmux")
+            .arg("-V")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    /// Derive a tmux session name from a plan name.
+    /// Replaces characters that tmux disallows in session names.
+    pub fn session_name_for(plan_name: &str) -> String {
+        let sanitized: String = plan_name
+            .chars()
+            .map(|c| {
+                if c.is_alphanumeric() || c == '-' || c == '_' {
+                    c
+                } else {
+                    '-'
+                }
+            })
+            .collect();
+        format!("edda-{sanitized}")
+    }
+
+    /// Create a new tmux session with panes for each phase + dashboard.
+    ///
+    /// Each phase pane runs `tail -f <transcript_dir>/<phase_id>*.jsonl` so
+    /// the human can see agent activity in real time. The bottom pane runs
+    /// `edda watch` for the coordination dashboard.
+    pub fn create(
+        plan_name: &str,
+        phase_ids: &[String],
+        transcript_dir: &Path,
+    ) -> Result<Self> {
+        if !Self::is_available() {
+            bail!("tmux is not installed or not in PATH");
+        }
+
+        let session_name = Self::session_name_for(plan_name);
+
+        // Kill stale session with the same name (best-effort)
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", &session_name])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+
+        // Create session with the first phase pane
+        let first_cmd = Self::tail_command(transcript_dir, &phase_ids[0]);
+        run_tmux(&[
+            "new-session",
+            "-d",
+            "-s",
+            &session_name,
+            "-n",
+            "conductor",
+            &first_cmd,
+        ])?;
+
+        // Set pane border format for status display
+        let _ = run_tmux(&[
+            "set-option",
+            "-t",
+            &session_name,
+            "pane-border-format",
+            " #{pane_title} ",
+        ]);
+        let _ = run_tmux(&[
+            "set-option",
+            "-t",
+            &session_name,
+            "pane-border-status",
+            "top",
+        ]);
+
+        // Title the first pane
+        let _ = run_tmux(&[
+            "select-pane",
+            "-t",
+            &format!("{session_name}:0.0"),
+            "-T",
+            &format!("[{}] Pending", phase_ids[0]),
+        ]);
+
+        let mut panes = vec![PaneInfo {
+            phase_id: phase_ids[0].clone(),
+            pane_id: format!("{session_name}:0.0"),
+        }];
+
+        // Create additional phase panes
+        for (i, phase_id) in phase_ids.iter().enumerate().skip(1) {
+            let cmd = Self::tail_command(transcript_dir, phase_id);
+            run_tmux(&[
+                "split-window",
+                "-t",
+                &session_name,
+                "-h",
+                &cmd,
+            ])?;
+
+            let pane_id = format!("{session_name}:0.{i}");
+            let _ = run_tmux(&[
+                "select-pane",
+                "-t",
+                &pane_id,
+                "-T",
+                &format!("[{phase_id}] Pending"),
+            ]);
+
+            panes.push(PaneInfo {
+                phase_id: phase_id.clone(),
+                pane_id,
+            });
+        }
+
+        // Dashboard pane: `edda watch` (or a placeholder if not available)
+        let dashboard_cmd =
+            "edda watch 2>/dev/null || { echo 'edda watch not available'; sleep infinity; }";
+        let dashboard_idx = phase_ids.len();
+        run_tmux(&[
+            "split-window",
+            "-t",
+            &session_name,
+            "-v",
+            "-l",
+            "30%",
+            "-f",
+            dashboard_cmd,
+        ])?;
+        let dashboard_pane = format!("{session_name}:0.{dashboard_idx}");
+        let _ = run_tmux(&[
+            "select-pane",
+            "-t",
+            &dashboard_pane,
+            "-T",
+            "Dashboard (edda watch)",
+        ]);
+
+        // Auto-tile the layout
+        let _ = run_tmux(&["select-layout", "-t", &session_name, "tiled"]);
+
+        Ok(Self {
+            session_name,
+            panes,
+            dashboard_pane: Some(dashboard_pane),
+        })
+    }
+
+    /// Update a phase pane's title to reflect its status.
+    pub fn update_phase_status(&self, phase_id: &str, status: &str) -> Result<()> {
+        if let Some(pane) = self.panes.iter().find(|p| p.phase_id == phase_id) {
+            let title = format!("[{phase_id}] {status}");
+            run_tmux(&["select-pane", "-t", &pane.pane_id, "-T", &title])?;
+        }
+        Ok(())
+    }
+
+    /// Destroy the tmux session.
+    pub fn destroy(&self) -> Result<()> {
+        run_tmux(&["kill-session", "-t", &self.session_name])?;
+        Ok(())
+    }
+
+    /// Print the planned tmux layout without creating it (for --dry-run).
+    pub fn print_layout_preview(plan_name: &str, phase_ids: &[String]) {
+        let session_name = Self::session_name_for(plan_name);
+        println!("\n  Tmux layout (session: {session_name}):");
+        for (i, id) in phase_ids.iter().enumerate() {
+            println!("    Pane {i}: [{id}] tail -f transcript");
+        }
+        println!("    Pane {}: Dashboard (edda watch)", phase_ids.len());
+        println!("    Layout: tiled");
+        println!("\n    Attach: tmux attach -t {session_name}");
+    }
+
+    /// Build the shell command to tail a phase transcript.
+    fn tail_command(transcript_dir: &Path, phase_id: &str) -> String {
+        let dir = transcript_dir.display();
+        // Wait for transcript file to appear, then tail it
+        format!(
+            "echo 'Waiting for phase {phase_id}...' && \
+             while ! ls \"{dir}/{phase_id}\"*.jsonl >/dev/null 2>&1; do sleep 1; done && \
+             tail -f \"{dir}/{phase_id}\"*.jsonl"
+        )
+    }
+}
+
+/// Run a tmux command, returning an error if it fails.
+fn run_tmux(args: &[&str]) -> Result<()> {
+    let output = Command::new("tmux")
+        .args(args)
+        .output()
+        .map_err(|e| anyhow::anyhow!("failed to run tmux: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "tmux {} failed: {}",
+            args.first().unwrap_or(&""),
+            stderr.trim()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_name_sanitization() {
+        assert_eq!(TmuxSession::session_name_for("my-plan"), "edda-my-plan");
+        assert_eq!(
+            TmuxSession::session_name_for("plan with spaces"),
+            "edda-plan-with-spaces"
+        );
+        assert_eq!(TmuxSession::session_name_for("plan.v2"), "edda-plan-v2");
+        assert_eq!(
+            TmuxSession::session_name_for("under_score"),
+            "edda-under_score"
+        );
+    }
+
+    #[test]
+    fn tail_command_format() {
+        let dir = std::path::PathBuf::from("/tmp/transcripts");
+        let cmd = TmuxSession::tail_command(&dir, "build");
+        assert!(cmd.contains("phase build"));
+        assert!(cmd.contains("tail -f"));
+        assert!(cmd.contains("/tmp/transcripts/build"));
+    }
+
+    #[test]
+    fn layout_preview_does_not_panic() {
+        let phases = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        TmuxSession::print_layout_preview("test-plan", &phases);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #46

- Add `--tmux` flag to `edda conduct run` that creates a tmux session with one pane per phase (tailing transcript files) plus a dashboard pane running `edda watch`
- New `tmux.rs` module in edda-conductor handles session creation, pane status updates, and teardown
- Phase pane titles update in real-time as phases transition (Running/Passed/Failed/Stale)
- Graceful fallback: if tmux is not installed, prints a warning and runs normally

## Architecture

Uses **Option C (transcript-tail)** from the issue discussion: the existing piped-stdout + StreamMonitor architecture is untouched. Tmux panes simply `tail -f` the transcript JSONL files that are already written by the launcher.

## Files changed

| File | Change |
|------|--------|
| `crates/edda-conductor/src/tmux.rs` | New module: `TmuxSession` for session/pane lifecycle |
| `crates/edda-conductor/src/lib.rs` | Register `pub mod tmux` |
| `crates/edda-conductor/src/runner/sequential.rs` | Add `tmux_session` to `RunContext`, insert pane status updates |
| `crates/edda-cli/src/cmd_conduct.rs` | Add `--tmux` flag, wire session create/attach info |
| `crates/edda-cli/src/cmd_pipeline.rs` | Pass new `tmux: false` parameter to `run()` |

## Test plan

- [x] `cargo clippy -- -D warnings` passes (zero warnings)
- [x] `cargo test -p edda-conductor` passes (147 tests)
- [ ] Manual: `edda conduct run plan.yaml --tmux` on a system with tmux
- [ ] Manual: `edda conduct run plan.yaml --tmux` without tmux installed (should warn and fall back)
- [ ] Manual: `edda conduct run plan.yaml --dry-run --tmux` shows layout preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)