### PR TITLE
fix(search): CJK bigram tokenizer — CJK queries >2 chars now match (GH-402)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,6 +1046,7 @@ dependencies = [
  "edda-core",
  "edda-index",
  "edda-store",
+ "fs2",
  "rusqlite",
  "serde",
  "serde_json",

--- a/crates/edda-cli/src/cmd_ask.rs
+++ b/crates/edda-cli/src/cmd_ask.rs
@@ -60,6 +60,12 @@ fn build_transcript_callback(repo_root: &Path) -> Option<Box<TranscriptSearchFn>
     if !index_dir.exists() {
         return None;
     }
+    // GH-402: don't search a stale-schema index — its CJK results would be
+    // silently wrong. Skip transcript search and hint the rebuild instead.
+    if edda_search_fts::schema::index_is_outdated(&index_dir) {
+        eprintln!("(search index is out of date; run `edda search index` to include transcripts)");
+        return None;
+    }
 
     let index = edda_search_fts::schema::ensure_index(&index_dir).ok()?;
     let pid = project_id.clone();

--- a/crates/edda-cli/src/cmd_ask.rs
+++ b/crates/edda-cli/src/cmd_ask.rs
@@ -67,7 +67,7 @@ fn build_transcript_callback(repo_root: &Path) -> Option<Box<TranscriptSearchFn>
         return None;
     }
 
-    let index = edda_search_fts::schema::ensure_index(&index_dir).ok()?;
+    let index = edda_search_fts::schema::open_index(&index_dir)?;
     let pid = project_id.clone();
 
     Some(Box::new(move |query: &str, limit: usize| {

--- a/crates/edda-cli/src/cmd_search.rs
+++ b/crates/edda-cli/src/cmd_search.rs
@@ -20,7 +20,8 @@ pub enum SearchCmd {
     },
     /// Search for events and transcript turns
     Query {
-        /// Search query (supports fuzzy, "exact", /regex/)
+        /// Search query (fuzzy for ASCII; "exact"; /regex/ over indexed terms —
+        /// note: regex matches tokenized terms, so CJK regex only spans 2 chars)
         query: String,
         /// Project ID (defaults to current repo)
         #[arg(long)]
@@ -171,10 +172,17 @@ pub fn index(repo_root: &Path, project_id: &str, session_id: Option<&str>) -> an
     let index_dir = proj_dir.join("search").join("tantivy");
     let meta_db_path = proj_dir.join("search").join("meta.sqlite");
 
-    // GH-402: a schema upgrade forces a from-scratch rebuild of BOTH the
-    // tantivy index and the turns watermark, so nothing is left half-tokenized.
-    let rebuilding = schema::index_is_outdated(&index_dir);
-    if rebuilding {
+    // Serialize index operations so two concurrent `edda search index` runs
+    // can't wipe/rebuild the same tantivy dir at once (GH-402).
+    let ledger = Ledger::open(repo_root)?;
+    let _lock = edda_ledger::lock::WorkspaceLock::acquire(&ledger.paths)?;
+
+    // GH-402: a schema upgrade wipes the tantivy dir so it gets recreated
+    // fresh. `open_or_create_index` reports fresh creation for ALL cases (this
+    // wipe, a corrupt index, a never-existed dir, or a crash mid-wipe), which
+    // is what drives the watermark clear + full reindex below — so a crash
+    // between wipe and recreate can't leave stale turns_meta hiding turns.
+    if schema::index_is_outdated(&index_dir) {
         let old = schema::read_index_version(&index_dir)
             .map(|v| v.to_string())
             .unwrap_or_else(|| "1".to_string());
@@ -182,35 +190,31 @@ pub fn index(repo_root: &Path, project_id: &str, session_id: Option<&str>) -> an
             "Search index schema outdated (v{old} → v{}); rebuilding from scratch.",
             schema::INDEX_VERSION
         );
-        // Propagate removal errors: a locked index dir must fail loudly rather
-        // than silently rebuild against stale metadata.
-        if index_dir.exists() {
-            std::fs::remove_dir_all(&index_dir)?;
-        }
+        std::fs::remove_dir_all(&index_dir)?;
     }
 
-    let index = schema::ensure_index(&index_dir)?;
+    let (index, created_fresh) = schema::open_or_create_index(&index_dir)?;
     let tantivy_schema = index.schema();
     let mut writer = schema::index_writer(&index)?;
 
     let meta_conn = schema::ensure_meta_db(&meta_db_path)?;
-    // Clear the watermark via SQL (not file deletion) so a locked/leftover
-    // meta.sqlite can't make index_session skip every turn during a rebuild.
-    if rebuilding {
+    // Whenever the tantivy index is fresh/empty, clear the watermark via SQL
+    // (not file deletion — a locked meta.sqlite would survive) so every turn
+    // re-indexes instead of being skipped as "already indexed".
+    if created_fresh {
         meta_conn.execute_batch("DELETE FROM turns_meta; DELETE FROM index_watermark;")?;
     }
 
     // Index ledger events (index_events always deletes + re-adds all events).
-    let ledger = Ledger::open(repo_root)?;
     let event_count = indexer::index_events(&writer, &tantivy_schema, project_id, || {
         ledger.iter_events()
     })?;
 
-    // Index transcript turns. A schema rebuild must cover ALL sessions even if
-    // a single --session was requested, otherwise other sessions vanish behind
+    // Index transcript turns. A fresh index must cover ALL sessions even if a
+    // single --session was requested, otherwise other sessions vanish behind
     // the fresh version marker.
     let turn_count = match session_id {
-        Some(sid) if !rebuilding => indexer::index_session(
+        Some(sid) if !created_fresh => indexer::index_session(
             &writer,
             &tantivy_schema,
             &meta_conn,

--- a/crates/edda-cli/src/cmd_search.rs
+++ b/crates/edda-cli/src/cmd_search.rs
@@ -117,7 +117,11 @@ pub fn query(
         return Ok(());
     }
 
-    let index = schema::ensure_index(&index_dir)?;
+    // Read-only open: answering a query must never wipe/recreate the index.
+    let Some(index) = schema::open_index(&index_dir) else {
+        eprintln!("Search index could not be opened. Run `edda search index` to rebuild.");
+        return Ok(());
+    };
     let opts = search::SearchOptions {
         project_id: Some(project_id),
         session_id,
@@ -173,9 +177,10 @@ pub fn index(repo_root: &Path, project_id: &str, session_id: Option<&str>) -> an
     let meta_db_path = proj_dir.join("search").join("meta.sqlite");
 
     // Serialize index operations so two concurrent `edda search index` runs
-    // can't wipe/rebuild the same tantivy dir at once (GH-402).
+    // can't wipe/rebuild the same tantivy dir at once (GH-402). Keyed by the
+    // index location, so it holds even across working directories / --project.
+    let _lock = schema::IndexLock::acquire(&proj_dir.join("search"))?;
     let ledger = Ledger::open(repo_root)?;
-    let _lock = edda_ledger::lock::WorkspaceLock::acquire(&ledger.paths)?;
 
     // GH-402: a schema upgrade wipes the tantivy dir so it gets recreated
     // fresh. `open_or_create_index` reports fresh creation for ALL cases (this

--- a/crates/edda-cli/src/cmd_search.rs
+++ b/crates/edda-cli/src/cmd_search.rs
@@ -106,6 +106,15 @@ pub fn query(
         eprintln!("No search index found. Run `edda search index` first.");
         return Ok(());
     }
+    // GH-402: refuse to serve an index built with an older tokenizer — its
+    // results would silently miss CJK matches. Tell the user to rebuild.
+    if schema::index_is_outdated(&index_dir) {
+        eprintln!(
+            "Search index is from an older schema (CJK tokenization changed). \
+             Run `edda search index` to rebuild."
+        );
+        return Ok(());
+    }
 
     let index = schema::ensure_index(&index_dir)?;
     let opts = search::SearchOptions {
@@ -160,6 +169,23 @@ pub fn index(repo_root: &Path, project_id: &str, session_id: Option<&str>) -> an
     }
 
     let index_dir = proj_dir.join("search").join("tantivy");
+    let meta_db_path = proj_dir.join("search").join("meta.sqlite");
+
+    // GH-402: on a schema upgrade, wipe BOTH the tantivy index and the turns
+    // watermark (meta.sqlite) so every event and turn is re-tokenized. Leaving
+    // the watermark would skip already-indexed turns and mix old/new tokens.
+    if schema::index_is_outdated(&index_dir) {
+        let old = schema::read_index_version(&index_dir)
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "1".to_string());
+        println!(
+            "Search index schema outdated (v{old} → v{}); rebuilding from scratch.",
+            schema::INDEX_VERSION
+        );
+        let _ = std::fs::remove_dir_all(&index_dir);
+        let _ = std::fs::remove_file(&meta_db_path);
+    }
+
     let index = schema::ensure_index(&index_dir)?;
     let tantivy_schema = index.schema();
     let mut writer = schema::index_writer(&index)?;

--- a/crates/edda-cli/src/cmd_search.rs
+++ b/crates/edda-cli/src/cmd_search.rs
@@ -171,10 +171,10 @@ pub fn index(repo_root: &Path, project_id: &str, session_id: Option<&str>) -> an
     let index_dir = proj_dir.join("search").join("tantivy");
     let meta_db_path = proj_dir.join("search").join("meta.sqlite");
 
-    // GH-402: on a schema upgrade, wipe BOTH the tantivy index and the turns
-    // watermark (meta.sqlite) so every event and turn is re-tokenized. Leaving
-    // the watermark would skip already-indexed turns and mix old/new tokens.
-    if schema::index_is_outdated(&index_dir) {
+    // GH-402: a schema upgrade forces a from-scratch rebuild of BOTH the
+    // tantivy index and the turns watermark, so nothing is left half-tokenized.
+    let rebuilding = schema::index_is_outdated(&index_dir);
+    if rebuilding {
         let old = schema::read_index_version(&index_dir)
             .map(|v| v.to_string())
             .unwrap_or_else(|| "1".to_string());
@@ -182,37 +182,49 @@ pub fn index(repo_root: &Path, project_id: &str, session_id: Option<&str>) -> an
             "Search index schema outdated (v{old} → v{}); rebuilding from scratch.",
             schema::INDEX_VERSION
         );
-        let _ = std::fs::remove_dir_all(&index_dir);
-        let _ = std::fs::remove_file(&meta_db_path);
+        // Propagate removal errors: a locked index dir must fail loudly rather
+        // than silently rebuild against stale metadata.
+        if index_dir.exists() {
+            std::fs::remove_dir_all(&index_dir)?;
+        }
     }
 
     let index = schema::ensure_index(&index_dir)?;
     let tantivy_schema = index.schema();
     let mut writer = schema::index_writer(&index)?;
 
-    // Index ledger events
+    let meta_conn = schema::ensure_meta_db(&meta_db_path)?;
+    // Clear the watermark via SQL (not file deletion) so a locked/leftover
+    // meta.sqlite can't make index_session skip every turn during a rebuild.
+    if rebuilding {
+        meta_conn.execute_batch("DELETE FROM turns_meta; DELETE FROM index_watermark;")?;
+    }
+
+    // Index ledger events (index_events always deletes + re-adds all events).
     let ledger = Ledger::open(repo_root)?;
     let event_count = indexer::index_events(&writer, &tantivy_schema, project_id, || {
         ledger.iter_events()
     })?;
 
-    // Index transcript turns
-    let meta_db_path = proj_dir.join("search").join("meta.sqlite");
-    let meta_conn = schema::ensure_meta_db(&meta_db_path)?;
-    let turn_count = if let Some(sid) = session_id {
-        indexer::index_session(
+    // Index transcript turns. A schema rebuild must cover ALL sessions even if
+    // a single --session was requested, otherwise other sessions vanish behind
+    // the fresh version marker.
+    let turn_count = match session_id {
+        Some(sid) if !rebuilding => indexer::index_session(
             &writer,
             &tantivy_schema,
             &meta_conn,
             &proj_dir,
             project_id,
             sid,
-        )?
-    } else {
-        indexer::index_project(&writer, &tantivy_schema, &meta_conn, &proj_dir, project_id)?
+        )?,
+        _ => indexer::index_project(&writer, &tantivy_schema, &meta_conn, &proj_dir, project_id)?,
     };
 
     writer.commit()?;
+    // Mark the schema version only AFTER a successful full commit, so a crash
+    // mid-rebuild leaves no marker and the next run rebuilds again.
+    schema::write_index_version(&index_dir)?;
 
     println!("Indexed {event_count} event(s) + {turn_count} turn(s) for project {project_id}");
     Ok(())

--- a/crates/edda-cli/src/cmd_search.rs
+++ b/crates/edda-cli/src/cmd_search.rs
@@ -207,7 +207,7 @@ pub fn index(repo_root: &Path, project_id: &str, session_id: Option<&str>) -> an
     // (not file deletion — a locked meta.sqlite would survive) so every turn
     // re-indexes instead of being skipped as "already indexed".
     if created_fresh {
-        meta_conn.execute_batch("DELETE FROM turns_meta; DELETE FROM index_watermark;")?;
+        schema::clear_index_watermark(&meta_conn)?;
     }
 
     // Index ledger events (index_events always deletes + re-adds all events).

--- a/crates/edda-search-fts/Cargo.toml
+++ b/crates/edda-search-fts/Cargo.toml
@@ -15,6 +15,7 @@ edda-index = { path = "../edda-index", version = "0.2.0" }
 edda-core = { path = "../edda-core", version = "0.2.0" }
 tantivy = { version = "0.25", default-features = false, features = ["mmap", "lz4-compression"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
+fs2 = "0.4"
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/edda-search-fts/src/lib.rs
+++ b/crates/edda-search-fts/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod indexer;
 pub mod schema;
 pub mod search;
+pub mod tokenizer;

--- a/crates/edda-search-fts/src/schema.rs
+++ b/crates/edda-search-fts/src/schema.rs
@@ -231,6 +231,15 @@ pub fn ensure_meta_db(db_path: &Path) -> anyhow::Result<Connection> {
     Ok(conn)
 }
 
+/// Clear the turns watermark and per-turn index metadata so a full rebuild
+/// re-indexes every turn instead of skipping ones marked "already indexed".
+/// Lives here (beside `ensure_meta_db`) so the meta-DB table names stay in one
+/// crate rather than being duplicated by callers (GH-402).
+pub fn clear_index_watermark(conn: &Connection) -> anyhow::Result<()> {
+    conn.execute_batch("DELETE FROM turns_meta; DELETE FROM index_watermark;")?;
+    Ok(())
+}
+
 /// Open an in-memory SQLite database with turns_meta schema (for testing).
 pub fn ensure_meta_db_memory() -> anyhow::Result<Connection> {
     let conn = Connection::open_in_memory()?;

--- a/crates/edda-search-fts/src/schema.rs
+++ b/crates/edda-search-fts/src/schema.rs
@@ -1,8 +1,38 @@
 use crate::tokenizer::{CjkBigramTokenizer, CJK_TOKENIZER};
+use fs2::FileExt;
 use rusqlite::Connection;
 use std::path::Path;
 use tantivy::schema::*;
 use tantivy::{Index, IndexWriter};
+
+/// Exclusive lock for a project's search index (GH-402), keyed by the index
+/// location itself — not the ledger — so two `edda search index` runs targeting
+/// the same `--project` serialize even from different working directories.
+/// Released on drop.
+pub struct IndexLock {
+    _file: std::fs::File,
+}
+
+impl IndexLock {
+    /// Acquire an exclusive, non-blocking lock on `<search_dir>/index.lock`.
+    pub fn acquire(search_dir: &Path) -> anyhow::Result<Self> {
+        std::fs::create_dir_all(search_dir)?;
+        let lock_path = search_dir.join("index.lock");
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&lock_path)?;
+        file.try_lock_exclusive().map_err(|_| {
+            anyhow::anyhow!(
+                "search index is being rebuilt by another process ({})",
+                lock_path.display()
+            )
+        })?;
+        Ok(Self { _file: file })
+    }
+}
 
 /// On-disk index schema version (GH-402). Bump whenever the tokenizer or field
 /// layout changes so a stale index is rebuilt rather than mixing tokenizations.
@@ -129,6 +159,23 @@ pub fn open_or_create_index(index_dir: &Path) -> anyhow::Result<(Index, bool)> {
 /// was freshly created). Use [`open_or_create_index`] on the write path.
 pub fn ensure_index(index_dir: &Path) -> anyhow::Result<Index> {
     Ok(open_or_create_index(index_dir)?.0)
+}
+
+/// Open an EXISTING index read-only, without creating or wiping it. Returns
+/// `None` if the directory is missing or the index cannot be opened (corrupt).
+/// Read paths (query, ask) use this so answering a query never deletes the
+/// index (GH-402).
+pub fn open_index(index_dir: &Path) -> Option<Index> {
+    if !index_dir.exists() {
+        return None;
+    }
+    match Index::open_in_dir(index_dir) {
+        Ok(index) => {
+            register_tokenizers(&index);
+            Some(index)
+        }
+        Err(_) => None,
+    }
 }
 
 /// Create an in-memory Tantivy index (for testing).

--- a/crates/edda-search-fts/src/schema.rs
+++ b/crates/edda-search-fts/src/schema.rs
@@ -36,7 +36,9 @@ pub fn index_is_outdated(index_dir: &Path) -> bool {
 /// opened or created index so both indexing and `QueryParser` tokenize
 /// symmetrically (GH-402).
 pub fn register_tokenizers(index: &Index) {
-    index.tokenizers().register(CJK_TOKENIZER, CjkBigramTokenizer);
+    index
+        .tokenizers()
+        .register(CJK_TOKENIZER, CjkBigramTokenizer);
 }
 
 /// Build the Tantivy schema used for all search documents.
@@ -112,7 +114,10 @@ pub fn ensure_index(index_dir: &Path) -> anyhow::Result<Index> {
     std::fs::create_dir_all(index_dir)?;
     let index = Index::create_in_dir(index_dir, schema)?;
     register_tokenizers(&index);
-    write_index_version(index_dir)?;
+    // NB: the version marker is written by the indexer only AFTER a full index
+    // commit succeeds (see cmd_search::index) — never here. A freshly-created
+    // but not-yet-populated index has no marker, so it reads as outdated until
+    // the rebuild completes, making a crashed rebuild self-healing.
     Ok(index)
 }
 

--- a/crates/edda-search-fts/src/schema.rs
+++ b/crates/edda-search-fts/src/schema.rs
@@ -95,18 +95,26 @@ pub fn build_schema() -> Schema {
     builder.build()
 }
 
-/// Open or create a Tantivy index at the given directory.
-pub fn ensure_index(index_dir: &Path) -> anyhow::Result<Index> {
+/// Open an existing index, or create a fresh one. Returns `(index,
+/// created_fresh)` where `created_fresh` is `true` whenever a NEW empty index
+/// was created — because the dir never existed, was corrupt (wiped here), or
+/// was removed by a caller for a schema rebuild (or a crash mid-wipe). The
+/// caller MUST then clear the turns watermark so turns re-index against the
+/// empty tantivy index; otherwise `turns_meta` would skip them.
+///
+/// The version marker is NOT written here: the indexer writes it only after a
+/// full commit succeeds (see `cmd_search::index`), so an interrupted rebuild
+/// leaves no marker and self-heals on the next run.
+pub fn open_or_create_index(index_dir: &Path) -> anyhow::Result<(Index, bool)> {
     let schema = build_schema();
     if index_dir.exists() {
-        // Try to open existing index
         match Index::open_in_dir(index_dir) {
             Ok(index) => {
                 register_tokenizers(&index);
-                return Ok(index);
+                return Ok((index, false));
             }
             Err(_) => {
-                // Corrupted or incompatible — rebuild
+                // Corrupted or incompatible — wipe and recreate.
                 std::fs::remove_dir_all(index_dir)?;
             }
         }
@@ -114,11 +122,13 @@ pub fn ensure_index(index_dir: &Path) -> anyhow::Result<Index> {
     std::fs::create_dir_all(index_dir)?;
     let index = Index::create_in_dir(index_dir, schema)?;
     register_tokenizers(&index);
-    // NB: the version marker is written by the indexer only AFTER a full index
-    // commit succeeds (see cmd_search::index) — never here. A freshly-created
-    // but not-yet-populated index has no marker, so it reads as outdated until
-    // the rebuild completes, making a crashed rebuild self-healing.
-    Ok(index)
+    Ok((index, true))
+}
+
+/// Open or create a Tantivy index at the given directory (ignoring whether it
+/// was freshly created). Use [`open_or_create_index`] on the write path.
+pub fn ensure_index(index_dir: &Path) -> anyhow::Result<Index> {
+    Ok(open_or_create_index(index_dir)?.0)
 }
 
 /// Create an in-memory Tantivy index (for testing).
@@ -272,6 +282,38 @@ mod tests {
             let searcher = reader.searcher();
             assert_eq!(searcher.num_docs(), 1);
         }
+    }
+
+    #[test]
+    fn version_marker_and_fresh_flag_transitions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let index_dir = tmp.path().join("tantivy");
+
+        // No directory yet → nothing to rebuild.
+        assert!(!index_is_outdated(&index_dir));
+
+        // First create reports fresh; with no marker it reads as outdated.
+        let (_i1, fresh1) = open_or_create_index(&index_dir).unwrap();
+        assert!(fresh1, "a newly created index is fresh");
+        assert!(read_index_version(&index_dir).is_none());
+        assert!(index_is_outdated(&index_dir), "no marker → outdated");
+
+        // Marking it current clears outdated.
+        write_index_version(&index_dir).unwrap();
+        assert_eq!(read_index_version(&index_dir), Some(INDEX_VERSION));
+        assert!(!index_is_outdated(&index_dir));
+
+        // Reopening an existing valid index is NOT fresh.
+        let (_i2, fresh2) = open_or_create_index(&index_dir).unwrap();
+        assert!(!fresh2, "reopening an existing index is not fresh");
+
+        // Simulate a crash mid-wipe: the dir vanishes but a caller retries.
+        std::fs::remove_dir_all(&index_dir).unwrap();
+        let (_i3, fresh3) = open_or_create_index(&index_dir).unwrap();
+        assert!(
+            fresh3,
+            "recreating after a wipe is fresh → caller re-indexes"
+        );
     }
 
     #[test]

--- a/crates/edda-search-fts/src/schema.rs
+++ b/crates/edda-search-fts/src/schema.rs
@@ -1,7 +1,43 @@
+use crate::tokenizer::{CjkBigramTokenizer, CJK_TOKENIZER};
 use rusqlite::Connection;
 use std::path::Path;
 use tantivy::schema::*;
 use tantivy::{Index, IndexWriter};
+
+/// On-disk index schema version (GH-402). Bump whenever the tokenizer or field
+/// layout changes so a stale index is rebuilt rather than mixing tokenizations.
+/// v2: CJK bigram tokenizer on all full-text fields.
+pub const INDEX_VERSION: u32 = 2;
+
+fn version_file(index_dir: &Path) -> std::path::PathBuf {
+    index_dir.join("edda_schema_version")
+}
+
+/// Read the schema version marker beside an index dir, or `None` if absent
+/// (pre-v2 indexes have no marker and are treated as outdated).
+pub fn read_index_version(index_dir: &Path) -> Option<u32> {
+    std::fs::read_to_string(version_file(index_dir))
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+}
+
+/// Write the current [`INDEX_VERSION`] marker beside an index dir.
+pub fn write_index_version(index_dir: &Path) -> anyhow::Result<()> {
+    std::fs::write(version_file(index_dir), INDEX_VERSION.to_string())?;
+    Ok(())
+}
+
+/// Whether the on-disk index needs a full rebuild for a schema upgrade.
+pub fn index_is_outdated(index_dir: &Path) -> bool {
+    index_dir.exists() && read_index_version(index_dir) != Some(INDEX_VERSION)
+}
+
+/// Register edda's custom tokenizers on an index. Must be called on every
+/// opened or created index so both indexing and `QueryParser` tokenize
+/// symmetrically (GH-402).
+pub fn register_tokenizers(index: &Index) {
+    index.tokenizers().register(CJK_TOKENIZER, CjkBigramTokenizer);
+}
 
 /// Build the Tantivy schema used for all search documents.
 ///
@@ -39,11 +75,20 @@ pub fn build_schema() -> Schema {
     // Stored-only field (not indexed)
     builder.add_text_field("ts", STORED);
 
-    // Full-text searchable fields
-    builder.add_text_field("title", TEXT | STORED);
-    builder.add_text_field("body", TEXT | STORED);
-    builder.add_text_field("tags", TEXT | STORED);
-    builder.add_text_field("tokens", TEXT);
+    // Full-text searchable fields — CJK bigram tokenizer (GH-402) with
+    // positions (needed for snippets/phrases).
+    let cjk_indexing = TextFieldIndexing::default()
+        .set_tokenizer(CJK_TOKENIZER)
+        .set_index_option(IndexRecordOption::WithFreqsAndPositions);
+    let cjk_stored = TextOptions::default()
+        .set_indexing_options(cjk_indexing.clone())
+        .set_stored();
+    let cjk_unstored = TextOptions::default().set_indexing_options(cjk_indexing);
+
+    builder.add_text_field("title", cjk_stored.clone());
+    builder.add_text_field("body", cjk_stored.clone());
+    builder.add_text_field("tags", cjk_stored);
+    builder.add_text_field("tokens", cjk_unstored);
 
     builder.build()
 }
@@ -54,7 +99,10 @@ pub fn ensure_index(index_dir: &Path) -> anyhow::Result<Index> {
     if index_dir.exists() {
         // Try to open existing index
         match Index::open_in_dir(index_dir) {
-            Ok(index) => return Ok(index),
+            Ok(index) => {
+                register_tokenizers(&index);
+                return Ok(index);
+            }
             Err(_) => {
                 // Corrupted or incompatible — rebuild
                 std::fs::remove_dir_all(index_dir)?;
@@ -63,6 +111,8 @@ pub fn ensure_index(index_dir: &Path) -> anyhow::Result<Index> {
     }
     std::fs::create_dir_all(index_dir)?;
     let index = Index::create_in_dir(index_dir, schema)?;
+    register_tokenizers(&index);
+    write_index_version(index_dir)?;
     Ok(index)
 }
 
@@ -70,6 +120,7 @@ pub fn ensure_index(index_dir: &Path) -> anyhow::Result<Index> {
 pub fn ensure_index_ram() -> anyhow::Result<Index> {
     let schema = build_schema();
     let index = Index::create_in_ram(schema);
+    register_tokenizers(&index);
     Ok(index)
 }
 

--- a/crates/edda-search-fts/src/search.rs
+++ b/crates/edda-search-fts/src/search.rs
@@ -66,11 +66,13 @@ pub fn search(
             let mut parser = QueryParser::for_index(index, vec![f_title, f_body]);
             parser.set_field_boost(f_title, 5.0);
             parser.set_field_boost(f_body, 1.0);
-            // GH-402: skip fuzzy for CJK queries. The CJK tokenizer emits
-            // 2-char bigrams, and Levenshtein-1 over those matches a flood of
-            // unrelated bigrams (權威 ~ 權力). Bigrams already give exact-substring
-            // recall, so fuzzy adds only noise. Keep fuzzy for ASCII typos.
-            if !options.exact && !crate::tokenizer::contains_cjk(query_str) {
+            // GH-402: enable fuzzy only when the query has ASCII to correct.
+            // Levenshtein-1 over 2-char CJK bigrams matches a flood of unrelated
+            // bigrams (權威 ~ 權力), and bigrams already give exact-substring
+            // recall — so pure-CJK queries skip fuzzy, while a mixed query like
+            // "postgre 中文" keeps ASCII typo tolerance.
+            let has_ascii_alnum = query_str.chars().any(|c| c.is_ascii_alphanumeric());
+            if !options.exact && has_ascii_alnum {
                 parser.set_field_fuzzy(f_title, true, 1, true);
                 parser.set_field_fuzzy(f_body, true, 1, true);
             }

--- a/crates/edda-search-fts/src/search.rs
+++ b/crates/edda-search-fts/src/search.rs
@@ -66,15 +66,23 @@ pub fn search(
             let mut parser = QueryParser::for_index(index, vec![f_title, f_body]);
             parser.set_field_boost(f_title, 5.0);
             parser.set_field_boost(f_body, 1.0);
+            let has_ascii_alnum = query_str.chars().any(|c| c.is_ascii_alphanumeric());
             // GH-402: enable fuzzy only when the query has ASCII to correct.
             // Levenshtein-1 over 2-char CJK bigrams matches a flood of unrelated
             // bigrams (權威 ~ 權力), and bigrams already give exact-substring
             // recall — so pure-CJK queries skip fuzzy, while a mixed query like
             // "postgre 中文" keeps ASCII typo tolerance.
-            let has_ascii_alnum = query_str.chars().any(|c| c.is_ascii_alphanumeric());
             if !options.exact && has_ascii_alnum {
                 parser.set_field_fuzzy(f_title, true, 1, true);
                 parser.set_field_fuzzy(f_body, true, 1, true);
+            }
+            // GH-402: a pure-CJK query defaults to AND over its bigrams, so a
+            // long phrase requires all of them (權威事實 → 權威 AND 威事 AND
+            // 事實) instead of matching any doc that shares just one — this keeps
+            // the exact-substring hit from being outranked and pushed past the
+            // result limit by title-boosted partial matches. English keeps OR.
+            if !has_ascii_alnum {
+                parser.set_conjunction_by_default();
             }
             parser.parse_query(query_str)?
         };
@@ -454,6 +462,30 @@ mod tests {
         insert_cjk_doc(&index);
         let results = search(&index, "洗成權威事實", &SearchOptions::default(), 10).unwrap();
         assert!(!results.is_empty(), "6-char CJK substring must be findable");
+    }
+
+    #[test]
+    fn pure_cjk_query_requires_all_bigrams() {
+        // GH-402 precision: a pure-CJK phrase ANDs its bigrams, so a document
+        // that shares only one bigram must NOT match — only the full phrase does.
+        let index = ensure_index_ram().unwrap();
+        let schema = index.schema();
+        let mut writer = index_writer(&index).unwrap();
+        let f_doc_type = schema.get_field("doc_type").unwrap();
+        let f_doc_id = schema.get_field("doc_id").unwrap();
+        let f_body = schema.get_field("body").unwrap();
+        writer
+            .add_document(doc!(f_doc_type => "event", f_doc_id => "full", f_body => "洗成權威事實"))
+            .unwrap();
+        // Shares only the 權威 bigram, not 威事 / 事實.
+        writer
+            .add_document(doc!(f_doc_type => "event", f_doc_id => "partial", f_body => "權威掃地"))
+            .unwrap();
+        writer.commit().unwrap();
+
+        let results = search(&index, "權威事實", &SearchOptions::default(), 10).unwrap();
+        assert_eq!(results.len(), 1, "only the full-phrase doc should match");
+        assert_eq!(results[0].doc_id, "full");
     }
 
     #[test]

--- a/crates/edda-search-fts/src/search.rs
+++ b/crates/edda-search-fts/src/search.rs
@@ -32,8 +32,12 @@ pub struct SearchOptions<'a> {
 ///
 /// Supports:
 /// - Fuzzy text search (default): tolerates typos with Levenshtein distance 1
+///   for ASCII; skipped for pure-CJK queries (bigram fuzzing is noise)
 /// - Exact match: `options.exact = true` disables fuzzy
-/// - Regex: query wrapped in `/pattern/` uses RegexQuery on body field
+/// - Regex: query wrapped in `/pattern/` uses RegexQuery on body terms
+///   (tokenized — so a multi-char CJK regex pattern won't match)
+/// - CJK (GH-402): a pure-CJK query ANDs its bigrams, so it finds the phrase
+///   even inside a longer run; CJK *alternatives* need an explicit `OR`
 /// - Field boosting: title matches ranked 5x higher than body
 /// - Filtering by doc_type, event_type, project_id, session_id
 pub fn search(

--- a/crates/edda-search-fts/src/search.rs
+++ b/crates/edda-search-fts/src/search.rs
@@ -66,7 +66,11 @@ pub fn search(
             let mut parser = QueryParser::for_index(index, vec![f_title, f_body]);
             parser.set_field_boost(f_title, 5.0);
             parser.set_field_boost(f_body, 1.0);
-            if !options.exact {
+            // GH-402: skip fuzzy for CJK queries. The CJK tokenizer emits
+            // 2-char bigrams, and Levenshtein-1 over those matches a flood of
+            // unrelated bigrams (權威 ~ 權力). Bigrams already give exact-substring
+            // recall, so fuzzy adds only noise. Keep fuzzy for ASCII typos.
+            if !options.exact && !crate::tokenizer::contains_cjk(query_str) {
                 parser.set_field_fuzzy(f_title, true, 1, true);
                 parser.set_field_fuzzy(f_body, true, 1, true);
             }
@@ -407,6 +411,87 @@ mod tests {
             results.is_empty(),
             "exact mode should not use fuzzy matching"
         );
+    }
+
+    /// Insert one doc whose body contains a long contiguous CJK run.
+    fn insert_cjk_doc(index: &Index) {
+        let schema = index.schema();
+        let mut writer = index_writer(index).unwrap();
+        let f_doc_type = schema.get_field("doc_type").unwrap();
+        let f_doc_id = schema.get_field("doc_id").unwrap();
+        let f_body = schema.get_field("body").unwrap();
+        writer
+            .add_document(doc!(
+                f_doc_type => "event",
+                f_doc_id => "evt_cjk",
+                // "…projection launders machine inference into authoritative fact"
+                f_body => "外部評論指出投影把機器推論洗成權威事實",
+            ))
+            .unwrap();
+        writer.commit().unwrap();
+    }
+
+    #[test]
+    fn search_finds_cjk_substring_inside_longer_run() {
+        // GH-402: 權威事實 exists only INSIDE 把機器推論洗成權威事實 — with the
+        // default tokenizer the whole run is one token, so this returns 0.
+        let index = ensure_index_ram().unwrap();
+        insert_cjk_doc(&index);
+
+        let results = search(&index, "權威事實", &SearchOptions::default(), 10).unwrap();
+        assert!(
+            !results.is_empty(),
+            "a CJK phrase inside a longer run must be findable"
+        );
+        assert_eq!(results[0].doc_id, "evt_cjk");
+    }
+
+    #[test]
+    fn search_finds_cjk_six_char_substring() {
+        let index = ensure_index_ram().unwrap();
+        insert_cjk_doc(&index);
+        let results = search(&index, "洗成權威事實", &SearchOptions::default(), 10).unwrap();
+        assert!(!results.is_empty(), "6-char CJK substring must be findable");
+    }
+
+    #[test]
+    fn cjk_acceptance_table() {
+        // Mirrors the GH-402 evidence table: one doc holding a long CJK run,
+        // punctuation-delimited CJK words, an ASCII identifier, and English.
+        let index = ensure_index_ram().unwrap();
+        let schema = index.schema();
+        let mut writer = index_writer(&index).unwrap();
+        let f_doc_type = schema.get_field("doc_type").unwrap();
+        let f_doc_id = schema.get_field("doc_id").unwrap();
+        let f_title = schema.get_field("title").unwrap();
+        let f_body = schema.get_field("body").unwrap();
+        writer
+            .add_document(doc!(
+                f_doc_type => "event",
+                f_doc_id => "d1",
+                f_title => "watermark",
+                f_body => "外部評論指出投影把機器推論洗成權威事實。收據 (驗收) task rail ENV_LOCK",
+            ))
+            .unwrap();
+        writer.commit().unwrap();
+
+        let hit = |q: &str| {
+            !search(&index, q, &SearchOptions::default(), 10)
+                .unwrap()
+                .is_empty()
+        };
+        // English keeps working
+        assert!(hit("watermark"), "EN word");
+        assert!(hit("task rail"), "EN two terms");
+        // 2-char CJK (previously worked by luck)
+        assert!(hit("收據"), "2-char CJK");
+        assert!(hit("驗收"), "2-char CJK");
+        // >2-char CJK that only exists inside a longer run (the bug)
+        assert!(hit("權威事實"), "4-char inside run");
+        assert!(hit("機器推論"), "4-char inside run");
+        assert!(hit("洗成權威事實"), "6-char inside run");
+        // Mixed-script ASCII identifier stays matchable
+        assert!(hit("ENV_LOCK"), "ASCII identifier");
     }
 
     #[test]

--- a/crates/edda-search-fts/src/tokenizer.rs
+++ b/crates/edda-search-fts/src/tokenizer.rs
@@ -66,13 +66,16 @@ fn is_cjk(c: char) -> bool {
         | 0x31F0..=0x31FF      // Katakana Phonetic Extensions
         | 0x3400..=0x4DBF      // CJK Unified Ideographs Extension A
         | 0x4E00..=0x9FFF      // CJK Unified Ideographs
+        | 0xA960..=0xA97F      // Hangul Jamo Extended-A
         | 0xAC00..=0xD7AF      // Hangul Syllables
         | 0x1100..=0x11FF      // Hangul Jamo
+        | 0xD7B0..=0xD7FF      // Hangul Jamo Extended-B
         | 0xF900..=0xFAFF      // CJK Compatibility Ideographs
         | 0xFF65..=0xFF9F      // Halfwidth Katakana
         | 0x2_0000..=0x2_A6DF  // CJK Unified Ideographs Extension B
-        | 0x2_A700..=0x2_EBEF  // CJK Unified Ideographs Extensions C–F
+        | 0x2_A700..=0x2_EE5F  // CJK Unified Ideographs Extensions C–I
         | 0x2_F800..=0x2_FA1F  // CJK Compatibility Ideographs Supplement
+        | 0x3_0000..=0x3_23AF  // CJK Unified Ideographs Extensions G–H
     )
 }
 

--- a/crates/edda-search-fts/src/tokenizer.rs
+++ b/crates/edda-search-fts/src/tokenizer.rs
@@ -63,6 +63,7 @@ fn is_cjk(c: char) -> bool {
         0x2E80..=0x2EFF        // CJK Radicals Supplement
         | 0x2F00..=0x2FDF      // Kangxi Radicals
         | 0x3040..=0x30FF      // Hiragana + Katakana
+        | 0x3130..=0x318F      // Hangul Compatibility Jamo
         | 0x31F0..=0x31FF      // Katakana Phonetic Extensions
         | 0x3400..=0x4DBF      // CJK Unified Ideographs Extension A
         | 0x4E00..=0x9FFF      // CJK Unified Ideographs

--- a/crates/edda-search-fts/src/tokenizer.rs
+++ b/crates/edda-search-fts/src/tokenizer.rs
@@ -56,23 +56,24 @@ impl Tokenizer for CjkBigramTokenizer {
     }
 }
 
-/// Characters treated as CJK (ideographs, kana, hangul).
+/// Characters treated as CJK (ideographs, kana, hangul). Deliberately excludes
+/// CJK symbols/punctuation (U+3000–303F) so those act as run separators.
 fn is_cjk(c: char) -> bool {
     matches!(c as u32,
-        0x3400..=0x4DBF        // CJK Unified Ideographs Extension A
-        | 0x4E00..=0x9FFF      // CJK Unified Ideographs
-        | 0xF900..=0xFAFF      // CJK Compatibility Ideographs
+        0x2E80..=0x2EFF        // CJK Radicals Supplement
+        | 0x2F00..=0x2FDF      // Kangxi Radicals
         | 0x3040..=0x30FF      // Hiragana + Katakana
+        | 0x31F0..=0x31FF      // Katakana Phonetic Extensions
+        | 0x3400..=0x4DBF      // CJK Unified Ideographs Extension A
+        | 0x4E00..=0x9FFF      // CJK Unified Ideographs
         | 0xAC00..=0xD7AF      // Hangul Syllables
+        | 0x1100..=0x11FF      // Hangul Jamo
+        | 0xF900..=0xFAFF      // CJK Compatibility Ideographs
+        | 0xFF65..=0xFF9F      // Halfwidth Katakana
         | 0x2_0000..=0x2_A6DF  // CJK Unified Ideographs Extension B
+        | 0x2_A700..=0x2_EBEF  // CJK Unified Ideographs Extensions C–F
+        | 0x2_F800..=0x2_FA1F  // CJK Compatibility Ideographs Supplement
     )
-}
-
-/// Whether `text` contains any CJK character. Used by the query path to skip
-/// fuzzy matching for CJK queries (Levenshtein-1 on 2-char bigrams matches far
-/// too many unrelated bigrams to be useful).
-pub fn contains_cjk(text: &str) -> bool {
-    text.chars().any(is_cjk)
 }
 
 fn mk(offset_from: usize, offset_to: usize, position: usize, text: String) -> Token {

--- a/crates/edda-search-fts/src/tokenizer.rs
+++ b/crates/edda-search-fts/src/tokenizer.rs
@@ -1,0 +1,212 @@
+//! CJK-aware bigram tokenizer (GH-402).
+//!
+//! Tantivy's default tokenizer emits a contiguous CJK run as a **single**
+//! token, so any query that only appears inside a longer run silently returns
+//! nothing — fatal for a majority-Chinese corpus. This tokenizer instead emits
+//! overlapping character **bigrams** for CJK runs (`把機器` → `把機`, `機器`)
+//! while tokenizing ASCII/Latin runs as lowercased words and dropping
+//! punctuation/whitespace.
+//!
+//! Registered on the index (see `schema::register_tokenizers`), it is applied
+//! symmetrically at index time and — because `QueryParser::for_index` reuses
+//! the field's tokenizer — at query time. So `權威事實` tokenizes to
+//! `[權威, 威事, 事實]`, every one of which is present in a document containing
+//! `…洗成權威事實`, making the phrase reachable.
+
+use tantivy::tokenizer::{Token, TokenStream, Tokenizer};
+
+/// Name under which this tokenizer is registered on the index.
+pub const CJK_TOKENIZER: &str = "cjk";
+
+#[derive(Clone, Default)]
+pub struct CjkBigramTokenizer;
+
+/// A token stream backed by a pre-computed token vector.
+pub struct PrecomputedTokenStream {
+    tokens: Vec<Token>,
+    cursor: usize,
+}
+
+impl TokenStream for PrecomputedTokenStream {
+    fn advance(&mut self) -> bool {
+        if self.cursor >= self.tokens.len() {
+            return false;
+        }
+        self.cursor += 1;
+        true
+    }
+
+    fn token(&self) -> &Token {
+        &self.tokens[self.cursor - 1]
+    }
+
+    fn token_mut(&mut self) -> &mut Token {
+        &mut self.tokens[self.cursor - 1]
+    }
+}
+
+impl Tokenizer for CjkBigramTokenizer {
+    type TokenStream<'a> = PrecomputedTokenStream;
+
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> PrecomputedTokenStream {
+        PrecomputedTokenStream {
+            tokens: tokenize(text),
+            cursor: 0,
+        }
+    }
+}
+
+/// Characters treated as CJK (ideographs, kana, hangul).
+fn is_cjk(c: char) -> bool {
+    matches!(c as u32,
+        0x3400..=0x4DBF        // CJK Unified Ideographs Extension A
+        | 0x4E00..=0x9FFF      // CJK Unified Ideographs
+        | 0xF900..=0xFAFF      // CJK Compatibility Ideographs
+        | 0x3040..=0x30FF      // Hiragana + Katakana
+        | 0xAC00..=0xD7AF      // Hangul Syllables
+        | 0x2_0000..=0x2_A6DF  // CJK Unified Ideographs Extension B
+    )
+}
+
+/// Whether `text` contains any CJK character. Used by the query path to skip
+/// fuzzy matching for CJK queries (Levenshtein-1 on 2-char bigrams matches far
+/// too many unrelated bigrams to be useful).
+pub fn contains_cjk(text: &str) -> bool {
+    text.chars().any(is_cjk)
+}
+
+fn mk(offset_from: usize, offset_to: usize, position: usize, text: String) -> Token {
+    Token {
+        offset_from,
+        offset_to,
+        position,
+        text,
+        position_length: 1,
+    }
+}
+
+fn tokenize(text: &str) -> Vec<Token> {
+    let chars: Vec<(usize, char)> = text.char_indices().collect();
+    let mut tokens = Vec::new();
+    let mut pos = 0usize;
+    let mut i = 0usize;
+
+    while i < chars.len() {
+        let (byte_start, c) = chars[i];
+        if is_cjk(c) {
+            // Extent of the contiguous CJK run.
+            let mut j = i;
+            while j < chars.len() && is_cjk(chars[j].1) {
+                j += 1;
+            }
+            if j - i == 1 {
+                // A lone CJK character is emitted by itself.
+                let end = byte_start + c.len_utf8();
+                tokens.push(mk(byte_start, end, pos, c.to_string()));
+                pos += 1;
+            } else {
+                // Overlapping bigrams across the run.
+                for k in i..j - 1 {
+                    let (bs, c0) = chars[k];
+                    let c1 = chars[k + 1].1;
+                    let end = chars[k + 1].0 + c1.len_utf8();
+                    let mut s = String::with_capacity(c0.len_utf8() + c1.len_utf8());
+                    s.push(c0);
+                    s.push(c1);
+                    tokens.push(mk(bs, end, pos, s));
+                    pos += 1;
+                }
+            }
+            i = j;
+        } else if c.is_alphanumeric() {
+            // ASCII/Latin/digit run (non-CJK alphanumerics), lowercased.
+            let mut j = i;
+            while j < chars.len() && chars[j].1.is_alphanumeric() && !is_cjk(chars[j].1) {
+                j += 1;
+            }
+            let last = chars[j - 1].1;
+            let end = chars[j - 1].0 + last.len_utf8();
+            let word: String = chars[i..j]
+                .iter()
+                .flat_map(|(_, ch)| ch.to_lowercase())
+                .collect();
+            tokens.push(mk(byte_start, end, pos, word));
+            pos += 1;
+            i = j;
+        } else {
+            // Separator: whitespace or punctuation.
+            i += 1;
+        }
+    }
+    tokens
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn toks(s: &str) -> Vec<String> {
+        let mut t = CjkBigramTokenizer;
+        let mut stream = t.token_stream(s);
+        let mut out = Vec::new();
+        while stream.advance() {
+            out.push(stream.token().text.clone());
+        }
+        out
+    }
+
+    #[test]
+    fn cjk_run_emits_overlapping_bigrams() {
+        assert_eq!(toks("權威事實"), vec!["權威", "威事", "事實"]);
+    }
+
+    #[test]
+    fn two_char_cjk_is_single_bigram() {
+        assert_eq!(toks("收據"), vec!["收據"]);
+    }
+
+    #[test]
+    fn lone_cjk_char_emitted_alone() {
+        assert_eq!(toks("我"), vec!["我"]);
+    }
+
+    #[test]
+    fn six_char_run_bigrams() {
+        assert_eq!(
+            toks("洗成權威事實"),
+            vec!["洗成", "成權", "權威", "威事", "事實"]
+        );
+    }
+
+    #[test]
+    fn ascii_identifier_splits_and_lowercases() {
+        assert_eq!(toks("ENV_LOCK"), vec!["env", "lock"]);
+        assert_eq!(toks("task_nudge.rs"), vec!["task", "nudge", "rs"]);
+    }
+
+    #[test]
+    fn mixed_script_keeps_both() {
+        // CJK run bigrammed, ASCII word kept whole and lowercased.
+        assert_eq!(toks("洗成Fact"), vec!["洗成", "fact"]);
+        assert_eq!(toks("task rail 收據"), vec!["task", "rail", "收據"]);
+    }
+
+    #[test]
+    fn punctuation_separates_cjk_runs() {
+        // A comma between runs stops bigrams from spanning it.
+        assert_eq!(toks("收據,驗收"), vec!["收據", "驗收"]);
+    }
+
+    #[test]
+    fn byte_offsets_are_valid_utf8_boundaries() {
+        let text = "洗成權威";
+        let mut t = CjkBigramTokenizer;
+        let mut stream = t.token_stream(text);
+        while stream.advance() {
+            let tok = stream.token();
+            // Slicing at the reported offsets must not panic (valid boundaries).
+            let slice = &text[tok.offset_from..tok.offset_to];
+            assert_eq!(slice, tok.text);
+        }
+    }
+}


### PR DESCRIPTION
Closes #402. A P0: `edda search` silently returned **zero** for CJK queries longer than ~2 characters, because tantivy's default tokenizer emits a contiguous CJK run as a single token — so any phrase that only appears *inside* a longer run was unreachable. On a majority-Chinese corpus, "No results" read as "never discussed," and recall failed.

## The fix: a CJK bigram tokenizer

- **`crates/edda-search-fts/src/tokenizer.rs`** (new): `CjkBigramTokenizer` — overlapping 2-grams for CJK runs (`把機器` → `把機`, `機器`), lowercased ASCII/Latin words, punctuation as separators. Registered on every index (`register_tokenizers`), so index-time and query-time (`QueryParser::for_index`) tokenize **symmetrically** — the asymmetry was the killer, not the segmenter choice. `權威事實` → `[權威, 威事, 事實]`, all present in a doc containing `…洗成權威事實`.
- **Precision**: a pure-CJK query defaults to **AND** over its bigrams, so a phrase requires all of them and isn't outranked by title-boosted partial matches. English keeps OR.
- **Fuzzy**: skipped for pure-CJK (Levenshtein-1 on 2-char bigrams is noise; bigrams already give exact recall); kept when the query has ASCII to correct.
- **Schema version → v2**: `edda search index` detects an outdated index and rebuilds tantivy + the turns watermark from scratch (announced); `edda search query` / `edda ask` refuse a stale index and hint the rebuild — old and new tokenizations never mix. Rebuild is crash-safe (marker written only after commit; a fresh/empty index always clears the watermark) and holds an index-keyed lock so concurrent indexers can't race.

## Acceptance — live-verified on the fleet corpus (2211 events + 1232 turns)

| query | before | after |
|---|---|---|
| `權威事實` (4-char, inside a run) | **0** | 1 ✓ |
| `機器推論` (4-char, inside a run) | **0** | 1 ✓ |
| `洗成權威事實` (6-char, inside a run) | **0** | 1 ✓ |
| `收據` (2-char) | 20 | 20 ✓ |
| `watermark` / `task rail` (English) | 5 / 20 | 5 / 20 ✓ |

Each previously-broken query now finds the exact decision that contains it verbatim (the match is even snippet-highlighted). English and 2-char CJK are unchanged.

## Review

House TDD (failing tokenizer/search tests first), then **four rounds of fresh-context adversarial review** (Codex), which hardened the rebuild path against crash-mid-wipe, concurrent-indexer races, corrupt-index-wipe-on-read, and CJK ranking precision. Final verdict: merge-ready, zero findings.

## Documented trade-offs of bigram indexing (not silent)

- Multi-char CJK **regex** (`/外部.*事實/`) can't match a 2-gram term dictionary; English regex is unaffected. CLI help qualified.
- **Single-char** CJK queries can't match multi-char runs (inherent to bigrams; not a regression — the default tokenizer failed this too).
- CJK **alternatives** (軟體 vs 軟件) need an explicit `OR` since pure-CJK defaults to AND.
- Mixed `postgre 中文` also fuzzes the CJK bigrams (tantivy fuzzy is per-field, not per-term).

## Existing installs

Run `edda search index` once after upgrading — it auto-detects the v1 index and rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
