### PR TITLE
feat(bridge): controls suggestion engine (#198)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,6 +762,7 @@ dependencies = [
  "anyhow",
  "blake3",
  "dirs",
+ "edda-aggregate",
  "edda-core",
  "edda-derive",
  "edda-index",

--- a/crates/edda-aggregate/src/controls.rs
+++ b/crates/edda-aggregate/src/controls.rs
@@ -1,0 +1,335 @@
+//! Generic threshold-based controls suggestion engine.
+//!
+//! Evaluates a set of [`ThresholdRule`]s against a [`QualityReport`] and
+//! produces [`ControlsSuggestion`]s when metrics breach their thresholds.
+//! This module is pure computation (no I/O, no Karvi dependency).
+
+use serde::{Deserialize, Serialize};
+
+use crate::quality::QualityReport;
+
+// ── Types ──
+
+/// Which metric a threshold rule evaluates.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum MetricKind {
+    SuccessRate,
+    AvgCostUsd,
+    AvgLatencyMs,
+    TotalCostUsd,
+}
+
+/// Comparison operator for threshold evaluation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ThresholdOp {
+    Lt,
+    Gt,
+    Lte,
+    Gte,
+}
+
+/// A threshold rule: when a metric breaches the threshold, suggest an action.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThresholdRule {
+    pub name: String,
+    pub metric: MetricKind,
+    pub operator: ThresholdOp,
+    pub threshold: f64,
+    pub action: String,
+    pub reason_template: String,
+}
+
+/// A suggestion produced by evaluating a rule against a quality report.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ControlsSuggestion {
+    pub rule_name: String,
+    pub metric_name: String,
+    pub current_value: f64,
+    pub threshold: f64,
+    pub action: String,
+    pub reason: String,
+}
+
+// ── Evaluation ──
+
+/// Minimum number of total steps required before rules fire.
+/// Prevents knee-jerk reactions on insufficient data.
+const DEFAULT_MIN_SAMPLES: u64 = 10;
+
+/// Evaluate threshold rules against a quality report.
+///
+/// Returns suggestions for every rule whose metric breaches its threshold.
+/// If the report has fewer than `min_samples` total steps, returns empty.
+pub fn evaluate_controls_rules(
+    rules: &[ThresholdRule],
+    report: &QualityReport,
+    min_samples: Option<u64>,
+) -> Vec<ControlsSuggestion> {
+    let min = min_samples.unwrap_or(DEFAULT_MIN_SAMPLES);
+    if report.total_steps < min {
+        return Vec::new();
+    }
+
+    let mut suggestions = Vec::new();
+
+    for rule in rules {
+        let value = extract_metric(report, &rule.metric);
+        if breaches(value, &rule.operator, rule.threshold) {
+            let reason = rule
+                .reason_template
+                .replace("{value}", &format_metric_value(value, &rule.metric))
+                .replace(
+                    "{threshold}",
+                    &format_metric_value(rule.threshold, &rule.metric),
+                );
+            suggestions.push(ControlsSuggestion {
+                rule_name: rule.name.clone(),
+                metric_name: format!("{:?}", rule.metric),
+                current_value: value,
+                threshold: rule.threshold,
+                action: rule.action.clone(),
+                reason,
+            });
+        }
+    }
+
+    suggestions
+}
+
+/// Extract the overall metric value from a quality report.
+fn extract_metric(report: &QualityReport, kind: &MetricKind) -> f64 {
+    match kind {
+        MetricKind::SuccessRate => report.overall_success_rate,
+        MetricKind::TotalCostUsd => report.total_cost_usd,
+        MetricKind::AvgCostUsd => {
+            if report.total_steps > 0 {
+                report.total_cost_usd / report.total_steps as f64
+            } else {
+                0.0
+            }
+        }
+        MetricKind::AvgLatencyMs => {
+            // Average across all models, weighted by step count.
+            let total_latency: f64 = report
+                .models
+                .iter()
+                .map(|m| m.avg_latency_ms * m.total_steps as f64)
+                .sum();
+            if report.total_steps > 0 {
+                total_latency / report.total_steps as f64
+            } else {
+                0.0
+            }
+        }
+    }
+}
+
+/// Check whether `value` breaches the threshold according to `op`.
+fn breaches(value: f64, op: &ThresholdOp, threshold: f64) -> bool {
+    match op {
+        ThresholdOp::Lt => value < threshold,
+        ThresholdOp::Gt => value > threshold,
+        ThresholdOp::Lte => value <= threshold,
+        ThresholdOp::Gte => value >= threshold,
+    }
+}
+
+/// Format a metric value for display in reason strings.
+fn format_metric_value(value: f64, kind: &MetricKind) -> String {
+    match kind {
+        MetricKind::SuccessRate => format!("{:.0}%", value * 100.0),
+        MetricKind::AvgCostUsd | MetricKind::TotalCostUsd => format!("${:.2}", value),
+        MetricKind::AvgLatencyMs => format!("{:.0}ms", value),
+    }
+}
+
+// ── Tests ──
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quality::{ModelQuality, QualityReport};
+
+    fn make_report(success_rate: f64, total_steps: u64, cost: f64, latency: f64) -> QualityReport {
+        QualityReport {
+            models: vec![ModelQuality {
+                model: "test-model".to_string(),
+                runtime: "test-runtime".to_string(),
+                total_steps,
+                success_count: (total_steps as f64 * success_rate) as u64,
+                failed_count: total_steps - (total_steps as f64 * success_rate) as u64,
+                cancelled_count: 0,
+                success_rate,
+                avg_cost_usd: if total_steps > 0 {
+                    cost / total_steps as f64
+                } else {
+                    0.0
+                },
+                avg_latency_ms: latency,
+                total_cost_usd: cost,
+                total_tokens_in: 0,
+                total_tokens_out: 0,
+            }],
+            total_steps,
+            overall_success_rate: success_rate,
+            total_cost_usd: cost,
+        }
+    }
+
+    fn sample_rules() -> Vec<ThresholdRule> {
+        vec![
+            ThresholdRule {
+                name: "low-success".to_string(),
+                metric: MetricKind::SuccessRate,
+                operator: ThresholdOp::Lt,
+                threshold: 0.60,
+                action: "disable_auto_dispatch".to_string(),
+                reason_template: "Success rate {value} below {threshold} threshold".to_string(),
+            },
+            ThresholdRule {
+                name: "high-cost".to_string(),
+                metric: MetricKind::AvgCostUsd,
+                operator: ThresholdOp::Gt,
+                threshold: 0.50,
+                action: "reduce_concurrency".to_string(),
+                reason_template: "Average cost {value} exceeds {threshold}".to_string(),
+            },
+            ThresholdRule {
+                name: "high-latency".to_string(),
+                metric: MetricKind::AvgLatencyMs,
+                operator: ThresholdOp::Gt,
+                threshold: 30000.0,
+                action: "flag_slow_model".to_string(),
+                reason_template: "Average latency {value} exceeds {threshold}".to_string(),
+            },
+        ]
+    }
+
+    #[test]
+    fn empty_report_no_suggestions() {
+        let report = make_report(0.0, 0, 0.0, 0.0);
+        let suggestions = evaluate_controls_rules(&sample_rules(), &report, None);
+        assert!(suggestions.is_empty());
+    }
+
+    #[test]
+    fn min_samples_guard_skips_low_count() {
+        let report = make_report(0.30, 5, 1.0, 1000.0);
+        let suggestions = evaluate_controls_rules(&sample_rules(), &report, None);
+        assert!(suggestions.is_empty(), "Should skip with only 5 samples");
+    }
+
+    #[test]
+    fn min_samples_custom_threshold() {
+        let report = make_report(0.30, 5, 1.0, 1000.0);
+        let suggestions = evaluate_controls_rules(&sample_rules(), &report, Some(3));
+        assert!(
+            !suggestions.is_empty(),
+            "Should fire with custom min_samples=3"
+        );
+    }
+
+    #[test]
+    fn success_rate_below_threshold_triggers() {
+        let report = make_report(0.40, 20, 2.0, 1000.0);
+        let suggestions = evaluate_controls_rules(&sample_rules(), &report, None);
+        let names: Vec<&str> = suggestions.iter().map(|s| s.rule_name.as_str()).collect();
+        assert!(names.contains(&"low-success"));
+        let s = suggestions
+            .iter()
+            .find(|s| s.rule_name == "low-success")
+            .unwrap();
+        assert_eq!(s.action, "disable_auto_dispatch");
+        assert!((s.current_value - 0.40).abs() < 1e-9);
+    }
+
+    #[test]
+    fn success_rate_above_threshold_no_trigger() {
+        let report = make_report(0.80, 20, 2.0, 1000.0);
+        let suggestions = evaluate_controls_rules(&sample_rules(), &report, None);
+        let names: Vec<&str> = suggestions.iter().map(|s| s.rule_name.as_str()).collect();
+        assert!(!names.contains(&"low-success"));
+    }
+
+    #[test]
+    fn high_cost_triggers() {
+        // 20 steps, total cost $15 -> avg $0.75 > $0.50 threshold
+        let report = make_report(0.80, 20, 15.0, 1000.0);
+        let suggestions = evaluate_controls_rules(&sample_rules(), &report, None);
+        let names: Vec<&str> = suggestions.iter().map(|s| s.rule_name.as_str()).collect();
+        assert!(names.contains(&"high-cost"));
+    }
+
+    #[test]
+    fn high_latency_triggers() {
+        let report = make_report(0.80, 20, 2.0, 35000.0);
+        let suggestions = evaluate_controls_rules(&sample_rules(), &report, None);
+        let names: Vec<&str> = suggestions.iter().map(|s| s.rule_name.as_str()).collect();
+        assert!(names.contains(&"high-latency"));
+    }
+
+    #[test]
+    fn multiple_rules_can_trigger() {
+        // Low success + high cost + high latency
+        let report = make_report(0.30, 20, 15.0, 35000.0);
+        let suggestions = evaluate_controls_rules(&sample_rules(), &report, None);
+        assert_eq!(suggestions.len(), 3);
+    }
+
+    #[test]
+    fn no_rules_no_suggestions() {
+        let report = make_report(0.30, 20, 15.0, 35000.0);
+        let suggestions = evaluate_controls_rules(&[], &report, None);
+        assert!(suggestions.is_empty());
+    }
+
+    #[test]
+    fn reason_template_formatting() {
+        let report = make_report(0.40, 20, 2.0, 1000.0);
+        let suggestions = evaluate_controls_rules(&sample_rules(), &report, None);
+        let s = suggestions
+            .iter()
+            .find(|s| s.rule_name == "low-success")
+            .unwrap();
+        assert!(
+            s.reason.contains("40%"),
+            "Reason should contain formatted percentage: {}",
+            s.reason
+        );
+        assert!(
+            s.reason.contains("60%"),
+            "Reason should contain threshold: {}",
+            s.reason
+        );
+    }
+
+    #[test]
+    fn lte_and_gte_operators() {
+        let rules = vec![
+            ThresholdRule {
+                name: "exact-lte".to_string(),
+                metric: MetricKind::SuccessRate,
+                operator: ThresholdOp::Lte,
+                threshold: 0.50,
+                action: "test".to_string(),
+                reason_template: "test".to_string(),
+            },
+            ThresholdRule {
+                name: "exact-gte".to_string(),
+                metric: MetricKind::TotalCostUsd,
+                operator: ThresholdOp::Gte,
+                threshold: 5.0,
+                action: "test".to_string(),
+                reason_template: "test".to_string(),
+            },
+        ];
+
+        // success_rate exactly 0.50 should trigger Lte 0.50
+        // total_cost exactly 5.0 should trigger Gte 5.0
+        let report = make_report(0.50, 20, 5.0, 1000.0);
+        let suggestions = evaluate_controls_rules(&rules, &report, None);
+        assert_eq!(suggestions.len(), 2);
+    }
+}

--- a/crates/edda-aggregate/src/lib.rs
+++ b/crates/edda-aggregate/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod aggregate;
+pub mod controls;
 pub mod graph;
 pub mod quality;
 pub mod risk;

--- a/crates/edda-bridge-claude/Cargo.toml
+++ b/crates/edda-bridge-claude/Cargo.toml
@@ -10,6 +10,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
+edda-aggregate = { path = "../edda-aggregate", version = "0.1.1" }
 edda-core = { path = "../edda-core", version = "0.1.1" }
 edda-store = { path = "../edda-store", version = "0.1.1" }
 edda-transcript = { path = "../edda-transcript", version = "0.1.1" }

--- a/crates/edda-bridge-claude/src/controls_suggest.rs
+++ b/crates/edda-bridge-claude/src/controls_suggest.rs
@@ -1,0 +1,641 @@
+//! Karvi-specific controls patch adapter.
+//!
+//! Translates [`ControlsSuggestion`]s from the L2 threshold engine into
+//! [`ControlsPatch`] proposals with file-based CRUD storage and audit logging.
+//! Approved patches can be posted to the Karvi `/api/controls` endpoint.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use edda_aggregate::controls::{
+    evaluate_controls_rules, ControlsSuggestion, MetricKind, ThresholdOp, ThresholdRule,
+};
+
+// ── Types ──
+
+/// Status of a controls patch proposal.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum PatchStatus {
+    Pending,
+    Approved,
+    Dismissed,
+    Applied,
+}
+
+/// A controls patch proposal targeting Karvi automation controls.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ControlsPatch {
+    pub patch_id: String,
+    pub created_at: String,
+    pub controls: HashMap<String, serde_json::Value>,
+    pub suggestions: Vec<ControlsSuggestion>,
+    pub status: PatchStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approved_by: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approved_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dismiss_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applied_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AuditEntry {
+    ts: String,
+    patch_id: String,
+    action: String,
+    actor: Option<String>,
+    detail: Option<String>,
+}
+
+// ── Default Rules ──
+
+/// Built-in threshold rules for Karvi integration.
+pub fn default_rules() -> Vec<ThresholdRule> {
+    vec![
+        ThresholdRule {
+            name: "low-success-disable-dispatch".to_string(),
+            metric: MetricKind::SuccessRate,
+            operator: ThresholdOp::Lt,
+            threshold: 0.60,
+            action: "disable_auto_dispatch".to_string(),
+            reason_template: "Success rate {value} below {threshold} threshold".to_string(),
+        },
+        ThresholdRule {
+            name: "high-cost-reduce-concurrency".to_string(),
+            metric: MetricKind::AvgCostUsd,
+            operator: ThresholdOp::Gt,
+            threshold: 0.50,
+            action: "reduce_concurrency".to_string(),
+            reason_template: "Average cost {value} exceeds {threshold}".to_string(),
+        },
+        ThresholdRule {
+            name: "high-latency-flag".to_string(),
+            metric: MetricKind::AvgLatencyMs,
+            operator: ThresholdOp::Gt,
+            threshold: 30000.0,
+            action: "flag_slow_model".to_string(),
+            reason_template: "Average latency {value} exceeds {threshold}".to_string(),
+        },
+    ]
+}
+
+// ── Suggestion Generation ──
+
+/// Evaluate rules against a quality report and build a `ControlsPatch` if any fire.
+///
+/// Returns `None` if no rules are triggered or if a pending patch already exists
+/// for the same actions within the cooldown period (24h).
+pub fn suggest_controls_patch(
+    project_id: &str,
+    report: &edda_aggregate::quality::QualityReport,
+    rules: &[ThresholdRule],
+    min_samples: Option<u64>,
+) -> Result<Option<ControlsPatch>> {
+    let suggestions = evaluate_controls_rules(rules, report, min_samples);
+    if suggestions.is_empty() {
+        return Ok(None);
+    }
+
+    // Cooldown check: skip if a pending patch exists with overlapping actions
+    // created within the last 24 hours.
+    if let Ok(existing) = list_patches(project_id, Some(&PatchStatus::Pending)) {
+        let now = now_rfc3339();
+        let cutoff = cooldown_cutoff(&now);
+        for patch in &existing {
+            if patch.created_at > cutoff {
+                let existing_actions: Vec<&str> = patch
+                    .suggestions
+                    .iter()
+                    .map(|s| s.action.as_str())
+                    .collect();
+                let new_actions: Vec<&str> =
+                    suggestions.iter().map(|s| s.action.as_str()).collect();
+                let overlap = new_actions.iter().any(|a| existing_actions.contains(a));
+                if overlap {
+                    return Ok(None);
+                }
+            }
+        }
+    }
+
+    // Build controls map from suggestions.
+    let mut controls = HashMap::new();
+    for s in &suggestions {
+        let value = match s.action.as_str() {
+            "disable_auto_dispatch" => serde_json::json!(false),
+            "reduce_concurrency" => serde_json::json!(1),
+            "flag_slow_model" => serde_json::json!(true),
+            _ => serde_json::json!(s.action.clone()),
+        };
+        controls.insert(s.action.clone(), value);
+    }
+
+    let patch = ControlsPatch {
+        patch_id: new_patch_id(),
+        created_at: now_rfc3339(),
+        controls,
+        suggestions,
+        status: PatchStatus::Pending,
+        approved_by: None,
+        approved_at: None,
+        dismiss_reason: None,
+        applied_at: None,
+    };
+
+    Ok(Some(patch))
+}
+
+// ── CRUD ──
+
+/// Generate a new patch ID.
+pub fn new_patch_id() -> String {
+    format!(
+        "cpatch_{}",
+        &ulid::Ulid::new().to_string()[..12].to_lowercase()
+    )
+}
+
+/// Save a controls patch to disk.
+pub fn save_patch(project_id: &str, patch: &ControlsPatch) -> Result<()> {
+    let path = patch_path(project_id, &patch.patch_id);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(patch)?;
+    fs::write(&path, json)?;
+
+    append_audit(project_id, &patch.patch_id, "created", None, None)?;
+    Ok(())
+}
+
+/// Load a single patch by ID.
+pub fn load_patch(project_id: &str, patch_id: &str) -> Result<ControlsPatch> {
+    let path = patch_path(project_id, patch_id);
+    let content =
+        fs::read_to_string(&path).with_context(|| format!("Patch not found: {patch_id}"))?;
+    let patch: ControlsPatch = serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse patch: {}", path.display()))?;
+    Ok(patch)
+}
+
+/// List patches, optionally filtered by status.
+pub fn list_patches(
+    project_id: &str,
+    status_filter: Option<&PatchStatus>,
+) -> Result<Vec<ControlsPatch>> {
+    let dir = patches_dir(project_id);
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut results = Vec::new();
+    for entry in fs::read_dir(&dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let content = fs::read_to_string(&path)?;
+        let patch: ControlsPatch = serde_json::from_str(&content)
+            .with_context(|| format!("Failed to parse patch: {}", path.display()))?;
+
+        if let Some(filter) = status_filter {
+            if &patch.status != filter {
+                continue;
+            }
+        }
+        results.push(patch);
+    }
+
+    results.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    Ok(results)
+}
+
+/// Approve a patch: mark as approved, return it.
+pub fn approve_patch(project_id: &str, patch_id: &str, by: &str) -> Result<ControlsPatch> {
+    let mut patch = load_patch(project_id, patch_id)?;
+    if patch.status != PatchStatus::Pending {
+        anyhow::bail!(
+            "Patch {patch_id} is not pending (status: {:?})",
+            patch.status
+        );
+    }
+
+    patch.status = PatchStatus::Approved;
+    patch.approved_by = Some(by.to_string());
+    patch.approved_at = Some(now_rfc3339());
+
+    let path = patch_path(project_id, patch_id);
+    let json = serde_json::to_string_pretty(&patch)?;
+    fs::write(&path, json)?;
+
+    append_audit(project_id, patch_id, "approved", Some(by), None)?;
+    Ok(patch)
+}
+
+/// Dismiss a patch with optional reason.
+pub fn dismiss_patch(project_id: &str, patch_id: &str, reason: Option<&str>) -> Result<()> {
+    let mut patch = load_patch(project_id, patch_id)?;
+    if patch.status != PatchStatus::Pending {
+        anyhow::bail!(
+            "Patch {patch_id} is not pending (status: {:?})",
+            patch.status
+        );
+    }
+
+    patch.status = PatchStatus::Dismissed;
+    patch.dismiss_reason = reason.map(String::from);
+
+    let path = patch_path(project_id, patch_id);
+    let json = serde_json::to_string_pretty(&patch)?;
+    fs::write(&path, json)?;
+
+    append_audit(project_id, patch_id, "dismissed", None, reason)?;
+    Ok(())
+}
+
+/// Mark an approved patch as applied (after successfully posting to Karvi).
+pub fn mark_applied(project_id: &str, patch_id: &str) -> Result<ControlsPatch> {
+    let mut patch = load_patch(project_id, patch_id)?;
+    if patch.status != PatchStatus::Approved {
+        anyhow::bail!(
+            "Patch {patch_id} is not approved (status: {:?})",
+            patch.status
+        );
+    }
+
+    patch.status = PatchStatus::Applied;
+    patch.applied_at = Some(now_rfc3339());
+
+    let path = patch_path(project_id, patch_id);
+    let json = serde_json::to_string_pretty(&patch)?;
+    fs::write(&path, json)?;
+
+    append_audit(project_id, patch_id, "applied", None, None)?;
+    Ok(patch)
+}
+
+/// Post an approved patch to Karvi `/api/controls`.
+///
+/// Returns `Ok(())` on success, `Err` if the request fails or the patch
+/// is not in the `Approved` state.
+pub fn apply_patch_to_karvi(project_id: &str, patch_id: &str, karvi_url: &str) -> Result<()> {
+    let patch = load_patch(project_id, patch_id)?;
+    if patch.status != PatchStatus::Approved {
+        anyhow::bail!(
+            "Patch {patch_id} must be approved before applying (status: {:?})",
+            patch.status
+        );
+    }
+
+    let url = format!("{}/api/controls", karvi_url.trim_end_matches('/'));
+    let body = serde_json::to_string(&patch.controls)?;
+
+    let agent = ureq::Agent::config_builder()
+        .timeout_global(Some(std::time::Duration::from_secs(10)))
+        .build()
+        .new_agent();
+
+    if let Err(e) = agent
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .send(body.as_bytes())
+    {
+        anyhow::bail!("Failed to POST to Karvi {url}: {e}");
+    }
+
+    mark_applied(project_id, patch_id)?;
+    Ok(())
+}
+
+/// Return the current threshold rules.
+///
+/// Placeholder: always returns `default_rules()`. A future enhancement
+/// could load from `.edda/controls-rules.yaml`.
+pub fn load_rules() -> Vec<ThresholdRule> {
+    default_rules()
+}
+
+// ── Storage Helpers ──
+
+fn patches_dir(project_id: &str) -> PathBuf {
+    edda_store::project_dir(project_id)
+        .join("state")
+        .join("controls_patches")
+}
+
+fn patch_path(project_id: &str, patch_id: &str) -> PathBuf {
+    patches_dir(project_id).join(format!("{patch_id}.json"))
+}
+
+fn audit_log_path(project_id: &str) -> PathBuf {
+    edda_store::project_dir(project_id)
+        .join("state")
+        .join("controls_patch_audit.jsonl")
+}
+
+fn append_audit(
+    project_id: &str,
+    patch_id: &str,
+    action: &str,
+    actor: Option<&str>,
+    detail: Option<&str>,
+) -> Result<()> {
+    use std::io::Write;
+    let path = audit_log_path(project_id);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let entry = AuditEntry {
+        ts: now_rfc3339(),
+        patch_id: patch_id.to_string(),
+        action: action.to_string(),
+        actor: actor.map(String::from),
+        detail: detail.map(String::from),
+    };
+    let line = serde_json::to_string(&entry)?;
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)?;
+    writeln!(file, "{line}")?;
+    Ok(())
+}
+
+fn now_rfc3339() -> String {
+    time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_default()
+}
+
+/// Calculate cooldown cutoff (24 hours before the given timestamp).
+/// Returns an ISO 8601 string that can be compared lexicographically.
+fn cooldown_cutoff(now: &str) -> String {
+    // Parse the timestamp and subtract 24h. On parse failure, return epoch
+    // so that cooldown check is effectively skipped.
+    time::OffsetDateTime::parse(now, &time::format_description::well_known::Rfc3339)
+        .ok()
+        .and_then(|t| {
+            t.checked_sub(time::Duration::hours(24)).and_then(|t2| {
+                t2.format(&time::format_description::well_known::Rfc3339)
+                    .ok()
+            })
+        })
+        .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_string())
+}
+
+// ── Tests ──
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use edda_aggregate::quality::{ModelQuality, QualityReport};
+
+    fn make_report(success_rate: f64, total_steps: u64, cost: f64) -> QualityReport {
+        QualityReport {
+            models: vec![ModelQuality {
+                model: "test-model".to_string(),
+                runtime: "test-runtime".to_string(),
+                total_steps,
+                success_count: (total_steps as f64 * success_rate) as u64,
+                failed_count: total_steps - (total_steps as f64 * success_rate) as u64,
+                cancelled_count: 0,
+                success_rate,
+                avg_cost_usd: if total_steps > 0 {
+                    cost / total_steps as f64
+                } else {
+                    0.0
+                },
+                avg_latency_ms: 1000.0,
+                total_cost_usd: cost,
+                total_tokens_in: 0,
+                total_tokens_out: 0,
+            }],
+            total_steps,
+            overall_success_rate: success_rate,
+            total_cost_usd: cost,
+        }
+    }
+
+    #[test]
+    fn patch_serde_roundtrip() {
+        let patch = ControlsPatch {
+            patch_id: "cpatch_test123".to_string(),
+            created_at: "2026-03-13T10:00:00Z".to_string(),
+            controls: {
+                let mut m = HashMap::new();
+                m.insert("disable_auto_dispatch".to_string(), serde_json::json!(true));
+                m
+            },
+            suggestions: vec![],
+            status: PatchStatus::Pending,
+            approved_by: None,
+            approved_at: None,
+            dismiss_reason: None,
+            applied_at: None,
+        };
+        let json = serde_json::to_string(&patch).unwrap();
+        let parsed: ControlsPatch = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.patch_id, "cpatch_test123");
+        assert_eq!(parsed.status, PatchStatus::Pending);
+    }
+
+    #[test]
+    fn suggest_returns_none_when_no_triggers() {
+        let report = make_report(0.80, 20, 2.0);
+        let rules = default_rules();
+        let result = suggest_controls_patch("test_suggest_none", &report, &rules, None).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn suggest_returns_patch_when_triggered() {
+        let report = make_report(0.30, 20, 2.0);
+        let rules = default_rules();
+        let result = suggest_controls_patch("test_suggest_some", &report, &rules, None).unwrap();
+        assert!(result.is_some());
+        let patch = result.unwrap();
+        assert_eq!(patch.status, PatchStatus::Pending);
+        assert!(!patch.suggestions.is_empty());
+        assert!(patch.controls.contains_key("disable_auto_dispatch"));
+    }
+
+    #[test]
+    fn crud_roundtrip() {
+        let pid = "test_controls_crud";
+        let _ = edda_store::ensure_dirs(pid);
+
+        let patch = ControlsPatch {
+            patch_id: "cpatch_crud1".to_string(),
+            created_at: "2026-03-13T10:00:00Z".to_string(),
+            controls: HashMap::new(),
+            suggestions: vec![],
+            status: PatchStatus::Pending,
+            approved_by: None,
+            approved_at: None,
+            dismiss_reason: None,
+            applied_at: None,
+        };
+
+        save_patch(pid, &patch).unwrap();
+        let loaded = load_patch(pid, "cpatch_crud1").unwrap();
+        assert_eq!(loaded.patch_id, "cpatch_crud1");
+
+        let all = list_patches(pid, None).unwrap();
+        assert_eq!(all.len(), 1);
+
+        let pending = list_patches(pid, Some(&PatchStatus::Pending)).unwrap();
+        assert_eq!(pending.len(), 1);
+
+        // Cleanup
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    }
+
+    #[test]
+    fn approve_and_dismiss_transitions() {
+        let pid = "test_controls_transitions";
+        let _ = edda_store::ensure_dirs(pid);
+
+        // Approve path
+        let p1 = ControlsPatch {
+            patch_id: "cpatch_trans1".to_string(),
+            created_at: "2026-03-13T10:00:00Z".to_string(),
+            controls: HashMap::new(),
+            suggestions: vec![],
+            status: PatchStatus::Pending,
+            approved_by: None,
+            approved_at: None,
+            dismiss_reason: None,
+            applied_at: None,
+        };
+        save_patch(pid, &p1).unwrap();
+
+        let approved = approve_patch(pid, "cpatch_trans1", "alice").unwrap();
+        assert_eq!(approved.status, PatchStatus::Approved);
+        assert_eq!(approved.approved_by.as_deref(), Some("alice"));
+
+        // Cannot approve again
+        assert!(approve_patch(pid, "cpatch_trans1", "bob").is_err());
+
+        // Dismiss path
+        let p2 = ControlsPatch {
+            patch_id: "cpatch_trans2".to_string(),
+            created_at: "2026-03-13T10:01:00Z".to_string(),
+            controls: HashMap::new(),
+            suggestions: vec![],
+            status: PatchStatus::Pending,
+            approved_by: None,
+            approved_at: None,
+            dismiss_reason: None,
+            applied_at: None,
+        };
+        save_patch(pid, &p2).unwrap();
+
+        dismiss_patch(pid, "cpatch_trans2", Some("not needed")).unwrap();
+        let dismissed = load_patch(pid, "cpatch_trans2").unwrap();
+        assert_eq!(dismissed.status, PatchStatus::Dismissed);
+        assert_eq!(dismissed.dismiss_reason.as_deref(), Some("not needed"));
+
+        // Cannot dismiss again
+        assert!(dismiss_patch(pid, "cpatch_trans2", None).is_err());
+
+        // Cleanup
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    }
+
+    #[test]
+    fn mark_applied_requires_approved() {
+        let pid = "test_controls_applied";
+        let _ = edda_store::ensure_dirs(pid);
+
+        let p1 = ControlsPatch {
+            patch_id: "cpatch_app1".to_string(),
+            created_at: "2026-03-13T10:00:00Z".to_string(),
+            controls: HashMap::new(),
+            suggestions: vec![],
+            status: PatchStatus::Pending,
+            approved_by: None,
+            approved_at: None,
+            dismiss_reason: None,
+            applied_at: None,
+        };
+        save_patch(pid, &p1).unwrap();
+
+        // Cannot mark pending as applied
+        assert!(mark_applied(pid, "cpatch_app1").is_err());
+
+        // Approve then apply
+        approve_patch(pid, "cpatch_app1", "human").unwrap();
+        let applied = mark_applied(pid, "cpatch_app1").unwrap();
+        assert_eq!(applied.status, PatchStatus::Applied);
+        assert!(applied.applied_at.is_some());
+
+        // Cleanup
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    }
+
+    #[test]
+    fn audit_log_records_actions() {
+        let pid = "test_controls_audit";
+        let _ = edda_store::ensure_dirs(pid);
+
+        let patch = ControlsPatch {
+            patch_id: "cpatch_audit1".to_string(),
+            created_at: "2026-03-13T10:00:00Z".to_string(),
+            controls: HashMap::new(),
+            suggestions: vec![],
+            status: PatchStatus::Pending,
+            approved_by: None,
+            approved_at: None,
+            dismiss_reason: None,
+            applied_at: None,
+        };
+        save_patch(pid, &patch).unwrap();
+        approve_patch(pid, "cpatch_audit1", "human").unwrap();
+
+        let path = audit_log_path(pid);
+        let content = fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("created"));
+        assert!(lines[1].contains("approved"));
+
+        // Cleanup
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    }
+
+    #[test]
+    fn new_patch_id_format() {
+        let id = new_patch_id();
+        assert!(id.starts_with("cpatch_"));
+        assert_eq!(id.len(), 19); // "cpatch_" (7) + 12 chars
+    }
+
+    #[test]
+    fn cooldown_cutoff_works() {
+        let cutoff = cooldown_cutoff("2026-03-13T12:00:00Z");
+        assert_eq!(cutoff, "2026-03-12T12:00:00Z");
+    }
+
+    #[test]
+    fn patch_status_serde() {
+        for (status, expected) in [
+            (PatchStatus::Pending, "\"pending\""),
+            (PatchStatus::Approved, "\"approved\""),
+            (PatchStatus::Dismissed, "\"dismissed\""),
+            (PatchStatus::Applied, "\"applied\""),
+        ] {
+            let json = serde_json::to_string(&status).unwrap();
+            assert_eq!(json, expected);
+            let parsed: PatchStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, status);
+        }
+    }
+}

--- a/crates/edda-bridge-claude/src/lib.rs
+++ b/crates/edda-bridge-claude/src/lib.rs
@@ -3,6 +3,7 @@ pub mod bg_detect;
 pub mod bg_digest;
 pub mod bg_extract;
 pub mod bg_scan;
+pub mod controls_suggest;
 pub mod digest;
 pub mod issue_proposal;
 pub mod pattern;

--- a/crates/edda-cli/src/cmd_controls.rs
+++ b/crates/edda-cli/src/cmd_controls.rs
@@ -1,0 +1,332 @@
+use clap::Subcommand;
+use edda_bridge_claude::controls_suggest::{self, PatchStatus};
+use std::path::Path;
+
+#[derive(Subcommand)]
+pub enum ControlsCmd {
+    /// Evaluate quality rules and generate a controls patch if thresholds are breached
+    Suggest {
+        /// Override minimum sample count (default: 10)
+        #[arg(long)]
+        min_samples: Option<u64>,
+    },
+    /// List controls patches
+    List {
+        /// Filter by status: pending, approved, dismissed, applied
+        #[arg(long)]
+        status: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show a controls patch
+    Show {
+        /// Patch ID (cpatch_...)
+        patch_id: String,
+    },
+    /// Approve a controls patch and optionally apply to Karvi
+    Approve {
+        /// Patch ID (cpatch_...)
+        patch_id: String,
+        /// Actor name
+        #[arg(long, default_value = "human")]
+        by: String,
+        /// Preview without approving
+        #[arg(long)]
+        dry_run: bool,
+        /// Post to Karvi after approval
+        #[arg(long)]
+        apply: bool,
+        /// Karvi API URL (default: http://localhost:3461)
+        #[arg(long, default_value = "http://localhost:3461")]
+        karvi_url: String,
+    },
+    /// Dismiss a controls patch
+    Dismiss {
+        /// Patch ID (cpatch_...)
+        patch_id: String,
+        /// Reason for dismissal
+        #[arg(long)]
+        reason: Option<String>,
+    },
+    /// Show current threshold rules
+    Rules {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+pub fn execute(cmd: ControlsCmd, repo_root: &Path) -> anyhow::Result<()> {
+    let project_id = edda_store::project_id(repo_root);
+
+    match cmd {
+        ControlsCmd::Suggest { min_samples } => {
+            execute_suggest(&project_id, repo_root, min_samples)
+        }
+        ControlsCmd::List { status, json } => execute_list(&project_id, status.as_deref(), json),
+        ControlsCmd::Show { patch_id } => execute_show(&project_id, &patch_id),
+        ControlsCmd::Approve {
+            patch_id,
+            by,
+            dry_run,
+            apply,
+            karvi_url,
+        } => execute_approve(
+            &project_id,
+            &patch_id,
+            &by,
+            dry_run,
+            apply,
+            &karvi_url,
+            repo_root,
+        ),
+        ControlsCmd::Dismiss { patch_id, reason } => {
+            execute_dismiss(&project_id, &patch_id, reason.as_deref())
+        }
+        ControlsCmd::Rules { json } => execute_rules(json),
+    }
+}
+
+fn execute_suggest(
+    project_id: &str,
+    repo_root: &Path,
+    min_samples: Option<u64>,
+) -> anyhow::Result<()> {
+    use edda_aggregate::aggregate::DateRange;
+    use edda_aggregate::quality::model_quality_from_events;
+    use edda_ledger::Ledger;
+
+    let ledger = Ledger::open(repo_root)?;
+    let events = ledger.iter_events_by_type("execution_event")?;
+    let report = model_quality_from_events(&events, &DateRange::default());
+
+    if report.total_steps == 0 {
+        println!("No execution events found. Cannot evaluate controls rules.");
+        return Ok(());
+    }
+
+    println!(
+        "Quality report: {} steps, {:.0}% success rate, ${:.2} total cost",
+        report.total_steps,
+        report.overall_success_rate * 100.0,
+        report.total_cost_usd
+    );
+
+    let rules = controls_suggest::load_rules();
+    let result =
+        controls_suggest::suggest_controls_patch(project_id, &report, &rules, min_samples)?;
+
+    match result {
+        Some(patch) => {
+            controls_suggest::save_patch(project_id, &patch)?;
+            println!();
+            println!("Controls patch created: {}", patch.patch_id);
+            println!("  Suggestions:");
+            for s in &patch.suggestions {
+                println!("    - {} -> {} ({})", s.rule_name, s.action, s.reason);
+            }
+            println!();
+            println!(
+                "Use `edda propose-patch approve {}` to approve and apply.",
+                patch.patch_id
+            );
+        }
+        None => {
+            println!();
+            println!("No threshold breaches detected (or cooldown active). No patch needed.");
+        }
+    }
+
+    Ok(())
+}
+
+fn execute_list(project_id: &str, status: Option<&str>, json: bool) -> anyhow::Result<()> {
+    let status_filter = match status {
+        Some("pending") => Some(PatchStatus::Pending),
+        Some("approved") => Some(PatchStatus::Approved),
+        Some("dismissed") => Some(PatchStatus::Dismissed),
+        Some("applied") => Some(PatchStatus::Applied),
+        Some(s) => {
+            anyhow::bail!("Unknown status: {s} (expected: pending, approved, dismissed, applied)")
+        }
+        None => None,
+    };
+
+    let patches = controls_suggest::list_patches(project_id, status_filter.as_ref())?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&patches)?);
+        return Ok(());
+    }
+
+    if patches.is_empty() {
+        let qualifier = status.unwrap_or("any");
+        println!("No {qualifier} controls patches found.");
+        println!("Use `edda propose-patch suggest` to evaluate quality rules.");
+        return Ok(());
+    }
+
+    for p in &patches {
+        let status_str = match p.status {
+            PatchStatus::Pending => "PENDING",
+            PatchStatus::Approved => "approved",
+            PatchStatus::Dismissed => "dismissed",
+            PatchStatus::Applied => "applied",
+        };
+        let actions: Vec<&str> = p.suggestions.iter().map(|s| s.action.as_str()).collect();
+        println!(
+            "  {} [{}] {} ({})",
+            p.patch_id,
+            status_str,
+            actions.join(", "),
+            p.created_at
+        );
+    }
+
+    Ok(())
+}
+
+fn execute_show(project_id: &str, patch_id: &str) -> anyhow::Result<()> {
+    let p = controls_suggest::load_patch(project_id, patch_id)?;
+
+    println!("Patch:     {}", p.patch_id);
+    println!("Status:    {:?}", p.status);
+    println!("Created:   {}", p.created_at);
+    println!();
+    println!("Controls:");
+    for (key, value) in &p.controls {
+        println!("  {key}: {value}");
+    }
+    println!();
+    println!("Suggestions:");
+    for s in &p.suggestions {
+        println!(
+            "  - [{}] {} -> {} ({} = {:.4}, threshold = {:.4})",
+            s.rule_name, s.reason, s.action, s.metric_name, s.current_value, s.threshold
+        );
+    }
+
+    if let Some(ref by) = p.approved_by {
+        println!();
+        println!("Approved by: {by}");
+        if let Some(ref at) = p.approved_at {
+            println!("Approved at: {at}");
+        }
+    }
+    if let Some(ref at) = p.applied_at {
+        println!("Applied at:  {at}");
+    }
+    if let Some(ref reason) = p.dismiss_reason {
+        println!();
+        println!("Dismiss reason: {reason}");
+    }
+
+    Ok(())
+}
+
+fn execute_approve(
+    project_id: &str,
+    patch_id: &str,
+    by: &str,
+    dry_run: bool,
+    apply: bool,
+    karvi_url: &str,
+    repo_root: &Path,
+) -> anyhow::Result<()> {
+    check_rbac_if_configured(repo_root, by, "approve_controls_patch")?;
+
+    if dry_run {
+        let patch = controls_suggest::load_patch(project_id, patch_id)?;
+        println!("=== DRY RUN ===");
+        println!("Would approve patch: {}", patch.patch_id);
+        println!("Controls:");
+        for (key, value) in &patch.controls {
+            println!("  {key}: {value}");
+        }
+        if apply {
+            println!();
+            println!("Would POST to {karvi_url}/api/controls");
+        }
+        return Ok(());
+    }
+
+    let _patch = controls_suggest::approve_patch(project_id, patch_id, by)?;
+    println!("Patch {patch_id} approved by {by}.");
+
+    if apply {
+        match controls_suggest::apply_patch_to_karvi(project_id, patch_id, karvi_url) {
+            Ok(()) => println!("Patch applied to Karvi at {karvi_url}."),
+            Err(e) => {
+                eprintln!("Warning: Patch approved but Karvi apply failed: {e}");
+                eprintln!("The patch is marked as approved. Retry with:");
+                eprintln!(
+                    "  edda propose-patch approve {patch_id} --apply --karvi-url {karvi_url}"
+                );
+            }
+        }
+    } else {
+        println!("Use --apply to also POST to Karvi, or apply manually.");
+    }
+
+    Ok(())
+}
+
+fn execute_dismiss(project_id: &str, patch_id: &str, reason: Option<&str>) -> anyhow::Result<()> {
+    controls_suggest::dismiss_patch(project_id, patch_id, reason)?;
+    println!("Patch {patch_id} dismissed.");
+    if let Some(r) = reason {
+        println!("  Reason: {r}");
+    }
+    Ok(())
+}
+
+fn execute_rules(json: bool) -> anyhow::Result<()> {
+    let rules = controls_suggest::load_rules();
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&rules)?);
+        return Ok(());
+    }
+
+    println!("Active threshold rules ({}):", rules.len());
+    println!();
+    for r in &rules {
+        let op_str = match r.operator {
+            edda_aggregate::controls::ThresholdOp::Lt => "<",
+            edda_aggregate::controls::ThresholdOp::Gt => ">",
+            edda_aggregate::controls::ThresholdOp::Lte => "<=",
+            edda_aggregate::controls::ThresholdOp::Gte => ">=",
+        };
+        println!(
+            "  {} : {:?} {} {:.4} -> {}",
+            r.name, r.metric, op_str, r.threshold, r.action
+        );
+        println!("    Reason: {}", r.reason_template);
+    }
+
+    Ok(())
+}
+
+/// Check RBAC if policy.yaml has permissions configured. Permissive default.
+fn check_rbac_if_configured(repo_root: &Path, actor: &str, action: &str) -> anyhow::Result<()> {
+    let edda_dir = repo_root.join(".edda");
+    let policy = edda_core::policy::load_policy_from_dir(&edda_dir)?;
+
+    if policy.permissions.is_none() {
+        return Ok(());
+    }
+
+    let actors = edda_core::policy::load_actors_from_dir(&edda_dir)?;
+    let req = edda_core::policy::AuthzRequest {
+        actor: actor.to_string(),
+        action: action.to_string(),
+        resource: None,
+    };
+    let result = edda_core::policy::evaluate_authz(&req, &policy, &actors);
+    if !result.allowed {
+        let reason = result.reason.unwrap_or_default();
+        anyhow::bail!("RBAC denied: actor '{actor}' lacks '{action}' permission. {reason}");
+    }
+    Ok(())
+}

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -9,6 +9,7 @@ mod cmd_commit;
 mod cmd_conduct;
 mod cmd_config;
 mod cmd_context;
+mod cmd_controls;
 mod cmd_draft;
 mod cmd_gc;
 mod cmd_group;
@@ -473,6 +474,12 @@ enum Command {
     ProposeIssue {
         #[command(subcommand)]
         cmd: cmd_propose::ProposeCmd,
+    },
+    /// Controls patch workflow — evaluate quality rules and propose Karvi controls adjustments
+    #[command(name = "propose-patch")]
+    ProposePatch {
+        #[command(subcommand)]
+        cmd: cmd_controls::ControlsCmd,
     },
     /// Manage skill registry (scan, list, show, search)
     Skill {
@@ -1141,6 +1148,7 @@ fn main() -> anyhow::Result<()> {
         Command::Rules { cmd } => cmd_rules::execute(cmd, &repo_root),
         Command::Scan { cmd } => cmd_scan::execute(cmd, &repo_root),
         Command::ProposeIssue { cmd } => cmd_propose::execute(cmd, &repo_root),
+        Command::ProposePatch { cmd } => cmd_controls::execute(cmd, &repo_root),
         Command::Skill { cmd } => cmd_skill::execute(cmd, &repo_root),
         Command::ToolTier { cmd } => cmd_tool_tier::run(cmd, &repo_root),
     }

--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use tower_http::cors::CorsLayer;
 
 use edda_aggregate::aggregate::{aggregate_decisions, aggregate_overview, DateRange};
+use edda_aggregate::controls::evaluate_controls_rules;
 use edda_aggregate::graph::build_dependency_graph;
 use edda_aggregate::quality::{model_quality_from_events, QualityReport};
 use edda_aggregate::risk::{compute_decision_risks, DecisionInput, DecisionRisk};
@@ -160,6 +161,12 @@ pub async fn serve(repo_root: &Path, config: ServeConfig) -> anyhow::Result<()> 
         .route("/api/briefs", get(get_briefs))
         .route("/api/briefs/{task_id}", get(get_brief))
         .route("/api/events/stream", get(get_event_stream))
+        .route("/api/controls/suggestions", get(get_controls_suggestions))
+        .route("/api/controls/patches", get(get_controls_patches))
+        .route(
+            "/api/controls/patches/{patch_id}/approve",
+            post(post_approve_controls_patch),
+        )
         .layer(CorsLayer::permissive())
         .with_state(state);
 
@@ -217,6 +224,12 @@ pub fn router(repo_root: &Path) -> Router {
         .route("/api/sync", post(post_sync))
         .route("/dashboard", get(serve_dashboard))
         .route("/api/events/stream", get(get_event_stream))
+        .route("/api/controls/suggestions", get(get_controls_suggestions))
+        .route("/api/controls/patches", get(get_controls_patches))
+        .route(
+            "/api/controls/patches/{patch_id}/approve",
+            post(post_approve_controls_patch),
+        )
         .layer(CorsLayer::permissive())
         .with_state(state)
 }
@@ -1096,6 +1109,100 @@ async fn get_quality_metrics(
     let events = ledger.iter_events_by_type("execution_event")?;
     let report = model_quality_from_events(&events, &range);
     Ok(Json(report))
+}
+
+// ── GET /api/controls/suggestions ──
+
+#[derive(Deserialize)]
+struct ControlsSuggestionsQuery {
+    after: Option<String>,
+    before: Option<String>,
+    min_samples: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct ControlsSuggestionsResponse {
+    suggestions: Vec<edda_aggregate::controls::ControlsSuggestion>,
+    quality: QualityReport,
+}
+
+async fn get_controls_suggestions(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<ControlsSuggestionsQuery>,
+) -> Result<Json<ControlsSuggestionsResponse>, AppError> {
+    let range = DateRange {
+        after: params.after,
+        before: params.before,
+    };
+    let ledger = state.open_ledger()?;
+    let events = ledger.iter_events_by_type("execution_event")?;
+    let report = model_quality_from_events(&events, &range);
+
+    let rules = edda_bridge_claude::controls_suggest::load_rules();
+    let suggestions = evaluate_controls_rules(&rules, &report, params.min_samples);
+
+    Ok(Json(ControlsSuggestionsResponse {
+        suggestions,
+        quality: report,
+    }))
+}
+
+// ── GET /api/controls/patches ──
+
+#[derive(Deserialize)]
+struct ControlsPatchesQuery {
+    status: Option<String>,
+}
+
+async fn get_controls_patches(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<ControlsPatchesQuery>,
+) -> Result<Json<Vec<edda_bridge_claude::controls_suggest::ControlsPatch>>, AppError> {
+    let project_id = edda_store::project_id(&state.repo_root);
+
+    let status_filter = match params.status.as_deref() {
+        Some("pending") => Some(edda_bridge_claude::controls_suggest::PatchStatus::Pending),
+        Some("approved") => Some(edda_bridge_claude::controls_suggest::PatchStatus::Approved),
+        Some("dismissed") => Some(edda_bridge_claude::controls_suggest::PatchStatus::Dismissed),
+        Some("applied") => Some(edda_bridge_claude::controls_suggest::PatchStatus::Applied),
+        Some(s) => {
+            return Err(AppError::Validation(format!(
+                "Unknown status: {s} (expected: pending, approved, dismissed, applied)"
+            )));
+        }
+        None => None,
+    };
+
+    let patches =
+        edda_bridge_claude::controls_suggest::list_patches(&project_id, status_filter.as_ref())?;
+    Ok(Json(patches))
+}
+
+// ── POST /api/controls/patches/{patch_id}/approve ──
+
+#[derive(Deserialize)]
+struct ApprovePatchBody {
+    #[serde(default = "default_approve_actor")]
+    by: String,
+}
+
+fn default_approve_actor() -> String {
+    "api".to_string()
+}
+
+async fn post_approve_controls_patch(
+    State(state): State<Arc<AppState>>,
+    AxumPath(patch_id): AxumPath<String>,
+    body: Result<Json<ApprovePatchBody>, JsonRejection>,
+) -> Result<Json<edda_bridge_claude::controls_suggest::ControlsPatch>, AppError> {
+    let project_id = edda_store::project_id(&state.repo_root);
+    let by = match body {
+        Ok(Json(b)) => b.by,
+        Err(_) => "api".to_string(),
+    };
+
+    let patch = edda_bridge_claude::controls_suggest::approve_patch(&project_id, &patch_id, &by)?;
+    Ok(Json(patch))
 }
 
 // ── POST /api/scope/check ──


### PR DESCRIPTION
## Summary
- **L2 threshold engine** (`edda-aggregate/src/controls.rs`): Generic `evaluate_controls_rules()` evaluates `ThresholdRule`s against `QualityReport`, producing `ControlsSuggestion`s when metrics breach thresholds. Supports `SuccessRate`, `AvgCostUsd`, `AvgLatencyMs`, `TotalCostUsd` metrics with `Lt/Gt/Lte/Gte` operators and configurable `min_samples` guard.
- **L3 Karvi adapter** (`edda-bridge-claude/src/controls_suggest.rs`): `ControlsPatch` CRUD with `Pending -> Approved -> Applied` lifecycle, 24h cooldown to prevent flapping, audit logging, and `apply_patch_to_karvi()` for POSTing to Karvi `/api/controls`.
- **CLI** (`edda-cli/src/cmd_controls.rs`): `edda propose-patch` with `suggest`, `list`, `show`, `approve`, `dismiss`, `rules` subcommands. RBAC check on approve.
- **HTTP API** (`edda-serve/src/lib.rs`): `GET /api/controls/suggestions`, `GET /api/controls/patches`, `POST /api/controls/patches/{id}/approve`.

## Architecture
Split architecture per plan: generic computation at L2, Karvi-specific integration at L3, following existing `quality.rs` / `issue_proposal.rs` patterns.

Default rules:
- `success_rate < 60%` -> `disable_auto_dispatch`
- `avg_cost_usd > $0.50` -> `reduce_concurrency`
- `avg_latency_ms > 30000ms` -> `flag_slow_model`

## Test plan
- [x] 11 L2 tests: threshold evaluation, min_samples guard, operator coverage, reason formatting
- [x] 10 L3 tests: CRUD roundtrip, status transitions, cooldown, audit log, serde
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [ ] Manual: `edda propose-patch rules` shows default rules
- [ ] Manual: `edda propose-patch suggest` with quality data generates patch

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)