### PR TITLE
feat(api): add DecideSnapshot storage endpoint (#272)

### DIFF
--- a/crates/edda-core/src/event.rs
+++ b/crates/edda-core/src/event.rs
@@ -667,6 +667,38 @@ pub fn new_execution_event(
     Ok(event)
 }
 
+/// Create a new `decide_snapshot` event.
+///
+/// The payload contains compact metadata; large context/result data should
+/// be offloaded to blob store by the caller and referenced via `blob_refs`.
+pub fn new_snapshot_event(
+    branch: &str,
+    parent_hash: Option<&str>,
+    payload: serde_json::Value,
+    blob_refs: Vec<String>,
+) -> anyhow::Result<Event> {
+    let mut event = Event {
+        event_id: new_event_id(),
+        ts: now_rfc3339(),
+        event_type: "decide_snapshot".to_string(),
+        branch: branch.to_string(),
+        parent_hash: parent_hash.map(|s| s.to_string()),
+        hash: String::new(),
+        payload,
+        refs: Refs {
+            blobs: blob_refs,
+            ..Default::default()
+        },
+        schema_version: SCHEMA_VERSION,
+        digests: Vec::new(),
+        event_family: None,
+        event_level: None,
+    };
+
+    finalize(&mut event)?;
+    Ok(event)
+}
+
 /// Parameters for creating an `approval_policy_match` event.
 #[derive(Debug, Clone)]
 pub struct ApprovalPolicyMatchParams {

--- a/crates/edda-core/src/types.rs
+++ b/crates/edda-core/src/types.rs
@@ -72,6 +72,7 @@ pub fn classify_event_type(event_type: &str) -> (Option<&'static str>, Option<&'
             Some(event_level::GOVERNANCE),
         ),
         "device_pair" | "device_revoke" => (Some(event_family::ADMIN), Some(event_level::INFO)),
+        "decide_snapshot" => (Some(event_family::GOVERNANCE), Some(event_level::MILESTONE)),
         _ => (None, None),
     }
 }
@@ -308,6 +309,11 @@ mod tests {
             ),
             ("device_pair", event_family::ADMIN, event_level::INFO),
             ("device_revoke", event_family::ADMIN, event_level::INFO),
+            (
+                "decide_snapshot",
+                event_family::GOVERNANCE,
+                event_level::MILESTONE,
+            ),
         ];
 
         for (event_type, expected_family, expected_level) in &table {

--- a/crates/edda-ledger/src/blob_store.rs
+++ b/crates/edda-ledger/src/blob_store.rs
@@ -139,6 +139,26 @@ pub fn blob_put_classified(
     Ok(blob_ref)
 }
 
+/// Threshold in bytes for offloading snapshot payloads to blob store.
+pub const SNAPSHOT_BLOB_THRESHOLD: usize = 8192;
+
+/// Conditionally write bytes to blob store if they exceed `threshold`.
+///
+/// Returns `Some(blob_ref)` if offloaded, `None` if the data is small
+/// enough to stay inline in the event payload.
+pub fn blob_put_if_large(
+    paths: &EddaPaths,
+    data: &[u8],
+    class: BlobClass,
+    threshold: usize,
+) -> anyhow::Result<Option<String>> {
+    if data.len() > threshold {
+        Ok(Some(blob_put_classified(paths, data, class)?))
+    } else {
+        Ok(None)
+    }
+}
+
 /// List archived blobs with their sizes.
 pub fn blob_list_archived(paths: &EddaPaths) -> anyhow::Result<Vec<BlobInfo>> {
     if !paths.archive_blobs_dir.exists() {

--- a/crates/edda-ledger/src/ledger.rs
+++ b/crates/edda-ledger/src/ledger.rs
@@ -361,6 +361,35 @@ impl Ledger {
     pub fn revoke_all_device_tokens(&self, revoke_event_id: &str) -> anyhow::Result<u64> {
         self.sqlite.revoke_all_device_tokens(revoke_event_id)
     }
+
+    // ── Decide Snapshots ────────────────────────────────────────────
+
+    /// Insert a row into the `decide_snapshots` materialized view.
+    pub fn insert_snapshot(
+        &self,
+        row: &crate::sqlite_store::DecideSnapshotRow,
+    ) -> anyhow::Result<()> {
+        self.sqlite.insert_snapshot(row)
+    }
+
+    /// Query snapshots with optional filtering by village_id and engine_version.
+    pub fn query_snapshots(
+        &self,
+        village_id: Option<&str>,
+        engine_version: Option<&str>,
+        limit: usize,
+    ) -> anyhow::Result<Vec<crate::sqlite_store::DecideSnapshotRow>> {
+        self.sqlite
+            .query_snapshots(village_id, engine_version, limit)
+    }
+
+    /// Find all snapshots for a given context_hash.
+    pub fn snapshots_by_context_hash(
+        &self,
+        context_hash: &str,
+    ) -> anyhow::Result<Vec<crate::sqlite_store::DecideSnapshotRow>> {
+        self.sqlite.snapshots_by_context_hash(context_hash)
+    }
 }
 
 // ── Init functions ──────────────────────────────────────────────────

--- a/crates/edda-ledger/src/lib.rs
+++ b/crates/edda-ledger/src/lib.rs
@@ -11,12 +11,13 @@ pub mod tombstone;
 pub use blob_meta::{BlobClass, BlobMetaEntry, BlobMetaMap, ClassChange};
 pub use blob_store::{
     blob_archive, blob_get_path, blob_is_archived, blob_list, blob_list_archived,
-    blob_put_classified, blob_remove, blob_size, BlobInfo,
+    blob_put_classified, blob_put_if_large, blob_remove, blob_size, BlobInfo,
+    SNAPSHOT_BLOB_THRESHOLD,
 };
 pub use ledger::Ledger;
 pub use lock::WorkspaceLock;
 pub use paths::EddaPaths;
 pub use sqlite_store::{
-    BundleRow, DecisionRow, DepRow, DeviceTokenRow, ImportParams, TaskBriefRow,
+    BundleRow, DecideSnapshotRow, DecisionRow, DepRow, DeviceTokenRow, ImportParams, TaskBriefRow,
 };
 pub use tombstone::{append_tombstone, list_tombstones, make_tombstone, DeleteReason, Tombstone};

--- a/crates/edda-ledger/src/sqlite_store.rs
+++ b/crates/edda-ledger/src/sqlite_store.rs
@@ -111,6 +111,24 @@ CREATE INDEX IF NOT EXISTS idx_device_tokens_name ON device_tokens(device_name);
 CREATE INDEX IF NOT EXISTS idx_device_tokens_active ON device_tokens(revoked_at) WHERE revoked_at IS NULL;
 ";
 
+const SCHEMA_V8_SQL: &str = "
+CREATE TABLE IF NOT EXISTS decide_snapshots (
+    event_id        TEXT PRIMARY KEY REFERENCES events(event_id),
+    context_hash    TEXT NOT NULL,
+    engine_version  TEXT NOT NULL,
+    schema_version  TEXT NOT NULL DEFAULT 'snapshot.v1',
+    redaction_level TEXT NOT NULL DEFAULT 'full',
+    village_id      TEXT,
+    cycle_id        TEXT,
+    has_blobs       BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_snapshots_context_hash ON decide_snapshots(context_hash);
+CREATE INDEX IF NOT EXISTS idx_snapshots_village ON decide_snapshots(village_id) WHERE village_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_snapshots_engine ON decide_snapshots(engine_version);
+CREATE INDEX IF NOT EXISTS idx_snapshots_village_engine ON decide_snapshots(village_id, engine_version);
+";
+
 const SCHEMA_V3_SQL: &str = "
 CREATE TABLE IF NOT EXISTS review_bundles (
     event_id TEXT PRIMARY KEY REFERENCES events(event_id),
@@ -228,6 +246,20 @@ pub struct DeviceTokenRow {
     pub revoke_event_id: Option<String>,
 }
 
+/// A row from the `decide_snapshots` table.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DecideSnapshotRow {
+    pub event_id: String,
+    pub context_hash: String,
+    pub engine_version: String,
+    pub schema_version: String,
+    pub redaction_level: String,
+    pub village_id: Option<String>,
+    pub cycle_id: Option<String>,
+    pub has_blobs: bool,
+    pub created_at: String,
+}
+
 /// Aggregated outcome metrics for a decision.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct OutcomeMetrics {
@@ -341,6 +373,12 @@ impl SqliteStore {
         let current = self.schema_version()?;
         if current < 7 {
             self.migrate_v6_to_v7()?;
+        }
+
+        // Migrate to v8 if needed (decide_snapshots table)
+        let current = self.schema_version()?;
+        if current < 8 {
+            self.migrate_v7_to_v8()?;
         }
 
         Ok(())
@@ -561,6 +599,55 @@ impl SqliteStore {
         self.conn.execute_batch(SCHEMA_V7_SQL)?;
         // No backfill needed — device_tokens is a new feature with no existing data.
         self.set_schema_version(7)?;
+        Ok(())
+    }
+
+    fn migrate_v7_to_v8(&self) -> anyhow::Result<()> {
+        self.conn.execute_batch(SCHEMA_V8_SQL)?;
+
+        // Backfill: scan existing decide_snapshot events
+        let mut stmt = self.conn.prepare(
+            "SELECT event_id, ts, payload FROM events
+             WHERE event_type = 'decide_snapshot' ORDER BY rowid",
+        )?;
+        let rows: Vec<(String, String, String)> = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        for (event_id, ts, payload_str) in &rows {
+            let payload: serde_json::Value = match serde_json::from_str(payload_str) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            let context_hash = payload["context_hash"].as_str().unwrap_or("");
+            let engine_version = payload["engine_version"].as_str().unwrap_or("");
+            let schema_version = payload["schema_version"].as_str().unwrap_or("snapshot.v1");
+            let redaction_level = payload["redaction_level"].as_str().unwrap_or("full");
+            let village_id = payload["village_id"].as_str();
+            let cycle_id = payload["cycle_id"].as_str();
+            let has_blobs =
+                payload.get("context_blob").is_some() || payload.get("result_blob").is_some();
+
+            self.conn.execute(
+                "INSERT OR IGNORE INTO decide_snapshots
+                 (event_id, context_hash, engine_version, schema_version,
+                  redaction_level, village_id, cycle_id, has_blobs, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                params![
+                    event_id,
+                    context_hash,
+                    engine_version,
+                    schema_version,
+                    redaction_level,
+                    village_id,
+                    cycle_id,
+                    has_blobs,
+                    ts
+                ],
+            )?;
+        }
+
+        self.set_schema_version(8)?;
         Ok(())
     }
 
@@ -2102,6 +2189,105 @@ impl SqliteStore {
         rows.collect::<Result<Vec<_>, _>>()
             .map_err(|e| anyhow::anyhow!("task brief list query failed: {e}"))
     }
+
+    // ── Decide Snapshots ─────────────────────────────────────────────
+
+    /// Insert a row into the `decide_snapshots` materialized view.
+    pub fn insert_snapshot(&self, row: &DecideSnapshotRow) -> anyhow::Result<()> {
+        self.conn.execute(
+            "INSERT INTO decide_snapshots
+             (event_id, context_hash, engine_version, schema_version,
+              redaction_level, village_id, cycle_id, has_blobs, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                row.event_id,
+                row.context_hash,
+                row.engine_version,
+                row.schema_version,
+                row.redaction_level,
+                row.village_id,
+                row.cycle_id,
+                row.has_blobs,
+                row.created_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Query snapshots with optional filtering by village_id and engine_version.
+    pub fn query_snapshots(
+        &self,
+        village_id: Option<&str>,
+        engine_version: Option<&str>,
+        limit: usize,
+    ) -> anyhow::Result<Vec<DecideSnapshotRow>> {
+        let base = "SELECT event_id, context_hash, engine_version, schema_version,
+                           redaction_level, village_id, cycle_id, has_blobs, created_at
+                    FROM decide_snapshots";
+
+        let mut conditions: Vec<&str> = Vec::new();
+        let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+
+        if let Some(v) = village_id {
+            conditions.push("village_id = ?");
+            param_values.push(Box::new(v.to_string()));
+        }
+        if let Some(e) = engine_version {
+            conditions.push("engine_version = ?");
+            param_values.push(Box::new(e.to_string()));
+        }
+
+        let sql = if conditions.is_empty() {
+            format!("{base} ORDER BY created_at DESC LIMIT ?")
+        } else {
+            format!(
+                "{base} WHERE {} ORDER BY created_at DESC LIMIT ?",
+                conditions.join(" AND ")
+            )
+        };
+        param_values.push(Box::new(limit as i64));
+
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            param_values.iter().map(|p| p.as_ref()).collect();
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(param_refs.as_slice(), map_snapshot_row)?;
+
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| anyhow::anyhow!("snapshot query failed: {e}"))
+    }
+
+    /// Find all snapshots with a given context_hash (for version comparison).
+    pub fn snapshots_by_context_hash(
+        &self,
+        context_hash: &str,
+    ) -> anyhow::Result<Vec<DecideSnapshotRow>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT event_id, context_hash, engine_version, schema_version,
+                    redaction_level, village_id, cycle_id, has_blobs, created_at
+             FROM decide_snapshots
+             WHERE context_hash = ?1
+             ORDER BY created_at DESC",
+        )?;
+        let rows = stmt.query_map(params![context_hash], map_snapshot_row)?;
+
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| anyhow::anyhow!("snapshot context_hash query failed: {e}"))
+    }
+}
+
+fn map_snapshot_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<DecideSnapshotRow> {
+    Ok(DecideSnapshotRow {
+        event_id: row.get(0)?,
+        context_hash: row.get(1)?,
+        engine_version: row.get(2)?,
+        schema_version: row.get(3)?,
+        redaction_level: row.get(4)?,
+        village_id: row.get(5)?,
+        cycle_id: row.get(6)?,
+        has_blobs: row.get(7)?,
+        created_at: row.get(8)?,
+    })
 }
 
 impl Drop for SqliteStore {
@@ -3325,7 +3511,8 @@ mod tests {
         assert!(tables.contains(&"decision_deps".to_string()));
         assert!(tables.contains(&"task_briefs".to_string()));
         assert!(tables.contains(&"device_tokens".to_string()));
-        assert_eq!(store.schema_version().unwrap(), 7);
+        assert!(tables.contains(&"decide_snapshots".to_string()));
+        assert_eq!(store.schema_version().unwrap(), 8);
         drop(store);
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -1632,16 +1632,14 @@ async fn post_snapshot(
         edda_ledger::BlobClass::DecisionEvidence,
         threshold,
     )
-    .ok()
-    .flatten();
+    .map_err(|e| anyhow::anyhow!("writing context blob: {e}"))?;
     let result_blob = edda_ledger::blob_put_if_large(
         &ledger.paths,
         &result_bytes,
         edda_ledger::BlobClass::DecisionEvidence,
         threshold,
     )
-    .ok()
-    .flatten();
+    .map_err(|e| anyhow::anyhow!("writing result blob: {e}"))?;
 
     let has_blobs = context_blob.is_some() || result_blob.is_some();
 
@@ -5722,5 +5720,224 @@ actors:
             !yellow_names.contains(&"normal"),
             "Normal project should not be in yellow"
         );
+    }
+
+    // ── DecideSnapshot endpoint tests ──
+
+    fn snapshot_json() -> serde_json::Value {
+        serde_json::json!({
+            "engine_version": "claude-3.5",
+            "context_hash": "abc123def456",
+            "context": {"files": ["main.rs"], "prompt": "test"},
+            "result": {"decisions": [{"key": "db.engine", "value": "sqlite"}]},
+        })
+    }
+
+    #[tokio::test]
+    async fn post_snapshot_returns_201() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/snapshot")
+                    .header("content-type", "application/json")
+                    .body(Body::from(snapshot_json().to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["event_id"].as_str().unwrap().starts_with("evt_"));
+        assert_eq!(json["context_hash"], "abc123def456");
+    }
+
+    #[tokio::test]
+    async fn post_snapshot_rejects_empty_engine_version() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let body = serde_json::json!({
+            "engine_version": "",
+            "context_hash": "abc123",
+            "context": {},
+            "result": {},
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/snapshot")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn post_snapshot_rejects_empty_context_hash() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let body = serde_json::json!({
+            "engine_version": "claude-3.5",
+            "context_hash": "",
+            "context": {},
+            "result": {},
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/snapshot")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn post_snapshot_rejects_missing_fields() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let body = serde_json::json!({"engine_version": "claude-3.5"});
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/snapshot")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn get_snapshots_returns_posted() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+
+        // POST a snapshot
+        let app = router(tmp.path());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/snapshot")
+                    .header("content-type", "application/json")
+                    .body(Body::from(snapshot_json().to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        // GET /api/snapshots
+        let app2 = router(tmp.path());
+        let resp2 = app2
+            .oneshot(
+                Request::builder()
+                    .uri("/api/snapshots")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp2.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp2.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json.len(), 1);
+        assert_eq!(json[0]["context_hash"], "abc123def456");
+        assert_eq!(json[0]["engine_version"], "claude-3.5");
+    }
+
+    #[tokio::test]
+    async fn get_snapshots_by_context_hash() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+
+        // POST a snapshot
+        let app = router(tmp.path());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/snapshot")
+                    .header("content-type", "application/json")
+                    .body(Body::from(snapshot_json().to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        // GET /api/snapshots/:context_hash
+        let app2 = router(tmp.path());
+        let resp2 = app2
+            .oneshot(
+                Request::builder()
+                    .uri("/api/snapshots/abc123def456")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp2.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp2.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json.len(), 1);
+        assert_eq!(json[0]["context_hash"], "abc123def456");
+    }
+
+    #[tokio::test]
+    async fn get_snapshots_by_hash_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_workspace(tmp.path());
+        let app = router(tmp.path());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/snapshots/nonexistent_hash")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -28,7 +28,7 @@ use edda_aggregate::rollup;
 use edda_core::agent_phase::{mobile_context_summary, AgentPhaseState};
 use edda_core::event::{
     finalize_event, new_approval_event, new_decision_event, new_execution_event, new_note_event,
-    ApprovalEventParams,
+    new_snapshot_event, ApprovalEventParams,
 };
 use edda_core::policy::{self, ActorKind};
 use edda_core::types::{rel, DecisionPayload, Provenance};
@@ -198,6 +198,9 @@ pub async fn serve(repo_root: &Path, config: ServeConfig) -> anyhow::Result<()> 
             "/api/controls/patches/{patch_id}/approve",
             post(post_approve_controls_patch),
         )
+        .route("/api/snapshot", post(post_snapshot))
+        .route("/api/snapshots", get(get_snapshots))
+        .route("/api/snapshots/{context_hash}", get(get_snapshots_by_hash))
         .route("/api/pair/new", post(create_pairing))
         .route("/api/pair/list", get(list_paired_devices))
         .route("/api/pair/revoke", post(revoke_device))
@@ -283,6 +286,9 @@ pub fn router(repo_root: &Path) -> Router {
             "/api/controls/patches/{patch_id}/approve",
             post(post_approve_controls_patch),
         )
+        .route("/api/snapshot", post(post_snapshot))
+        .route("/api/snapshots", get(get_snapshots))
+        .route("/api/snapshots/{context_hash}", get(get_snapshots_by_hash))
         .route("/pair", get(complete_pairing))
         .route("/api/pair/new", post(create_pairing))
         .route("/api/pair/list", get(list_paired_devices))
@@ -1560,6 +1566,248 @@ async fn post_karvi_event(
     };
 
     Ok((status, Json(response)).into_response())
+}
+
+// ── POST /api/snapshot ──
+
+#[derive(Deserialize)]
+struct SnapshotBody {
+    context: serde_json::Value,
+    result: serde_json::Value,
+    engine_version: String,
+    #[serde(default = "default_snapshot_schema")]
+    schema_version: String,
+    context_hash: String,
+    #[serde(default = "default_redaction_level")]
+    redaction_level: String,
+    village_id: Option<String>,
+    cycle_id: Option<String>,
+}
+
+fn default_snapshot_schema() -> String {
+    "snapshot.v1".to_string()
+}
+
+fn default_redaction_level() -> String {
+    "full".to_string()
+}
+
+#[derive(Serialize)]
+struct SnapshotResponse {
+    event_id: String,
+    context_hash: String,
+}
+
+async fn post_snapshot(
+    State(state): State<Arc<AppState>>,
+    body: Result<Json<SnapshotBody>, JsonRejection>,
+) -> Result<impl IntoResponse, AppError> {
+    let Json(body) = body.map_err(|e| AppError::Validation(e.body_text()))?;
+
+    if body.engine_version.is_empty() {
+        return Err(AppError::Validation(
+            "engine_version must not be empty".into(),
+        ));
+    }
+    if body.context_hash.is_empty() {
+        return Err(AppError::Validation(
+            "context_hash must not be empty".into(),
+        ));
+    }
+
+    let ledger = state.open_ledger()?;
+    let _lock = WorkspaceLock::acquire(&ledger.paths)?;
+
+    let branch = ledger.head_branch()?;
+    let parent_hash = ledger.last_event_hash()?;
+
+    // Attempt blob offload for large payloads
+    let context_bytes = serde_json::to_vec(&body.context)?;
+    let result_bytes = serde_json::to_vec(&body.result)?;
+
+    let threshold = edda_ledger::SNAPSHOT_BLOB_THRESHOLD;
+    let context_blob = edda_ledger::blob_put_if_large(
+        &ledger.paths,
+        &context_bytes,
+        edda_ledger::BlobClass::DecisionEvidence,
+        threshold,
+    )
+    .ok()
+    .flatten();
+    let result_blob = edda_ledger::blob_put_if_large(
+        &ledger.paths,
+        &result_bytes,
+        edda_ledger::BlobClass::DecisionEvidence,
+        threshold,
+    )
+    .ok()
+    .flatten();
+
+    let has_blobs = context_blob.is_some() || result_blob.is_some();
+
+    // Build event payload: metadata + inline or blob refs
+    let mut payload = serde_json::json!({
+        "engine_version": body.engine_version,
+        "schema_version": body.schema_version,
+        "context_hash": body.context_hash,
+        "redaction_level": body.redaction_level,
+    });
+    if let Some(ref vid) = body.village_id {
+        payload["village_id"] = serde_json::Value::String(vid.clone());
+    }
+    if let Some(ref cid) = body.cycle_id {
+        payload["cycle_id"] = serde_json::Value::String(cid.clone());
+    }
+
+    let mut blob_refs = Vec::new();
+    if let Some(ref br) = context_blob {
+        payload["context_blob"] = serde_json::Value::String(br.clone());
+        blob_refs.push(br.clone());
+    } else {
+        payload["context_inline"] = body.context;
+    }
+    if let Some(ref br) = result_blob {
+        payload["result_blob"] = serde_json::Value::String(br.clone());
+        blob_refs.push(br.clone());
+    } else {
+        payload["result_inline"] = body.result;
+    }
+
+    let event = new_snapshot_event(&branch, parent_hash.as_deref(), payload, blob_refs)?;
+    let event_id = event.event_id.clone();
+    let created_at = event.ts.clone();
+
+    ledger.append_event(&event)?;
+
+    // Insert into materialized view
+    ledger.insert_snapshot(&edda_ledger::DecideSnapshotRow {
+        event_id: event_id.clone(),
+        context_hash: body.context_hash.clone(),
+        engine_version: body.engine_version,
+        schema_version: body.schema_version,
+        redaction_level: body.redaction_level,
+        village_id: body.village_id,
+        cycle_id: body.cycle_id,
+        has_blobs,
+        created_at,
+    })?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(SnapshotResponse {
+            event_id,
+            context_hash: body.context_hash,
+        }),
+    ))
+}
+
+// ── GET /api/snapshots ──
+
+#[derive(Deserialize)]
+struct SnapshotsQuery {
+    village_id: Option<String>,
+    engine_version: Option<String>,
+    #[serde(default = "default_snapshot_limit")]
+    limit: usize,
+}
+
+fn default_snapshot_limit() -> usize {
+    20
+}
+
+async fn get_snapshots(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<SnapshotsQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    let ledger = state.open_ledger()?;
+    let rows = ledger.query_snapshots(
+        query.village_id.as_deref(),
+        query.engine_version.as_deref(),
+        query.limit,
+    )?;
+
+    let mut snapshots = Vec::new();
+    for row in &rows {
+        let snapshot = reconstruct_snapshot(&ledger, row)?;
+        snapshots.push(snapshot);
+    }
+
+    Ok(Json(snapshots))
+}
+
+// ── GET /api/snapshots/:context_hash ──
+
+async fn get_snapshots_by_hash(
+    State(state): State<Arc<AppState>>,
+    AxumPath(context_hash): AxumPath<String>,
+) -> Result<impl IntoResponse, AppError> {
+    let ledger = state.open_ledger()?;
+    let rows = ledger.snapshots_by_context_hash(&context_hash)?;
+
+    if rows.is_empty() {
+        return Err(AppError::NotFound(format!(
+            "no snapshots found for context_hash: {context_hash}"
+        )));
+    }
+
+    let mut snapshots = Vec::new();
+    for row in &rows {
+        let snapshot = reconstruct_snapshot(&ledger, row)?;
+        snapshots.push(snapshot);
+    }
+
+    Ok(Json(snapshots))
+}
+
+/// Reconstruct a full snapshot JSON from a materialized view row + event payload.
+fn reconstruct_snapshot(
+    ledger: &Ledger,
+    row: &edda_ledger::DecideSnapshotRow,
+) -> Result<serde_json::Value, AppError> {
+    let event = ledger
+        .get_event(&row.event_id)?
+        .ok_or_else(|| AppError::Internal(anyhow::anyhow!("event {} not found", row.event_id)))?;
+
+    let payload = &event.payload;
+
+    // Resolve context: inline or blob
+    let context = if let Some(inline) = payload.get("context_inline") {
+        inline.clone()
+    } else if let Some(blob_ref) = payload.get("context_blob").and_then(|v| v.as_str()) {
+        let path =
+            edda_ledger::blob_get_path(&ledger.paths, blob_ref).map_err(AppError::Internal)?;
+        let bytes = std::fs::read(&path)
+            .map_err(|e| AppError::Internal(anyhow::anyhow!("read context blob: {e}")))?;
+        serde_json::from_slice(&bytes)?
+    } else {
+        serde_json::Value::Null
+    };
+
+    // Resolve result: inline or blob
+    let result = if let Some(inline) = payload.get("result_inline") {
+        inline.clone()
+    } else if let Some(blob_ref) = payload.get("result_blob").and_then(|v| v.as_str()) {
+        let path =
+            edda_ledger::blob_get_path(&ledger.paths, blob_ref).map_err(AppError::Internal)?;
+        let bytes = std::fs::read(&path)
+            .map_err(|e| AppError::Internal(anyhow::anyhow!("read result blob: {e}")))?;
+        serde_json::from_slice(&bytes)?
+    } else {
+        serde_json::Value::Null
+    };
+
+    Ok(serde_json::json!({
+        "event_id": row.event_id,
+        "context_hash": row.context_hash,
+        "engine_version": row.engine_version,
+        "schema_version": row.schema_version,
+        "redaction_level": row.redaction_level,
+        "village_id": row.village_id,
+        "cycle_id": row.cycle_id,
+        "context": context,
+        "result": result,
+        "created_at": row.created_at,
+    }))
 }
 
 // ── GET /api/recap ──


### PR DESCRIPTION
## Summary

- Adds `decide_snapshot` event type with governance/milestone taxonomy classification
- Schema v8 migration creates `decide_snapshots` materialized view with indexes on `context_hash`, `village_id`, `engine_version`
- 3 HTTP endpoints: `POST /api/snapshot`, `GET /api/snapshots`, `GET /api/snapshots/:context_hash`
- Blob offload for payloads >8KB using `DecisionEvidence` classification
- Hash chain integrity maintained via existing `finalize()` + `append_event()` flow

## Changes

### L1 (edda-core)
- `classify_event_type("decide_snapshot")` returns `(governance, milestone)`
- `new_snapshot_event()` builder function

### L2 (edda-ledger)
- `blob_put_if_large()` — conditional blob offload helper
- `SCHEMA_V8_SQL` — `decide_snapshots` table with FK to events
- `insert_snapshot()`, `query_snapshots()`, `snapshots_by_context_hash()` CRUD
- Schema migration v7->v8 with backfill from existing events
- Ledger facade pass-through methods

### L4 (edda-serve)
- `POST /api/snapshot` — accepts DecideSnapshot, offloads large payloads to blob store
- `GET /api/snapshots?village_id=&engine_version=&limit=` — filtered listing
- `GET /api/snapshots/:context_hash` — find all versions for same context (A/B comparison)
- `reconstruct_snapshot()` resolves inline/blob data for GET responses

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` clean
- [x] Existing tests pass (3 pre-existing failures unrelated to this PR)
- [x] Schema migration test updated for v8
- [ ] Manual: POST snapshot with small payload (inline)
- [ ] Manual: POST snapshot with large payload (blob offload)
- [ ] Manual: GET snapshots with village_id filter
- [ ] Manual: GET snapshots/:context_hash returns multiple versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)