### PR TITLE
feat(bridge): real-time coordination diff injection (#146)

### DIFF
--- a/crates/edda-bridge-claude/src/dispatch/session.rs
+++ b/crates/edda-bridge-claude/src/dispatch/session.rs
@@ -163,6 +163,14 @@ pub(super) fn dispatch_with_workspace_only(
         }
     }
 
+    // Coordination diff: inject new events since last check (#146)
+    if let Some(diff) = crate::peers::render_coord_diff(project_id, session_id) {
+        ws = Some(match ws {
+            Some(w) => format!("{w}\n{diff}"),
+            None => diff,
+        });
+    }
+
     if let Some(ws) = ws {
         let wrapped = wrap_context_boundary(&ws);
         // Dedup: skip if identical to last injection
@@ -483,6 +491,8 @@ pub(super) fn cleanup_session_state(project_id: &str, session_id: &str, peers_ac
     let _ = fs::remove_file(state_dir.join(format!("signal_count.{session_id}")));
     // Late peer detection counter (#11)
     let _ = fs::remove_file(state_dir.join(format!("peer_count.{session_id}")));
+    // Coordination diff offset (#146)
+    let _ = fs::remove_file(state_dir.join(format!("coord_offset.{session_id}")));
     // Auto-claim state file (#24)
     crate::peers::remove_autoclaim_state(project_id, session_id);
     // Agent phase state file (#55)
@@ -618,6 +628,12 @@ pub(super) fn dispatch_session_start(
     // re-inject the full protocol on the first prompt after SessionStart (#11).
     let peers = crate::peers::discover_active_peers(project_id, session_id);
     write_peer_count(project_id, session_id, peers.len());
+
+    // Seed coordination offset so first UserPromptSubmit only diffs new events (#146).
+    let coord_path = crate::peers::coordination_path(project_id);
+    if let Ok(meta) = std::fs::metadata(&coord_path) {
+        crate::state::write_coord_offset(project_id, session_id, meta.len());
+    }
 
     // Remaining body sections (truncatable — nice-to-have context).
 

--- a/crates/edda-bridge-claude/src/peers/mod.rs
+++ b/crates/edda-bridge-claude/src/peers/mod.rs
@@ -209,7 +209,7 @@ fn heartbeat_path(project_id: &str, session_id: &str) -> PathBuf {
         .join(format!("session.{session_id}.json"))
 }
 
-fn coordination_path(project_id: &str) -> PathBuf {
+pub(crate) fn coordination_path(project_id: &str) -> PathBuf {
     let dir = edda_store::project_dir(project_id).join("state");
     let new_path = dir.join("coordination.jsonl");
     // One-time migration: rename legacy decisions.jsonl → coordination.jsonl
@@ -244,7 +244,7 @@ pub use heartbeat::{
 };
 pub use helpers::format_age;
 pub(crate) use helpers::{format_peer_suffix, pending_requests_for_session};
-pub(crate) use render_coord::render_peer_updates_with;
+pub(crate) use render_coord::{render_coord_diff, render_peer_updates_with};
 pub use render_coord::{render_coordination_protocol, render_coordination_protocol_with};
 
 #[cfg(test)]

--- a/crates/edda-bridge-claude/src/peers/render_coord.rs
+++ b/crates/edda-bridge-claude/src/peers/render_coord.rs
@@ -4,7 +4,7 @@ use super::autoclaim::derive_scope_from_files;
 use super::board::compute_board_state;
 use super::discovery::discover_active_peers;
 use super::heartbeat::read_heartbeat;
-use super::helpers::{format_age, format_peer_suffix, truncate_to_budget};
+use super::helpers::{self, format_age, format_peer_suffix, truncate_to_budget};
 use super::{
     protocol_budget, BoardState, PeerSummary, RequestEntry, SessionHeartbeat, PEER_UPDATES_BUDGET,
 };
@@ -390,4 +390,132 @@ pub(crate) fn render_peer_updates_with(
     } else {
         Some(result)
     }
+}
+
+// ── Coordination Diff (Real-time Delta Injection) ──
+
+/// Maximum chars for the coordination diff section.
+const COORD_DIFF_BUDGET: usize = 200;
+
+/// Maximum number of events to include in a single diff injection.
+const COORD_DIFF_MAX_EVENTS: usize = 5;
+
+/// Render new coordination events since the last injection for this session.
+///
+/// Reads `coordination.jsonl` from the stored byte offset, parses new lines,
+/// filters out own events and low-priority types, and returns a compact diff.
+/// Updates the offset after reading.
+///
+/// Returns `None` if no new relevant events exist.
+pub(crate) fn render_coord_diff(project_id: &str, session_id: &str) -> Option<String> {
+    use super::{coordination_path, CoordEvent, CoordEventType};
+    use crate::state::{read_coord_offset, write_coord_offset};
+    use std::io::Read;
+
+    let coord_path = coordination_path(project_id);
+    let file_len = std::fs::metadata(&coord_path).ok()?.len();
+
+    // Check if offset was ever seeded (by SessionStart). If not, seed it now
+    // and skip this cycle to avoid injecting all historical events.
+    let offset_path = edda_store::project_dir(project_id)
+        .join("state")
+        .join(format!("coord_offset.{session_id}"));
+    if !offset_path.exists() {
+        write_coord_offset(project_id, session_id, file_len);
+        return None;
+    }
+
+    let offset = read_coord_offset(project_id, session_id);
+
+    // Compaction guard: if file shrank, reset offset
+    let effective_offset = if file_len < offset { 0 } else { offset };
+
+    // No new data
+    if file_len == effective_offset {
+        return None;
+    }
+
+    // Read bytes from offset to EOF
+    let mut file = std::fs::File::open(&coord_path).ok()?;
+    std::io::Seek::seek(&mut file, std::io::SeekFrom::Start(effective_offset)).ok()?;
+    let mut tail = String::new();
+    file.read_to_string(&mut tail).ok()?;
+
+    // Update offset to current file end
+    write_coord_offset(project_id, session_id, file_len);
+
+    let now_epoch = {
+        let now = time::OffsetDateTime::now_utc();
+        now.unix_timestamp() as u64
+    };
+
+    let mut diff_lines: Vec<String> = Vec::new();
+
+    for line in tail.lines() {
+        if diff_lines.len() >= COORD_DIFF_MAX_EVENTS {
+            break;
+        }
+        let event: CoordEvent = match serde_json::from_str(line) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        // Skip own events
+        if event.session_id == session_id {
+            continue;
+        }
+
+        // Skip low-priority event types
+        match event.event_type {
+            CoordEventType::Unclaim
+            | CoordEventType::TaskCompleted
+            | CoordEventType::SubagentCompleted
+            | CoordEventType::RequestAck => continue,
+            _ => {}
+        }
+
+        let age = helpers::parse_rfc3339_to_epoch(&event.ts)
+            .map(|ts| helpers::format_age(now_epoch.saturating_sub(ts)))
+            .unwrap_or_else(|| "just now".to_string());
+
+        let label = event.payload["label"]
+            .as_str()
+            .or_else(|| event.payload["from_label"].as_str())
+            .or_else(|| event.payload["by_label"].as_str())
+            .unwrap_or("peer");
+
+        let rendered = match event.event_type {
+            CoordEventType::Claim => {
+                let paths: Vec<&str> = event.payload["paths"]
+                    .as_array()
+                    .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+                    .unwrap_or_default();
+                format!("- {label} claimed {} ({age})", paths.join(", "))
+            }
+            CoordEventType::Binding => {
+                let key = event.payload["key"].as_str().unwrap_or("?");
+                let value = event.payload["value"].as_str().unwrap_or("?");
+                format!("- {label} decided \"{key}={value}\" ({age})")
+            }
+            CoordEventType::Request => {
+                let msg = event.payload["message"].as_str().unwrap_or("");
+                let to = event.payload["to_label"].as_str().unwrap_or("?");
+                format!("- {label} -> {to}: \"{msg}\" ({age})")
+            }
+            // Already filtered above
+            _ => continue,
+        };
+
+        diff_lines.push(rendered);
+    }
+
+    if diff_lines.is_empty() {
+        return None;
+    }
+
+    let mut result = format!("[coordination update]\n{}", diff_lines.join("\n"));
+    if result.len() > COORD_DIFF_BUDGET {
+        result = helpers::truncate_to_budget(&result, COORD_DIFF_BUDGET);
+    }
+    Some(result)
 }

--- a/crates/edda-bridge-claude/src/peers/tests.rs
+++ b/crates/edda-bridge-claude/src/peers/tests.rs
@@ -2318,3 +2318,106 @@ fn peer_updates_filters_acked_requests() {
     remove_heartbeat(pid, "s2");
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }
+
+// ── Coordination Diff Tests (#146) ──
+
+#[test]
+fn coord_diff_renders_new_events() {
+    let pid = "test_coord_diff_new";
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    // Seed offset at 0 (simulate SessionStart with empty file)
+    crate::state::write_coord_offset(pid, "my-sess", 0);
+
+    // Write events from a different session
+    write_claim(pid, "other-sess", "auth", &["src/auth/*".into()]);
+    write_binding(pid, "other-sess", "auth", "db.engine", "sqlite");
+
+    let diff = render_coord_diff(pid, "my-sess");
+    assert!(diff.is_some(), "should render new events");
+    let text = diff.unwrap();
+    assert!(text.contains("[coordination update]"));
+    assert!(text.contains("auth"));
+    assert!(text.contains("claimed"));
+    assert!(text.contains("db.engine=sqlite"));
+
+    // Second call — no new events, should return None
+    let diff2 = render_coord_diff(pid, "my-sess");
+    assert!(diff2.is_none(), "should return None when no new events");
+
+    let _ = fs::remove_file(coordination_path(pid));
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn coord_diff_filters_own_events() {
+    let pid = "test_coord_diff_own";
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    // Seed offset
+    crate::state::write_coord_offset(pid, "my-sess", 0);
+
+    // Write event from own session
+    write_claim(pid, "my-sess", "auth", &["src/auth/*".into()]);
+
+    let diff = render_coord_diff(pid, "my-sess");
+    assert!(diff.is_none(), "own events should be filtered out");
+
+    let _ = fs::remove_file(coordination_path(pid));
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn coord_diff_compaction_guard() {
+    let pid = "test_coord_diff_compact";
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    // Write some events and set offset past them
+    write_claim(pid, "peer-sess", "api", &["src/api/*".into()]);
+    crate::state::write_coord_offset(pid, "my-sess", 99999);
+
+    // File is smaller than offset → compaction guard triggers, reset to 0
+    let diff = render_coord_diff(pid, "my-sess");
+    assert!(
+        diff.is_some(),
+        "should render events after compaction reset"
+    );
+    let text = diff.unwrap();
+    assert!(text.contains("api"));
+
+    let _ = fs::remove_file(coordination_path(pid));
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn coord_diff_skips_when_no_offset_file() {
+    let pid = "test_coord_diff_no_offset";
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    // Write events but do NOT seed offset (simulates no SessionStart)
+    write_claim(pid, "peer-sess", "api", &["src/api/*".into()]);
+
+    // First call: no offset file exists → seeds offset and returns None
+    let diff = render_coord_diff(pid, "my-sess");
+    assert!(diff.is_none(), "should skip when offset file not seeded");
+
+    // Write more events
+    write_binding(pid, "peer-sess", "api", "api.style", "REST");
+
+    // Second call: offset file now exists, new events since last seed
+    let diff2 = render_coord_diff(pid, "my-sess");
+    assert!(diff2.is_some(), "should render new events after seeding");
+    let text = diff2.unwrap();
+    assert!(text.contains("REST"));
+
+    let _ = fs::remove_file(coordination_path(pid));
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}

--- a/crates/edda-bridge-claude/src/state.rs
+++ b/crates/edda-bridge-claude/src/state.rs
@@ -152,6 +152,27 @@ pub fn write_peer_count(project_id: &str, session_id: &str, count: usize) {
     let _ = fs::write(&path, count.to_string());
 }
 
+// ── Coordination Offset Tracking ──
+
+/// Read the last-seen byte offset into coordination.jsonl for this session.
+pub fn read_coord_offset(project_id: &str, session_id: &str) -> u64 {
+    let path = edda_store::project_dir(project_id)
+        .join("state")
+        .join(format!("coord_offset.{session_id}"));
+    fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(0)
+}
+
+/// Write the current byte offset into coordination.jsonl for this session.
+pub fn write_coord_offset(project_id: &str, session_id: &str, offset: u64) {
+    let path = edda_store::project_dir(project_id)
+        .join("state")
+        .join(format!("coord_offset.{session_id}"));
+    let _ = fs::write(&path, offset.to_string());
+}
+
 // ── Utility ──
 
 fn now_rfc3339() -> String {
@@ -229,6 +250,21 @@ mod tests {
         assert_eq!(read_peer_count(pid, sid), 0);
         write_peer_count(pid, sid, 3);
         assert_eq!(read_peer_count(pid, sid), 3);
+
+        let _ = std::fs::remove_dir_all(edda_store::project_dir(pid));
+    }
+
+    #[test]
+    fn coord_offset_round_trip() {
+        let pid = "test_state_coord_off";
+        let sid = "s1";
+        let _ = edda_store::ensure_dirs(pid);
+
+        assert_eq!(read_coord_offset(pid, sid), 0);
+        write_coord_offset(pid, sid, 1234);
+        assert_eq!(read_coord_offset(pid, sid), 1234);
+        write_coord_offset(pid, sid, 0);
+        assert_eq!(read_coord_offset(pid, sid), 0);
 
         let _ = std::fs::remove_dir_all(edda_store::project_dir(pid));
     }


### PR DESCRIPTION
## Summary
- Add per-session byte offset tracking for `coordination.jsonl` so `UserPromptSubmit` injects only **new** coordination events since last check
- `render_coord_diff()` reads tail bytes from offset, filters own/low-priority events, renders compact diff (`[coordination update]` section)
- Offset seeded at `SessionStart`, cleaned up at `SessionEnd`, with compaction guard and lazy seeding for robustness

## Changes
| File | What |
|------|------|
| `state.rs` | `read_coord_offset` / `write_coord_offset` + test |
| `peers/render_coord.rs` | `render_coord_diff()` with offset tracking, filtering, budget |
| `peers/mod.rs` | Re-export + `coordination_path` visibility bump |
| `dispatch/session.rs` | Integration in dispatch + SessionStart seed + SessionEnd cleanup |
| `peers/tests.rs` | 4 test cases (render, filter, compaction, lazy seed) |

## Design Decisions
- **Byte offset** (not timestamp) for O(1) tail read without full file re-parse
- **Compaction guard**: if file size < stored offset, reset to 0
- **Lazy seeding**: if no offset file exists (SessionStart not called), seed and skip to avoid replaying history
- **200-char budget**, max 5 events per diff injection
- **Self-event filter**: skip events from own session_id
- **Priority filter**: only Claim, Binding, Request (skip Unclaim, TaskCompleted, SubagentCompleted, RequestAck)

## Test plan
- [x] `coord_offset_round_trip` — state file read/write
- [x] `coord_diff_renders_new_events` — renders peer events, returns None on second call
- [x] `coord_diff_filters_own_events` — own session events excluded
- [x] `coord_diff_compaction_guard` — offset reset when file shrinks
- [x] `coord_diff_skips_when_no_offset_file` — lazy seeding behavior
- [x] `user_prompt_submit_dedup_skips_identical_state` — existing dedup test still passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` passes

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)