### PR TITLE
fix(bridge): join SessionEnd background threads before process exit (#287)

### DIFF
--- a/crates/edda-bridge-claude/src/dispatch/session.rs
+++ b/crates/edda-bridge-claude/src/dispatch/session.rs
@@ -288,19 +288,32 @@ pub(super) fn dispatch_session_end(
     // 2e. L3 post-mortem analysis (best-effort, fire-and-forget)
     run_postmortem(project_id, session_id, cwd);
 
-    // 2f. Background decision extraction (non-blocking, best-effort)
+    // 2f–2i. Background tasks with channel-based completion tracking.
+    // Previously these were fire-and-forget spawns whose JoinHandles were
+    // dropped.  Because SessionEnd is the last hook event the process could
+    // exit before the threads finished, truncating LLM API calls and state
+    // writes.  We now collect completions via an mpsc channel and join with
+    // a configurable timeout (EDDA_BG_JOIN_TIMEOUT_SECS, default 45).
+    let (bg_tx, bg_rx) = std::sync::mpsc::channel::<&'static str>();
+    let mut bg_count: usize = 0;
+
+    // 2f. Background decision extraction
     if crate::bg_extract::should_run(project_id, session_id) {
+        let tx = bg_tx.clone();
         let pid = project_id.to_string();
         let sid = session_id.to_string();
         std::thread::spawn(move || {
             if let Err(e) = crate::bg_extract::run_extraction(&pid, &sid) {
                 tracing::warn!(error = %e, "decision extraction failed");
             }
+            let _ = tx.send("bg_extract");
         });
+        bg_count += 1;
     }
 
-    // 2g. Background session digest (non-blocking, best-effort)
+    // 2g. Background session digest
     if crate::bg_digest::should_run(project_id, session_id) {
+        let tx = bg_tx.clone();
         let pid = project_id.to_string();
         let sid = session_id.to_string();
         let cwd_str = cwd.to_string();
@@ -308,32 +321,78 @@ pub(super) fn dispatch_session_end(
             if let Err(e) = crate::bg_digest::run_digest(&pid, &sid, &cwd_str) {
                 tracing::warn!(error = %e, "session digest failed");
             }
+            let _ = tx.send("bg_digest");
         });
+        bg_count += 1;
     }
 
-    // 2h. Background capability scan (non-blocking, cooldown-gated)
+    // 2h. Background capability scan (cooldown-gated)
     if crate::bg_scan::should_run(project_id)
         || crate::bg_scan::has_recent_milestone(project_id, cwd)
     {
+        let tx = bg_tx.clone();
         let pid = project_id.to_string();
         let cwd_owned = cwd.to_string();
         std::thread::spawn(move || {
             if let Err(e) = crate::bg_scan::run_scan(&pid, &cwd_owned) {
                 tracing::warn!(error = %e, "capability scan failed");
             }
+            let _ = tx.send("bg_scan");
         });
+        bg_count += 1;
     }
 
-    // 2i. Background pattern detection (non-blocking, interval-gated)
+    // 2i. Background pattern detection (interval-gated)
     crate::bg_detect::increment_session_count(project_id);
     if crate::bg_detect::should_run(project_id) {
+        let tx = bg_tx.clone();
         let pid = project_id.to_string();
         let cwd_owned = cwd.to_string();
         std::thread::spawn(move || {
             if let Err(e) = crate::bg_detect::run_detect(&pid, &cwd_owned) {
                 eprintln!("[edda-bg] pattern detection failed: {e}");
             }
+            let _ = tx.send("bg_detect");
         });
+        bg_count += 1;
+    }
+
+    // Drop the original sender so the channel closes when all threads finish.
+    drop(bg_tx);
+
+    // Join background threads with a configurable timeout.
+    let bg_timeout = std::time::Duration::from_secs(
+        std::env::var("EDDA_BG_JOIN_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(45),
+    );
+    let deadline = std::time::Instant::now() + bg_timeout;
+    let mut completed = 0;
+    while completed < bg_count {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            tracing::warn!(
+                completed,
+                total = bg_count,
+                "background thread join timeout — abandoning remaining"
+            );
+            break;
+        }
+        match bg_rx.recv_timeout(remaining) {
+            Ok(name) => {
+                completed += 1;
+                tracing::debug!(name, completed, total = bg_count, "bg thread done");
+            }
+            Err(_) => {
+                tracing::warn!(
+                    completed,
+                    total = bg_count,
+                    "background thread join timeout"
+                );
+                break;
+            }
+        }
     }
 
     // 2d. Push notification (best-effort, fire-and-forget)

--- a/crates/edda-bridge-claude/src/dispatch/tests.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tests.rs
@@ -2719,3 +2719,33 @@ fn read_project_state_empty_tasks() {
     let summary = result.unwrap();
     assert!(summary.contains("Tasks: (none)"));
 }
+
+// ── Issue #287: SessionEnd background thread join ──
+
+#[test]
+fn session_end_bg_threads_joined_zero_threads() {
+    // Regression test: when no background threads are spawned (no API key),
+    // the channel-based join must complete immediately without hanging.
+    let pid = "test_se_bg_join_zero";
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    let _ = edda_store::ensure_dirs(pid);
+    let cwd = tempfile::tempdir().unwrap();
+
+    // Disable features that would require external state
+    std::env::set_var("EDDA_BRIDGE_AUTO_DIGEST", "0");
+    std::env::set_var("EDDA_PLANS_DIR", "/nonexistent");
+    std::env::set_var("EDDA_POSTMORTEM", "0");
+    // No EDDA_LLM_API_KEY → all should_run() return false → bg_count=0
+    std::env::remove_var("EDDA_LLM_API_KEY");
+    // Use a short join timeout to catch hangs quickly
+    std::env::set_var("EDDA_BG_JOIN_TIMEOUT_SECS", "1");
+
+    let result = dispatch_session_end(pid, "s1", "", cwd.path().to_str().unwrap(), false);
+    assert!(result.is_ok(), "dispatch_session_end should succeed with zero bg threads");
+
+    std::env::remove_var("EDDA_BRIDGE_AUTO_DIGEST");
+    std::env::remove_var("EDDA_PLANS_DIR");
+    std::env::remove_var("EDDA_POSTMORTEM");
+    std::env::remove_var("EDDA_BG_JOIN_TIMEOUT_SECS");
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}

--- a/crates/edda-cli/src/cmd_bridge.rs
+++ b/crates/edda-cli/src/cmd_bridge.rs
@@ -379,12 +379,15 @@ where
     }
 }
 
-/// Hook timeout in milliseconds. Configurable via `EDDA_HOOK_TIMEOUT_MS` (default: 10s).
+/// Hook timeout in milliseconds. Configurable via `EDDA_HOOK_TIMEOUT_MS` (default: 60s).
+///
+/// Raised from 10s to 60s to accommodate SessionEnd background threads that
+/// make LLM API calls (bg_extract, bg_digest, bg_scan, bg_detect).  See #287.
 fn hook_timeout_ms() -> u64 {
     std::env::var("EDDA_HOOK_TIMEOUT_MS")
         .ok()
         .and_then(|v| v.parse().ok())
-        .unwrap_or(10_000)
+        .unwrap_or(60_000)
 }
 
 fn debug_log(msg: &str) {
@@ -1457,9 +1460,9 @@ mod tests {
     }
 
     #[test]
-    fn hook_timeout_ms_defaults_to_10s() {
+    fn hook_timeout_ms_defaults_to_60s() {
         std::env::remove_var("EDDA_HOOK_TIMEOUT_MS");
-        assert_eq!(hook_timeout_ms(), 10_000);
+        assert_eq!(hook_timeout_ms(), 60_000);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace fire-and-forget `std::thread::spawn` in `dispatch_session_end` with channel-based (`mpsc`) completion tracking — background threads now signal done via channel, joined with configurable timeout (`EDDA_BG_JOIN_TIMEOUT_SECS`, default 45s)
- Raise default `EDDA_HOOK_TIMEOUT_MS` from 10s to 60s to accommodate SessionEnd LLM API calls
- Add regression test for zero-thread join case (channel completes immediately)

## Test plan

- [x] `cargo clippy -p edda-bridge-claude -p edda -- -D warnings` passes
- [x] All 11 `session_end` tests pass (`cargo test -p edda-bridge-claude -- session_end`)
- [x] `hook_timeout_ms` tests updated and passing (default now 60s)
- [x] New `session_end_bg_threads_joined_zero_threads` test passes
- [ ] Manual: verify with `EDDA_LLM_API_KEY` set that bg threads complete before process exit

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)