### PR TITLE
fix(serve): acquire WorkspaceLock in post_karvi_event

### DIFF
--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -1773,6 +1773,7 @@ async fn post_karvi_event(
     });
 
     let ledger = state.open_ledger()?;
+    let _lock = WorkspaceLock::acquire(&ledger.paths)?;
     let branch = ledger.head_branch()?;
     let parent_hash = ledger.last_event_hash()?;
 


### PR DESCRIPTION
## Summary

- Add `WorkspaceLock::acquire()` to `post_karvi_event` handler, matching the pattern used by all other write endpoints (`post_note`, `post_decide`, `post_snapshot`, `handle_draft_action`)
- Without the lock, concurrent requests could read the same `last_event_hash()` and fork the parent_hash chain

## Test plan

- [x] All 5 karvi tests pass (`karvi_event_creates_execution_event`, `karvi_event_idempotent`, `karvi_event_with_decision_ref`, `karvi_event_rejects_bad_version`, `karvi_event_rejects_bad_event_type`)
- [x] No new clippy warnings (7 pre-existing dead_code warnings unchanged)
- [x] SI-1: No `unwrap()` added — uses `?` propagation
- [x] SI-2: Error propagated via existing `From<anyhow::Error>` impl
- [x] SI-3: Zero clippy suppressions

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)