### PR TITLE
search: index --project X from X's own repo, not the current one (GH-414)

### DIFF
--- a/crates/edda-cli/src/cmd_search.rs
+++ b/crates/edda-cli/src/cmd_search.rs
@@ -3,7 +3,7 @@ use edda_index::fetch_store_line;
 use edda_ledger::Ledger;
 use edda_search_fts::{schema, search, sync};
 use edda_store::project_dir;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 // ── CLI Schema ──
 
@@ -112,26 +112,26 @@ pub fn query(
     // command is the complaint this issue exists to answer.
     let missing = !index_dir.exists();
     let outdated = schema::index_is_outdated(&index_dir);
-    // Only auto-build the project this repo actually resolves to. `--project`
-    // names a project independently of where we are standing, and repo_root's
-    // ledger is not that project's ledger — building from it would write these
-    // events into someone else's index. For a project that isn't here, the
-    // explicit message is the honest answer.
-    let is_local_project = project_id == resolve_project_id(repo_root);
-    if (missing || outdated) && !is_local_project {
-        eprintln!(
-            "No usable search index for project {project_id}. Run \
-             `edda search index --project {project_id}` from that project's repo."
-        );
-        return Ok(());
-    }
     if missing || outdated {
         if missing {
             println!("No search index — building now (one-time)…");
         } else {
             println!("Search index schema is outdated — rebuilding now (one-time)…");
         }
-        let ledger = Ledger::open(repo_root)?;
+        // Build from the ledger that actually backs this project, which may not
+        // be the repo we are standing in (GH-414). Degrade rather than hard-fail:
+        // a query that cannot work out where to build from should say so, not
+        // abort with an error.
+        let ledger_root = match ledger_root_for(repo_root, project_id, |pid| {
+            edda_store::registry::get_project(pid).map(|e| e.path)
+        }) {
+            Ok(root) => root,
+            Err(e) => {
+                eprintln!("{e}");
+                return Ok(());
+            }
+        };
+        let ledger = Ledger::open(&ledger_root)?;
         let stats = sync::sync(&proj_dir, project_id, None, |after| {
             ledger.events_after_rowid(after)
         })?;
@@ -229,6 +229,46 @@ fn print_watermark(repo_root: &Path, proj_dir: &Path, project_id: &str) {
     }
 }
 
+/// Decide whose ledger backs `project_id` (GH-414).
+///
+/// `--project` names a project independently of where the user is standing, so
+/// the two can diverge. Pairing this repo's ledger with another project's index
+/// writes these events into that project — silently, and reported as success.
+///
+/// The registry knows where each project lives, so a foreign project is resolved
+/// to its own repo rather than refused. `lookup` is injected (production passes
+/// `edda_store::get_project`) because resolving it for real reads the
+/// process-wide store root, which a test cannot redirect without corrupting its
+/// siblings.
+fn ledger_root_for(
+    repo_root: &Path,
+    project_id: &str,
+    lookup: impl FnOnce(&str) -> Option<String>,
+) -> anyhow::Result<PathBuf> {
+    if project_id == resolve_project_id(repo_root) {
+        return Ok(repo_root.to_path_buf());
+    }
+
+    let Some(path) = lookup(project_id) else {
+        anyhow::bail!(
+            "Project {project_id} is not in the registry, so there is no way to tell \
+             whose events it holds. Run `edda search index` from that project's repo."
+        );
+    };
+
+    // Same staleness rule the registry itself uses: a live repo has a `.edda/`.
+    // Falling back to repo_root here would be the bug this exists to fix.
+    let root = PathBuf::from(path);
+    if !root.join(".edda").is_dir() {
+        anyhow::bail!(
+            "Project {project_id} is registered at {} but that path no longer holds \
+             an edda ledger. Run `edda search index` from that project's repo.",
+            root.display()
+        );
+    }
+    Ok(root)
+}
+
 /// Execute `edda search index` — build/update the Tantivy index for a project.
 pub fn index(repo_root: &Path, project_id: &str, session_id: Option<&str>) -> anyhow::Result<()> {
     let proj_dir = project_dir(project_id);
@@ -236,7 +276,10 @@ pub fn index(repo_root: &Path, project_id: &str, session_id: Option<&str>) -> an
         anyhow::bail!("Project directory not found: {}", proj_dir.display());
     }
 
-    let ledger = Ledger::open(repo_root)?;
+    let ledger_root = ledger_root_for(repo_root, project_id, |pid| {
+        edda_store::registry::get_project(pid).map(|e| e.path)
+    })?;
+    let ledger = Ledger::open(&ledger_root)?;
     let stats = sync::sync(&proj_dir, project_id, session_id, |after| {
         ledger.events_after_rowid(after)
     })?;
@@ -356,4 +399,74 @@ fn extract_message_text(json: &serde_json::Value) -> String {
     }
 
     String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The registry must not even be consulted for the project we are standing
+    /// in — that is the overwhelmingly common case and it must not depend on
+    /// being registered.
+    #[test]
+    fn local_project_uses_this_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let pid = resolve_project_id(root);
+
+        let got = ledger_root_for(root, &pid, |_| {
+            panic!("registry must not be consulted for the local project")
+        })
+        .unwrap();
+
+        assert_eq!(got, root);
+    }
+
+    /// GH-414: `--project X` names a project independently of where we stand, so
+    /// its events must come from ITS repo. Using this repo's ledger writes these
+    /// events into that project's index.
+    #[test]
+    fn foreign_project_uses_its_own_registered_repo() {
+        let here = tempfile::tempdir().unwrap();
+        let there = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(there.path().join(".edda")).unwrap();
+        let there_path = there.path().to_string_lossy().into_owned();
+
+        let got = ledger_root_for(here.path(), "other-pid", |_| Some(there_path.clone())).unwrap();
+
+        assert_eq!(
+            got,
+            there.path(),
+            "a foreign project must be indexed from its own repo, never ours"
+        );
+    }
+
+    #[test]
+    fn foreign_project_not_in_the_registry_is_refused() {
+        let here = tempfile::tempdir().unwrap();
+
+        let err = ledger_root_for(here.path(), "unknown-pid", |_| None).unwrap_err();
+
+        assert!(
+            err.to_string().contains("not in the registry"),
+            "unhelpful error: {err}"
+        );
+    }
+
+    /// The registry is full of entries whose repos are gone (see #417). A stale
+    /// one must refuse, not fall back to whatever repo we happen to be in.
+    #[test]
+    fn foreign_project_whose_repo_is_gone_is_refused() {
+        let here = tempfile::tempdir().unwrap();
+        let gone = tempfile::tempdir().unwrap();
+        let gone_path = gone.path().to_string_lossy().into_owned();
+        drop(gone);
+
+        let err = ledger_root_for(here.path(), "stale-pid", |_| Some(gone_path)).unwrap_err();
+
+        assert!(
+            err.to_string().contains("no longer holds"),
+            "unhelpful error: {err}"
+        );
+    }
 }

--- a/crates/edda-cli/src/cmd_search.rs
+++ b/crates/edda-cli/src/cmd_search.rs
@@ -272,9 +272,15 @@ fn ledger_root_for(
     // cursor as ahead and purge every event document the project has — reported
     // as a successful rebuild. Require the ledger itself.
     if !root.join(".edda").join("ledger.db").is_file() {
+        // Deliberately does NOT advise reindexing from that repo. Running there
+        // takes the local fast path above, which does not reach this check, and
+        // `Ledger::open` would invent an empty ledger — emptying the project's
+        // index instead of rebuilding it (#418). Refusing and then prescribing
+        // the same destruction by hand would be worse than not refusing at all.
         anyhow::bail!(
-            "Project {project_id} is registered at {} but that path holds no edda \
-             ledger. Run `edda search index` from that project's repo.",
+            "Project {project_id} is registered at {} but .edda/ledger.db is missing \
+             there, so there is no ledger to index from. The registry entry is stale, \
+             or that ledger was deleted.",
             root.display()
         );
     }
@@ -479,11 +485,23 @@ mod tests {
         std::fs::create_dir_all(there.path().join(".edda")).unwrap(); // no ledger.db
         let there_path = there.path().to_string_lossy().into_owned();
 
-        let err = ledger_root_for(here.path(), "orphan-pid", |_| Some(there_path)).unwrap_err();
+        let err = ledger_root_for(here.path(), "orphan-pid", |_| Some(there_path))
+            .unwrap_err()
+            .to_string();
 
         assert!(
-            err.to_string().contains("no edda ledger"),
+            err.contains("ledger.db is missing"),
             "unhelpful error: {err}"
+        );
+
+        // And it must not send the user around the guard it just applied.
+        // Reindexing from that repo takes the local fast path, which never
+        // reaches this check; Ledger::open would invent an empty ledger and the
+        // rebuild would empty the project's index (#418). Refusing and then
+        // prescribing the same destruction by hand is worse than not refusing.
+        assert!(
+            !err.contains("Run `edda search index`"),
+            "must not prescribe the destruction it just refused: {err}"
         );
     }
 

--- a/crates/edda-cli/src/cmd_search.rs
+++ b/crates/edda-cli/src/cmd_search.rs
@@ -256,13 +256,36 @@ fn ledger_root_for(
         );
     };
 
-    // Same staleness rule the registry itself uses: a live repo has a `.edda/`.
-    // Falling back to repo_root here would be the bug this exists to fix.
     let root = PathBuf::from(path);
-    if !root.join(".edda").is_dir() {
+    if !root.exists() {
         anyhow::bail!(
             "Project {project_id} is registered at {} but that path no longer holds \
              an edda ledger. Run `edda search index` from that project's repo.",
+            root.display()
+        );
+    }
+
+    // The registry's staleness rule is only "the path still has a `.edda/`", which
+    // is too weak to resolve a ledger from: `Ledger::open` checks the directory
+    // and then CREATES an empty ledger.db if none is there. An orphan `.edda/`
+    // would hand us an empty ledger, and an empty ledger makes `sync` treat the
+    // cursor as ahead and purge every event document the project has — reported
+    // as a successful rebuild. Require the ledger itself.
+    if !root.join(".edda").join("ledger.db").is_file() {
+        anyhow::bail!(
+            "Project {project_id} is registered at {} but that path holds no edda \
+             ledger. Run `edda search index` from that project's repo.",
+            root.display()
+        );
+    }
+
+    // Verify the registry's claim rather than trusting it. It is demonstrably
+    // unreliable (#417), and acting on a wrong path here is precisely the bug
+    // being fixed — just sourced from bad data instead of bad logic.
+    if resolve_project_id(&root) != project_id {
+        anyhow::bail!(
+            "Registry says project {project_id} lives at {}, but that repo does not \
+             hold project {project_id}. The registry entry is stale or wrong.",
             root.display()
         );
     }
@@ -430,14 +453,57 @@ mod tests {
         let here = tempfile::tempdir().unwrap();
         let there = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(there.path().join(".edda")).unwrap();
+        std::fs::write(there.path().join(".edda").join("ledger.db"), b"").unwrap();
         let there_path = there.path().to_string_lossy().into_owned();
+        // The id the registry would really have stored for that repo.
+        let there_pid = resolve_project_id(there.path());
 
-        let got = ledger_root_for(here.path(), "other-pid", |_| Some(there_path.clone())).unwrap();
+        let got = ledger_root_for(here.path(), &there_pid, |_| Some(there_path.clone())).unwrap();
 
         assert_eq!(
             got,
             there.path(),
             "a foreign project must be indexed from its own repo, never ours"
+        );
+    }
+
+    /// `.edda/` presence is the registry's staleness rule, but it is too weak to
+    /// resolve a ledger: `Ledger::open` only checks the directory and then
+    /// CREATES an empty `ledger.db` if none exists. An empty ledger makes `sync`
+    /// treat the cursor as ahead and purge every event document the project has —
+    /// reported as a successful rebuild. An orphan `.edda/` must refuse.
+    #[test]
+    fn foreign_project_with_an_orphan_edda_dir_is_refused() {
+        let here = tempfile::tempdir().unwrap();
+        let there = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(there.path().join(".edda")).unwrap(); // no ledger.db
+        let there_path = there.path().to_string_lossy().into_owned();
+
+        let err = ledger_root_for(here.path(), "orphan-pid", |_| Some(there_path)).unwrap_err();
+
+        assert!(
+            err.to_string().contains("no edda ledger"),
+            "unhelpful error: {err}"
+        );
+    }
+
+    /// The registry is demonstrably unreliable (#417: 1628 of 1644 entries dead),
+    /// so its claim is verified rather than trusted: the repo it names must
+    /// actually be the project that was asked for.
+    #[test]
+    fn registry_entry_naming_a_different_project_is_refused() {
+        let here = tempfile::tempdir().unwrap();
+        let there = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(there.path().join(".edda")).unwrap();
+        std::fs::write(there.path().join(".edda").join("ledger.db"), b"").unwrap();
+        let there_path = there.path().to_string_lossy().into_owned();
+
+        // `there` does not hash to "wrong-pid"; the registry is lying.
+        let err = ledger_root_for(here.path(), "wrong-pid", |_| Some(there_path)).unwrap_err();
+
+        assert!(
+            err.to_string().contains("does not hold project"),
+            "unhelpful error: {err}"
         );
     }
 


### PR DESCRIPTION
Closes #414.

## Problem

`edda search index --project X` run from repo Y silently filled **X's** search index with **Y's** events, and reported success.

`run_cmd` resolves `--project` independently of `repo_root`, and `index()` paired `Ledger::open(repo_root)` with `project_dir(project_id)`. Normally those agree (the project id is derived from the repo you are in); only an explicit `--project` makes them diverge — which is exactly when it fires. #412 fixed the two equivalents on the read path and left this one, since `query` had never opened a ledger before and `index` always had.

## Fix — resolve, don't refuse

The registry already knows where each project lives, so `--project X` now genuinely indexes X **from X's own repo** rather than being rejected.

That keeps `--project` meaning "operate on X" the way it does for `query` and `show`, instead of making `index` the one subcommand that refuses. It also matches the shape of the `fleet.cross-repo-reads1` ruling: truth stays home, so X's events come from X's repo.

`query`'s build-if-missing goes through the same resolution. #412 had guarded it by telling the user to run `index --project X` "from that project's repo" — with index now working from anywhere, that message would have become a lie.

## Guarding the registry rather than trusting it

Adversarial review (codex) turned up that resolving through the registry needs more care than the registry's own staleness rule provides:

- **`.edda/` presence is too weak.** `Ledger::open` only checks the *directory* (`is_initialized()` is `edda_dir.is_dir()`) and then calls `SqliteStore::open_or_create` — it **creates** an empty `ledger.db`. An orphan `.edda/` would hand back an empty ledger, and an empty ledger makes `sync` see the cursor as ahead and **purge every event document the project has**, reported as a successful rebuild. Resolution now requires `.edda/ledger.db` itself.
- **The registry's claim is verified, not trusted.** The repo it names must actually hash to the project asked for. Acting on a wrong path is precisely this issue's bug; sourcing it from bad data rather than bad logic is no improvement. And the registry is demonstrably unreliable — 1628 of 1644 entries on a real machine point at paths that no longer exist (#417).

## Tests

`cmd_search.rs` had **no tests**. It now has six. The resolution is split into `ledger_root_for` with an injected lookup — resolving for real reads the process-wide store root, which a test cannot redirect without corrupting parallel siblings (the same shape as `bg_index::index_exists`).

| Case | Behaviour |
|---|---|
| local project | uses this repo; registry never consulted (test panics the lookup to prove it) |
| foreign, registered, live | resolves to **its** repo |
| foreign, unregistered | refused |
| foreign, path gone | refused |
| foreign, orphan `.edda/` without a ledger | refused |
| registry names a repo that isn't that project | refused |

195 tests in `edda`, clippy clean at `-D warnings`, fmt clean.

## Filed rather than folded in

- **#418** — a missing `ledger.db` silently purges the index and reports success. This PR closes the *foreign* path into it, but the local path (your own repo, `ledger.db` gone) still purges. Not a regression: the pre-#412 bulk path did the same thing more directly.
- **#417** — the registry is 99% dead entries because tests register temp dirs and never clean up.

Two further codex findings judged out of scope, both pre-existing and neither worsened here: `project_id()` deliberately maps every git worktree of a repo to the same id, so "same id ⇒ same ledger" is not strictly sound (but the local fast path only preserves what `index` already did); and `query` returns exit 0 when it could not search at all, which predates this work and applies to every "no index" path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
