### PR TITLE
fix(bridge): replace path.parent().unwrap() with .context()? (SI-1)

### DIFF
--- a/crates/edda-bridge-claude/src/bg_detect.rs
+++ b/crates/edda-bridge-claude/src/bg_detect.rs
@@ -766,7 +766,10 @@ fn save_detect_result(project_id: &str, result: &DetectResult) -> Result<()> {
 fn append_audit_log(project_id: &str, entry: &AuditEntry) -> Result<()> {
     use std::io::Write;
     let path = audit_log_path(project_id);
-    fs::create_dir_all(path.parent().context("detect audit log path has no parent")?)?;
+    fs::create_dir_all(
+        path.parent()
+            .context("detect audit log path has no parent")?,
+    )?;
     let line = serde_json::to_string(entry)?;
     let mut file = fs::OpenOptions::new()
         .create(true)

--- a/crates/edda-bridge-claude/src/bg_scan.rs
+++ b/crates/edda-bridge-claude/src/bg_scan.rs
@@ -743,7 +743,7 @@ fn save_scan_state(project_id: &str, result: &ScanResult) -> Result<()> {
         status: "completed".to_string(),
     };
     let path = scan_state_path(project_id);
-    fs::create_dir_all(path.parent().unwrap())?;
+    fs::create_dir_all(path.parent().context("scan state path has no parent")?)?;
     let json = serde_json::to_string_pretty(&state)?;
     fs::write(&path, json)?;
     Ok(())
@@ -751,7 +751,7 @@ fn save_scan_state(project_id: &str, result: &ScanResult) -> Result<()> {
 
 fn save_scan_drafts(project_id: &str, result: &ScanResult) -> Result<()> {
     let path = scan_draft_path(project_id, &result.scan_id);
-    fs::create_dir_all(path.parent().unwrap())?;
+    fs::create_dir_all(path.parent().context("scan draft path has no parent")?)?;
     let json = serde_json::to_string_pretty(result)?;
     fs::write(&path, json)?;
     Ok(())
@@ -760,7 +760,7 @@ fn save_scan_drafts(project_id: &str, result: &ScanResult) -> Result<()> {
 fn append_audit_log(project_id: &str, entry: &AuditEntry) -> Result<()> {
     use std::io::Write;
     let path = audit_log_path(project_id);
-    fs::create_dir_all(path.parent().unwrap())?;
+    fs::create_dir_all(path.parent().context("audit log path has no parent")?)?;
     let line = serde_json::to_string(entry)?;
     let mut file = fs::OpenOptions::new()
         .create(true)

--- a/crates/edda-bridge-claude/src/issue_proposal.rs
+++ b/crates/edda-bridge-claude/src/issue_proposal.rs
@@ -74,7 +74,7 @@ pub fn new_proposal_id() -> String {
 /// Save an issue proposal to disk.
 pub fn save_proposal(project_id: &str, proposal: &IssueProposal) -> Result<()> {
     let path = proposal_path(project_id, &proposal.proposal_id);
-    fs::create_dir_all(path.parent().unwrap())?;
+    fs::create_dir_all(path.parent().context("proposal path has no parent")?)?;
     let json = serde_json::to_string_pretty(proposal)?;
     fs::write(&path, json)?;
 
@@ -288,7 +288,7 @@ fn append_audit(
 ) -> Result<()> {
     use std::io::Write;
     let path = audit_log_path(project_id);
-    fs::create_dir_all(path.parent().unwrap())?;
+    fs::create_dir_all(path.parent().context("audit log path has no parent")?)?;
     let entry = AuditEntry {
         ts: now_rfc3339(),
         proposal_id: proposal_id.to_string(),


### PR DESCRIPTION
## Summary
- Replace 5 instances of `path.parent().unwrap()` with `.context("...")?` in `bg_scan.rs` and `issue_proposal.rs`
- Prevents potential panic on edge-case root paths, propagates error gracefully instead

Closes #313

## Test plan
- [x] 516 passed, 0 new failures (1 pre-existing unrelated failure)
- [x] clippy -D warnings clean
- [x] cargo fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)