### PR TITLE
search: auto-index — turns read early-out + incremental events + SessionEnd hook (GH-403)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,6 +773,7 @@ dependencies = [
  "edda-notify",
  "edda-pack",
  "edda-postmortem",
+ "edda-search-fts",
  "edda-store",
  "edda-transcript",
  "globset",

--- a/crates/edda-bridge-claude/Cargo.toml
+++ b/crates/edda-bridge-claude/Cargo.toml
@@ -17,6 +17,7 @@ edda-transcript = { path = "../edda-transcript", version = "0.2.0" }
 edda-index = { path = "../edda-index", version = "0.2.0" }
 edda-pack = { path = "../edda-pack", version = "0.2.0" }
 edda-ledger = { path = "../edda-ledger", version = "0.2.0" }
+edda-search-fts = { path = "../edda-search-fts", version = "0.2.0" }
 edda-notify = { path = "../edda-notify", version = "0.2.0" }
 edda-postmortem = { path = "../edda-postmortem", version = "0.2.0" }
 edda-derive = { path = "../edda-derive", version = "0.2.0" }

--- a/crates/edda-bridge-claude/src/bg_index.rs
+++ b/crates/edda-bridge-claude/src/bg_index.rs
@@ -1,0 +1,69 @@
+//! Incremental search reindex at SessionEnd (GH-403).
+//!
+//! Design: non-blocking, idempotent, cheap.
+//!
+//! Two deliberate departures from the sibling background tasks:
+//!
+//! - **No cooldown or interval gate.** `bg_scan`/`bg_detect` are gated because
+//!   they spend LLM calls; an incremental sync with nothing new is a cursor read
+//!   and a no-op commit. Gating it would only reintroduce the staleness this
+//!   exists to remove.
+//! - **No cold build.** A missing index is left alone and picked up by
+//!   `edda search query`'s build-if-missing. A first build costs ~25s on a real
+//!   corpus, and a session's exit must never pay that.
+
+use anyhow::Result;
+use edda_store::project_dir;
+use std::path::Path;
+
+/// Run only when there is already an index to top up.
+pub fn should_run(project_id: &str) -> bool {
+    if std::env::var("EDDA_BG_ENABLED").unwrap_or_else(|_| "1".into()) == "0" {
+        return false;
+    }
+    index_exists(&project_dir(project_id))
+}
+
+/// Whether a project has an index worth topping up.
+///
+/// Split out from `should_run` so it can be tested against a temp dir: resolving
+/// a project dir means reading the process-wide store root, and a test that
+/// redirected it would corrupt every other test sharing this process.
+fn index_exists(proj_dir: &Path) -> bool {
+    proj_dir.join("search").join("tantivy").exists()
+}
+
+/// Bring the index up to date with events written during this session.
+pub fn run_index(project_id: &str, cwd: &str) -> Result<()> {
+    let ledger = edda_ledger::Ledger::open(std::path::Path::new(cwd))?;
+    let proj = project_dir(project_id);
+    let stats = edda_search_fts::sync::sync(&proj, project_id, None, |after| {
+        ledger.events_after_rowid(after)
+    })?;
+    tracing::debug!(
+        events = stats.events,
+        turns = stats.turns,
+        "search index synced"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Deliberately tests `index_exists` rather than `should_run`: the latter
+    // resolves the store root from the environment, and setting that here would
+    // redirect it for every other test in this process (cargo runs them in
+    // parallel threads), breaking bg_detect/bg_scan/bg_digest.
+    #[test]
+    fn index_exists_only_when_the_tantivy_dir_is_present() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Cold builds belong to `edda search query`, never to a session's exit.
+        assert!(!index_exists(tmp.path()));
+
+        std::fs::create_dir_all(tmp.path().join("search").join("tantivy")).unwrap();
+        assert!(index_exists(tmp.path()));
+    }
+}

--- a/crates/edda-bridge-claude/src/dispatch/session.rs
+++ b/crates/edda-bridge-claude/src/dispatch/session.rs
@@ -357,6 +357,21 @@ pub(super) fn dispatch_session_end(
         bg_count += 1;
     }
 
+    // 2j. Background incremental search reindex (GH-403). Ungated by cooldown:
+    // with nothing new this is a cursor read and a no-op commit.
+    if crate::bg_index::should_run(project_id) {
+        let tx = bg_tx.clone();
+        let pid = project_id.to_string();
+        let cwd_owned = cwd.to_string();
+        std::thread::spawn(move || {
+            if let Err(e) = crate::bg_index::run_index(&pid, &cwd_owned) {
+                tracing::warn!(error = %e, "search reindex failed");
+            }
+            let _ = tx.send("bg_index");
+        });
+        bg_count += 1;
+    }
+
     // Drop the original sender so the channel closes when all threads finish.
     drop(bg_tx);
 

--- a/crates/edda-bridge-claude/src/lib.rs
+++ b/crates/edda-bridge-claude/src/lib.rs
@@ -2,6 +2,7 @@ pub mod agent_phase;
 pub mod bg_detect;
 pub mod bg_digest;
 pub mod bg_extract;
+pub mod bg_index;
 pub mod bg_scan;
 pub mod controls_suggest;
 pub mod digest;

--- a/crates/edda-cli/src/cmd_search.rs
+++ b/crates/edda-cli/src/cmd_search.rs
@@ -195,6 +195,14 @@ pub fn query(
 /// Report how current the index is (GH-403), so silence is never mistaken for
 /// absence. Best-effort: a broken watermark must not fail a query that already
 /// produced results.
+///
+/// `indexed through` is read from the project's own meta.sqlite and is therefore
+/// correct for any project. The "newer events" count is not: it can only be
+/// computed against a ledger, and the only ledger we have is `repo_root`'s. For
+/// a `--project` that is not this repo, that count would compare an unrelated
+/// project's cursor against these events — a fabricated number. Since the point
+/// of this line is honesty about staleness, a confidently wrong count is worse
+/// than none, so it is omitted rather than guessed.
 fn print_watermark(repo_root: &Path, proj_dir: &Path, project_id: &str) {
     let meta_path = proj_dir.join("search").join("meta.sqlite");
     let Ok(conn) = schema::ensure_meta_db(&meta_path) else {
@@ -206,6 +214,10 @@ fn print_watermark(repo_root: &Path, proj_dir: &Path, project_id: &str) {
     let Some(ts) = cursor.ts else {
         return;
     };
+    if project_id != resolve_project_id(repo_root) {
+        println!("  (indexed through {ts})");
+        return;
+    }
     let newer = Ledger::open(repo_root)
         .and_then(|l| l.events_after_rowid(cursor.rowid))
         .map(|v| v.len())

--- a/crates/edda-cli/src/cmd_search.rs
+++ b/crates/edda-cli/src/cmd_search.rs
@@ -73,6 +73,7 @@ pub fn run_cmd(cmd: SearchCmd, repo_root: &Path) -> anyhow::Result<()> {
         } => {
             let pid = project.as_deref().unwrap_or(&default_pid);
             query(
+                repo_root,
                 pid,
                 &q,
                 session.as_deref(),
@@ -91,8 +92,10 @@ pub fn run_cmd(cmd: SearchCmd, repo_root: &Path) -> anyhow::Result<()> {
 
 // ── Command Implementations ──
 
-/// Execute `edda search <query>` — full-text search over Tantivy index.
+/// Execute `edda search <query>` — full-text search over the Tantivy index.
+#[allow(clippy::too_many_arguments)]
 pub fn query(
+    repo_root: &Path,
     project_id: &str,
     query_str: &str,
     session_id: Option<&str>,
@@ -103,18 +106,26 @@ pub fn query(
 ) -> anyhow::Result<()> {
     let proj_dir = project_dir(project_id);
     let index_dir = proj_dir.join("search").join("tantivy");
-    if !index_dir.exists() {
-        eprintln!("No search index found. Run `edda search index` first.");
-        return Ok(());
-    }
-    // GH-402: refuse to serve an index built with an older tokenizer — its
-    // results would silently miss CJK matches. Tell the user to rebuild.
-    if schema::index_is_outdated(&index_dir) {
-        eprintln!(
-            "Search index is from an older schema (CJK tokenization changed). \
-             Run `edda search index` to rebuild."
+
+    // GH-403: an unusable index is not a dead end. Announce, then fix it — a
+    // silent 25s stall reads as a hang, and telling the user to go run another
+    // command is the complaint this issue exists to answer.
+    let missing = !index_dir.exists();
+    let outdated = schema::index_is_outdated(&index_dir);
+    if missing || outdated {
+        if missing {
+            println!("No search index — building now (one-time)…");
+        } else {
+            println!("Search index schema is outdated — rebuilding now (one-time)…");
+        }
+        let ledger = Ledger::open(repo_root)?;
+        let stats = sync::sync(&proj_dir, project_id, None, |after| {
+            ledger.events_after_rowid(after)
+        })?;
+        println!(
+            "Indexed {} event(s) + {} turn(s).\n",
+            stats.events, stats.turns
         );
-        return Ok(());
     }
 
     // Read-only open: answering a query must never wipe/recreate the index.
@@ -133,6 +144,7 @@ pub fn query(
 
     if results.is_empty() {
         println!("No results found for: {query_str}");
+        print_watermark(repo_root, &proj_dir, project_id);
         return Ok(());
     }
 
@@ -163,7 +175,33 @@ pub fn query(
         }
     }
 
+    print_watermark(repo_root, &proj_dir, project_id);
     Ok(())
+}
+
+/// Report how current the index is (GH-403), so silence is never mistaken for
+/// absence. Best-effort: a broken watermark must not fail a query that already
+/// produced results.
+fn print_watermark(repo_root: &Path, proj_dir: &Path, project_id: &str) {
+    let meta_path = proj_dir.join("search").join("meta.sqlite");
+    let Ok(conn) = schema::ensure_meta_db(&meta_path) else {
+        return;
+    };
+    let Ok(cursor) = schema::read_events_cursor(&conn, project_id) else {
+        return;
+    };
+    let Some(ts) = cursor.ts else {
+        return;
+    };
+    let newer = Ledger::open(repo_root)
+        .and_then(|l| l.events_after_rowid(cursor.rowid))
+        .map(|v| v.len())
+        .unwrap_or(0);
+    if newer > 0 {
+        println!("  (indexed through {ts}; {newer} newer event(s) not yet indexed)");
+    } else {
+        println!("  (indexed through {ts})");
+    }
 }
 
 /// Execute `edda search index` — build/update the Tantivy index for a project.

--- a/crates/edda-cli/src/cmd_search.rs
+++ b/crates/edda-cli/src/cmd_search.rs
@@ -112,6 +112,19 @@ pub fn query(
     // command is the complaint this issue exists to answer.
     let missing = !index_dir.exists();
     let outdated = schema::index_is_outdated(&index_dir);
+    // Only auto-build the project this repo actually resolves to. `--project`
+    // names a project independently of where we are standing, and repo_root's
+    // ledger is not that project's ledger — building from it would write these
+    // events into someone else's index. For a project that isn't here, the
+    // explicit message is the honest answer.
+    let is_local_project = project_id == resolve_project_id(repo_root);
+    if (missing || outdated) && !is_local_project {
+        eprintln!(
+            "No usable search index for project {project_id}. Run \
+             `edda search index --project {project_id}` from that project's repo."
+        );
+        return Ok(());
+    }
     if missing || outdated {
         if missing {
             println!("No search index — building now (one-time)…");

--- a/crates/edda-cli/src/cmd_search.rs
+++ b/crates/edda-cli/src/cmd_search.rs
@@ -1,7 +1,7 @@
 use clap::Subcommand;
 use edda_index::fetch_store_line;
 use edda_ledger::Ledger;
-use edda_search_fts::{indexer, schema, search};
+use edda_search_fts::{schema, search, sync};
 use edda_store::project_dir;
 use std::path::Path;
 
@@ -166,76 +166,25 @@ pub fn query(
     Ok(())
 }
 
-/// Execute `edda search index` — build/update Tantivy index for a project.
+/// Execute `edda search index` — build/update the Tantivy index for a project.
 pub fn index(repo_root: &Path, project_id: &str, session_id: Option<&str>) -> anyhow::Result<()> {
     let proj_dir = project_dir(project_id);
     if !proj_dir.exists() {
         anyhow::bail!("Project directory not found: {}", proj_dir.display());
     }
 
-    let index_dir = proj_dir.join("search").join("tantivy");
-    let meta_db_path = proj_dir.join("search").join("meta.sqlite");
-
-    // Serialize index operations so two concurrent `edda search index` runs
-    // can't wipe/rebuild the same tantivy dir at once (GH-402). Keyed by the
-    // index location, so it holds even across working directories / --project.
-    let _lock = schema::IndexLock::acquire(&proj_dir.join("search"))?;
     let ledger = Ledger::open(repo_root)?;
-
-    // GH-402: a schema upgrade wipes the tantivy dir so it gets recreated
-    // fresh. `open_or_create_index` reports fresh creation for ALL cases (this
-    // wipe, a corrupt index, a never-existed dir, or a crash mid-wipe), which
-    // is what drives the watermark clear + full reindex below — so a crash
-    // between wipe and recreate can't leave stale turns_meta hiding turns.
-    if schema::index_is_outdated(&index_dir) {
-        let old = schema::read_index_version(&index_dir)
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| "1".to_string());
-        println!(
-            "Search index schema outdated (v{old} → v{}); rebuilding from scratch.",
-            schema::INDEX_VERSION
-        );
-        std::fs::remove_dir_all(&index_dir)?;
-    }
-
-    let (index, created_fresh) = schema::open_or_create_index(&index_dir)?;
-    let tantivy_schema = index.schema();
-    let mut writer = schema::index_writer(&index)?;
-
-    let meta_conn = schema::ensure_meta_db(&meta_db_path)?;
-    // Whenever the tantivy index is fresh/empty, clear the watermark via SQL
-    // (not file deletion — a locked meta.sqlite would survive) so every turn
-    // re-indexes instead of being skipped as "already indexed".
-    if created_fresh {
-        schema::clear_index_watermark(&meta_conn)?;
-    }
-
-    // Index ledger events (index_events always deletes + re-adds all events).
-    let event_count = indexer::index_events(&writer, &tantivy_schema, project_id, || {
-        ledger.iter_events()
+    let stats = sync::sync(&proj_dir, project_id, session_id, |after| {
+        ledger.events_after_rowid(after)
     })?;
 
-    // Index transcript turns. A fresh index must cover ALL sessions even if a
-    // single --session was requested, otherwise other sessions vanish behind
-    // the fresh version marker.
-    let turn_count = match session_id {
-        Some(sid) if !created_fresh => indexer::index_session(
-            &writer,
-            &tantivy_schema,
-            &meta_conn,
-            &proj_dir,
-            project_id,
-            sid,
-        )?,
-        _ => indexer::index_project(&writer, &tantivy_schema, &meta_conn, &proj_dir, project_id)?,
-    };
-
-    writer.commit()?;
-    // Mark the schema version only AFTER a successful full commit, so a crash
-    // mid-rebuild leaves no marker and the next run rebuilds again.
-    schema::write_index_version(&index_dir)?;
-
-    println!("Indexed {event_count} event(s) + {turn_count} turn(s) for project {project_id}");
+    if stats.rebuilt {
+        println!("Rebuilt index from scratch.");
+    }
+    println!(
+        "Indexed {} event(s) + {} turn(s) for project {project_id}",
+        stats.events, stats.turns
+    );
     Ok(())
 }
 

--- a/crates/edda-search-fts/src/indexer.rs
+++ b/crates/edda-search-fts/src/indexer.rs
@@ -32,9 +32,34 @@ where
     Ok(count)
 }
 
+/// Index a batch of `(rowid, Event)` pairs incrementally (GH-403).
+///
+/// Each event is replaced rather than blindly added: `delete_term` on its
+/// `doc_id` first, then re-add. That makes re-running a batch a no-op in effect,
+/// which is what allows the caller to commit before advancing its cursor — a
+/// crash in between simply re-runs this batch on the next pass.
+///
+/// Unlike the bulk path this deletes nothing outside the batch, so callers must
+/// pass only events the index has not seen.
+pub fn index_events_since(
+    writer: &IndexWriter,
+    schema: &Schema,
+    project_id: &str,
+    events: &[(i64, edda_core::Event)],
+) -> anyhow::Result<usize> {
+    let f_doc_id = schema.get_field("doc_id")?;
+    let mut count = 0;
+    for (_rowid, event) in events {
+        writer.delete_term(Term::from_field_text(f_doc_id, event.event_id.as_str()));
+        add_event_doc(writer, schema, project_id, event)?;
+        count += 1;
+    }
+    Ok(count)
+}
+
 /// Add a single ledger event as a Tantivy document.
 ///
-/// Used both by bulk `index_events` and by append-time indexing.
+/// Used by `index_events_since`; kept public for direct use in tests.
 pub fn add_event_doc(
     writer: &IndexWriter,
     schema: &Schema,
@@ -620,6 +645,68 @@ mod tests {
             1,
             "events should not be duplicated on re-index"
         );
+    }
+
+    fn mk_test_event(id: &str) -> edda_core::Event {
+        edda_core::Event {
+            event_id: id.to_string(),
+            ts: "2026-07-15T12:00:00Z".to_string(),
+            event_type: "note".to_string(),
+            branch: "main".to_string(),
+            parent_hash: None,
+            hash: "h".to_string(),
+            payload: serde_json::json!({ "text": "hello world" }),
+            refs: Default::default(),
+            schema_version: 1,
+            digests: Vec::new(),
+            event_family: None,
+            event_level: None,
+        }
+    }
+
+    #[test]
+    fn index_events_since_is_idempotent_per_event() {
+        let index = ensure_index_ram().unwrap();
+        let schema = index.schema();
+        let mut writer = index_writer(&index).unwrap();
+
+        let batch = vec![(1i64, mk_test_event("evt_a")), (2i64, mk_test_event("evt_b"))];
+
+        let n = index_events_since(&writer, &schema, "p1", &batch).unwrap();
+        writer.commit().unwrap();
+        assert_eq!(n, 2);
+
+        // Re-running the same batch is what happens after a crash between commit
+        // and the cursor write. It must replace, not duplicate.
+        index_events_since(&writer, &schema, "p1", &batch).unwrap();
+        writer.commit().unwrap();
+
+        let reader = index.reader().unwrap();
+        reader.reload().unwrap();
+        assert_eq!(
+            reader.searcher().num_docs(),
+            2,
+            "re-run must not duplicate docs"
+        );
+    }
+
+    #[test]
+    fn index_events_since_appends_without_touching_existing() {
+        let index = ensure_index_ram().unwrap();
+        let schema = index.schema();
+        let mut writer = index_writer(&index).unwrap();
+
+        index_events_since(&writer, &schema, "p1", &[(1i64, mk_test_event("evt_a"))]).unwrap();
+        writer.commit().unwrap();
+
+        // An incremental batch must not delete docs outside it — the whole point
+        // of dropping the old delete-all.
+        index_events_since(&writer, &schema, "p1", &[(2i64, mk_test_event("evt_b"))]).unwrap();
+        writer.commit().unwrap();
+
+        let reader = index.reader().unwrap();
+        reader.reload().unwrap();
+        assert_eq!(reader.searcher().num_docs(), 2);
     }
 
     #[test]

--- a/crates/edda-search-fts/src/indexer.rs
+++ b/crates/edda-search-fts/src/indexer.rs
@@ -6,32 +6,6 @@ use std::path::Path;
 use tantivy::schema::*;
 use tantivy::{doc, IndexWriter, Term};
 
-/// Index all ledger events into Tantivy.
-///
-/// Deletes existing event documents first (dedup by rebuild), then re-adds all.
-/// Returns the number of documents added.
-pub fn index_events<F>(
-    writer: &IndexWriter,
-    schema: &Schema,
-    project_id: &str,
-    iter_fn: F,
-) -> anyhow::Result<usize>
-where
-    F: FnOnce() -> anyhow::Result<Vec<edda_core::Event>>,
-{
-    // Delete all existing event docs to avoid duplicates on re-index
-    let f_doc_type = schema.get_field("doc_type")?;
-    writer.delete_term(Term::from_field_text(f_doc_type, "event"));
-
-    let events = iter_fn()?;
-    let mut count = 0;
-    for event in &events {
-        add_event_doc(writer, schema, project_id, event)?;
-        count += 1;
-    }
-    Ok(count)
-}
-
 /// Index a batch of `(rowid, Event)` pairs incrementally (GH-403).
 ///
 /// Each event is replaced rather than blindly added: `delete_term` on its
@@ -591,60 +565,15 @@ mod tests {
             },
         ];
 
-        let count = index_events(&writer, &schema, "p1", || Ok(events)).unwrap();
+        let batch: Vec<(i64, edda_core::Event)> =
+            events.into_iter().enumerate().map(|(i, e)| (i as i64 + 1, e)).collect();
+        let count = index_events_since(&writer, &schema, "p1", &batch).unwrap();
         writer.commit().unwrap();
         assert_eq!(count, 2);
 
         let reader = index.reader().unwrap();
         let searcher = reader.searcher();
         assert_eq!(searcher.num_docs(), 2);
-    }
-
-    #[test]
-    fn index_events_dedup_on_reindex() {
-        let index = ensure_index_ram().unwrap();
-        let schema = index.schema();
-        let mut writer = index_writer(&index).unwrap();
-
-        let make_events = || {
-            Ok(vec![edda_core::Event {
-                event_id: "evt_dedup".to_string(),
-                ts: "2026-02-17T12:00:00Z".to_string(),
-                event_type: "note".to_string(),
-                branch: "main".to_string(),
-                parent_hash: None,
-                hash: "abc".to_string(),
-                payload: serde_json::json!({"text": "hello"}),
-                refs: Default::default(),
-                schema_version: 1,
-                digests: Vec::new(),
-                event_family: None,
-                event_level: None,
-            }])
-        };
-
-        // First index
-        let count = index_events(&writer, &schema, "p1", make_events).unwrap();
-        writer.commit().unwrap();
-        assert_eq!(count, 1);
-
-        let reader = index.reader().unwrap();
-        let searcher = reader.searcher();
-        assert_eq!(searcher.num_docs(), 1);
-
-        // Second index — should delete old events then re-add, NOT duplicate
-        let count2 = index_events(&writer, &schema, "p1", make_events).unwrap();
-        writer.commit().unwrap();
-        assert_eq!(count2, 1);
-
-        // Reload reader to see merged segments
-        let reader2 = index.reader().unwrap();
-        let searcher2 = reader2.searcher();
-        assert_eq!(
-            searcher2.num_docs(),
-            1,
-            "events should not be duplicated on re-index"
-        );
     }
 
     fn mk_test_event(id: &str) -> edda_core::Event {

--- a/crates/edda-search-fts/src/indexer.rs
+++ b/crates/edda-search-fts/src/indexer.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use edda_index::{fetch_store_line, IndexRecordV1};
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 use std::collections::HashMap;
 use std::path::Path;
 use tantivy::schema::*;
@@ -131,6 +131,21 @@ pub fn index_session(
         .join("index")
         .join(format!("{session_id}.jsonl"));
     if !index_path.exists() {
+        return Ok(0);
+    }
+
+    // GH-403: skip a session whose index file has not grown since the last run.
+    //
+    // Everything below — reading every record, building the uuid map, walking
+    // each assistant's parent chain, and fetching + parsing its transcript line
+    // off disk — runs BEFORE the per-turn `turns_meta` check that decides the
+    // turn is already indexed. So without this early-out a no-op reindex does
+    // the entire read and parse of every session, then throws it all away:
+    // measured at ~25s for 100 sessions / 24MB, linear in session count. The
+    // watermark stopped duplicate *writes*, never duplicate *reads*.
+    let file_len = std::fs::metadata(&index_path)?.len() as i64;
+    let consumed = read_session_offset(meta_conn, project_id, session_id)?;
+    if consumed == file_len {
         return Ok(0);
     }
 
@@ -300,8 +315,46 @@ pub fn index_session(
         count += 1;
     }
 
+    // Record how much of the file we consumed, in the same transaction as the
+    // turns_meta rows it corresponds to. A rewritten (shrunk) file will not
+    // match on the next run and gets re-read, which is safe because turns_meta
+    // dedups by turn_id.
+    write_session_offset(meta_conn, project_id, session_id, file_len)?;
+
     tx.commit()?;
     Ok(count)
+}
+
+/// How many bytes of a session's index file previous runs have consumed.
+/// Absent means zero — read the whole file.
+fn read_session_offset(
+    conn: &Connection,
+    project_id: &str,
+    session_id: &str,
+) -> anyhow::Result<i64> {
+    let v = conn
+        .query_row(
+            "SELECT last_offset FROM index_watermark WHERE project_id = ?1 AND session_id = ?2",
+            params![project_id, session_id],
+            |r| r.get::<_, i64>(0),
+        )
+        .optional()?;
+    Ok(v.unwrap_or(0))
+}
+
+/// Mark a session's index file as consumed up to `offset` bytes.
+fn write_session_offset(
+    conn: &Connection,
+    project_id: &str,
+    session_id: &str,
+    offset: i64,
+) -> anyhow::Result<()> {
+    conn.execute(
+        "INSERT INTO index_watermark (project_id, session_id, last_offset) VALUES (?1, ?2, ?3)
+         ON CONFLICT(project_id, session_id) DO UPDATE SET last_offset = ?3",
+        params![project_id, session_id, offset],
+    )?;
+    Ok(())
 }
 
 /// Index all sessions for a project.
@@ -574,6 +627,165 @@ mod tests {
         let reader = index.reader().unwrap();
         let searcher = reader.searcher();
         assert_eq!(searcher.num_docs(), 2);
+    }
+
+    /// Write a minimal one-turn session fixture (user + assistant), appending if
+    /// the session already exists. Returns the session's index file path.
+    fn write_session_fixture(
+        project_dir: &Path,
+        session_id: &str,
+        n: &str,
+    ) -> std::path::PathBuf {
+        let index_dir = project_dir.join("index");
+        std::fs::create_dir_all(&index_dir).unwrap();
+        let transcripts_dir = project_dir.join("transcripts");
+        std::fs::create_dir_all(&transcripts_dir).unwrap();
+
+        let u = format!("u{n}");
+        let a = format!("a{n}");
+        let user_record = serde_json::json!({
+            "type": "user", "uuid": u, "timestamp": "2026-02-14T10:00:00Z",
+            "message": { "content": "how do I search?" }
+        });
+        let assistant_record = serde_json::json!({
+            "type": "assistant", "uuid": a, "parentUuid": u,
+            "timestamp": "2026-02-14T10:00:05Z",
+            "message": { "content": [{"type": "text", "text": "use tantivy"}] }
+        });
+
+        let store_path = transcripts_dir.join(format!("{session_id}.jsonl"));
+        let user_line = serde_json::to_string(&user_record).unwrap();
+        let asst_line = serde_json::to_string(&assistant_record).unwrap();
+        let user_len = user_line.len() as u64 + 1;
+        let asst_len = asst_line.len() as u64 + 1;
+
+        let base = std::fs::metadata(&store_path).map(|m| m.len()).unwrap_or(0);
+        let mut content = std::fs::read_to_string(&store_path).unwrap_or_default();
+        content.push_str(&format!("{user_line}\n{asst_line}\n"));
+        std::fs::write(&store_path, content).unwrap();
+
+        let user_index = edda_index::IndexRecordV1 {
+            v: 1,
+            session_id: session_id.into(),
+            uuid: u.clone(),
+            parent_uuid: None,
+            record_type: "user".into(),
+            ts: "2026-02-14T10:00:00Z".into(),
+            git_branch: Some("main".into()),
+            cwd: Some("/tmp/p".into()),
+            store_offset: base,
+            store_len: user_len,
+            assistant: None,
+            usage: None,
+        };
+        let asst_index = edda_index::IndexRecordV1 {
+            v: 1,
+            session_id: session_id.into(),
+            uuid: a,
+            parent_uuid: Some(u),
+            record_type: "assistant".into(),
+            ts: "2026-02-14T10:00:05Z".into(),
+            git_branch: Some("main".into()),
+            cwd: Some("/tmp/p".into()),
+            store_offset: base + user_len,
+            store_len: asst_len,
+            assistant: None,
+            usage: None,
+        };
+
+        let index_path = index_dir.join(format!("{session_id}.jsonl"));
+        edda_index::append_index(&index_path, &user_index).unwrap();
+        edda_index::append_index(&index_path, &asst_index).unwrap();
+        index_path
+    }
+
+    #[test]
+    fn unchanged_session_file_is_skipped_without_reading_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path();
+        let index_path = write_session_fixture(project_dir, "s1", "1");
+
+        let index = ensure_index_ram().unwrap();
+        let schema = index.schema();
+        let writer = index_writer(&index).unwrap();
+        let meta_conn = ensure_meta_db_memory().unwrap();
+
+        // Pretend a previous run already consumed the whole file.
+        let len = std::fs::metadata(&index_path).unwrap().len() as i64;
+        meta_conn
+            .execute(
+                "INSERT INTO index_watermark (project_id, session_id, last_offset) \
+                 VALUES (?1, ?2, ?3)",
+                params!["p1", "s1", len],
+            )
+            .unwrap();
+
+        let count = index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap();
+        assert_eq!(count, 0, "an unchanged file must be skipped");
+
+        // The decisive assertion: turns_meta is still EMPTY. This turn was never
+        // indexed, which is only possible if the file was never read — a path
+        // that read it would find the turn absent from turns_meta and index it.
+        // Distinguishes "skipped the read" from "read it, then deduped".
+        let n: i64 = meta_conn
+            .query_row("SELECT count(*) FROM turns_meta", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 0, "skipping must mean not reading, not read-then-dedup");
+    }
+
+    #[test]
+    fn indexing_a_session_records_its_consumed_offset() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path();
+        let index_path = write_session_fixture(project_dir, "s1", "1");
+
+        let index = ensure_index_ram().unwrap();
+        let schema = index.schema();
+        let writer = index_writer(&index).unwrap();
+        let meta_conn = ensure_meta_db_memory().unwrap();
+
+        let count = index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap();
+        assert_eq!(count, 1);
+
+        let len = std::fs::metadata(&index_path).unwrap().len() as i64;
+        let stored: i64 = meta_conn
+            .query_row(
+                "SELECT last_offset FROM index_watermark WHERE project_id = ?1 AND session_id = ?2",
+                params!["p1", "s1"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, len, "must record how much of the file it consumed");
+    }
+
+    #[test]
+    fn a_grown_session_file_is_reprocessed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path();
+        write_session_fixture(project_dir, "s1", "1");
+
+        let index = ensure_index_ram().unwrap();
+        let schema = index.schema();
+        let writer = index_writer(&index).unwrap();
+        let meta_conn = ensure_meta_db_memory().unwrap();
+
+        assert_eq!(
+            index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap(),
+            1
+        );
+        // Unchanged: skipped.
+        assert_eq!(
+            index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap(),
+            0
+        );
+
+        // The live session grows — the early-out must not blind us to new turns.
+        write_session_fixture(project_dir, "s1", "2");
+        assert_eq!(
+            index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap(),
+            1,
+            "a grown file must be reprocessed"
+        );
     }
 
     fn mk_test_event(id: &str) -> edda_core::Event {

--- a/crates/edda-search-fts/src/indexer.rs
+++ b/crates/edda-search-fts/src/indexer.rs
@@ -6,6 +6,19 @@ use std::path::Path;
 use tantivy::schema::*;
 use tantivy::{doc, IndexWriter, Term};
 
+/// Delete every event document in the index.
+///
+/// For the rebuild path only. The incremental path must never touch documents
+/// outside its batch — but a rebuild must, because events the ledger no longer
+/// has would otherwise stay searchable forever. The removed bulk `index_events`
+/// did this implicitly on every run; doing it only on rebuild keeps the cost off
+/// the hot path while preserving the purge.
+pub fn delete_all_event_docs(writer: &IndexWriter, schema: &Schema) -> anyhow::Result<()> {
+    let f_doc_type = schema.get_field("doc_type")?;
+    writer.delete_term(Term::from_field_text(f_doc_type, "event"));
+    Ok(())
+}
+
 /// Index a batch of `(rowid, Event)` pairs incrementally (GH-403).
 ///
 /// Each event is replaced rather than blindly added: `delete_term` on its

--- a/crates/edda-search-fts/src/indexer.rs
+++ b/crates/edda-search-fts/src/indexer.rs
@@ -618,8 +618,11 @@ mod tests {
             },
         ];
 
-        let batch: Vec<(i64, edda_core::Event)> =
-            events.into_iter().enumerate().map(|(i, e)| (i as i64 + 1, e)).collect();
+        let batch: Vec<(i64, edda_core::Event)> = events
+            .into_iter()
+            .enumerate()
+            .map(|(i, e)| (i as i64 + 1, e))
+            .collect();
         let count = index_events_since(&writer, &schema, "p1", &batch).unwrap();
         writer.commit().unwrap();
         assert_eq!(count, 2);
@@ -631,11 +634,7 @@ mod tests {
 
     /// Write a minimal one-turn session fixture (user + assistant), appending if
     /// the session already exists. Returns the session's index file path.
-    fn write_session_fixture(
-        project_dir: &Path,
-        session_id: &str,
-        n: &str,
-    ) -> std::path::PathBuf {
+    fn write_session_fixture(project_dir: &Path, session_id: &str, n: &str) -> std::path::PathBuf {
         let index_dir = project_dir.join("index");
         std::fs::create_dir_all(&index_dir).unwrap();
         let transcripts_dir = project_dir.join("transcripts");
@@ -811,7 +810,10 @@ mod tests {
         let schema = index.schema();
         let mut writer = index_writer(&index).unwrap();
 
-        let batch = vec![(1i64, mk_test_event("evt_a")), (2i64, mk_test_event("evt_b"))];
+        let batch = vec![
+            (1i64, mk_test_event("evt_a")),
+            (2i64, mk_test_event("evt_b")),
+        ];
 
         let n = index_events_since(&writer, &schema, "p1", &batch).unwrap();
         writer.commit().unwrap();

--- a/crates/edda-search-fts/src/indexer.rs
+++ b/crates/edda-search-fts/src/indexer.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use edda_index::{fetch_store_line, IndexRecordV1};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection};
 use std::collections::HashMap;
 use std::path::Path;
 use tantivy::schema::*;
@@ -157,7 +157,7 @@ pub fn index_session(
     // measured at ~25s for 100 sessions / 24MB, linear in session count. The
     // watermark stopped duplicate *writes*, never duplicate *reads*.
     let file_len = std::fs::metadata(&index_path)?.len() as i64;
-    let consumed = read_session_offset(meta_conn, project_id, session_id)?;
+    let consumed = crate::schema::read_session_offset(meta_conn, project_id, session_id)?;
     if consumed == file_len {
         return Ok(0);
     }
@@ -332,42 +332,10 @@ pub fn index_session(
     // turns_meta rows it corresponds to. A rewritten (shrunk) file will not
     // match on the next run and gets re-read, which is safe because turns_meta
     // dedups by turn_id.
-    write_session_offset(meta_conn, project_id, session_id, file_len)?;
+    crate::schema::write_session_offset(meta_conn, project_id, session_id, file_len)?;
 
     tx.commit()?;
     Ok(count)
-}
-
-/// How many bytes of a session's index file previous runs have consumed.
-/// Absent means zero — read the whole file.
-fn read_session_offset(
-    conn: &Connection,
-    project_id: &str,
-    session_id: &str,
-) -> anyhow::Result<i64> {
-    let v = conn
-        .query_row(
-            "SELECT last_offset FROM index_watermark WHERE project_id = ?1 AND session_id = ?2",
-            params![project_id, session_id],
-            |r| r.get::<_, i64>(0),
-        )
-        .optional()?;
-    Ok(v.unwrap_or(0))
-}
-
-/// Mark a session's index file as consumed up to `offset` bytes.
-fn write_session_offset(
-    conn: &Connection,
-    project_id: &str,
-    session_id: &str,
-    offset: i64,
-) -> anyhow::Result<()> {
-    conn.execute(
-        "INSERT INTO index_watermark (project_id, session_id, last_offset) VALUES (?1, ?2, ?3)
-         ON CONFLICT(project_id, session_id) DO UPDATE SET last_offset = ?3",
-        params![project_id, session_id, offset],
-    )?;
-    Ok(())
 }
 
 /// Index all sessions for a project.

--- a/crates/edda-search-fts/src/lib.rs
+++ b/crates/edda-search-fts/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod indexer;
 pub mod schema;
 pub mod search;
+pub mod sync;
 pub mod tokenizer;

--- a/crates/edda-search-fts/src/schema.rs
+++ b/crates/edda-search-fts/src/schema.rs
@@ -251,6 +251,42 @@ pub fn clear_index_watermark(conn: &Connection) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// How many bytes of a session's index file previous runs have consumed.
+/// Absent means zero — read the whole file.
+///
+/// Lives here, beside the DDL and the event cursor, so every `index_watermark` /
+/// `events_watermark` column name stays in one module. Split across modules,
+/// renaming a column breaks the other one at runtime rather than compile time.
+pub fn read_session_offset(
+    conn: &Connection,
+    project_id: &str,
+    session_id: &str,
+) -> anyhow::Result<i64> {
+    let v = conn
+        .query_row(
+            "SELECT last_offset FROM index_watermark WHERE project_id = ?1 AND session_id = ?2",
+            rusqlite::params![project_id, session_id],
+            |r| r.get::<_, i64>(0),
+        )
+        .optional()?;
+    Ok(v.unwrap_or(0))
+}
+
+/// Mark a session's index file as consumed up to `offset` bytes.
+pub fn write_session_offset(
+    conn: &Connection,
+    project_id: &str,
+    session_id: &str,
+    offset: i64,
+) -> anyhow::Result<()> {
+    conn.execute(
+        "INSERT INTO index_watermark (project_id, session_id, last_offset) VALUES (?1, ?2, ?3)
+         ON CONFLICT(project_id, session_id) DO UPDATE SET last_offset = ?3",
+        rusqlite::params![project_id, session_id, offset],
+    )?;
+    Ok(())
+}
+
 /// Where the event index has reached: the ledger rowid of the last indexed
 /// event, plus its timestamp for staleness reporting (GH-403).
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/edda-search-fts/src/schema.rs
+++ b/crates/edda-search-fts/src/schema.rs
@@ -1,6 +1,6 @@
 use crate::tokenizer::{CjkBigramTokenizer, CJK_TOKENIZER};
 use fs2::FileExt;
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 use std::path::Path;
 use tantivy::schema::*;
 use tantivy::{Index, IndexWriter};
@@ -193,6 +193,37 @@ pub fn index_writer(index: &Index) -> anyhow::Result<IndexWriter> {
     Ok(writer)
 }
 
+/// Schema for the search meta database, shared by the on-disk and in-memory
+/// builders so a test DB can never drift from the real one. All statements are
+/// `IF NOT EXISTS`, so adding a table needs no migration.
+const META_DDL: &str = "
+    CREATE TABLE IF NOT EXISTS turns_meta (
+        turn_id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        ts TEXT,
+        user_uuid TEXT,
+        assistant_uuid TEXT,
+        user_store_offset INTEGER,
+        user_store_len INTEGER,
+        assistant_store_offset INTEGER,
+        assistant_store_len INTEGER
+    );
+
+    CREATE TABLE IF NOT EXISTS index_watermark (
+        project_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        last_offset INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (project_id, session_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS events_watermark (
+        project_id TEXT PRIMARY KEY,
+        last_rowid INTEGER NOT NULL DEFAULT 0,
+        last_ts TEXT
+    );
+";
+
 /// Open (or create) the SQLite database for turns_meta (byte-offset pointers).
 ///
 /// This is kept alongside Tantivy because `show` needs byte offsets
@@ -204,29 +235,7 @@ pub fn ensure_meta_db(db_path: &Path) -> anyhow::Result<Connection> {
     let conn = Connection::open(db_path)?;
     conn.pragma_update(None, "journal_mode", "WAL")?;
 
-    conn.execute_batch(
-        "
-        CREATE TABLE IF NOT EXISTS turns_meta (
-            turn_id TEXT PRIMARY KEY,
-            project_id TEXT NOT NULL,
-            session_id TEXT NOT NULL,
-            ts TEXT,
-            user_uuid TEXT,
-            assistant_uuid TEXT,
-            user_store_offset INTEGER,
-            user_store_len INTEGER,
-            assistant_store_offset INTEGER,
-            assistant_store_len INTEGER
-        );
-
-        CREATE TABLE IF NOT EXISTS index_watermark (
-            project_id TEXT NOT NULL,
-            session_id TEXT NOT NULL,
-            last_offset INTEGER NOT NULL DEFAULT 0,
-            PRIMARY KEY (project_id, session_id)
-        );
-        ",
-    )?;
+    conn.execute_batch(META_DDL)?;
 
     Ok(conn)
 }
@@ -236,36 +245,56 @@ pub fn ensure_meta_db(db_path: &Path) -> anyhow::Result<Connection> {
 /// Lives here (beside `ensure_meta_db`) so the meta-DB table names stay in one
 /// crate rather than being duplicated by callers (GH-402).
 pub fn clear_index_watermark(conn: &Connection) -> anyhow::Result<()> {
-    conn.execute_batch("DELETE FROM turns_meta; DELETE FROM index_watermark;")?;
+    conn.execute_batch(
+        "DELETE FROM turns_meta; DELETE FROM index_watermark; DELETE FROM events_watermark;",
+    )?;
+    Ok(())
+}
+
+/// Where the event index has reached: the ledger rowid of the last indexed
+/// event, plus its timestamp for staleness reporting (GH-403).
+#[derive(Debug, Clone, PartialEq)]
+pub struct EventsCursor {
+    pub rowid: i64,
+    pub ts: Option<String>,
+}
+
+/// Read a project's event cursor. An absent cursor is `rowid = 0` — index from
+/// the beginning — not an error.
+pub fn read_events_cursor(conn: &Connection, project_id: &str) -> anyhow::Result<EventsCursor> {
+    let row = conn
+        .query_row(
+            "SELECT last_rowid, last_ts FROM events_watermark WHERE project_id = ?1",
+            [project_id],
+            |r| Ok((r.get::<_, i64>(0)?, r.get::<_, Option<String>>(1)?)),
+        )
+        .optional()?;
+    Ok(match row {
+        Some((rowid, ts)) => EventsCursor { rowid, ts },
+        None => EventsCursor { rowid: 0, ts: None },
+    })
+}
+
+/// Advance a project's event cursor. Written only AFTER a successful commit, so
+/// a crash in between re-runs the batch instead of skipping it.
+pub fn write_events_cursor(
+    conn: &Connection,
+    project_id: &str,
+    rowid: i64,
+    ts: Option<&str>,
+) -> anyhow::Result<()> {
+    conn.execute(
+        "INSERT INTO events_watermark (project_id, last_rowid, last_ts) VALUES (?1, ?2, ?3)
+         ON CONFLICT(project_id) DO UPDATE SET last_rowid = ?2, last_ts = ?3",
+        rusqlite::params![project_id, rowid, ts],
+    )?;
     Ok(())
 }
 
 /// Open an in-memory SQLite database with turns_meta schema (for testing).
 pub fn ensure_meta_db_memory() -> anyhow::Result<Connection> {
     let conn = Connection::open_in_memory()?;
-    conn.execute_batch(
-        "
-        CREATE TABLE IF NOT EXISTS turns_meta (
-            turn_id TEXT PRIMARY KEY,
-            project_id TEXT NOT NULL,
-            session_id TEXT NOT NULL,
-            ts TEXT,
-            user_uuid TEXT,
-            assistant_uuid TEXT,
-            user_store_offset INTEGER,
-            user_store_len INTEGER,
-            assistant_store_offset INTEGER,
-            assistant_store_len INTEGER
-        );
-
-        CREATE TABLE IF NOT EXISTS index_watermark (
-            project_id TEXT NOT NULL,
-            session_id TEXT NOT NULL,
-            last_offset INTEGER NOT NULL DEFAULT 0,
-            PRIMARY KEY (project_id, session_id)
-        );
-        ",
-    )?;
+    conn.execute_batch(META_DDL)?;
     Ok(conn)
 }
 
@@ -385,5 +414,60 @@ mod tests {
             .query_row("SELECT count(*) FROM index_watermark", [], |row| row.get(0))
             .unwrap();
         assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn events_cursor_roundtrip_and_default() {
+        let conn = ensure_meta_db_memory().unwrap();
+
+        // Absent cursor reads as zero, not an error.
+        let c = read_events_cursor(&conn, "p1").unwrap();
+        assert_eq!(c.rowid, 0);
+        assert_eq!(c.ts, None);
+
+        write_events_cursor(&conn, "p1", 42, Some("2026-07-15T09:40:00Z")).unwrap();
+        let c = read_events_cursor(&conn, "p1").unwrap();
+        assert_eq!(c.rowid, 42);
+        assert_eq!(c.ts.as_deref(), Some("2026-07-15T09:40:00Z"));
+
+        // Upsert, not a second row.
+        write_events_cursor(&conn, "p1", 99, Some("2026-07-15T10:00:00Z")).unwrap();
+        let c = read_events_cursor(&conn, "p1").unwrap();
+        assert_eq!(c.rowid, 99);
+
+        // Cursors are per project.
+        assert_eq!(read_events_cursor(&conn, "p2").unwrap().rowid, 0);
+    }
+
+    #[test]
+    fn clear_index_watermark_also_clears_events_cursor() {
+        let conn = ensure_meta_db_memory().unwrap();
+        write_events_cursor(&conn, "p1", 42, Some("2026-07-15T09:40:00Z")).unwrap();
+
+        clear_index_watermark(&conn).unwrap();
+
+        // A fresh index must re-index every event, so the cursor must reset too.
+        assert_eq!(read_events_cursor(&conn, "p1").unwrap().rowid, 0);
+    }
+
+    #[test]
+    fn memory_and_file_meta_dbs_have_the_same_tables() {
+        // The two builders share one DDL const; this pins that they cannot drift.
+        let tmp = tempfile::tempdir().unwrap();
+        let file_conn = ensure_meta_db(&tmp.path().join("meta.sqlite")).unwrap();
+        let mem_conn = ensure_meta_db_memory().unwrap();
+
+        let tables = |c: &Connection| -> Vec<String> {
+            let mut stmt = c
+                .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+                .unwrap();
+            let rows = stmt.query_map([], |r| r.get::<_, String>(0)).unwrap();
+            rows.map(|r| r.unwrap())
+                .filter(|n| !n.starts_with("sqlite_"))
+                .collect()
+        };
+
+        assert_eq!(tables(&file_conn), tables(&mem_conn));
+        assert!(tables(&mem_conn).contains(&"events_watermark".to_string()));
     }
 }

--- a/crates/edda-search-fts/src/sync.rs
+++ b/crates/edda-search-fts/src/sync.rs
@@ -1,0 +1,300 @@
+//! One home for search index orchestration (GH-403).
+//!
+//! Three callers need identical behaviour — the manual `edda search index`, the
+//! query-time cold build, and the SessionEnd background task — so the lock /
+//! open / cursor / commit dance lives here exactly once rather than being
+//! re-implemented per call site.
+//!
+//! Events arrive through an injected closure, keeping this crate unaware of
+//! `edda-ledger` (the same inversion `index_events` already used).
+
+use crate::{indexer, schema};
+use std::path::Path;
+
+/// What a sync did. `indexed_through` is the timestamp of the newest indexed
+/// event — reported even when this run indexed nothing, so callers can always
+/// tell the user how current the index is.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SyncStats {
+    pub events: usize,
+    pub turns: usize,
+    pub indexed_through: Option<String>,
+    pub rebuilt: bool,
+}
+
+/// Bring a project's search index up to date with its ledger and transcripts.
+///
+/// `events_after` is `|rowid| ledger.events_after_rowid(rowid)`. It is `Fn`
+/// rather than `FnOnce` because a cursor that has run ahead of the ledger can
+/// only be detected by probing, then re-reading from the start.
+///
+/// The cursor is owned here: callers never pass or reset it. `sync` resets to a
+/// full rebuild when the index was created fresh (schema upgrade, corruption,
+/// crash mid-wipe) or when the stored cursor no longer matches the ledger.
+pub fn sync<F>(
+    proj_dir: &Path,
+    project_id: &str,
+    session_id: Option<&str>,
+    events_after: F,
+) -> anyhow::Result<SyncStats>
+where
+    F: Fn(i64) -> anyhow::Result<Vec<(i64, edda_core::Event)>>,
+{
+    let search_dir = proj_dir.join("search");
+    let index_dir = search_dir.join("tantivy");
+    let meta_db_path = search_dir.join("meta.sqlite");
+
+    // Serialize against any other indexer touching this project (GH-402).
+    let _lock = schema::IndexLock::acquire(&search_dir)?;
+
+    // Schema upgrade: wipe so it is recreated fresh below.
+    if schema::index_is_outdated(&index_dir) {
+        std::fs::remove_dir_all(&index_dir)?;
+    }
+
+    let (index, created_fresh) = schema::open_or_create_index(&index_dir)?;
+    let tantivy_schema = index.schema();
+    let mut writer = schema::index_writer(&index)?;
+    let meta_conn = schema::ensure_meta_db(&meta_db_path)?;
+
+    // A fresh tantivy index means every watermark is a lie — including the event
+    // cursor. Clearing before reading is what makes a missing index dir safe
+    // even when meta.sqlite outlived it.
+    if created_fresh {
+        schema::clear_index_watermark(&meta_conn)?;
+    }
+
+    let cursor = schema::read_events_cursor(&meta_conn, project_id)?;
+    let (batch, rebuilt) = resolve_batch(&events_after, cursor.rowid)?;
+
+    let events = indexer::index_events_since(&writer, &tantivy_schema, project_id, &batch)?;
+
+    // A rebuild must cover every session, otherwise sessions other than the
+    // requested one vanish behind the fresh index.
+    let turns = match session_id {
+        Some(sid) if !rebuilt => indexer::index_session(
+            &writer,
+            &tantivy_schema,
+            &meta_conn,
+            proj_dir,
+            project_id,
+            sid,
+        )?,
+        _ => indexer::index_project(&writer, &tantivy_schema, &meta_conn, proj_dir, project_id)?,
+    };
+
+    // Commit BEFORE advancing the cursor. A crash in between re-runs this batch,
+    // which index_events_since makes idempotent. The reverse order would mark
+    // events indexed that are not, hiding them forever.
+    writer.commit()?;
+    schema::write_index_version(&index_dir)?;
+
+    let indexed_through = if let Some((rowid, ev)) = batch.last() {
+        schema::write_events_cursor(&meta_conn, project_id, *rowid, Some(ev.ts.as_str()))?;
+        Some(ev.ts.clone())
+    } else if rebuilt {
+        // Rebuilt against an empty ledger: clear a stale-ahead cursor rather
+        // than letting it survive.
+        schema::write_events_cursor(&meta_conn, project_id, 0, None)?;
+        None
+    } else {
+        cursor.ts.clone()
+    };
+
+    Ok(SyncStats {
+        events,
+        turns,
+        indexed_through,
+        rebuilt,
+    })
+}
+
+/// Choose the events to index and report whether this is a full rebuild.
+///
+/// Probes at `cursor - 1` rather than `cursor` so the boundary event itself
+/// comes back: if it is gone, the ledger was rebuilt or truncated under a
+/// surviving cursor. Trusting the cursor there would make every event invisible
+/// — the exact failure GH-403 exists to remove — so we rebuild instead. The
+/// probe costs one extra event on the hot path and a second read only in the
+/// rare broken case.
+fn resolve_batch<F>(
+    events_after: &F,
+    cursor: i64,
+) -> anyhow::Result<(Vec<(i64, edda_core::Event)>, bool)>
+where
+    F: Fn(i64) -> anyhow::Result<Vec<(i64, edda_core::Event)>>,
+{
+    if cursor <= 0 {
+        return Ok((events_after(0)?, true));
+    }
+    let probe = events_after(cursor - 1)?;
+    match probe.first() {
+        // Boundary event still there: it is already indexed, so skip it.
+        Some((rowid, _)) if *rowid == cursor => Ok((probe[1..].to_vec(), false)),
+        _ => Ok((events_after(0)?, true)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    fn mk_event(id: &str, ts: &str) -> edda_core::Event {
+        edda_core::Event {
+            event_id: id.to_string(),
+            ts: ts.to_string(),
+            event_type: "note".to_string(),
+            branch: "main".to_string(),
+            parent_hash: None,
+            hash: "h".to_string(),
+            payload: serde_json::json!({ "text": "hello world" }),
+            refs: Default::default(),
+            schema_version: 1,
+            digests: Vec::new(),
+            event_family: None,
+            event_level: None,
+        }
+    }
+
+    /// A fake ledger: a fixed event list plus a call counter, so tests can assert
+    /// both what was indexed and how the cursor probe behaved.
+    struct FakeLedger {
+        events: Vec<(i64, edda_core::Event)>,
+        calls: RefCell<Vec<i64>>,
+    }
+
+    impl FakeLedger {
+        fn new(events: Vec<(i64, edda_core::Event)>) -> Self {
+            Self {
+                events,
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+        fn source(&self) -> impl Fn(i64) -> anyhow::Result<Vec<(i64, edda_core::Event)>> + '_ {
+            move |after: i64| {
+                self.calls.borrow_mut().push(after);
+                Ok(self
+                    .events
+                    .iter()
+                    .filter(|(r, _)| *r > after)
+                    .cloned()
+                    .collect())
+            }
+        }
+    }
+
+    /// THE RED TEST: the executable form of the 24.7s measurement in the spec.
+    #[test]
+    fn second_sync_over_unchanged_ledger_indexes_zero_events() {
+        let tmp = tempfile::tempdir().unwrap();
+        let led = FakeLedger::new(vec![
+            (1, mk_event("evt_a", "2026-07-15T12:00:00Z")),
+            (2, mk_event("evt_b", "2026-07-15T12:01:00Z")),
+        ]);
+
+        let first = sync(tmp.path(), "p1", None, led.source()).unwrap();
+        assert_eq!(first.events, 2);
+        assert_eq!(first.indexed_through.as_deref(), Some("2026-07-15T12:01:00Z"));
+
+        let second = sync(tmp.path(), "p1", None, led.source()).unwrap();
+        assert_eq!(second.events, 0, "unchanged ledger must not re-index");
+        // Still reports where the index reached, even having done nothing.
+        assert_eq!(
+            second.indexed_through.as_deref(),
+            Some("2026-07-15T12:01:00Z")
+        );
+    }
+
+    #[test]
+    fn sync_indexes_only_new_events() {
+        let tmp = tempfile::tempdir().unwrap();
+        let led = FakeLedger::new(vec![(1, mk_event("evt_a", "2026-07-15T12:00:00Z"))]);
+        assert_eq!(sync(tmp.path(), "p1", None, led.source()).unwrap().events, 1);
+
+        let led2 = FakeLedger::new(vec![
+            (1, mk_event("evt_a", "2026-07-15T12:00:00Z")),
+            (2, mk_event("evt_b", "2026-07-15T12:01:00Z")),
+        ]);
+        let stats = sync(tmp.path(), "p1", None, led2.source()).unwrap();
+        assert_eq!(stats.events, 1, "only the new event");
+        assert!(!stats.rebuilt);
+    }
+
+    #[test]
+    fn cursor_ahead_of_ledger_triggers_full_rebuild() {
+        let tmp = tempfile::tempdir().unwrap();
+        let led = FakeLedger::new(vec![
+            (1, mk_event("evt_a", "2026-07-15T12:00:00Z")),
+            (2, mk_event("evt_b", "2026-07-15T12:01:00Z")),
+        ]);
+        sync(tmp.path(), "p1", None, led.source()).unwrap();
+
+        // Ledger rebuilt underneath us: rowids reset, cursor now points past the
+        // end. Leaving it alone would hide every event forever — the GH-403 bug.
+        let rebuilt_ledger = FakeLedger::new(vec![(1, mk_event("evt_z", "2026-07-15T13:00:00Z"))]);
+        let stats = sync(tmp.path(), "p1", None, rebuilt_ledger.source()).unwrap();
+
+        assert!(stats.rebuilt, "must detect the cursor is ahead");
+        assert_eq!(stats.events, 1, "must re-index from scratch");
+        assert_eq!(stats.indexed_through.as_deref(), Some("2026-07-15T13:00:00Z"));
+    }
+
+    #[test]
+    fn wiped_index_with_surviving_meta_db_rebuilds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let led = FakeLedger::new(vec![
+            (1, mk_event("evt_a", "2026-07-15T12:00:00Z")),
+            (2, mk_event("evt_b", "2026-07-15T12:01:00Z")),
+        ]);
+        sync(tmp.path(), "p1", None, led.source()).unwrap();
+
+        // A missing tantivy dir does NOT imply a missing cursor: meta.sqlite
+        // outlives it. created_fresh must clear the cursor, or every event stays
+        // invisible behind a watermark that describes an index that is gone.
+        std::fs::remove_dir_all(tmp.path().join("search").join("tantivy")).unwrap();
+
+        let stats = sync(tmp.path(), "p1", None, led.source()).unwrap();
+        assert!(stats.rebuilt);
+        assert_eq!(stats.events, 2, "fresh index must re-take every event");
+
+        let index = crate::schema::open_index(&tmp.path().join("search").join("tantivy")).unwrap();
+        let reader = index.reader().unwrap();
+        reader.reload().unwrap();
+        assert_eq!(reader.searcher().num_docs(), 2);
+    }
+
+    #[test]
+    fn empty_ledger_syncs_cleanly() {
+        let tmp = tempfile::tempdir().unwrap();
+        let led = FakeLedger::new(vec![]);
+        let stats = sync(tmp.path(), "p1", None, led.source()).unwrap();
+        assert_eq!(stats.events, 0);
+        assert_eq!(stats.indexed_through, None);
+    }
+
+    #[test]
+    fn crash_between_commit_and_cursor_write_recovers_without_duplicates() {
+        let tmp = tempfile::tempdir().unwrap();
+        let led = FakeLedger::new(vec![
+            (1, mk_event("evt_a", "2026-07-15T12:00:00Z")),
+            (2, mk_event("evt_b", "2026-07-15T12:01:00Z")),
+        ]);
+        sync(tmp.path(), "p1", None, led.source()).unwrap();
+
+        // Simulate the crash window: docs are committed, but the cursor never
+        // advanced. The next run must re-run the batch harmlessly.
+        let meta =
+            crate::schema::ensure_meta_db(&tmp.path().join("search").join("meta.sqlite")).unwrap();
+        crate::schema::write_events_cursor(&meta, "p1", 0, None).unwrap();
+        drop(meta);
+
+        let stats = sync(tmp.path(), "p1", None, led.source()).unwrap();
+        assert_eq!(stats.events, 2, "re-runs the batch");
+
+        let index = crate::schema::open_index(&tmp.path().join("search").join("tantivy")).unwrap();
+        let reader = index.reader().unwrap();
+        reader.reload().unwrap();
+        assert_eq!(reader.searcher().num_docs(), 2, "must not duplicate");
+    }
+}

--- a/crates/edda-search-fts/src/sync.rs
+++ b/crates/edda-search-fts/src/sync.rs
@@ -65,7 +65,15 @@ where
     }
 
     let cursor = schema::read_events_cursor(&meta_conn, project_id)?;
-    let (batch, rebuilt) = resolve_batch(&events_after, cursor.rowid)?;
+    let (batch, rebuilt) = resolve_batch(&events_after, &cursor)?;
+
+    // A rebuild must purge events the ledger no longer has. Re-adding the
+    // current ones is not enough: a truncated or replaced ledger would leave
+    // the old documents searchable forever, answering queries with events that
+    // no longer exist. (No-op when the index was just created fresh.)
+    if rebuilt {
+        indexer::delete_all_event_docs(&writer, &tantivy_schema)?;
+    }
 
     let events = indexer::index_events_since(&writer, &tantivy_schema, project_id, &batch)?;
 
@@ -111,26 +119,37 @@ where
 
 /// Choose the events to index and report whether this is a full rebuild.
 ///
-/// Probes at `cursor - 1` rather than `cursor` so the boundary event itself
-/// comes back: if it is gone, the ledger was rebuilt or truncated under a
-/// surviving cursor. Trusting the cursor there would make every event invisible
-/// — the exact failure GH-403 exists to remove — so we rebuild instead. The
-/// probe costs one extra event on the hot path and a second read only in the
-/// rare broken case.
+/// Probes at `rowid - 1` rather than `rowid` so the boundary event itself comes
+/// back, then checks it is still the *same* event we indexed — matching both its
+/// rowid and its timestamp.
+///
+/// The rowid alone is not identity. A ledger restored from a different backup,
+/// or another repo mapped onto this project id, can occupy the same rowid range
+/// with entirely different events; a rowid-only check would see the boundary,
+/// trust the cursor, and silently skip every event in the replacement forever.
+/// Matching the timestamp too means a ledger restored from its *own* backup
+/// still compares equal and avoids a needless rebuild.
+///
+/// Costs one extra event on the hot path, and a second read only in the rare
+/// broken case.
 fn resolve_batch<F>(
     events_after: &F,
-    cursor: i64,
+    cursor: &schema::EventsCursor,
 ) -> anyhow::Result<(Vec<(i64, edda_core::Event)>, bool)>
 where
     F: Fn(i64) -> anyhow::Result<Vec<(i64, edda_core::Event)>>,
 {
-    if cursor <= 0 {
+    if cursor.rowid <= 0 {
         return Ok((events_after(0)?, true));
     }
-    let probe = events_after(cursor - 1)?;
+    let probe = events_after(cursor.rowid - 1)?;
     match probe.first() {
-        // Boundary event still there: it is already indexed, so skip it.
-        Some((rowid, _)) if *rowid == cursor => Ok((probe[1..].to_vec(), false)),
+        // Same rowid AND same event: already indexed, so skip just it.
+        Some((rowid, ev))
+            if *rowid == cursor.rowid && cursor.ts.as_deref() == Some(ev.ts.as_str()) =>
+        {
+            Ok((probe[1..].to_vec(), false))
+        }
         _ => Ok((events_after(0)?, true)),
     }
 }
@@ -271,6 +290,58 @@ mod tests {
         let reader = index.reader().unwrap();
         reader.reload().unwrap();
         assert_eq!(reader.searcher().num_docs(), 2);
+    }
+
+    #[test]
+    fn ledger_replaced_at_the_same_rowids_is_not_trusted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let led = FakeLedger::new(vec![
+            (1, mk_event("evt_a", "2026-07-15T12:00:00Z")),
+            (2, mk_event("evt_b", "2026-07-15T12:01:00Z")),
+        ]);
+        sync(tmp.path(), "p1", None, led.source()).unwrap();
+
+        // A DIFFERENT ledger now occupies the same rowid range — restored from
+        // another backup, or another repo mapped onto this project id. The
+        // boundary rowid still exists, so validating on rowid alone would trust
+        // the cursor and silently skip every event in the replacement.
+        let other = FakeLedger::new(vec![
+            (1, mk_event("evt_x", "2026-07-15T20:00:00Z")),
+            (2, mk_event("evt_y", "2026-07-15T20:01:00Z")),
+        ]);
+        let stats = sync(tmp.path(), "p1", None, other.source()).unwrap();
+
+        assert!(
+            stats.rebuilt,
+            "a replaced ledger must not be trusted on rowid alone"
+        );
+        assert_eq!(stats.events, 2, "the replacement's events must be indexed");
+    }
+
+    #[test]
+    fn rebuild_purges_events_the_ledger_no_longer_has() {
+        let tmp = tempfile::tempdir().unwrap();
+        let led = FakeLedger::new(vec![
+            (1, mk_event("evt_a", "2026-07-15T12:00:00Z")),
+            (2, mk_event("evt_b", "2026-07-15T12:01:00Z")),
+        ]);
+        sync(tmp.path(), "p1", None, led.source()).unwrap();
+
+        // Ledger truncated. The removed bulk path purged orphans implicitly by
+        // deleting every event doc before re-adding; the incremental path must
+        // do it explicitly on rebuild, or these stay searchable forever.
+        let empty = FakeLedger::new(vec![]);
+        let stats = sync(tmp.path(), "p1", None, empty.source()).unwrap();
+        assert!(stats.rebuilt);
+
+        let index = crate::schema::open_index(&tmp.path().join("search").join("tantivy")).unwrap();
+        let reader = index.reader().unwrap();
+        reader.reload().unwrap();
+        assert_eq!(
+            reader.searcher().num_docs(),
+            0,
+            "orphaned event docs must be purged on rebuild"
+        );
     }
 
     #[test]

--- a/crates/edda-search-fts/src/sync.rs
+++ b/crates/edda-search-fts/src/sync.rs
@@ -195,7 +195,10 @@ mod tests {
 
         let first = sync(tmp.path(), "p1", None, led.source()).unwrap();
         assert_eq!(first.events, 2);
-        assert_eq!(first.indexed_through.as_deref(), Some("2026-07-15T12:01:00Z"));
+        assert_eq!(
+            first.indexed_through.as_deref(),
+            Some("2026-07-15T12:01:00Z")
+        );
 
         let second = sync(tmp.path(), "p1", None, led.source()).unwrap();
         assert_eq!(second.events, 0, "unchanged ledger must not re-index");
@@ -210,7 +213,10 @@ mod tests {
     fn sync_indexes_only_new_events() {
         let tmp = tempfile::tempdir().unwrap();
         let led = FakeLedger::new(vec![(1, mk_event("evt_a", "2026-07-15T12:00:00Z"))]);
-        assert_eq!(sync(tmp.path(), "p1", None, led.source()).unwrap().events, 1);
+        assert_eq!(
+            sync(tmp.path(), "p1", None, led.source()).unwrap().events,
+            1
+        );
 
         let led2 = FakeLedger::new(vec![
             (1, mk_event("evt_a", "2026-07-15T12:00:00Z")),
@@ -237,7 +243,10 @@ mod tests {
 
         assert!(stats.rebuilt, "must detect the cursor is ahead");
         assert_eq!(stats.events, 1, "must re-index from scratch");
-        assert_eq!(stats.indexed_through.as_deref(), Some("2026-07-15T13:00:00Z"));
+        assert_eq!(
+            stats.indexed_through.as_deref(),
+            Some("2026-07-15T13:00:00Z")
+        );
     }
 
     #[test]

--- a/docs/plan/search-auto-index/IMPLEMENTATION_PLAN.md
+++ b/docs/plan/search-auto-index/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,1208 @@
+# Search Auto-Index Implementation Plan (GH-403)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Tantivy event index incremental and keep it current automatically, so `edda search` never ships cold or silently omits recent history.
+
+**Architecture:** A single `sync` entry point in `edda-search-fts` owns all index orchestration (lock, open/create, cursor, incremental event indexing, turns, commit, cursor write). Events become incremental via a sqlite rowid cursor over the existing `Ledger::events_after_rowid`, with per-event `delete_term` replace for idempotence and commit-before-cursor ordering for crash safety. Three callers sit in front of it: manual `edda search index`, query-time build-if-missing, and a new SessionEnd background task.
+
+**Tech Stack:** Rust workspace, tantivy 0.25, rusqlite (bundled), fs2 file locks, anyhow, tracing.
+
+**Spec:** `docs/plan/search-auto-index/SEARCH_AUTO_INDEX_V1.md`
+
+## Global Constraints
+
+- Branch: `agent/GH-403`. Repo `main` accepts PRs only; merge is the operator's gate.
+- **No new Tantivy field.** `INDEX_VERSION` stays `2` — a bump forces every user through a second full rebuild days after #410 forced one.
+- **Commit before cursor write, always.** The reverse order loses events permanently.
+- Callers never pass or reset the cursor; `sync` owns it.
+- SessionEnd must never block exit: best-effort, `tracing::warn!` on failure, no cold build.
+- **Do not touch `cmd_ask.rs`.** Its transcript callback stays read-only (`open_index`). Build-if-missing belongs to the user-facing `search query` only — a background hook must never silently stall ~25s on a cold build.
+- `RUSTFLAGS: -Dwarnings` in CI — no warnings, including unused imports after removals.
+- Tests run with `cargo test -p edda-search-fts` / `-p edda` (the CLI package is named **`edda`**, not `edda-cli`).
+- Known flake, not caused by this work: `secret_guard::tests::hot_path_under_ten_ms_for_realistic_length` fails under parallel load, passes in isolation.
+
+---
+
+### Task 1: Meta-DB cursor storage
+
+Adds the `events_watermark` table and its accessors. The DDL is currently duplicated verbatim between `ensure_meta_db` and `ensure_meta_db_memory`; adding a third table to both by hand would let the test DB drift from the real one, so extract it first.
+
+**Files:**
+- Modify: `crates/edda-search-fts/src/schema.rs:200-270`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `pub struct EventsCursor { pub rowid: i64, pub ts: Option<String> }`
+  - `pub fn read_events_cursor(conn: &Connection, project_id: &str) -> anyhow::Result<EventsCursor>`
+  - `pub fn write_events_cursor(conn: &Connection, project_id: &str, rowid: i64, ts: Option<&str>) -> anyhow::Result<()>`
+  - `clear_index_watermark` additionally clears `events_watermark`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `mod tests` block at the bottom of `crates/edda-search-fts/src/schema.rs`:
+
+```rust
+    #[test]
+    fn events_cursor_roundtrip_and_default() {
+        let conn = ensure_meta_db_memory().unwrap();
+
+        // Absent cursor reads as zero, not an error.
+        let c = read_events_cursor(&conn, "p1").unwrap();
+        assert_eq!(c.rowid, 0);
+        assert_eq!(c.ts, None);
+
+        write_events_cursor(&conn, "p1", 42, Some("2026-07-15T09:40:00Z")).unwrap();
+        let c = read_events_cursor(&conn, "p1").unwrap();
+        assert_eq!(c.rowid, 42);
+        assert_eq!(c.ts.as_deref(), Some("2026-07-15T09:40:00Z"));
+
+        // Upsert, not a second row.
+        write_events_cursor(&conn, "p1", 99, Some("2026-07-15T10:00:00Z")).unwrap();
+        let c = read_events_cursor(&conn, "p1").unwrap();
+        assert_eq!(c.rowid, 99);
+
+        // Cursors are per project.
+        assert_eq!(read_events_cursor(&conn, "p2").unwrap().rowid, 0);
+    }
+
+    #[test]
+    fn clear_index_watermark_also_clears_events_cursor() {
+        let conn = ensure_meta_db_memory().unwrap();
+        write_events_cursor(&conn, "p1", 42, Some("2026-07-15T09:40:00Z")).unwrap();
+
+        clear_index_watermark(&conn).unwrap();
+
+        // A fresh index must re-index every event, so the cursor must reset too.
+        assert_eq!(read_events_cursor(&conn, "p1").unwrap().rowid, 0);
+    }
+
+    #[test]
+    fn memory_and_file_meta_dbs_have_the_same_tables() {
+        // The two builders share one DDL const; this pins that they cannot drift.
+        let tmp = tempfile::tempdir().unwrap();
+        let file_conn = ensure_meta_db(&tmp.path().join("meta.sqlite")).unwrap();
+        let mem_conn = ensure_meta_db_memory().unwrap();
+
+        let tables = |c: &Connection| -> Vec<String> {
+            let mut stmt = c
+                .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+                .unwrap();
+            let rows = stmt.query_map([], |r| r.get::<_, String>(0)).unwrap();
+            rows.map(|r| r.unwrap())
+                .filter(|n| !n.starts_with("sqlite_"))
+                .collect()
+        };
+
+        assert_eq!(tables(&file_conn), tables(&mem_conn));
+        assert!(tables(&mem_conn).contains(&"events_watermark".to_string()));
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p edda-search-fts schema:: 2>&1 | tail -20`
+Expected: FAIL — `cannot find function 'read_events_cursor'`, `cannot find function 'write_events_cursor'`, `cannot find type 'EventsCursor'`.
+
+- [ ] **Step 3: Extract the DDL to a single const**
+
+In `crates/edda-search-fts/src/schema.rs`, add above `ensure_meta_db`:
+
+```rust
+/// Schema for the search meta database, shared by the on-disk and in-memory
+/// builders so a test DB can never drift from the real one. All statements are
+/// `IF NOT EXISTS`, so adding a table needs no migration.
+const META_DDL: &str = "
+    CREATE TABLE IF NOT EXISTS turns_meta (
+        turn_id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        ts TEXT,
+        user_uuid TEXT,
+        assistant_uuid TEXT,
+        user_store_offset INTEGER,
+        user_store_len INTEGER,
+        assistant_store_offset INTEGER,
+        assistant_store_len INTEGER
+    );
+
+    CREATE TABLE IF NOT EXISTS index_watermark (
+        project_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        last_offset INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (project_id, session_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS events_watermark (
+        project_id TEXT PRIMARY KEY,
+        last_rowid INTEGER NOT NULL DEFAULT 0,
+        last_ts TEXT
+    );
+";
+```
+
+Replace the body of `ensure_meta_db` (the `conn.execute_batch(\"...\")?;` call with the inline DDL string) with:
+
+```rust
+    conn.execute_batch(META_DDL)?;
+```
+
+Replace the same inline DDL inside `ensure_meta_db_memory` with:
+
+```rust
+    conn.execute_batch(META_DDL)?;
+```
+
+- [ ] **Step 4: Add the cursor accessors**
+
+In `crates/edda-search-fts/src/schema.rs`, change the rusqlite import at the top of the file:
+
+```rust
+use rusqlite::{Connection, OptionalExtension};
+```
+
+Add after `clear_index_watermark`:
+
+```rust
+/// Where the event index has reached: the ledger rowid of the last indexed
+/// event, plus its timestamp for staleness reporting (GH-403).
+#[derive(Debug, Clone, PartialEq)]
+pub struct EventsCursor {
+    pub rowid: i64,
+    pub ts: Option<String>,
+}
+
+/// Read a project's event cursor. An absent cursor is `rowid = 0` — index from
+/// the beginning — not an error.
+pub fn read_events_cursor(conn: &Connection, project_id: &str) -> anyhow::Result<EventsCursor> {
+    let row = conn
+        .query_row(
+            "SELECT last_rowid, last_ts FROM events_watermark WHERE project_id = ?1",
+            [project_id],
+            |r| Ok((r.get::<_, i64>(0)?, r.get::<_, Option<String>>(1)?)),
+        )
+        .optional()?;
+    Ok(match row {
+        Some((rowid, ts)) => EventsCursor { rowid, ts },
+        None => EventsCursor { rowid: 0, ts: None },
+    })
+}
+
+/// Advance a project's event cursor. Written only AFTER a successful commit, so
+/// a crash in between re-runs the batch instead of skipping it.
+pub fn write_events_cursor(
+    conn: &Connection,
+    project_id: &str,
+    rowid: i64,
+    ts: Option<&str>,
+) -> anyhow::Result<()> {
+    conn.execute(
+        "INSERT INTO events_watermark (project_id, last_rowid, last_ts) VALUES (?1, ?2, ?3)
+         ON CONFLICT(project_id) DO UPDATE SET last_rowid = ?2, last_ts = ?3",
+        rusqlite::params![project_id, rowid, ts],
+    )?;
+    Ok(())
+}
+```
+
+Extend `clear_index_watermark` to cover the new table:
+
+```rust
+pub fn clear_index_watermark(conn: &Connection) -> anyhow::Result<()> {
+    conn.execute_batch(
+        "DELETE FROM turns_meta; DELETE FROM index_watermark; DELETE FROM events_watermark;",
+    )?;
+    Ok(())
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test -p edda-search-fts 2>&1 | tail -8`
+Expected: PASS — all schema tests green, including the three new ones.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/edda-search-fts/src/schema.rs
+git commit -m "feat(search): events_watermark cursor storage (GH-403)
+
+Adds a per-project ledger-rowid cursor for the event index, plus accessors.
+clear_index_watermark now clears it too, so the existing fresh-index reset keeps
+covering the whole cursor set.
+
+The meta DDL was duplicated verbatim between the on-disk and in-memory builders;
+extracted to one META_DDL const so the test DB cannot drift from the real one."
+```
+
+---
+
+### Task 2: Idempotent incremental event indexing
+
+**Files:**
+- Modify: `crates/edda-search-fts/src/indexer.rs:13-37`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `pub fn index_events_since(writer: &IndexWriter, schema: &Schema, project_id: &str, events: &[(i64, edda_core::Event)]) -> anyhow::Result<usize>`
+
+`index_events` is left in place for now — Task 4 removes it once its last caller is gone, so every task compiles green.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `mod tests` block in `crates/edda-search-fts/src/indexer.rs`:
+
+```rust
+    fn mk_test_event(id: &str) -> edda_core::Event {
+        edda_core::Event {
+            event_id: id.to_string(),
+            ts: "2026-07-15T12:00:00Z".to_string(),
+            event_type: "note".to_string(),
+            branch: "main".to_string(),
+            parent_hash: None,
+            hash: "h".to_string(),
+            payload: serde_json::json!({ "text": "hello world" }),
+            refs: Default::default(),
+            schema_version: 1,
+            digests: Vec::new(),
+            event_family: None,
+            event_level: None,
+        }
+    }
+
+    #[test]
+    fn index_events_since_is_idempotent_per_event() {
+        let index = ensure_index_ram().unwrap();
+        let schema = index.schema();
+        let mut writer = index_writer(&index).unwrap();
+
+        let batch = vec![(1i64, mk_test_event("evt_a")), (2i64, mk_test_event("evt_b"))];
+
+        let n = index_events_since(&writer, &schema, "p1", &batch).unwrap();
+        writer.commit().unwrap();
+        assert_eq!(n, 2);
+
+        // Re-running the same batch is what happens after a crash between commit
+        // and the cursor write. It must replace, not duplicate.
+        index_events_since(&writer, &schema, "p1", &batch).unwrap();
+        writer.commit().unwrap();
+
+        let reader = index.reader().unwrap();
+        reader.reload().unwrap();
+        assert_eq!(reader.searcher().num_docs(), 2, "re-run must not duplicate docs");
+    }
+
+    #[test]
+    fn index_events_since_appends_without_touching_existing() {
+        let index = ensure_index_ram().unwrap();
+        let schema = index.schema();
+        let mut writer = index_writer(&index).unwrap();
+
+        index_events_since(&writer, &schema, "p1", &[(1i64, mk_test_event("evt_a"))]).unwrap();
+        writer.commit().unwrap();
+
+        // An incremental batch must not delete docs outside it — the whole point
+        // of dropping the old delete-all.
+        index_events_since(&writer, &schema, "p1", &[(2i64, mk_test_event("evt_b"))]).unwrap();
+        writer.commit().unwrap();
+
+        let reader = index.reader().unwrap();
+        reader.reload().unwrap();
+        assert_eq!(reader.searcher().num_docs(), 2);
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p edda-search-fts index_events_since 2>&1 | tail -12`
+Expected: FAIL — `cannot find function 'index_events_since' in this scope`.
+
+- [ ] **Step 3: Implement `index_events_since`**
+
+In `crates/edda-search-fts/src/indexer.rs`, add directly after `index_events`:
+
+```rust
+/// Index a batch of `(rowid, Event)` pairs incrementally (GH-403).
+///
+/// Each event is replaced rather than blindly added: `delete_term` on its
+/// `doc_id` first, then re-add. That makes re-running a batch a no-op in effect,
+/// which is what allows the caller to commit before advancing its cursor — a
+/// crash in between simply re-runs this batch on the next pass.
+///
+/// Unlike the bulk path this deletes nothing outside the batch, so callers must
+/// pass only events the index has not seen.
+pub fn index_events_since(
+    writer: &IndexWriter,
+    schema: &Schema,
+    project_id: &str,
+    events: &[(i64, edda_core::Event)],
+) -> anyhow::Result<usize> {
+    let f_doc_id = schema.get_field("doc_id")?;
+    let mut count = 0;
+    for (_rowid, event) in events {
+        writer.delete_term(Term::from_field_text(f_doc_id, event.event_id.as_str()));
+        add_event_doc(writer, schema, project_id, event)?;
+        count += 1;
+    }
+    Ok(count)
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p edda-search-fts 2>&1 | tail -8`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/edda-search-fts/src/indexer.rs
+git commit -m "feat(search): index_events_since — idempotent incremental event indexing (GH-403)
+
+Replaces per event (delete_term on doc_id, then add) instead of the bulk path's
+delete-everything-then-re-add. Re-running a batch is therefore harmless, which is
+what lets the caller commit before advancing its cursor."
+```
+
+---
+
+### Task 3: The `sync` module
+
+The heart of the change. This is where the RED test from the spec lives.
+
+**Files:**
+- Create: `crates/edda-search-fts/src/sync.rs`
+- Modify: `crates/edda-search-fts/src/lib.rs:1-4`
+
+**Interfaces:**
+- Consumes: `schema::{IndexLock, index_is_outdated, open_or_create_index, index_writer, ensure_meta_db, clear_index_watermark, read_events_cursor, write_events_cursor, write_index_version}` (Task 1), `indexer::{index_events_since, index_project, index_session}` (Task 2).
+- Produces:
+  - `pub struct SyncStats { pub events: usize, pub turns: usize, pub indexed_through: Option<String>, pub rebuilt: bool }`
+  - `pub fn sync<F>(proj_dir: &Path, project_id: &str, session_id: Option<&str>, events_after: F) -> anyhow::Result<SyncStats> where F: Fn(i64) -> anyhow::Result<Vec<(i64, edda_core::Event)>>`
+
+Note `Fn`, not `FnOnce` (the spec's sketch said `FnOnce`): detecting a cursor that has run ahead of the ledger requires a second call in the rare broken case.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `crates/edda-search-fts/src/sync.rs` with the tests only for now (implementation follows in Step 3):
+
+```rust
+//! Placeholder — implementation added in Step 3.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    fn mk_event(id: &str, ts: &str) -> edda_core::Event {
+        edda_core::Event {
+            event_id: id.to_string(),
+            ts: ts.to_string(),
+            event_type: "note".to_string(),
+            branch: "main".to_string(),
+            parent_hash: None,
+            hash: "h".to_string(),
+            payload: serde_json::json!({ "text": "hello world" }),
+            refs: Default::default(),
+            schema_version: 1,
+            digests: Vec::new(),
+            event_family: None,
+            event_level: None,
+        }
+    }
+
+    /// A fake ledger: a fixed event list plus a call counter, so tests can assert
+    /// both what was indexed and how the cursor probe behaved.
+    struct FakeLedger {
+        events: Vec<(i64, edda_core::Event)>,
+        calls: RefCell<Vec<i64>>,
+    }
+
+    impl FakeLedger {
+        fn new(events: Vec<(i64, edda_core::Event)>) -> Self {
+            Self { events, calls: RefCell::new(Vec::new()) }
+        }
+        fn source(&self) -> impl Fn(i64) -> anyhow::Result<Vec<(i64, edda_core::Event)>> + '_ {
+            move |after: i64| {
+                self.calls.borrow_mut().push(after);
+                Ok(self
+                    .events
+                    .iter()
+                    .filter(|(r, _)| *r > after)
+                    .cloned()
+                    .collect())
+            }
+        }
+    }
+
+    /// THE RED TEST: the executable form of the 24.7s measurement in the spec.
+    #[test]
+    fn second_sync_over_unchanged_ledger_indexes_zero_events() {
+        let tmp = tempfile::tempdir().unwrap();
+        let led = FakeLedger::new(vec![
+            (1, mk_event("evt_a", "2026-07-15T12:00:00Z")),
+            (2, mk_event("evt_b", "2026-07-15T12:01:00Z")),
+        ]);
+
+        let first = sync(tmp.path(), "p1", None, led.source()).unwrap();
+        assert_eq!(first.events, 2);
+        assert_eq!(first.indexed_through.as_deref(), Some("2026-07-15T12:01:00Z"));
+
+        let second = sync(tmp.path(), "p1", None, led.source()).unwrap();
+        assert_eq!(second.events, 0, "unchanged ledger must not re-index");
+        // Still reports where the index reached, even having done nothing.
+        assert_eq!(second.indexed_through.as_deref(), Some("2026-07-15T12:01:00Z"));
+    }
+
+    #[test]
+    fn sync_indexes_only_new_events() {
+        let tmp = tempfile::tempdir().unwrap();
+        let led = FakeLedger::new(vec![(1, mk_event("evt_a", "2026-07-15T12:00:00Z"))]);
+        assert_eq!(sync(tmp.path(), "p1", None, led.source()).unwrap().events, 1);
+
+        let led2 = FakeLedger::new(vec![
+            (1, mk_event("evt_a", "2026-07-15T12:00:00Z")),
+            (2, mk_event("evt_b", "2026-07-15T12:01:00Z")),
+        ]);
+        let stats = sync(tmp.path(), "p1", None, led2.source()).unwrap();
+        assert_eq!(stats.events, 1, "only the new event");
+        assert!(!stats.rebuilt);
+    }
+
+    #[test]
+    fn cursor_ahead_of_ledger_triggers_full_rebuild() {
+        let tmp = tempfile::tempdir().unwrap();
+        let led = FakeLedger::new(vec![
+            (1, mk_event("evt_a", "2026-07-15T12:00:00Z")),
+            (2, mk_event("evt_b", "2026-07-15T12:01:00Z")),
+        ]);
+        sync(tmp.path(), "p1", None, led.source()).unwrap();
+
+        // Ledger rebuilt underneath us: rowids reset, cursor now points past the
+        // end. Leaving it alone would hide every event forever — the GH-403 bug.
+        let rebuilt_ledger = FakeLedger::new(vec![(1, mk_event("evt_z", "2026-07-15T13:00:00Z"))]);
+        let stats = sync(tmp.path(), "p1", None, rebuilt_ledger.source()).unwrap();
+
+        assert!(stats.rebuilt, "must detect the cursor is ahead");
+        assert_eq!(stats.events, 1, "must re-index from scratch");
+        assert_eq!(stats.indexed_through.as_deref(), Some("2026-07-15T13:00:00Z"));
+    }
+
+    #[test]
+    fn wiped_index_with_surviving_meta_db_rebuilds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let led = FakeLedger::new(vec![
+            (1, mk_event("evt_a", "2026-07-15T12:00:00Z")),
+            (2, mk_event("evt_b", "2026-07-15T12:01:00Z")),
+        ]);
+        sync(tmp.path(), "p1", None, led.source()).unwrap();
+
+        // A missing tantivy dir does NOT imply a missing cursor: meta.sqlite
+        // outlives it. created_fresh must clear the cursor, or every event stays
+        // invisible behind a watermark that describes an index that is gone.
+        std::fs::remove_dir_all(tmp.path().join("search").join("tantivy")).unwrap();
+
+        let stats = sync(tmp.path(), "p1", None, led.source()).unwrap();
+        assert!(stats.rebuilt);
+        assert_eq!(stats.events, 2, "fresh index must re-take every event");
+
+        let index = crate::schema::open_index(&tmp.path().join("search").join("tantivy")).unwrap();
+        let reader = index.reader().unwrap();
+        reader.reload().unwrap();
+        assert_eq!(reader.searcher().num_docs(), 2);
+    }
+
+    #[test]
+    fn empty_ledger_syncs_cleanly() {
+        let tmp = tempfile::tempdir().unwrap();
+        let led = FakeLedger::new(vec![]);
+        let stats = sync(tmp.path(), "p1", None, led.source()).unwrap();
+        assert_eq!(stats.events, 0);
+        assert_eq!(stats.indexed_through, None);
+    }
+
+    #[test]
+    fn crash_between_commit_and_cursor_write_recovers_without_duplicates() {
+        let tmp = tempfile::tempdir().unwrap();
+        let led = FakeLedger::new(vec![
+            (1, mk_event("evt_a", "2026-07-15T12:00:00Z")),
+            (2, mk_event("evt_b", "2026-07-15T12:01:00Z")),
+        ]);
+        sync(tmp.path(), "p1", None, led.source()).unwrap();
+
+        // Simulate the crash window: docs are committed, but the cursor never
+        // advanced. The next run must re-run the batch harmlessly.
+        let meta = crate::schema::ensure_meta_db(&tmp.path().join("search").join("meta.sqlite")).unwrap();
+        crate::schema::write_events_cursor(&meta, "p1", 0, None).unwrap();
+        drop(meta);
+
+        let stats = sync(tmp.path(), "p1", None, led.source()).unwrap();
+        assert_eq!(stats.events, 2, "re-runs the batch");
+
+        let index = crate::schema::open_index(&tmp.path().join("search").join("tantivy")).unwrap();
+        let reader = index.reader().unwrap();
+        reader.reload().unwrap();
+        assert_eq!(reader.searcher().num_docs(), 2, "must not duplicate");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Add `pub mod sync;` to `crates/edda-search-fts/src/lib.rs` so the module compiles:
+
+```rust
+pub mod indexer;
+pub mod schema;
+pub mod search;
+pub mod sync;
+pub mod tokenizer;
+```
+
+Run: `cargo test -p edda-search-fts sync:: 2>&1 | tail -12`
+Expected: FAIL — `cannot find function 'sync' in this scope`.
+
+- [ ] **Step 3: Implement `sync`**
+
+Replace the placeholder line at the top of `crates/edda-search-fts/src/sync.rs` (keep the `mod tests` block) with:
+
+```rust
+//! One home for search index orchestration (GH-403).
+//!
+//! Three callers need identical behaviour — the manual `edda search index`, the
+//! query-time cold build, and the SessionEnd background task — so the lock /
+//! open / cursor / commit dance lives here exactly once rather than being
+//! re-implemented per call site.
+//!
+//! Events arrive through an injected closure, keeping this crate unaware of
+//! `edda-ledger` (the same inversion `index_events` already used).
+
+use crate::{indexer, schema};
+use std::path::Path;
+
+/// What a sync did. `indexed_through` is the timestamp of the newest indexed
+/// event — reported even when this run indexed nothing, so callers can always
+/// tell the user how current the index is.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SyncStats {
+    pub events: usize,
+    pub turns: usize,
+    pub indexed_through: Option<String>,
+    pub rebuilt: bool,
+}
+
+/// Bring a project's search index up to date with its ledger and transcripts.
+///
+/// `events_after` is `|rowid| ledger.events_after_rowid(rowid)`. It is `Fn`
+/// rather than `FnOnce` because a cursor that has run ahead of the ledger can
+/// only be detected by probing, then re-reading from the start.
+///
+/// The cursor is owned here: callers never pass or reset it. `sync` resets to a
+/// full rebuild when the index was created fresh (schema upgrade, corruption,
+/// crash mid-wipe) or when the stored cursor no longer matches the ledger.
+pub fn sync<F>(
+    proj_dir: &Path,
+    project_id: &str,
+    session_id: Option<&str>,
+    events_after: F,
+) -> anyhow::Result<SyncStats>
+where
+    F: Fn(i64) -> anyhow::Result<Vec<(i64, edda_core::Event)>>,
+{
+    let search_dir = proj_dir.join("search");
+    let index_dir = search_dir.join("tantivy");
+    let meta_db_path = search_dir.join("meta.sqlite");
+
+    // Serialize against any other indexer touching this project (GH-402).
+    let _lock = schema::IndexLock::acquire(&search_dir)?;
+
+    // Schema upgrade: wipe so it is recreated fresh below.
+    if schema::index_is_outdated(&index_dir) {
+        std::fs::remove_dir_all(&index_dir)?;
+    }
+
+    let (index, created_fresh) = schema::open_or_create_index(&index_dir)?;
+    let tantivy_schema = index.schema();
+    let mut writer = schema::index_writer(&index)?;
+    let meta_conn = schema::ensure_meta_db(&meta_db_path)?;
+
+    // A fresh tantivy index means every watermark is a lie — including the event
+    // cursor. Clearing before reading is what makes a missing index dir safe
+    // even when meta.sqlite outlived it.
+    if created_fresh {
+        schema::clear_index_watermark(&meta_conn)?;
+    }
+
+    let cursor = schema::read_events_cursor(&meta_conn, project_id)?;
+    let (batch, rebuilt) = resolve_batch(&events_after, cursor.rowid)?;
+
+    let events = indexer::index_events_since(&writer, &tantivy_schema, project_id, &batch)?;
+
+    // A rebuild must cover every session, otherwise sessions other than the
+    // requested one vanish behind the fresh index.
+    let turns = match session_id {
+        Some(sid) if !rebuilt => indexer::index_session(
+            &writer,
+            &tantivy_schema,
+            &meta_conn,
+            proj_dir,
+            project_id,
+            sid,
+        )?,
+        _ => indexer::index_project(&writer, &tantivy_schema, &meta_conn, proj_dir, project_id)?,
+    };
+
+    // Commit BEFORE advancing the cursor. A crash in between re-runs this batch,
+    // which index_events_since makes idempotent. The reverse order would mark
+    // events indexed that are not, hiding them forever.
+    writer.commit()?;
+    schema::write_index_version(&index_dir)?;
+
+    let indexed_through = if let Some((rowid, ev)) = batch.last() {
+        schema::write_events_cursor(&meta_conn, project_id, *rowid, Some(ev.ts.as_str()))?;
+        Some(ev.ts.clone())
+    } else if rebuilt {
+        // Rebuilt against an empty ledger: clear a stale-ahead cursor rather
+        // than letting it survive.
+        schema::write_events_cursor(&meta_conn, project_id, 0, None)?;
+        None
+    } else {
+        cursor.ts.clone()
+    };
+
+    Ok(SyncStats { events, turns, indexed_through, rebuilt })
+}
+
+/// Choose the events to index and report whether this is a full rebuild.
+///
+/// Probes at `cursor - 1` rather than `cursor` so the boundary event itself
+/// comes back: if it is gone, the ledger was rebuilt or truncated under a
+/// surviving cursor. Trusting the cursor there would make every event invisible
+/// — the exact failure GH-403 exists to remove — so we rebuild instead. The
+/// probe costs one extra event on the hot path and a second read only in the
+/// rare broken case.
+fn resolve_batch<F>(
+    events_after: &F,
+    cursor: i64,
+) -> anyhow::Result<(Vec<(i64, edda_core::Event)>, bool)>
+where
+    F: Fn(i64) -> anyhow::Result<Vec<(i64, edda_core::Event)>>,
+{
+    if cursor <= 0 {
+        return Ok((events_after(0)?, true));
+    }
+    let probe = events_after(cursor - 1)?;
+    match probe.first() {
+        // Boundary event still there: it is already indexed, so skip it.
+        Some((rowid, _)) if *rowid == cursor => Ok((probe[1..].to_vec(), false)),
+        _ => Ok((events_after(0)?, true)),
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p edda-search-fts 2>&1 | tail -8`
+Expected: PASS — all sync tests green, including the RED test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/edda-search-fts/src/sync.rs crates/edda-search-fts/src/lib.rs
+git commit -m "feat(search): sync module — incremental index orchestration (GH-403)
+
+One home for lock/open/cursor/commit, shared by the three callers so the dance
+is not re-implemented per call site. Events arrive via an injected closure,
+keeping this crate unaware of edda-ledger.
+
+Commits before advancing the cursor, so a crash in between re-runs the batch
+idempotently rather than marking events indexed that are not. A cursor that has
+run ahead of the ledger is detected by probing the boundary event and triggers a
+full rebuild."
+```
+
+---
+
+### Task 4: Rewire `edda search index` onto sync, retire the bulk path
+
+**Files:**
+- Modify: `crates/edda-cli/src/cmd_search.rs:169-240` (the `index` fn)
+- Modify: `crates/edda-search-fts/src/indexer.rs:13-37` (remove `index_events`, fix stale comment)
+
+**Interfaces:**
+- Consumes: `sync::sync` (Task 3).
+- Produces: no new API. `indexer::index_events` ceases to exist.
+
+- [ ] **Step 1: Replace the body of `index`**
+
+In `crates/edda-cli/src/cmd_search.rs`, replace the whole `index` function with:
+
+```rust
+/// Execute `edda search index` — build/update the Tantivy index for a project.
+pub fn index(repo_root: &Path, project_id: &str, session_id: Option<&str>) -> anyhow::Result<()> {
+    let proj_dir = project_dir(project_id);
+    if !proj_dir.exists() {
+        anyhow::bail!("Project directory not found: {}", proj_dir.display());
+    }
+
+    let ledger = Ledger::open(repo_root)?;
+    let stats = sync::sync(&proj_dir, project_id, session_id, |after| {
+        ledger.events_after_rowid(after)
+    })?;
+
+    if stats.rebuilt {
+        println!("Rebuilt index from scratch.");
+    }
+    println!(
+        "Indexed {} event(s) + {} turn(s) for project {project_id}",
+        stats.events, stats.turns
+    );
+    Ok(())
+}
+```
+
+Update the imports at the top of `crates/edda-cli/src/cmd_search.rs`:
+
+```rust
+use edda_search_fts::{schema, search, sync};
+```
+
+(`indexer` is no longer referenced from this file.)
+
+- [ ] **Step 2: Remove the retired bulk path**
+
+In `crates/edda-search-fts/src/indexer.rs`, delete the entire `index_events` function (from its doc comment through its closing brace).
+
+Then fix the stale claim on `add_event_doc` — it advertises a caller that has never existed:
+
+```rust
+/// Add a single ledger event as a Tantivy document.
+///
+/// Used by `index_events_since`; kept public for direct use in tests.
+pub fn add_event_doc(
+```
+
+- [ ] **Step 3: Build and run the full test suite**
+
+Run: `cargo build -p edda 2>&1 | tail -5 && cargo test -p edda-search-fts 2>&1 | tail -5`
+Expected: clean build (no unused-import warnings — CI runs `-Dwarnings`), all tests PASS.
+
+If `cargo test -p edda-search-fts` reports `index_events` still referenced, a test in `indexer.rs` or `search.rs` still calls the bulk path; port it to `index_events_since` with a `[(1i64, event)]` batch.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/edda-cli/src/cmd_search.rs crates/edda-search-fts/src/indexer.rs
+git commit -m "refactor(search): edda search index goes through sync; drop index_events (GH-403)
+
+The bulk path deleted every event doc and re-added all of them on every run —
+24.7s on a 2227-event corpus even with nothing new. Its last caller is gone, so
+it goes. Full rebuilds are now expressed as a sync with a reset cursor.
+
+Also drops the add_event_doc doc comment's claim of an append-time caller, which
+never existed."
+```
+
+---
+
+### Task 5: Build-if-missing and staleness honesty on query
+
+**Files:**
+- Modify: `crates/edda-cli/src/cmd_search.rs:58-90` (`run_cmd` dispatch), `:94-167` (the `query` fn)
+
+**Interfaces:**
+- Consumes: `sync::sync` (Task 3), `schema::read_events_cursor` (Task 1).
+- Produces: `query` gains a leading `repo_root: &Path` parameter.
+
+Note a deliberate extension beyond the spec's letter: an **outdated** index also auto-rebuilds here, rather than keeping #402's refusal. Both states are "unusable index, one command away", and a dead-end error is exactly what GH-403 objects to. The message distinguishes the two cases.
+
+- [ ] **Step 1: Thread `repo_root` into `query`**
+
+In `crates/edda-cli/src/cmd_search.rs`, in `run_cmd`, change the `SearchCmd::Query` arm's call:
+
+```rust
+            query(
+                repo_root,
+                pid,
+                &q,
+                session.as_deref(),
+                doc_type.as_deref(),
+                event_type.as_deref(),
+                exact,
+                limit,
+            )
+```
+
+- [ ] **Step 2: Replace the head of `query` with build-if-missing**
+
+Replace the signature and the opening index-resolution block of `query` (down to and including the `let Some(index) = schema::open_index(&index_dir) else { ... };` block) with:
+
+```rust
+/// Execute `edda search <query>` — full-text search over the Tantivy index.
+#[allow(clippy::too_many_arguments)]
+pub fn query(
+    repo_root: &Path,
+    project_id: &str,
+    query_str: &str,
+    session_id: Option<&str>,
+    doc_type: Option<&str>,
+    event_type: Option<&str>,
+    exact: bool,
+    limit: usize,
+) -> anyhow::Result<()> {
+    let proj_dir = project_dir(project_id);
+    let index_dir = proj_dir.join("search").join("tantivy");
+
+    // GH-403: an unusable index is not a dead end. Announce, then fix it — a
+    // silent 25s stall reads as a hang, and telling the user to go run another
+    // command is the complaint this issue exists to answer.
+    let missing = !index_dir.exists();
+    let outdated = schema::index_is_outdated(&index_dir);
+    if missing || outdated {
+        if missing {
+            println!("No search index — building now (one-time)…");
+        } else {
+            println!("Search index schema is outdated — rebuilding now (one-time)…");
+        }
+        let ledger = Ledger::open(repo_root)?;
+        let stats = sync::sync(&proj_dir, project_id, None, |after| {
+            ledger.events_after_rowid(after)
+        })?;
+        println!("Indexed {} event(s) + {} turn(s).\n", stats.events, stats.turns);
+    }
+
+    let Some(index) = schema::open_index(&index_dir) else {
+        eprintln!("Search index could not be opened. Run `edda search index` to rebuild.");
+        return Ok(());
+    };
+```
+
+- [ ] **Step 3: Print the watermark after results**
+
+In `query`, replace the early return for the empty case and add the watermark to both paths. Replace:
+
+```rust
+    if results.is_empty() {
+        println!("No results found for: {query_str}");
+        return Ok(());
+    }
+```
+
+with:
+
+```rust
+    if results.is_empty() {
+        println!("No results found for: {query_str}");
+        print_watermark(repo_root, &proj_dir, project_id);
+        return Ok(());
+    }
+```
+
+and add at the very end of `query`, replacing its trailing `Ok(())`:
+
+```rust
+    print_watermark(repo_root, &proj_dir, project_id);
+    Ok(())
+}
+
+/// Report how current the index is (GH-403), so silence is never mistaken for
+/// absence. Best-effort: a broken watermark must not fail a query that already
+/// produced results.
+fn print_watermark(repo_root: &Path, proj_dir: &Path, project_id: &str) {
+    let meta_path = proj_dir.join("search").join("meta.sqlite");
+    let Ok(conn) = schema::ensure_meta_db(&meta_path) else {
+        return;
+    };
+    let Ok(cursor) = schema::read_events_cursor(&conn, project_id) else {
+        return;
+    };
+    let Some(ts) = cursor.ts else {
+        return;
+    };
+    let newer = Ledger::open(repo_root)
+        .and_then(|l| l.events_after_rowid(cursor.rowid))
+        .map(|v| v.len())
+        .unwrap_or(0);
+    if newer > 0 {
+        println!("  (indexed through {ts}; {newer} newer event(s) not yet indexed)");
+    } else {
+        println!("  (indexed through {ts})");
+    }
+}
+```
+
+- [ ] **Step 4: Build and test**
+
+Run: `cargo build -p edda 2>&1 | tail -5 && cargo test -p edda 2>&1 | tail -6`
+Expected: clean build, tests PASS (ignore the known `secret_guard` timing flake if it appears; re-run it alone to confirm: `cargo test -p edda secret_guard::tests::hot_path_under_ten_ms_for_realistic_length -- --exact`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/edda-cli/src/cmd_search.rs
+git commit -m "feat(search): build-if-missing and staleness watermark on query (GH-403)
+
+A missing or schema-outdated index now announces itself and builds, instead of
+telling the user to go run another command — the dead end this issue is about.
+Every query reports the timestamp it is indexed through, and the count of newer
+events it has not seen, so silence is never mistaken for absence."
+```
+
+---
+
+### Task 6: SessionEnd incremental reindex
+
+**Files:**
+- Create: `crates/edda-bridge-claude/src/bg_index.rs`
+- Modify: `crates/edda-bridge-claude/Cargo.toml` (dependencies)
+- Modify: `crates/edda-bridge-claude/src/lib.rs` (module list)
+- Modify: `crates/edda-bridge-claude/src/dispatch/session.rs:345-361` (insert before `drop(bg_tx)`)
+
+**Interfaces:**
+- Consumes: `edda_search_fts::sync::sync` (Task 3).
+- Produces: `pub fn should_run(project_id: &str) -> bool`, `pub fn run_index(project_id: &str, cwd: &str) -> anyhow::Result<()>`
+
+- [ ] **Step 1: Add the dependency**
+
+In `crates/edda-bridge-claude/Cargo.toml`, add to `[dependencies]` beside the other `edda-*` path deps:
+
+```toml
+edda-search-fts = { path = "../edda-search-fts", version = "0.2.0" }
+```
+
+(No cycle: `edda-search-fts` depends on neither `edda-bridge-claude` nor `edda-ledger`.)
+
+- [ ] **Step 2: Write the failing test**
+
+Create `crates/edda-bridge-claude/src/bg_index.rs` containing only:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Both assertions live in ONE test on purpose: they share the process-wide
+    // EDDA_STORE_ROOT, and cargo runs tests in parallel threads — as two tests
+    // they would clobber each other's store root intermittently.
+    #[test]
+    fn should_run_only_when_an_index_already_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("EDDA_STORE_ROOT", tmp.path());
+
+        // Cold builds belong to `edda search query`, never to a session's exit.
+        assert!(!should_run("p1"));
+
+        let idx = tmp
+            .path()
+            .join("projects")
+            .join("p1")
+            .join("search")
+            .join("tantivy");
+        std::fs::create_dir_all(&idx).unwrap();
+        assert!(should_run("p1"));
+    }
+}
+```
+
+Add to `crates/edda-bridge-claude/src/lib.rs`, in the module list beside the other `bg_*` modules:
+
+```rust
+pub mod bg_index;
+```
+
+Run: `cargo test -p edda-bridge-claude bg_index 2>&1 | tail -8`
+Expected: FAIL — `cannot find function 'should_run' in this scope`.
+
+- [ ] **Step 3: Implement `bg_index`**
+
+Put this above the `mod tests` block in `crates/edda-bridge-claude/src/bg_index.rs`:
+
+```rust
+//! Incremental search reindex at SessionEnd (GH-403).
+//!
+//! Design: non-blocking, idempotent, cheap.
+//!
+//! Two deliberate departures from the sibling background tasks:
+//!
+//! - **No cooldown or interval gate.** `bg_scan`/`bg_detect` are gated because
+//!   they spend LLM calls; an incremental sync with nothing new is a cursor read
+//!   and a no-op commit. Gating it would only reintroduce the staleness this
+//!   exists to remove.
+//! - **No cold build.** A missing index is left alone and picked up by
+//!   `edda search query`'s build-if-missing. A first build costs ~25s on a
+//!   real corpus, and a session's exit must never pay that.
+
+use anyhow::Result;
+use edda_store::project_dir;
+
+/// Run only when there is already an index to top up.
+pub fn should_run(project_id: &str) -> bool {
+    if std::env::var("EDDA_BG_ENABLED").unwrap_or_else(|_| "1".into()) == "0" {
+        return false;
+    }
+    project_dir(project_id)
+        .join("search")
+        .join("tantivy")
+        .exists()
+}
+
+/// Bring the index up to date with events written during this session.
+pub fn run_index(project_id: &str, cwd: &str) -> Result<()> {
+    let ledger = edda_ledger::Ledger::open(std::path::Path::new(cwd))?;
+    let proj = project_dir(project_id);
+    let stats = edda_search_fts::sync::sync(&proj, project_id, None, |after| {
+        ledger.events_after_rowid(after)
+    })?;
+    tracing::debug!(
+        events = stats.events,
+        turns = stats.turns,
+        "search index synced"
+    );
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p edda-bridge-claude bg_index 2>&1 | tail -6`
+Expected: PASS.
+
+- [ ] **Step 5: Wire it into SessionEnd**
+
+In `crates/edda-bridge-claude/src/dispatch/session.rs`, insert immediately before the `// Drop the original sender…` / `drop(bg_tx);` lines:
+
+```rust
+    // 2j. Background incremental search reindex (GH-403). Ungated by cooldown:
+    // with nothing new this is a cursor read and a no-op commit.
+    if crate::bg_index::should_run(project_id) {
+        let tx = bg_tx.clone();
+        let pid = project_id.to_string();
+        let cwd_owned = cwd.to_string();
+        std::thread::spawn(move || {
+            if let Err(e) = crate::bg_index::run_index(&pid, &cwd_owned) {
+                tracing::warn!(error = %e, "search reindex failed");
+            }
+            let _ = tx.send("bg_index");
+        });
+        bg_count += 1;
+    }
+```
+
+- [ ] **Step 6: Build and test the workspace**
+
+Run: `cargo build --workspace 2>&1 | tail -5 && cargo test -p edda-bridge-claude 2>&1 | tail -6`
+Expected: clean build, tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/edda-bridge-claude/Cargo.toml crates/edda-bridge-claude/src/bg_index.rs crates/edda-bridge-claude/src/lib.rs crates/edda-bridge-claude/src/dispatch/session.rs
+git commit -m "feat(search): incremental reindex at SessionEnd (GH-403)
+
+Nothing in the hook lifecycle ever built or updated the index, so the flagship
+retrieval feature shipped cold and rotted from the first event onward. SessionEnd
+now tops it up incrementally, following the existing bg_* pattern (gated spawn,
+mpsc completion, join within the background budget).
+
+No cooldown: with nothing new a sync is a cursor read and a no-op commit, and
+gating it would just reintroduce staleness. No cold build: a missing index is
+left to query-time build-if-missing, so a session's exit never pays ~25s."
+```
+
+---
+
+### Task 7: Live verification against the real corpus
+
+Unit tests cannot answer the question the whole design rests on: is an empty sync actually sub-second on a real corpus? The spec's budget is verified here, on real data, or the SessionEnd hook is not shippable.
+
+**Files:**
+- No source changes expected. Fixes land in the task they belong to if this fails.
+
+- [ ] **Step 1: Install the built binary**
+
+`cargo install` fails at the replace step while this session's hooks hold `edda.exe` (Windows cannot replace a running exe). Build to the workspace target and copy:
+
+```bash
+cargo build --release -p edda
+```
+
+Then, in PowerShell:
+
+```powershell
+$src = "C:\ai_agent\edda\target\release\edda.exe"
+$dst = "C:\Users\synvoke\.cargo\bin\edda.exe"
+foreach ($i in 1..8) {
+  try { Copy-Item $src $dst -Force -ErrorAction Stop; "COPY OK on attempt $i"; break }
+  catch { "attempt $i locked"; Start-Sleep -Milliseconds 1500 }
+}
+```
+
+- [ ] **Step 2: Verify the budget — the number that decides shippability**
+
+Against the real corpus (project `043a8e81dcb8fa43a08c8b6e00d6d38b`, ~2227 events), from `C:\ai_project\AI Delivery Foundry`:
+
+```bash
+time edda search index          # first run after the change
+time edda search index          # second run: nothing new
+```
+
+Expected: the **second** run completes in **< 1s** (baseline before this work: 24.7s).
+If it does not, the SessionEnd hook is over budget — stop and fix before proceeding.
+
+- [ ] **Step 3: Verify build-if-missing on a cold index**
+
+```bash
+mv "C:/Users/synvoke/AppData/Roaming/edda/projects/043a8e81dcb8fa43a08c8b6e00d6d38b/search" "C:/Users/synvoke/AppData/Roaming/edda/projects/043a8e81dcb8fa43a08c8b6e00d6d38b/search.bak"
+edda search query "權威事實"
+```
+
+Expected: prints `No search index — building now (one-time)…`, builds, then returns the hit. (Restore or discard `search.bak` afterwards; a rebuild reproduces it.)
+
+- [ ] **Step 4: Verify staleness honesty**
+
+```bash
+edda note "auto-index watermark probe" --tag test
+edda search query "權威事實"
+```
+
+Expected: results, followed by `(indexed through <ts>; 1 newer event(s) not yet indexed)`.
+
+- [ ] **Step 5: Verify CJK search still works (GH-402 regression)**
+
+```bash
+edda search query "機器推論"
+edda search query "洗成權威事實"
+edda search query "provenance"
+```
+
+Expected: 2 hits, 2 hits, 20 hits — matching the #410 live-verification baseline.
+
+- [ ] **Step 6: Verify SessionEnd actually indexes**
+
+The hook entrypoint is `edda hook claude`, which parses Claude Code's event JSON
+from stdin (`hook_event_name`, `session_id`, `transcript_path`, `cwd`); the
+project is derived from `cwd`. Use `printf`, never `echo` — Git Bash's `echo`
+mangles backslashes in JSON payloads.
+
+```bash
+edda note "session-end reindex probe" --tag test
+printf '%s' '{"hook_event_name":"SessionEnd","session_id":"verify-403","transcript_path":"","cwd":"C:/ai_project/AI Delivery Foundry"}' | edda hook claude 2>&1 | tail -3
+edda search query "session-end reindex probe"
+```
+
+Expected: the note is found without any manual `edda search index` — the issue's second acceptance criterion.
+
+- [ ] **Step 7: Record the receipt**
+
+```bash
+edda note "GH-403 live verify: empty sync <Ns> (was 24.7s), cold build OK, watermark OK, CJK intact, SessionEnd indexes" --tag verify
+```
+
+---
+
+## Wrap-up
+
+- [ ] **Full workspace green:** `cargo fmt --check && cargo clippy --workspace --all-targets 2>&1 | tail -5 && cargo test --workspace 2>&1 | tail -8`
+- [ ] **Adversarial review:** hand the diff to codex for a correctness pass (crash-safety of the cursor ordering, the `resolve_batch` probe, and the `Fn` closure's re-read behaviour are the places to press).
+- [ ] **PR to `main`** referencing GH-403, with the before/after budget numbers in the body. Do not merge — merge is the operator's gate.

--- a/docs/plan/search-auto-index/SEARCH_AUTO_INDEX_V1.md
+++ b/docs/plan/search-auto-index/SEARCH_AUTO_INDEX_V1.md
@@ -96,10 +96,21 @@ pub struct SyncStats {
     pub indexed_through: Option<String>, // ts of last indexed event
 }
 
-pub fn sync<F>(proj_dir: &Path, project_id: &str, events_after: F) -> anyhow::Result<SyncStats>
+pub fn sync<F>(
+    proj_dir: &Path,
+    project_id: &str,
+    session_id: Option<&str>,
+    events_after: F,
+) -> anyhow::Result<SyncStats>
 where
-    F: FnOnce(i64) -> anyhow::Result<Vec<(i64, edda_core::Event)>>;
+    F: Fn(i64) -> anyhow::Result<Vec<(i64, edda_core::Event)>>;
 ```
+
+`Fn`, not `FnOnce`: detecting a cursor that has run ahead of the ledger means
+probing the boundary event and then re-reading from the start, so the closure is
+called twice in that case. `session_id` preserves the existing `--session` flag's
+behaviour (session-scoped turns except during a rebuild, which must cover every
+session).
 
 `sync` owns: `IndexLock` acquisition, open-or-create, outdated-schema wipe,
 cursor read, incremental event indexing, turn indexing, `commit`, cursor write,

--- a/docs/plan/search-auto-index/SEARCH_AUTO_INDEX_V1.md
+++ b/docs/plan/search-auto-index/SEARCH_AUTO_INDEX_V1.md
@@ -1,0 +1,242 @@
+# Search Auto-Index v1 (GH-403)
+
+Status: design approved, pending implementation
+Issue: https://github.com/fagemx/edda/issues/403
+Depends on: GH-402 (CJK tokenizer) — landed as #410; this work must respect its
+`INDEX_VERSION` / `IndexLock` / `created_fresh` rebuild path.
+
+## Problem
+
+The Tantivy index is only ever built by a manual `edda search index`. Nothing in
+the hook lifecycle builds or updates it, so the flagship retrieval feature ships
+cold: on 2026-07-15 the fleet's daily-driver workspace (2147 events, months of
+transcripts) had never been indexed at all. `edda search` answered "No search
+index found" since forever and nobody noticed, because the SessionStart pack
+covered daily recall.
+
+Even after a manual build the index rots immediately — every new event is
+invisible until someone remembers to re-run the command.
+
+### The measurement that reframes the issue
+
+The issue assumed an incremental step would be cheap. Measured on the real
+corpus (project `043a8e81…`, 2227 events):
+
+| Run | Result | Time |
+|-----|--------|------|
+| 1st | 2227 events + 35 turns | 24.661s |
+| 2nd, immediately after, nothing changed | 2227 events + **0** turns | **24.729s** |
+
+A re-index with zero new work still costs 24.7s. Cause: `indexer::index_events`
+issues `delete_term(doc_type="event")` — deleting every event doc — then re-adds
+all of them, on every run. **Turns are already incremental** (`index_watermark`
+holds a per-session transcript byte offset; the 2nd run indexed 0 turns). Events
+are not incremental at all, and they are the entire cost.
+
+Consequence: wiring the *current* indexer to SessionEnd would add ~25s to every
+session exit — over half the 45s background-join budget, and a direct violation
+of the issue's own "must never block a session's exit". **Events must become
+incremental first**; that is in scope here, not a follow-up.
+
+`Ledger::events_after_rowid(after_rowid)` already exists (edda-serve uses it for
+streaming) but the search indexer never adopted it. There is no event cursor:
+`index_watermark` is `(project_id, session_id, last_offset)` and is turns-only.
+
+Related cleanup: `indexer.rs` claims `add_event_doc` is "used both by bulk
+`index_events` and by append-time indexing". That is stale — no append-time
+caller exists.
+
+## Decisions
+
+Ruled by the operator during design:
+
+1. **Scope**: make events incremental *and* wire auto-indexing in one change.
+   The issue's acceptance criteria demand sub-second incremental, so splitting
+   would leave GH-403 blocked on its own prerequisite.
+2. **Build-if-missing**: `edda search query` against a missing index prints one
+   notice, builds, then answers. Not silent (a 25s stall with no explanation
+   reads as a hang, and contradicts the issue's own "staleness honesty").
+3. **Cold build on SessionEnd**: no. SessionEnd only tops up an index that
+   already exists; a missing index is left for query-time build-if-missing. The
+   session-exit budget is never spent on a cold build.
+
+### Approach: sqlite rowid cursor + idempotent per-event replace
+
+Rejected alternatives:
+
+- **Sentinel row in `index_watermark`** (store the event rowid in `last_offset`
+  with `session_id="__events__"`): saves a table, but overloads a column that
+  means "transcript byte offset" to sometimes mean "ledger rowid". A semantic
+  lie every future reader must decode.
+- **Derive the cursor from Tantivy** (store rowid as a fast field, take
+  `max(rowid)` per run): a genuinely cleaner single source of truth with no
+  cursor to drift — but it adds a field, which bumps `INDEX_VERSION` 2→3 and
+  forces *every user through a second full rebuild* days after #410 forced one.
+  The drift it prevents is already rendered harmless by commit-then-cursor
+  ordering (below). Paying a forced rebuild for a property we already have.
+
+The chosen approach adds **no Tantivy field**, so `INDEX_VERSION` stays at 2 and
+no forced rebuild is triggered.
+
+## Architecture
+
+`edda-search-fts` deliberately does not depend on `edda-ledger` — that is why
+`index_events` takes an injected closure. This design keeps that inversion.
+
+The sync orchestration gets exactly one home, because it has three callers
+(manual `search index`, query-time cold build, SessionEnd hook) and duplicating
+it across crates is the cross-crate coupling class already flagged in #410
+review.
+
+```rust
+// edda-search-fts::sync (new module)
+pub struct SyncStats {
+    pub events: usize,
+    pub turns: usize,
+    pub indexed_through: Option<String>, // ts of last indexed event
+}
+
+pub fn sync<F>(proj_dir: &Path, project_id: &str, events_after: F) -> anyhow::Result<SyncStats>
+where
+    F: FnOnce(i64) -> anyhow::Result<Vec<(i64, edda_core::Event)>>;
+```
+
+`sync` owns: `IndexLock` acquisition, open-or-create, outdated-schema wipe,
+cursor read, incremental event indexing, turn indexing, `commit`, cursor write,
+version-marker write. Callers supply only `|cursor| ledger.events_after_rowid(cursor)`.
+
+**Cursor ownership**: callers never pass or reset the cursor — `sync` decides.
+It resets to 0 (full rebuild) when `open_or_create_index` reports
+`created_fresh`, or when the stored cursor is ahead of the ledger's max rowid.
+This matters because a missing Tantivy dir does not imply a missing cursor:
+`meta.sqlite` can outlive a deleted or wiped index, and a caller that assumed
+"no index dir ⇒ start from 0" would read the stale cursor and skip every
+existing event — the GH-403 bug, rebuilt. `created_fresh` (from #410) is the
+single signal that governs this, for every fresh path at once.
+
+Dependency direction is safe: `edda-bridge-claude` already has `edda-ledger` and
+gains `edda-search-fts`; `edda-search-fts` depends on neither, so no cycle.
+
+## Components
+
+### edda-search-fts
+
+- `schema.rs`
+  - new table `events_watermark(project_id TEXT PRIMARY KEY, last_rowid INTEGER NOT NULL, last_ts TEXT)`
+    in both `ensure_meta_db` and `ensure_meta_db_memory`. All table creation is
+    `CREATE TABLE IF NOT EXISTS`, so no migration is needed.
+  - `read_events_cursor(conn, project_id) -> anyhow::Result<i64>` (0 when absent)
+  - `write_events_cursor(conn, project_id, rowid, ts) -> anyhow::Result<()>`
+  - extend `clear_index_watermark` to also clear `events_watermark`, so the
+    existing fresh-index reset keeps covering the whole cursor set.
+- `indexer.rs`
+  - new `index_events_since(writer, schema, project_id, events: &[(i64, Event)]) -> anyhow::Result<usize>`:
+    per event, `delete_term(Term::from_field_text(doc_id, id))` then
+    `add_event_doc`. `doc_id` uses the same `string_opts` as `doc_type`, which
+    `index_events` already deletes by term, so no schema change is required.
+  - **remove `index_events`** — its delete-all is precisely the behaviour being
+    eliminated, and the full-rebuild path is expressed as `sync` with cursor 0.
+  - fix the stale "append-time indexing" doc comment on `add_event_doc`.
+- `sync.rs` — new, as above.
+
+### edda-cli (`cmd_search.rs`)
+
+- `index()` delegates to `sync`, supplying the ledger closure.
+- `query()` takes `repo_root` (already available in `run_cmd`) so it can reach
+  the ledger for build-if-missing and for the staleness count.
+  - missing index → print `No search index — building now (one-time)…`, run
+    `sync`, then answer. (The caller never passes a cursor; `sync` resets it
+    itself — see "cursor ownership" below.)
+  - present index → answer, then print `indexed through <last_ts>` and, when
+    newer events exist, `N newer events not yet indexed`.
+  - `N` is `ledger.events_after_rowid(cursor).len()` — the same cursor call the
+    sync path uses, no new ledger API. It deserializes the un-indexed tail only,
+    which is small in the steady state (SessionEnd keeps the cursor current); a
+    cold or long-stale index pays a one-off read that is still far below the
+    Tantivy commit cost it is reporting on.
+
+### edda-bridge-claude
+
+- `Cargo.toml`: add `edda-search-fts`.
+- `bg_index.rs` (new): `should_run(project_id) -> bool` (true iff the index dir
+  exists — cold build is not SessionEnd's job) and `run_index(project_id, cwd)`
+  calling `sync`. Deliberately **no cooldown or interval gate**, unlike
+  `bg_scan`/`bg_detect`: those are gated because they cost LLM calls, whereas an
+  incremental sync with nothing new is a cursor read and a no-op commit. Gating
+  it would only reintroduce staleness — the thing this issue exists to remove.
+- `dispatch/session.rs`: spawn in `dispatch_session_end` following the existing
+  `bg_extract`/`bg_digest` shape — gated spawn, `tx.send("bg_index")`, counted
+  into the mpsc join with the `EDDA_BG_JOIN_TIMEOUT_SECS` (default 45s) budget.
+
+## Data flow
+
+**SessionEnd (hot path, must be sub-second)**
+`should_run` → index missing? skip → else spawn thread → `sync` → read cursor →
+`events_after_rowid(cursor)` → replace-add only new docs → `commit` → write
+cursor → `tx.send` → main thread joins within budget.
+
+**query**
+Index missing → notice → `sync` (cursor 0, full build) → answer.
+Index present → answer → `indexed through <ts>` (+ `N newer…` when N > 0).
+
+**manual `edda search index`**
+The same `sync`, ungated. `sync` always creates a missing index; what differs
+between the three callers is only the gate in front of it — SessionEnd skips a
+missing index (`bg_index::should_run`), query announces before building, and the
+manual command just runs.
+
+## Error handling and edge cases
+
+- **Killed mid-reindex**: `commit` happens *before* the cursor write. A crash
+  between them leaves the cursor stale, so the next run re-does that batch;
+  `delete_term(doc_id)` makes re-adding idempotent. Never duplicates, never
+  misses. This is the issue's "idempotent by watermark" criterion.
+- **Cursor ahead of the ledger** (ledger rebuilt / rowids reset): if
+  `cursor > max_rowid`, reset to 0 and rebuild. Otherwise events would be
+  invisible forever — the exact bug shape GH-403 exists to kill; we must not
+  reintroduce it in the fix.
+- **Schema upgrade**: `created_fresh` (from #410) → cursor reset to 0 → full
+  build. Reuses the existing path, no new mechanism.
+- **Lock contention**: `sync` always takes `IndexLock`; a SessionEnd sync racing
+  a manual `search index` means one waits.
+- **Hook read paths must not build**: `cmd_ask`'s transcript callback stays
+  read-only (`open_index`) and must not build-if-missing — otherwise a
+  background hook could silently stall ~25s.
+- **SessionEnd failure**: best-effort. `tracing::warn!` and move on; never block
+  exit, consistent with the sibling background tasks.
+
+## Testing
+
+Test-driven; the RED test comes first.
+
+1. **RED**: a second `sync` over an unchanged ledger reports 0 events indexed.
+   This is the executable form of the 24.7s measurement above and must be seen
+   failing before the incremental path exists — a straight port of today's
+   `index_events` re-adds every event and fails it.
+2. **Idempotence**: syncing the same batch twice leaves doc count unchanged, no
+   duplicates.
+3. **Crash recovery**: interrupt between `commit` and cursor write → next run
+   completes the batch without duplicates.
+4. **Cursor ahead of ledger** → reset to 0 and full rebuild.
+5. **`created_fresh`** → cursor reset to 0.
+6. **Cold build**: empty index + `query` → auto-builds and returns results.
+7. **Watermark output**: `N newer events not yet indexed` appears iff N > 0.
+8. **Budget (live)**: an empty `sync` (no new events) against the real 2227-event
+   corpus must complete in < 1s. This is the number that decides whether the
+   SessionEnd hook is shippable, so it is verified on the real corpus, not a
+   fixture.
+
+## Out of scope
+
+- Turns are already incremental; untouched.
+- No new Tantivy field → `INDEX_VERSION` stays 2 → no second forced rebuild.
+- `query` does not auto-catch-up (only cold-builds). Freshness is SessionEnd's
+  job; query's job is to be honest about staleness.
+
+## Acceptance (from the issue)
+
+- Fresh workspace: first `search query` works without a manual index step.
+- After a session writes events, a new session's `search query` finds them with
+  no manual reindex.
+- Query output shows the indexed-through watermark.
+- Kill the process mid-reindex: next run recovers, no corrupt index.

--- a/docs/plan/search-auto-index/SEARCH_AUTO_INDEX_V1.md
+++ b/docs/plan/search-auto-index/SEARCH_AUTO_INDEX_V1.md
@@ -27,16 +27,40 @@ corpus (project `043a8e81…`, 2227 events):
 | 1st | 2227 events + 35 turns | 24.661s |
 | 2nd, immediately after, nothing changed | 2227 events + **0** turns | **24.729s** |
 
-A re-index with zero new work still costs 24.7s. Cause: `indexer::index_events`
-issues `delete_term(doc_type="event")` — deleting every event doc — then re-adds
-all of them, on every run. **Turns are already incremental** (`index_watermark`
-holds a per-session transcript byte offset; the 2nd run indexed 0 turns). Events
-are not incremental at all, and they are the entire cost.
+A re-index with zero new work still costs 24.7s.
 
-Consequence: wiring the *current* indexer to SessionEnd would add ~25s to every
-session exit — over half the 45s background-join budget, and a direct violation
-of the issue's own "must never block a session's exit". **Events must become
-incremental first**; that is in scope here, not a follow-up.
+> **CORRECTION (2026-07-15, after live measurement).** The original diagnosis in
+> this section was **wrong**, and is preserved below only so the error is legible.
+>
+> It blamed `indexer::index_events` (which does `delete_term(doc_type="event")`
+> then re-adds every event on each run) and asserted "turns are already
+> incremental, events are the entire cost". Live measurement falsified both
+> halves:
+>
+> | Run | Result | Time |
+> |-----|--------|------|
+> | old code, no-op | 2227 events + 0 turns | 24.7s |
+> | events made incremental, no-op | **0** events + 0 turns | **24.8s** |
+> | 1 session vs 100 sessions | 0 events + 0 turns | **0.111s vs 24.848s** |
+>
+> Making events incremental bought **nothing** on the no-op path. The cost is
+> `index_session`, and it is linear in session count: it reads every index
+> record, builds the uuid map, walks each assistant's parent chain, and fetches
+> and parses that turn's transcript line off disk — all *before* the per-turn
+> `turns_meta` check that decides the turn is already indexed. 100 sessions /
+> 24MB, read and parsed and discarded, every run.
+>
+> Turns are incremental in what they **write**, not in what they **read**. The
+> watermark stopped duplicate writes only. `index_watermark.last_offset` — the
+> byte cursor built for precisely this — was never consulted in `indexer.rs`.
+>
+> **Real fix:** skip a session whose index file has not grown (see "Turns read
+> early-out" below). Event incrementality is still worth having on the rebuild
+> path, but it is not what buys the budget.
+
+Consequence either way: wiring the *current* indexer to SessionEnd would add
+~25s to every session exit — over half the 45s background-join budget, and a
+direct violation of the issue's own "must never block a session's exit".
 
 `Ledger::events_after_rowid(after_rowid)` already exists (edda-serve uses it for
 streaming) but the search indexer never adopted it. There is no event cursor:
@@ -237,9 +261,35 @@ Test-driven; the RED test comes first.
    SessionEnd hook is shippable, so it is verified on the real corpus, not a
    fixture.
 
+## Turns read early-out (added after the premise correction)
+
+`index_session` takes the byte length of `<project_dir>/index/<session_id>.jsonl`
+and compares it against `index_watermark.last_offset` for that
+`(project_id, session_id)`. Equal means nothing new: return without opening the
+file. Otherwise process as before and record the new length, in the same
+transaction as the `turns_meta` rows it corresponds to.
+
+A shrunk file (a rewritten session) will not compare equal, so it is re-read —
+safe, because `turns_meta` dedups by `turn_id`. A grown file is re-read in full
+rather than from the offset; that is deliberate and sufficient, because only the
+live session grows, so a run reads one file instead of a hundred.
+
+`clear_index_watermark` already wipes `index_watermark`, so a fresh index resets
+these offsets along with everything else.
+
+**Known limitation, pre-existing and not introduced here:** `index_session`
+commits `turns_meta` (and now the offset) *before* the caller commits the Tantivy
+writer. A crash in that window leaves turns marked indexed that Tantivy never
+received, making them invisible. This predates GH-403 — the existing per-turn
+`turns_meta` dedup has the same hole — and the events cursor deliberately does
+not share it (it commits first, then advances). Filed separately rather than
+folded in here.
+
 ## Out of scope
 
-- Turns are already incremental; untouched.
+- Making a grown session file read *from* its offset rather than in full.
+  Skipping untouched sessions is what buys the budget; the live session is one
+  file.
 - No new Tantivy field → `INDEX_VERSION` stays 2 → no second forced rebuild.
 - `query` does not auto-catch-up (only cold-builds). Freshness is SessionEnd's
   job; query's job is to be honest about staleness.


### PR DESCRIPTION
Closes #403.

## The headline

A no-op reindex on the real fleet corpus (2261 events / 1329 turns / 100 sessions):

| | before | after |
|---|---|---|
| `edda search index`, nothing new | **24.7s** | **0.139s** |

~178x. That is what makes a SessionEnd hook shippable at all — the issue's own rule is that it must never block a session's exit, and the 45s background-join budget could not absorb 25s.

## The issue's premise was wrong, and so was mine

#403 assumed the cost was event re-indexing and that "turns are already incremental". I built on that assumption and it was **falsified by measurement**:

| run | result | time |
|---|---|---|
| old code, no-op | 2227 events + 0 turns | 24.7s |
| **events made fully incremental**, no-op | **0** events + 0 turns | **24.8s** |
| 1 session vs 100 sessions | 0 events + 0 turns | **0.111s vs 24.848s** |

Making events incremental bought **nothing**. The cost was `index_session`, linear in session count: it read every index record, built a uuid map, walked each assistant's parent chain, and fetched + JSON-parsed that turn's transcript line off disk — all *before* the per-turn `turns_meta` check that decides the turn is already indexed. 100 sessions / 24MB read, parsed, and discarded on every run.

Turns were incremental in what they **write**, never in what they **read**. `index_watermark.last_offset` — the byte cursor built for exactly this — was never consulted in `indexer.rs` at all. Now it is: a session whose index file has not grown is skipped without being opened.

The spec ([SEARCH_AUTO_INDEX_V1.md](docs/plan/search-auto-index/SEARCH_AUTO_INDEX_V1.md)) marks the wrong diagnosis in place rather than quietly rewriting it, so the error stays legible.

## What landed

- **`edda-search-fts::sync`** — one home for lock/open/cursor/commit, shared by all three callers (manual `search index`, query-time cold build, SessionEnd), so the dance is not re-implemented per call site. Events arrive via an injected closure, keeping the crate unaware of `edda-ledger`.
- **Turns read early-out** — the actual fix. Skip sessions whose index file has not grown.
- **Events incremental** — `events_watermark` rowid cursor over the existing `Ledger::events_after_rowid`; `index_events_since` replaces per event (`delete_term` on doc_id) instead of delete-all-then-re-add. Kept because it is correct and crash-safe on the rebuild path, but it is not what buys the budget.
- **Build-if-missing** — a missing or schema-outdated index announces itself and builds, instead of the dead-end error the issue is about. (This supersedes #410's refuse-on-outdated: both states are an unusable index one command away, and fixing beats complaining.)
- **Staleness honesty** — every query reports the timestamp it is indexed through and the count of newer events it has not seen.
- **SessionEnd `bg_index`** — gated spawn + mpsc join, following the existing `bg_*` pattern. No cooldown (a no-op sync is a cursor read), no cold build (a session's exit must never pay ~25s).
- **No new Tantivy field** — `INDEX_VERSION` stays at 2, so nobody eats a second forced rebuild days after #410 forced one.

## Crash safety

`writer.commit()` happens **before** `write_events_cursor`. A crash between them re-runs the batch, which the per-event `delete_term` makes idempotent — never duplicates, never misses.

## Adversarial review (codex) found two real bugs, both fixed with failing tests first

1. **A rebuild left orphans searchable.** The old bulk `index_events` deleted every event doc before re-adding — that was not only dedup, it was *also* purging events the ledger no longer had. Going incremental dropped that safety net: truncate or replace a ledger and the old docs answered queries forever. `delete_all_event_docs` now runs on the rebuild path only.
2. **The cursor was validated on rowid alone, which is not identity.** A ledger restored from a different backup can occupy the same rowid range with different events; the probe would trust the cursor and skip every event in the replacement forever. It now matches the boundary event's timestamp too, using the `last_ts` already stored (no schema change).

## Live verification (installed binary, real corpus)

- Budget: **24.7s → 0.139s**, stable across runs
- Cold build-if-missing: announces, builds 2261 events + 1329 turns, answers — 25.3s one-time
- Staleness: `(indexed through …; 1 newer event(s) not yet indexed)` after writing a note
- SessionEnd: dispatched a real `SessionEnd` hook → watermark advanced, 0 newer, note findable with **no manual index**
- #410 CJK regression intact: `權威事實`/`機器推論`/`洗成權威事實` → 2/2/2, `provenance` → 20

## Known limitations, filed separately, not folded in here

- `index_session` commits `turns_meta` (and now the session offset) *before* the caller's Tantivy commit. A crash there marks turns indexed that Tantivy never received. **Pre-existing** — the per-turn `turns_meta` dedup already had this hole — and the events cursor deliberately does not share it.
- Rewritten turns are not reconciled (`turns_meta` dedups by `turn_id` and has no update path). Also pre-existing.
- The early-out uses file length as the change signal, so a same-length in-place rewrite of an append-only index file would be missed.

Tests: 51 in `edda-search-fts`, workspace 1931 passed / 0 failed, fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
