### PR TITLE
fix(bridge): fix test isolation for nudge_counter test

### DIFF
--- a/crates/edda-bridge-claude/src/dispatch/tests.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tests.rs
@@ -928,6 +928,7 @@ fn post_tool_use_after_decide_cooldown_still_applies() {
 fn post_tool_use_cooldown_suppresses() {
     let pid = "test_nudge_cooldown";
     let sid = "sess-nudge-3";
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = edda_store::ensure_dirs(pid);
 
     // First commit → nudge
@@ -1046,6 +1047,7 @@ fn counter_increment_and_read() {
 fn post_tool_use_increments_nudge_counter() {
     let pid = "test_nudge_counter";
     let sid = "sess-nudge-cnt-1";
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = edda_store::ensure_dirs(pid);
 
     // First commit → nudge emitted → counter = 1
@@ -1080,6 +1082,7 @@ fn post_tool_use_increments_nudge_counter() {
 fn post_tool_use_increments_decide_counter() {
     let pid = "test_decide_counter";
     let sid = "sess-decide-cnt-1";
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = edda_store::ensure_dirs(pid);
 
     let raw = serde_json::json!({


### PR DESCRIPTION
## Summary
- Fixes #348: `post_tool_use_increments_nudge_counter` test fails because stale `nudge_ts` files from previous runs cause cooldown suppression, preventing nudge emission.
- Added `fs::remove_dir_all` cleanup before `ensure_dirs` in three tests: `post_tool_use_cooldown_suppresses`, `post_tool_use_increments_nudge_counter`, and `post_tool_use_increments_decide_counter`.
- This matches the pattern already used by `counter_increment_and_read` (line 1030).

## Test plan
- [x] `cargo test -p edda-bridge-claude --lib -- post_tool_use_increments_nudge_counter` passes
- [x] `cargo test -p edda-bridge-claude --lib -- post_tool_use_cooldown_suppresses` passes
- [x] `cargo test -p edda-bridge-claude --lib -- post_tool_use_increments_decide_counter` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)