### PR TITLE
fix(ask): check a decision's glob against the directory it names (GH-405)

### DIFF
--- a/crates/edda-ask/src/staleness.rs
+++ b/crates/edda-ask/src/staleness.rs
@@ -9,10 +9,15 @@
 //! query-time derivation, not a mutation. Best-effort: unreadable repo /
 //! missing file returns "unknown" rather than false-positive stale.
 //!
+//! Paths are recorded as globs (`edda claim --paths "crates/foo/*"`), so what
+//! gets probed is the deepest wildcard-free ancestor — the area the decision
+//! governs — not the pattern itself, which resolves to nothing. See
+//! [`probe_target`]. Literal paths are probed exactly as written.
+//!
 //! Vocabulary alignment:
-//! - `fresh`: the path exists and its mtime is at or before the decision ts.
-//! - `stale_modified`: file exists but its mtime is strictly after decision ts.
-//! - `missing`: path does not resolve on disk (repo-relative or absolute).
+//! - `fresh`: the probed path exists and its mtime is at or before the decision ts.
+//! - `stale_modified`: it exists but its mtime is strictly after decision ts.
+//! - `missing`: it does not resolve on disk (repo-relative or absolute).
 //! - `unknown`: repo root not supplied, or path attributes unreadable.
 
 use crate::DecisionHit;

--- a/crates/edda-ask/src/staleness.rs
+++ b/crates/edda-ask/src/staleness.rs
@@ -46,6 +46,36 @@ pub struct DecisionStaleness {
     pub paths: Vec<PathStaleness>,
 }
 
+/// What to actually probe on disk for a recorded path pattern.
+///
+/// Scopes are recorded as globs — `edda claim --paths "crates/foo/*"` is the
+/// documented form — and a glob cannot be probed literally, because nothing is
+/// named `*`. Doing so reported every such decision as `Missing` regardless of
+/// the truth (GH-405), which trains readers to ignore the hint and so destroys
+/// it for genuinely stale paths.
+///
+/// The deepest wildcard-free ancestor is what the hint is really asserting:
+/// "the area this decision governs still exists". `crates/foo/*` probes
+/// `crates/foo`; `a/*/c.rs` probes `a`. A pattern with no wildcard is returned
+/// unchanged, so literal paths keep their exact previous behaviour — including
+/// per-file mtime.
+fn probe_target(pattern: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for comp in pattern.components() {
+        let text = comp.as_os_str().to_string_lossy();
+        if text.contains('*') || text.contains('?') || text.contains('[') {
+            break;
+        }
+        out.push(comp);
+    }
+    // An all-wildcard pattern (`*`) leaves nothing to probe; keep it literal so
+    // it resolves against the repo root rather than silently becoming "".
+    if out.as_os_str().is_empty() {
+        return pattern.to_path_buf();
+    }
+    out
+}
+
 /// Filesystem oracle abstracts real fs so tests can be deterministic.
 pub trait FsOracle {
     /// Return (exists, mtime_rfc3339 when available).
@@ -84,8 +114,11 @@ pub fn check_paths_staleness<F: FsOracle>(
     let mut out = Vec::with_capacity(affected_paths.len());
     let mut any_stale = false;
     for rel in affected_paths {
+        // Reduce a glob to the directory it names before resolving; the reported
+        // path stays the pattern the decision actually recorded (GH-405).
+        let pattern = probe_target(Path::new(rel));
         let resolved: PathBuf = {
-            let p = Path::new(rel);
+            let p = pattern.as_path();
             if p.is_absolute() {
                 p.to_path_buf()
             } else {
@@ -191,6 +224,73 @@ mod tests {
         let fs = MockFs::new();
         let out = check_paths_staleness(&[], "2026-07-01T00:00:00Z", None, &fs);
         assert!(out.is_none());
+    }
+
+    /// GH-405: `edda claim --paths "crates/foo/*"` is the documented way to
+    /// record a decision's scope, so globs are the norm rather than an edge case.
+    /// Probing one literally can only ever fail — nothing is named `*` — so every
+    /// such decision carried a false `(Missing)`, which trains readers to ignore
+    /// the hint and kills it for genuinely stale paths.
+    #[test]
+    fn a_glob_is_checked_against_the_directory_it_names_not_literally() {
+        let fs = MockFs::new();
+        // The directory the glob names exists and predates the decision. Note
+        // nothing is registered for the literal "*" path — that is the point.
+        fs.set("/repo/crates/foo", true, Some("2026-06-01T00:00:00Z"));
+
+        let out = check_paths_staleness(
+            &["crates/foo/*".to_string()],
+            "2026-07-01T00:00:00Z",
+            Some(Path::new("/repo")),
+            &fs,
+        )
+        .unwrap();
+
+        assert_eq!(
+            out.paths[0].status,
+            PathStatus::Fresh,
+            "a glob over an existing, untouched directory is not missing"
+        );
+        assert!(!out.is_stale);
+    }
+
+    /// The same defect, and the form the issue actually observed: an absolute
+    /// glob into a sibling repo that is present on this machine.
+    #[test]
+    fn an_absolute_glob_into_another_repo_that_exists_is_not_missing() {
+        let fs = MockFs::new();
+        fs.set(
+            "C:/ai_agent/edda/crates",
+            true,
+            Some("2026-06-01T00:00:00Z"),
+        );
+
+        let out = check_paths_staleness(
+            &["C:/ai_agent/edda/crates/*".to_string()],
+            "2026-07-01T00:00:00Z",
+            Some(Path::new("/some/other/repo")),
+            &fs,
+        )
+        .unwrap();
+
+        assert_eq!(out.paths[0].status, PathStatus::Fresh);
+    }
+
+    /// The signal must survive the fix: a real deletion still warns.
+    #[test]
+    fn a_glob_whose_directory_is_gone_still_reports_missing() {
+        let fs = MockFs::new(); // nothing exists
+
+        let out = check_paths_staleness(
+            &["crates/deleted/*".to_string()],
+            "2026-07-01T00:00:00Z",
+            Some(Path::new("/repo")),
+            &fs,
+        )
+        .unwrap();
+
+        assert_eq!(out.paths[0].status, PathStatus::Missing);
+        assert!(out.is_stale);
     }
 
     #[test]

--- a/crates/edda-ask/src/staleness.rs
+++ b/crates/edda-ask/src/staleness.rs
@@ -14,6 +14,20 @@
 //! governs — not the pattern itself, which resolves to nothing. See
 //! [`probe_target`]. Literal paths are probed exactly as written.
 //!
+//! **What a glob can and cannot detect (GH-405).** Probing the directory means a
+//! glob-scoped decision detects entries being *added or removed*, but not a file
+//! inside being *edited* — a directory's mtime does not move when its contents
+//! are rewritten in place. So for globs the contract above is coarser than it
+//! reads: the most common way a decision goes stale is invisible.
+//!
+//! That is a deliberate trade, and it sits with this module's stated preference
+//! for false-negatives over false-positives: before, a glob resolved to nothing
+//! and every such decision was reported `missing`, which trains readers to
+//! ignore the hint and destroys it for the paths that really are stale. A hint
+//! that rarely fires beats one that always lies. Detecting edits properly means
+//! enumerating the glob's matches and taking their newest mtime, which needs an
+//! [`FsOracle`] that can walk a directory rather than only probe one path.
+//!
 //! Vocabulary alignment:
 //! - `fresh`: the probed path exists and its mtime is at or before the decision ts.
 //! - `stale_modified`: it exists but its mtime is strictly after decision ts.

--- a/crates/edda-ask/src/staleness.rs
+++ b/crates/edda-ask/src/staleness.rs
@@ -277,15 +277,21 @@ mod tests {
     /// glob into a sibling repo that is present on this machine.
     #[test]
     fn an_absolute_glob_into_another_repo_that_exists_is_not_missing() {
+        // The pattern must match the platform. `Path::is_absolute` only counts a
+        // drive letter as absolute on Windows — on Unix `C:/x` is a *relative*
+        // path, so a hardcoded drive letter would quietly exercise the repo-root
+        // branch instead of the absolute one, testing nothing it claims to. CI
+        // caught this; a Windows-only run cannot.
+        #[cfg(windows)]
+        let (dir, pattern) = ("C:/ai_agent/edda/crates", "C:/ai_agent/edda/crates/*");
+        #[cfg(not(windows))]
+        let (dir, pattern) = ("/ai_agent/edda/crates", "/ai_agent/edda/crates/*");
+
         let fs = MockFs::new();
-        fs.set(
-            "C:/ai_agent/edda/crates",
-            true,
-            Some("2026-06-01T00:00:00Z"),
-        );
+        fs.set(dir, true, Some("2026-06-01T00:00:00Z"));
 
         let out = check_paths_staleness(
-            &["C:/ai_agent/edda/crates/*".to_string()],
+            &[pattern.to_string()],
             "2026-07-01T00:00:00Z",
             Some(Path::new("/some/other/repo")),
             &fs,


### PR DESCRIPTION
Closes #405.

## Problem

Every decision recorded with `edda claim --paths` carried a false `⚠ stale-code hint: … (Missing)`.

Reproduced live before touching anything:

```
$ ls -d C:/ai_agent/edda/crates/edda-bridge-claude C:/ai_agent/edda/crates/edda-core
→ both exist

$ edda ask "cross-repo reads federate"
  ⚠ stale-code hint: C:/ai_agent/edda/crates/* (Missing)
```

A hint that cries wolf on **every** decision trains readers to ignore it — which destroys it for the paths that really are stale. That is the actual damage, not the noise.

## The issue's diagnosis was wrong

#405 blamed absolute cross-repo paths being resolved against the current repo root, and proposed detecting absolute patterns. But `check_paths_staleness` **already** does that:

```rust
if p.is_absolute() { p.to_path_buf() } else { root.join(p) }
```

So the proposed fix would have changed nothing. The proof the model was wrong is that the **relative** form false-positives identically — from inside the repo that contains it:

```
⚠ stale-code hint: crates/edda-search-fts/* (Missing)
```

#405 asserts relative patterns "keep the current repo-root behavior", implying they work. They don't.

**The axis is glob vs literal, not absolute vs relative.** `edda claim --paths "crates/foo/*"` is the documented way to record a scope, so the stored patterns are globs — and the probe was `fs::metadata` on the pattern itself. Nothing is named `*`, so the check could only ever fail, for every decision, on both path forms.

## Fix

Probe the **deepest wildcard-free ancestor** — which is what the hint actually asserts: *the area this decision governs still exists*.

- `crates/foo/*` → probes `crates/foo`
- `a/*/c.rs` → probes `a`
- no wildcard → returned unchanged, so literal paths keep their exact previous behaviour, including per-file mtime

No new dependency; the existing absolute/relative handling is untouched and now actually reachable.

## Tests

Seen failing first. The deletion signal is pinned so the fix cannot quietly swallow the thing the hint exists for:

| Test | Pins |
|---|---|
| `a_glob_is_checked_against_the_directory_it_names_not_literally` | the relative form (which #405 believed was fine) |
| `an_absolute_glob_into_another_repo_that_exists_is_not_missing` | the observed drive-letter form |
| `a_glob_whose_directory_is_gone_still_reports_missing` | **a real deletion still warns** |

43 green in `edda-ask`, clippy clean at `-D warnings`.

## Acceptance

- ✅ a decision with existing absolute cross-repo paths shows no warning
- ✅ a decision whose relative path was deleted still warns `Missing`
- ✅ tests covering both, including the Windows drive-letter form

## Not done: `(unreachable from this workspace)`

#405's Fix section also wanted absolute paths that are absent to say *unreachable* rather than *Missing* — a fleet ledger legitimately gets read on machines without every repo checked out.

Deliberately skipped: it adds a variant to a `Serialize`d public enum (an API change) for a distinction none of the three acceptance criteria require, and the idea was premised on the diagnosis this PR just disproved. Worth its own issue if the fleet work (#407) needs it, where the "absent repo vs deleted code" distinction actually has a consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
