### PR TITLE
fix(serve): restrict CORS to localhost + narrow router visibility

### DIFF
--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -15,7 +15,7 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use edda_ledger::device_token::{generate_device_token, hash_token};
 use serde::{Deserialize, Serialize};
-use tower_http::cors::CorsLayer;
+use tower_http::cors::{AllowOrigin, CorsLayer};
 
 use edda_aggregate::aggregate::{
     aggregate_decisions, aggregate_overview, per_project_metrics, DateRange, ProjectMetrics,
@@ -210,10 +210,26 @@ pub async fn serve(repo_root: &Path, config: ServeConfig) -> anyhow::Result<()> 
             auth_middleware,
         ));
 
+    // SECURITY: restrict CORS to localhost origins only. edda is a local
+    // development tool; if remote access is needed, consider adding an
+    // explicit --cors-origin CLI flag.
+    let cors = CorsLayer::new()
+        .allow_origin(AllowOrigin::list([
+            format!("http://127.0.0.1:{}", config.port)
+                .parse()
+                .unwrap(),
+            format!("http://localhost:{}", config.port)
+                .parse()
+                .unwrap(),
+            format!("http://[::1]:{}", config.port).parse().unwrap(),
+        ]))
+        .allow_methods(tower_http::cors::Any)
+        .allow_headers(tower_http::cors::Any);
+
     let app = Router::new()
         .merge(public_routes)
         .merge(protected_routes)
-        .layer(CorsLayer::permissive())
+        .layer(cors)
         .with_state(state);
 
     let addr = format!("{}:{}", config.bind, config.port);
@@ -229,7 +245,8 @@ pub async fn serve(repo_root: &Path, config: ServeConfig) -> anyhow::Result<()> 
 
 /// Build the router (for testing without binding to a port).
 /// Note: no auth middleware is applied here — tests run as localhost.
-pub fn router(repo_root: &Path) -> Router {
+#[allow(dead_code)]
+pub(crate) fn router(repo_root: &Path) -> Router {
     let store_root = edda_store::store_root();
     let chronicle = if store_root.exists() {
         Some(ChronicleContext {
@@ -294,7 +311,6 @@ pub fn router(repo_root: &Path) -> Router {
         .route("/api/pair/list", get(list_paired_devices))
         .route("/api/pair/revoke", post(revoke_device))
         .route("/api/pair/revoke-all", post(revoke_all_devices))
-        .layer(CorsLayer::permissive())
         .with_state(state)
 }
 
@@ -2545,6 +2561,9 @@ struct ScopeCheckResponse {
     results: Vec<ScopeCheckResult>,
 }
 
+// SECURITY: `project_id` is caller-supplied and not validated against any
+// ACL. Acceptable because edda is a single-user local tool; revisit if
+// multi-tenant isolation is ever required.
 async fn post_scope_check(
     Json(body): Json<ScopeCheckBody>,
 ) -> Result<Json<ScopeCheckResponse>, AppError> {
@@ -2634,6 +2653,9 @@ struct WhitelistResponse {
     claims: Vec<WhitelistClaim>,
 }
 
+// SECURITY: `project_id` is caller-supplied and not validated against any
+// ACL. Acceptable because edda is a single-user local tool; revisit if
+// multi-tenant isolation is ever required.
 async fn get_scope_whitelist(
     Query(query): Query<WhitelistQuery>,
 ) -> Result<Json<WhitelistResponse>, AppError> {

--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -217,11 +217,13 @@ pub async fn serve(repo_root: &Path, config: ServeConfig) -> anyhow::Result<()> 
         .allow_origin(AllowOrigin::list([
             format!("http://127.0.0.1:{}", config.port)
                 .parse()
-                .unwrap(),
+                .expect("valid localhost origin"),
             format!("http://localhost:{}", config.port)
                 .parse()
-                .unwrap(),
-            format!("http://[::1]:{}", config.port).parse().unwrap(),
+                .expect("valid localhost origin"),
+            format!("http://[::1]:{}", config.port)
+                .parse()
+                .expect("valid localhost origin"),
         ]))
         .allow_methods(tower_http::cors::Any)
         .allow_headers(tower_http::cors::Any);
@@ -245,8 +247,8 @@ pub async fn serve(repo_root: &Path, config: ServeConfig) -> anyhow::Result<()> 
 
 /// Build the router (for testing without binding to a port).
 /// Note: no auth middleware is applied here — tests run as localhost.
-#[allow(dead_code)]
-pub(crate) fn router(repo_root: &Path) -> Router {
+#[cfg(test)]
+fn router(repo_root: &Path) -> Router {
     let store_root = edda_store::store_root();
     let chronicle = if store_root.exists() {
         Some(ChronicleContext {


### PR DESCRIPTION
## Summary

Closes #288

- Replace `CorsLayer::permissive()` in `serve()` with localhost-only CORS origins (`127.0.0.1`, `localhost`, `[::1]` on the configured port), preventing cross-origin attacks from arbitrary websites
- Remove `CorsLayer` entirely from test-only `router()` (axum test clients don't enforce CORS)
- Change `pub fn router()` to `pub(crate) fn router()` since no external crate consumes it
- Add `SECURITY:` comments on `post_scope_check` and `get_scope_whitelist` documenting the unvalidated `project_id` (acceptable for single-user tool, flagged for future multi-tenant work)

## Test plan

- [x] `cargo clippy -p edda-serve -- -D warnings` passes cleanly
- [x] `cargo test -p edda-serve` -- 66 tests pass; 1 pre-existing failure (`overview_returns_structure`) unrelated to this change
- [ ] Verify dashboard at `http://localhost:7433` still works with the tightened CORS

🤖 Generated with [Claude Code](https://claude.com/claude-code)