### PR TITLE
test(bridge): stop two tests leaving residue in the real store (GH-415)

### DIFF
--- a/crates/edda-bridge-claude/src/bg_digest.rs
+++ b/crates/edda-bridge-claude/src/bg_digest.rs
@@ -449,6 +449,19 @@ mod tests {
     #[test]
     fn audit_log_appends() {
         let pid = "test_digest_audit";
+
+        // Start from a known state (GH-415). This test asserts an exact row
+        // count, and it appends to a log in the real store — so a previous run
+        // that panicked before reaching its cleanup leaves rows behind and this
+        // one counts them too. That failure is self-perpetuating: it panics
+        // again, skips cleanup again, and the log grows by two every attempt.
+        // Once red on a machine, red forever, with a message ("expected 2, got
+        // 3") describing the leftovers rather than the defect.
+        //
+        // Cleaning up first rather than only last is what makes it self-healing:
+        // the trailing cleanup still runs on the happy path, and this one
+        // recovers the unhappy one.
+        let _ = std::fs::remove_dir_all(edda_store::project_dir(pid));
         let _ = edda_store::ensure_dirs(pid);
 
         let entry = AuditEntry {

--- a/crates/edda-bridge-claude/src/bg_scan.rs
+++ b/crates/edda-bridge-claude/src/bg_scan.rs
@@ -1179,6 +1179,12 @@ End of analysis."#;
     fn audit_log_appends() {
         let pid = "test_scan_audit";
         let _ = edda_store::ensure_dirs(pid);
+        // Start from a known state (GH-415), as bg_detect's copy of this test
+        // already does. Appending to a log in the real store while asserting an
+        // exact count means a run that panicked before its cleanup leaves rows
+        // for this one to count — which panics, skips cleanup, and leaves more.
+        // Once red on a machine, red forever.
+        let _ = fs::remove_file(audit_log_path(pid));
 
         let entry = AuditEntry {
             ts: "2026-03-12T10:00:00Z".to_string(),

--- a/crates/edda-bridge-claude/src/digest/tests.rs
+++ b/crates/edda-bridge-claude/src/digest/tests.rs
@@ -653,6 +653,11 @@ fn digest_permanent_failure_after_3_retries() {
 #[test]
 fn digest_state_round_trip() {
     let project_id = "test_state_rt";
+    // Writes to the real per-user store and, unlike its neighbours, never
+    // cleaned up — so it left `projects/test_state_rt` on every developer
+    // machine that ever ran the suite (GH-415). Clearing first also makes it
+    // independent of whatever a previous run left behind.
+    let _ = std::fs::remove_dir_all(edda_store::project_dir(project_id));
     let _ = edda_store::ensure_dirs(project_id);
 
     let state = DigestState {
@@ -666,6 +671,9 @@ fn digest_state_round_trip() {
     save_digest_state(project_id, &state).unwrap();
 
     let loaded = load_digest_state(project_id);
+
+    let _ = std::fs::remove_dir_all(edda_store::project_dir(project_id));
+
     assert_eq!(loaded.session_id, "sess-123");
     assert_eq!(loaded.event_id, "evt_abc");
     assert_eq!(loaded.retry_count, 0);


### PR DESCRIPTION
Closes #415.

## Problem

Two tests in `edda-bridge-claude` wrote into the **developer's real store** and left it that way. One of them failed permanently once it failed once.

### `bg_digest::tests::audit_log_appends`

It asserts an exact row count while appending to a log in the real store, and cleans up only as its **last statement**:

```rust
let pid = "test_digest_audit";
let _ = edda_store::ensure_dirs(pid);          // real store
...
assert_eq!(content2.lines().count(), 2);       // exact count
...
let _ = fs::remove_dir_all(edda_store::project_dir(pid));   // last line — skipped on panic
```

A run that panics before reaching that line leaves rows behind. The next run counts those too, panics again, and skips the cleanup again. **Self-perpetuating**: once red on a machine, red forever — and the message (`expected 2, got 3`) describes the leftovers rather than the defect, so the next person debugs the wrong thing.

Reproduced before fixing, rather than taken on faith:

```
one leftover row  →  assertion failed: left: 3, right: 2
second run        →  fails identically
```

During that exercise the leftover log grew to **5 rows** — the accumulation made visible.

### `digest::tests::digest_state_round_trip`

No cleanup at all. That is why `projects/test_state_rt` sits in the store of every machine that has ever run the suite.

CI never saw either: its containers start empty. Only developers accumulate this.

## Fix

**Clear first, not only last.** The trailing cleanup still handles the happy path; clearing at the start recovers the unhappy one, so a poisoned state self-heals instead of persisting.

For `digest_state_round_trip`, the cleanup is placed **before** the assertions rather than after, so a failing assertion cannot skip it.

## Verified

| Criterion | Result |
|---|---|
| passes twice in a row on a machine where it previously failed, no manual cleanup | ✅ verified from a deliberately dirtied store, then re-dirtied and run twice |
| no `test_*` project dirs in the real store after a full run | ✅ clean |
| tests | **542 green**, clippy clean at `-D warnings` |

## Scope note

These tests still *write* to the real store — they just no longer poison themselves or leave residue. Redirecting them properly is the `EDDA_STORE_ROOT` isolation work, and that turned out to be all-or-nothing: the store root is process-wide, so isolating some tests breaks siblings that still use the real store (proven in #421, where isolating two edda-cli files duly broke two `cmd_bridge` tests). This crate has **91+ real-store touches across 10 files**, so doing it here would be a change of a different size — and it belongs with #417's remaining work, not with a two-test hygiene fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
