### PR TITLE
feat(cursor): add native hook bridge support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-07-13
+
+### Added
+
+- **Cursor bridge** with native hook installation, context injection, lifecycle tracking, and CLI doctor support
+
+### Fixed
+
+- Workspace formatting and Clippy failures that prevented CI from completing
+
 ## [0.2.0] - 2026-07-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "edda"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -700,6 +700,7 @@ dependencies = [
  "edda-ask",
  "edda-bridge-claude",
  "edda-bridge-codex",
+ "edda-bridge-cursor",
  "edda-bridge-hermes",
  "edda-bridge-openclaw",
  "edda-chronicle",
@@ -732,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "edda-aggregate"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -746,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "edda-ask"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -759,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "edda-bridge-claude"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -789,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "edda-bridge-codex"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -807,8 +808,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "edda-bridge-cursor"
+version = "0.2.1"
+dependencies = [
+ "anyhow",
+ "dirs",
+ "edda-bridge-claude",
+ "edda-pack",
+ "edda-postmortem",
+ "edda-store",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "time",
+]
+
+[[package]]
 name = "edda-bridge-hermes"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -828,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "edda-bridge-openclaw"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -845,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "edda-chronicle"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -867,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "edda-conductor"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -886,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "edda-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "globset",
@@ -904,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "edda-derive"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -917,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "edda-index"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "edda-store",
@@ -929,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "edda-ingestion"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -943,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "edda-ledger"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -963,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "edda-mcp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "edda-ask",
@@ -980,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "edda-notify"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "edda-ledger",
@@ -992,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "edda-pack"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "edda-index",
@@ -1006,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "edda-postmortem"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -1022,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "edda-search-fts"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -1039,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "edda-serve"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1073,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "edda-store"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1089,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "edda-transcript"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "edda-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/edda-store",
     "crates/edda-bridge-claude",
     "crates/edda-bridge-codex",
+    "crates/edda-bridge-cursor",
     "crates/edda-bridge-hermes",
     "crates/edda-bridge-openclaw",
     "crates/edda-transcript",
@@ -26,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fagemx/edda"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">
   <strong>Your agent's decisions shouldn't reset every session.</strong><br/>
   Edda gives coding agents a local, automatic memory of what was decided — and why.<br/>
-  Works with Claude Code, Codex, OpenClaw, and any MCP client.
+  Works with Claude Code, Cursor, Codex, OpenClaw, and any MCP client.
 </p>
 
 <p align="center">
@@ -173,6 +173,21 @@ Every ledger query runs locally against SQLite — same answer every time, in mi
 edda init    # detects Claude Code, installs hooks automatically
 ```
 
+**Cursor** — supported via native Cursor hooks. Session start pushes the existing hot pack, doctrine, and workspace context into the Agent model.
+
+```bash
+edda bridge cursor install      # installs ~/.cursor/hooks.json entries
+edda doctor cursor              # verifies PATH, hooks, and writable store
+```
+
+Cursor v1 uses the same read path as the Codex bridge. Cursor can send `transcript_path: null` at `sessionStart`, so the bridge reads the existing hot pack and does not claim to rebuild the Cursor transcript at that point.
+
+**Codex** — supported via native hooks with the same shared Edda context machinery.
+
+```bash
+edda bridge codex install
+```
+
 **OpenClaw** — supported via bridge plugin.
 
 ```bash
@@ -248,7 +263,7 @@ edda watch                 # real-time TUI: peers, events, decisions
 
 ## Architecture
 
-14 Rust crates:
+16 Rust crates:
 
 | Crate | What it does |
 |-------|-------------|
@@ -256,6 +271,8 @@ edda watch                 # real-time TUI: peers, events, decisions
 | `edda-ledger` | Append-only ledger (SQLite), blob store, locking |
 | `edda-cli` | All commands + TUI (`tui` feature, default on) |
 | `edda-bridge-claude` | Claude Code hooks, transcript ingest, context injection |
+| `edda-bridge-cursor` | Cursor native hooks, context injection, lifecycle tracking |
+| `edda-bridge-codex` | Codex hooks and context injection |
 | `edda-bridge-openclaw` | OpenClaw hooks and plugin |
 | `edda-mcp` | MCP server (7 tools) |
 | `edda-ask` | Cross-source decision query engine |

--- a/crates/edda-aggregate/src/aggregate.rs
+++ b/crates/edda-aggregate/src/aggregate.rs
@@ -368,7 +368,7 @@ pub fn rollup_metrics_by_date(projects: &[ProjectEntry], range: &DateRange) -> R
                 revert_count: 0,
             })
             .collect();
-        edits.sort_by(|a, b| b.edit_count.cmp(&a.edit_count));
+        edits.sort_by_key(|stat| std::cmp::Reverse(stat.edit_count));
         file_edits.insert(date, edits);
     }
 
@@ -529,7 +529,7 @@ pub fn file_edits_by_date(
             })
             .collect();
         // Sort by edit_count descending for consistent output
-        edits.sort_by(|a, b| b.edit_count.cmp(&a.edit_count));
+        edits.sort_by_key(|stat| std::cmp::Reverse(stat.edit_count));
         result.insert(date, edits);
     }
 

--- a/crates/edda-ask/src/lib.rs
+++ b/crates/edda-ask/src/lib.rs
@@ -445,7 +445,7 @@ fn compute_override_risk(dependents: &[DependentHit]) -> OverrideRisk {
     // Suggestion: reverse BFS order = override leaves first
     let suggestion = if count > 0 {
         let mut sorted: Vec<&DependentHit> = dependents.iter().collect();
-        sorted.sort_by(|a, b| b.depth.cmp(&a.depth));
+        sorted.sort_by_key(|dependent| std::cmp::Reverse(dependent.depth));
         let keys: Vec<&str> = sorted.iter().map(|d| d.key.as_str()).collect();
         Some(format!("建議覆蓋順序: {}", keys.join(" → ")))
     } else {

--- a/crates/edda-ask/src/lib.rs
+++ b/crates/edda-ask/src/lib.rs
@@ -731,9 +731,13 @@ pub fn format_human(result: &AskResult) -> String {
             ));
             if let Some(st) = &d.staleness {
                 if st.is_stale {
-                    let bad: Vec<String> = st.paths.iter()
-                        .filter(|p| p.status != staleness::PathStatus::Fresh
-                                 && p.status != staleness::PathStatus::Unknown)
+                    let bad: Vec<String> = st
+                        .paths
+                        .iter()
+                        .filter(|p| {
+                            p.status != staleness::PathStatus::Fresh
+                                && p.status != staleness::PathStatus::Unknown
+                        })
                         .map(|p| format!("{} ({:?})", p.path, p.status))
                         .collect();
                     if !bad.is_empty() {
@@ -850,10 +854,7 @@ fn to_decision_hit(row: &DecisionView) -> DecisionHit {
 /// Return the affected_paths carried by each decision in `result.decisions`,
 /// looked up from the ledger by event_id. Position-aligned with the input;
 /// missing/unreadable rows return empty Vec (best-effort).
-pub fn affected_paths_for_hits(
-    ledger: &Ledger,
-    hits: &[DecisionHit],
-) -> Vec<Vec<String>> {
+pub fn affected_paths_for_hits(ledger: &Ledger, hits: &[DecisionHit]) -> Vec<Vec<String>> {
     hits.iter()
         .map(|h| {
             ledger

--- a/crates/edda-ask/src/staleness.rs
+++ b/crates/edda-ask/src/staleness.rs
@@ -165,7 +165,9 @@ mod tests {
     }
     impl MockFs {
         fn new() -> Self {
-            Self { entries: RefCell::new(HashMap::new()) }
+            Self {
+                entries: RefCell::new(HashMap::new()),
+            }
         }
         fn set(&self, path: &str, exists: bool, mtime: Option<&str>) {
             self.entries
@@ -200,7 +202,8 @@ mod tests {
             "2026-07-01T00:00:00Z",
             Some(Path::new("/repo")),
             &fs,
-        ).unwrap();
+        )
+        .unwrap();
         assert!(out.is_stale);
         assert_eq!(out.paths[0].status, PathStatus::StaleModified);
     }
@@ -214,7 +217,8 @@ mod tests {
             "2026-07-01T00:00:00Z",
             Some(Path::new("/repo")),
             &fs,
-        ).unwrap();
+        )
+        .unwrap();
         assert!(!out.is_stale);
         assert_eq!(out.paths[0].status, PathStatus::Fresh);
     }
@@ -228,7 +232,8 @@ mod tests {
             "2026-07-01T00:00:00Z",
             Some(Path::new("/repo")),
             &fs,
-        ).unwrap();
+        )
+        .unwrap();
         assert!(out.is_stale, "missing counts as stale");
         assert_eq!(out.paths[0].status, PathStatus::Missing);
     }
@@ -237,14 +242,14 @@ mod tests {
     fn absolute_path_bypasses_repo_root() {
         let fs = MockFs::new();
         // Use OS-appropriate absolute path so Path::is_absolute agrees.
-        let abs = if cfg!(windows) { "C:/opt/config.json" } else { "/opt/config.json" };
+        let abs = if cfg!(windows) {
+            "C:/opt/config.json"
+        } else {
+            "/opt/config.json"
+        };
         fs.set(abs, true, Some("2026-07-05T00:00:00Z"));
-        let out = check_paths_staleness(
-            &[abs.to_string()],
-            "2026-07-01T00:00:00Z",
-            None,
-            &fs,
-        ).unwrap();
+        let out =
+            check_paths_staleness(&[abs.to_string()], "2026-07-01T00:00:00Z", None, &fs).unwrap();
         assert_eq!(out.paths[0].status, PathStatus::StaleModified);
     }
 
@@ -256,8 +261,12 @@ mod tests {
             "2026-07-01T00:00:00Z",
             None,
             &fs,
-        ).unwrap();
-        assert!(!out.is_stale, "unknown does not flip is_stale (F9-shaped restraint)");
+        )
+        .unwrap();
+        assert!(
+            !out.is_stale,
+            "unknown does not flip is_stale (F9-shaped restraint)"
+        );
         assert_eq!(out.paths[0].status, PathStatus::Unknown);
     }
 
@@ -270,7 +279,8 @@ mod tests {
             "not-a-date",
             Some(Path::new("/repo")),
             &fs,
-        ).unwrap();
+        )
+        .unwrap();
         assert!(!out.is_stale);
         assert_eq!(out.paths[0].status, PathStatus::Unknown);
     }
@@ -281,11 +291,16 @@ mod tests {
         fs.set("/repo/fresh.rs", true, Some("2026-06-01T00:00:00Z"));
         fs.set("/repo/modified.rs", true, Some("2026-07-05T00:00:00Z"));
         let out = check_paths_staleness(
-            &["fresh.rs".to_string(), "modified.rs".to_string(), "deleted.rs".to_string()],
+            &[
+                "fresh.rs".to_string(),
+                "modified.rs".to_string(),
+                "deleted.rs".to_string(),
+            ],
             "2026-07-01T00:00:00Z",
             Some(Path::new("/repo")),
             &fs,
-        ).unwrap();
+        )
+        .unwrap();
         assert!(out.is_stale);
         assert_eq!(out.paths[0].status, PathStatus::Fresh);
         assert_eq!(out.paths[1].status, PathStatus::StaleModified);
@@ -301,7 +316,11 @@ mod tests {
             "2026-07-01T00:00:00Z",
             Some(Path::new("/repo")),
             &fs,
-        ).unwrap();
-        assert_eq!(out.paths[0].touched_at.as_deref(), Some("2026-07-05T10:00:00Z"));
+        )
+        .unwrap();
+        assert_eq!(
+            out.paths[0].touched_at.as_deref(),
+            Some("2026-07-05T10:00:00Z")
+        );
     }
 }

--- a/crates/edda-bridge-claude/src/bg_detect.rs
+++ b/crates/edda-bridge-claude/src/bg_detect.rs
@@ -200,7 +200,7 @@ pub fn run_detect(project_id: &str, cwd: &str) -> Result<DetectResult> {
 
     let detect_id = format!(
         "detect_{}",
-        &ulid::Ulid::new().to_string()[..12].to_lowercase()
+        ulid::Ulid::new().to_string()[..12].to_lowercase()
     );
     let result = DetectResult {
         detect_id: detect_id.clone(),

--- a/crates/edda-bridge-claude/src/bg_scan.rs
+++ b/crates/edda-bridge-claude/src/bg_scan.rs
@@ -164,7 +164,7 @@ pub fn run_scan(project_id: &str, cwd: &str) -> Result<ScanResult> {
 
     let scan_id = format!(
         "scan_{}",
-        &ulid::Ulid::new().to_string()[..12].to_lowercase()
+        ulid::Ulid::new().to_string()[..12].to_lowercase()
     );
     let result = ScanResult {
         scan_id: scan_id.clone(),

--- a/crates/edda-bridge-claude/src/controls_suggest.rs
+++ b/crates/edda-bridge-claude/src/controls_suggest.rs
@@ -158,7 +158,7 @@ pub fn suggest_controls_patch(
 pub fn new_patch_id() -> String {
     format!(
         "cpatch_{}",
-        &ulid::Ulid::new().to_string()[..12].to_lowercase()
+        ulid::Ulid::new().to_string()[..12].to_lowercase()
     )
 }
 

--- a/crates/edda-bridge-claude/src/issue_proposal.rs
+++ b/crates/edda-bridge-claude/src/issue_proposal.rs
@@ -67,7 +67,7 @@ struct AuditEntry {
 pub fn new_proposal_id() -> String {
     format!(
         "prop_{}",
-        &ulid::Ulid::new().to_string()[..12].to_lowercase()
+        ulid::Ulid::new().to_string()[..12].to_lowercase()
     )
 }
 

--- a/crates/edda-bridge-claude/src/peers/helpers.rs
+++ b/crates/edda-bridge-claude/src/peers/helpers.rs
@@ -39,7 +39,8 @@ pub(crate) fn pending_requests_for_session(
 
 /// True if a normalized path is absolute (`/...` or `C:/...`).
 pub(super) fn is_absolute_normalized(path: &str) -> bool {
-    path.starts_with('/') || matches!(path.as_bytes(), [a, b':', b'/', ..] if a.is_ascii_alphabetic())
+    path.starts_with('/')
+        || matches!(path.as_bytes(), [a, b':', b'/', ..] if a.is_ascii_alphabetic())
 }
 
 /// Make a path project-relative when possible.

--- a/crates/edda-bridge-claude/src/peers/render_coord.rs
+++ b/crates/edda-bridge-claude/src/peers/render_coord.rs
@@ -82,7 +82,9 @@ pub(super) fn suggest_claim_command(label: &str, heartbeat: &Option<SessionHeart
             let proc_cwd = std::env::current_dir()
                 .ok()
                 .map(|p| p.to_string_lossy().to_string());
-            if let Some((derived_label, paths)) = derive_scope_from_files(&files, proc_cwd.as_deref()) {
+            if let Some((derived_label, paths)) =
+                derive_scope_from_files(&files, proc_cwd.as_deref())
+            {
                 let claim_label = if !label.is_empty() {
                     label
                 } else {

--- a/crates/edda-bridge-claude/src/signals.rs
+++ b/crates/edda-bridge-claude/src/signals.rs
@@ -306,7 +306,7 @@ pub(crate) fn extract_session_signals(transcript_store_path: &Path) -> SessionSi
         .into_iter()
         .map(|(path, count)| FileEditCount { path, count })
         .collect();
-    sorted_files.sort_by(|a, b| b.count.cmp(&a.count));
+    sorted_files.sort_by_key(|file| std::cmp::Reverse(file.count));
 
     // Build failed commands list, sorted by count descending
     let mut failed_commands: Vec<FailedBashCmd> = failed_cmd_map
@@ -317,7 +317,7 @@ pub(crate) fn extract_session_signals(transcript_store_path: &Path) -> SessionSi
             count,
         })
         .collect();
-    failed_commands.sort_by(|a, b| b.count.cmp(&a.count));
+    failed_commands.sort_by_key(|command| std::cmp::Reverse(command.count));
 
     SessionSignals {
         tasks: sorted_tasks,

--- a/crates/edda-bridge-codex/src/admin.rs
+++ b/crates/edda-bridge-codex/src/admin.rs
@@ -132,15 +132,15 @@ pub fn uninstall(target: Option<&Path>) -> anyhow::Result<()> {
     let mut config: serde_json::Value = match serde_json::from_str(&raw) {
         Ok(v) => v,
         Err(_) => {
-            println!("Hooks config at {} is not valid JSON; leaving untouched", path.display());
+            println!(
+                "Hooks config at {} is not valid JSON; leaving untouched",
+                path.display()
+            );
             return Ok(());
         }
     };
 
-    if let Some(hooks_map) = config
-        .get_mut("hooks")
-        .and_then(|h| h.as_object_mut())
-    {
+    if let Some(hooks_map) = config.get_mut("hooks").and_then(|h| h.as_object_mut()) {
         for entries in hooks_map.values_mut() {
             if let Some(array) = entries.as_array_mut() {
                 array.retain(|group| {
@@ -158,9 +158,7 @@ pub fn uninstall(target: Option<&Path>) -> anyhow::Result<()> {
             }
         }
         // Drop empty event arrays entirely.
-        hooks_map.retain(|_, v| {
-            v.as_array().map(|a| !a.is_empty()).unwrap_or(true)
-        });
+        hooks_map.retain(|_, v| v.as_array().map(|a| !a.is_empty()).unwrap_or(true));
     }
 
     let pretty = serde_json::to_string_pretty(&config)?;

--- a/crates/edda-bridge-codex/src/dispatch.rs
+++ b/crates/edda-bridge-codex/src/dispatch.rs
@@ -79,10 +79,7 @@ pub fn hook_entrypoint_from_stdin(stdin: &str) -> anyhow::Result<HookResult> {
         "PreCompact" => dispatch_pre_compact(&project_id),
         "SessionEnd" | "Stop" => dispatch_session_end(&project_id, &envelope),
         // Codex-only events — forward-compatible stubs
-        "SubagentStart"
-        | "SubagentStop"
-        | "PostCompact"
-        | "PermissionRequest"
+        "SubagentStart" | "SubagentStop" | "PostCompact" | "PermissionRequest"
         | "PostToolUseFailure" => Ok(ok()),
         _ => Ok(ok()),
     }
@@ -184,10 +181,7 @@ fn dispatch_user_prompt_submit(
 
 // ── PreToolUse: L3 rule evaluation ──
 
-fn dispatch_pre_tool_use(
-    project_id: &str,
-    envelope: &CodexEnvelope,
-) -> anyhow::Result<HookResult> {
+fn dispatch_pre_tool_use(project_id: &str, envelope: &CodexEnvelope) -> anyhow::Result<HookResult> {
     if std::env::var("EDDA_POSTMORTEM").unwrap_or_else(|_| "1".into()) == "0" {
         return Ok(ok());
     }
@@ -268,10 +262,7 @@ fn dispatch_pre_compact(project_id: &str) -> anyhow::Result<HookResult> {
     Ok(ok())
 }
 
-fn dispatch_session_end(
-    project_id: &str,
-    envelope: &CodexEnvelope,
-) -> anyhow::Result<HookResult> {
+fn dispatch_session_end(project_id: &str, envelope: &CodexEnvelope) -> anyhow::Result<HookResult> {
     let cwd = &envelope.cwd;
     let session_id = &envelope.session_id;
     if !session_id.is_empty() {

--- a/crates/edda-bridge-cursor/Cargo.toml
+++ b/crates/edda-bridge-cursor/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "edda-bridge-cursor"
+description = "Cursor Agent hooks and context injection for Edda"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+categories.workspace = true
+keywords.workspace = true
+
+[dependencies]
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.2.0" }
+edda-pack = { path = "../edda-pack", version = "0.2.0" }
+edda-postmortem = { path = "../edda-postmortem", version = "0.2.0" }
+edda-store = { path = "../edda-store", version = "0.2.0" }
+anyhow.workspace = true
+dirs.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+time.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/edda-bridge-cursor/src/admin.rs
+++ b/crates/edda-bridge-cursor/src/admin.rs
@@ -1,0 +1,300 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const HOOK_COMMAND: &str = "edda hook cursor";
+const HOOK_EVENTS: &[&str] = &[
+    "sessionStart",
+    "beforeSubmitPrompt",
+    "preToolUse",
+    "postToolUse",
+    "preCompact",
+    "sessionEnd",
+    "stop",
+    "subagentStart",
+    "subagentStop",
+];
+
+fn default_hooks_path() -> anyhow::Result<PathBuf> {
+    dirs::home_dir()
+        .map(|home| home.join(".cursor").join("hooks.json"))
+        .ok_or_else(|| anyhow::anyhow!("cannot determine home directory"))
+}
+
+pub fn install(target: Option<&Path>) -> anyhow::Result<PathBuf> {
+    let path = match target {
+        Some(path) => path.to_path_buf(),
+        None => default_hooks_path()?,
+    };
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut config = if path.exists() {
+        serde_json::from_str::<serde_json::Value>(&fs::read_to_string(&path)?)?
+    } else {
+        serde_json::json!({})
+    };
+    let root = config
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("Cursor hooks config must be a JSON object"))?;
+    root.entry("version".to_string())
+        .or_insert(serde_json::json!(1));
+    let hooks = root
+        .entry("hooks".to_string())
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("Cursor hooks field must be a JSON object"))?;
+    for event in HOOK_EVENTS {
+        let entries = hooks
+            .entry((*event).to_string())
+            .or_insert_with(|| serde_json::json!([]))
+            .as_array_mut()
+            .ok_or_else(|| anyhow::anyhow!("Cursor hook event {event} must be an array"))?;
+        let installed = entries.iter().any(|entry| {
+            entry.get("command").and_then(serde_json::Value::as_str) == Some(HOOK_COMMAND)
+        });
+        if !installed {
+            entries.push(serde_json::json!({"command": HOOK_COMMAND}));
+        }
+    }
+    fs::write(&path, serde_json::to_string_pretty(&config)?)?;
+    println!("Installed edda Cursor hooks to {}", path.display());
+    Ok(path)
+}
+
+pub fn uninstall(target: Option<&Path>) -> anyhow::Result<()> {
+    let path = match target {
+        Some(path) => path.to_path_buf(),
+        None => default_hooks_path()?,
+    };
+    if !path.exists() {
+        println!("No Cursor hooks config at {}", path.display());
+        return Ok(());
+    }
+
+    let mut config: serde_json::Value = serde_json::from_str(&fs::read_to_string(&path)?)?;
+    if let Some(hooks) = config
+        .get_mut("hooks")
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        for entries in hooks.values_mut() {
+            if let Some(entries) = entries.as_array_mut() {
+                entries.retain(|entry| {
+                    entry.get("command").and_then(serde_json::Value::as_str) != Some(HOOK_COMMAND)
+                });
+            }
+        }
+        hooks.retain(|_, entries| entries.as_array().is_none_or(|entries| !entries.is_empty()));
+    }
+
+    fs::write(&path, serde_json::to_string_pretty(&config)?)?;
+    println!("Removed edda Cursor hooks from {}", path.display());
+    Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct HookHealth {
+    configured_events: usize,
+    expected_events: usize,
+}
+
+fn inspect_hooks(path: &Path) -> anyhow::Result<HookHealth> {
+    if !path.exists() {
+        return Ok(HookHealth {
+            configured_events: 0,
+            expected_events: HOOK_EVENTS.len(),
+        });
+    }
+    let config: serde_json::Value = serde_json::from_str(&fs::read_to_string(path)?)?;
+    let hooks = config.get("hooks").and_then(serde_json::Value::as_object);
+    let configured_events = HOOK_EVENTS
+        .iter()
+        .filter(|event| {
+            hooks
+                .and_then(|hooks| hooks.get(**event))
+                .and_then(serde_json::Value::as_array)
+                .is_some_and(|entries| {
+                    entries.iter().any(|entry| {
+                        entry.get("command").and_then(serde_json::Value::as_str)
+                            == Some(HOOK_COMMAND)
+                    })
+                })
+        })
+        .count();
+    Ok(HookHealth {
+        configured_events,
+        expected_events: HOOK_EVENTS.len(),
+    })
+}
+
+pub fn doctor() -> anyhow::Result<()> {
+    let edda = which_edda();
+    println!(
+        "[{}] edda in PATH: {}",
+        if edda.is_some() { "OK" } else { "WARN" },
+        edda.as_deref().unwrap_or("not found")
+    );
+
+    let path = default_hooks_path()?;
+    let health = inspect_hooks(&path)?;
+    let hooks_ok = health.configured_events == health.expected_events;
+    println!(
+        "[{}] Cursor hooks installed: {}/{} events ({})",
+        if hooks_ok { "OK" } else { "WARN" },
+        health.configured_events,
+        health.expected_events,
+        path.display()
+    );
+
+    let store_root = edda_store::store_root();
+    let store_writable = store_is_writable(&store_root);
+    println!(
+        "[{}] store writable: {}",
+        if store_writable { "OK" } else { "WARN" },
+        store_root.display()
+    );
+
+    if claude_hook_detected() {
+        println!(
+            "[WARN] Claude edda hooks also detected; disable Cursor third-party hook import to avoid duplicate injection"
+        );
+    }
+    Ok(())
+}
+
+fn which_edda() -> Option<String> {
+    let separator = if cfg!(windows) { ';' } else { ':' };
+    let executable = if cfg!(windows) { "edda.exe" } else { "edda" };
+    std::env::var("PATH")
+        .unwrap_or_default()
+        .split(separator)
+        .map(|directory| Path::new(directory).join(executable))
+        .find(|candidate| candidate.is_file())
+        .map(|candidate| candidate.to_string_lossy().into_owned())
+}
+
+fn store_is_writable(store_root: &Path) -> bool {
+    if fs::create_dir_all(store_root).is_err() {
+        return false;
+    }
+    let probe = store_root.join(format!(".doctor-write-{}", std::process::id()));
+    if fs::write(&probe, b"ok").is_err() {
+        return false;
+    }
+    fs::remove_file(probe).is_ok()
+}
+
+fn claude_hook_detected() -> bool {
+    let Some(home) = dirs::home_dir() else {
+        return false;
+    };
+    [
+        home.join(".claude").join("settings.json"),
+        home.join(".claude").join("settings.local.json"),
+    ]
+    .iter()
+    .filter_map(|path| fs::read_to_string(path).ok())
+    .any(|settings| settings.contains("edda hook claude"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hooks_path(temp: &tempfile::TempDir) -> std::path::PathBuf {
+        temp.path().join(".cursor").join("hooks.json")
+    }
+
+    #[test]
+    fn install_creates_native_cursor_hooks_for_all_events() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = hooks_path(&temp);
+
+        let installed = install(Some(&path)).unwrap();
+
+        assert_eq!(installed, path);
+        let config: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(config["version"], 1);
+        for event in HOOK_EVENTS {
+            let entries = config["hooks"][event].as_array().unwrap();
+            assert_eq!(entries.len(), 1, "event {event} should have one hook");
+            assert_eq!(entries[0]["command"], HOOK_COMMAND);
+        }
+    }
+
+    #[test]
+    fn install_preserves_existing_cursor_hooks() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = hooks_path(&temp);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            r#"{"version":1,"hooks":{"preToolUse":[{"command":"other-tool","matcher":"Shell"}]},"custom":true}"#,
+        )
+        .unwrap();
+
+        install(Some(&path)).unwrap();
+
+        let config: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(config["custom"], true);
+        let entries = config["hooks"]["preToolUse"].as_array().unwrap();
+        assert!(entries.iter().any(|entry| entry["command"] == "other-tool"));
+        assert!(entries.iter().any(|entry| entry["command"] == HOOK_COMMAND));
+    }
+
+    #[test]
+    fn install_is_idempotent() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = hooks_path(&temp);
+
+        install(Some(&path)).unwrap();
+        install(Some(&path)).unwrap();
+
+        let config: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        for event in HOOK_EVENTS {
+            let count = config["hooks"][event]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter(|entry| entry["command"] == HOOK_COMMAND)
+                .count();
+            assert_eq!(count, 1, "event {event} should not duplicate edda");
+        }
+    }
+
+    #[test]
+    fn uninstall_removes_only_edda_entries() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = hooks_path(&temp);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            r#"{"version":1,"hooks":{"sessionStart":[{"command":"other-tool"}]}}"#,
+        )
+        .unwrap();
+        install(Some(&path)).unwrap();
+
+        uninstall(Some(&path)).unwrap();
+
+        let config: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        let serialized = serde_json::to_string(&config).unwrap();
+        assert!(serialized.contains("other-tool"));
+        assert!(!serialized.contains(HOOK_COMMAND));
+    }
+
+    #[test]
+    fn hook_health_counts_configured_edda_events() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = hooks_path(&temp);
+        install(Some(&path)).unwrap();
+
+        let health = inspect_hooks(&path).unwrap();
+
+        assert_eq!(health.configured_events, HOOK_EVENTS.len());
+        assert_eq!(health.expected_events, HOOK_EVENTS.len());
+    }
+}

--- a/crates/edda-bridge-cursor/src/dispatch.rs
+++ b/crates/edda-bridge-cursor/src/dispatch.rs
@@ -1,0 +1,490 @@
+use edda_bridge_claude::{render, state};
+
+use crate::parse::CursorEnvelope;
+
+#[derive(Debug, Default, Clone)]
+pub struct HookResult {
+    pub stdout: Option<String>,
+    pub stderr: Option<String>,
+}
+
+impl HookResult {
+    fn output(stdout: String) -> Self {
+        Self {
+            stdout: Some(stdout),
+            stderr: None,
+        }
+    }
+}
+
+fn empty_json() -> HookResult {
+    HookResult::output("{}".to_string())
+}
+
+fn continue_json() -> HookResult {
+    HookResult::output(r#"{"continue":true}"#.to_string())
+}
+
+fn allow_json() -> HookResult {
+    HookResult::output(r#"{"permission":"allow"}"#.to_string())
+}
+
+fn pre_tool_warning(warning: &str) -> anyhow::Result<HookResult> {
+    let output = serde_json::json!({
+        "permission": "allow",
+        "agent_message": warning,
+    });
+    Ok(HookResult::output(serde_json::to_string(&output)?))
+}
+
+fn additional_context(context: &str) -> anyhow::Result<HookResult> {
+    let output = serde_json::json!({"additional_context": context});
+    Ok(HookResult::output(serde_json::to_string(&output)?))
+}
+
+pub fn hook_entrypoint_from_stdin(stdin: &str) -> anyhow::Result<HookResult> {
+    if stdin.trim().is_empty() {
+        return Ok(HookResult::default());
+    }
+    let envelope = match crate::parse::parse_hook_stdin(stdin) {
+        Ok(envelope) => envelope,
+        Err(_) => return Ok(empty_json()),
+    };
+    let cwd = envelope.cwd();
+    let project_id = edda_store::project_id(&cwd);
+    let _ = edda_store::ensure_dirs(&project_id);
+    let _ = crate::parse::append_to_session_ledger(&envelope);
+    if !envelope.session_id().is_empty() {
+        edda_bridge_claude::peers::touch_heartbeat(&project_id, envelope.session_id());
+    }
+
+    let result = match envelope.event_name() {
+        "sessionStart" => dispatch_session_start(&project_id, &envelope),
+        "beforeSubmitPrompt" => Ok(continue_json()),
+        "preToolUse" => dispatch_pre_tool_use(&project_id, &envelope),
+        "postToolUse" => dispatch_post_tool_use(&project_id, &envelope),
+        "preCompact" => {
+            state::set_compact_pending(&project_id);
+            Ok(empty_json())
+        }
+        "sessionEnd" | "stop" => dispatch_session_end(&project_id, &envelope),
+        "subagentStart" => Ok(dispatch_subagent_start(&project_id, &envelope)),
+        "subagentStop" => Ok(dispatch_subagent_stop(&project_id, &envelope)),
+        _ => Ok(empty_json()),
+    };
+    Ok(result.unwrap_or_else(|_| empty_json()))
+}
+
+fn dispatch_subagent_start(project_id: &str, envelope: &CursorEnvelope) -> HookResult {
+    if !envelope.subagent_id.is_empty() {
+        let label = if envelope.subagent_type.is_empty() {
+            "subagent"
+        } else {
+            &envelope.subagent_type
+        };
+        edda_bridge_claude::peers::write_heartbeat_minimal(
+            project_id,
+            &envelope.subagent_id,
+            label,
+            &envelope.cwd().to_string_lossy(),
+        );
+    }
+    allow_json()
+}
+
+fn dispatch_subagent_stop(project_id: &str, envelope: &CursorEnvelope) -> HookResult {
+    if !envelope.subagent_id.is_empty() {
+        edda_bridge_claude::peers::remove_heartbeat(project_id, &envelope.subagent_id);
+    }
+    empty_json()
+}
+
+fn dispatch_session_end(project_id: &str, envelope: &CursorEnvelope) -> anyhow::Result<HookResult> {
+    let session_id = envelope.session_id();
+    if !session_id.is_empty() {
+        let cwd = envelope.cwd();
+        let _ = edda_bridge_claude::digest::digest_session_manual(
+            project_id,
+            session_id,
+            &cwd.to_string_lossy(),
+            true,
+        );
+    }
+    let peers_active = !session_id.is_empty()
+        && !edda_bridge_claude::peers::discover_active_peers(project_id, session_id).is_empty();
+    cleanup_session_state(project_id, session_id, peers_active);
+    Ok(empty_json())
+}
+
+fn cleanup_session_state(project_id: &str, session_id: &str, peers_active: bool) {
+    let state_dir = edda_store::project_dir(project_id).join("state");
+    for name in [
+        "inject_hash",
+        "nudge_ts",
+        "nudge_count",
+        "decide_count",
+        "signal_count",
+        "peer_count",
+        "coord_offset",
+    ] {
+        let _ = std::fs::remove_file(state_dir.join(format!("{name}.{session_id}")));
+    }
+    let _ = std::fs::remove_file(state_dir.join(format!("phase.{session_id}.json")));
+    let _ = std::fs::remove_file(state_dir.join("compact_pending"));
+    edda_bridge_claude::peers::remove_heartbeat(project_id, session_id);
+    if peers_active {
+        edda_bridge_claude::peers::write_unclaim(project_id, session_id);
+    }
+}
+
+fn dispatch_post_tool_use(
+    project_id: &str,
+    envelope: &CursorEnvelope,
+) -> anyhow::Result<HookResult> {
+    let session_id = envelope.session_id();
+    let tool_name = if envelope.tool_name == "Shell" {
+        "Bash"
+    } else {
+        &envelope.tool_name
+    };
+    let raw = serde_json::json!({
+        "tool_name": tool_name,
+        "tool_input": envelope.tool_input,
+    });
+    let signal = match edda_bridge_claude::nudge::detect_signal(&raw) {
+        Some(signal) => signal,
+        None => return Ok(empty_json()),
+    };
+
+    state::increment_counter(project_id, session_id, "signal_count");
+    if signal == edda_bridge_claude::nudge::NudgeSignal::SelfRecord {
+        state::increment_counter(project_id, session_id, "decide_count");
+        return Ok(empty_json());
+    }
+    if !state::should_nudge(project_id, session_id) {
+        return Ok(empty_json());
+    }
+
+    let decide_count = state::read_counter(project_id, session_id, "decide_count");
+    let nudge = edda_bridge_claude::nudge::format_nudge(&signal, decide_count);
+    if nudge.is_empty() {
+        return Ok(empty_json());
+    }
+    state::mark_nudge_sent(project_id, session_id);
+    state::increment_counter(project_id, session_id, "nudge_count");
+    additional_context(&nudge)
+}
+
+fn dispatch_pre_tool_use(
+    project_id: &str,
+    envelope: &CursorEnvelope,
+) -> anyhow::Result<HookResult> {
+    if std::env::var("EDDA_POSTMORTEM").unwrap_or_else(|_| "1".to_string()) == "0" {
+        return Ok(empty_json());
+    }
+
+    let mut rules_store = edda_postmortem::RulesStore::load_project(project_id);
+    if rules_store.active_rules().is_empty() {
+        return Ok(empty_json());
+    }
+
+    let files_touched = ["file_path", "path", "filePath"]
+        .iter()
+        .find_map(|key| {
+            envelope
+                .tool_input
+                .get(key)
+                .and_then(|value| value.as_str())
+        })
+        .map(|path| vec![path.to_string()])
+        .unwrap_or_default();
+    let command = envelope
+        .tool_input
+        .get("command")
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+    let context = edda_postmortem::hooks::HookContext {
+        hook_event: "PreToolUse".to_string(),
+        tool_name: envelope.tool_name.clone(),
+        files_touched,
+        cwd: envelope.cwd().to_string_lossy().into_owned(),
+        command,
+    };
+
+    let evaluation = edda_postmortem::hooks::evaluate_rules(&rules_store, &context);
+    if !evaluation.matched_rule_ids.is_empty() {
+        edda_postmortem::hooks::record_matched_hits(&mut rules_store, &evaluation.matched_rule_ids);
+        let _ = rules_store.save_project(project_id);
+    }
+    match edda_postmortem::hooks::format_warnings(&evaluation) {
+        Some(warning) => pre_tool_warning(&warning),
+        None => Ok(empty_json()),
+    }
+}
+
+fn dispatch_session_start(
+    project_id: &str,
+    envelope: &CursorEnvelope,
+) -> anyhow::Result<HookResult> {
+    let cwd = envelope.cwd();
+    let cwd_text = cwd.to_string_lossy();
+    let session_id = envelope.session_id();
+
+    if !session_id.is_empty() {
+        let label = std::env::var("EDDA_SESSION_LABEL").unwrap_or_default();
+        edda_bridge_claude::peers::write_heartbeat_minimal(
+            project_id, session_id, &label, &cwd_text,
+        );
+    }
+
+    let mut body_parts = Vec::new();
+    let doctrine_budget = env_usize("EDDA_DOCTRINE_BUDGET_CHARS", 4000);
+    if let Some(doctrine) = edda_pack::read_doctrine_pack(&cwd, doctrine_budget) {
+        body_parts.push(doctrine);
+    }
+
+    let workspace_budget = env_usize("EDDA_WORKSPACE_BUDGET_CHARS", 2500);
+    if let Some(workspace) = render::workspace(&cwd_text, workspace_budget) {
+        body_parts.push(workspace);
+    }
+    if let Some(pack) = render::pack(project_id) {
+        body_parts.push(pack);
+    }
+    if let Some(plan) = render::plan(Some(project_id)) {
+        body_parts.push(plan);
+    }
+
+    let body = body_parts.join("\n\n");
+    let mut tail = format!("\n\n{}", render::writeback());
+    if let Some(coordination) =
+        edda_bridge_claude::peers::render_coordination_protocol(project_id, session_id, &cwd_text)
+    {
+        tail.push_str("\n\n");
+        tail.push_str(&coordination);
+    }
+
+    let body_budget = render::context_budget(&cwd_text).saturating_sub(tail.len());
+    let content = format!("{}{tail}", render::apply_budget(&body, body_budget));
+    let wrapped = render::wrap_boundary(&content);
+    let sidefile = context_sidefile(project_id, &wrapped)?;
+    let output = serde_json::json!({
+        "env": {
+            "EDDA_HOT_PACK_PATH": sidefile.to_string_lossy(),
+        },
+        "additional_context": wrapped,
+    });
+    Ok(HookResult::output(serde_json::to_string(&output)?))
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn context_sidefile(project_id: &str, context: &str) -> anyhow::Result<std::path::PathBuf> {
+    let packs_dir = edda_store::project_dir(project_id).join("packs");
+    let hot_path = packs_dir.join("hot.md");
+    if hot_path.is_file() {
+        return Ok(hot_path);
+    }
+
+    std::fs::create_dir_all(&packs_dir)?;
+    let generated_path = packs_dir.join("cursor-context.md");
+    std::fs::write(&generated_path, context)?;
+    Ok(generated_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_stdin_returns_no_output() {
+        let result = hook_entrypoint_from_stdin("").unwrap();
+
+        assert!(result.stdout.is_none());
+        assert!(result.stderr.is_none());
+    }
+
+    #[test]
+    fn malformed_stdin_fails_open_with_empty_json() {
+        let result = hook_entrypoint_from_stdin("not json").unwrap();
+
+        assert_eq!(result.stdout.as_deref(), Some("{}"));
+        assert!(result.stderr.is_none());
+    }
+
+    #[test]
+    fn session_start_pushes_context_and_readable_sidefile() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stdin = serde_json::json!({
+            "hook_event_name": "sessionStart",
+            "session_id": "cursor-session-start-1",
+            "workspace_roots": [tmp.path()],
+            "composer_mode": "agent"
+        })
+        .to_string();
+
+        let result = hook_entrypoint_from_stdin(&stdin).unwrap();
+        let output: serde_json::Value =
+            serde_json::from_str(result.stdout.as_deref().unwrap()).unwrap();
+
+        let context = output["additional_context"].as_str().unwrap();
+        assert!(context.contains("Write-Back Protocol"));
+        assert!(context.contains("edda decide"));
+        let sidefile = output["env"]["EDDA_HOT_PACK_PATH"].as_str().unwrap();
+        assert!(std::path::Path::new(sidefile).is_file());
+    }
+
+    #[test]
+    fn before_submit_prompt_explicitly_continues() {
+        let stdin = serde_json::json!({
+            "hook_event_name": "beforeSubmitPrompt",
+            "conversation_id": "cursor-prompt-1",
+            "cwd": "/work/project"
+        })
+        .to_string();
+
+        let result = hook_entrypoint_from_stdin(&stdin).unwrap();
+        let output: serde_json::Value =
+            serde_json::from_str(result.stdout.as_deref().unwrap()).unwrap();
+
+        assert_eq!(output["continue"], true);
+    }
+
+    #[test]
+    fn pre_tool_warning_uses_cursor_permission_schema() {
+        let result = pre_tool_warning("Review the governing decision").unwrap();
+        let output: serde_json::Value =
+            serde_json::from_str(result.stdout.as_deref().unwrap()).unwrap();
+
+        assert_eq!(output["permission"], "allow");
+        assert_eq!(output["agent_message"], "Review the governing decision");
+    }
+
+    #[test]
+    fn post_tool_use_maps_cursor_shell_and_pushes_nudge() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stdin = serde_json::json!({
+            "hook_event_name": "postToolUse",
+            "session_id": "cursor-post-tool-1",
+            "workspace_roots": [tmp.path()],
+            "tool_name": "Shell",
+            "tool_input": {"command": "git commit -m checkpoint"}
+        })
+        .to_string();
+
+        let result = hook_entrypoint_from_stdin(&stdin).unwrap();
+        let output: serde_json::Value =
+            serde_json::from_str(result.stdout.as_deref().unwrap()).unwrap();
+
+        let context = output["additional_context"].as_str().unwrap();
+        assert!(context.contains("edda decide"));
+    }
+
+    #[test]
+    fn pre_compact_marks_recovery_state_without_claiming_rebuild() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_id = edda_store::project_id(tmp.path());
+        let _ = edda_bridge_claude::state::take_compact_pending(&project_id);
+        let stdin = serde_json::json!({
+            "hook_event_name": "preCompact",
+            "session_id": "cursor-compact-1",
+            "workspace_roots": [tmp.path()]
+        })
+        .to_string();
+
+        let result = hook_entrypoint_from_stdin(&stdin).unwrap();
+
+        assert_eq!(result.stdout.as_deref(), Some("{}"));
+        assert!(edda_bridge_claude::state::take_compact_pending(&project_id));
+    }
+
+    #[test]
+    fn session_end_cleans_session_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_id = edda_store::project_id(tmp.path());
+        let session_id = "cursor-session-end-1";
+        let start = serde_json::json!({
+            "hook_event_name": "sessionStart",
+            "session_id": session_id,
+            "workspace_roots": [tmp.path()]
+        })
+        .to_string();
+        hook_entrypoint_from_stdin(&start).unwrap();
+        let heartbeat = edda_store::project_dir(&project_id)
+            .join("state")
+            .join(format!("session.{session_id}.json"));
+        assert!(heartbeat.is_file());
+
+        let end = serde_json::json!({
+            "hook_event_name": "sessionEnd",
+            "session_id": session_id,
+            "workspace_roots": [tmp.path()]
+        })
+        .to_string();
+        let result = hook_entrypoint_from_stdin(&end).unwrap();
+
+        assert_eq!(result.stdout.as_deref(), Some("{}"));
+        assert!(!heartbeat.exists());
+    }
+
+    #[test]
+    fn hook_events_are_recorded_in_cursor_session_ledger() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_id = edda_store::project_id(tmp.path());
+        let session_id = "cursor-ledger-1";
+        let stdin = serde_json::json!({
+            "hook_event_name": "beforeSubmitPrompt",
+            "session_id": session_id,
+            "workspace_roots": [tmp.path()],
+            "model": "composer"
+        })
+        .to_string();
+
+        hook_entrypoint_from_stdin(&stdin).unwrap();
+
+        let ledger = edda_store::project_dir(&project_id)
+            .join("ledger")
+            .join(format!("{session_id}.jsonl"));
+        let recorded = std::fs::read_to_string(ledger).unwrap();
+        assert!(recorded.contains(r#""bridge":"cursor""#));
+        assert!(recorded.contains(r#""hook_event_name":"beforeSubmitPrompt""#));
+    }
+
+    #[test]
+    fn subagent_lifecycle_tracks_and_clears_peer_heartbeat() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_id = edda_store::project_id(tmp.path());
+        let subagent_id = "cursor-subagent-1";
+        let start = serde_json::json!({
+            "hook_event_name": "subagentStart",
+            "conversation_id": "cursor-parent-1",
+            "workspace_roots": [tmp.path()],
+            "subagent_id": subagent_id,
+            "subagent_type": "explore"
+        })
+        .to_string();
+
+        let result = hook_entrypoint_from_stdin(&start).unwrap();
+        let output: serde_json::Value =
+            serde_json::from_str(result.stdout.as_deref().unwrap()).unwrap();
+        assert_eq!(output["permission"], "allow");
+        let heartbeat = edda_store::project_dir(&project_id)
+            .join("state")
+            .join(format!("session.{subagent_id}.json"));
+        assert!(heartbeat.is_file());
+
+        let stop = serde_json::json!({
+            "hook_event_name": "subagentStop",
+            "conversation_id": "cursor-parent-1",
+            "workspace_roots": [tmp.path()],
+            "subagent_id": subagent_id
+        })
+        .to_string();
+        hook_entrypoint_from_stdin(&stop).unwrap();
+        assert!(!heartbeat.exists());
+    }
+}

--- a/crates/edda-bridge-cursor/src/lib.rs
+++ b/crates/edda-bridge-cursor/src/lib.rs
@@ -1,0 +1,8 @@
+//! Cursor Agent bridge for Edda.
+
+mod admin;
+mod dispatch;
+mod parse;
+
+pub use admin::{doctor, install, uninstall};
+pub use dispatch::{hook_entrypoint_from_stdin, HookResult};

--- a/crates/edda-bridge-cursor/src/parse.rs
+++ b/crates/edda-bridge-cursor/src/parse.rs
@@ -1,0 +1,268 @@
+use serde::Deserialize;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub(crate) struct CursorEnvelope {
+    #[serde(default)]
+    pub hook_event_name: String,
+    #[serde(default)]
+    pub session_id: String,
+    #[serde(default)]
+    pub conversation_id: String,
+    #[serde(default)]
+    pub generation_id: String,
+    #[serde(default)]
+    pub cwd: String,
+    #[serde(default)]
+    pub workspace_roots: Vec<String>,
+    #[serde(default)]
+    pub cursor_version: String,
+    #[serde(default)]
+    pub composer_mode: String,
+    #[serde(default)]
+    pub is_background_agent: bool,
+    #[serde(default)]
+    pub transcript_path: Option<PathBuf>,
+    #[serde(default)]
+    pub model: String,
+    #[serde(default)]
+    pub model_id: String,
+    #[serde(default)]
+    pub user_email: Option<String>,
+    #[serde(default)]
+    pub tool_name: String,
+    #[serde(default)]
+    pub tool_use_id: String,
+    #[serde(default)]
+    pub tool_input: serde_json::Value,
+    #[serde(default)]
+    pub tool_output: serde_json::Value,
+    #[serde(default)]
+    pub duration: Option<u64>,
+    #[serde(default)]
+    pub subagent_id: String,
+    #[serde(default)]
+    pub subagent_type: String,
+    #[serde(default)]
+    pub parent_conversation_id: String,
+    #[serde(default)]
+    pub task: String,
+    #[serde(default)]
+    pub git_branch: String,
+}
+
+impl CursorEnvelope {
+    pub(crate) fn event_name(&self) -> &str {
+        match self.hook_event_name.as_str() {
+            "SessionStart" => "sessionStart",
+            "UserPromptSubmit" => "beforeSubmitPrompt",
+            "PreToolUse" => "preToolUse",
+            "PostToolUse" => "postToolUse",
+            "PreCompact" => "preCompact",
+            "SessionEnd" => "sessionEnd",
+            "Stop" => "stop",
+            "SubagentStart" => "subagentStart",
+            "SubagentStop" => "subagentStop",
+            event => event,
+        }
+    }
+
+    pub(crate) fn session_id(&self) -> &str {
+        if self.session_id.is_empty() {
+            &self.conversation_id
+        } else {
+            &self.session_id
+        }
+    }
+
+    pub(crate) fn cwd(&self) -> PathBuf {
+        if !self.cwd.is_empty() {
+            return cursor_path(&self.cwd);
+        }
+        self.workspace_roots
+            .first()
+            .map(|root| cursor_path(root))
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+    }
+}
+
+fn cursor_path(path: &str) -> PathBuf {
+    #[cfg(windows)]
+    if path.len() >= 4 {
+        let bytes = path.as_bytes();
+        if bytes[0] == b'/' && bytes[1].is_ascii_alphabetic() && bytes[2] == b':' {
+            return PathBuf::from(&path[1..]);
+        }
+    }
+    PathBuf::from(path)
+}
+
+pub(crate) fn parse_hook_stdin(stdin: &str) -> anyhow::Result<CursorEnvelope> {
+    let envelope: CursorEnvelope = serde_json::from_str(stdin)?;
+    if envelope.hook_event_name.is_empty() {
+        anyhow::bail!("missing required field: hook_event_name");
+    }
+    Ok(envelope)
+}
+
+pub(crate) fn append_to_session_ledger(envelope: &CursorEnvelope) -> anyhow::Result<()> {
+    let session_id = envelope.session_id();
+    if session_id.is_empty() {
+        return Ok(());
+    }
+
+    let cwd = envelope.cwd();
+    let project_id = edda_store::project_id(&cwd);
+    let ledger_dir = edda_store::project_dir(&project_id).join("ledger");
+    fs::create_dir_all(&ledger_dir)?;
+    let ledger_path = ledger_dir.join(format!("{session_id}.jsonl"));
+    let timestamp =
+        time::OffsetDateTime::now_utc().format(&time::format_description::well_known::Rfc3339)?;
+    let record = serde_json::json!({
+        "ts": timestamp,
+        "project_id": project_id,
+        "session_id": session_id,
+        "conversation_id": envelope.conversation_id,
+        "generation_id": envelope.generation_id,
+        "hook_event_name": envelope.event_name(),
+        "cwd": cwd,
+        "cursor_version": envelope.cursor_version,
+        "composer_mode": envelope.composer_mode,
+        "is_background_agent": envelope.is_background_agent,
+        "transcript_path": envelope.transcript_path,
+        "user_email": envelope.user_email,
+        "model": envelope.model,
+        "model_id": envelope.model_id,
+        "tool_name": envelope.tool_name,
+        "tool_use_id": envelope.tool_use_id,
+        "tool_output": envelope.tool_output,
+        "duration": envelope.duration,
+        "subagent_id": envelope.subagent_id,
+        "subagent_type": envelope.subagent_type,
+        "parent_conversation_id": envelope.parent_conversation_id,
+        "task": envelope.task,
+        "git_branch": envelope.git_branch,
+        "bridge": "cursor",
+    });
+
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(ledger_path)?;
+    writeln!(file, "{}", serde_json::to_string(&record)?)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_native_session_start_envelope() {
+        let stdin = r#"{
+            "hook_event_name": "sessionStart",
+            "session_id": "cursor-session-1",
+            "conversation_id": "conversation-1",
+            "workspace_roots": ["C:/work/project"],
+            "cursor_version": "3.10.20",
+            "composer_mode": "agent",
+            "is_background_agent": false,
+            "transcript_path": null
+        }"#;
+
+        let envelope = parse_hook_stdin(stdin).unwrap();
+
+        assert_eq!(envelope.hook_event_name, "sessionStart");
+        assert_eq!(envelope.session_id(), "cursor-session-1");
+        assert_eq!(envelope.cwd(), std::path::Path::new("C:/work/project"));
+        assert_eq!(envelope.cursor_version, "3.10.20");
+        assert_eq!(envelope.composer_mode, "agent");
+        assert!(!envelope.is_background_agent);
+        assert!(envelope.transcript_path.is_none());
+    }
+
+    #[test]
+    fn parses_native_pre_tool_use_fields() {
+        let stdin = r#"{
+            "hook_event_name": "preToolUse",
+            "conversation_id": "conversation-2",
+            "cwd": "/work/project",
+            "tool_name": "Shell",
+            "tool_use_id": "tool-1",
+            "tool_input": {"command": "cargo test"},
+            "tool_output": "not available yet"
+        }"#;
+
+        let envelope = parse_hook_stdin(stdin).unwrap();
+
+        assert_eq!(envelope.session_id(), "conversation-2");
+        assert_eq!(envelope.tool_name, "Shell");
+        assert_eq!(envelope.tool_use_id, "tool-1");
+        assert_eq!(envelope.tool_input["command"], "cargo test");
+        assert_eq!(envelope.tool_output, "not available yet");
+    }
+
+    #[test]
+    fn preserves_common_cursor_metadata() {
+        let stdin = r#"{
+            "hook_event_name": "postToolUse",
+            "conversation_id": "conversation-3",
+            "generation_id": "generation-3",
+            "model": "claude-opus-thinking",
+            "model_id": "claude-opus",
+            "user_email": "dev@example.com",
+            "duration": 5432
+        }"#;
+
+        let envelope = parse_hook_stdin(stdin).unwrap();
+
+        assert_eq!(envelope.generation_id, "generation-3");
+        assert_eq!(envelope.model, "claude-opus-thinking");
+        assert_eq!(envelope.model_id, "claude-opus");
+        assert_eq!(envelope.user_email.as_deref(), Some("dev@example.com"));
+        assert_eq!(envelope.duration, Some(5432));
+    }
+
+    #[test]
+    fn normalizes_legacy_pascal_case_event_names() {
+        let envelope =
+            parse_hook_stdin(r#"{"hook_event_name":"SessionStart","session_id":"legacy-session"}"#)
+                .unwrap();
+
+        assert_eq!(envelope.event_name(), "sessionStart");
+    }
+
+    #[test]
+    fn parses_subagent_lifecycle_fields() {
+        let envelope = parse_hook_stdin(
+            r#"{
+                "hook_event_name":"subagentStart",
+                "subagent_id":"subagent-1",
+                "subagent_type":"explore",
+                "parent_conversation_id":"conversation-parent",
+                "task":"Inspect bridge behavior",
+                "git_branch":"feature/cursor"
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(envelope.subagent_id, "subagent-1");
+        assert_eq!(envelope.subagent_type, "explore");
+        assert_eq!(envelope.parent_conversation_id, "conversation-parent");
+        assert_eq!(envelope.task, "Inspect bridge behavior");
+        assert_eq!(envelope.git_branch, "feature/cursor");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn normalizes_cursor_windows_workspace_root() {
+        let envelope = parse_hook_stdin(
+            r#"{"hook_event_name":"sessionStart","workspace_roots":["/C:/work/project"]}"#,
+        )
+        .unwrap();
+
+        assert_eq!(envelope.cwd(), std::path::Path::new("C:/work/project"));
+    }
+}

--- a/crates/edda-bridge-hermes/src/admin.rs
+++ b/crates/edda-bridge-hermes/src/admin.rs
@@ -59,7 +59,8 @@ pub fn install(target: Option<&Path>) -> anyhow::Result<PathBuf> {
     // mapping — never crash the user's config.
     let mut root: serde_yaml::Value = if path.exists() {
         let raw = fs::read_to_string(&path)?;
-        serde_yaml::from_str(&raw).unwrap_or_else(|_| serde_yaml::Value::Mapping(Default::default()))
+        serde_yaml::from_str(&raw)
+            .unwrap_or_else(|_| serde_yaml::Value::Mapping(Default::default()))
     } else {
         serde_yaml::Value::Mapping(Default::default())
     };
@@ -72,7 +73,10 @@ pub fn install(target: Option<&Path>) -> anyhow::Result<PathBuf> {
     // Get or create the top-level `hooks:` mapping.
     let hooks_key = serde_yaml::Value::String("hooks".into());
     if !root_map.contains_key(&hooks_key)
-        || !root_map.get(&hooks_key).map(|v| v.is_mapping()).unwrap_or(false)
+        || !root_map
+            .get(&hooks_key)
+            .map(|v| v.is_mapping())
+            .unwrap_or(false)
     {
         root_map.insert(
             hooks_key.clone(),
@@ -105,7 +109,7 @@ pub fn install(target: Option<&Path>) -> anyhow::Result<PathBuf> {
         let already_present = entries.iter().any(|entry| {
             entry
                 .as_mapping()
-                .and_then(|m| m.get(&serde_yaml::Value::String("command".into())))
+                .and_then(|m| m.get(serde_yaml::Value::String("command".into())))
                 .and_then(|c| c.as_str())
                 .map(|c| c == HOOK_COMMAND)
                 .unwrap_or(false)
@@ -163,7 +167,7 @@ pub fn uninstall(target: Option<&Path>) -> anyhow::Result<()> {
 
     if let Some(hooks) = root
         .as_mapping_mut()
-        .and_then(|m| m.get_mut(&serde_yaml::Value::String("hooks".into())))
+        .and_then(|m| m.get_mut(serde_yaml::Value::String("hooks".into())))
     {
         if let Some(hooks_map) = hooks.as_mapping_mut() {
             let event_names: Vec<serde_yaml::Value> = hooks_map.keys().cloned().collect();
@@ -175,7 +179,7 @@ pub fn uninstall(target: Option<&Path>) -> anyhow::Result<()> {
                     seq.retain(|entry| {
                         entry
                             .as_mapping()
-                            .and_then(|m| m.get(&serde_yaml::Value::String("command".into())))
+                            .and_then(|m| m.get(serde_yaml::Value::String("command".into())))
                             .and_then(|c| c.as_str())
                             .map(|c| c != HOOK_COMMAND)
                             .unwrap_or(true)
@@ -226,8 +230,8 @@ pub fn doctor() -> anyhow::Result<()> {
 
     // Check consent status. Even if hooks are installed, they don't fire
     // until approved once via TTY/env/config.
-    let allowlist_path = dirs::home_dir()
-        .map(|h| h.join(".hermes").join("shell-hooks-allowlist.json"));
+    let allowlist_path =
+        dirs::home_dir().map(|h| h.join(".hermes").join("shell-hooks-allowlist.json"));
     let approved_here = allowlist_path
         .as_ref()
         .and_then(|p| fs::read_to_string(p).ok())
@@ -235,7 +239,12 @@ pub fn doctor() -> anyhow::Result<()> {
         .unwrap_or(false);
     let auto_accept_env = std::env::var("HERMES_ACCEPT_HOOKS")
         .ok()
-        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .map(|v| {
+            matches!(
+                v.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
         .unwrap_or(false);
     let consent_ok = approved_here || auto_accept_env;
     println!(
@@ -338,7 +347,7 @@ hooks_auto_accept: false
         let v: serde_yaml::Value = serde_yaml::from_str(&raw).unwrap();
         // Other top-level keys preserved.
         assert_eq!(v["model"].as_str().unwrap(), "claude-sonnet");
-        assert_eq!(v["hooks_auto_accept"].as_bool().unwrap(), false);
+        assert!(!v["hooks_auto_accept"].as_bool().unwrap());
         assert_eq!(
             v["providers"]["anthropic"]["api_key"].as_str().unwrap(),
             "fake"

--- a/crates/edda-bridge-hermes/src/parse.rs
+++ b/crates/edda-bridge-hermes/src/parse.rs
@@ -139,7 +139,8 @@ mod tests {
 
     #[test]
     fn parse_subsequent_turn_defaults_to_false() {
-        let stdin = r#"{"hook_event_name":"pre_llm_call","session_id":"h3","cwd":"/tmp","extra":{}}"#;
+        let stdin =
+            r#"{"hook_event_name":"pre_llm_call","session_id":"h3","cwd":"/tmp","extra":{}}"#;
         let env = parse_hook_stdin(stdin).unwrap();
         assert!(!extra_bool(&env, "is_first_turn"));
     }

--- a/crates/edda-cli/Cargo.toml
+++ b/crates/edda-cli/Cargo.toml
@@ -23,6 +23,7 @@ edda-derive = { path = "../edda-derive", version = "0.2.0" }
 edda-store = { path = "../edda-store", version = "0.2.0" }
 edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.2.0" }
 edda-bridge-codex = { path = "../edda-bridge-codex", version = "0.2.0" }
+edda-bridge-cursor = { path = "../edda-bridge-cursor", version = "0.2.0" }
 edda-bridge-hermes = { path = "../edda-bridge-hermes", version = "0.2.0" }
 edda-bridge-openclaw = { path = "../edda-bridge-openclaw", version = "0.2.0" }
 edda-transcript = { path = "../edda-transcript", version = "0.2.0" }

--- a/crates/edda-cli/src/cmd_bridge.rs
+++ b/crates/edda-cli/src/cmd_bridge.rs
@@ -661,7 +661,11 @@ pub fn decide(
     let reason: Option<&str> = safe_reason.as_deref();
     let all_hits = value_hits.len() + reason_hits.len();
     if all_hits > 0 {
-        let kinds: Vec<_> = value_hits.iter().chain(reason_hits.iter()).map(|h| h.kind).collect();
+        let kinds: Vec<_> = value_hits
+            .iter()
+            .chain(reason_hits.iter())
+            .map(|h| h.kind)
+            .collect();
         eprintln!(
             "⚠ secret-guard: redacted {all_hits} secret pattern(s) before writing decision ({})",
             kinds.join(", ")

--- a/crates/edda-cli/src/cmd_export.rs
+++ b/crates/edda-cli/src/cmd_export.rs
@@ -8,9 +8,9 @@
 //!   normalized to "generated at run-time" in the header only; body content is
 //!   sorted so idempotent re-export doesn't create noise.
 //! - Layout:
-//!     <out>/INDEX.md             — table of contents
-//!     <out>/decisions/<domain>.md — one file per domain (active decisions)
-//!     <out>/notes.md             — chronological notes (optional)
+//!   <out>/INDEX.md             — table of contents
+//!   <out>/decisions/<domain>.md — one file per domain (active decisions)
+//!   <out>/notes.md             — chronological notes (optional)
 
 use anyhow::{Context, Result};
 use edda_core::secret_guard::redact;
@@ -55,13 +55,19 @@ pub fn execute(repo_root: &Path, out_dir: &Path, include_notes: bool) -> Result<
         "wrote {} decision files ({} total) + INDEX.md{} at {}",
         domain_stats.len(),
         domain_stats.iter().map(|(_, n, _)| n).sum::<usize>(),
-        if notes_line.is_some() { " + notes.md" } else { "" },
+        if notes_line.is_some() {
+            " + notes.md"
+        } else {
+            ""
+        },
         out_dir.display(),
     );
     Ok(())
 }
 
-fn group_by_domain(rows: Vec<edda_ledger::DecisionView>) -> BTreeMap<String, Vec<edda_ledger::DecisionView>> {
+fn group_by_domain(
+    rows: Vec<edda_ledger::DecisionView>,
+) -> BTreeMap<String, Vec<edda_ledger::DecisionView>> {
     let mut out: BTreeMap<String, Vec<edda_ledger::DecisionView>> = BTreeMap::new();
     for row in rows {
         let dom = if row.domain.is_empty() {
@@ -74,14 +80,18 @@ fn group_by_domain(rows: Vec<edda_ledger::DecisionView>) -> BTreeMap<String, Vec
     out
 }
 
-const HEADER: &str = "<!-- edda-ledger-export v1 — GENERATED FILE, DO NOT EDIT — SQLite ledger is authoritative -->";
+const HEADER: &str =
+    "<!-- edda-ledger-export v1 — GENERATED FILE, DO NOT EDIT — SQLite ledger is authoritative -->";
 
 fn render_domain(domain: &str, rows: &[edda_ledger::DecisionView]) -> String {
     let mut out = String::with_capacity(1024);
     out.push_str(HEADER);
     out.push('\n');
     out.push_str(&format!("# Domain: `{}`\n\n", domain));
-    out.push_str(&format!("{} active decision(s), sorted by key.\n\n", rows.len()));
+    out.push_str(&format!(
+        "{} active decision(s), sorted by key.\n\n",
+        rows.len()
+    ));
     for row in rows {
         // Secret guard the reason at export time as a belt-and-braces safety
         // — decisions written before secret_guard shipped may still carry
@@ -96,13 +106,21 @@ fn render_domain(domain: &str, rows: &[edda_ledger::DecisionView]) -> String {
         if !row.affected_paths.is_empty() {
             out.push_str(&format!(
                 "- **Affected paths**: {}\n",
-                row.affected_paths.iter().map(|p| format!("`{}`", p)).collect::<Vec<_>>().join(", ")
+                row.affected_paths
+                    .iter()
+                    .map(|p| format!("`{}`", p))
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ));
         }
         if !row.tags.is_empty() {
             out.push_str(&format!(
                 "- **Tags**: {}\n",
-                row.tags.iter().map(|t| format!("`{}`", t)).collect::<Vec<_>>().join(", ")
+                row.tags
+                    .iter()
+                    .map(|t| format!("`{}`", t))
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ));
         }
         out.push_str(&format!("- **event_id**: `{}`\n\n", row.event_id));
@@ -118,7 +136,11 @@ fn render_notes(events: &[edda_core::Event]) -> String {
     let mut sorted: Vec<&edda_core::Event> = events.iter().collect();
     sorted.sort_by(|a, b| a.ts.cmp(&b.ts));
     for ev in sorted {
-        let text = ev.payload.get("text").and_then(|v| v.as_str()).unwrap_or("");
+        let text = ev
+            .payload
+            .get("text")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
         if text.trim().is_empty() {
             continue;
         }
@@ -234,7 +256,10 @@ mod tests {
         let mut row = dec("test.key", "val", "test", vec![]);
         row.reason = "temp token sk-abcdefghijklmnopqrstuvwxyz012345".into();
         let md = render_domain("test", &[row]);
-        assert!(md.contains("[REDACTED:openai_api_key]"), "export must not leak old secrets: {md}");
+        assert!(
+            md.contains("[REDACTED:openai_api_key]"),
+            "export must not leak old secrets: {md}"
+        );
         assert!(!md.contains("sk-abcdefghijklmnopqrstuvwxyz012345"));
     }
 

--- a/crates/edda-cli/src/cmd_gc.rs
+++ b/crates/edda-cli/src/cmd_gc.rs
@@ -369,7 +369,7 @@ pub fn execute(params: &GcParams) -> anyhow::Result<()> {
                     let _ = tombstone::append_tombstone(&ledger.paths, &t);
                 }
             }
-            Err(e) => eprintln!("  warning: failed to process blob {}: {e}", &candidate.hash),
+            Err(e) => eprintln!("  warning: failed to process blob {}: {e}", candidate.hash),
         }
     }
 

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -328,12 +328,12 @@ enum Command {
         #[arg(long = "include-notes")]
         include_notes: bool,
     },
-    /// Bridge operations (install/uninstall hooks for Claude Code)
+    /// Bridge operations (install/uninstall hooks for supported coding agents)
     Bridge {
         #[command(subcommand)]
         cmd: cmd_bridge::BridgeCmd,
     },
-    /// Hook entrypoint (called by Claude Code hooks)
+    /// Hook entrypoint (called by supported coding-agent hooks)
     Hook {
         #[command(subcommand)]
         cmd: cmd_bridge::HookCmd,
@@ -1098,7 +1098,11 @@ fn main() -> anyhow::Result<()> {
         Command::Switch { name } => cmd_switch::execute(&repo_root, &name),
         Command::Merge { src, dst, reason } => cmd_merge::execute(&repo_root, &src, &dst, &reason),
         Command::Draft { cmd } => cmd_draft::run(cmd, &repo_root),
-        Command::Export { format, out, include_notes } => {
+        Command::Export {
+            format,
+            out,
+            include_notes,
+        } => {
             if format != "md" {
                 anyhow::bail!("only 'md' export format is supported (got: {format})");
             }

--- a/crates/edda-core/src/secret_guard.rs
+++ b/crates/edda-core/src/secret_guard.rs
@@ -131,7 +131,10 @@ mod tests {
     fn openai_key_redacted() {
         let text = "auth: sk-abcdefghijklmnopqrstuvwxyz012345 do stuff";
         let (out, hits) = redact(text);
-        assert!(out.contains("[REDACTED:openai_api_key]"), "openai key redacted; got: {out}");
+        assert!(
+            out.contains("[REDACTED:openai_api_key]"),
+            "openai key redacted; got: {out}"
+        );
         assert_eq!(hits.len(), 1);
     }
 

--- a/crates/edda-derive/src/context/session.rs
+++ b/crates/edda-derive/src/context/session.rs
@@ -45,7 +45,7 @@ pub(super) fn render_persistent_tasks(digests: &[SessionDigestEntry]) -> String 
         .into_iter()
         .filter(|(_, t)| t.pending_sessions >= 2)
         .collect();
-    persistent.sort_by(|a, b| b.1.pending_sessions.cmp(&a.1.pending_sessions));
+    persistent.sort_by_key(|entry| std::cmp::Reverse(entry.1.pending_sessions));
 
     if persistent.is_empty() {
         return String::new();

--- a/crates/edda-postmortem/src/candidates.rs
+++ b/crates/edda-postmortem/src/candidates.rs
@@ -412,7 +412,10 @@ mod tests {
 
         let a = fs::read_to_string(dir_a.path().join("i.md")).unwrap();
         let b = fs::read_to_string(dir_b.path().join("i.md")).unwrap();
-        assert_eq!(a, b, "empty hint slice = zero behavior change (opt-in guard)");
+        assert_eq!(
+            a, b,
+            "empty hint slice = zero behavior change (opt-in guard)"
+        );
     }
 
     #[test]
@@ -422,20 +425,26 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = dir.path().join("incubation.md");
         // Candidate maxim contains "shared family" — align a doctrine entry to it.
-        let entries = parse_entries(
-            "### FM-9: shared family topic\nbody\n",
-            "failure-memory.md",
-        );
+        let entries = parse_entries("### FM-9: shared family topic\nbody\n", "failure-memory.md");
         let result = result_with(
-            vec![lesson("shared family topic (surfaced)", LessonSeverity::High)],
+            vec![lesson(
+                "shared family topic (surfaced)",
+                LessonSeverity::High,
+            )],
             vec![],
         );
         let cands = select_candidates(&result, 3);
         sync_candidates_to_incubation_with_hints(&path, &cands, &entries).unwrap();
         let content = fs::read_to_string(&path).unwrap();
-        assert!(content.contains("Related in doctrine"), "hint block present");
+        assert!(
+            content.contains("Related in doctrine"),
+            "hint block present"
+        );
         assert!(content.contains("FM-9"), "specific matching heading named");
-        assert!(content.contains("not judgment"), "machine-hint red-line phrasing kept");
+        assert!(
+            content.contains("not judgment"),
+            "machine-hint red-line phrasing kept"
+        );
     }
 
     #[test]

--- a/crates/edda-postmortem/src/lessons.rs
+++ b/crates/edda-postmortem/src/lessons.rs
@@ -105,7 +105,7 @@ impl LessonsStore {
     /// Get the top N lessons by occurrence count, for CLAUDE.md sync.
     pub fn top_lessons(&self, n: usize) -> Vec<&StoredLesson> {
         let mut sorted: Vec<&StoredLesson> = self.lessons.iter().collect();
-        sorted.sort_by(|a, b| b.occurrences.cmp(&a.occurrences));
+        sorted.sort_by_key(|lesson| std::cmp::Reverse(lesson.occurrences));
         sorted.truncate(n);
         sorted
     }

--- a/crates/edda-postmortem/src/rules.rs
+++ b/crates/edda-postmortem/src/rules.rs
@@ -326,7 +326,7 @@ impl RulesStore {
             .filter(|r| r.status == RuleStatus::Active)
             .map(|r| (r.id.clone(), r.hits))
             .collect();
-        active_ids.sort_by(|a, b| b.1.cmp(&a.1)); // Sort by hits descending
+        active_ids.sort_by_key(|entry| std::cmp::Reverse(entry.1)); // Sort by hits descending
         if active_ids.len() > MAX_ACTIVE_RULES {
             let demote_ids: Vec<String> = active_ids[MAX_ACTIVE_RULES..]
                 .iter()

--- a/crates/edda-postmortem/src/scars.rs
+++ b/crates/edda-postmortem/src/scars.rs
@@ -133,7 +133,7 @@ fn new_lesson_id(tag: &str, prefix: &str) -> String {
     hasher.update(tag.as_bytes());
     hasher.update(b"|");
     hasher.update(prefix.as_bytes());
-    format!("lesson_scar_{}", hex::encode(hasher.finalize())[..12].to_string())
+    format!("lesson_scar_{}", &hex::encode(hasher.finalize())[..12])
 }
 
 /// JSONL row shape used by `edda log --json` output (only the fields we need).
@@ -205,7 +205,9 @@ pub fn notes_from_events(events: &[edda_core::types::Event]) -> Vec<LedgerNote> 
             .cloned()
             .unwrap_or_default();
         for tag in tags {
-            let Some(tag_str) = tag.as_str() else { continue };
+            let Some(tag_str) = tag.as_str() else {
+                continue;
+            };
             if is_scar_tag(tag_str) {
                 out.push(LedgerNote {
                     ts: event.ts.clone(),
@@ -241,17 +243,25 @@ mod tests {
             "friction",
             "worktree has no .edda, executor cannot inject context",
         )];
-        assert!(analyze_recurring_scars(&notes, now()).is_empty(),
-            "one hit is not a scar (havamal 二犯規矩)");
+        assert!(
+            analyze_recurring_scars(&notes, now()).is_empty(),
+            "one hit is not a scar (havamal 二犯規矩)"
+        );
     }
 
     #[test]
     fn two_occurrences_same_prefix_yields_high_lesson_with_excerpt() {
         let notes = vec![
-            note("2026-07-05T01:00:00Z", "friction",
-                "Worktree has no .edda; executor cannot inject context on start"),
-            note("2026-07-08T01:00:00Z", "friction",
-                "worktree has no .edda — executor context broken again in nested session"),
+            note(
+                "2026-07-05T01:00:00Z",
+                "friction",
+                "Worktree has no .edda; executor cannot inject context on start",
+            ),
+            note(
+                "2026-07-08T01:00:00Z",
+                "friction",
+                "worktree has no .edda — executor context broken again in nested session",
+            ),
         ];
         let lessons = analyze_recurring_scars(&notes, now());
         assert_eq!(lessons.len(), 1);
@@ -259,40 +269,75 @@ mod tests {
         assert!(lessons[0].tags.contains(&"friction".to_string()));
         assert!(lessons[0].tags.contains(&"recurring".to_string()));
         assert!(lessons[0].text.contains("2x"), "count in text");
-        assert!(lessons[0].text.to_lowercase().contains("worktree has no .edda"),
-            "candidate cites the scar text verbatim (not template)");
+        assert!(
+            lessons[0]
+                .text
+                .to_lowercase()
+                .contains("worktree has no .edda"),
+            "candidate cites the scar text verbatim (not template)"
+        );
     }
 
     #[test]
     fn out_of_window_occurrences_dont_count() {
         let notes = vec![
-            note("2026-05-01T00:00:00Z", "friction", "old worktree issue in stale window"),
-            note("2026-07-08T00:00:00Z", "friction", "old worktree issue back in fresh window"),
+            note(
+                "2026-05-01T00:00:00Z",
+                "friction",
+                "old worktree issue in stale window",
+            ),
+            note(
+                "2026-07-08T00:00:00Z",
+                "friction",
+                "old worktree issue back in fresh window",
+            ),
         ];
-        assert!(analyze_recurring_scars(&notes, now()).is_empty(),
-            "one in-window hit only (窗外的不算)");
+        assert!(
+            analyze_recurring_scars(&notes, now()).is_empty(),
+            "one in-window hit only (窗外的不算)"
+        );
     }
 
     #[test]
     fn non_scar_tags_ignored() {
         let notes = vec![
-            note("2026-07-08T01:00:00Z", "session", "same prefix same day tag session"),
-            note("2026-07-08T02:00:00Z", "session", "same prefix same day tag session"),
+            note(
+                "2026-07-08T01:00:00Z",
+                "session",
+                "same prefix same day tag session",
+            ),
+            note(
+                "2026-07-08T02:00:00Z",
+                "session",
+                "same prefix same day tag session",
+            ),
         ];
-        assert!(analyze_recurring_scars(&notes, now()).is_empty(),
-            "session tag is not a scar family");
+        assert!(
+            analyze_recurring_scars(&notes, now()).is_empty(),
+            "session tag is not a scar family"
+        );
     }
 
     #[test]
     fn prefix_normalization_matches_case_and_whitespace_variants() {
         let notes = vec![
-            note("2026-07-08T01:00:00Z", "review",
-                "  Findings: dispatch layer authored discipline text\n\nmore detail"),
-            note("2026-07-08T02:00:00Z", "review",
-                "FINDINGS:   dispatch  layer authored discipline text!"),
+            note(
+                "2026-07-08T01:00:00Z",
+                "review",
+                "  Findings: dispatch layer authored discipline text\n\nmore detail",
+            ),
+            note(
+                "2026-07-08T02:00:00Z",
+                "review",
+                "FINDINGS:   dispatch  layer authored discipline text!",
+            ),
         ];
         let lessons = analyze_recurring_scars(&notes, now());
-        assert_eq!(lessons.len(), 1, "case+whitespace+punct differences collapse to one family");
+        assert_eq!(
+            lessons.len(),
+            1,
+            "case+whitespace+punct differences collapse to one family"
+        );
     }
 
     #[test]
@@ -303,6 +348,10 @@ mod tests {
             note("2026-07-08T02:00:00Z", "friction", "hit b"),
         ];
         let lessons = analyze_recurring_scars(&notes, now());
-        assert_eq!(lessons.len(), 1, "garbage-ts note dropped, valid pair remains");
+        assert_eq!(
+            lessons.len(),
+            1,
+            "garbage-ts note dropped, valid pair remains"
+        );
     }
 }

--- a/crates/edda-postmortem/src/sign_check.rs
+++ b/crates/edda-postmortem/src/sign_check.rs
@@ -67,7 +67,7 @@ pub fn parse_entries(body: &str, file_label: &str) -> Vec<DoctrineEntry> {
                     break;
                 }
                 let cleaned = candidate
-                    .trim_start_matches(|c: char| matches!(c, '-' | '*' | '>' | ' '))
+                    .trim_start_matches(['-', '*', '>', ' '])
                     .to_string();
                 first_line = cleaned;
                 break;
@@ -208,7 +208,9 @@ mod tests {
         let entries = parse_entries(body, "failure-memory.md");
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].heading, "FM-1: watch out for silent walls");
-        assert!(entries[0].first_line.contains("retrying without new signal"));
+        assert!(entries[0]
+            .first_line
+            .contains("retrying without new signal"));
     }
 
     #[test]
@@ -255,7 +257,10 @@ mod tests {
         assert_eq!(strip_entry_number("6.3: Paid lesson"), "Paid lesson");
         assert_eq!(strip_entry_number("L1.2: The belief"), "The belief");
         // Not a number: keep as-is (defensive — arbitrary long prefixes stay).
-        assert_eq!(strip_entry_number("Something: with colon"), "Something: with colon");
+        assert_eq!(
+            strip_entry_number("Something: with colon"),
+            "Something: with colon"
+        );
         // No colon: keep as-is.
         assert_eq!(strip_entry_number("No colon here"), "No colon here");
     }
@@ -291,13 +296,17 @@ mod tests {
         // Case + whitespace variation (safe: no clause-break chars).
         let a = "Retrying   Into a Silent WALL";
         let b = "retrying into a silent wall";
-        assert_eq!(normalize_prefix(a), normalize_prefix(b),
-            "scars.rs normalize_prefix is the single family key vocabulary");
-        let entries = parse_entries(
-            &format!("### FM-x: {a}\nbody\n"),
-            "failure-memory.md",
+        assert_eq!(
+            normalize_prefix(a),
+            normalize_prefix(b),
+            "scars.rs normalize_prefix is the single family key vocabulary"
         );
+        let entries = parse_entries(&format!("### FM-x: {a}\nbody\n"), "failure-memory.md");
         let related = related_entries(b, &entries);
-        assert_eq!(related.len(), 1, "case/whitespace-normalized keys collide as scars.rs guarantees");
+        assert_eq!(
+            related.len(),
+            1,
+            "case/whitespace-normalized keys collide as scars.rs guarantees"
+        );
     }
 }

--- a/crates/edda-postmortem/src/signals.rs
+++ b/crates/edda-postmortem/src/signals.rs
@@ -91,7 +91,12 @@ pub fn record_conflict_signal_if_cross_actor(
     existing_actor: &str,
     current_actor: &str,
 ) -> io::Result<()> {
-    record_conflict_if_cross_actor(&signals_path(project_id), key, existing_actor, current_actor)
+    record_conflict_if_cross_actor(
+        &signals_path(project_id),
+        key,
+        existing_actor,
+        current_actor,
+    )
 }
 
 /// Append one signal to an explicit file path (testable core).
@@ -178,8 +183,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("sig.jsonl");
         // 同 actor 進版:should_record_conflict=false
-        assert!(!should_record_conflict("cli", "cli"),
-            "same actor progressing own binding is not a conflict (病一)");
+        assert!(
+            !should_record_conflict("cli", "cli"),
+            "same actor progressing own binding is not a conflict (病一)"
+        );
         // 呼叫 record_conflict_if_cross_actor 應該不寫檔
         record_conflict_if_cross_actor(&path, "db.engine", "cli", "cli").unwrap();
         assert_eq!(count_signals_at(&path, None, None).conflicts, 0);
@@ -189,8 +196,10 @@ mod tests {
     fn conflict_signal_recorded_when_different_actor() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("sig.jsonl");
-        assert!(should_record_conflict("cli", "product"),
-            "different actor = real cross-agent conflict (照記)");
+        assert!(
+            should_record_conflict("cli", "product"),
+            "different actor = real cross-agent conflict (照記)"
+        );
         record_conflict_if_cross_actor(&path, "db.engine", "product", "cli").unwrap();
         assert_eq!(count_signals_at(&path, None, None).conflicts, 1);
     }

--- a/docs/README_zh-TW.md
+++ b/docs/README_zh-TW.md
@@ -172,6 +172,21 @@ Edda 將每個事件以 hash-chained JSON 記錄儲存在本地 SQLite 資料庫
 edda init    # 偵測 Claude Code，自動安裝 hooks
 ```
 
+**Cursor** — 透過原生 Cursor hooks 支援。Session 開始時會把既有 hot pack、doctrine 與 workspace context 推送進 Agent 模型。
+
+```bash
+edda bridge cursor install      # 安裝 ~/.cursor/hooks.json 條目
+edda doctor cursor              # 驗證 PATH、hooks 與 store 可寫性
+```
+
+Cursor v1 與 Codex bridge 共用相同的讀取路徑。Cursor 在 `sessionStart` 可能送出 `transcript_path: null`，因此 bridge 會讀取既有 hot pack，不會宣稱在該時點重建 Cursor transcript。
+
+**Codex** — 透過原生 hooks 支援，並共用 Edda 的 context 機制。
+
+```bash
+edda bridge codex install
+```
+
 **OpenClaw** — 透過 bridge 插件支援。
 
 ```bash
@@ -247,7 +262,7 @@ edda watch                 # 即時 TUI：peers、事件、決策
 
 ## 架構
 
-14 個 Rust crates：
+16 個 Rust crates：
 
 | Crate | 功能 |
 |-------|------|
@@ -255,6 +270,8 @@ edda watch                 # 即時 TUI：peers、事件、決策
 | `edda-ledger` | Append-only ledger（SQLite）、blob store、locking |
 | `edda-cli` | 所有指令 + TUI（`tui` feature，預設開啟） |
 | `edda-bridge-claude` | Claude Code hooks、transcript 攝取、context 注入 |
+| `edda-bridge-cursor` | Cursor 原生 hooks、context 注入、生命週期追蹤 |
+| `edda-bridge-codex` | Codex hooks 與 context 注入 |
 | `edda-bridge-openclaw` | OpenClaw hooks 和插件 |
 | `edda-mcp` | MCP server（7 個工具） |
 | `edda-ask` | 跨來源決策查詢引擎 |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -14,7 +14,7 @@ below it, never above.
 | **L1 Foundation** | Event model, schema, hashing | `edda-core` |
 | **L2 Persistence** | Storage, ledger, blobs | `edda-ledger`, `edda-store` |
 | **L3 Processing** | View building, indexing, orchestration, analysis | `edda-derive`, `edda-transcript`, `edda-index`, `edda-conductor`, `edda-aggregate`, `edda-chronicle`, `edda-postmortem` |
-| **L3 Bridge** | External system integration | `edda-bridge-claude`, `edda-bridge-openclaw` |
+| **L3 Bridge** | External system integration | `edda-bridge-claude`, `edda-bridge-cursor`, `edda-bridge-codex`, `edda-bridge-hermes`, `edda-bridge-openclaw` |
 | **L3 Query** | Cross-source queries, context generation | `edda-ask`, `edda-pack`, `edda-search-fts` |
 | **L4 Interface** | User-facing CLI, MCP, HTTP, notifications | `edda-cli`, `edda-mcp`, `edda-serve`, `edda-notify` |
 
@@ -51,9 +51,12 @@ Same-layer dependencies are allowed (e.g. an L3 crate may depend on another L3 c
 L4 Interface         L3 Bridge                 L2 Persistence     L1 Foundation
 ─────────────        ──────────────────        ──────────────     ──────────────
 edda-cli             edda-bridge-claude        edda-ledger        edda-core
-edda-mcp             edda-bridge-openclaw      edda-store
+edda-mcp             edda-bridge-cursor        edda-store
 edda-serve
 edda-notify
+                     edda-bridge-codex
+                     edda-bridge-hermes
+                     edda-bridge-openclaw
 
 L3 Query             L3 Processing
 ──────────────       ──────────────
@@ -72,6 +75,9 @@ edda-search-fts      edda-index
 | `edda-ledger` | L2 Persistence | Append-only ledger (SQLite), blob store, locking |
 | `edda-store` | L2 Persistence | Per-user store, atomic writes |
 | `edda-bridge-claude` | L3 Bridge | Claude Code hooks, transcript ingest, context injection, peer coordination |
+| `edda-bridge-cursor` | L3 Bridge | Cursor native hooks, context injection, lifecycle tracking |
+| `edda-bridge-codex` | L3 Bridge | Codex hooks and context injection |
+| `edda-bridge-hermes` | L3 Bridge | Hermes shell hooks and context injection |
 | `edda-bridge-openclaw` | L3 Bridge | OpenClaw hooks and plugin |
 | `edda-transcript` | L3 Processing | Transcript delta ingest, classification |
 | `edda-derive` | L3 Processing | View rebuilding, tiered history |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -36,6 +36,8 @@ Health check for bridge integration.
 
 ```bash
 edda doctor claude     # check Claude Code hooks
+edda doctor cursor     # check Cursor native hooks
+edda doctor codex      # check Codex hooks
 edda doctor openclaw   # check OpenClaw hooks
 ```
 
@@ -288,6 +290,10 @@ Install or uninstall bridge hooks.
 ```bash
 edda bridge claude install      # install Claude Code hooks
 edda bridge claude uninstall    # remove hooks
+edda bridge cursor install      # install native Cursor hooks
+edda bridge cursor uninstall
+edda bridge codex install       # install Codex hooks
+edda bridge codex uninstall
 edda bridge openclaw install    # install OpenClaw plugin
 edda bridge openclaw uninstall
 ```


### PR DESCRIPTION
## Summary
- add a complete native Cursor bridge with hook install, uninstall, doctor, event parsing, context injection, and lifecycle tracking
- wire Cursor support into the CLI and update English, Traditional Chinese, architecture, and CLI documentation
- prepare workspace version 0.2.1 and fix existing formatting and Clippy failures that blocked CI

## Behavior
- preserves existing user-defined Cursor hooks and installs Edda entries idempotently
- handles session, tool, lifecycle, and subagent events with fail-open dispatch
- injects the existing Edda hot pack and exposes `EDDA_HOT_PACK_PATH` at session start
- normalizes Cursor event aliases and Windows workspace paths

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo test --workspace --no-fail-fast --quiet` (1,806 tests)
- [x] Cursor CLI doctor, session-start context, hook install, and hook uninstall smoke checks