### PR TITLE
test(chronicle): add 40 tests across all 7 submodules

### DIFF
--- a/crates/edda-chronicle/src/anchor.rs
+++ b/crates/edda-chronicle/src/anchor.rs
@@ -163,3 +163,125 @@ impl Anchor {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RecapOptions;
+
+    fn default_opts() -> RecapOptions {
+        RecapOptions::default()
+    }
+
+    #[test]
+    fn test_from_options_query() {
+        let opts = RecapOptions {
+            query: Some("auth flow".into()),
+            ..default_opts()
+        };
+        let anchor = Anchor::from_options(&opts);
+        assert!(matches!(anchor, Anchor::Topic(q) if q == "auth flow"));
+    }
+
+    #[test]
+    fn test_from_options_project() {
+        let opts = RecapOptions {
+            project: Some("edda".into()),
+            ..default_opts()
+        };
+        let anchor = Anchor::from_options(&opts);
+        assert!(matches!(anchor, Anchor::Project(p) if p == "edda"));
+    }
+
+    #[test]
+    fn test_from_options_week() {
+        let opts = RecapOptions {
+            week: true,
+            ..default_opts()
+        };
+        let anchor = Anchor::from_options(&opts);
+        assert!(matches!(anchor, Anchor::Week));
+    }
+
+    #[test]
+    fn test_from_options_since() {
+        let opts = RecapOptions {
+            since: Some("2026-01-01T00:00:00Z".into()),
+            ..default_opts()
+        };
+        let anchor = Anchor::from_options(&opts);
+        assert!(matches!(anchor, Anchor::Since(s) if s == "2026-01-01T00:00:00Z"));
+    }
+
+    #[test]
+    fn test_from_options_all() {
+        let opts = RecapOptions {
+            all: true,
+            ..default_opts()
+        };
+        let anchor = Anchor::from_options(&opts);
+        assert!(matches!(anchor, Anchor::All));
+    }
+
+    #[test]
+    fn test_from_options_default() {
+        let anchor = Anchor::from_options(&default_opts());
+        assert!(matches!(anchor, Anchor::Default));
+    }
+
+    #[test]
+    fn test_resolve_default_no_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let opts = default_opts();
+        let resolved = resolve_anchor(&Anchor::Default, &tmp.path().to_path_buf(), &opts).unwrap();
+
+        assert_eq!(resolved.anchor_type, "default");
+        assert!(resolved.project_filter.is_none());
+        assert!(resolved.topic_query.is_none());
+        assert!(resolved.session_ids.is_empty());
+
+        let (start, end) = resolved.time_filter.expect("should have time filter");
+        assert!(start < end);
+        let duration = end - start;
+        let expected = chrono::Duration::hours(24);
+        assert!(
+            (duration - expected).num_seconds().abs() < 5,
+            "duration should be ~24h, got {}s",
+            duration.num_seconds()
+        );
+    }
+
+    #[test]
+    fn test_resolve_project_anchor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let opts = default_opts();
+        let resolved = resolve_anchor(
+            &Anchor::Project("myproject".into()),
+            &tmp.path().to_path_buf(),
+            &opts,
+        )
+        .unwrap();
+
+        assert_eq!(resolved.anchor_type, "project");
+        assert_eq!(resolved.project_filter, Some("myproject".into()));
+        assert!(resolved.time_filter.is_none());
+    }
+
+    #[test]
+    fn test_resolve_week_anchor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let opts = default_opts();
+        let resolved =
+            resolve_anchor(&Anchor::Week, &tmp.path().to_path_buf(), &opts).unwrap();
+
+        assert_eq!(resolved.anchor_type, "week");
+        let (start, end) = resolved.time_filter.expect("should have time filter");
+        assert!(start < end);
+        let duration = end - start;
+        let expected = chrono::Duration::weeks(1);
+        assert!(
+            (duration - expected).num_seconds().abs() < 5,
+            "duration should be ~1 week"
+        );
+    }
+}

--- a/crates/edda-chronicle/src/attention.rs
+++ b/crates/edda-chronicle/src/attention.rs
@@ -70,3 +70,62 @@ fn truncate_text(text: &str, max_len: usize) -> String {
         format!("{}...", &text[..end])
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use edda_core::event::new_note_event;
+
+    fn setup_ledger() -> (tempfile::TempDir, Ledger) {
+        let tmp = tempfile::tempdir().unwrap();
+        let ledger = Ledger::open_or_init(tmp.path()).unwrap();
+        (tmp, ledger)
+    }
+
+    #[test]
+    fn test_empty_ledger() {
+        let (_tmp, ledger) = setup_ledger();
+        let items = get_attention_items(&ledger, None).unwrap();
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn test_blocker_detected() {
+        let (_tmp, ledger) = setup_ledger();
+        let event =
+            new_note_event("main", None, "system", "This is a blocker for release", &[]).unwrap();
+        ledger.append_event(&event).unwrap();
+
+        let items = get_attention_items(&ledger, None).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].item_type, "blocker");
+        assert_eq!(items[0].priority, "high");
+        assert!(items[0].description.contains("blocker"));
+    }
+
+    #[test]
+    fn test_non_blocker_ignored() {
+        let (_tmp, ledger) = setup_ledger();
+        let event =
+            new_note_event("main", None, "system", "Normal progress update", &[]).unwrap();
+        ledger.append_event(&event).unwrap();
+
+        let items = get_attention_items(&ledger, None).unwrap();
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn test_truncate_text_long_input() {
+        let long = "a".repeat(200);
+        let result = truncate_text(&long, 100);
+        assert!(result.len() <= 100);
+        assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn test_truncate_text_short_input() {
+        let short = "hello world";
+        let result = truncate_text(short, 100);
+        assert_eq!(result, "hello world");
+    }
+}

--- a/crates/edda-chronicle/src/classify.rs
+++ b/crates/edda-chronicle/src/classify.rs
@@ -159,3 +159,80 @@ fn calculate_scores(
 
     scores
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(val: &str) -> String {
+        val.to_string()
+    }
+
+    #[test]
+    fn test_coding_session() {
+        let tools = vec![s("Edit"), s("Read"), s("Bash")];
+        let bash = vec![s("git commit -m 'fix'")];
+        let result = classify_session(&tools, &bash, 5, 3, 10, 600);
+        assert_eq!(result, SessionType::Coding);
+    }
+
+    #[test]
+    fn test_research_session() {
+        let tools = vec![s("Read"), s("Grep"), s("Write")];
+        let bash: Vec<String> = vec![];
+        let result = classify_session(&tools, &bash, 1, 10, 8, 600);
+        assert_eq!(result, SessionType::Research);
+    }
+
+    #[test]
+    fn test_discussion_session() {
+        let tools = vec![s("Read")];
+        let bash: Vec<String> = vec![];
+        let result = classify_session(&tools, &bash, 0, 0, 15, 3600);
+        assert_eq!(result, SessionType::Discussion);
+    }
+
+    #[test]
+    fn test_analysis_session() {
+        // Read + Grep + Write + Edit → Analysis (score 3.5)
+        // Avoid test commands to keep Debugging at 0
+        let tools = vec![s("Read"), s("Grep"), s("Write"), s("Edit")];
+        let bash: Vec<String> = vec![];
+        let result = classify_session(&tools, &bash, 2, 5, 8, 600);
+        assert_eq!(result, SessionType::Analysis);
+    }
+
+    #[test]
+    fn test_automated_session() {
+        let tools = vec![s("SubagentStart"), s("Read"), s("Bash")];
+        let bash = vec![s("some-command")];
+        let result = classify_session(&tools, &bash, 0, 1, 5, 300);
+        assert_eq!(result, SessionType::Automated);
+    }
+
+    #[test]
+    fn test_debugging_session() {
+        // cargo test + Edit → Debugging (score 3.5)
+        // Avoid git commit to keep Coding lower
+        let tools = vec![s("Edit"), s("Read"), s("Bash")];
+        let bash = vec![s("cargo test")];
+        let result = classify_session(&tools, &bash, 1, 2, 8, 600);
+        assert_eq!(result, SessionType::Debugging);
+    }
+
+    #[test]
+    fn test_quick_ops_session() {
+        let tools = vec![s("Read")];
+        let bash: Vec<String> = vec![];
+        let result = classify_session(&tools, &bash, 0, 0, 2, 60);
+        assert_eq!(result, SessionType::QuickOps);
+    }
+
+    #[test]
+    fn test_empty_input_defaults_to_quick_ops() {
+        let tools: Vec<String> = vec![];
+        let bash: Vec<String> = vec![];
+        let result = classify_session(&tools, &bash, 0, 0, 0, 0);
+        assert_eq!(result, SessionType::QuickOps);
+    }
+}

--- a/crates/edda-chronicle/src/extract.rs
+++ b/crates/edda-chronicle/src/extract.rs
@@ -247,3 +247,143 @@ fn extract_quick_ops_turns(_records: &[serde_json::Value], _max_turns: usize) ->
     // Skip quick ops - use digest only
     vec![]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_index_jsonl(dir: &std::path::Path, session_id: &str, records: &[serde_json::Value]) {
+        let index_dir = dir.join("index");
+        std::fs::create_dir_all(&index_dir).unwrap();
+        let lines: Vec<String> = records.iter().map(|r| r.to_string()).collect();
+        std::fs::write(
+            index_dir.join(format!("{}.jsonl", session_id)),
+            lines.join("\n"),
+        )
+        .unwrap();
+    }
+
+    fn assistant_record(tools: &[&str], offset: u64, len: u64) -> serde_json::Value {
+        serde_json::json!({
+            "record_type": "assistant",
+            "assistant": {
+                "tool_use_names": tools,
+            },
+            "store_offset": offset,
+            "store_len": len,
+        })
+    }
+
+    fn user_record(offset: u64, len: u64) -> serde_json::Value {
+        serde_json::json!({
+            "record_type": "user",
+            "store_offset": offset,
+            "store_len": len,
+        })
+    }
+
+    #[test]
+    fn test_missing_index_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result =
+            extract_key_turns("nonexistent", &SessionType::Coding, tmp.path(), 5).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_coding_turns_edit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let records = vec![
+            assistant_record(&["Edit"], 0, 100),
+            assistant_record(&["Read"], 100, 50),
+            assistant_record(&["Write"], 150, 80),
+        ];
+        write_index_jsonl(tmp.path(), "s1", &records);
+
+        let turns = extract_key_turns("s1", &SessionType::Coding, tmp.path(), 5).unwrap();
+        // Edit and Write both match has_edit (Edit || Write)
+        assert_eq!(turns.len(), 2);
+        assert_eq!(turns[0].reason, "Edit operation");
+        assert_eq!(turns[0].relevance_score, 3.0);
+    }
+
+    #[test]
+    fn test_coding_turns_bash() {
+        let tmp = tempfile::tempdir().unwrap();
+        let records = vec![
+            assistant_record(&["Bash"], 0, 100),
+            assistant_record(&["Read"], 100, 50),
+        ];
+        write_index_jsonl(tmp.path(), "s1", &records);
+
+        let turns = extract_key_turns("s1", &SessionType::Coding, tmp.path(), 5).unwrap();
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].reason, "Bash command");
+        assert_eq!(turns[0].relevance_score, 2.0);
+    }
+
+    #[test]
+    fn test_research_turns_write() {
+        let tmp = tempfile::tempdir().unwrap();
+        let records = vec![
+            assistant_record(&["Write"], 0, 100),
+            user_record(100, 50),
+            assistant_record(&["Read"], 150, 80),
+        ];
+        write_index_jsonl(tmp.path(), "s1", &records);
+
+        let turns = extract_key_turns("s1", &SessionType::Research, tmp.path(), 5).unwrap();
+        assert_eq!(turns.len(), 2);
+        assert_eq!(turns[0].relevance_score, 3.0);
+        assert_eq!(turns[0].reason, "Write operation (documentation)");
+    }
+
+    #[test]
+    fn test_discussion_turns_head_tail() {
+        let tmp = tempfile::tempdir().unwrap();
+        let records: Vec<serde_json::Value> = (0..10)
+            .map(|i| {
+                serde_json::json!({
+                    "record_type": "user",
+                    "store_offset": i * 100,
+                    "store_len": 100,
+                })
+            })
+            .collect();
+        write_index_jsonl(tmp.path(), "s1", &records);
+
+        let turns = extract_key_turns("s1", &SessionType::Discussion, tmp.path(), 10).unwrap();
+        // head(3) + tail(3), indices 0-2 and 7-9
+        assert_eq!(turns.len(), 6);
+        let head_turns: Vec<_> = turns.iter().filter(|t| t.reason == "Session start").collect();
+        let tail_turns: Vec<_> = turns.iter().filter(|t| t.reason == "Session end").collect();
+        assert_eq!(head_turns.len(), 3);
+        assert_eq!(tail_turns.len(), 3);
+    }
+
+    #[test]
+    fn test_automated_turns_last() {
+        let tmp = tempfile::tempdir().unwrap();
+        let records = vec![
+            assistant_record(&["Bash"], 0, 100),
+            assistant_record(&["Bash"], 100, 50),
+            assistant_record(&["Bash"], 150, 80),
+        ];
+        write_index_jsonl(tmp.path(), "s1", &records);
+
+        let turns = extract_key_turns("s1", &SessionType::Automated, tmp.path(), 5).unwrap();
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].turn_index, 2);
+        assert_eq!(turns[0].reason, "Final result");
+    }
+
+    #[test]
+    fn test_quick_ops_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let records = vec![assistant_record(&["Edit"], 0, 100)];
+        write_index_jsonl(tmp.path(), "s1", &records);
+
+        let turns = extract_key_turns("s1", &SessionType::QuickOps, tmp.path(), 5).unwrap();
+        assert!(turns.is_empty());
+    }
+}

--- a/crates/edda-chronicle/src/relate.rs
+++ b/crates/edda-chronicle/src/relate.rs
@@ -39,3 +39,22 @@ pub fn build_search_index_if_needed(project_root: &std::path::Path) -> Result<()
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_no_index_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = find_related_content("some query", tmp.path(), 10).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_build_search_index_if_needed_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = build_search_index_if_needed(tmp.path());
+        assert!(result.is_ok());
+    }
+}

--- a/crates/edda-chronicle/src/state.rs
+++ b/crates/edda-chronicle/src/state.rs
@@ -45,3 +45,62 @@ pub fn save_state(edda_root: &Path, state: &RecapState) -> Result<()> {
         .with_context(|| format!("Failed to rename state file: {:?} -> {:?}", tmp_path, path))?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_state(ts: &str, sessions: Vec<String>) -> RecapState {
+        RecapState {
+            last_recap: LastRecap {
+                timestamp: ts.to_string(),
+                anchor: "default".to_string(),
+                sessions_covered: sessions,
+            },
+        }
+    }
+
+    #[test]
+    fn test_load_missing_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = load_state(tmp.path()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_save_and_load_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = make_state("2026-01-01T00:00:00Z", vec!["s1".into(), "s2".into()]);
+        save_state(tmp.path(), &state).unwrap();
+
+        let loaded = load_state(tmp.path()).unwrap().expect("state should exist");
+        assert_eq!(loaded.last_recap.timestamp, "2026-01-01T00:00:00Z");
+        assert_eq!(loaded.last_recap.sessions_covered, vec!["s1", "s2"]);
+        assert_eq!(loaded.last_recap.anchor, "default");
+    }
+
+    #[test]
+    fn test_corrupted_state_returns_err() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("chronicle");
+        std::fs::create_dir_all(&path).unwrap();
+        std::fs::write(path.join("state.json"), "not valid json{{{").unwrap();
+
+        let result = load_state(tmp.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_save_creates_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let chronicle_dir = tmp.path().join("chronicle");
+        assert!(!chronicle_dir.exists());
+
+        let state = make_state("2026-01-01T00:00:00Z", vec![]);
+        save_state(tmp.path(), &state).unwrap();
+
+        assert!(chronicle_dir.exists());
+        assert!(chronicle_dir.join("state.json").exists());
+        assert!(!chronicle_dir.join("state.tmp").exists());
+    }
+}

--- a/crates/edda-chronicle/src/synthesize.rs
+++ b/crates/edda-chronicle/src/synthesize.rs
@@ -276,3 +276,105 @@ fn parse_llm_output(text: &str) -> Result<crate::RecapOutput> {
         relations,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::attention::AttentionItem;
+
+    fn empty_input() -> SynthesisInput {
+        SynthesisInput {
+            anchor_description: String::new(),
+            session_types: vec![],
+            key_turns: vec![],
+            related_content: vec![],
+            attention_items: vec![],
+            commits: vec![],
+            decisions: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn test_template_fallback_happy_path() {
+        std::env::remove_var("EDDA_LLM_API_KEY");
+
+        let input = SynthesisInput {
+            anchor_description: "Last 24 hours".into(),
+            session_types: vec!["Coding".into(), "Research".into()],
+            key_turns: vec![],
+            related_content: vec![],
+            attention_items: vec![AttentionItem {
+                item_type: "blocker".into(),
+                description: "CI is red".into(),
+                priority: "high".into(),
+                source: "ledger".into(),
+                event_id: None,
+            }],
+            commits: vec!["abc123".into(), "def456".into()],
+            decisions: vec!["db.engine=sqlite".into()],
+        };
+
+        let output = synthesize_recap(input).await.unwrap();
+        assert!(output.net_result.contains("Coding"));
+        assert!(output.net_result.contains("Research"));
+        assert!(output.net_result.contains("Commits: 2"));
+        assert!(output.net_result.contains("Decisions: 1"));
+        assert!(output.needs_you.contains("CI is red"));
+        assert_eq!(output.decision_context, "db.engine=sqlite");
+    }
+
+    #[tokio::test]
+    async fn test_template_empty_input() {
+        std::env::remove_var("EDDA_LLM_API_KEY");
+
+        let output = synthesize_recap(empty_input()).await.unwrap();
+        assert_eq!(output.needs_you, "No blockers detected");
+        assert_eq!(output.decision_context, "No decisions recorded");
+        assert_eq!(output.relations, "No related historical content found");
+    }
+
+    #[test]
+    fn test_parse_llm_output_traditional() {
+        let text = "## 淨結果\n新增了認證模組，通過所有測試。\n\n## 需要你\nCI pipeline 需要設定新的 secret。\n\n## 決策脈絡\n選擇 JWT 而非 session cookie，因為需要跨服務驗證。\n\n## 關聯\n與上週的 API gateway 重構相關。";
+
+        let output = parse_llm_output(text).unwrap();
+        assert!(output.net_result.contains("認證模組"));
+        assert!(output.needs_you.contains("CI pipeline"));
+        assert!(output.decision_context.contains("JWT"));
+        assert!(output.relations.contains("API gateway"));
+    }
+
+    #[test]
+    fn test_parse_llm_output_simplified() {
+        let text = "## 净结果\n完成了数据库迁移。\n\n## 需要你\n需要审核 PR #42。\n\n## 决策脉络\n使用 SQLite 作为嵌入式存储。\n\n## 关联\n参考了 edda-store 的实现。";
+
+        let output = parse_llm_output(text).unwrap();
+        assert!(output.net_result.contains("数据库迁移"));
+        assert!(output.needs_you.contains("PR #42"));
+        assert!(output.decision_context.contains("SQLite"));
+        assert!(output.relations.contains("edda-store"));
+    }
+
+    #[test]
+    fn test_build_prompt_contains_sections() {
+        let input = SynthesisInput {
+            anchor_description: "Last 24 hours".into(),
+            session_types: vec!["Coding".into()],
+            key_turns: vec![TurnContent {
+                turn_index: 0,
+                content: "edited auth.rs".into(),
+            }],
+            related_content: vec![],
+            attention_items: vec![],
+            commits: vec!["abc".into()],
+            decisions: vec!["auth=jwt".into()],
+        };
+
+        let prompt = build_prompt(&input);
+        assert!(prompt.contains("Last 24 hours"));
+        assert!(prompt.contains("Coding"));
+        assert!(prompt.contains("edited auth.rs"));
+        assert!(prompt.contains("Commits: 1"));
+        assert!(prompt.contains("Decisions: 1"));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #284

- Added **40 unit tests** across all 7 submodules of `edda-chronicle` (previously 0 tests / 1,048 LOC)
- Uses inline `#[cfg(test)]` modules following project convention
- All tests are meaningful with real assertions, not stubs

## Test coverage by module

| Module | Tests | What's covered |
|--------|-------|---------------|
| `classify.rs` | 8 | All 7 `SessionType` variants + empty input fallback |
| `extract.rs` | 7 | Each extraction strategy, missing file, empty results |
| `synthesize.rs` | 5 | Template fallback, empty input, LLM output parsing (traditional + simplified Chinese), prompt structure |
| `anchor.rs` | 9 | `from_options` mapping (6 variants) + resolve for default/project/week |
| `attention.rs` | 5 | Empty ledger, blocker detection, non-blocker filtering, truncate_text |
| `relate.rs` | 2 | No index returns empty, build_search_index no-panic |
| `state.rs` | 4 | Roundtrip, missing file, corrupted JSON, directory creation |

## Test plan

- [x] `cargo clippy -p edda-chronicle --tests -- -D warnings` passes clean
- [x] `cargo test -p edda-chronicle` — all 40 tests pass
- [x] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)