### PR TITLE
perf(aggregate): single-pass rollup metrics collection

### DIFF
--- a/crates/edda-aggregate/src/aggregate.rs
+++ b/crates/edda-aggregate/src/aggregate.rs
@@ -214,6 +214,160 @@ pub fn aggregate_decisions(projects: &[ProjectEntry]) -> Vec<DecisionRecord> {
     records
 }
 
+/// Combined rollup metrics collected in a single pass over the event ledger.
+///
+/// Instead of calling 5 separate functions (each opening ledgers and scanning
+/// all events independently), this struct holds all metrics produced by a
+/// single traversal via [`rollup_metrics_by_date`].
+pub struct RollupMetrics {
+    pub events: BTreeMap<String, usize>,
+    pub commits: BTreeMap<String, usize>,
+    pub file_edits: BTreeMap<String, Vec<FileEditStat>>,
+    pub cost: BTreeMap<String, f64>,
+    pub quality: BTreeMap<String, (u64, u64)>,
+}
+
+/// Collect all rollup metrics in a single pass over each project's ledger.
+///
+/// This replaces 5 separate calls to `events_by_date`, `commits_by_date`,
+/// `file_edits_by_date`, `cost_by_date`, and `quality_by_date`, reducing
+/// ledger opens and event scans from 5N to 1N (where N = number of projects).
+pub fn rollup_metrics_by_date(projects: &[ProjectEntry], range: &DateRange) -> RollupMetrics {
+    use std::collections::{HashMap, HashSet};
+
+    // Per-file accumulator for file edits: (edit_count, last_ts, unique sessions)
+    type FileAcc = (u64, String, HashSet<String>);
+
+    let mut events: BTreeMap<String, usize> = BTreeMap::new();
+    let mut commits: BTreeMap<String, usize> = BTreeMap::new();
+    let mut cost: BTreeMap<String, f64> = BTreeMap::new();
+    let mut quality: BTreeMap<String, (u64, u64)> = BTreeMap::new();
+    let mut file_edits_acc: HashMap<String, HashMap<String, FileAcc>> = HashMap::new();
+
+    for entry in projects {
+        let root = Path::new(&entry.path);
+        let ledger = match Ledger::open(root) {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        let all_events = match ledger.iter_events() {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        for event in &all_events {
+            if !range.matches(&event.ts) {
+                continue;
+            }
+            let date = &event.ts[..10.min(event.ts.len())];
+            let date_str = date.to_string();
+
+            // Always count events
+            *events.entry(date_str.clone()).or_insert(0) += 1;
+
+            // Count commits
+            if event.event_type == "commit" {
+                *commits.entry(date_str.clone()).or_insert(0) += 1;
+            }
+
+            // Accumulate cost and quality for execution events
+            if event.event_type == "execution_event" {
+                // Cost
+                let cost_val = event
+                    .payload
+                    .get("usage")
+                    .and_then(|u| u.get("cost_usd"))
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(0.0);
+                if cost_val > 0.0 {
+                    *cost.entry(date_str.clone()).or_insert(0.0) += cost_val;
+                }
+
+                // Quality
+                let status = event
+                    .payload
+                    .get("result")
+                    .and_then(|r| r.get("status"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown");
+                let q_entry = quality.entry(date_str.clone()).or_insert((0, 0));
+                if status == "success" {
+                    q_entry.0 += 1;
+                }
+                q_entry.1 += 1;
+            }
+
+            // Accumulate file edits from session_stats
+            let stats = match event.payload.get("session_stats") {
+                Some(s) => s,
+                None => continue,
+            };
+
+            let file_edit_counts = match stats.get("file_edit_counts").and_then(|v| v.as_array()) {
+                Some(arr) => arr,
+                None => continue,
+            };
+
+            let session_id = event
+                .payload
+                .get("session_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+
+            for edit in file_edit_counts {
+                let arr = match edit.as_array() {
+                    Some(a) if a.len() == 2 => a,
+                    _ => continue,
+                };
+                let path = match arr[0].as_str() {
+                    Some(p) => p.to_string(),
+                    None => continue,
+                };
+                let count = arr[1].as_u64().unwrap_or(0);
+
+                let day_map = file_edits_acc.entry(date_str.clone()).or_default();
+                let file_entry = day_map
+                    .entry(path)
+                    .or_insert_with(|| (0, String::new(), HashSet::new()));
+                file_entry.0 += count;
+                if event.ts > file_entry.1 {
+                    file_entry.1.clone_from(&event.ts);
+                }
+                if !session_id.is_empty() {
+                    file_entry.2.insert(session_id.clone());
+                }
+            }
+        }
+    }
+
+    // Convert file edits accumulator to final structure
+    let mut file_edits: BTreeMap<String, Vec<FileEditStat>> = BTreeMap::new();
+    for (date, files) in file_edits_acc {
+        let mut edits: Vec<FileEditStat> = files
+            .into_iter()
+            .map(|(path, (edit_count, last_edited, sessions))| FileEditStat {
+                path,
+                edit_count,
+                agent_count: sessions.len(),
+                last_edited,
+                revert_count: 0,
+            })
+            .collect();
+        edits.sort_by(|a, b| b.edit_count.cmp(&a.edit_count));
+        file_edits.insert(date, edits);
+    }
+
+    RollupMetrics {
+        events,
+        commits,
+        file_edits,
+        cost,
+        quality,
+    }
+}
+
 /// Count events by date (YYYY-MM-DD) across all projects.
 pub fn events_by_date(projects: &[ProjectEntry], range: &DateRange) -> BTreeMap<String, usize> {
     let mut counts: BTreeMap<String, usize> = BTreeMap::new();
@@ -837,5 +991,162 @@ mod tests {
         assert_eq!(main_rs.edit_count, 8);
         // Unique sessions: 2 (sess-1 and sess-2)
         assert_eq!(main_rs.agent_count, 2);
+    }
+
+    /// Helper: create an execution event with cost and result status.
+    fn make_execution_event(cost_usd: f64, status: &str) -> edda_core::types::Event {
+        let mut event =
+            edda_core::event::new_note_event("main", None, "system", "exec", &[]).unwrap();
+        event.event_type = "execution_event".to_string();
+        event.payload = serde_json::json!({
+            "usage": { "cost_usd": cost_usd },
+            "result": { "status": status },
+        });
+        event
+    }
+
+    /// Helper: create a commit event.
+    fn make_commit_event() -> edda_core::types::Event {
+        let mut event =
+            edda_core::event::new_note_event("main", None, "system", "commit", &[]).unwrap();
+        event.event_type = "commit".to_string();
+        event.payload = serde_json::json!({ "title": "test commit" });
+        event
+    }
+
+    #[test]
+    fn rollup_metrics_single_pass_collects_all_metrics() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        let paths = edda_ledger::EddaPaths::discover(root);
+        edda_ledger::ledger::init_workspace(&paths).unwrap();
+        edda_ledger::ledger::init_head(&paths, "main").unwrap();
+
+        let ledger = Ledger::open(root).unwrap();
+
+        // Add a commit event
+        ledger.append_event(&make_commit_event()).unwrap();
+
+        // Add an execution event with cost
+        ledger
+            .append_event(&make_execution_event(0.05, "success"))
+            .unwrap();
+
+        // Add a failed execution event
+        ledger
+            .append_event(&make_execution_event(0.02, "failure"))
+            .unwrap();
+
+        // Add a session event with file edits
+        let session_event =
+            make_session_event("sess-1", &[("src/main.rs", 3), ("src/lib.rs", 1)]);
+        ledger.append_event(&session_event).unwrap();
+
+        let entry = ProjectEntry {
+            project_id: "test".to_string(),
+            path: root.to_string_lossy().to_string(),
+            name: "test".to_string(),
+            registered_at: "2026-01-01".to_string(),
+            last_seen: "2026-01-01".to_string(),
+            group: None,
+        };
+
+        let range = DateRange::default();
+        let metrics = rollup_metrics_by_date(&[entry], &range);
+
+        // All 4 events counted
+        let total_events: usize = metrics.events.values().sum();
+        assert_eq!(total_events, 4);
+
+        // 1 commit
+        let total_commits: usize = metrics.commits.values().sum();
+        assert_eq!(total_commits, 1);
+
+        // Cost: 0.05 + 0.02 = 0.07
+        let total_cost: f64 = metrics.cost.values().sum();
+        assert!((total_cost - 0.07).abs() < 1e-9);
+
+        // Quality: 1 success out of 2 execution events
+        let (total_success, total_exec): (u64, u64) =
+            metrics.quality.values().fold((0, 0), |acc, &(s, t)| {
+                (acc.0 + s, acc.1 + t)
+            });
+        assert_eq!(total_success, 1);
+        assert_eq!(total_exec, 2);
+
+        // File edits: 2 files
+        let total_files: usize = metrics.file_edits.values().map(|v| v.len()).sum();
+        assert_eq!(total_files, 2);
+    }
+
+    #[test]
+    fn rollup_metrics_matches_individual_functions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        let paths = edda_ledger::EddaPaths::discover(root);
+        edda_ledger::ledger::init_workspace(&paths).unwrap();
+        edda_ledger::ledger::init_head(&paths, "main").unwrap();
+
+        let ledger = Ledger::open(root).unwrap();
+        ledger.append_event(&make_commit_event()).unwrap();
+        ledger
+            .append_event(&make_execution_event(0.10, "success"))
+            .unwrap();
+        ledger
+            .append_event(&make_execution_event(0.03, "failure"))
+            .unwrap();
+        let session_event = make_session_event("sess-1", &[("src/main.rs", 7)]);
+        ledger.append_event(&session_event).unwrap();
+
+        let entry = ProjectEntry {
+            project_id: "test".to_string(),
+            path: root.to_string_lossy().to_string(),
+            name: "test".to_string(),
+            registered_at: "2026-01-01".to_string(),
+            last_seen: "2026-01-01".to_string(),
+            group: None,
+        };
+
+        let range = DateRange::default();
+        let projects = &[entry];
+
+        // Single-pass
+        let metrics = rollup_metrics_by_date(projects, &range);
+
+        // Individual functions
+        let ind_events = events_by_date(projects, &range);
+        let ind_commits = commits_by_date(projects, &range);
+        let ind_cost = cost_by_date(projects, &range);
+        let ind_quality = quality_by_date(projects, &range);
+        let ind_file_edits = file_edits_by_date(projects, &range);
+
+        // Compare results
+        assert_eq!(metrics.events, ind_events);
+        assert_eq!(metrics.commits, ind_commits);
+        assert_eq!(metrics.quality, ind_quality);
+
+        // Compare cost with floating-point tolerance
+        assert_eq!(metrics.cost.len(), ind_cost.len());
+        for (date, val) in &metrics.cost {
+            let ind_val = ind_cost.get(date).copied().unwrap_or(0.0);
+            assert!(
+                (val - ind_val).abs() < 1e-9,
+                "cost mismatch on {date}: {val} vs {ind_val}"
+            );
+        }
+
+        // Compare file edits structure
+        assert_eq!(metrics.file_edits.len(), ind_file_edits.len());
+        for (date, edits) in &metrics.file_edits {
+            let ind_edits = &ind_file_edits[date];
+            assert_eq!(edits.len(), ind_edits.len());
+            for edit in edits {
+                let ind_edit = ind_edits.iter().find(|e| e.path == edit.path).unwrap();
+                assert_eq!(edit.edit_count, ind_edit.edit_count);
+                assert_eq!(edit.agent_count, ind_edit.agent_count);
+            }
+        }
     }
 }

--- a/crates/edda-aggregate/src/rollup.rs
+++ b/crates/edda-aggregate/src/rollup.rs
@@ -129,19 +129,18 @@ pub fn save_rollup(rollup: &Rollup) -> anyhow::Result<()> {
 }
 
 /// Compute a full rollup from scratch.
+///
+/// Uses a single-pass aggregation to collect all metrics in one traversal
+/// per project ledger, instead of 5 separate scans.
 pub fn compute_rollup(projects: &[ProjectEntry], range: &DateRange, tool: &str) -> Rollup {
-    let events_map = aggregate::events_by_date(projects, range);
-    let commits_map = aggregate::commits_by_date(projects, range);
-    let file_edits_map = aggregate::file_edits_by_date(projects, range);
-    let cost_map = aggregate::cost_by_date(projects, range);
-    let quality_map = aggregate::quality_by_date(projects, range);
+    let metrics = aggregate::rollup_metrics_by_date(projects, range);
 
     let daily = build_daily_stats(
-        &events_map,
-        &commits_map,
-        &file_edits_map,
-        &cost_map,
-        &quality_map,
+        &metrics.events,
+        &metrics.commits,
+        &metrics.file_edits,
+        &metrics.cost,
+        &metrics.quality,
     );
     let weekly = build_weekly_stats(&daily);
     let monthly = build_monthly_stats(&daily);


### PR DESCRIPTION
## Summary

- Add `RollupMetrics` struct and `rollup_metrics_by_date()` single-pass function in `aggregate.rs` that collects all 5 metric types (events, commits, file_edits, cost, quality) in one ledger traversal per project
- Update `compute_rollup()` in `rollup.rs` to use the new single-pass function instead of 5 separate calls
- Keep existing individual functions (`events_by_date`, `commits_by_date`, etc.) for backward compatibility
- Add 2 tests: one verifying all metrics are collected correctly, one verifying equivalence with the individual functions

## Performance Impact

| Metric | Before | After |
|---|---|---|
| Ledger opens per project | 5 | 1 |
| Full event scans per project | 5 | 1 |
| JSON payload deserialization | 5x per event | 1x per event |

For N=10 projects with 1000 events each: **50 scans -> 10 scans** (5x reduction).

## Test plan

- [x] `cargo clippy -p edda-aggregate -- -D warnings` passes with zero warnings
- [x] `cargo test -p edda-aggregate` passes all 47 tests (including 2 new)
- [x] New `rollup_metrics_matches_individual_functions` test verifies output equivalence

Closes #291

Generated with [Claude Code](https://claude.com/claude-code)