### PR TITLE
fix(ci): prevent Windows timeout test from hanging

### DIFF
--- a/crates/edda-conductor/src/check/cmd_succeeds.rs
+++ b/crates/edda-conductor/src/check/cmd_succeeds.rs
@@ -113,7 +113,12 @@ mod tests {
         #[cfg(not(windows))]
         let cmd = "sleep 60";
         #[cfg(windows)]
-        let cmd = "ping -n 60 127.0.0.1";
+        // Keep the delay inside the selected shell so no child retains captured pipes.
+        let cmd = if which_exists("pwsh") || which_exists("powershell") {
+            "while ($true) { Start-Sleep -Milliseconds 100 }"
+        } else {
+            "for /L %i in (1,1,2147483647) do @rem"
+        };
         let out = check_cmd_succeeds(cmd, 1, dir.path()).await;
         assert!(!out.passed);
         assert!(out.detail.unwrap().contains("timed out"));


### PR DESCRIPTION
## Summary
- replace the Windows timeout test's external `ping.exe` delay with a loop inside the selected shell
- prevent descendant processes from retaining captured output pipes after `kill_on_drop`
- keep coverage for the same one-second command timeout path across PowerShell and cmd.exe

## Root cause
The test timed out the shell after one second, but `ping.exe` remained alive with inherited stdout/stderr pipes. The test assertion returned promptly while the Windows test harness waited for the descendant process, taking 59.90 seconds locally and hanging GitHub runners much longer.

## Test plan
- [x] reproduce baseline: targeted test finished in 59.90s
- [x] targeted Rust 1.97 test finishes in 1.42s
- [x] `cargo +1.97.0 fmt --all --check`
- [x] `RUSTFLAGS=-Dwarnings cargo +1.97.0 clippy -p edda-conductor --all-targets`
- [x] `cargo +1.97.0 test -p edda-conductor --quiet` (147 passed in 2.02s)