### PR TITLE
feat(bridge): inject karvi board state via UserPromptSubmit

### DIFF
--- a/crates/edda-bridge-claude/src/dispatch/helpers.rs
+++ b/crates/edda-bridge-claude/src/dispatch/helpers.rs
@@ -218,6 +218,151 @@ pub(super) fn extract_prior_session_last_message(
     edda_transcript::extract_last_assistant_text(&transcript_path, max_chars)
 }
 
+// ── Project State ──
+
+/// Maximum characters for the karvi board summary.
+const BOARD_SUMMARY_MAX_CHARS: usize = 500;
+/// Maximum number of tasks to display in the board summary.
+const BOARD_MAX_TASKS: usize = 5;
+/// Maximum characters for a task subject.
+const BOARD_TASK_SUBJECT_MAX: usize = 30;
+/// Maximum number of recent signals to display.
+const BOARD_MAX_SIGNALS: usize = 3;
+/// Maximum characters for a signal content snippet.
+const BOARD_SIGNAL_CONTENT_MAX: usize = 40;
+
+/// Read project-level state for context injection.
+///
+/// Currently supports karvi projects (detected by `server/board.json`).
+/// Returns a compact summary suitable for `additionalContext` injection.
+/// Returns `None` for non-karvi projects or on any parse error (graceful degradation).
+pub(super) fn read_project_state(cwd: &str) -> Option<String> {
+    let board_path = Path::new(cwd).join("server/board.json");
+    if board_path.exists() {
+        return read_karvi_board(cwd);
+    }
+    // Future: other project types
+    None
+}
+
+/// Read and format a compact summary of a karvi board.json.
+///
+/// All JSON access is defensive (`Option` chains). Malformed or missing
+/// fields are silently skipped — never returns an error.
+fn read_karvi_board(cwd: &str) -> Option<String> {
+    let board_path = Path::new(cwd).join("server/board.json");
+    let content = fs::read_to_string(&board_path).ok()?;
+    let board: serde_json::Value = serde_json::from_str(&content).ok()?;
+
+    let mut lines = vec!["[karvi board]".to_string()];
+
+    // Goal and phase
+    if let Some(task_plan) = board.get("taskPlan") {
+        if let Some(goal) = task_plan.get("goal").and_then(|v| v.as_str()) {
+            lines.push(format!("Goal: {goal}"));
+        }
+        if let Some(phase) = task_plan.get("phase").and_then(|v| v.as_str()) {
+            lines.push(format!("Phase: {phase}"));
+        }
+
+        // Tasks
+        if let Some(tasks) = task_plan.get("tasks").and_then(|v| v.as_array()) {
+            if tasks.is_empty() {
+                lines.push("Tasks: (none)".to_string());
+            } else {
+                lines.push("Tasks:".to_string());
+                for task in tasks.iter().take(BOARD_MAX_TASKS) {
+                    let id = task.get("id").and_then(|v| v.as_str()).unwrap_or("?");
+                    let subject = task
+                        .get("subject")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("(untitled)");
+                    let subject_trunc = if subject.len() > BOARD_TASK_SUBJECT_MAX {
+                        format!("{}...", &subject[..BOARD_TASK_SUBJECT_MAX])
+                    } else {
+                        subject.to_string()
+                    };
+                    let status = task
+                        .get("status")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown");
+
+                    let mut parts = vec![status.to_string()];
+
+                    if let Some(assigned) = task.get("assigned").and_then(|v| v.as_str()) {
+                        parts.push(format!("assigned: {assigned}"));
+                    }
+
+                    if let Some(review) = task.get("review") {
+                        if let Some(state) = review.get("state").and_then(|v| v.as_str()) {
+                            parts.push(state.to_string());
+                        }
+                    }
+
+                    if let Some(depends) = task.get("depends").and_then(|v| v.as_array()) {
+                        if !depends.is_empty() {
+                            let dep_ids: Vec<&str> =
+                                depends.iter().filter_map(|d| d.as_str()).collect();
+                            if !dep_ids.is_empty() {
+                                parts.push(format!("blocked by {}", dep_ids.join(", ")));
+                            }
+                        }
+                    }
+
+                    lines.push(format!(
+                        "  - {id} \"{subject_trunc}\" ({})",
+                        parts.join(", ")
+                    ));
+                }
+                if tasks.len() > BOARD_MAX_TASKS {
+                    lines.push(format!("  ... and {} more", tasks.len() - BOARD_MAX_TASKS));
+                }
+            }
+        }
+    }
+
+    // Lessons count
+    if let Some(lessons) = board.get("lessons").and_then(|v| v.as_array()) {
+        if !lessons.is_empty() {
+            lines.push(format!("Lessons: {} active", lessons.len()));
+        }
+    }
+
+    // Recent signals (last N)
+    if let Some(signals) = board.get("signals").and_then(|v| v.as_array()) {
+        if !signals.is_empty() {
+            let recent: Vec<String> = signals
+                .iter()
+                .rev()
+                .take(BOARD_MAX_SIGNALS)
+                .filter_map(|s| {
+                    let c = s.get("content").and_then(|v| v.as_str())?;
+                    if c.len() > BOARD_SIGNAL_CONTENT_MAX {
+                        Some(format!("\"{}...\"", &c[..BOARD_SIGNAL_CONTENT_MAX]))
+                    } else {
+                        Some(format!("\"{c}\""))
+                    }
+                })
+                .collect();
+            if !recent.is_empty() {
+                lines.push(format!("Signals: {}", recent.join(" | ")));
+            }
+        }
+    }
+
+    let summary = lines.join("\n");
+
+    // Enforce hard cap
+    if summary.len() > BOARD_SUMMARY_MAX_CHARS {
+        Some(format!(
+            "{}...(truncated)",
+            &summary[..BOARD_SUMMARY_MAX_CHARS]
+        ))
+    } else {
+        Some(summary)
+    }
+}
+
 /// Inject karvi task brief if working in a karvi project.
 ///
 /// Detection: Check if server/board.json exists

--- a/crates/edda-bridge-claude/src/dispatch/helpers.rs
+++ b/crates/edda-bridge-claude/src/dispatch/helpers.rs
@@ -278,7 +278,8 @@ fn read_karvi_board(cwd: &str) -> Option<String> {
                         .and_then(|v| v.as_str())
                         .unwrap_or("(untitled)");
                     let subject_trunc = if subject.len() > BOARD_TASK_SUBJECT_MAX {
-                        format!("{}...", &subject[..BOARD_TASK_SUBJECT_MAX])
+                        let end = subject.floor_char_boundary(BOARD_TASK_SUBJECT_MAX);
+                        format!("{}...", &subject[..end])
                     } else {
                         subject.to_string()
                     };
@@ -338,7 +339,8 @@ fn read_karvi_board(cwd: &str) -> Option<String> {
                 .filter_map(|s| {
                     let c = s.get("content").and_then(|v| v.as_str())?;
                     if c.len() > BOARD_SIGNAL_CONTENT_MAX {
-                        Some(format!("\"{}...\"", &c[..BOARD_SIGNAL_CONTENT_MAX]))
+                        let end = c.floor_char_boundary(BOARD_SIGNAL_CONTENT_MAX);
+                        Some(format!("\"{}...\"", &c[..end]))
                     } else {
                         Some(format!("\"{c}\""))
                     }
@@ -354,10 +356,8 @@ fn read_karvi_board(cwd: &str) -> Option<String> {
 
     // Enforce hard cap
     if summary.len() > BOARD_SUMMARY_MAX_CHARS {
-        Some(format!(
-            "{}...(truncated)",
-            &summary[..BOARD_SUMMARY_MAX_CHARS]
-        ))
+        let end = summary.floor_char_boundary(BOARD_SUMMARY_MAX_CHARS);
+        Some(format!("{}...(truncated)", &summary[..end]))
     } else {
         Some(summary)
     }
@@ -394,7 +394,7 @@ pub(super) fn inject_karvi_brief(cwd: &str) -> Option<String> {
 
     let contents = fs::read_to_string(&brief_path).ok()?;
     let truncated = if contents.len() > 2000 {
-        &contents[..2000]
+        &contents[..contents.floor_char_boundary(2000)]
     } else {
         &contents
     };

--- a/crates/edda-bridge-claude/src/dispatch/session.rs
+++ b/crates/edda-bridge-claude/src/dispatch/session.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use crate::signals::{extract_session_signals, save_session_signals, TaskSnapshot};
 
 use super::helpers::{
-    extract_prior_session_last_message, inject_karvi_brief, render_active_plan,
+    extract_prior_session_last_message, inject_karvi_brief, read_project_state, render_active_plan,
     render_skill_guide_directive, run_auto_digest,
 };
 use super::{
@@ -127,6 +127,14 @@ pub(super) fn dispatch_with_workspace_only(
         .and_then(|v| v.parse().ok())
         .unwrap_or(2500);
     let mut ws = render_workspace_section(cwd, workspace_budget);
+
+    // Inject project-level state (karvi board summary, etc.)
+    if let Some(project_state) = read_project_state(cwd) {
+        ws = Some(match ws {
+            Some(w) => format!("{w}\n\n{project_state}"),
+            None => project_state,
+        });
+    }
 
     // Compute peers + board ONCE for the entire dispatch (#83).
     // Before: discover_active_peers called 2-3×, compute_board_state 3-4× per hook.
@@ -588,6 +596,14 @@ pub(super) fn dispatch_session_start(
         content = Some(match content {
             Some(c) => format!("{c}\n\n{brief}"),
             None => brief,
+        });
+    }
+
+    // Inject project-level state (karvi board summary, etc.)
+    if let Some(project_state) = read_project_state(cwd) {
+        content = Some(match content {
+            Some(c) => format!("{c}\n\n{project_state}"),
+            None => project_state,
         });
     }
 

--- a/crates/edda-bridge-claude/src/dispatch/tests.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tests.rs
@@ -12,7 +12,7 @@ use super::{
 use super::events::{
     extract_task_id, is_karvi_project, try_write_commit_event, try_write_merge_event,
 };
-use super::helpers::{inject_karvi_brief, render_active_plan_from_dir};
+use super::helpers::{inject_karvi_brief, read_project_state, render_active_plan_from_dir};
 use super::session::{
     cleanup_session_state, collect_session_end_warnings, dispatch_session_end,
     dispatch_session_start, dispatch_user_prompt_submit, dispatch_with_workspace_only,
@@ -2517,4 +2517,205 @@ fn offlimits_skips_non_edit_tools() {
     std::env::remove_var("EDDA_ENFORCE_OFFLIMITS");
     std::env::remove_var("EDDA_CLAUDE_AUTO_APPROVE");
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+// ── Karvi Board State (read_project_state) Tests ──
+
+#[test]
+fn read_project_state_non_karvi() {
+    let tmp = tempfile::tempdir().unwrap();
+    let result = read_project_state(tmp.path().to_str().unwrap());
+    assert!(result.is_none(), "Should return None for non-karvi project");
+}
+
+#[test]
+fn read_project_state_malformed_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("server")).unwrap();
+    fs::write(tmp.path().join("server/board.json"), "not valid json {{{").unwrap();
+
+    let result = read_project_state(tmp.path().to_str().unwrap());
+    assert!(
+        result.is_none(),
+        "Should return None for malformed board.json"
+    );
+}
+
+#[test]
+fn read_project_state_minimal_board() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("server")).unwrap();
+    let board = serde_json::json!({
+        "taskPlan": {
+            "goal": "implement auth",
+            "phase": "execution"
+        }
+    });
+    fs::write(
+        tmp.path().join("server/board.json"),
+        serde_json::to_string(&board).unwrap(),
+    )
+    .unwrap();
+
+    let result = read_project_state(tmp.path().to_str().unwrap());
+    assert!(result.is_some(), "Should return summary for minimal board");
+    let summary = result.unwrap();
+    assert!(summary.contains("[karvi board]"));
+    assert!(summary.contains("Goal: implement auth"));
+    assert!(summary.contains("Phase: execution"));
+}
+
+#[test]
+fn read_project_state_full_board() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("server")).unwrap();
+    let board = serde_json::json!({
+        "taskPlan": {
+            "goal": "build the app",
+            "phase": "testing",
+            "tasks": [
+                {
+                    "id": "T1",
+                    "subject": "setup project",
+                    "status": "completed",
+                    "review": { "state": "approved" }
+                },
+                {
+                    "id": "T2",
+                    "subject": "implement auth",
+                    "status": "in_progress",
+                    "assigned": "engineer_pro"
+                },
+                {
+                    "id": "T3",
+                    "subject": "deploy",
+                    "status": "blocked",
+                    "depends": ["T2"]
+                }
+            ]
+        },
+        "lessons": [
+            { "rule": "always run tests" },
+            { "rule": "check types" }
+        ],
+        "signals": [
+            { "content": "test coverage at 85%" },
+            { "content": "auth module ready" },
+            { "content": "schema migrated" }
+        ]
+    });
+    fs::write(
+        tmp.path().join("server/board.json"),
+        serde_json::to_string(&board).unwrap(),
+    )
+    .unwrap();
+
+    let result = read_project_state(tmp.path().to_str().unwrap());
+    assert!(result.is_some());
+    let summary = result.unwrap();
+
+    assert!(summary.contains("[karvi board]"));
+    assert!(summary.contains("Goal: build the app"));
+    assert!(summary.contains("Phase: testing"));
+    assert!(summary.contains("T1 \"setup project\" (completed, approved)"));
+    assert!(summary.contains("T2 \"implement auth\" (in_progress, assigned: engineer_pro)"));
+    assert!(summary.contains("T3 \"deploy\" (blocked, blocked by T2)"));
+    assert!(summary.contains("Lessons: 2 active"));
+    assert!(summary.contains("Signals:"));
+    assert!(summary.contains("\"test coverage at 85%\""));
+    assert!(summary.contains("\"auth module ready\""));
+    assert!(summary.contains("\"schema migrated\""));
+}
+
+#[test]
+fn read_project_state_respects_500_char_budget() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("server")).unwrap();
+
+    // Create a board with many tasks to exceed 500 chars
+    let mut tasks = Vec::new();
+    for i in 0..20 {
+        tasks.push(serde_json::json!({
+            "id": format!("T{i}"),
+            "subject": format!("a very long task subject number {i} that takes space"),
+            "status": "in_progress",
+            "assigned": "engineer_pro",
+            "depends": ["T0", "T1"]
+        }));
+    }
+    let board = serde_json::json!({
+        "taskPlan": {
+            "goal": "a goal that is quite long to help push the char count",
+            "phase": "execution",
+            "tasks": tasks
+        },
+        "lessons": [
+            { "rule": "r1" }, { "rule": "r2" }, { "rule": "r3" },
+            { "rule": "r4" }, { "rule": "r5" }
+        ],
+        "signals": [
+            { "content": "signal one" },
+            { "content": "signal two" },
+            { "content": "signal three" }
+        ]
+    });
+    fs::write(
+        tmp.path().join("server/board.json"),
+        serde_json::to_string(&board).unwrap(),
+    )
+    .unwrap();
+
+    let result = read_project_state(tmp.path().to_str().unwrap());
+    assert!(result.is_some());
+    let summary = result.unwrap();
+    // 500 chars + "...(truncated)" suffix
+    assert!(
+        summary.len() <= 500 + 15,
+        "Summary should be at most 515 chars, got {}",
+        summary.len()
+    );
+    assert!(summary.contains("...(truncated)"));
+}
+
+#[test]
+fn read_project_state_missing_fields() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("server")).unwrap();
+
+    // Empty JSON object — no taskPlan at all
+    fs::write(tmp.path().join("server/board.json"), "{}").unwrap();
+
+    let result = read_project_state(tmp.path().to_str().unwrap());
+    assert!(
+        result.is_some(),
+        "Should still return header for valid JSON"
+    );
+    let summary = result.unwrap();
+    assert!(summary.contains("[karvi board]"));
+    // Should NOT contain Goal/Phase/Tasks since taskPlan is missing
+    assert!(!summary.contains("Goal:"));
+    assert!(!summary.contains("Phase:"));
+}
+
+#[test]
+fn read_project_state_empty_tasks() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("server")).unwrap();
+    let board = serde_json::json!({
+        "taskPlan": {
+            "goal": "test",
+            "phase": "idle",
+            "tasks": []
+        }
+    });
+    fs::write(
+        tmp.path().join("server/board.json"),
+        serde_json::to_string(&board).unwrap(),
+    )
+    .unwrap();
+
+    let result = read_project_state(tmp.path().to_str().unwrap());
+    assert!(result.is_some());
+    let summary = result.unwrap();
+    assert!(summary.contains("Tasks: (none)"));
 }


### PR DESCRIPTION
## Summary

Closes #147

- Add `read_project_state()` / `read_karvi_board()` helpers in `dispatch/helpers.rs` that read `server/board.json` and produce a compact summary (goal, phase, tasks, lessons count, recent signals) under 500 chars
- Integrate at both `UserPromptSubmit` (workspace-only injection) and `SessionStart` injection points
- Leverages existing pipeline-level dedup (`is_same_as_last_inject`) — no separate hash tracking needed
- All JSON access is defensive (`Option` chains); malformed/missing fields silently skipped

## Test plan

- [x] `read_project_state_non_karvi` — returns None for non-karvi dir
- [x] `read_project_state_malformed_json` — returns None for invalid JSON
- [x] `read_project_state_minimal_board` — formats correctly with just goal/phase
- [x] `read_project_state_full_board` — formats with tasks, lessons, signals
- [x] `read_project_state_respects_500_char_budget` — truncates large boards
- [x] `read_project_state_missing_fields` — gracefully handles missing taskPlan
- [x] `read_project_state_empty_tasks` — shows "(none)" for empty tasks array
- [x] `cargo clippy -p edda-bridge-claude -- -D warnings` passes
- [x] Pre-existing test failure (`post_tool_use_increments_nudge_counter`) confirmed on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)