### PR TITLE
feat(bridge): PreToolUse decision file warning (GH-333)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,7 @@ dependencies = [
  "edda-transcript",
  "globset",
  "regex",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/edda-bridge-claude/Cargo.toml
+++ b/crates/edda-bridge-claude/Cargo.toml
@@ -35,3 +35,4 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile.workspace = true
+rusqlite = { version = "0.32", features = ["bundled"] }

--- a/crates/edda-bridge-claude/src/decision_warning.rs
+++ b/crates/edda-bridge-claude/src/decision_warning.rs
@@ -1,0 +1,277 @@
+//! PreToolUse decision file warning (Track E).
+//!
+//! Checks whether a file being edited is governed by any active decision.
+//! If so, returns a formatted markdown warning string for injection into
+//! `additionalContext`.
+//!
+//! # Boundary Rules
+//! - BOUNDARY-01: No import of `DecisionRow` — only `DecisionView`
+//! - BOUNDARY-02: Reads through `to_view()`, never parses `affected_paths` JSON
+//! - PERF-01: Total time < 100ms — uses `DECISION_CACHE`
+
+use edda_ledger::view::DecisionView;
+use std::path::Path;
+use std::sync::LazyLock;
+use std::sync::Mutex;
+
+// ── Session-scoped cache ────────────────────────────────────────────
+
+struct DecisionCache {
+    /// Cache key: (repo_root_str, branch) to detect invalidation
+    key: Option<(String, String)>,
+    /// Cached decisions with non-empty affected_paths
+    decisions: Vec<DecisionView>,
+    /// Timestamp of last load, for TTL-based expiration
+    loaded_at: std::time::Instant,
+}
+
+static DECISION_CACHE: LazyLock<Mutex<DecisionCache>> = LazyLock::new(|| {
+    Mutex::new(DecisionCache {
+        key: None,
+        decisions: Vec::new(),
+        loaded_at: std::time::Instant::now(),
+    })
+});
+
+const CACHE_TTL_SECS: u64 = 120;
+
+// ── Public API ──────────────────────────────────────────────────────
+
+/// Check if `file_path` is governed by any active decision.
+///
+/// Returns a formatted markdown warning listing matching decisions,
+/// or `None` if no decisions match.
+///
+/// Performance: must complete in < 100ms (CONTRACT PERF-01).
+/// Uses `DECISION_CACHE` to avoid re-querying within the same session.
+///
+/// # Arguments
+/// - `repo_root`: path to the repository root (passed to `Ledger::open`)
+/// - `file_path`: the file being edited (concrete path, e.g. `crates/edda-ledger/src/lib.rs`)
+/// - `branch`: current git branch name
+pub(crate) fn decision_file_warning(
+    repo_root: &Path,
+    file_path: &str,
+    branch: &str,
+) -> Option<String> {
+    let decisions = load_decisions_cached(repo_root, branch);
+    if decisions.is_empty() {
+        return None;
+    }
+
+    let matched: Vec<&DecisionView> = decisions
+        .iter()
+        .filter(|d| !d.affected_paths.is_empty() && matches_any_path(file_path, &d.affected_paths))
+        .collect();
+
+    if matched.is_empty() {
+        return None;
+    }
+
+    Some(format_warning(&matched))
+}
+
+// ── Internal helpers ────────────────────────────────────────────────
+
+fn load_decisions_cached(repo_root: &Path, branch: &str) -> Vec<DecisionView> {
+    let mut cache = DECISION_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    let key = (repo_root.display().to_string(), branch.to_string());
+
+    if let Some(ref cached_key) = cache.key {
+        if *cached_key == key && cache.loaded_at.elapsed().as_secs() < CACHE_TTL_SECS {
+            return cache.decisions.clone();
+        }
+    }
+
+    // Query via edda-ledger view API (BOUNDARY-01, BOUNDARY-02)
+    let decisions = match edda_ledger::Ledger::open(repo_root) {
+        Ok(ledger) => ledger
+            .query_active_with_paths(Some(branch), None)
+            .unwrap_or_default(),
+        Err(_) => Vec::new(),
+    };
+
+    cache.key = Some(key);
+    cache.decisions = decisions.clone();
+    cache.loaded_at = std::time::Instant::now();
+    decisions
+}
+
+fn matches_any_path(file_path: &str, affected_paths: &[String]) -> bool {
+    // Normalize path separators (Windows compat)
+    let normalized = file_path.replace('\\', "/");
+
+    for pattern in affected_paths {
+        if let Ok(glob) = globset::Glob::new(pattern) {
+            let matcher = glob.compile_matcher();
+            if matcher.is_match(&normalized) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn format_warning(matches: &[&DecisionView]) -> String {
+    let mut lines = vec!["**[edda] Active decisions governing this file:**".to_string()];
+    for d in matches {
+        let reason_suffix = if d.reason.is_empty() {
+            String::new()
+        } else {
+            format!(" — {}", d.reason)
+        };
+        lines.push(format!(
+            "  - `{}={}` [{}]{}",
+            d.key, d.value, d.status, reason_suffix
+        ));
+    }
+    lines.join("\n")
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: set up a temp workspace with ledger, returning (tmp_dir, repo_root).
+    fn setup_workspace() -> (tempfile::TempDir, std::path::PathBuf) {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let root = tmp.path().to_path_buf();
+        let ledger = edda_ledger::Ledger::open_or_init(&root).expect("init workspace");
+        // Set HEAD branch to "main"
+        ledger.set_head_branch("main").expect("set head");
+        (tmp, root)
+    }
+
+    /// Helper: insert a decision with affected_paths via raw SQL.
+    fn insert_decision_with_paths(
+        root: &Path,
+        key: &str,
+        value: &str,
+        reason: &str,
+        paths: &[&str],
+    ) {
+        let ledger = edda_ledger::Ledger::open(root).expect("open ledger");
+        let event = edda_core::event::new_note_event(
+            "main",
+            None,
+            "system",
+            &format!("{key}: {value}"),
+            &[],
+        )
+        .expect("create event");
+        let event_id = event.event_id.clone();
+        ledger.append_event(&event).expect("append event");
+
+        // Update the materialized decision row via raw SQL
+        let paths_json = serde_json::to_string(paths).unwrap();
+        let conn = rusqlite::Connection::open(ledger.paths.ledger_db.clone()).expect("open db");
+        conn.execute(
+            "INSERT OR REPLACE INTO decisions (event_id, key, value, reason, domain, branch, is_active, status, authority, affected_paths, tags, scope, reversibility) VALUES (?1, ?2, ?3, ?4, ?5, 'main', 1, 'active', 'human', ?6, '[]', 'local', 'medium')",
+            rusqlite::params![event_id, key, value, reason, key.split('.').next().unwrap_or(""), paths_json],
+        ).expect("insert decision");
+    }
+
+    /// Invalidate the static cache between tests.
+    fn invalidate_cache() {
+        let mut cache = DECISION_CACHE.lock().unwrap();
+        cache.key = None;
+        cache.decisions.clear();
+    }
+
+    #[test]
+    fn test_no_decisions_returns_none() {
+        invalidate_cache();
+        let (_tmp, root) = setup_workspace();
+        let result = decision_file_warning(&root, "src/main.rs", "main");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_no_matching_paths_returns_none() {
+        invalidate_cache();
+        let (_tmp, root) = setup_workspace();
+        insert_decision_with_paths(
+            &root,
+            "db.engine",
+            "sqlite",
+            "embedded",
+            &["crates/edda-ledger/**"],
+        );
+        let result = decision_file_warning(&root, "crates/edda-cli/src/main.rs", "main");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_matching_glob_returns_warning() {
+        invalidate_cache();
+        let (_tmp, root) = setup_workspace();
+        insert_decision_with_paths(
+            &root,
+            "db.engine",
+            "sqlite",
+            "embedded",
+            &["crates/edda-ledger/**"],
+        );
+        let result = decision_file_warning(&root, "crates/edda-ledger/src/lib.rs", "main");
+        assert!(result.is_some());
+        let warning = result.unwrap();
+        assert!(warning.contains("Active decisions governing this file"));
+        assert!(warning.contains("db.engine=sqlite"));
+        assert!(warning.contains("embedded"));
+    }
+
+    #[test]
+    fn test_multiple_matches() {
+        invalidate_cache();
+        let (_tmp, root) = setup_workspace();
+        insert_decision_with_paths(&root, "db.engine", "sqlite", "embedded", &["crates/**"]);
+        insert_decision_with_paths(
+            &root,
+            "error.pattern",
+            "thiserror",
+            "typed errors",
+            &["crates/**"],
+        );
+        let result = decision_file_warning(&root, "crates/edda-ledger/src/lib.rs", "main");
+        assert!(result.is_some());
+        let warning = result.unwrap();
+        assert!(warning.contains("db.engine=sqlite"));
+        assert!(warning.contains("error.pattern=thiserror"));
+    }
+
+    #[test]
+    fn test_matches_any_path_normalization() {
+        // Backslash paths should match forward-slash globs
+        assert!(matches_any_path(
+            r"crates\edda-ledger\src\lib.rs",
+            &["crates/edda-ledger/**".to_string()]
+        ));
+    }
+
+    #[test]
+    fn test_format_warning_empty_reason() {
+        let view = DecisionView {
+            event_id: "evt_1".to_string(),
+            branch: "main".to_string(),
+            ts: None,
+            key: "test.key".to_string(),
+            value: "val".to_string(),
+            reason: String::new(),
+            domain: "test".to_string(),
+            status: "active".to_string(),
+            authority: "human".to_string(),
+            reversibility: "medium".to_string(),
+            affected_paths: vec!["src/**".to_string()],
+            tags: vec![],
+            propagation: "local".to_string(),
+            supersedes_id: None,
+            review_after: None,
+        };
+        let warning = format_warning(&[&view]);
+        assert!(warning.contains("`test.key=val` [active]"));
+        // No trailing " — " when reason is empty
+        assert!(!warning.contains(" — "));
+    }
+}

--- a/crates/edda-bridge-claude/src/dispatch/tools.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tools.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use globset::Glob;
 
+use crate::decision_warning::decision_file_warning;
 use crate::parse::*;
 
 use super::events::{
@@ -102,8 +103,39 @@ pub(super) fn dispatch_pre_tool_use(
     // L3: evaluate learned rules (warn-only, via additionalContext)
     let rules_warning = evaluate_learned_rules(raw, project_id, cwd);
 
-    // Combine pattern context, request nudge, and rules warning
-    let combined_ctx = [pattern_ctx, request_nudge, rules_warning]
+    // Decision file warning: check if edited file is governed by active decisions
+    let decision_warning = {
+        let dw_start = std::time::Instant::now();
+        let tool_name_dw = get_str(raw, "tool_name");
+        let result = if tool_name_dw == "Edit" {
+            let file_path = raw
+                .pointer("/tool_input/file_path")
+                .or_else(|| raw.pointer("/input/file_path"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if file_path.is_empty() {
+                None
+            } else {
+                let cwd_path = std::path::Path::new(cwd);
+                match edda_ledger::EddaPaths::find_root(cwd_path) {
+                    Some(root) => {
+                        let branch = edda_ledger::Ledger::open(&root)
+                            .and_then(|l| l.head_branch())
+                            .unwrap_or_default();
+                        decision_file_warning(&root, file_path, &branch)
+                    }
+                    None => None,
+                }
+            }
+        } else {
+            None // Only trigger on Edit tool
+        };
+        tracing::debug!("decision_warning_ms={}", dw_start.elapsed().as_millis());
+        result
+    };
+
+    // Combine pattern context, request nudge, rules warning, and decision warning
+    let combined_ctx = [pattern_ctx, request_nudge, rules_warning, decision_warning]
         .into_iter()
         .flatten()
         .collect::<Vec<_>>();

--- a/crates/edda-bridge-claude/src/lib.rs
+++ b/crates/edda-bridge-claude/src/lib.rs
@@ -14,6 +14,7 @@ pub mod state;
 pub mod watch;
 
 mod admin;
+pub(crate) mod decision_warning;
 mod dispatch;
 mod narrative;
 pub mod nudge;


### PR DESCRIPTION
## Summary

- Add `decision_warning.rs` with glob-matching engine that checks whether an edited file is governed by active decisions
- Integrate into `dispatch_pre_tool_use` as a fourth `additionalContext` source, triggered only on `Edit` tool calls
- Session-scoped `DECISION_CACHE` with 120s TTL ensures repeated PreToolUse calls avoid re-querying SQLite (PERF-01 < 100ms)

## Boundary Compliance

- **BOUNDARY-01**: No `DecisionRow` import in `edda-bridge-claude` — only `DecisionView`
- **BOUNDARY-02**: Reads via `query_active_with_paths()` which uses `to_view()` internally
- **PERF-01**: Timing instrumented via `tracing::debug!("decision_warning_ms=...")`

## Test plan

- [x] `test_no_decisions_returns_none` — empty ledger returns `None`
- [x] `test_no_matching_paths_returns_none` — non-matching glob returns `None`
- [x] `test_matching_glob_returns_warning` — matching glob returns formatted warning
- [x] `test_multiple_matches` — two matching decisions both appear in warning
- [x] `test_matches_any_path_normalization` — backslash paths match forward-slash globs
- [x] `test_format_warning_empty_reason` — empty reason omits trailing separator
- [x] `cargo clippy -p edda-bridge-claude --all-targets` — zero warnings
- [x] `grep -rn "DecisionRow" crates/edda-bridge-claude/` — 0 code results (only comment)

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)