### PR TITLE
fix(serve): isolate EDDA_STORE_ROOT in overview test (#311)

### DIFF
--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -3910,7 +3910,11 @@ mod tests {
 
     #[tokio::test]
     async fn overview_returns_structure() {
+        let _lock = STORE_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir().unwrap();
+        let store_dir = tmp.path().join("store");
+        std::fs::create_dir_all(&store_dir).unwrap();
+        std::env::set_var("EDDA_STORE_ROOT", &store_dir);
         setup_workspace(tmp.path());
         let app = router(tmp.path());
 
@@ -3933,6 +3937,7 @@ mod tests {
         assert!(json["yellow"].as_array().unwrap().is_empty());
         assert!(json["green"].as_array().unwrap().is_empty());
         assert!(json["updated_at"].is_string());
+        std::env::remove_var("EDDA_STORE_ROOT");
     }
 
     #[tokio::test]

--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -3660,6 +3660,14 @@ mod tests {
     /// Serialize tests that set EDDA_STORE_ROOT env var.
     static STORE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    /// RAII guard that removes EDDA_STORE_ROOT on drop (panic-safe cleanup).
+    struct StoreRootGuard;
+    impl Drop for StoreRootGuard {
+        fn drop(&mut self) {
+            std::env::remove_var("EDDA_STORE_ROOT");
+        }
+    }
+
     fn setup_workspace(dir: &Path) {
         let paths = edda_ledger::EddaPaths::discover(dir);
         paths.ensure_layout().unwrap();
@@ -3915,6 +3923,7 @@ mod tests {
         let store_dir = tmp.path().join("store");
         std::fs::create_dir_all(&store_dir).unwrap();
         std::env::set_var("EDDA_STORE_ROOT", &store_dir);
+        let _guard = StoreRootGuard;
         setup_workspace(tmp.path());
         let app = router(tmp.path());
 
@@ -3937,7 +3946,6 @@ mod tests {
         assert!(json["yellow"].as_array().unwrap().is_empty());
         assert!(json["green"].as_array().unwrap().is_empty());
         assert!(json["updated_at"].is_string());
-        std::env::remove_var("EDDA_STORE_ROOT");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- `overview_returns_structure` test was reading from the global `~/.edda/registry.json` instead of an isolated store, causing failures on machines with registered projects
- Wraps the test with `STORE_LOCK` + isolated `EDDA_STORE_ROOT` + cleanup, matching the established pattern used by `scope_check` tests

Closes #311

## Test plan
- [x] `overview_returns_structure` passes (was failing)
- [x] Full suite: 84 passed, 0 failed
- [x] clippy + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)