### PR TITLE
chore: add lefthook pre-commit and pre-push hooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,18 @@ Thanks for your interest in contributing! This guide covers how to build, test, 
 - Rust stable (1.75+)
 - Git
 
+## Git Hooks (optional)
+
+We use [Lefthook](https://github.com/evilmartians/lefthook) for local pre-commit and pre-push checks:
+
+```bash
+npm install -g @evilmartians/lefthook
+lefthook install
+```
+
+This runs `cargo fmt --check` on commit and `cargo clippy --workspace -- -D warnings` on push.
+Lefthook is local-only and does not affect CI.
+
 ## Build and Test
 
 ```bash

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Lefthook — Git hooks for Rust quality checks
+# Install: npm install -g @evilmartians/lefthook && lefthook install
+
+pre-commit:
+  commands:
+    fmt-check:
+      run: cargo fmt --check
+      stage_fixed: true
+
+pre-push:
+  commands:
+    clippy:
+      run: cargo clippy --workspace -- -D warnings


### PR DESCRIPTION
## Summary
- Add `lefthook.yml` with `cargo fmt --check` on pre-commit and `cargo clippy --workspace -- -D warnings` on pre-push
- Document lefthook setup in `CONTRIBUTING.md` under a new "Git Hooks (optional)" section
- Local dev only, no CI impact

Closes #309

## Test plan
- [ ] Install lefthook: `npm install -g @evilmartians/lefthook && lefthook install`
- [ ] Verify pre-commit runs fmt check: `lefthook run pre-commit`
- [ ] Verify pre-push runs clippy: `lefthook run pre-push`
- [ ] Verify CI passes (lefthook is not involved in CI)

Generated with Claude Code