### PR TITLE
perf(query): optimize snapshot decision hot path

### DIFF
--- a/crates/edda-ledger/src/sqlite_store.rs
+++ b/crates/edda-ledger/src/sqlite_store.rs
@@ -165,6 +165,13 @@ CREATE INDEX IF NOT EXISTS idx_decisions_active_domain
     ON decisions(is_active, domain) WHERE is_active = TRUE;
 ";
 
+const SCHEMA_V10_SQL: &str = "
+CREATE INDEX IF NOT EXISTS idx_snapshots_village_created
+    ON decide_snapshots(village_id, created_at DESC) WHERE village_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_snapshots_village_type_created
+    ON decide_snapshots(village_id, decision_type, created_at DESC) WHERE village_id IS NOT NULL;
+";
+
 /// A row from the `decisions` table.
 #[derive(Debug, Clone)]
 pub struct DecisionRow {
@@ -271,6 +278,7 @@ pub struct DecideSnapshotRow {
     pub engine_version: String,
     pub schema_version: String,
     pub redaction_level: String,
+    pub decision_type: Option<String>,
     pub village_id: Option<String>,
     pub cycle_id: Option<String>,
     pub has_blobs: bool,
@@ -402,6 +410,12 @@ impl SqliteStore {
         let current = self.schema_version()?;
         if current < 9 {
             self.migrate_v8_to_v9()?;
+        }
+
+        // Migrate to v10 if needed (snapshot hot path indexes + decision_type)
+        let current = self.schema_version()?;
+        if current < 10 {
+            self.migrate_v9_to_v10()?;
         }
 
         Ok(())
@@ -646,6 +660,7 @@ impl SqliteStore {
             let engine_version = payload["engine_version"].as_str().unwrap_or("");
             let schema_version = payload["schema_version"].as_str().unwrap_or("snapshot.v1");
             let redaction_level = payload["redaction_level"].as_str().unwrap_or("full");
+            let decision_type = payload["decision_type"].as_str();
             let village_id = payload["village_id"].as_str();
             let cycle_id = payload["cycle_id"].as_str();
             let has_blobs =
@@ -654,14 +669,15 @@ impl SqliteStore {
             self.conn.execute(
                 "INSERT OR IGNORE INTO decide_snapshots
                  (event_id, context_hash, engine_version, schema_version,
-                  redaction_level, village_id, cycle_id, has_blobs, created_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                  redaction_level, decision_type, village_id, cycle_id, has_blobs, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
                 params![
                     event_id,
                     context_hash,
                     engine_version,
                     schema_version,
                     redaction_level,
+                    decision_type,
                     village_id,
                     cycle_id,
                     has_blobs,
@@ -677,6 +693,22 @@ impl SqliteStore {
     fn migrate_v8_to_v9(&self) -> anyhow::Result<()> {
         self.conn.execute_batch(SCHEMA_V9_SQL)?;
         self.set_schema_version(9)?;
+        Ok(())
+    }
+
+    fn migrate_v9_to_v10(&self) -> anyhow::Result<()> {
+        let has_decision_type: bool = self
+            .conn
+            .prepare("SELECT decision_type FROM decide_snapshots LIMIT 0")
+            .is_ok();
+        if !has_decision_type {
+            self.conn.execute(
+                "ALTER TABLE decide_snapshots ADD COLUMN decision_type TEXT",
+                [],
+            )?;
+        }
+        self.conn.execute_batch(SCHEMA_V10_SQL)?;
+        self.set_schema_version(10)?;
         Ok(())
     }
 
@@ -2345,14 +2377,15 @@ impl SqliteStore {
         self.conn.execute(
             "INSERT INTO decide_snapshots
              (event_id, context_hash, engine_version, schema_version,
-              redaction_level, village_id, cycle_id, has_blobs, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+              redaction_level, decision_type, village_id, cycle_id, has_blobs, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             params![
                 row.event_id,
                 row.context_hash,
                 row.engine_version,
                 row.schema_version,
                 row.redaction_level,
+                row.decision_type,
                 row.village_id,
                 row.cycle_id,
                 row.has_blobs,
@@ -2369,40 +2402,74 @@ impl SqliteStore {
         engine_version: Option<&str>,
         limit: usize,
     ) -> anyhow::Result<Vec<DecideSnapshotRow>> {
-        let base = "SELECT event_id, context_hash, engine_version, schema_version,
-                           redaction_level, village_id, cycle_id, has_blobs, created_at
-                    FROM decide_snapshots";
-
-        let mut conditions: Vec<&str> = Vec::new();
-        let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-
-        if let Some(v) = village_id {
-            conditions.push("village_id = ?");
-            param_values.push(Box::new(v.to_string()));
-        }
-        if let Some(e) = engine_version {
-            conditions.push("engine_version = ?");
-            param_values.push(Box::new(e.to_string()));
-        }
-
-        let sql = if conditions.is_empty() {
-            format!("{base} ORDER BY created_at DESC LIMIT ?")
-        } else {
-            format!(
-                "{base} WHERE {} ORDER BY created_at DESC LIMIT ?",
-                conditions.join(" AND ")
-            )
+        let start = Instant::now();
+        let limit_i64 = limit as i64;
+        let collected = match (village_id, engine_version) {
+            (Some(v), Some(e)) => {
+                let mut stmt = self.conn.prepare(
+                    "SELECT event_id, context_hash, engine_version, schema_version,
+                            redaction_level, decision_type, village_id, cycle_id, has_blobs, created_at
+                     FROM decide_snapshots
+                     WHERE village_id = ?1 AND engine_version = ?2
+                     ORDER BY created_at DESC
+                     LIMIT ?3",
+                )?;
+                let rows = stmt.query_map(params![v, e, limit_i64], map_snapshot_row)?;
+                rows.collect::<Result<Vec<_>, _>>()
+                    .map_err(|e| anyhow::anyhow!("snapshot query failed: {e}"))?
+            }
+            (Some(v), None) => {
+                let mut stmt = self.conn.prepare(
+                    "SELECT event_id, context_hash, engine_version, schema_version,
+                            redaction_level, decision_type, village_id, cycle_id, has_blobs, created_at
+                     FROM decide_snapshots
+                     WHERE village_id = ?1
+                     ORDER BY created_at DESC
+                     LIMIT ?2",
+                )?;
+                let rows = stmt.query_map(params![v, limit_i64], map_snapshot_row)?;
+                rows.collect::<Result<Vec<_>, _>>()
+                    .map_err(|e| anyhow::anyhow!("snapshot query failed: {e}"))?
+            }
+            (None, Some(e)) => {
+                let mut stmt = self.conn.prepare(
+                    "SELECT event_id, context_hash, engine_version, schema_version,
+                            redaction_level, decision_type, village_id, cycle_id, has_blobs, created_at
+                     FROM decide_snapshots
+                     WHERE engine_version = ?1
+                     ORDER BY created_at DESC
+                     LIMIT ?2",
+                )?;
+                let rows = stmt.query_map(params![e, limit_i64], map_snapshot_row)?;
+                rows.collect::<Result<Vec<_>, _>>()
+                    .map_err(|e| anyhow::anyhow!("snapshot query failed: {e}"))?
+            }
+            (None, None) => {
+                let mut stmt = self.conn.prepare(
+                    "SELECT event_id, context_hash, engine_version, schema_version,
+                            redaction_level, decision_type, village_id, cycle_id, has_blobs, created_at
+                     FROM decide_snapshots
+                     ORDER BY created_at DESC
+                     LIMIT ?1",
+                )?;
+                let rows = stmt.query_map(params![limit_i64], map_snapshot_row)?;
+                rows.collect::<Result<Vec<_>, _>>()
+                    .map_err(|e| anyhow::anyhow!("snapshot query failed: {e}"))?
+            }
         };
-        param_values.push(Box::new(limit as i64));
 
-        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
-            param_values.iter().map(|p| p.as_ref()).collect();
+        debug!(
+            village_id = village_id.unwrap_or(""),
+            engine_version = engine_version.unwrap_or(""),
+            limit,
+            offset = 0,
+            decision_type = "",
+            result_count = collected.len(),
+            elapsed_ms = start.elapsed().as_millis(),
+            "query_snapshots"
+        );
 
-        let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map(param_refs.as_slice(), map_snapshot_row)?;
-
-        rows.collect::<Result<Vec<_>, _>>()
-            .map_err(|e| anyhow::anyhow!("snapshot query failed: {e}"))
+        Ok(collected)
     }
 
     /// Find all snapshots with a given context_hash (for version comparison).
@@ -2412,7 +2479,7 @@ impl SqliteStore {
     ) -> anyhow::Result<Vec<DecideSnapshotRow>> {
         let mut stmt = self.conn.prepare(
             "SELECT event_id, context_hash, engine_version, schema_version,
-                    redaction_level, village_id, cycle_id, has_blobs, created_at
+                    redaction_level, decision_type, village_id, cycle_id, has_blobs, created_at
              FROM decide_snapshots
              WHERE context_hash = ?1
              ORDER BY created_at DESC",
@@ -2456,10 +2523,11 @@ fn map_snapshot_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<DecideSnapshotR
         engine_version: row.get(2)?,
         schema_version: row.get(3)?,
         redaction_level: row.get(4)?,
-        village_id: row.get(5)?,
-        cycle_id: row.get(6)?,
-        has_blobs: row.get(7)?,
-        created_at: row.get(8)?,
+        decision_type: row.get(5)?,
+        village_id: row.get(6)?,
+        cycle_id: row.get(7)?,
+        has_blobs: row.get(8)?,
+        created_at: row.get(9)?,
     })
 }
 
@@ -3705,7 +3773,25 @@ mod tests {
         assert!(tables.contains(&"task_briefs".to_string()));
         assert!(tables.contains(&"device_tokens".to_string()));
         assert!(tables.contains(&"decide_snapshots".to_string()));
-        assert_eq!(store.schema_version().unwrap(), 9);
+        assert_eq!(store.schema_version().unwrap(), 10);
+        drop(store);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn snapshot_hot_path_indexes_exist() {
+        let (dir, store) = tmp_db();
+        let indexes: Vec<String> = store
+            .conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='index' ORDER BY name")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert!(indexes.contains(&"idx_snapshots_village_created".to_string()));
+        assert!(indexes.contains(&"idx_snapshots_village_type_created".to_string()));
         drop(store);
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -3,7 +3,7 @@ use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{ConnectInfo, Path as AxumPath, Query, State};
@@ -16,6 +16,7 @@ use axum::{Json, Router};
 use edda_ledger::device_token::{generate_device_token, hash_token};
 use serde::{Deserialize, Serialize};
 use tower_http::cors::{AllowOrigin, CorsLayer};
+use tracing::{debug, warn};
 
 use edda_aggregate::aggregate::{
     aggregate_decisions, aggregate_overview, per_project_metrics, DateRange, ProjectMetrics,
@@ -50,6 +51,13 @@ struct AppState {
     repo_root: PathBuf,
     chronicle: Option<ChronicleContext>,
     pending_pairings: Mutex<HashMap<String, PairingRequest>>,
+    snapshot_cache: Mutex<HashMap<String, SnapshotCacheEntry>>,
+}
+
+#[derive(Clone)]
+struct SnapshotCacheEntry {
+    rows: Vec<edda_ledger::DecideSnapshotRow>,
+    expires_at: Instant,
 }
 
 struct PairingRequest {
@@ -149,6 +157,7 @@ pub async fn serve(repo_root: &Path, config: ServeConfig) -> anyhow::Result<()> 
         repo_root: repo_root.to_path_buf(),
         chronicle,
         pending_pairings: Mutex::new(HashMap::new()),
+        snapshot_cache: Mutex::new(HashMap::new()),
     });
 
     // Public routes (no auth required)
@@ -263,6 +272,7 @@ fn router(repo_root: &Path) -> Router {
         repo_root: repo_root.to_path_buf(),
         chronicle,
         pending_pairings: Mutex::new(HashMap::new()),
+        snapshot_cache: Mutex::new(HashMap::new()),
     });
     Router::new()
         .route("/api/health", get(health))
@@ -1829,6 +1839,7 @@ struct SnapshotBody {
     context_hash: String,
     #[serde(default = "default_redaction_level")]
     redaction_level: String,
+    decision_type: Option<String>,
     village_id: Option<String>,
     cycle_id: Option<String>,
 }
@@ -1899,6 +1910,9 @@ async fn post_snapshot(
         "context_hash": body.context_hash,
         "redaction_level": body.redaction_level,
     });
+    if let Some(ref decision_type) = body.decision_type {
+        payload["decision_type"] = serde_json::Value::String(decision_type.clone());
+    }
     if let Some(ref vid) = body.village_id {
         payload["village_id"] = serde_json::Value::String(vid.clone());
     }
@@ -1933,6 +1947,7 @@ async fn post_snapshot(
         engine_version: body.engine_version,
         schema_version: body.schema_version,
         redaction_level: body.redaction_level,
+        decision_type: body.decision_type,
         village_id: body.village_id,
         cycle_id: body.cycle_id,
         has_blobs,
@@ -1954,29 +1969,142 @@ async fn post_snapshot(
 struct SnapshotsQuery {
     village_id: Option<String>,
     engine_version: Option<String>,
+    decision_type: Option<String>,
     #[serde(default = "default_snapshot_limit")]
     limit: usize,
+    #[serde(default)]
+    offset: usize,
 }
 
 fn default_snapshot_limit() -> usize {
     20
 }
 
+const SNAPSHOT_CACHE_TTL: Duration = Duration::from_secs(300);
+const SNAPSHOT_CACHE_LIMIT: usize = 100;
+
+fn apply_snapshot_filters_and_page(
+    rows: &[edda_ledger::DecideSnapshotRow],
+    decision_type: Option<&str>,
+    offset: usize,
+    limit: usize,
+) -> Vec<edda_ledger::DecideSnapshotRow> {
+    rows.iter()
+        .filter(|row| {
+            decision_type
+                .map(|dt| row.decision_type.as_deref() == Some(dt))
+                .unwrap_or(true)
+        })
+        .skip(offset)
+        .take(limit)
+        .cloned()
+        .collect()
+}
+
 async fn get_snapshots(
     State(state): State<Arc<AppState>>,
     Query(query): Query<SnapshotsQuery>,
 ) -> Result<impl IntoResponse, AppError> {
+    let started = Instant::now();
+    let limit = query.limit.min(SNAPSHOT_CACHE_LIMIT);
+    let offset = query.offset;
+    let decision_type = query.decision_type.as_deref();
+    let mut cache_hit = false;
+    let mut hot_path = false;
+
     let ledger = state.open_ledger()?;
-    let rows = ledger.query_snapshots(
-        query.village_id.as_deref(),
-        query.engine_version.as_deref(),
-        query.limit,
-    )?;
+    let rows = if let Some(village_id) = query.village_id.as_deref() {
+        hot_path = true;
+        if query.engine_version.is_none() {
+            let now = Instant::now();
+            if let Some(entry) = state
+                .snapshot_cache
+                .lock()
+                .map_err(|_| AppError::Internal(anyhow::anyhow!("snapshot cache lock poisoned")))?
+                .get(village_id)
+                .cloned()
+            {
+                if entry.expires_at > now {
+                    cache_hit = true;
+                    apply_snapshot_filters_and_page(&entry.rows, decision_type, offset, limit)
+                } else {
+                    let mut cache = state.snapshot_cache.lock().map_err(|_| {
+                        AppError::Internal(anyhow::anyhow!("snapshot cache lock poisoned"))
+                    })?;
+                    cache.remove(village_id);
+                    let fetched =
+                        ledger.query_snapshots(Some(village_id), None, SNAPSHOT_CACHE_LIMIT)?;
+                    cache.insert(
+                        village_id.to_string(),
+                        SnapshotCacheEntry {
+                            rows: fetched.clone(),
+                            expires_at: now + SNAPSHOT_CACHE_TTL,
+                        },
+                    );
+                    apply_snapshot_filters_and_page(&fetched, decision_type, offset, limit)
+                }
+            } else {
+                let fetched =
+                    ledger.query_snapshots(Some(village_id), None, SNAPSHOT_CACHE_LIMIT)?;
+                state
+                    .snapshot_cache
+                    .lock()
+                    .map_err(|_| {
+                        AppError::Internal(anyhow::anyhow!("snapshot cache lock poisoned"))
+                    })?
+                    .insert(
+                        village_id.to_string(),
+                        SnapshotCacheEntry {
+                            rows: fetched.clone(),
+                            expires_at: now + SNAPSHOT_CACHE_TTL,
+                        },
+                    );
+                apply_snapshot_filters_and_page(&fetched, decision_type, offset, limit)
+            }
+        } else {
+            let fetched = ledger.query_snapshots(
+                Some(village_id),
+                query.engine_version.as_deref(),
+                SNAPSHOT_CACHE_LIMIT,
+            )?;
+            apply_snapshot_filters_and_page(&fetched, decision_type, offset, limit)
+        }
+    } else {
+        ledger.query_snapshots(None, query.engine_version.as_deref(), limit)?
+    };
 
     let mut snapshots = Vec::new();
     for row in &rows {
         let snapshot = reconstruct_snapshot(&ledger, row)?;
         snapshots.push(snapshot);
+    }
+
+    let elapsed_ms = started.elapsed().as_millis();
+    debug!(
+        cache_hit,
+        hot_path,
+        village_id = query.village_id.as_deref().unwrap_or(""),
+        engine_version = query.engine_version.as_deref().unwrap_or(""),
+        decision_type = decision_type.unwrap_or(""),
+        limit,
+        offset,
+        result_count = snapshots.len(),
+        elapsed_ms,
+        "get_snapshots"
+    );
+    if elapsed_ms > 100 {
+        warn!(
+            cache_hit,
+            hot_path,
+            village_id = query.village_id.as_deref().unwrap_or(""),
+            engine_version = query.engine_version.as_deref().unwrap_or(""),
+            decision_type = decision_type.unwrap_or(""),
+            limit,
+            offset,
+            result_count = snapshots.len(),
+            elapsed_ms,
+            "get_snapshots slow query"
+        );
     }
 
     Ok(Json(snapshots))
@@ -2049,6 +2177,7 @@ fn reconstruct_snapshot(
         "engine_version": row.engine_version,
         "schema_version": row.schema_version,
         "redaction_level": row.redaction_level,
+        "decision_type": row.decision_type,
         "village_id": row.village_id,
         "cycle_id": row.cycle_id,
         "context": context,
@@ -6004,6 +6133,8 @@ actors:
         serde_json::json!({
             "engine_version": "claude-3.5",
             "context_hash": "abc123def456",
+            "decision_type": "approve",
+            "village_id": "village-alpha",
             "context": {"files": ["main.rs"], "prompt": "test"},
             "result": {"decisions": [{"key": "db.engine", "value": "sqlite"}]},
         })
@@ -6215,6 +6346,52 @@ actors:
             .unwrap();
 
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn snapshot_filter_and_offset_applies_after_decision_type() {
+        let rows = vec![
+            edda_ledger::DecideSnapshotRow {
+                event_id: "evt_1".to_string(),
+                context_hash: "h1".to_string(),
+                engine_version: "e".to_string(),
+                schema_version: "snapshot.v1".to_string(),
+                redaction_level: "full".to_string(),
+                decision_type: Some("approve".to_string()),
+                village_id: Some("village-beta".to_string()),
+                cycle_id: None,
+                has_blobs: false,
+                created_at: "2026-01-01T00:00:03Z".to_string(),
+            },
+            edda_ledger::DecideSnapshotRow {
+                event_id: "evt_2".to_string(),
+                context_hash: "h2".to_string(),
+                engine_version: "e".to_string(),
+                schema_version: "snapshot.v1".to_string(),
+                redaction_level: "full".to_string(),
+                decision_type: Some("approve".to_string()),
+                village_id: Some("village-beta".to_string()),
+                cycle_id: None,
+                has_blobs: false,
+                created_at: "2026-01-01T00:00:02Z".to_string(),
+            },
+            edda_ledger::DecideSnapshotRow {
+                event_id: "evt_3".to_string(),
+                context_hash: "h3".to_string(),
+                engine_version: "e".to_string(),
+                schema_version: "snapshot.v1".to_string(),
+                redaction_level: "full".to_string(),
+                decision_type: Some("reject".to_string()),
+                village_id: Some("village-beta".to_string()),
+                cycle_id: None,
+                has_blobs: false,
+                created_at: "2026-01-01T00:00:01Z".to_string(),
+            },
+        ];
+
+        let filtered = apply_snapshot_filters_and_page(&rows, Some("approve"), 1, 10);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].event_id, "evt_2");
     }
 
     // ── POST /api/decisions/batch tests ──
@@ -6753,6 +6930,7 @@ actors:
             repo_root: repo_root.to_path_buf(),
             chronicle,
             pending_pairings: Mutex::new(HashMap::new()),
+            snapshot_cache: Mutex::new(HashMap::new()),
         });
 
         let public_routes = Router::new().route("/api/health", get(health));


### PR DESCRIPTION
## Summary
- add snapshot schema migration to support `decision_type` and hot-path indexes for village-based recency queries
- add per-village 5-minute snapshot cache (max 100 rows) with `decision_type`, `limit`, and `offset` handling in `/api/snapshots`
- add/adjust snapshot tests and latency debug/warn logging for hot-path observability

## Validation
- cargo test -p edda-ledger hot_path_query_performance -- --nocapture
- cargo test -p edda-ledger snapshot_hot_path_indexes_exist -- --nocapture
- cargo test -p edda-serve get_snapshots_returns_posted -- --nocapture
- cargo test -p edda-serve snapshot_filter_and_offset_applies_after_decision_type -- --nocapture
- cargo test -p edda-serve get_snapshots -- --nocapture