### PR TITLE
ci: cut Windows test time (debug-info trim + platform-sensitive crate scope)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
+  # Trim debug info in CI: keeps readable backtraces (function name + line) but
+  # skips the heavy PDB generation and linking that dominate Windows build time.
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
 
 jobs:
   fmt:
@@ -39,9 +43,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            args: --workspace
+          - os: macos-latest
+            args: --workspace
+          # Windows is non-blocking (continue-on-error) and its build/link is
+          # ~5x slower, so it runs only the platform-divergent crates
+          # (filesystem paths, file locks, process spawn, mmap) instead of all
+          # 23. Linux/macOS keep full-workspace coverage.
+          - os: windows-latest
+            args: >-
+              -p edda-store
+              -p edda-ledger
+              -p edda-search-fts
+              -p edda-bridge-claude
+              -p edda
     steps:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --workspace
+      - run: cargo test ${{ matrix.args }}


### PR DESCRIPTION
Windows Test was 7-8 min vs ~1.5 min on Linux/macOS with the same `rust-cache`. The cached deps aren't the cost — it's recompiling and **linking 23 crates' test binaries with full debug info** on the slow MSVC linker.

Two changes:

**1. Trim debug info in CI** — `CARGO_PROFILE_{DEV,TEST}_DEBUG=line-tables-only`. Keeps readable backtraces (function name + line) but skips the heavy PDB generation/linking that dominates Windows build time (~30-50% link win). CI-only env; local dev unaffected.

**2. Narrow the Windows matrix to platform-divergent crates.** Windows is already `continue-on-error` (non-blocking), so instead of all 23 crates it now tests only the ones with genuinely OS-specific behaviour:
- `edda-store` — `%APPDATA%` vs `~/.edda` path resolution
- `edda-ledger` — file locks, paths, bundled SQLite
- `edda-search-fts` — tantivy mmap + fs2 index lock
- `edda-bridge-claude` — process spawn, hooks, heartbeat files, paths
- `edda` (CLI) — integration, spawn, paths

Linux and macOS keep full `--workspace` coverage, so pure-logic crates (edda-core, etc.) are still exercised every run — just not recompiled on the slow Windows runner.

Combined, this should bring the Windows job well under the current 7-8 min. If Windows coverage ever needs to be broader, add crates to the matrix list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)