### PR TITLE
feat(ledger): DecisionView projection + query_by_paths (GH-331)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,6 +891,7 @@ dependencies = [
  "anyhow",
  "edda-core",
  "fs2",
+ "globset",
  "hex",
  "rand 0.8.5",
  "rusqlite",

--- a/crates/edda-ledger/Cargo.toml
+++ b/crates/edda-ledger/Cargo.toml
@@ -23,3 +23,4 @@ rand.workspace = true
 sha2.workspace = true
 hex.workspace = true
 tracing.workspace = true
+globset.workspace = true

--- a/crates/edda-ledger/src/ledger.rs
+++ b/crates/edda-ledger/src/ledger.rs
@@ -1,5 +1,6 @@
 use crate::paths::EddaPaths;
 use crate::sqlite_store::{BundleRow, DecisionRow, SqliteStore};
+use crate::view::{self, DecisionView};
 use edda_core::Event;
 use std::path::Path;
 
@@ -235,6 +236,61 @@ impl Ledger {
         key: &str,
     ) -> anyhow::Result<Option<DecisionRow>> {
         self.sqlite.find_active_decision(branch, key)
+    }
+
+    /// Return active decisions that have non-empty `affected_paths`.
+    /// Used by Injection to get the candidate set for glob matching.
+    pub fn query_active_with_paths(
+        &self,
+        branch: Option<&str>,
+        limit: Option<usize>,
+    ) -> anyhow::Result<Vec<DecisionView>> {
+        let rows = self.sqlite.active_decisions_with_paths(branch, limit)?;
+        Ok(rows.iter().map(view::to_view).collect())
+    }
+
+    /// Given a list of file paths, return decisions whose `affected_paths` globs
+    /// match any of them. Uses `globset` for pattern matching.
+    ///
+    /// This is the primary query for PreToolUse hook (Track E):
+    /// "which active decisions govern the file I'm about to edit?"
+    ///
+    /// # Arguments
+    /// - `paths`: concrete file paths to check (e.g., `["crates/edda-ledger/src/lib.rs"]`)
+    /// - `branch`: optional branch filter
+    /// - `limit`: max decisions to return
+    pub fn query_by_paths(
+        &self,
+        paths: &[&str],
+        branch: Option<&str>,
+        limit: Option<usize>,
+    ) -> anyhow::Result<Vec<DecisionView>> {
+        // 1. Get all active decisions that have affected_paths
+        let candidates = self.query_active_with_paths(branch, None)?;
+
+        // 2. Filter by glob match
+        let mut matched: Vec<DecisionView> = Vec::new();
+        for decision in candidates {
+            let dominated = decision.affected_paths.iter().any(|glob_pattern| {
+                match globset::Glob::new(glob_pattern) {
+                    Ok(glob) => {
+                        let matcher = glob.compile_matcher();
+                        paths.iter().any(|p| matcher.is_match(p))
+                    }
+                    Err(_) => false, // invalid glob -> skip silently
+                }
+            });
+            if dominated {
+                matched.push(decision);
+            }
+            if let Some(lim) = limit {
+                if matched.len() >= lim {
+                    break;
+                }
+            }
+        }
+
+        Ok(matched)
     }
 
     // ── Cross-Project Sync ────────────────────────────────────────────
@@ -962,6 +1018,143 @@ mod tests {
         let active: Vec<_> = all.iter().filter(|t| t.revoked_at.is_none()).collect();
         assert_eq!(active.len(), 1);
         assert_eq!(active[0].device_name, "active-dev");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    // ── query_by_paths tests ─────────────────────────────────────────
+
+    /// Helper: create a decision event and set its affected_paths via raw SQL.
+    fn insert_decision_with_paths(
+        ledger: &Ledger,
+        key: &str,
+        value: &str,
+        paths: &[&str],
+    ) -> String {
+        let event = make_decision_event("main", key, value);
+        let event_id = event.event_id.clone();
+        ledger.append_event(&event).unwrap();
+
+        // Update affected_paths via raw SQL (materialization doesn't set it from payload)
+        let paths_json = serde_json::to_string(paths).unwrap();
+        let conn = rusqlite::Connection::open(&ledger.paths.ledger_db).unwrap();
+        conn.execute(
+            "UPDATE decisions SET affected_paths = ?1 WHERE event_id = ?2",
+            rusqlite::params![paths_json, event_id],
+        )
+        .unwrap();
+
+        event_id
+    }
+
+    #[test]
+    fn query_by_paths_glob_matches() {
+        let (tmp, ledger) = setup_workspace();
+        insert_decision_with_paths(&ledger, "db.engine", "sqlite", &["crates/edda-ledger/**"]);
+
+        let results = ledger
+            .query_by_paths(&["crates/edda-ledger/src/lib.rs"], Some("main"), None)
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].key, "db.engine");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn query_by_paths_no_match() {
+        let (tmp, ledger) = setup_workspace();
+        insert_decision_with_paths(&ledger, "db.engine", "sqlite", &["crates/edda-ledger/**"]);
+
+        let results = ledger
+            .query_by_paths(
+                &["crates/edda-cli/src/main.rs"], // doesn't match ledger glob
+                Some("main"),
+                None,
+            )
+            .unwrap();
+
+        assert!(results.is_empty());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn query_by_paths_skips_superseded() {
+        let (tmp, ledger) = setup_workspace();
+
+        // First decision: db.engine=postgres
+        insert_decision_with_paths(&ledger, "db.engine", "postgres", &["crates/**"]);
+
+        // Second decision supersedes first (same key+branch → first becomes is_active=FALSE)
+        insert_decision_with_paths(&ledger, "db.engine", "sqlite", &["crates/**"]);
+
+        let results = ledger
+            .query_by_paths(&["crates/edda-ledger/src/lib.rs"], Some("main"), None)
+            .unwrap();
+
+        // Only the active decision should appear
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].value, "sqlite");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn query_by_paths_multiple_globs() {
+        let (tmp, ledger) = setup_workspace();
+        insert_decision_with_paths(
+            &ledger,
+            "error.pattern",
+            "thiserror",
+            &["crates/edda-ledger/**", "crates/edda-core/**"],
+        );
+
+        // Match on second glob
+        let results = ledger
+            .query_by_paths(&["crates/edda-core/src/types.rs"], Some("main"), None)
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].key, "error.pattern");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn query_by_paths_respects_limit() {
+        let (tmp, ledger) = setup_workspace();
+
+        // Insert 3 decisions all matching "crates/**"
+        insert_decision_with_paths(&ledger, "db.engine", "sqlite", &["crates/**"]);
+        insert_decision_with_paths(&ledger, "error.pattern", "thiserror", &["crates/**"]);
+        insert_decision_with_paths(&ledger, "auth.strategy", "jwt", &["crates/**"]);
+
+        let results = ledger
+            .query_by_paths(&["crates/edda-ledger/src/lib.rs"], Some("main"), Some(2))
+            .unwrap();
+
+        assert!(results.len() <= 2);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn query_active_with_paths_excludes_empty() {
+        let (tmp, ledger) = setup_workspace();
+
+        // Decision without paths (defaults to "[]")
+        ledger
+            .append_event(&make_decision_event("main", "no.paths", "val"))
+            .unwrap();
+
+        // Decision with paths
+        insert_decision_with_paths(&ledger, "has.paths", "val", &["src/**"]);
+
+        let results = ledger.query_active_with_paths(Some("main"), None).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].key, "has.paths");
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/crates/edda-ledger/src/lib.rs
+++ b/crates/edda-ledger/src/lib.rs
@@ -7,6 +7,7 @@ pub mod paths;
 pub mod sqlite_store;
 pub mod sync;
 pub mod tombstone;
+pub mod view;
 
 pub use blob_meta::{BlobClass, BlobMetaEntry, BlobMetaMap, ClassChange};
 pub use blob_store::{
@@ -22,3 +23,4 @@ pub use sqlite_store::{
     TaskBriefRow,
 };
 pub use tombstone::{append_tombstone, list_tombstones, make_tombstone, DeleteReason, Tombstone};
+pub use view::DecisionView;

--- a/crates/edda-ledger/src/sqlite_store.rs
+++ b/crates/edda-ledger/src/sqlite_store.rs
@@ -1575,6 +1575,53 @@ impl SqliteStore {
         Ok(result)
     }
 
+    /// Return active/experimental decisions where `affected_paths` is non-empty.
+    /// This pre-filters at the SQL level so glob matching runs on a small set.
+    pub fn active_decisions_with_paths(
+        &self,
+        branch: Option<&str>,
+        limit: Option<usize>,
+    ) -> anyhow::Result<Vec<DecisionRow>> {
+        let mut sql = String::from(
+            "SELECT d.event_id, d.key, d.value, d.reason, d.domain, d.branch,
+                    d.supersedes_id, d.is_active, e.ts,
+                    d.scope, d.source_project_id, d.source_event_id,
+                    d.status, d.authority, d.affected_paths, d.tags,
+                    d.review_after, d.reversibility
+             FROM decisions d JOIN events e ON d.event_id = e.event_id
+             WHERE d.is_active = TRUE
+               AND d.affected_paths IS NOT NULL
+               AND d.affected_paths != '[]'",
+        );
+
+        let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+        let mut idx = 1;
+
+        if let Some(b) = branch {
+            sql.push_str(&format!(" AND d.branch = ?{idx}"));
+            param_values.push(Box::new(b.to_string()));
+            idx += 1;
+        }
+
+        sql.push_str(" ORDER BY e.ts DESC");
+
+        if let Some(lim) = limit {
+            sql.push_str(&format!(" LIMIT ?{idx}"));
+            param_values.push(Box::new(lim as i64));
+        }
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let refs: Vec<&dyn rusqlite::types::ToSql> =
+            param_values.iter().map(|b| b.as_ref()).collect();
+        let rows = stmt.query_map(refs.as_slice(), map_decision_row)?;
+
+        let result = rows
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| anyhow::anyhow!("active_decisions_with_paths query failed: {e}"))?;
+
+        Ok(result)
+    }
+
     /// All decisions for a key (active + superseded), ordered by time.
     /// `after`/`before` are optional ISO 8601 bounds for temporal filtering.
     pub fn decision_timeline(

--- a/crates/edda-ledger/src/view.rs
+++ b/crates/edda-ledger/src/view.rs
@@ -1,0 +1,164 @@
+//! Read-side projection of decisions.
+//!
+//! `DecisionView` is the delivery type consumed by Injection (hooks, pack builder).
+//! Storage code uses `DecisionRow`; read-side consumers use `DecisionView` (BOUNDARY-01).
+
+use crate::sqlite_store::DecisionRow;
+
+/// Read-side projection of a decision. Injection consumers use this type
+/// instead of `DecisionRow` (BOUNDARY-01).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DecisionView {
+    // Identity
+    pub event_id: String,
+    pub branch: String,
+    pub ts: Option<String>,
+
+    // What
+    pub key: String,
+    pub value: String,
+    pub reason: String,
+    pub domain: String,
+
+    // Governance state
+    /// "active" | "experimental" | "proposed" | "deprecated" | "superseded"
+    pub status: String,
+    /// "human" | "agent" | "system"
+    pub authority: String,
+    /// "easy" | "medium" | "hard"
+    pub reversibility: String,
+
+    // Scope — parsed arrays, not JSON strings
+    pub affected_paths: Vec<String>,
+    pub tags: Vec<String>,
+    /// Renamed from `scope` column.
+    pub propagation: String,
+
+    // Graph (optional)
+    pub supersedes_id: Option<String>,
+
+    // Review schedule
+    pub review_after: Option<String>,
+}
+
+/// Convert a storage row into a delivery view.
+///
+/// - Parses `affected_paths` and `tags` from JSON string → `Vec<String>`
+/// - Renames `scope` → `propagation`
+/// - Drops `is_active`, `source_project_id`, `source_event_id`
+///
+/// If `affected_paths` or `tags` JSON is invalid or missing, defaults to `vec![]`.
+pub fn to_view(row: &DecisionRow) -> DecisionView {
+    let affected_paths: Vec<String> = serde_json::from_str(&row.affected_paths).unwrap_or_default();
+
+    let tags: Vec<String> = serde_json::from_str(&row.tags).unwrap_or_default();
+
+    DecisionView {
+        event_id: row.event_id.clone(),
+        branch: row.branch.clone(),
+        ts: row.ts.clone(),
+        key: row.key.clone(),
+        value: row.value.clone(),
+        reason: row.reason.clone(),
+        domain: row.domain.clone(),
+        status: row.status.clone(),
+        authority: row.authority.clone(),
+        reversibility: row.reversibility.clone(),
+        affected_paths,
+        tags,
+        propagation: row.scope.clone(),
+        supersedes_id: row.supersedes_id.clone(),
+        review_after: row.review_after.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_default_row() -> DecisionRow {
+        DecisionRow {
+            event_id: "evt_test".to_string(),
+            key: "db.engine".to_string(),
+            value: "sqlite".to_string(),
+            reason: "embedded".to_string(),
+            domain: "db".to_string(),
+            branch: "main".to_string(),
+            supersedes_id: None,
+            is_active: true,
+            ts: Some("2026-03-20T00:00:00Z".to_string()),
+            scope: "local".to_string(),
+            source_project_id: None,
+            source_event_id: None,
+            status: "active".to_string(),
+            authority: "human".to_string(),
+            affected_paths: "[]".to_string(),
+            tags: "[]".to_string(),
+            review_after: None,
+            reversibility: "medium".to_string(),
+        }
+    }
+
+    fn make_row_with_paths(affected_paths: &str, tags: &str) -> DecisionRow {
+        let mut row = make_default_row();
+        row.affected_paths = affected_paths.to_string();
+        row.tags = tags.to_string();
+        row
+    }
+
+    #[test]
+    fn to_view_parses_json_arrays() {
+        let row = make_row_with_paths(
+            r#"["crates/edda-ledger/**", "crates/edda-core/**"]"#,
+            r#"["architecture", "storage"]"#,
+        );
+        let view = to_view(&row);
+        assert_eq!(
+            view.affected_paths,
+            vec!["crates/edda-ledger/**", "crates/edda-core/**"]
+        );
+        assert_eq!(view.tags, vec!["architecture", "storage"]);
+    }
+
+    #[test]
+    fn to_view_defaults_empty_on_empty_array() {
+        let row = make_row_with_paths("[]", "[]");
+        let view = to_view(&row);
+        assert!(view.affected_paths.is_empty());
+        assert!(view.tags.is_empty());
+    }
+
+    #[test]
+    fn to_view_defaults_empty_on_invalid_json() {
+        let row = make_row_with_paths("not json", "{bad}");
+        let view = to_view(&row);
+        assert!(view.affected_paths.is_empty());
+        assert!(view.tags.is_empty());
+    }
+
+    #[test]
+    fn to_view_renames_scope_to_propagation() {
+        let mut row = make_default_row();
+        row.scope = "shared".to_string();
+        let view = to_view(&row);
+        assert_eq!(view.propagation, "shared");
+    }
+
+    #[test]
+    fn decision_view_has_no_is_active() {
+        // Compile-time check: DecisionView must not have is_active field.
+        // If someone adds `is_active`, the struct definition changes but
+        // this test ensures we only access `status`.
+        let view = to_view(&make_default_row());
+        let _ = view.status; // exists
+                             // view.is_active; // must not compile
+    }
+
+    #[test]
+    fn to_view_preserves_review_after() {
+        let mut row = make_default_row();
+        row.review_after = Some("2026-06-01".to_string());
+        let view = to_view(&row);
+        assert_eq!(view.review_after, Some("2026-06-01".to_string()));
+    }
+}


### PR DESCRIPTION
## Summary

- **C1**: New `view.rs` module with `DecisionView` struct and `to_view()` function — the read-side projection consumed by Injection (BOUNDARY-01). Parses `affected_paths`/`tags` from JSON strings to `Vec<String>`, renames `scope` → `propagation`, drops `is_active`.
- **C2**: `query_by_paths()` on `Ledger` — given file paths, returns decisions whose `affected_paths` globs match, using `globset` crate. SQL pre-filters active decisions with non-empty paths for performance (PERF-01).
- 12 new tests: JSON parsing, empty defaults, scope rename, glob matching, no-match, superseded filtering, limit enforcement, path exclusion.

Closes #331

## Test plan

- [x] `cargo test -p edda-ledger -- view` (6 tests pass)
- [x] `cargo test -p edda-ledger -- query_by_paths` (5 tests pass)
- [x] `cargo test -p edda-ledger -- query_active_with_paths` (1 test passes)
- [x] `cargo test -p edda-ledger` (146 tests pass, 0 failures)
- [x] `cargo clippy -p edda-ledger --lib -- -D warnings` (zero warnings)
- [ ] CI: `cargo clippy --workspace --all-targets` (pre-existing `too_many_arguments` in test helpers)
- [ ] CI: `cargo test --workspace` (pre-existing flaky test in `edda-bridge-claude`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)