### PR TITLE
fix(ledger): remove unnecessary to_string() in clippy warning

### DIFF
--- a/crates/edda-ledger/src/sqlite_store.rs
+++ b/crates/edda-ledger/src/sqlite_store.rs
@@ -6088,7 +6088,7 @@ mod tests {
 
         for col in &expected {
             assert!(
-                columns.contains(&col.to_string()),
+                columns.contains(*col),
                 "expected column `{col}` to exist after verify_decisions_schema, but it was missing. actual: {columns:?}"
             );
         }


### PR DESCRIPTION
## Summary
- Remove unnecessary `.to_string()` call in `sqlite_store.rs:6091` that triggers a clippy warning
- `HashSet<String>::contains` accepts `&str` via the `Borrow` trait, so `columns.contains(*col)` works directly

Closes #349

## Test plan
- [x] `cargo clippy --all-targets` passes with zero warnings
- [x] `cargo test -p edda-ledger` — all 151 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)