### PR TITLE
fix(bridge): pass workspace cwd to heartbeat/autoclaim branch detection

### DIFF
--- a/crates/edda-bridge-claude/src/dispatch/mod.rs
+++ b/crates/edda-bridge-claude/src/dispatch/mod.rs
@@ -198,7 +198,7 @@ pub fn hook_entrypoint_from_stdin(stdin: &str) -> anyhow::Result<HookResult> {
             // writes heartbeat as a side-effect, but skips when the transcript
             // file doesn't exist yet — the normal case for brand-new sessions
             // where Claude Code creates the file AFTER SessionStart fires.
-            crate::peers::ensure_heartbeat_exists(&project_id, &session_id);
+            crate::peers::ensure_heartbeat_exists(&project_id, &session_id, &cwd);
             dispatch_session_start(&project_id, &session_id, &cwd, digest_warning.as_deref())
         }
         "UserPromptSubmit" => {

--- a/crates/edda-bridge-claude/src/dispatch/session.rs
+++ b/crates/edda-bridge-claude/src/dispatch/session.rs
@@ -108,10 +108,10 @@ pub(super) fn ingest_and_build_pack(
     save_session_signals(project_id, session_id, &signals);
 
     // Write full peer heartbeat with signals snapshot (unconditional — peer discovery depends on it)
-    crate::peers::write_heartbeat(project_id, session_id, &signals, None);
+    crate::peers::write_heartbeat(project_id, session_id, &signals, None, cwd);
 
     // Auto-claim scope from edited files (L1 auto-detection, #24)
-    crate::peers::maybe_auto_claim(project_id, session_id, &signals);
+    crate::peers::maybe_auto_claim(project_id, session_id, &signals, cwd);
 }
 /// Lightweight injection: workspace context only (~2K chars), no turns.
 /// Supports session-scoped dedup: if workspace context is identical to the

--- a/crates/edda-bridge-claude/src/dispatch/tests.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tests.rs
@@ -1212,8 +1212,8 @@ fn cross_session_binding_visible_via_user_prompt_submit() {
 
     // Multi-session: write heartbeats for s1 and s2
     let signals = crate::signals::SessionSignals::default();
-    crate::peers::write_heartbeat(pid, "s1", &signals, Some("auth"));
-    crate::peers::write_heartbeat(pid, "s2", &signals, Some("billing"));
+    crate::peers::write_heartbeat(pid, "s1", &signals, Some("auth"), ".");
+    crate::peers::write_heartbeat(pid, "s2", &signals, Some("billing"), ".");
 
     // Session A (s1) writes a binding
     crate::peers::write_binding(pid, "s1", "auth", "db.engine", "postgres");
@@ -1478,7 +1478,7 @@ fn late_peer_detection_injects_full_protocol() {
     // No peer_count file yet (virgin session) → prev_count = 0
     // Create a peer heartbeat to simulate a second agent joining
     let signals = crate::signals::SessionSignals::default();
-    crate::peers::write_heartbeat(pid, "peer-a", &signals, Some("billing"));
+    crate::peers::write_heartbeat(pid, "peer-a", &signals, Some("billing"), ".");
 
     let result =
         dispatch_with_workspace_only(pid, sid, cwd.to_str().unwrap(), "UserPromptSubmit").unwrap();
@@ -1532,7 +1532,7 @@ fn subsequent_prompts_use_lightweight_updates() {
 
     // Peer heartbeat still active
     let signals = crate::signals::SessionSignals::default();
-    crate::peers::write_heartbeat(pid, "peer-b", &signals, Some("auth"));
+    crate::peers::write_heartbeat(pid, "peer-b", &signals, Some("auth"), ".");
 
     let result =
         dispatch_with_workspace_only(pid, sid, cwd.to_str().unwrap(), "UserPromptSubmit").unwrap();
@@ -2400,7 +2400,7 @@ fn offlimits_blocks_peer_claimed_file() {
     let _ = edda_store::ensure_dirs(pid);
 
     // Create peer heartbeat so it's discovered as active
-    crate::peers::write_heartbeat_minimal(pid, peer_sid, "store-refactor");
+    crate::peers::write_heartbeat_minimal(pid, peer_sid, "store-refactor", ".");
     // Create peer claim
     crate::peers::write_claim(
         pid,
@@ -2427,7 +2427,7 @@ fn offlimits_allows_own_claimed_file() {
     let _ = edda_store::ensure_dirs(pid);
 
     // Create own heartbeat and claim
-    crate::peers::write_heartbeat_minimal(pid, sid, "my-agent");
+    crate::peers::write_heartbeat_minimal(pid, sid, "my-agent", ".");
     crate::peers::write_claim(pid, sid, "my-agent", &["src/auth/*".into()]);
     write_peer_count(pid, sid, 1);
 
@@ -2445,7 +2445,7 @@ fn offlimits_allows_unclaimed_file() {
     let _ = edda_store::ensure_dirs(pid);
 
     // Create peer with claims on different paths
-    crate::peers::write_heartbeat_minimal(pid, peer_sid, "db-agent");
+    crate::peers::write_heartbeat_minimal(pid, peer_sid, "db-agent", ".");
     crate::peers::write_claim(pid, peer_sid, "db-agent", &["crates/edda-store/*".into()]);
     write_peer_count(pid, sid, 1);
 
@@ -2491,7 +2491,7 @@ fn offlimits_env_var_enables_enforcement() {
     let _ = edda_store::ensure_dirs(pid);
 
     // Set up peer
-    crate::peers::write_heartbeat_minimal(pid, peer_sid, "env-agent");
+    crate::peers::write_heartbeat_minimal(pid, peer_sid, "env-agent", ".");
     crate::peers::write_claim(pid, peer_sid, "env-agent", &["src/core/*".into()]);
     write_peer_count(pid, sid, 1);
 
@@ -2542,7 +2542,7 @@ fn offlimits_skips_non_edit_tools() {
     let _ = edda_store::ensure_dirs(pid);
 
     // Set up peer with claim
-    crate::peers::write_heartbeat_minimal(pid, peer_sid, "bash-agent");
+    crate::peers::write_heartbeat_minimal(pid, peer_sid, "bash-agent", ".");
     crate::peers::write_claim(pid, peer_sid, "bash-agent", &["src/*".into()]);
     write_peer_count(pid, sid, 1);
 
@@ -2797,7 +2797,10 @@ fn session_end_bg_threads_joined_zero_threads() {
     std::env::set_var("EDDA_BG_JOIN_TIMEOUT_SECS", "1");
 
     let result = dispatch_session_end(pid, "s1", "", cwd.path().to_str().unwrap(), false);
-    assert!(result.is_ok(), "dispatch_session_end should succeed with zero bg threads");
+    assert!(
+        result.is_ok(),
+        "dispatch_session_end should succeed with zero bg threads"
+    );
 
     std::env::remove_var("EDDA_BRIDGE_AUTO_DIGEST");
     std::env::remove_var("EDDA_PLANS_DIR");

--- a/crates/edda-bridge-claude/src/peers/autoclaim.rs
+++ b/crates/edda-bridge-claude/src/peers/autoclaim.rs
@@ -5,7 +5,7 @@ use crate::signals::{FileEditCount, SessionSignals};
 
 use super::board::compute_board_state;
 use super::heartbeat::write_claim;
-use super::{autoclaim_state_path, detect_git_branch, AutoClaimState};
+use super::{autoclaim_state_path, detect_git_branch_in, AutoClaimState};
 
 // ── Auto-Claim ──
 
@@ -107,7 +107,12 @@ pub(super) fn derive_scope_from_files(files: &[FileEditCount]) -> Option<(String
 /// - Skips if session already has an explicit claim in `coordination.jsonl`
 /// - Skips if derived scope is identical to last auto-claim (dedup)
 /// - Writes claim event + saves state file for dedup
-pub(crate) fn maybe_auto_claim(project_id: &str, session_id: &str, signals: &SessionSignals) {
+pub(crate) fn maybe_auto_claim(
+    project_id: &str,
+    session_id: &str,
+    signals: &SessionSignals,
+    cwd: &str,
+) {
     // 1. Check existing state
     let board = compute_board_state(project_id);
     let existing_claim = board.claims.iter().find(|c| c.session_id == session_id);
@@ -127,7 +132,7 @@ pub(crate) fn maybe_auto_claim(project_id: &str, session_id: &str, signals: &Ses
         None => {
             // No file edits yet (fresh session) — use git branch as fallback label
             // so the peer is visible in `edda watch` immediately (#128)
-            match detect_git_branch() {
+            match detect_git_branch_in(cwd) {
                 Some(branch) => (branch, vec!["**/*".to_string()]),
                 None => return,
             }

--- a/crates/edda-bridge-claude/src/peers/heartbeat.rs
+++ b/crates/edda-bridge-claude/src/peers/heartbeat.rs
@@ -7,8 +7,8 @@ use crate::signals::SessionSignals;
 use super::board::compute_board_state;
 use super::helpers::auto_label;
 use super::{
-    coordination_path, detect_git_branch, detect_git_branch_in, env_label, heartbeat_path,
-    BindingConflict, CoordEvent, CoordEventType, SessionHeartbeat,
+    coordination_path, detect_git_branch_in, env_label, heartbeat_path, BindingConflict,
+    CoordEvent, CoordEventType, SessionHeartbeat,
 };
 
 // ── Heartbeat Write/Read ──
@@ -19,6 +19,7 @@ pub(crate) fn write_heartbeat(
     session_id: &str,
     signals: &SessionSignals,
     label: Option<&str>,
+    cwd: &str,
 ) {
     let now = now_rfc3339();
     let path = heartbeat_path(project_id, session_id);
@@ -54,7 +55,7 @@ pub(crate) fn write_heartbeat(
             .take(3)
             .map(|c| format!("{} {}", &c.hash[..7.min(c.hash.len())], c.message))
             .collect(),
-        branch: detect_git_branch(),
+        branch: detect_git_branch_in(cwd),
         current_phase: crate::agent_phase::read_phase_state(project_id, session_id)
             .map(|ps| ps.phase.to_string()),
         parent_session_id: None,
@@ -99,11 +100,17 @@ pub(crate) fn update_heartbeat_branch(project_id: &str, session_id: &str, branch
 /// This is needed because `ingest_and_build_pack` skips when the transcript file
 /// doesn't exist yet — which is the normal case for brand-new SessionStart events
 /// (Claude Code creates the transcript *after* the hook fires).
-pub(crate) fn ensure_heartbeat_exists(project_id: &str, session_id: &str) {
+pub(crate) fn ensure_heartbeat_exists(project_id: &str, session_id: &str, cwd: &str) {
     if read_heartbeat(project_id, session_id).is_some() {
         return;
     }
-    write_heartbeat(project_id, session_id, &SessionSignals::default(), None);
+    write_heartbeat(
+        project_id,
+        session_id,
+        &SessionSignals::default(),
+        None,
+        cwd,
+    );
 }
 
 /// Remove heartbeat on SessionEnd.
@@ -115,7 +122,7 @@ pub fn remove_heartbeat(project_id: &str, session_id: &str) {
 ///
 /// Creates a heartbeat with the given label and empty signals, sufficient
 /// for peer discovery. Use `write_heartbeat` for full signal-enriched heartbeats.
-pub fn write_heartbeat_minimal(project_id: &str, session_id: &str, label: &str) {
+pub fn write_heartbeat_minimal(project_id: &str, session_id: &str, label: &str, cwd: &str) {
     let now = now_rfc3339();
     let path = heartbeat_path(project_id, session_id);
 
@@ -133,7 +140,7 @@ pub fn write_heartbeat_minimal(project_id: &str, session_id: &str, label: &str) 
         files_modified_count: 0,
         total_edits: 0,
         recent_commits: Vec::new(),
-        branch: detect_git_branch(),
+        branch: detect_git_branch_in(cwd),
         current_phase: None,
         parent_session_id: None,
     };

--- a/crates/edda-bridge-claude/src/peers/mod.rs
+++ b/crates/edda-bridge-claude/src/peers/mod.rs
@@ -32,12 +32,6 @@ fn env_label() -> Option<String> {
         .filter(|v| !v.is_empty())
 }
 
-/// Detect the current git branch via `git rev-parse --abbrev-ref HEAD`.
-/// Returns `None` if not in a git repo or git is unavailable.
-fn detect_git_branch() -> Option<String> {
-    detect_git_branch_in(".")
-}
-
 /// Detect git branch in a specific directory.
 pub(crate) fn detect_git_branch_in(cwd: &str) -> Option<String> {
     std::process::Command::new("git")

--- a/crates/edda-bridge-claude/src/peers/tests.rs
+++ b/crates/edda-bridge-claude/src/peers/tests.rs
@@ -40,7 +40,7 @@ fn heartbeat_write_read_roundtrip() {
         ..Default::default()
     };
 
-    write_heartbeat(pid, sid, &signals, Some("auth"));
+    write_heartbeat(pid, sid, &signals, Some("auth"), ".");
     let hb = read_heartbeat(pid, sid).expect("should read heartbeat");
 
     assert_eq!(hb.session_id, sid);
@@ -94,8 +94,8 @@ fn discover_peers_excludes_self() {
     let _ = edda_store::ensure_dirs(pid);
 
     let signals = SessionSignals::default();
-    write_heartbeat(pid, "self-session", &signals, Some("self"));
-    write_heartbeat(pid, "peer-session", &signals, Some("peer"));
+    write_heartbeat(pid, "self-session", &signals, Some("self"), ".");
+    write_heartbeat(pid, "peer-session", &signals, Some("peer"), ".");
 
     let peers = discover_active_peers(pid, "self-session");
     assert_eq!(peers.len(), 1);
@@ -125,8 +125,8 @@ fn render_protocol_multi_session() {
     let _ = fs::remove_file(coordination_path(pid));
 
     let signals = SessionSignals::default();
-    write_heartbeat(pid, "s1", &signals, Some("auth"));
-    write_heartbeat(pid, "s2", &signals, Some("billing"));
+    write_heartbeat(pid, "s1", &signals, Some("auth"), ".");
+    write_heartbeat(pid, "s2", &signals, Some("billing"), ".");
     write_claim(pid, "s1", "auth", &["src/auth/*".into()]);
     write_claim(pid, "s2", "billing", &["src/billing/*".into()]);
     write_binding(pid, "s1", "auth", "auth.method", "JWT RS256");
@@ -235,10 +235,10 @@ fn full_lifecycle_multi_session() {
 
     // Simulate 4 sessions starting
     let signals = SessionSignals::default();
-    write_heartbeat(pid, "s1", &signals, Some("auth"));
-    write_heartbeat(pid, "s2", &signals, Some("billing"));
-    write_heartbeat(pid, "s3", &signals, Some("api"));
-    write_heartbeat(pid, "s4", &signals, Some("frontend"));
+    write_heartbeat(pid, "s1", &signals, Some("auth"), ".");
+    write_heartbeat(pid, "s2", &signals, Some("billing"), ".");
+    write_heartbeat(pid, "s3", &signals, Some("api"), ".");
+    write_heartbeat(pid, "s4", &signals, Some("frontend"), ".");
 
     // Claims
     write_claim(pid, "s1", "auth", &["src/auth/*".into()]);
@@ -413,8 +413,8 @@ fn render_protocol_shows_peer_tasks() {
         }],
         ..Default::default()
     };
-    write_heartbeat(pid, "s1", &signals_with_task, Some("auth"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"));
+    write_heartbeat(pid, "s1", &signals_with_task, Some("auth"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"), ".");
 
     let result = render_coordination_protocol(pid, "s2", ".").unwrap();
     assert!(
@@ -445,8 +445,8 @@ fn render_protocol_shows_focus_files_when_no_tasks() {
         }],
         ..Default::default()
     };
-    write_heartbeat(pid, "s1", &signals, Some("auth"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"));
+    write_heartbeat(pid, "s1", &signals, Some("auth"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"), ".");
 
     let result = render_coordination_protocol(pid, "s2", ".").unwrap();
     assert!(
@@ -481,8 +481,8 @@ fn render_peer_updates_shows_tasks() {
         }],
         ..Default::default()
     };
-    write_heartbeat(pid, "s1", &signals, Some("billing"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("auth"));
+    write_heartbeat(pid, "s1", &signals, Some("billing"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("auth"), ".");
 
     let result = render_peer_updates(pid, "s2").unwrap();
     assert!(
@@ -509,8 +509,8 @@ fn render_peer_updates_shows_focus_files() {
         }],
         ..Default::default()
     };
-    write_heartbeat(pid, "s1", &signals, Some("billing"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("auth"));
+    write_heartbeat(pid, "s1", &signals, Some("billing"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("auth"), ".");
 
     let result = render_peer_updates(pid, "s2").unwrap();
     assert!(
@@ -534,8 +534,8 @@ fn render_peer_updates_shows_bare_label() {
     let _ = fs::remove_file(coordination_path(pid));
 
     // Peer with no tasks and no focus files
-    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("billing"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("auth"));
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("billing"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("auth"), ".");
 
     let result = render_peer_updates(pid, "s2").unwrap();
     assert!(
@@ -560,8 +560,8 @@ fn render_peer_updates_includes_l2_instructions() {
     let _ = edda_store::ensure_dirs(pid);
     let _ = fs::remove_file(coordination_path(pid));
 
-    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("billing"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("auth"));
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("billing"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("auth"), ".");
 
     let result = render_peer_updates(pid, "s2").unwrap();
     assert!(
@@ -720,7 +720,13 @@ fn infer_session_one_active() {
     let pid = "test_infer_one";
     let _ = edda_store::ensure_dirs(pid);
 
-    write_heartbeat(pid, "sess-abc", &SessionSignals::default(), Some("auth"));
+    write_heartbeat(
+        pid,
+        "sess-abc",
+        &SessionSignals::default(),
+        Some("auth"),
+        ".",
+    );
 
     let result = infer_session_id(pid);
     assert_eq!(result, Some(("sess-abc".into(), "auth".into())));
@@ -734,8 +740,8 @@ fn infer_session_two_active_is_ambiguous() {
     let pid = "test_infer_two";
     let _ = edda_store::ensure_dirs(pid);
 
-    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"));
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"), ".");
 
     let result = infer_session_id(pid);
     assert!(result.is_none(), "two active → ambiguous → None");
@@ -751,7 +757,13 @@ fn infer_session_one_active_one_stale() {
     let _ = edda_store::ensure_dirs(pid);
 
     // Write one fresh heartbeat
-    write_heartbeat(pid, "fresh", &SessionSignals::default(), Some("frontend"));
+    write_heartbeat(
+        pid,
+        "fresh",
+        &SessionSignals::default(),
+        Some("frontend"),
+        ".",
+    );
 
     // Write a stale heartbeat by manually setting old timestamp
     let stale_path = heartbeat_path(pid, "stale");
@@ -833,8 +845,8 @@ fn cross_session_binding_conflict_last_write_wins() {
     assert_eq!(board.bindings[0].by_session, "s2");
 
     // Both sessions see the latest value via render_peer_updates
-    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"));
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"), ".");
 
     let updates_s1 = render_peer_updates(pid, "s1").unwrap();
     assert!(
@@ -872,8 +884,8 @@ fn cross_session_different_keys_both_visible() {
     );
 
     // Both sessions see both bindings
-    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"));
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"), ".");
 
     let updates_s1 = render_peer_updates(pid, "s1").unwrap();
     assert!(
@@ -909,8 +921,8 @@ fn request_delivered_via_heartbeat_label_no_claim() {
     let _ = fs::remove_file(coordination_path(pid));
 
     // Two sessions: s1 (peer) and s2 (me) — both have heartbeats, no claims
-    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"));
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"), ".");
 
     // s1 sends request to "billing" (s2's heartbeat label)
     write_request(pid, "s1", "auth", "billing", "please expose /api/users");
@@ -937,8 +949,8 @@ fn explicit_claim_wins_over_heartbeat_for_requests() {
     let _ = fs::remove_file(coordination_path(pid));
 
     // s2 has heartbeat "auth" but claim "backend"
-    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("peer"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("auth"));
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("peer"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("auth"), ".");
     write_claim(pid, "s2", "backend", &[]);
 
     // Request to "backend" (claim label) should arrive
@@ -968,7 +980,7 @@ fn no_heartbeat_no_claim_no_requests() {
     let _ = fs::remove_file(coordination_path(pid));
 
     // s1 is peer, s2 has no heartbeat and no claim
-    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"));
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"), ".");
     write_request(pid, "s1", "auth", "ghost", "hello ghost");
 
     // s2 renders — should not see the request (no identity)
@@ -988,8 +1000,8 @@ fn heartbeat_scope_display_without_claim() {
     let _ = edda_store::ensure_dirs(pid);
     let _ = fs::remove_file(coordination_path(pid));
 
-    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("peer"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("auth"));
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("peer"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("auth"), ".");
 
     let result = render_coordination_protocol(pid, "s2", ".").unwrap();
     // Without a claim, should show actionable nudge with label-based suggestion
@@ -1013,8 +1025,8 @@ fn claim_scope_display_with_paths() {
     let _ = edda_store::ensure_dirs(pid);
     let _ = fs::remove_file(coordination_path(pid));
 
-    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("peer"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("auth"));
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("peer"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("auth"), ".");
     write_claim(pid, "s2", "backend", &["src/api/*".into()]);
 
     let result = render_coordination_protocol(pid, "s2", ".").unwrap();
@@ -1034,8 +1046,8 @@ fn multi_session_shows_l2_instructions() {
     let _ = edda_store::ensure_dirs(pid);
     let _ = fs::remove_file(coordination_path(pid));
 
-    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"));
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"), ".");
 
     let result = render_coordination_protocol(pid, "s2", ".").unwrap();
     assert!(
@@ -1079,8 +1091,8 @@ fn peer_updates_request_via_heartbeat_fallback() {
     let _ = edda_store::ensure_dirs(pid);
     let _ = fs::remove_file(coordination_path(pid));
 
-    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"));
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"), ".");
     write_request(pid, "s1", "auth", "billing", "need billing API");
 
     let result = render_peer_updates(pid, "s2").unwrap();
@@ -1149,7 +1161,7 @@ fn auto_claim_writes_claim_from_signals() {
         ..Default::default()
     };
 
-    maybe_auto_claim(pid, "s1", &signals);
+    maybe_auto_claim(pid, "s1", &signals, ".");
 
     let board = compute_board_state(pid);
     assert_eq!(board.claims.len(), 1, "should have 1 claim");
@@ -1177,7 +1189,7 @@ fn auto_claim_skips_when_manual_claim_exists() {
         ..Default::default()
     };
 
-    maybe_auto_claim(pid, "s1", &signals);
+    maybe_auto_claim(pid, "s1", &signals, ".");
 
     let board = compute_board_state(pid);
     let claim = board.claims.iter().find(|c| c.session_id == "s1").unwrap();
@@ -1204,8 +1216,8 @@ fn auto_claim_dedup_no_repeated_writes() {
         ..Default::default()
     };
 
-    maybe_auto_claim(pid, "s1", &signals);
-    maybe_auto_claim(pid, "s1", &signals);
+    maybe_auto_claim(pid, "s1", &signals, ".");
+    maybe_auto_claim(pid, "s1", &signals, ".");
 
     let content = fs::read_to_string(coordination_path(pid)).unwrap_or_default();
     let claim_count = content.lines().filter(|l| l.contains("\"claim\"")).count();
@@ -1228,7 +1240,7 @@ fn auto_claim_updates_on_scope_change() {
         }],
         ..Default::default()
     };
-    maybe_auto_claim(pid, "s1", &signals1);
+    maybe_auto_claim(pid, "s1", &signals1, ".");
 
     let signals2 = SessionSignals {
         files_modified: vec![FileEditCount {
@@ -1237,7 +1249,7 @@ fn auto_claim_updates_on_scope_change() {
         }],
         ..Default::default()
     };
-    maybe_auto_claim(pid, "s1", &signals2);
+    maybe_auto_claim(pid, "s1", &signals2, ".");
 
     let board = compute_board_state(pid);
     let claim = board.claims.iter().find(|c| c.session_id == "s1").unwrap();
@@ -1263,7 +1275,7 @@ fn auto_claim_cleanup_removes_state_file() {
         }],
         ..Default::default()
     };
-    maybe_auto_claim(pid, "s1", &signals);
+    maybe_auto_claim(pid, "s1", &signals, ".");
 
     let state_path = autoclaim_state_path(pid, "s1");
     assert!(
@@ -1305,7 +1317,7 @@ fn render_shows_branch_when_present() {
     let _ = fs::create_dir_all(path.parent().unwrap());
     fs::write(&path, serde_json::to_string_pretty(&hb_json).unwrap()).unwrap();
 
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"));
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"), ".");
 
     let result = render_coordination_protocol(pid, "s2", ".").unwrap();
     assert!(
@@ -1348,7 +1360,7 @@ fn render_omits_branch_when_absent() {
     let _ = fs::create_dir_all(path.parent().unwrap());
     fs::write(&path, serde_json::to_string_pretty(&hb_json).unwrap()).unwrap();
 
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"));
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"), ".");
 
     let result = render_coordination_protocol(pid, "s2", ".").unwrap();
     assert!(
@@ -1377,8 +1389,8 @@ fn render_peer_updates_with_matches_original() {
         }],
         ..Default::default()
     };
-    write_heartbeat(pid, "s1", &signals, Some("auth"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"));
+    write_heartbeat(pid, "s1", &signals, Some("auth"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"), ".");
     write_binding(pid, "s1", "auth", "db.engine", "postgres");
 
     // Call original wrapper
@@ -1413,8 +1425,8 @@ fn render_coordination_protocol_with_matches_original() {
         }],
         ..Default::default()
     };
-    write_heartbeat(pid, "s1", &signals, Some("billing"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("auth"));
+    write_heartbeat(pid, "s1", &signals, Some("billing"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("auth"), ".");
     write_binding(pid, "s1", "billing", "payment.provider", "stripe");
 
     // Call original wrapper
@@ -1514,8 +1526,8 @@ fn protocol_no_claim_shows_nudge() {
         }],
         ..Default::default()
     };
-    write_heartbeat(pid, "s1", &signals, Some("peer-agent"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("my-agent"));
+    write_heartbeat(pid, "s1", &signals, Some("peer-agent"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("my-agent"), ".");
 
     let peers = discover_active_peers(pid, "s2");
     let board = compute_board_state(pid);
@@ -1543,8 +1555,14 @@ fn protocol_with_claim_shows_scope() {
     let _ = edda_store::ensure_dirs(pid);
     let _ = fs::remove_file(coordination_path(pid));
 
-    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("peer-agent"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("my-agent"));
+    write_heartbeat(
+        pid,
+        "s1",
+        &SessionSignals::default(),
+        Some("peer-agent"),
+        ".",
+    );
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("my-agent"), ".");
     write_claim(pid, "s2", "my-agent", &["crates/edda-cli/*".to_string()]);
 
     let peers = discover_active_peers(pid, "s2");
@@ -1593,7 +1611,13 @@ fn protocol_nudge_uses_branch_context() {
     let _ = fs::write(&hb_path, serde_json::to_string_pretty(&hb).unwrap());
 
     // Create peer
-    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("peer-agent"));
+    write_heartbeat(
+        pid,
+        "s1",
+        &SessionSignals::default(),
+        Some("peer-agent"),
+        ".",
+    );
 
     let peers = discover_active_peers(pid, "s2");
     let board = compute_board_state(pid);
@@ -1995,7 +2019,7 @@ fn cleanup_subagent_heartbeats_selective() {
     let _ = edda_store::ensure_dirs(pid);
 
     // Create parent heartbeat
-    write_heartbeat_minimal(pid, "parent-1", "main-session");
+    write_heartbeat_minimal(pid, "parent-1", "main-session", ".");
     // Create two sub-agent heartbeats for parent-1
     write_subagent_heartbeat(pid, "sub-a", "parent-1", "sub:Explore", ".");
     write_subagent_heartbeat(pid, "sub-b", "parent-1", "sub:Plan", ".");
@@ -2244,8 +2268,8 @@ fn render_coordination_filters_acked_requests() {
     let _ = fs::remove_file(coordination_path(pid));
 
     // Set up two peers: s1 (auth) and s2 (billing)
-    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"));
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"), ".");
     write_claim(pid, "s1", "auth", &["src/auth/*".into()]);
 
     // billing sends a request to auth
@@ -2286,8 +2310,8 @@ fn peer_updates_filters_acked_requests() {
     let _ = edda_store::ensure_dirs(pid);
     let _ = fs::remove_file(coordination_path(pid));
 
-    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"));
-    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"));
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"), ".");
     write_claim(pid, "s1", "auth", &["src/auth/*".into()]);
 
     // billing sends a request to auth
@@ -2429,7 +2453,7 @@ fn resolve_teammate_by_label() {
     let _ = edda_store::ensure_dirs(pid);
 
     let signals = SessionSignals::default();
-    write_heartbeat(pid, sid, &signals, Some("worker-auth"));
+    write_heartbeat(pid, sid, &signals, Some("worker-auth"), ".");
 
     // Should resolve by label
     let resolved = resolve_teammate_session(pid, "worker-auth");
@@ -2460,7 +2484,7 @@ fn teammate_idle_writes_coord_event_and_updates_phase() {
 
     // Setup: create a heartbeat for the teammate
     let signals = SessionSignals::default();
-    write_heartbeat(pid, teammate_sid, &signals, Some("worker-auth"));
+    write_heartbeat(pid, teammate_sid, &signals, Some("worker-auth"), ".");
 
     // Verify teammate starts without "idle" phase
     let hb_before = read_heartbeat(pid, teammate_sid).expect("heartbeat should exist");

--- a/crates/edda-bridge-openclaw/src/dispatch.rs
+++ b/crates/edda-bridge-openclaw/src/dispatch.rs
@@ -91,7 +91,7 @@ fn dispatch_session_start(
     // Write minimal heartbeat for peer discovery
     if !session_id.is_empty() {
         let label = std::env::var("EDDA_SESSION_LABEL").unwrap_or_default();
-        edda_bridge_claude::peers::write_heartbeat_minimal(project_id, session_id, &label);
+        edda_bridge_claude::peers::write_heartbeat_minimal(project_id, session_id, &label, cwd);
     }
 
     // Auto-digest previous sessions

--- a/crates/edda-cli/src/cmd_bridge.rs
+++ b/crates/edda-cli/src/cmd_bridge.rs
@@ -849,7 +849,12 @@ pub fn heartbeat_write(
     let project_id = edda_store::project_id(repo_root);
     let (session_id, _) = resolve_session_id(cli_session, &project_id, label);
     let _ = edda_store::ensure_dirs(&project_id);
-    edda_bridge_claude::peers::write_heartbeat_minimal(&project_id, &session_id, label);
+    edda_bridge_claude::peers::write_heartbeat_minimal(
+        &project_id,
+        &session_id,
+        label,
+        repo_root.to_str().unwrap_or("."),
+    );
     println!("Heartbeat written: {label} ({session_id})");
     Ok(())
 }
@@ -1383,7 +1388,7 @@ mod tests {
         let _ = edda_store::ensure_dirs(pid);
 
         // Write
-        edda_bridge_claude::peers::write_heartbeat_minimal(pid, sid, "worker");
+        edda_bridge_claude::peers::write_heartbeat_minimal(pid, sid, "worker", ".");
         let state_dir = edda_store::project_dir(pid).join("state");
         let hb_path = state_dir.join(format!("session.{sid}.json"));
         assert!(hb_path.exists(), "heartbeat file should exist after write");


### PR DESCRIPTION
## Summary
- Remove `detect_git_branch()` (zero-arg wrapper hardcoding `"."` as cwd) from `peers/mod.rs`
- Add `cwd: &str` parameter to `write_heartbeat`, `write_heartbeat_minimal`, `ensure_heartbeat_exists`, and `maybe_auto_claim`
- Update all callers in `dispatch/session.rs`, `dispatch/mod.rs`, `cmd_bridge.rs`, `edda-bridge-openclaw/dispatch.rs`, and test files to pass the actual workspace cwd

## Test plan
- [x] `cargo clippy -p edda-bridge-claude -- -D warnings` passes clean
- [x] `cargo clippy -p edda-bridge-openclaw -- -D warnings` passes clean
- [x] `cargo check -p edda` (CLI crate) compiles clean
- [x] `cargo test -p edda-bridge-claude` — 516 passed, 1 pre-existing failure unrelated to this change
- [x] No new `unwrap()` in lib code (SI-1)
- [x] Zero clippy suppression (SI-3)

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)