### PR TITLE
refactor(ledger): extract map_event_row helper to deduplicate EventRow mapping

### DIFF
--- a/crates/edda-ledger/src/sqlite_store.rs
+++ b/crates/edda-ledger/src/sqlite_store.rs
@@ -1056,30 +1056,7 @@ impl SqliteStore {
         )?;
 
         let events = stmt
-            .query_map([], |row| {
-                let payload_str: String = row.get(6)?;
-                let refs_blobs_str: String = row.get(7)?;
-                let refs_events_str: String = row.get(8)?;
-                let refs_prov_str: String = row.get(9)?;
-                let digests_str: String = row.get(11)?;
-
-                Ok(EventRow {
-                    event_id: row.get(0)?,
-                    ts: row.get(1)?,
-                    event_type: row.get(2)?,
-                    branch: row.get(3)?,
-                    parent_hash: row.get(4)?,
-                    hash: row.get(5)?,
-                    payload_str,
-                    refs_blobs_str,
-                    refs_events_str,
-                    refs_prov_str,
-                    schema_version: row.get(10)?,
-                    digests_str,
-                    event_family: row.get(12)?,
-                    event_level: row.get(13)?,
-                })
-            })?
+            .query_map([], map_event_row)?
             .collect::<Result<Vec<_>, _>>()?;
 
         events.into_iter().map(row_to_event).collect()
@@ -1095,30 +1072,7 @@ impl SqliteStore {
         )?;
 
         let events = stmt
-            .query_map(params![event_type], |row| {
-                let payload_str: String = row.get(6)?;
-                let refs_blobs_str: String = row.get(7)?;
-                let refs_events_str: String = row.get(8)?;
-                let refs_prov_str: String = row.get(9)?;
-                let digests_str: String = row.get(11)?;
-
-                Ok(EventRow {
-                    event_id: row.get(0)?,
-                    ts: row.get(1)?,
-                    event_type: row.get(2)?,
-                    branch: row.get(3)?,
-                    parent_hash: row.get(4)?,
-                    hash: row.get(5)?,
-                    payload_str,
-                    refs_blobs_str,
-                    refs_events_str,
-                    refs_prov_str,
-                    schema_version: row.get(10)?,
-                    digests_str,
-                    event_family: row.get(12)?,
-                    event_level: row.get(13)?,
-                })
-            })?
+            .query_map(params![event_type], map_event_row)?
             .collect::<Result<Vec<_>, _>>()?;
 
         events.into_iter().map(row_to_event).collect()
@@ -1134,30 +1088,7 @@ impl SqliteStore {
         )?;
 
         let events = stmt
-            .query_map(params![branch], |row| {
-                let payload_str: String = row.get(6)?;
-                let refs_blobs_str: String = row.get(7)?;
-                let refs_events_str: String = row.get(8)?;
-                let refs_prov_str: String = row.get(9)?;
-                let digests_str: String = row.get(11)?;
-
-                Ok(EventRow {
-                    event_id: row.get(0)?,
-                    ts: row.get(1)?,
-                    event_type: row.get(2)?,
-                    branch: row.get(3)?,
-                    parent_hash: row.get(4)?,
-                    hash: row.get(5)?,
-                    payload_str,
-                    refs_blobs_str,
-                    refs_events_str,
-                    refs_prov_str,
-                    schema_version: row.get(10)?,
-                    digests_str,
-                    event_family: row.get(12)?,
-                    event_level: row.get(13)?,
-                })
-            })?
+            .query_map(params![branch], map_event_row)?
             .collect::<Result<Vec<_>, _>>()?;
 
         events.into_iter().map(row_to_event).collect()
@@ -1210,30 +1141,7 @@ impl SqliteStore {
         let mut stmt = self.conn.prepare(&sql)?;
 
         let events = stmt
-            .query_map(param_refs.as_slice(), |row| {
-                let payload_str: String = row.get(6)?;
-                let refs_blobs_str: String = row.get(7)?;
-                let refs_events_str: String = row.get(8)?;
-                let refs_prov_str: String = row.get(9)?;
-                let digests_str: String = row.get(11)?;
-
-                Ok(EventRow {
-                    event_id: row.get(0)?,
-                    ts: row.get(1)?,
-                    event_type: row.get(2)?,
-                    branch: row.get(3)?,
-                    parent_hash: row.get(4)?,
-                    hash: row.get(5)?,
-                    payload_str,
-                    refs_blobs_str,
-                    refs_events_str,
-                    refs_prov_str,
-                    schema_version: row.get(10)?,
-                    digests_str,
-                    event_family: row.get(12)?,
-                    event_level: row.get(13)?,
-                })
-            })?
+            .query_map(param_refs.as_slice(), map_event_row)?
             .collect::<Result<Vec<_>, _>>()?;
 
         events.into_iter().map(row_to_event).collect()
@@ -1290,30 +1198,7 @@ impl SqliteStore {
         let mut stmt = self.conn.prepare(&sql)?;
 
         let events = stmt
-            .query_map(param_refs.as_slice(), |row| {
-                let payload_str: String = row.get(6)?;
-                let refs_blobs_str: String = row.get(7)?;
-                let refs_events_str: String = row.get(8)?;
-                let refs_prov_str: String = row.get(9)?;
-                let digests_str: String = row.get(11)?;
-
-                Ok(EventRow {
-                    event_id: row.get(0)?,
-                    ts: row.get(1)?,
-                    event_type: row.get(2)?,
-                    branch: row.get(3)?,
-                    parent_hash: row.get(4)?,
-                    hash: row.get(5)?,
-                    payload_str,
-                    refs_blobs_str,
-                    refs_events_str,
-                    refs_prov_str,
-                    schema_version: row.get(10)?,
-                    digests_str,
-                    event_family: row.get(12)?,
-                    event_level: row.get(13)?,
-                })
-            })?
+            .query_map(param_refs.as_slice(), map_event_row)?
             .collect::<Result<Vec<_>, _>>()?;
 
         events.into_iter().map(row_to_event).collect()
@@ -1361,30 +1246,7 @@ impl SqliteStore {
         let mut stmt = self.conn.prepare(&sql)?;
 
         let events = stmt
-            .query_map(param_refs.as_slice(), |row| {
-                let payload_str: String = row.get(6)?;
-                let refs_blobs_str: String = row.get(7)?;
-                let refs_events_str: String = row.get(8)?;
-                let refs_prov_str: String = row.get(9)?;
-                let digests_str: String = row.get(11)?;
-
-                Ok(EventRow {
-                    event_id: row.get(0)?,
-                    ts: row.get(1)?,
-                    event_type: row.get(2)?,
-                    branch: row.get(3)?,
-                    parent_hash: row.get(4)?,
-                    hash: row.get(5)?,
-                    payload_str,
-                    refs_blobs_str,
-                    refs_events_str,
-                    refs_prov_str,
-                    schema_version: row.get(10)?,
-                    digests_str,
-                    event_family: row.get(12)?,
-                    event_level: row.get(13)?,
-                })
-            })?
+            .query_map(param_refs.as_slice(), map_event_row)?
             .collect::<Result<Vec<_>, _>>()?;
 
         events.into_iter().map(row_to_event).collect()
@@ -1400,30 +1262,7 @@ impl SqliteStore {
                         schema_version, digests, event_family, event_level
                  FROM events WHERE event_id = ?1",
                 params![event_id],
-                |row| {
-                    let payload_str: String = row.get(6)?;
-                    let refs_blobs_str: String = row.get(7)?;
-                    let refs_events_str: String = row.get(8)?;
-                    let refs_prov_str: String = row.get(9)?;
-                    let digests_str: String = row.get(11)?;
-
-                    Ok(EventRow {
-                        event_id: row.get(0)?,
-                        ts: row.get(1)?,
-                        event_type: row.get(2)?,
-                        branch: row.get(3)?,
-                        parent_hash: row.get(4)?,
-                        hash: row.get(5)?,
-                        payload_str,
-                        refs_blobs_str,
-                        refs_events_str,
-                        refs_prov_str,
-                        schema_version: row.get(10)?,
-                        digests_str,
-                        event_family: row.get(12)?,
-                        event_level: row.get(13)?,
-                    })
-                },
+                map_event_row,
             )
             .optional()?;
 
@@ -2542,6 +2381,31 @@ impl SqliteStore {
         rows.collect::<Result<Vec<_>, _>>()
             .map_err(|e| anyhow::anyhow!("snapshot context_hash query failed: {e}"))
     }
+}
+
+fn map_event_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<EventRow> {
+    let payload_str: String = row.get(6)?;
+    let refs_blobs_str: String = row.get(7)?;
+    let refs_events_str: String = row.get(8)?;
+    let refs_prov_str: String = row.get(9)?;
+    let digests_str: String = row.get(11)?;
+
+    Ok(EventRow {
+        event_id: row.get(0)?,
+        ts: row.get(1)?,
+        event_type: row.get(2)?,
+        branch: row.get(3)?,
+        parent_hash: row.get(4)?,
+        hash: row.get(5)?,
+        payload_str,
+        refs_blobs_str,
+        refs_events_str,
+        refs_prov_str,
+        schema_version: row.get(10)?,
+        digests_str,
+        event_family: row.get(12)?,
+        event_level: row.get(13)?,
+    })
 }
 
 fn map_snapshot_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<DecideSnapshotRow> {


### PR DESCRIPTION
## Summary

- Extracted a shared `map_event_row` helper function following the existing `map_*_row` pattern in `sqlite_store.rs`
- Replaced 7 identical inline closures (~112 lines removed, net -136 lines)
- Kept `events_after_rowid` closure inline since it has a different column layout (prepends `rowid`, shifting all indices by +1)

## Details

The file already had 5 `map_*_row` helpers (`map_snapshot_row`, `map_bundle_row`, `map_dep_row`, `map_decision_row`, `map_task_brief_row`). The new `map_event_row` follows the exact same pattern.

**Call sites updated:**
1. `iter_events` — `query_map([], map_event_row)`
2. `iter_events_by_type` — `query_map(params![event_type], map_event_row)`
3. `iter_branch_events` — `query_map(params![branch], map_event_row)`
4. `iter_events_filtered` — `query_map(param_refs.as_slice(), map_event_row)`
5. `find_related_commits` — `query_map(param_refs.as_slice(), map_event_row)`
6. `find_related_notes` — `query_map(param_refs.as_slice(), map_event_row)`
7. `get_event` — `query_row(..., map_event_row)`

## Test plan

- [x] `cargo clippy -p edda-ledger -- -D warnings` passes (zero warnings)
- [x] `cargo test -p edda-ledger` — 129/130 pass; 1 pre-existing failure (`schema_migration_v1_to_v2`, unrelated to this change)
- [x] No public API changes — `map_event_row` is a private function

Closes #290

Generated with [Claude Code](https://claude.com/claude-code)