### PR TITLE
docs(bridge): teach read verbs first — ask before decide, search before build

### DIFF
--- a/crates/edda-bridge-claude/src/render.rs
+++ b/crates/edda-bridge-claude/src/render.rs
@@ -48,9 +48,15 @@ pub fn apply_budget(content: &str, budget: usize) -> String {
 
 // ── Write-Back Protocol ──
 
-/// Static write-back protocol text that teaches agents to use `edda decide` and `edda note`.
+/// Static write-back protocol text that teaches agents the read verbs first
+/// (ask/search), then the write verbs (decide/note/task). Read before you
+/// write: an unqueried ledger is a write-only ledger.
 pub fn writeback() -> String {
     "## Write-Back Protocol\n\
+     Read before you write — the ledger answers questions:\n  \
+     `edda ask \"<domain or keyword>\"` — has this been decided already? (run before any `edda decide`)\n  \
+     `edda search query \"<keyword>\"` — has this been done before? (run before building)\n\
+     \n\
      Record architectural decisions with: `edda decide \"domain.aspect=value\" --reason \"justification\"`\n\
      \n\
      Examples:\n  \

--- a/crates/edda-cli/src/cmd_bridge.rs
+++ b/crates/edda-cli/src/cmd_bridge.rs
@@ -1654,6 +1654,10 @@ mod tests {
             output.contains("edda task done") && output.contains("--receipt"),
             "should teach the task rail verbs at the same level as decide/note (§5)"
         );
+        assert!(
+            output.contains("edda ask") && output.contains("edda search query"),
+            "should teach the read verbs — read before you write, or the ledger is write-only"
+        );
     }
 
     #[test]


### PR DESCRIPTION
One-slice follow-up to the retrieval review (#402–#405 filed the capability side; this is the habit side).

The write-back protocol taught every write verb and zero read verbs. Empirical consequence: the fleet's search index had never been built — zero pull demand in months of operation. This adds the two read verbs at the top of the protocol, so every session learns ask-before-decide / search-before-build at the same place it learns to record.

Test extended first (RED), then the text (GREEN); bridge suite 536 green, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)