### PR TITLE
fix: correct grammar "not a edda" to "not an edda"

### DIFF
--- a/crates/edda-bridge-claude/src/admin.rs
+++ b/crates/edda-bridge-claude/src/admin.rs
@@ -22,7 +22,7 @@ const HOOK_EVENTS: &[&str] = &[
     "TeammateIdle",
 ];
 
-/// Check if a matcher group (Claude Code hook format) contains a edda hook.
+/// Check if a matcher group (Claude Code hook format) contains an edda hook.
 fn matcher_group_contains_edda(group: &serde_json::Value) -> bool {
     // New format: { "matcher": "", "hooks": [{ "type": "command", "command": "edda hook claude" }] }
     if let Some(hooks_arr) = group.get("hooks").and_then(|h| h.as_array()) {

--- a/crates/edda-conductor/src/check/edda_event.rs
+++ b/crates/edda-conductor/src/check/edda_event.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::time::Instant;
 use tokio::process::Command;
 
-/// Check that a edda event of the given type exists.
+/// Check that an edda event of the given type exists.
 /// Shells out to `edda log` (or `edda log` after rename).
 pub async fn check_edda_event(event_type: &str, after: Option<&str>, cwd: &Path) -> CheckOutput {
     let start = Instant::now();

--- a/crates/edda-ledger/src/ledger.rs
+++ b/crates/edda-ledger/src/ledger.rs
@@ -16,7 +16,7 @@ impl Ledger {
         let paths = EddaPaths::discover(repo_root);
         if !paths.is_initialized() {
             anyhow::bail!(
-                "not a edda workspace ({}/.edda not found). Run `edda init` first.",
+                "not an edda workspace ({}/.edda not found). Run `edda init` first.",
                 paths.root.display()
             );
         }

--- a/crates/edda-mcp/src/lib.rs
+++ b/crates/edda-mcp/src/lib.rs
@@ -508,7 +508,7 @@ fn to_mcp_err(e: anyhow::Error) -> McpError {
 pub async fn serve(repo_root: &Path) -> anyhow::Result<()> {
     let paths = edda_ledger::paths::EddaPaths::discover(repo_root);
     if !paths.is_initialized() {
-        anyhow::bail!("not a edda workspace (run `edda init` first)");
+        anyhow::bail!("not an edda workspace (run `edda init` first)");
     }
 
     let server = EddaServer::new(repo_root.to_path_buf());

--- a/crates/edda-serve/src/lib.rs
+++ b/crates/edda-serve/src/lib.rs
@@ -133,7 +133,7 @@ impl IntoResponse for AppError {
 pub async fn serve(repo_root: &Path, config: ServeConfig) -> anyhow::Result<()> {
     let paths = edda_ledger::EddaPaths::discover(repo_root);
     if !paths.is_initialized() {
-        anyhow::bail!("not a edda workspace (run `edda init` first)");
+        anyhow::bail!("not an edda workspace (run `edda init` first)");
     }
 
     let store_root = edda_store::store_root();


### PR DESCRIPTION
## Summary
- Fix grammar error "not a edda" to "not an edda" in error messages and doc comments across 5 files
- Closes #350

## Changes
- `crates/edda-mcp/src/lib.rs` — error message
- `crates/edda-ledger/src/ledger.rs` — error message
- `crates/edda-serve/src/lib.rs` — error message
- `crates/edda-conductor/src/check/edda_event.rs` — doc comment
- `crates/edda-bridge-claude/src/admin.rs` — doc comment

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test` passes for all affected crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)