### PR TITLE
search: defer turns_meta writes until after the Tantivy commit (GH-413)

### DIFF
--- a/crates/edda-search-fts/src/indexer.rs
+++ b/crates/edda-search-fts/src/indexer.rs
@@ -946,6 +946,47 @@ mod tests {
         assert_eq!(reader.searcher().num_docs(), 1, "and to one document");
     }
 
+    /// `index_project` is the production path — `bg_index` passes no session id,
+    /// so every SessionEnd goes through here rather than `index_session`. It is
+    /// also the only caller of `PendingMeta::merge`, so without this the merge is
+    /// never executed by any test.
+    #[test]
+    fn index_project_merges_turns_and_offsets_across_sessions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path();
+        write_session_fixture(project_dir, "s1", "1");
+        write_session_fixture(project_dir, "s2", "2");
+
+        let index = ensure_index_ram().unwrap();
+        let schema = index.schema();
+        let mut writer = index_writer(&index).unwrap();
+        let meta_conn = ensure_meta_db_memory().unwrap();
+
+        let pending = index_project(&writer, &schema, &meta_conn, project_dir, "p1").unwrap();
+        assert_eq!(
+            pending.turns(),
+            2,
+            "both sessions' turns must survive merge"
+        );
+
+        writer.commit().unwrap();
+        assert_eq!(pending.flush(&meta_conn).unwrap(), 2);
+
+        // Every session's offset must survive too. Losing them here would not
+        // fail anything loudly — it would just re-read every session on every
+        // sync forever, which is exactly the GH-403 cost this is built to avoid.
+        for sid in ["s1", "s2"] {
+            assert!(
+                crate::schema::read_session_offset(&meta_conn, "p1", sid).unwrap() > 0,
+                "offset for {sid} must survive merge"
+            );
+        }
+
+        // With the offsets recorded, a second pass does nothing.
+        let again = index_project(&writer, &schema, &meta_conn, project_dir, "p1").unwrap();
+        assert_eq!(again.turns(), 0, "unchanged sessions must all skip");
+    }
+
     #[test]
     fn indexing_a_session_records_its_consumed_offset() {
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/edda-search-fts/src/indexer.rs
+++ b/crates/edda-search-fts/src/indexer.rs
@@ -125,13 +125,94 @@ fn extract_event_tags(event: &edda_core::Event) -> String {
         .unwrap_or_default()
 }
 
+/// SQLite writes held back until the Tantivy commit succeeds (GH-413).
+///
+/// `turns_meta` is the dedup source: once a turn is in it, every later run skips
+/// that turn. Writing it before the documents are committed means a crash in
+/// between marks turns as indexed that Tantivy never received — invisible to
+/// search forever, with no self-healing path. So nothing in here touches SQLite
+/// until the caller has committed the writer.
+///
+/// This is the ordering the events cursor already uses: `sync::sync` commits the
+/// writer, *then* advances `events_watermark`.
+#[derive(Debug, Default)]
+pub struct PendingMeta {
+    turns: Vec<TurnMetaRow>,
+    /// `(project_id, session_id, consumed byte length)`
+    offsets: Vec<(String, String, i64)>,
+}
+
+#[derive(Debug)]
+struct TurnMetaRow {
+    turn_id: String,
+    project_id: String,
+    session_id: String,
+    ts: String,
+    user_uuid: String,
+    assistant_uuid: String,
+    user_store_offset: i64,
+    user_store_len: i64,
+    assistant_store_offset: i64,
+    assistant_store_len: i64,
+}
+
+impl PendingMeta {
+    /// How many turns will be recorded once flushed.
+    pub fn turns(&self) -> usize {
+        self.turns.len()
+    }
+
+    /// Absorb another batch (used by `index_project` across sessions).
+    pub fn merge(&mut self, other: PendingMeta) {
+        self.turns.extend(other.turns);
+        self.offsets.extend(other.offsets);
+    }
+
+    /// Write everything in one transaction, returning the number of turns
+    /// recorded.
+    ///
+    /// Call this ONLY after the Tantivy writer has committed. Flushing early
+    /// reintroduces GH-413.
+    pub fn flush(self, conn: &Connection) -> anyhow::Result<usize> {
+        let tx = conn.unchecked_transaction()?;
+        for r in &self.turns {
+            tx.execute(
+                "INSERT INTO turns_meta (turn_id, project_id, session_id, ts, \
+                 user_uuid, assistant_uuid, \
+                 user_store_offset, user_store_len, \
+                 assistant_store_offset, assistant_store_len) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                params![
+                    r.turn_id,
+                    r.project_id,
+                    r.session_id,
+                    r.ts,
+                    r.user_uuid,
+                    r.assistant_uuid,
+                    r.user_store_offset,
+                    r.user_store_len,
+                    r.assistant_store_offset,
+                    r.assistant_store_len,
+                ],
+            )
+            .context("insert turns_meta")?;
+        }
+        for (project_id, session_id, offset) in &self.offsets {
+            crate::schema::write_session_offset(conn, project_id, session_id, *offset)?;
+        }
+        tx.commit()?;
+        Ok(self.turns.len())
+    }
+}
+
 /// Index a single session's transcript records into Tantivy + turns_meta.
 ///
 /// Reads index records from `<project_dir>/index/<session_id>.jsonl`,
 /// fetches raw transcript data from `<project_dir>/transcripts/<session_id>.jsonl`,
 /// and creates Tantivy documents + turns_meta entries.
 ///
-/// Returns the number of newly indexed turns.
+/// Returns the SQLite writes the caller must [`PendingMeta::flush`] *after*
+/// committing the Tantivy writer (GH-413).
 pub fn index_session(
     writer: &IndexWriter,
     schema: &Schema,
@@ -139,12 +220,12 @@ pub fn index_session(
     project_dir: &Path,
     project_id: &str,
     session_id: &str,
-) -> anyhow::Result<usize> {
+) -> anyhow::Result<PendingMeta> {
     let index_path = project_dir
         .join("index")
         .join(format!("{session_id}.jsonl"));
     if !index_path.exists() {
-        return Ok(0);
+        return Ok(PendingMeta::default());
     }
 
     // GH-403: skip a session whose index file has not grown since the last run.
@@ -159,7 +240,7 @@ pub fn index_session(
     let file_len = std::fs::metadata(&index_path)?.len() as i64;
     let consumed = crate::schema::read_session_offset(meta_conn, project_id, session_id)?;
     if consumed == file_len {
-        return Ok(0);
+        return Ok(PendingMeta::default());
     }
 
     let store_path = project_dir
@@ -169,7 +250,7 @@ pub fn index_session(
     // Read all index records
     let records = edda_index::read_index_tail(&index_path, 100_000, 256 * 1024 * 1024)?;
     if records.is_empty() {
-        return Ok(0);
+        return Ok(PendingMeta::default());
     }
 
     // Build lookup by uuid
@@ -194,8 +275,7 @@ pub fn index_session(
     let f_tags = schema.get_field("tags")?;
     let f_tokens = schema.get_field("tokens")?;
 
-    let tx = meta_conn.unchecked_transaction()?;
-    let mut count = 0;
+    let mut pending = PendingMeta::default();
 
     for asst_rec in &assistants {
         // Walk parent chain to find root user prompt
@@ -237,8 +317,10 @@ pub fn index_session(
 
         let turn_id = format!("{}:{}", user_rec.uuid, asst_rec.uuid);
 
-        // Check if already indexed (via turns_meta)
-        let exists: bool = tx
+        // Check if already indexed (via turns_meta). Reads only what previous
+        // runs flushed — this run's rows are still pending, which is correct:
+        // turn ids are unique, so nothing in this batch can dedup against itself.
+        let exists: bool = meta_conn
             .query_row(
                 "SELECT 1 FROM turns_meta WHERE turn_id = ?1",
                 params![turn_id],
@@ -303,58 +385,52 @@ pub fn index_session(
             f_tokens => tokens.as_str(),
         ))?;
 
-        // Insert into turns_meta (for show command byte offsets)
-        tx.execute(
-            "INSERT INTO turns_meta (turn_id, project_id, session_id, ts, \
-             user_uuid, assistant_uuid, \
-             user_store_offset, user_store_len, \
-             assistant_store_offset, assistant_store_len) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
-            params![
-                turn_id,
-                project_id,
-                session_id,
-                ts,
-                user_rec.uuid,
-                asst_rec.uuid,
-                user_rec.store_offset as i64,
-                user_rec.store_len as i64,
-                asst_rec.store_offset as i64,
-                asst_rec.store_len as i64,
-            ],
-        )
-        .context("insert turns_meta")?;
-
-        count += 1;
+        // Hold the turns_meta row (for show's byte offsets) until the caller has
+        // committed the documents above.
+        pending.turns.push(TurnMetaRow {
+            turn_id,
+            project_id: project_id.to_string(),
+            session_id: session_id.to_string(),
+            ts: ts.clone(),
+            user_uuid: user_rec.uuid.clone(),
+            assistant_uuid: asst_rec.uuid.clone(),
+            user_store_offset: user_rec.store_offset as i64,
+            user_store_len: user_rec.store_len as i64,
+            assistant_store_offset: asst_rec.store_offset as i64,
+            assistant_store_len: asst_rec.store_len as i64,
+        });
     }
 
-    // Record how much of the file we consumed, in the same transaction as the
-    // turns_meta rows it corresponds to. A rewritten (shrunk) file will not
-    // match on the next run and gets re-read, which is safe because turns_meta
-    // dedups by turn_id.
-    crate::schema::write_session_offset(meta_conn, project_id, session_id, file_len)?;
+    // Record how much of the file we consumed, alongside the turns_meta rows it
+    // corresponds to — both land in one transaction at flush time. A rewritten
+    // (shrunk) file will not match on the next run and gets re-read, which is
+    // safe because turns_meta dedups by turn_id.
+    pending
+        .offsets
+        .push((project_id.to_string(), session_id.to_string(), file_len));
 
-    tx.commit()?;
-    Ok(count)
+    Ok(pending)
 }
 
 /// Index all sessions for a project.
 ///
 /// Scans `<project_dir>/index/` for `*.jsonl` files and indexes each session.
-/// Returns total number of newly indexed turns.
+///
+/// Returns the SQLite writes the caller must [`PendingMeta::flush`] *after*
+/// committing the Tantivy writer (GH-413).
 pub fn index_project(
     writer: &IndexWriter,
     schema: &Schema,
     meta_conn: &Connection,
     project_dir: &Path,
     project_id: &str,
-) -> anyhow::Result<usize> {
+) -> anyhow::Result<PendingMeta> {
     let index_dir = project_dir.join("index");
     if !index_dir.exists() {
-        return Ok(0);
+        return Ok(PendingMeta::default());
     }
 
-    let mut total = 0;
+    let mut total = PendingMeta::default();
     for entry in std::fs::read_dir(&index_dir)? {
         let entry = entry?;
         let path = entry.path();
@@ -375,7 +451,7 @@ pub fn index_project(
                 project_id,
                 &session_id,
             ) {
-                Ok(n) => total += n,
+                Ok(pending) => total.merge(pending),
                 Err(e) => {
                     tracing::warn!(%session_id, error = %e, "indexing session failed");
                 }
@@ -700,8 +776,9 @@ mod tests {
             )
             .unwrap();
 
-        let count = index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap();
-        assert_eq!(count, 0, "an unchanged file must be skipped");
+        let pending = index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap();
+        assert_eq!(pending.turns(), 0, "an unchanged file must be skipped");
+        pending.flush(&meta_conn).unwrap();
 
         // The decisive assertion: turns_meta is still EMPTY. This turn was never
         // indexed, which is only possible if the file was never read — a path
@@ -711,6 +788,63 @@ mod tests {
             .query_row("SELECT count(*) FROM turns_meta", [], |r| r.get(0))
             .unwrap();
         assert_eq!(n, 0, "skipping must mean not reading, not read-then-dedup");
+    }
+
+    /// GH-413: turns must survive a crash between the SQLite commit and the
+    /// Tantivy commit.
+    ///
+    /// The crash is simulated the only way it actually happens: the writer is
+    /// dropped without committing, so Tantivy never receives the documents. If
+    /// SQLite already recorded the turn as indexed, the dedup skips it forever
+    /// and it is invisible to search with no self-healing path.
+    #[test]
+    fn crash_before_tantivy_commit_leaves_turns_reindexable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path();
+        write_session_fixture(project_dir, "s1", "1");
+
+        let index_dir = project_dir.join("search").join("tantivy");
+        let (index, _) = crate::schema::open_or_create_index(&index_dir).unwrap();
+        let tschema = index.schema();
+        let meta_conn =
+            crate::schema::ensure_meta_db(&project_dir.join("search").join("meta.sqlite")).unwrap();
+
+        // ── the crash ──
+        {
+            let writer = index_writer(&index).unwrap();
+            let _pending =
+                index_session(&writer, &tschema, &meta_conn, project_dir, "p1", "s1").unwrap();
+            // Dropped without commit and without flush: Tantivy has nothing, and
+            // nothing claims otherwise.
+        }
+
+        let reader = index.reader().unwrap();
+        reader.reload().unwrap();
+        assert_eq!(
+            reader.searcher().num_docs(),
+            0,
+            "precondition: the crash must have lost the documents"
+        );
+
+        // ── the next run ──
+        let mut writer = index_writer(&index).unwrap();
+        let pending =
+            index_session(&writer, &tschema, &meta_conn, project_dir, "p1", "s1").unwrap();
+        writer.commit().unwrap();
+        let n = pending.flush(&meta_conn).unwrap();
+
+        assert_eq!(
+            n, 1,
+            "a turn whose documents were never committed must be re-indexed, \
+             not skipped as already done"
+        );
+
+        reader.reload().unwrap();
+        assert_eq!(
+            reader.searcher().num_docs(),
+            1,
+            "the turn must be searchable after recovery"
+        );
     }
 
     #[test]
@@ -724,18 +858,23 @@ mod tests {
         let writer = index_writer(&index).unwrap();
         let meta_conn = ensure_meta_db_memory().unwrap();
 
-        let count = index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap();
-        assert_eq!(count, 1);
+        let pending = index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap();
+        assert_eq!(pending.turns(), 1);
 
+        // The offset is only recorded once flushed — i.e. once the caller has
+        // committed the documents it describes.
         let len = std::fs::metadata(&index_path).unwrap().len() as i64;
-        let stored: i64 = meta_conn
-            .query_row(
-                "SELECT last_offset FROM index_watermark WHERE project_id = ?1 AND session_id = ?2",
-                params!["p1", "s1"],
-                |r| r.get(0),
-            )
-            .unwrap();
-        assert_eq!(stored, len, "must record how much of the file it consumed");
+        assert_eq!(
+            crate::schema::read_session_offset(&meta_conn, "p1", "s1").unwrap(),
+            0,
+            "nothing may be recorded before the flush"
+        );
+        pending.flush(&meta_conn).unwrap();
+        assert_eq!(
+            crate::schema::read_session_offset(&meta_conn, "p1", "s1").unwrap(),
+            len,
+            "must record how much of the file it consumed"
+        );
     }
 
     #[test]
@@ -749,23 +888,20 @@ mod tests {
         let writer = index_writer(&index).unwrap();
         let meta_conn = ensure_meta_db_memory().unwrap();
 
-        assert_eq!(
-            index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap(),
-            1
-        );
+        // Each flush stands for a run whose documents were committed.
+        let first = index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap();
+        assert_eq!(first.turns(), 1);
+        first.flush(&meta_conn).unwrap();
+
         // Unchanged: skipped.
-        assert_eq!(
-            index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap(),
-            0
-        );
+        let second = index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap();
+        assert_eq!(second.turns(), 0);
+        second.flush(&meta_conn).unwrap();
 
         // The live session grows — the early-out must not blind us to new turns.
         write_session_fixture(project_dir, "s1", "2");
-        assert_eq!(
-            index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap(),
-            1,
-            "a grown file must be reprocessed"
-        );
+        let third = index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap();
+        assert_eq!(third.turns(), 1, "a grown file must be reprocessed");
     }
 
     fn mk_test_event(id: &str) -> edda_core::Event {
@@ -848,7 +984,7 @@ mod tests {
             "p1",
             "nonexistent",
         );
-        assert_eq!(result.unwrap(), 0);
+        assert_eq!(result.unwrap().turns(), 0);
     }
 
     #[test]
@@ -946,9 +1082,10 @@ mod tests {
         let mut writer = index_writer(&index).unwrap();
         let meta_conn = ensure_meta_db_memory().unwrap();
 
-        let count = index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap();
-        assert_eq!(count, 1);
+        let pending = index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap();
+        assert_eq!(pending.turns(), 1);
         writer.commit().unwrap();
+        assert_eq!(pending.flush(&meta_conn).unwrap(), 1);
 
         // Verify Tantivy has the document
         let reader = index.reader().unwrap();
@@ -966,7 +1103,7 @@ mod tests {
         assert_eq!(turn_id, "u1:a1");
 
         // Re-index is idempotent (dedup via turns_meta check)
-        let count2 = index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap();
-        assert_eq!(count2, 0);
+        let again = index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap();
+        assert_eq!(again.turns(), 0);
     }
 }

--- a/crates/edda-search-fts/src/indexer.rs
+++ b/crates/edda-search-fts/src/indexer.rs
@@ -169,39 +169,50 @@ impl PendingMeta {
     }
 
     /// Write everything in one transaction, returning the number of turns
-    /// recorded.
+    /// actually recorded.
     ///
     /// Call this ONLY after the Tantivy writer has committed. Flushing early
     /// reintroduces GH-413.
+    ///
+    /// `OR IGNORE` is load-bearing, not laziness. The per-turn dedup upstream
+    /// can only see rows previous runs flushed, so two records carrying the same
+    /// `turn_id` within one run both arrive here. A plain `INSERT` would raise a
+    /// PRIMARY KEY error that aborts the whole transaction — recording nothing,
+    /// and failing identically on every retry, which is worse than the crash
+    /// window this deferral exists to close. Collapsing the duplicate is also
+    /// the behaviour the old code had for free, since its dedup read from its
+    /// own open transaction.
     pub fn flush(self, conn: &Connection) -> anyhow::Result<usize> {
         let tx = conn.unchecked_transaction()?;
+        let mut recorded = 0;
         for r in &self.turns {
-            tx.execute(
-                "INSERT INTO turns_meta (turn_id, project_id, session_id, ts, \
-                 user_uuid, assistant_uuid, \
-                 user_store_offset, user_store_len, \
-                 assistant_store_offset, assistant_store_len) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
-                params![
-                    r.turn_id,
-                    r.project_id,
-                    r.session_id,
-                    r.ts,
-                    r.user_uuid,
-                    r.assistant_uuid,
-                    r.user_store_offset,
-                    r.user_store_len,
-                    r.assistant_store_offset,
-                    r.assistant_store_len,
-                ],
-            )
-            .context("insert turns_meta")?;
+            recorded += tx
+                .execute(
+                    "INSERT OR IGNORE INTO turns_meta (turn_id, project_id, session_id, ts, \
+                     user_uuid, assistant_uuid, \
+                     user_store_offset, user_store_len, \
+                     assistant_store_offset, assistant_store_len) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                    params![
+                        r.turn_id,
+                        r.project_id,
+                        r.session_id,
+                        r.ts,
+                        r.user_uuid,
+                        r.assistant_uuid,
+                        r.user_store_offset,
+                        r.user_store_len,
+                        r.assistant_store_offset,
+                        r.assistant_store_len,
+                    ],
+                )
+                .context("insert turns_meta")?;
         }
         for (project_id, session_id, offset) in &self.offsets {
             crate::schema::write_session_offset(conn, project_id, session_id, *offset)?;
         }
         tx.commit()?;
-        Ok(self.turns.len())
+        Ok(recorded)
     }
 }
 
@@ -369,6 +380,13 @@ pub fn index_session(
         };
 
         let tokens = format!("{tool_names} {tool_commands} {file_paths}");
+
+        // Replace rather than blindly add, exactly as `index_events_since` does.
+        // The caller commits BEFORE flushing, so a crash in between re-runs this
+        // turn on the next pass; without the delete that re-run would add a
+        // second copy of every turn, permanently, and normal syncing has no path
+        // that would ever clean it up.
+        writer.delete_term(Term::from_field_text(f_doc_id, turn_id.as_str()));
 
         // Add Tantivy document
         writer.add_document(doc!(
@@ -845,6 +863,87 @@ mod tests {
             1,
             "the turn must be searchable after recovery"
         );
+    }
+
+    /// GH-413 follow-up: the fix moved the crash window from "before the Tantivy
+    /// commit" to "after it, before the flush". That window must not duplicate.
+    ///
+    /// Events survive it because `index_events_since` deletes the doc_id before
+    /// re-adding. Turns must have the same property or the recovery run adds a
+    /// second copy of every turn, permanently.
+    #[test]
+    fn crash_between_commit_and_flush_does_not_duplicate_turns() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path();
+        write_session_fixture(project_dir, "s1", "1");
+
+        let index_dir = project_dir.join("search").join("tantivy");
+        let (index, _) = crate::schema::open_or_create_index(&index_dir).unwrap();
+        let tschema = index.schema();
+        let meta_conn =
+            crate::schema::ensure_meta_db(&project_dir.join("search").join("meta.sqlite")).unwrap();
+
+        // Run 1: documents committed, then the crash — flush never happens.
+        {
+            let mut writer = index_writer(&index).unwrap();
+            let _pending =
+                index_session(&writer, &tschema, &meta_conn, project_dir, "p1", "s1").unwrap();
+            writer.commit().unwrap();
+            // dropped without flushing
+        }
+
+        // Run 2: SQLite knows nothing, so the turn is indexed again.
+        let mut writer = index_writer(&index).unwrap();
+        let pending =
+            index_session(&writer, &tschema, &meta_conn, project_dir, "p1", "s1").unwrap();
+        writer.commit().unwrap();
+        pending.flush(&meta_conn).unwrap();
+
+        let reader = index.reader().unwrap();
+        reader.reload().unwrap();
+        assert_eq!(
+            reader.searcher().num_docs(),
+            1,
+            "re-indexing a turn must replace it, not add a second copy"
+        );
+    }
+
+    /// GH-413 follow-up: two records carrying the same turn_id inside ONE run.
+    ///
+    /// The old code deduped against its own open transaction, so this collapsed
+    /// silently. Deferring the writes means the dedup only sees flushed rows, so
+    /// both rows reach the flush — and a plain INSERT makes the PRIMARY KEY blow
+    /// up the whole transaction, recording nothing and failing identically on
+    /// every retry. That is worse than the bug this all started from.
+    #[test]
+    fn duplicate_turn_id_within_one_run_does_not_poison_the_flush() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path();
+        // Same suffix twice = same uuids = the same turn_id appearing twice.
+        write_session_fixture(project_dir, "s1", "1");
+        write_session_fixture(project_dir, "s1", "1");
+
+        let index = ensure_index_ram().unwrap();
+        let schema = index.schema();
+        let mut writer = index_writer(&index).unwrap();
+        let meta_conn = ensure_meta_db_memory().unwrap();
+
+        let pending = index_session(&writer, &schema, &meta_conn, project_dir, "p1", "s1").unwrap();
+        writer.commit().unwrap();
+
+        let recorded = pending
+            .flush(&meta_conn)
+            .expect("a duplicate turn_id must not abort the whole flush");
+        assert_eq!(recorded, 1, "the duplicate collapses to one row");
+
+        let rows: i64 = meta_conn
+            .query_row("SELECT count(*) FROM turns_meta", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(rows, 1);
+
+        let reader = index.reader().unwrap();
+        reader.reload().unwrap();
+        assert_eq!(reader.searcher().num_docs(), 1, "and to one document");
     }
 
     #[test]

--- a/crates/edda-search-fts/src/sync.rs
+++ b/crates/edda-search-fts/src/sync.rs
@@ -79,7 +79,10 @@ where
 
     // A rebuild must cover every session, otherwise sessions other than the
     // requested one vanish behind the fresh index.
-    let turns = match session_id {
+    //
+    // Nothing here touches SQLite: the turns_meta rows and session offsets come
+    // back pending and are flushed only after the commit below (GH-413).
+    let pending = match session_id {
         Some(sid) if !rebuilt => indexer::index_session(
             &writer,
             &tantivy_schema,
@@ -91,11 +94,15 @@ where
         _ => indexer::index_project(&writer, &tantivy_schema, &meta_conn, proj_dir, project_id)?,
     };
 
-    // Commit BEFORE advancing the cursor. A crash in between re-runs this batch,
-    // which index_events_since makes idempotent. The reverse order would mark
-    // events indexed that are not, hiding them forever.
+    // Commit BEFORE recording anything. A crash in between re-runs this batch:
+    // index_events_since makes the event re-add idempotent, and the turns are
+    // simply not marked done, so the next run picks them up. The reverse order
+    // would mark work done that Tantivy never received, hiding it forever.
     writer.commit()?;
     schema::write_index_version(&index_dir)?;
+
+    // Now that the documents are durable, it is safe to say so.
+    let turns = pending.flush(&meta_conn)?;
 
     let indexed_through = if let Some((rowid, ev)) = batch.last() {
         schema::write_events_cursor(&meta_conn, project_id, *rowid, Some(ev.ts.as_str()))?;


### PR DESCRIPTION
Closes #413.

## Problem

`index_session` recorded turns in SQLite and committed that transaction **before** its caller committed the Tantivy writer:

```
turns_meta rows → tx.commit()     ← SQLite: "these turns are indexed"
                                  ← ★ crash here
writer.commit()                   ← Tantivy only now receives the documents
```

Because the dedup is `SELECT 1 FROM turns_meta WHERE turn_id = ?1`, every later run **skipped** those turns. Permanently invisible to search, no self-healing path — and #403's own acceptance criterion says a kill mid-reindex must recover.

This predates #403, but #403 made it load-bearing (SessionEnd now syncs on every session exit) and widened the blast radius by putting the session offset in the same pre-commit transaction: a crash then skipped the whole file, not just the turn.

## Fix

`index_session`/`index_project` return a `PendingMeta` holding the `turns_meta` rows and session offsets. They touch SQLite only for **reads** (the early-out offset, the per-turn dedup). `sync` flushes it **after** `writer.commit()` succeeds.

This is the ordering the events cursor already used — commit, then advance `events_watermark`. The turns path now shares it.

## Adversarial review found two bugs in the fix itself — both fixed, tests first

The deferral moved the crash window rather than removing it, and the first version handled the new window badly:

1. **Duplicate turn documents.** Events survive that window because `index_events_since` deletes the `doc_id` before re-adding. Turns were still doing a plain `add_document`, so the recovery run added a *second copy of every turn*, permanently, with no cleanup path in normal syncing. Turns now `delete_term` first — the property that makes the ordering safe in the first place. (`crash_between_commit_and_flush_does_not_duplicate_turns`, failed with `left: 2, right: 1`.)

2. **A duplicate `turn_id` within one run aborted the entire flush.** The old dedup read from its own open transaction, so same-run duplicates collapsed for free. Deferring means the check only sees *flushed* rows, so both records reach the flush — where a plain `INSERT` raised `PRIMARY KEY constraint failed` and rolled back the whole transaction, recording nothing and failing identically on every retry. **Worse than the window being closed.** `INSERT OR IGNORE` restores the old semantics, and `flush` now reports rows actually inserted rather than attempted. (`duplicate_turn_id_within_one_run_does_not_poison_the_flush`, failed with `Error code 1555`.)

## Tests

`crash_before_tantivy_commit_leaves_turns_reindexable` is the executable form of the issue: it drops the writer without committing — the only way the crash actually happens — and asserted **0** re-indexed turns before the fix.

54 tests in `edda-search-fts` (was 52), workspace 1934 passed / 0 failed, clippy clean at `-D warnings`, fmt clean.

## Known limitation (not fixed here)

`PendingMeta` buffers a full rebuild's `turns_meta` rows in memory before flushing — O(total project turns). At the real corpus's ~1300 turns this is trivial, but it is unbounded in principle. Chunking would mean multiple commits, which is a different design; flagged rather than folded in.

## Not yet verified live

The deferral touches the hot path, so the #403 budget (no-op sync 0.157s, down from 24.7s) must still hold. Release build + live check on the real corpus pending — numbers will be posted here before this is ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
