### PR TITLE
feat(metrics): cross-project metrics dashboard

### DIFF
--- a/crates/edda-aggregate/src/aggregate.rs
+++ b/crates/edda-aggregate/src/aggregate.rs
@@ -369,6 +369,225 @@ pub fn file_edits_by_date(
     result
 }
 
+/// Aggregate execution event cost by date (YYYY-MM-DD) across all projects.
+pub fn cost_by_date(projects: &[ProjectEntry], range: &DateRange) -> BTreeMap<String, f64> {
+    let mut costs: BTreeMap<String, f64> = BTreeMap::new();
+
+    for entry in projects {
+        let root = Path::new(&entry.path);
+        let ledger = match Ledger::open(root) {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        let events = match ledger.iter_events() {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        for event in &events {
+            if event.event_type != "execution_event" {
+                continue;
+            }
+            if !range.matches(&event.ts) {
+                continue;
+            }
+            let cost = event
+                .payload
+                .get("usage")
+                .and_then(|u| u.get("cost_usd"))
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0);
+            if cost > 0.0 {
+                let date = &event.ts[..10.min(event.ts.len())];
+                *costs.entry(date.to_string()).or_insert(0.0) += cost;
+            }
+        }
+    }
+
+    costs
+}
+
+/// Aggregate execution event quality by date (YYYY-MM-DD) across all projects.
+///
+/// Returns `BTreeMap<date, (success_count, total_count)>`.
+pub fn quality_by_date(
+    projects: &[ProjectEntry],
+    range: &DateRange,
+) -> BTreeMap<String, (u64, u64)> {
+    let mut quality: BTreeMap<String, (u64, u64)> = BTreeMap::new();
+
+    for entry in projects {
+        let root = Path::new(&entry.path);
+        let ledger = match Ledger::open(root) {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        let events = match ledger.iter_events() {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        for event in &events {
+            if event.event_type != "execution_event" {
+                continue;
+            }
+            if !range.matches(&event.ts) {
+                continue;
+            }
+            let status = event
+                .payload
+                .get("result")
+                .and_then(|r| r.get("status"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+
+            let date = &event.ts[..10.min(event.ts.len())];
+            let entry = quality.entry(date.to_string()).or_insert((0, 0));
+            if status == "success" {
+                entry.0 += 1;
+            }
+            entry.1 += 1;
+        }
+    }
+
+    quality
+}
+
+/// Per-project metrics with cost, quality, and activity breakdown.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectMetrics {
+    pub project_id: String,
+    pub name: String,
+    pub group: Option<String>,
+    pub activity: ActivityMetrics,
+    pub cost: CostMetrics,
+    pub quality: QualityMetrics,
+}
+
+/// Activity counts for a project within a time range.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActivityMetrics {
+    pub events: usize,
+    pub commits: usize,
+    pub decisions: usize,
+    pub sessions: usize,
+}
+
+/// Per-model cost breakdown entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelCost {
+    pub model: String,
+    pub cost_usd: f64,
+    pub steps: u64,
+}
+
+/// Cost metrics for a project within a time range.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CostMetrics {
+    pub total_usd: f64,
+    pub daily_avg_usd: f64,
+    pub by_model: Vec<ModelCost>,
+}
+
+/// Quality metrics for a project within a time range.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QualityMetrics {
+    pub success_rate: f64,
+    pub avg_latency_ms: f64,
+    pub total_steps: u64,
+}
+
+/// Compute per-project metrics for all given projects within the specified date range.
+pub fn per_project_metrics(
+    projects: &[ProjectEntry],
+    range: &DateRange,
+    days: usize,
+) -> Vec<ProjectMetrics> {
+    use crate::quality::model_quality_from_events;
+
+    let mut results = Vec::new();
+
+    for entry in projects {
+        let root = Path::new(&entry.path);
+        let ledger = match Ledger::open(root) {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        let events = match ledger.iter_events() {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        let filtered: Vec<&Event> = events.iter().filter(|e| range.matches(&e.ts)).collect();
+        let commit_count = filtered.iter().filter(|e| e.event_type == "commit").count();
+        let decision_count = filtered
+            .iter()
+            .filter(|e| e.event_type == "note" && edda_core::decision::is_decision(&e.payload))
+            .count();
+        let session_count = count_unique_sessions(&filtered);
+
+        // Quality: filter execution events and compute
+        let exec_events: Vec<Event> = events
+            .iter()
+            .filter(|e| e.event_type == "execution_event" && range.matches(&e.ts))
+            .cloned()
+            .collect();
+        let quality_report = model_quality_from_events(&exec_events, range);
+
+        let by_model: Vec<ModelCost> = quality_report
+            .models
+            .iter()
+            .map(|m| ModelCost {
+                model: m.model.clone(),
+                cost_usd: m.total_cost_usd,
+                steps: m.total_steps,
+            })
+            .collect();
+
+        let daily_avg = if days > 0 {
+            quality_report.total_cost_usd / days as f64
+        } else {
+            0.0
+        };
+
+        results.push(ProjectMetrics {
+            project_id: entry.project_id.clone(),
+            name: entry.name.clone(),
+            group: entry.group.clone(),
+            activity: ActivityMetrics {
+                events: filtered.len(),
+                commits: commit_count,
+                decisions: decision_count,
+                sessions: session_count,
+            },
+            cost: CostMetrics {
+                total_usd: quality_report.total_cost_usd,
+                daily_avg_usd: daily_avg,
+                by_model,
+            },
+            quality: QualityMetrics {
+                success_rate: quality_report.overall_success_rate,
+                avg_latency_ms: if quality_report.total_steps > 0 {
+                    quality_report
+                        .models
+                        .iter()
+                        .map(|m| m.avg_latency_ms * m.total_steps as f64)
+                        .sum::<f64>()
+                        / quality_report.total_steps as f64
+                } else {
+                    0.0
+                },
+                total_steps: quality_report.total_steps,
+            },
+        });
+    }
+
+    results
+}
+
 /// Count unique session IDs from events.
 fn count_unique_sessions(events: &[&Event]) -> usize {
     let mut sessions = std::collections::HashSet::new();

--- a/crates/edda-aggregate/src/aggregate.rs
+++ b/crates/edda-aggregate/src/aggregate.rs
@@ -488,6 +488,9 @@ pub struct ModelCost {
 pub struct CostMetrics {
     pub total_usd: f64,
     pub daily_avg_usd: f64,
+    /// Cost of the most recent day in the period (for anomaly detection).
+    #[serde(default)]
+    pub last_day_usd: f64,
     pub by_model: Vec<ModelCost>,
 }
 
@@ -553,6 +556,25 @@ pub fn per_project_metrics(
             0.0
         };
 
+        // Compute per-day costs to find the most recent day's cost
+        let last_day_usd = {
+            let mut day_costs: BTreeMap<&str, f64> = BTreeMap::new();
+            for event in &exec_events {
+                let cost = event
+                    .payload
+                    .get("usage")
+                    .and_then(|u| u.get("cost_usd"))
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(0.0);
+                if cost > 0.0 {
+                    let date = &event.ts[..10.min(event.ts.len())];
+                    *day_costs.entry(date).or_insert(0.0) += cost;
+                }
+            }
+            // Last entry in BTreeMap is the most recent date
+            day_costs.values().last().copied().unwrap_or(0.0)
+        };
+
         results.push(ProjectMetrics {
             project_id: entry.project_id.clone(),
             name: entry.name.clone(),
@@ -566,6 +588,7 @@ pub fn per_project_metrics(
             cost: CostMetrics {
                 total_usd: quality_report.total_cost_usd,
                 daily_avg_usd: daily_avg,
+                last_day_usd,
                 by_model,
             },
             quality: QualityMetrics {

--- a/crates/edda-aggregate/src/rollup.rs
+++ b/crates/edda-aggregate/src/rollup.rs
@@ -36,6 +36,15 @@ pub struct DayStat {
     /// Per-file edit statistics for this day.
     #[serde(default)]
     pub file_edits: Vec<FileEditStat>,
+    /// Total cost in USD from execution events.
+    #[serde(default)]
+    pub cost_usd: f64,
+    /// Number of execution events.
+    #[serde(default)]
+    pub execution_count: u64,
+    /// Number of successful execution events.
+    #[serde(default)]
+    pub success_count: u64,
 }
 
 /// Weekly statistics.
@@ -47,6 +56,15 @@ pub struct WeekStat {
     /// Per-file edit statistics for this week.
     #[serde(default)]
     pub file_edits: Vec<FileEditStat>,
+    /// Total cost in USD from execution events.
+    #[serde(default)]
+    pub cost_usd: f64,
+    /// Number of execution events.
+    #[serde(default)]
+    pub execution_count: u64,
+    /// Number of successful execution events.
+    #[serde(default)]
+    pub success_count: u64,
 }
 
 /// Monthly statistics.
@@ -58,6 +76,15 @@ pub struct MonthStat {
     /// Per-file edit statistics for this month.
     #[serde(default)]
     pub file_edits: Vec<FileEditStat>,
+    /// Total cost in USD from execution events.
+    #[serde(default)]
+    pub cost_usd: f64,
+    /// Number of execution events.
+    #[serde(default)]
+    pub execution_count: u64,
+    /// Number of successful execution events.
+    #[serde(default)]
+    pub success_count: u64,
 }
 
 /// The full rollup cache.
@@ -106,8 +133,16 @@ pub fn compute_rollup(projects: &[ProjectEntry], range: &DateRange, tool: &str) 
     let events_map = aggregate::events_by_date(projects, range);
     let commits_map = aggregate::commits_by_date(projects, range);
     let file_edits_map = aggregate::file_edits_by_date(projects, range);
+    let cost_map = aggregate::cost_by_date(projects, range);
+    let quality_map = aggregate::quality_by_date(projects, range);
 
-    let daily = build_daily_stats(&events_map, &commits_map, &file_edits_map);
+    let daily = build_daily_stats(
+        &events_map,
+        &commits_map,
+        &file_edits_map,
+        &cost_map,
+        &quality_map,
+    );
     let weekly = build_weekly_stats(&daily);
     let monthly = build_monthly_stats(&daily);
 
@@ -187,6 +222,8 @@ fn build_daily_stats(
     events_map: &BTreeMap<String, usize>,
     commits_map: &BTreeMap<String, usize>,
     file_edits_map: &BTreeMap<String, Vec<FileEditStat>>,
+    cost_map: &BTreeMap<String, f64>,
+    quality_map: &BTreeMap<String, (u64, u64)>,
 ) -> Vec<DayStat> {
     let mut all_dates: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
     for key in events_map.keys() {
@@ -198,65 +235,105 @@ fn build_daily_stats(
     for key in file_edits_map.keys() {
         all_dates.insert(key.as_str());
     }
+    for key in cost_map.keys() {
+        all_dates.insert(key.as_str());
+    }
+    for key in quality_map.keys() {
+        all_dates.insert(key.as_str());
+    }
 
     all_dates
         .into_iter()
-        .map(|date| DayStat {
-            date: date.to_string(),
-            events: events_map.get(date).copied().unwrap_or(0),
-            commits: commits_map.get(date).copied().unwrap_or(0),
-            sessions: 0,
-            file_edits: file_edits_map.get(date).cloned().unwrap_or_default(),
+        .map(|date| {
+            let (success_count, execution_count) = quality_map.get(date).copied().unwrap_or((0, 0));
+            DayStat {
+                date: date.to_string(),
+                events: events_map.get(date).copied().unwrap_or(0),
+                commits: commits_map.get(date).copied().unwrap_or(0),
+                sessions: 0,
+                file_edits: file_edits_map.get(date).cloned().unwrap_or_default(),
+                cost_usd: cost_map.get(date).copied().unwrap_or(0.0),
+                execution_count,
+                success_count,
+            }
         })
         .collect()
 }
 
+/// Accumulator for aggregating stats: (events, commits, file_edits, cost_usd, exec_count, success_count).
+type StatAccum = (usize, usize, Vec<FileEditStat>, f64, u64, u64);
+
 /// Build weekly stats from daily stats.
 fn build_weekly_stats(daily: &[DayStat]) -> Vec<WeekStat> {
-    let mut weekly_map: BTreeMap<String, (usize, usize, Vec<FileEditStat>)> = BTreeMap::new();
+    let mut weekly_map: BTreeMap<String, StatAccum> = BTreeMap::new();
 
     for d in daily {
         if let Some(week_start) = iso_week_start(&d.date) {
-            let entry = weekly_map.entry(week_start).or_insert((0, 0, Vec::new()));
+            let entry = weekly_map
+                .entry(week_start)
+                .or_insert((0, 0, Vec::new(), 0.0, 0, 0));
             entry.0 += d.events;
             entry.1 += d.commits;
             merge_file_edits(&mut entry.2, &d.file_edits);
+            entry.3 += d.cost_usd;
+            entry.4 += d.execution_count;
+            entry.5 += d.success_count;
         }
     }
 
     weekly_map
         .into_iter()
-        .map(|(week_start, (events, commits, file_edits))| WeekStat {
-            week_start,
-            events,
-            commits,
-            file_edits,
-        })
+        .map(
+            |(
+                week_start,
+                (events, commits, file_edits, cost_usd, execution_count, success_count),
+            )| {
+                WeekStat {
+                    week_start,
+                    events,
+                    commits,
+                    file_edits,
+                    cost_usd,
+                    execution_count,
+                    success_count,
+                }
+            },
+        )
         .collect()
 }
 
 /// Build monthly stats from daily stats.
 fn build_monthly_stats(daily: &[DayStat]) -> Vec<MonthStat> {
-    let mut monthly_map: BTreeMap<String, (usize, usize, Vec<FileEditStat>)> = BTreeMap::new();
+    let mut monthly_map: BTreeMap<String, StatAccum> = BTreeMap::new();
 
     for d in daily {
         let month = &d.date[..7.min(d.date.len())];
         let entry = monthly_map
             .entry(month.to_string())
-            .or_insert((0, 0, Vec::new()));
+            .or_insert((0, 0, Vec::new(), 0.0, 0, 0));
         entry.0 += d.events;
         entry.1 += d.commits;
         merge_file_edits(&mut entry.2, &d.file_edits);
+        entry.3 += d.cost_usd;
+        entry.4 += d.execution_count;
+        entry.5 += d.success_count;
     }
 
     monthly_map
         .into_iter()
-        .map(|(month, (events, commits, file_edits))| MonthStat {
-            month,
-            events,
-            commits,
-            file_edits,
-        })
+        .map(
+            |(month, (events, commits, file_edits, cost_usd, execution_count, success_count))| {
+                MonthStat {
+                    month,
+                    events,
+                    commits,
+                    file_edits,
+                    cost_usd,
+                    execution_count,
+                    success_count,
+                }
+            },
+        )
         .collect()
 }
 
@@ -322,15 +399,13 @@ mod tests {
                     date: "2026-03-01".into(),
                     events: 5,
                     commits: 1,
-                    sessions: 0,
-                    file_edits: vec![],
+                    ..Default::default()
                 },
                 DayStat {
                     date: "2026-03-02".into(),
                     events: 3,
                     commits: 0,
-                    sessions: 0,
-                    file_edits: vec![],
+                    ..Default::default()
                 },
             ],
             weekly: vec![],
@@ -344,15 +419,13 @@ mod tests {
                     date: "2026-03-02".into(),
                     events: 10,
                     commits: 2,
-                    sessions: 0,
-                    file_edits: vec![],
+                    ..Default::default()
                 },
                 DayStat {
                     date: "2026-03-03".into(),
                     events: 7,
                     commits: 3,
-                    sessions: 0,
-                    file_edits: vec![],
+                    ..Default::default()
                 },
             ],
             weekly: vec![],
@@ -383,8 +456,10 @@ mod tests {
         commits.insert("2026-03-03".to_string(), 1);
 
         let file_edits = BTreeMap::new();
+        let cost_map = BTreeMap::new();
+        let quality_map = BTreeMap::new();
 
-        let daily = build_daily_stats(&events, &commits, &file_edits);
+        let daily = build_daily_stats(&events, &commits, &file_edits, &cost_map, &quality_map);
         assert_eq!(daily.len(), 3);
         assert_eq!(daily[0].date, "2026-03-01");
         assert_eq!(daily[0].events, 5);
@@ -399,6 +474,71 @@ mod tests {
         let stat: DayStat = serde_json::from_str(json).unwrap();
         assert_eq!(stat.date, "2026-03-01");
         assert!(stat.file_edits.is_empty());
+        // New fields default to zero
+        assert_eq!(stat.cost_usd, 0.0);
+        assert_eq!(stat.execution_count, 0);
+        assert_eq!(stat.success_count, 0);
+    }
+
+    #[test]
+    fn backward_compat_weekstat_without_cost_fields() {
+        let json = r#"{"week_start":"2026-03-02","events":10,"commits":3}"#;
+        let stat: WeekStat = serde_json::from_str(json).unwrap();
+        assert_eq!(stat.week_start, "2026-03-02");
+        assert_eq!(stat.cost_usd, 0.0);
+        assert_eq!(stat.execution_count, 0);
+        assert_eq!(stat.success_count, 0);
+    }
+
+    #[test]
+    fn build_daily_stats_includes_cost_quality() {
+        let mut events = BTreeMap::new();
+        events.insert("2026-03-01".to_string(), 5);
+
+        let commits = BTreeMap::new();
+        let file_edits = BTreeMap::new();
+
+        let mut cost_map = BTreeMap::new();
+        cost_map.insert("2026-03-01".to_string(), 0.05);
+
+        let mut quality_map = BTreeMap::new();
+        quality_map.insert("2026-03-01".to_string(), (8u64, 10u64));
+
+        let daily = build_daily_stats(&events, &commits, &file_edits, &cost_map, &quality_map);
+        assert_eq!(daily.len(), 1);
+        assert!((daily[0].cost_usd - 0.05).abs() < 1e-9);
+        assert_eq!(daily[0].execution_count, 10);
+        assert_eq!(daily[0].success_count, 8);
+    }
+
+    #[test]
+    fn weekly_stats_sum_cost_quality() {
+        let daily = vec![
+            DayStat {
+                date: "2026-03-02".into(),
+                events: 5,
+                commits: 1,
+                cost_usd: 0.10,
+                execution_count: 5,
+                success_count: 4,
+                ..Default::default()
+            },
+            DayStat {
+                date: "2026-03-03".into(),
+                events: 3,
+                commits: 0,
+                cost_usd: 0.05,
+                execution_count: 3,
+                success_count: 3,
+                ..Default::default()
+            },
+        ];
+
+        let weekly = build_weekly_stats(&daily);
+        assert_eq!(weekly.len(), 1);
+        assert!((weekly[0].cost_usd - 0.15).abs() < 1e-9);
+        assert_eq!(weekly[0].execution_count, 8);
+        assert_eq!(weekly[0].success_count, 7);
     }
 
     #[test]

--- a/crates/edda-aggregate/src/rollup.rs
+++ b/crates/edda-aggregate/src/rollup.rs
@@ -260,8 +260,16 @@ fn build_daily_stats(
         .collect()
 }
 
-/// Accumulator for aggregating stats: (events, commits, file_edits, cost_usd, exec_count, success_count).
-type StatAccum = (usize, usize, Vec<FileEditStat>, f64, u64, u64);
+/// Accumulator for aggregating stats across days into weekly/monthly buckets.
+#[derive(Default)]
+struct StatAccum {
+    events: usize,
+    commits: usize,
+    file_edits: Vec<FileEditStat>,
+    cost_usd: f64,
+    execution_count: u64,
+    success_count: u64,
+}
 
 /// Build weekly stats from daily stats.
 fn build_weekly_stats(daily: &[DayStat]) -> Vec<WeekStat> {
@@ -269,36 +277,27 @@ fn build_weekly_stats(daily: &[DayStat]) -> Vec<WeekStat> {
 
     for d in daily {
         if let Some(week_start) = iso_week_start(&d.date) {
-            let entry = weekly_map
-                .entry(week_start)
-                .or_insert((0, 0, Vec::new(), 0.0, 0, 0));
-            entry.0 += d.events;
-            entry.1 += d.commits;
-            merge_file_edits(&mut entry.2, &d.file_edits);
-            entry.3 += d.cost_usd;
-            entry.4 += d.execution_count;
-            entry.5 += d.success_count;
+            let entry = weekly_map.entry(week_start).or_default();
+            entry.events += d.events;
+            entry.commits += d.commits;
+            merge_file_edits(&mut entry.file_edits, &d.file_edits);
+            entry.cost_usd += d.cost_usd;
+            entry.execution_count += d.execution_count;
+            entry.success_count += d.success_count;
         }
     }
 
     weekly_map
         .into_iter()
-        .map(
-            |(
-                week_start,
-                (events, commits, file_edits, cost_usd, execution_count, success_count),
-            )| {
-                WeekStat {
-                    week_start,
-                    events,
-                    commits,
-                    file_edits,
-                    cost_usd,
-                    execution_count,
-                    success_count,
-                }
-            },
-        )
+        .map(|(week_start, acc)| WeekStat {
+            week_start,
+            events: acc.events,
+            commits: acc.commits,
+            file_edits: acc.file_edits,
+            cost_usd: acc.cost_usd,
+            execution_count: acc.execution_count,
+            success_count: acc.success_count,
+        })
         .collect()
 }
 
@@ -308,32 +307,26 @@ fn build_monthly_stats(daily: &[DayStat]) -> Vec<MonthStat> {
 
     for d in daily {
         let month = &d.date[..7.min(d.date.len())];
-        let entry = monthly_map
-            .entry(month.to_string())
-            .or_insert((0, 0, Vec::new(), 0.0, 0, 0));
-        entry.0 += d.events;
-        entry.1 += d.commits;
-        merge_file_edits(&mut entry.2, &d.file_edits);
-        entry.3 += d.cost_usd;
-        entry.4 += d.execution_count;
-        entry.5 += d.success_count;
+        let entry = monthly_map.entry(month.to_string()).or_default();
+        entry.events += d.events;
+        entry.commits += d.commits;
+        merge_file_edits(&mut entry.file_edits, &d.file_edits);
+        entry.cost_usd += d.cost_usd;
+        entry.execution_count += d.execution_count;
+        entry.success_count += d.success_count;
     }
 
     monthly_map
         .into_iter()
-        .map(
-            |(month, (events, commits, file_edits, cost_usd, execution_count, success_count))| {
-                MonthStat {
-                    month,
-                    events,
-                    commits,
-                    file_edits,
-                    cost_usd,
-                    execution_count,
-                    success_count,
-                }
-            },
-        )
+        .map(|(month, acc)| MonthStat {
+            month,
+            events: acc.events,
+            commits: acc.commits,
+            file_edits: acc.file_edits,
+            cost_usd: acc.cost_usd,
+            execution_count: acc.execution_count,
+            success_count: acc.success_count,
+        })
         .collect()
 }
 

--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -1628,7 +1628,6 @@ async fn post_approve_controls_patch(
     Ok(Json(patch))
 }
 
-
 // ── GET /api/metrics/overview ──
 
 fn default_overview_days() -> usize {
@@ -1845,7 +1844,6 @@ async fn get_metrics_trends(
         granularity: params.granularity,
         data,
     }))
->>>>>>> 2677ce3 (feat(metrics): cross-project metrics dashboard (#199))
 }
 
 // ── POST /api/scope/check ──
@@ -2549,9 +2547,9 @@ fn compute_attention(
     if days > 0 {
         for pm in project_metrics {
             let daily_avg = pm.cost.daily_avg_usd;
-            if daily_avg > 0.0 && pm.cost.total_usd > 0.0 {
-                // Estimate today's cost as total / days (rough approximation)
-                let last_day_cost = pm.cost.total_usd / days as f64;
+            if daily_avg > 0.0 && pm.cost.last_day_usd > 0.0 {
+                // Use the actual most-recent-day cost from rollup data
+                let last_day_cost = pm.cost.last_day_usd;
                 if last_day_cost > daily_avg * 5.0 {
                     red.push(OverviewRedItem {
                         project: pm.name.clone(),
@@ -4957,5 +4955,116 @@ actors:
             .unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].payload["device_id"], "iphone-14-xyz");
+    }
+
+    #[test]
+    fn cost_anomaly_detection_yellow_and_red() {
+        use edda_aggregate::aggregate::{
+            ActivityMetrics, CostMetrics, ProjectMetrics, QualityMetrics,
+        };
+
+        let range = DateRange {
+            after: Some("2026-03-01".to_string()),
+            before: Some("2026-03-08".to_string()),
+        };
+
+        // Project with 6x spike on last day → should be red
+        let red_project = ProjectMetrics {
+            project_id: "proj-red".to_string(),
+            name: "red-spike".to_string(),
+            group: None,
+            activity: ActivityMetrics {
+                events: 10,
+                commits: 2,
+                decisions: 0,
+                sessions: 1,
+            },
+            cost: CostMetrics {
+                total_usd: 0.70,
+                daily_avg_usd: 0.10,
+                last_day_usd: 0.60, // 6x the daily avg
+                by_model: vec![],
+            },
+            quality: QualityMetrics {
+                success_rate: 1.0,
+                avg_latency_ms: 0.0,
+                total_steps: 10,
+            },
+        };
+
+        // Project with 3x spike on last day → should be yellow
+        let yellow_project = ProjectMetrics {
+            project_id: "proj-yellow".to_string(),
+            name: "yellow-spike".to_string(),
+            group: None,
+            activity: ActivityMetrics {
+                events: 10,
+                commits: 2,
+                decisions: 0,
+                sessions: 1,
+            },
+            cost: CostMetrics {
+                total_usd: 0.40,
+                daily_avg_usd: 0.10,
+                last_day_usd: 0.30, // 3x the daily avg
+                by_model: vec![],
+            },
+            quality: QualityMetrics {
+                success_rate: 1.0,
+                avg_latency_ms: 0.0,
+                total_steps: 10,
+            },
+        };
+
+        // Project with normal cost → should not trigger
+        let normal_project = ProjectMetrics {
+            project_id: "proj-normal".to_string(),
+            name: "normal".to_string(),
+            group: None,
+            activity: ActivityMetrics {
+                events: 10,
+                commits: 2,
+                decisions: 0,
+                sessions: 1,
+            },
+            cost: CostMetrics {
+                total_usd: 0.70,
+                daily_avg_usd: 0.10,
+                last_day_usd: 0.10, // exactly average
+                by_model: vec![],
+            },
+            quality: QualityMetrics {
+                success_rate: 1.0,
+                avg_latency_ms: 0.0,
+                total_steps: 10,
+            },
+        };
+
+        let metrics = vec![red_project, yellow_project, normal_project];
+        let result = compute_attention(&[], &[], &range, &metrics, 7);
+
+        // Red should contain the 6x spike project
+        let red_names: Vec<&str> = result.red.iter().map(|r| r.project.as_str()).collect();
+        assert!(
+            red_names.contains(&"red-spike"),
+            "Expected red-spike in red items, got: {red_names:?}"
+        );
+
+        // Yellow should contain the 3x spike project
+        let yellow_names: Vec<&str> = result.yellow.iter().map(|y| y.project.as_str()).collect();
+        assert!(
+            yellow_names.contains(&"yellow-spike"),
+            "Expected yellow-spike in yellow items, got: {yellow_names:?}"
+        );
+
+        // Normal project should not appear in red or yellow
+        assert!(
+            !red_names.contains(&"normal"),
+            "Normal project should not be in red"
+        );
+        assert!(
+            !yellow_names.contains(&"normal"),
+            "Normal project should not be in yellow"
+        );
     }
 }

--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -13,11 +13,14 @@ use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 use tower_http::cors::CorsLayer;
 
-use edda_aggregate::aggregate::{aggregate_decisions, aggregate_overview, DateRange};
+use edda_aggregate::aggregate::{
+    aggregate_decisions, aggregate_overview, per_project_metrics, DateRange, ProjectMetrics,
+};
 use edda_aggregate::controls::evaluate_controls_rules;
 use edda_aggregate::graph::build_dependency_graph;
 use edda_aggregate::quality::{model_quality_from_events, QualityReport};
 use edda_aggregate::risk::{compute_decision_risks, DecisionInput, DecisionRisk};
+use edda_aggregate::rollup;
 use edda_core::agent_phase::{mobile_context_summary, AgentPhaseState};
 use edda_core::event::{
     finalize_event, new_approval_event, new_decision_event, new_execution_event, new_note_event,
@@ -160,6 +163,8 @@ pub async fn serve(repo_root: &Path, config: ServeConfig) -> anyhow::Result<()> 
         .route("/api/overview", get(get_overview))
         .route("/api/projects", get(get_projects))
         .route("/api/metrics/quality", get(get_quality_metrics))
+        .route("/api/metrics/overview", get(get_metrics_overview))
+        .route("/api/metrics/trends", get(get_metrics_trends))
         .route("/api/dashboard", get(get_dashboard))
         .route("/dashboard", get(serve_dashboard))
         .route("/api/actors", get(get_actors))
@@ -228,6 +233,8 @@ pub fn router(repo_root: &Path) -> Router {
         .route("/api/briefs", get(get_briefs))
         .route("/api/briefs/{task_id}", get(get_brief))
         .route("/api/metrics/quality", get(get_quality_metrics))
+        .route("/api/metrics/overview", get(get_metrics_overview))
+        .route("/api/metrics/trends", get(get_metrics_trends))
         .route("/api/dashboard", get(get_dashboard))
         .route("/api/sync", post(post_sync))
         .route("/dashboard", get(serve_dashboard))
@@ -1402,7 +1409,7 @@ async fn get_overview(
         &std::collections::HashSet::new(),
     );
 
-    let response = compute_attention(&risks, &projects, &range);
+    let response = compute_attention(&risks, &projects, &range, &[], 7);
     Ok(Json(response))
 }
 
@@ -1619,6 +1626,226 @@ async fn post_approve_controls_patch(
 
     let patch = edda_bridge_claude::controls_suggest::approve_patch(&project_id, &patch_id, &by)?;
     Ok(Json(patch))
+}
+
+
+// ── GET /api/metrics/overview ──
+
+fn default_overview_days() -> usize {
+    30
+}
+
+#[derive(Deserialize)]
+struct MetricsOverviewQuery {
+    #[serde(default = "default_overview_days")]
+    days: usize,
+    group: Option<String>,
+}
+
+#[derive(Serialize)]
+struct MetricsOverviewResponse {
+    period: DashboardPeriod,
+    projects: Vec<ProjectMetrics>,
+    totals: MetricsTotals,
+}
+
+#[derive(Serialize)]
+struct MetricsTotals {
+    total_cost_usd: f64,
+    total_events: usize,
+    total_commits: usize,
+    total_steps: u64,
+    overall_success_rate: f64,
+}
+
+async fn get_metrics_overview(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<MetricsOverviewQuery>,
+) -> Result<Json<MetricsOverviewResponse>, AppError> {
+    if state.chronicle.is_none() {
+        return Err(anyhow::anyhow!("chronicle feature not enabled").into());
+    }
+
+    let all_projects = list_projects();
+    let projects: Vec<_> = if let Some(ref group) = params.group {
+        all_projects
+            .into_iter()
+            .filter(|p| p.group.as_deref() == Some(group.as_str()))
+            .collect()
+    } else {
+        all_projects
+    };
+
+    let now = time::OffsetDateTime::now_utc();
+    let from_date = now - time::Duration::days(params.days as i64);
+    let to_str = now
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_default();
+    let from_str = from_date
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_default();
+
+    let range = DateRange {
+        after: Some(from_str[..10].to_string()),
+        before: None,
+    };
+
+    let metrics = per_project_metrics(&projects, &range, params.days);
+
+    let total_cost: f64 = metrics.iter().map(|m| m.cost.total_usd).sum();
+    let total_events: usize = metrics.iter().map(|m| m.activity.events).sum();
+    let total_commits: usize = metrics.iter().map(|m| m.activity.commits).sum();
+    let total_steps: u64 = metrics.iter().map(|m| m.quality.total_steps).sum();
+    let total_success: u64 = metrics
+        .iter()
+        .map(|m| (m.quality.success_rate * m.quality.total_steps as f64) as u64)
+        .sum();
+
+    let period = DashboardPeriod {
+        from: from_str[..10].to_string(),
+        to: to_str[..10].to_string(),
+        days: params.days,
+    };
+
+    Ok(Json(MetricsOverviewResponse {
+        period,
+        projects: metrics,
+        totals: MetricsTotals {
+            total_cost_usd: total_cost,
+            total_events,
+            total_commits,
+            total_steps,
+            overall_success_rate: if total_steps > 0 {
+                total_success as f64 / total_steps as f64
+            } else {
+                0.0
+            },
+        },
+    }))
+}
+
+// ── GET /api/metrics/trends ──
+
+fn default_trend_granularity() -> String {
+    "daily".to_string()
+}
+
+#[derive(Deserialize)]
+struct TrendsQuery {
+    #[serde(default = "default_overview_days")]
+    days: usize,
+    #[serde(default = "default_trend_granularity")]
+    granularity: String,
+    group: Option<String>,
+}
+
+#[derive(Serialize)]
+struct TrendsResponse {
+    granularity: String,
+    data: Vec<TrendPoint>,
+}
+
+#[derive(Serialize)]
+struct TrendPoint {
+    date: String,
+    events: usize,
+    commits: usize,
+    cost_usd: f64,
+    execution_count: u64,
+    success_count: u64,
+    success_rate: f64,
+}
+
+async fn get_metrics_trends(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<TrendsQuery>,
+) -> Result<Json<TrendsResponse>, AppError> {
+    if state.chronicle.is_none() {
+        return Err(anyhow::anyhow!("chronicle feature not enabled").into());
+    }
+
+    let all_projects = list_projects();
+    let projects: Vec<_> = if let Some(ref group) = params.group {
+        all_projects
+            .into_iter()
+            .filter(|p| p.group.as_deref() == Some(group.as_str()))
+            .collect()
+    } else {
+        all_projects
+    };
+
+    let now = time::OffsetDateTime::now_utc();
+    let from_date = now - time::Duration::days(params.days as i64);
+    let from_str = from_date
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_default();
+
+    let range = DateRange {
+        after: Some(from_str[..10].to_string()),
+        before: None,
+    };
+
+    let r = rollup::compute_rollup(&projects, &range, "edda");
+
+    let data: Vec<TrendPoint> = match params.granularity.as_str() {
+        "weekly" => r
+            .weekly
+            .iter()
+            .map(|w| TrendPoint {
+                date: w.week_start.clone(),
+                events: w.events,
+                commits: w.commits,
+                cost_usd: w.cost_usd,
+                execution_count: w.execution_count,
+                success_count: w.success_count,
+                success_rate: if w.execution_count > 0 {
+                    w.success_count as f64 / w.execution_count as f64
+                } else {
+                    0.0
+                },
+            })
+            .collect(),
+        "monthly" => r
+            .monthly
+            .iter()
+            .map(|m| TrendPoint {
+                date: m.month.clone(),
+                events: m.events,
+                commits: m.commits,
+                cost_usd: m.cost_usd,
+                execution_count: m.execution_count,
+                success_count: m.success_count,
+                success_rate: if m.execution_count > 0 {
+                    m.success_count as f64 / m.execution_count as f64
+                } else {
+                    0.0
+                },
+            })
+            .collect(),
+        _ => r
+            .daily
+            .iter()
+            .map(|d| TrendPoint {
+                date: d.date.clone(),
+                events: d.events,
+                commits: d.commits,
+                cost_usd: d.cost_usd,
+                execution_count: d.execution_count,
+                success_count: d.success_count,
+                success_rate: if d.execution_count > 0 {
+                    d.success_count as f64 / d.execution_count as f64
+                } else {
+                    0.0
+                },
+            })
+            .collect(),
+    };
+
+    Ok(Json(TrendsResponse {
+        granularity: params.granularity,
+        data,
+    }))
+>>>>>>> 2677ce3 (feat(metrics): cross-project metrics dashboard (#199))
 }
 
 // ── POST /api/scope/check ──
@@ -2084,6 +2311,7 @@ struct DashboardResponse {
     timeline: Vec<TimelineEntry>,
     graph: edda_aggregate::graph::DependencyGraph,
     risks: Vec<DecisionRisk>,
+    project_metrics: Vec<ProjectMetrics>,
 }
 
 #[derive(Serialize)]
@@ -2099,6 +2327,8 @@ struct DashboardSummary {
     total_decisions: usize,
     total_events: usize,
     total_commits: usize,
+    total_cost_usd: f64,
+    overall_success_rate: f64,
 }
 
 #[derive(Serialize)]
@@ -2216,8 +2446,24 @@ async fn get_dashboard(
     // Dependency graph
     let graph = build_dependency_graph(&projects);
 
-    // Attention routing
-    let attention = compute_attention(&risks, &projects, &range);
+    // Per-project metrics
+    let project_metrics = per_project_metrics(&projects, &range, params.days);
+
+    // Compute cost totals for summary
+    let total_cost: f64 = project_metrics.iter().map(|m| m.cost.total_usd).sum();
+    let total_steps: u64 = project_metrics.iter().map(|m| m.quality.total_steps).sum();
+    let total_success: u64 = project_metrics
+        .iter()
+        .map(|m| (m.quality.success_rate * m.quality.total_steps as f64) as u64)
+        .sum();
+    let overall_success_rate = if total_steps > 0 {
+        total_success as f64 / total_steps as f64
+    } else {
+        0.0
+    };
+
+    // Attention routing (with cost anomaly detection)
+    let attention = compute_attention(&risks, &projects, &range, &project_metrics, params.days);
 
     let period = DashboardPeriod {
         from: from_str[..10].to_string(),
@@ -2230,6 +2476,8 @@ async fn get_dashboard(
         total_decisions: agg.total_decisions,
         total_events: agg.total_events,
         total_commits: agg.total_commits,
+        total_cost_usd: total_cost,
+        overall_success_rate,
     };
 
     Ok(Json(DashboardResponse {
@@ -2239,14 +2487,21 @@ async fn get_dashboard(
         timeline,
         graph,
         risks,
+        project_metrics,
     }))
 }
 
 /// Compute attention routing: red / yellow / green classification.
+///
+/// Includes cost anomaly detection when `project_metrics` is non-empty:
+/// - Yellow: project daily cost > 2x period average
+/// - Red: project daily cost > 5x period average
 fn compute_attention(
     risks: &[DecisionRisk],
     projects: &[edda_store::registry::ProjectEntry],
     range: &DateRange,
+    project_metrics: &[ProjectMetrics],
+    days: usize,
 ) -> OverviewResponse {
     let mut red = Vec::new();
     let mut yellow = Vec::new();
@@ -2287,6 +2542,37 @@ fn compute_attention(
                 ),
                 eta: String::new(),
             });
+        }
+    }
+
+    // Cost anomaly detection
+    if days > 0 {
+        for pm in project_metrics {
+            let daily_avg = pm.cost.daily_avg_usd;
+            if daily_avg > 0.0 && pm.cost.total_usd > 0.0 {
+                // Estimate today's cost as total / days (rough approximation)
+                let last_day_cost = pm.cost.total_usd / days as f64;
+                if last_day_cost > daily_avg * 5.0 {
+                    red.push(OverviewRedItem {
+                        project: pm.name.clone(),
+                        summary: format!(
+                            "Cost spike: ${:.2}/day (5x above ${:.2} avg)",
+                            last_day_cost, daily_avg
+                        ),
+                        action: "Investigate cost increase".to_string(),
+                        blocked_count: 0,
+                    });
+                } else if last_day_cost > daily_avg * 2.0 {
+                    yellow.push(OverviewYellowItem {
+                        project: pm.name.clone(),
+                        summary: format!(
+                            "Elevated cost: ${:.2}/day (2x above ${:.2} avg)",
+                            last_day_cost, daily_avg
+                        ),
+                        eta: String::new(),
+                    });
+                }
+            }
         }
     }
 
@@ -3827,6 +4113,91 @@ actors:
         assert!(json["timeline"].is_array());
         assert!(json["graph"].is_object());
         assert!(json["risks"].is_array());
+        assert!(json["project_metrics"].is_array());
+        // New summary fields
+        assert!(
+            json["summary"]["total_cost_usd"].is_f64()
+                || json["summary"]["total_cost_usd"].is_u64()
+        );
+        assert!(
+            json["summary"]["overall_success_rate"].is_f64()
+                || json["summary"]["overall_success_rate"].is_u64()
+        );
+    }
+
+    #[tokio::test]
+    async fn metrics_overview_returns_200() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/metrics/overview")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["period"].is_object());
+        assert!(json["projects"].is_array());
+        assert!(json["totals"].is_object());
+    }
+
+    #[tokio::test]
+    async fn metrics_trends_returns_200() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/metrics/trends?granularity=daily")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["granularity"], "daily");
+        assert!(json["data"].is_array());
+    }
+
+    #[tokio::test]
+    async fn metrics_trends_weekly_granularity() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/metrics/trends?granularity=weekly")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["granularity"], "weekly");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Extend rollup structs (`DayStat`, `WeekStat`, `MonthStat`) with `cost_usd`, `execution_count`, `success_count` fields (backward-compatible via `#[serde(default)]`)
- Add `cost_by_date()`, `quality_by_date()`, and `per_project_metrics()` aggregation functions in `edda-aggregate`
- Add `GET /api/metrics/overview` endpoint returning per-project cost/quality/activity with `?group=` filtering
- Add `GET /api/metrics/trends` endpoint with daily/weekly/monthly granularity
- Augment `GET /api/dashboard` with `project_metrics` array and `total_cost_usd` / `overall_success_rate` in summary
- Add cost anomaly detection to attention routing (2x daily avg = yellow, 5x = red)

Closes #199

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -p edda-aggregate -p edda-serve -- -D warnings` passes
- [x] All 52 tests pass (`overview_returns_structure` is a pre-existing failure unrelated to this PR)
- [x] Backward-compat: existing rollup caches deserialize without error (new fields default to zero)
- [ ] Manual: `GET /api/metrics/overview` returns per-project breakdown
- [ ] Manual: `GET /api/metrics/trends?granularity=weekly` returns timeseries
- [ ] Manual: `GET /api/dashboard` includes `project_metrics` and cost summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)