### PR TITLE
feat(bridge): register TeammateIdle hook for handoff coordination

### DIFF
--- a/crates/edda-bridge-claude/src/admin.rs
+++ b/crates/edda-bridge-claude/src/admin.rs
@@ -19,6 +19,7 @@ const HOOK_EVENTS: &[&str] = &[
     "SubagentStart",
     "SubagentStop",
     "TaskCompleted",
+    "TeammateIdle",
 ];
 
 /// Check if a matcher group (Claude Code hook format) contains a edda hook.

--- a/crates/edda-bridge-claude/src/dispatch/mod.rs
+++ b/crates/edda-bridge-claude/src/dispatch/mod.rs
@@ -297,6 +297,22 @@ pub fn hook_entrypoint_from_stdin(stdin: &str) -> anyhow::Result<HookResult> {
 
             Ok(HookResult::empty())
         }
+        "TeammateIdle" => {
+            let teammate_name = get_str(&raw, "teammate_name");
+            let team_name = get_str(&raw, "team_name");
+
+            // Best-effort: update teammate's heartbeat phase to "idle"
+            if let Some(teammate_sid) =
+                crate::peers::resolve_teammate_session(&project_id, &teammate_name)
+            {
+                crate::peers::update_teammate_phase(&project_id, &teammate_sid, "idle");
+            }
+
+            // Write idle event to coordination.jsonl (always, even if name resolution fails)
+            crate::peers::write_teammate_idle(&project_id, &session_id, &teammate_name, &team_name);
+
+            Ok(HookResult::empty())
+        }
         _ => Ok(HookResult::empty()),
     }
 }

--- a/crates/edda-bridge-claude/src/peers/board.rs
+++ b/crates/edda-bridge-claude/src/peers/board.rs
@@ -92,9 +92,9 @@ pub fn compute_board_state(project_id: &str) -> BoardState {
                     ts: event.ts,
                 });
             }
-            CoordEventType::TaskCompleted => {
-                // TaskCompleted events are informational milestones;
-                // no board-level state aggregation needed yet.
+            CoordEventType::TaskCompleted | CoordEventType::TeammateIdle => {
+                // TaskCompleted and TeammateIdle events are informational;
+                // no board-level state aggregation needed.
             }
             CoordEventType::SubagentCompleted => {
                 let parent_session_id = event.payload["parent_session_id"]

--- a/crates/edda-bridge-claude/src/peers/heartbeat.rs
+++ b/crates/edda-bridge-claude/src/peers/heartbeat.rs
@@ -375,3 +375,56 @@ pub fn find_binding_conflict(
         ts: existing.ts.clone(),
     })
 }
+
+/// Resolve a teammate name to a session_id by scanning active heartbeats.
+/// Returns `None` if no match found (teammate_name doesn't match any label or session_id).
+pub(crate) fn resolve_teammate_session(project_id: &str, teammate_name: &str) -> Option<String> {
+    let state_dir = edda_store::project_dir(project_id).join("state");
+    let entries = fs::read_dir(&state_dir).ok()?;
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !name.starts_with("session.") || !name.ends_with(".json") {
+            continue;
+        }
+        if let Ok(content) = fs::read_to_string(entry.path()) {
+            if let Ok(hb) = serde_json::from_str::<SessionHeartbeat>(&content) {
+                if hb.label == teammate_name || hb.session_id == teammate_name {
+                    return Some(hb.session_id);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Update a teammate's heartbeat phase to the given value.
+/// Used to set phase to "idle" when a TeammateIdle event is received.
+pub(crate) fn update_teammate_phase(project_id: &str, session_id: &str, phase: &str) {
+    let path = heartbeat_path(project_id, session_id);
+    if let Some(mut hb) = read_heartbeat(project_id, session_id) {
+        hb.current_phase = Some(phase.to_string());
+        hb.last_heartbeat = now_rfc3339();
+        if let Ok(data) = serde_json::to_string_pretty(&hb) {
+            let _ = edda_store::write_atomic(&path, data.as_bytes());
+        }
+    }
+}
+
+/// Write a teammate idle event to coordination.jsonl.
+pub(crate) fn write_teammate_idle(
+    project_id: &str,
+    notified_session_id: &str,
+    teammate_name: &str,
+    team_name: &str,
+) {
+    let event = CoordEvent {
+        ts: now_rfc3339(),
+        session_id: notified_session_id.to_string(),
+        event_type: CoordEventType::TeammateIdle,
+        payload: serde_json::json!({
+            "teammate_name": teammate_name,
+            "team_name": team_name,
+        }),
+    };
+    append_coord_event(project_id, &event);
+}

--- a/crates/edda-bridge-claude/src/peers/mod.rs
+++ b/crates/edda-bridge-claude/src/peers/mod.rs
@@ -97,6 +97,7 @@ pub(crate) enum CoordEventType {
     RequestAck,
     SubagentCompleted,
     TaskCompleted,
+    TeammateIdle,
 }
 
 /// A scope claim by a session.
@@ -234,9 +235,9 @@ pub(crate) use autoclaim::{maybe_auto_claim, maybe_auto_claim_file, remove_autoc
 pub use board::{compute_board_state, compute_board_state_for_compaction};
 pub use discovery::{discover_active_peers, discover_all_sessions, infer_session_id};
 pub(crate) use heartbeat::{
-    cleanup_subagent_heartbeats, ensure_heartbeat_exists, read_heartbeat, update_heartbeat_branch,
-    write_heartbeat, write_subagent_completed, write_subagent_heartbeat, write_task_completed,
-    SubagentReport,
+    cleanup_subagent_heartbeats, ensure_heartbeat_exists, read_heartbeat, resolve_teammate_session,
+    update_heartbeat_branch, update_teammate_phase, write_heartbeat, write_subagent_completed,
+    write_subagent_heartbeat, write_task_completed, write_teammate_idle, SubagentReport,
 };
 pub use heartbeat::{
     find_binding_conflict, remove_heartbeat, touch_heartbeat, write_binding, write_claim,

--- a/crates/edda-bridge-claude/src/peers/render_coord.rs
+++ b/crates/edda-bridge-claude/src/peers/render_coord.rs
@@ -480,6 +480,7 @@ pub(crate) fn render_coord_diff(project_id: &str, session_id: &str) -> Option<St
 
         let label = event.payload["label"]
             .as_str()
+            .or_else(|| event.payload["teammate_name"].as_str())
             .or_else(|| event.payload["from_label"].as_str())
             .or_else(|| event.payload["by_label"].as_str())
             .unwrap_or("peer");
@@ -501,6 +502,10 @@ pub(crate) fn render_coord_diff(project_id: &str, session_id: &str) -> Option<St
                 let msg = event.payload["message"].as_str().unwrap_or("");
                 let to = event.payload["to_label"].as_str().unwrap_or("?");
                 format!("- {label} -> {to}: \"{msg}\" ({age})")
+            }
+            CoordEventType::TeammateIdle => {
+                let teammate = event.payload["teammate_name"].as_str().unwrap_or("?");
+                format!("- {teammate} is now idle (available for handoff) ({age})")
             }
             // Already filtered above
             _ => continue,

--- a/crates/edda-bridge-claude/src/peers/tests.rs
+++ b/crates/edda-bridge-claude/src/peers/tests.rs
@@ -2421,3 +2421,83 @@ fn coord_diff_skips_when_no_offset_file() {
     let _ = fs::remove_file(coordination_path(pid));
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }
+
+#[test]
+fn resolve_teammate_by_label() {
+    let pid = "test_resolve_teammate";
+    let sid = "teammate-session-123";
+    let _ = edda_store::ensure_dirs(pid);
+
+    let signals = SessionSignals::default();
+    write_heartbeat(pid, sid, &signals, Some("worker-auth"));
+
+    // Should resolve by label
+    let resolved = resolve_teammate_session(pid, "worker-auth");
+    assert_eq!(resolved, Some(sid.to_string()));
+
+    // Should resolve by session_id
+    let resolved2 = resolve_teammate_session(pid, sid);
+    assert_eq!(resolved2, Some(sid.to_string()));
+
+    // Should return None for nonexistent
+    let resolved3 = resolve_teammate_session(pid, "nonexistent");
+    assert!(resolved3.is_none());
+
+    // Cleanup
+    remove_heartbeat(pid, sid);
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn teammate_idle_writes_coord_event_and_updates_phase() {
+    let pid = "test_teammate_idle";
+    let notifier_sid = "notifier-session";
+    let teammate_sid = "teammate-session";
+    let _ = edda_store::ensure_dirs(pid);
+
+    // Clean up any existing coordination file
+    let _ = fs::remove_file(coordination_path(pid));
+
+    // Setup: create a heartbeat for the teammate
+    let signals = SessionSignals::default();
+    write_heartbeat(pid, teammate_sid, &signals, Some("worker-auth"));
+
+    // Verify teammate starts without "idle" phase
+    let hb_before = read_heartbeat(pid, teammate_sid).expect("heartbeat should exist");
+    assert_ne!(hb_before.current_phase.as_deref(), Some("idle"));
+
+    // Update teammate phase to "idle"
+    update_teammate_phase(pid, teammate_sid, "idle");
+
+    // Verify heartbeat phase is now "idle"
+    let hb_after = read_heartbeat(pid, teammate_sid).expect("heartbeat should exist");
+    assert_eq!(hb_after.current_phase.as_deref(), Some("idle"));
+
+    // Write teammate idle event
+    write_teammate_idle(pid, notifier_sid, "worker-auth", "team-alpha");
+
+    // Verify coordination.jsonl contains the event
+    let coord_content =
+        fs::read_to_string(coordination_path(pid)).expect("coord file should exist");
+    assert!(
+        coord_content.contains("teammate_idle"),
+        "should contain teammate_idle event type"
+    );
+    assert!(
+        coord_content.contains("worker-auth"),
+        "should contain teammate_name"
+    );
+    assert!(
+        coord_content.contains("team-alpha"),
+        "should contain team_name"
+    );
+
+    // Board state should not crash on the new event type
+    let board = compute_board_state(pid);
+    assert!(board.claims.is_empty());
+
+    // Cleanup
+    remove_heartbeat(pid, teammate_sid);
+    let _ = fs::remove_file(coordination_path(pid));
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}


### PR DESCRIPTION
## Summary

- Register `TeammateIdle` in `HOOK_EVENTS` so `edda install` subscribes to idle notifications from Claude Code
- Add `TeammateIdle` variant to `CoordEventType` for coordination log serialization
- Add dispatch branch: resolve `teammate_name` to session_id via heartbeat scan, update phase to "idle", write event to `coordination.jsonl`
- Add `resolve_teammate_session()` for best-effort name-to-session mapping (matches label or session_id)
- Render idle events in coord diff so peers see availability notifications at next `UserPromptSubmit`
- Handle new variant in board state computation (informational, no aggregation needed)

Closes #144

## Test plan

- [x] `resolve_teammate_by_label` — verifies name resolution by label, session_id, and nonexistent name
- [x] `teammate_idle_writes_coord_event_and_updates_phase` — verifies heartbeat phase update, coordination event write, and board state compatibility
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` passes
- [x] Pre-existing test failure (`post_tool_use_increments_nudge_counter`) confirmed unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)