### PR TITLE
test(cli): stop edda-cli tests writing to the developer's real store (GH-417)

### DIFF
--- a/crates/edda-cli/src/cmd_bridge.rs
+++ b/crates/edda-cli/src/cmd_bridge.rs
@@ -1497,6 +1497,7 @@ mod tests {
 
     #[test]
     fn decide_writes_binding_to_coordination_log() {
+        let _store = crate::test_support::isolated_store();
         let _env = env_guard();
         let (tmp, _ledger) = setup_workspace();
         let pid = edda_store::project_id(&tmp);
@@ -1541,6 +1542,7 @@ mod tests {
 
     #[test]
     fn decide_writes_structured_ledger_event() {
+        let _store = crate::test_support::isolated_store();
         let _env = env_guard();
         let (tmp, ledger) = setup_workspace();
         let pid = edda_store::project_id(&tmp);
@@ -1588,6 +1590,7 @@ mod tests {
 
     #[test]
     fn ratify_records_separate_event_and_makes_decision_binding() {
+        let _store = crate::test_support::isolated_store();
         let _env = env_guard();
         let (tmp, ledger) = setup_workspace();
         let pid = edda_store::project_id(&tmp);
@@ -1639,6 +1642,7 @@ mod tests {
 
     #[test]
     fn ratify_unknown_key_errors() {
+        let _store = crate::test_support::isolated_store();
         let _env = env_guard();
         let (tmp, _ledger) = setup_workspace();
         let pid = edda_store::project_id(&tmp);
@@ -1656,6 +1660,7 @@ mod tests {
 
     #[test]
     fn decide_supersedes_prior_decision_same_key() {
+        let _store = crate::test_support::isolated_store();
         let _env = env_guard();
         let (tmp, ledger) = setup_workspace();
         let pid = edda_store::project_id(&tmp);
@@ -1702,6 +1707,7 @@ mod tests {
 
     #[test]
     fn resolve_session_id_tiers() {
+        let _store = crate::test_support::isolated_store();
         let _env = env_guard();
         let pid = "test_resolve_sid_tiers";
         let _ = edda_store::ensure_dirs(pid);
@@ -1822,6 +1828,7 @@ mod tests {
 
     #[test]
     fn render_coordination_solo_no_bindings() {
+        let _store = crate::test_support::isolated_store();
         let pid = "test_render_coord_solo";
         let _ = edda_store::ensure_dirs(pid);
         let result = edda_bridge_claude::render::coordination(pid, "solo-session");
@@ -1835,6 +1842,7 @@ mod tests {
 
     #[test]
     fn render_pack_no_pack_file() {
+        let _store = crate::test_support::isolated_store();
         let pid = "test_render_pack_empty";
         let _ = edda_store::ensure_dirs(pid);
         let result = edda_bridge_claude::render::pack(pid);
@@ -1844,6 +1852,7 @@ mod tests {
 
     #[test]
     fn heartbeat_write_touch_remove_lifecycle() {
+        let _store = crate::test_support::isolated_store();
         let pid = "test_hb_lifecycle";
         let sid = "sess-lifecycle-1";
         let _ = edda_store::ensure_dirs(pid);

--- a/crates/edda-cli/src/cmd_draft.rs
+++ b/crates/edda-cli/src/cmd_draft.rs
@@ -1446,6 +1446,7 @@ mod tests {
 
     #[test]
     fn list_json_empty_dir() {
+        let _store = crate::test_support::isolated_store();
         let tmp = tempfile::tempdir().unwrap();
         init_workspace(tmp.path());
         // No drafts — should produce no output (no panic)
@@ -1455,6 +1456,7 @@ mod tests {
 
     #[test]
     fn list_json_single_draft() {
+        let _store = crate::test_support::isolated_store();
         let tmp = tempfile::tempdir().unwrap();
         init_workspace(tmp.path());
 
@@ -1468,6 +1470,7 @@ mod tests {
 
     #[test]
     fn list_json_output_is_valid_jsonl() {
+        let _store = crate::test_support::isolated_store();
         let tmp = tempfile::tempdir().unwrap();
         init_workspace(tmp.path());
 
@@ -1525,6 +1528,7 @@ mod tests {
 
     #[test]
     fn list_json_multiple_drafts_sorted() {
+        let _store = crate::test_support::isolated_store();
         let tmp = tempfile::tempdir().unwrap();
         init_workspace(tmp.path());
 
@@ -1549,6 +1553,7 @@ mod tests {
 
     #[test]
     fn inbox_json_empty() {
+        let _store = crate::test_support::isolated_store();
         let tmp = tempfile::tempdir().unwrap();
         init_workspace(tmp.path());
         let result = inbox(tmp.path(), None, None, true);
@@ -1557,6 +1562,7 @@ mod tests {
 
     #[test]
     fn inbox_json_with_pending_stage() {
+        let _store = crate::test_support::isolated_store();
         let tmp = tempfile::tempdir().unwrap();
         init_workspace(tmp.path());
 
@@ -1574,6 +1580,7 @@ mod tests {
 
     #[test]
     fn inbox_json_skips_applied() {
+        let _store = crate::test_support::isolated_store();
         let tmp = tempfile::tempdir().unwrap();
         init_workspace(tmp.path());
 
@@ -1592,6 +1599,7 @@ mod tests {
 
     #[test]
     fn inbox_json_skips_approved_stages() {
+        let _store = crate::test_support::isolated_store();
         let tmp = tempfile::tempdir().unwrap();
         init_workspace(tmp.path());
 
@@ -1613,6 +1621,7 @@ mod tests {
 
     #[test]
     fn inbox_json_filter_by_actor() {
+        let _store = crate::test_support::isolated_store();
         let tmp = tempfile::tempdir().unwrap();
         init_workspace(tmp.path());
 
@@ -1635,6 +1644,7 @@ mod tests {
 
     #[test]
     fn inbox_json_filter_by_role() {
+        let _store = crate::test_support::isolated_store();
         let tmp = tempfile::tempdir().unwrap();
         init_workspace(tmp.path());
 
@@ -1657,6 +1667,7 @@ mod tests {
 
     #[test]
     fn inbox_json_output_fields() {
+        let _store = crate::test_support::isolated_store();
         let tmp = tempfile::tempdir().unwrap();
         init_workspace(tmp.path());
 

--- a/crates/edda-cli/src/cmd_init.rs
+++ b/crates/edda-cli/src/cmd_init.rs
@@ -194,6 +194,7 @@ mod tests {
 
     #[test]
     fn init_detects_claude_and_installs_hooks() {
+        let _store = crate::test_support::isolated_store();
         let tmp = temp_dir();
         std::fs::create_dir_all(tmp.join(".claude")).unwrap();
 
@@ -226,6 +227,7 @@ mod tests {
 
     #[test]
     fn init_no_hooks_skips_bridge() {
+        let _store = crate::test_support::isolated_store();
         let tmp = temp_dir();
         std::fs::create_dir_all(tmp.join(".claude")).unwrap();
 
@@ -244,6 +246,7 @@ mod tests {
 
     #[test]
     fn init_without_claude_dir_no_error() {
+        let _store = crate::test_support::isolated_store();
         let tmp = temp_dir();
 
         execute(&tmp, false, false).unwrap();
@@ -258,6 +261,7 @@ mod tests {
 
     #[test]
     fn reinit_also_installs_hooks() {
+        let _store = crate::test_support::isolated_store();
         let tmp = temp_dir();
 
         // First init — no .claude/ dir
@@ -280,6 +284,7 @@ mod tests {
 
     #[test]
     fn init_scaffolds_coord_skills() {
+        let _store = crate::test_support::isolated_store();
         let tmp = temp_dir();
         std::fs::create_dir_all(tmp.join(".claude")).unwrap();
 
@@ -309,6 +314,7 @@ mod tests {
 
     #[test]
     fn init_skips_existing_skills() {
+        let _store = crate::test_support::isolated_store();
         let tmp = temp_dir();
         let skill_dir = tmp.join(".claude").join("skills").join("coord-sync");
         std::fs::create_dir_all(&skill_dir).unwrap();
@@ -328,6 +334,7 @@ mod tests {
 
     #[test]
     fn init_force_skills_overwrites() {
+        let _store = crate::test_support::isolated_store();
         let tmp = temp_dir();
         let skill_dir = tmp.join(".claude").join("skills").join("coord-sync");
         std::fs::create_dir_all(&skill_dir).unwrap();

--- a/crates/edda-cli/src/cmd_scan.rs
+++ b/crates/edda-cli/src/cmd_scan.rs
@@ -265,6 +265,7 @@ mod tests {
 
     #[test]
     fn execute_list_handles_empty() {
+        let _store = crate::test_support::isolated_store();
         // Just verify no panic on a fresh project
         let pid = "test_cmd_scan_empty";
         let _ = edda_store::ensure_dirs(pid);

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -44,6 +44,8 @@ mod cmd_tool_tier;
 mod cmd_user;
 mod cmd_watch;
 mod pipeline_templates;
+#[cfg(test)]
+mod test_support;
 #[cfg(feature = "tui")]
 mod tui;
 

--- a/crates/edda-cli/src/test_support.rs
+++ b/crates/edda-cli/src/test_support.rs
@@ -1,5 +1,6 @@
 //! Test-only helpers shared by the `cmd_*` test modules.
 
+use std::ffi::OsString;
 use std::sync::{Mutex, MutexGuard};
 
 /// Serialize tests that redirect `EDDA_STORE_ROOT`.
@@ -9,16 +10,27 @@ use std::sync::{Mutex, MutexGuard};
 static ENV_STORE_LOCK: Mutex<()> = Mutex::new(());
 
 /// Holds the redirect open for the duration of a test, and — importantly —
-/// takes it back down on drop, so a panicking test cannot leave
+/// puts back whatever was there on drop, so a panicking test cannot leave
 /// `EDDA_STORE_ROOT` pointing at a `TempDir` that is about to be deleted.
 pub(crate) struct IsolatedStore {
+    /// What `EDDA_STORE_ROOT` was before we took it over, if anything.
+    prev: Option<OsString>,
     _dir: tempfile::TempDir,
     _guard: MutexGuard<'static, ()>,
 }
 
 impl Drop for IsolatedStore {
     fn drop(&mut self) {
-        std::env::remove_var("EDDA_STORE_ROOT");
+        // Restore rather than remove. Someone who already knows about this
+        // pollution may well run `EDDA_STORE_ROOT=/somewhere cargo test` to keep
+        // the suite off their real store; removing the variable here would drop
+        // every later test back onto the real one, writing exactly the entries
+        // they redirected to avoid — and silently, since they believe they are
+        // covered.
+        match self.prev.take() {
+            Some(prev) => std::env::set_var("EDDA_STORE_ROOT", prev),
+            None => std::env::remove_var("EDDA_STORE_ROOT"),
+        }
     }
 }
 
@@ -39,10 +51,25 @@ pub(crate) fn isolated_store() -> IsolatedStore {
     // of one test, and must not cascade into every later one, so the poison is
     // taken rather than unwrapped.
     let guard = ENV_STORE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let prev = std::env::var_os("EDDA_STORE_ROOT");
     let dir = tempfile::tempdir().expect("tempdir for isolated store");
     std::env::set_var("EDDA_STORE_ROOT", dir.path());
     IsolatedStore {
+        prev,
         _dir: dir,
         _guard: guard,
     }
 }
+
+// No test for the restore path, deliberately.
+//
+// It was attempted and it is racy at every available seam. Any assertion has to
+// compare against the process-wide `EDDA_STORE_ROOT`, and the only window in
+// which that value is stable is while the lock is held — but acquiring it means
+// calling `isolated_store()`, which takes the same non-reentrant lock, so a
+// nested read deadlocks and an unnested one is a coin flip against whichever
+// sibling test is mid-redirect. The first version of this test duly failed that
+// way.
+//
+// A flaky test here would be worse than none: it would train the next person to
+// re-run until green, which is the habit that lets real failures through.

--- a/crates/edda-cli/src/test_support.rs
+++ b/crates/edda-cli/src/test_support.rs
@@ -1,0 +1,48 @@
+//! Test-only helpers shared by the `cmd_*` test modules.
+
+use std::sync::{Mutex, MutexGuard};
+
+/// Serialize tests that redirect `EDDA_STORE_ROOT`.
+///
+/// The store root is process-wide, and cargo runs a crate's tests in parallel
+/// threads, so two tests redirecting it at once would each see the other's root.
+static ENV_STORE_LOCK: Mutex<()> = Mutex::new(());
+
+/// Holds the redirect open for the duration of a test, and — importantly —
+/// takes it back down on drop, so a panicking test cannot leave
+/// `EDDA_STORE_ROOT` pointing at a `TempDir` that is about to be deleted.
+pub(crate) struct IsolatedStore {
+    _dir: tempfile::TempDir,
+    _guard: MutexGuard<'static, ()>,
+}
+
+impl Drop for IsolatedStore {
+    fn drop(&mut self) {
+        std::env::remove_var("EDDA_STORE_ROOT");
+    }
+}
+
+/// Point the per-user store at a throwaway directory for this test.
+///
+/// Anything that writes to the store — `edda init` and `edda group` both call
+/// `registry::register_project` — must be wrapped in this, or it writes into the
+/// developer's real `registry.json` and stays there (GH-417). CI never notices,
+/// because its containers start empty; only the developer's machine accumulates.
+///
+/// Keep the returned value alive for the whole test:
+///
+/// ```ignore
+/// let _store = test_support::isolated_store();
+/// ```
+pub(crate) fn isolated_store() -> IsolatedStore {
+    // A test that panics while holding the lock poisons it. That is the failure
+    // of one test, and must not cascade into every later one, so the poison is
+    // taken rather than unwrapped.
+    let guard = ENV_STORE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().expect("tempdir for isolated store");
+    std::env::set_var("EDDA_STORE_ROOT", dir.path());
+    IsolatedStore {
+        _dir: dir,
+        _guard: guard,
+    }
+}


### PR DESCRIPTION
Part of #417 (does not close it — see "What remains").

## Problem

edda-cli's tests wrote into the **developer's real per-user store** and left it that way. Measured: one `cargo test -p edda` added **11 registry entries**, and 1644 had accumulated — 1628 of them pointing at paths that no longer exist. CI never notices, because its containers start empty. Only the developer's machine accumulates.

Two sources, both reaching `registry::register_project` via `cmd_init::execute`:

- `cmd_init`'s own 7 tests
- `cmd_draft`'s `init_workspace` helper, used by 11 more

Neither redirected the store.

## Fix

`edda-store` already solved this for itself (`with_isolated_store` + `ENV_STORE_LOCK`), but that lock is `#[cfg(test)] pub(crate)` — edda-cli cannot reach it. This adds the equivalent in `test_support.rs`, with two improvements over the original:

- the redirect is undone by **`Drop`**, not a trailing statement, so a panicking test cannot leave `EDDA_STORE_ROOT` pointing at a `TempDir` that is about to be deleted
- a **poisoned lock is taken, not unwrapped**, so one failing test does not cascade into every later one

### The env approach is all-or-nothing

The store root is process-wide, so isolating *some* tests breaks the siblings that still use the real store. Isolating init and draft duly broke two `cmd_bridge` tests — the exact trap already documented in `bg_index`'s own comment.

`cmd_bridge` (9 tests) and `cmd_scan` (1) also write to the real store; they are what leaves `test_state_rt` / `test_wmfail_*` in `projects/` — the #415 class. Isolating them fixes the breakage and their pollution in one move.

## Verified by measurement, not inspection

| | before | after |
|---|---|---|
| `cargo test -p edda` registry delta | **+11** | **+0** |
| tests | 193 | **195 green** |

The registry itself was also swept, using a command that already existed — see the correction below.

## Two corrections to the issue, both mine

**"The staleness rule just needs a caller" was false.** `edda gc --global` phase 4d already calls `validate_projects()` and unregisters stale entries. It found all 1788; with a dry-run first confirming it would touch nothing else (0 blobs, 0 transcripts), the sweep took **1644 → 16 entries, all live**. No prune needed building.

**The culprits were wrong.** `registry.rs`'s own tests are already isolated; the real sources were `cmd_init` and `cmd_draft`.

## What remains — `edda-conductor` adds 13/run

Bisected across all 85 workspace members; it is the only remaining source, and it resists the obvious explanations: it depends only on `edda-store`, uses just `project_dir`/`project_id`/`write_atomic`, never calls `register_project`, and reproducing its `Command::new("edda")` subprocess by hand registers nothing. Left open on #417 with the evidence.

## A measurement trap, recorded

Two false "+0 pollution" readings occurred while working this, both because **`cargo test --workspace` aborts the remaining crates once one fails** — so a broken run reports less pollution *and* a smaller passed count. The first "+0" was a run with 2 failures, not a fix. A sudden drop in the total passed count is a red flag, not noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
