### PR TITLE
feat(fleet): read fan-out + ask --fleet (GH-407)

### DIFF
--- a/crates/edda-cli/src/cmd_ask.rs
+++ b/crates/edda-cli/src/cmd_ask.rs
@@ -6,6 +6,7 @@ use edda_ledger::Ledger;
 use std::path::Path;
 
 /// `edda ask [query]` — query project decisions, history, and conversations.
+#[allow(clippy::too_many_arguments)]
 pub fn execute(
     repo_root: &Path,
     query: Option<&str>,
@@ -14,8 +15,8 @@ pub fn execute(
     all: bool,
     branch: Option<&str>,
     impact: bool,
+    fleet: bool,
 ) -> anyhow::Result<()> {
-    let ledger = Ledger::open(repo_root)?;
     let q = query.unwrap_or("");
 
     let opts = AskOptions {
@@ -25,6 +26,12 @@ pub fn execute(
         impact,
         ..Default::default()
     };
+
+    if fleet {
+        return execute_fleet(repo_root, q, &opts, json);
+    }
+
+    let ledger = Ledger::open(repo_root)?;
 
     // Build transcript search callback
     let transcript_cb = build_transcript_callback(repo_root);
@@ -45,6 +52,71 @@ pub fn execute(
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
         print!("{}", format_human(&result));
+    }
+
+    Ok(())
+}
+
+/// `edda ask --fleet` — the same question, asked of every project in scope.
+///
+/// Rendered as per-project sections rather than one merged, ranked list. That is
+/// deliberate: relevance scores are TF-IDF against a *corpus*, so a score from
+/// the foundry ledger and one from the edda ledger are not comparable, and
+/// interleaving them by rank would invent an ordering that means nothing.
+/// Sections also keep every hit unambiguously attributed to its home.
+fn execute_fleet(repo_root: &Path, q: &str, opts: &AskOptions, json: bool) -> anyhow::Result<()> {
+    let scope = edda_store::registry::fleet_scope(repo_root);
+
+    let (hits, misses) = crate::fleet::fan_out(&scope, |entry| {
+        let root = Path::new(&entry.path);
+        let ledger = Ledger::open(root)?;
+        let cb = build_transcript_callback(root);
+        let cb_ref: Option<&TranscriptSearchFn> = cb.as_ref().map(|f| f.as_ref());
+        let mut result = ask(&ledger, q, opts, cb_ref)?;
+
+        let decisions_paths = affected_paths_for_hits(&ledger, &result.decisions);
+        annotate_hits(&mut result.decisions, &decisions_paths, Some(root));
+        let timeline_paths = affected_paths_for_hits(&ledger, &result.timeline);
+        annotate_hits(&mut result.timeline, &timeline_paths, Some(root));
+
+        Ok(vec![result])
+    });
+
+    if json {
+        let payload = serde_json::json!({
+            "fleet": hits.iter().map(|h| serde_json::json!({
+                "project": h.project,
+                "result": h.item,
+            })).collect::<Vec<_>>(),
+            "unreadable": misses.iter().map(|m| serde_json::json!({
+                "project": m.project,
+                "reason": m.reason,
+            })).collect::<Vec<_>>(),
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(());
+    }
+
+    let mut answered = 0;
+    for hit in &hits {
+        let body = format_human(&hit.item);
+        if body.trim().is_empty() {
+            continue;
+        }
+        answered += 1;
+        println!("── [{}] ──────────────────────────", hit.project);
+        print!("{body}");
+    }
+
+    // Misses are printed as results, not swallowed: a fleet read that quietly
+    // skipped a repo would answer "nothing there" when the truth is "did not
+    // look", which is the failure this whole verb exists to remove.
+    for miss in &misses {
+        println!("  [{}] unreadable: {}", miss.project, miss.reason);
+    }
+
+    if answered == 0 && misses.is_empty() {
+        println!("No results across {} project(s) for: {q}", scope.len());
     }
 
     Ok(())

--- a/crates/edda-cli/src/cmd_ask.rs
+++ b/crates/edda-cli/src/cmd_ask.rs
@@ -34,7 +34,7 @@ pub fn execute(
     let ledger = Ledger::open(repo_root)?;
 
     // Build transcript search callback
-    let transcript_cb = build_transcript_callback(repo_root);
+    let transcript_cb = build_transcript_callback(repo_root, None);
     let transcript_ref: Option<&edda_ask::TranscriptSearchFn> =
         transcript_cb.as_ref().map(|f| f.as_ref());
 
@@ -70,7 +70,7 @@ fn execute_fleet(repo_root: &Path, q: &str, opts: &AskOptions, json: bool) -> an
     let (hits, misses) = crate::fleet::fan_out(&scope, |entry| {
         let root = Path::new(&entry.path);
         let ledger = Ledger::open(root)?;
-        let cb = build_transcript_callback(root);
+        let cb = build_transcript_callback(root, Some(&entry.name));
         let cb_ref: Option<&TranscriptSearchFn> = cb.as_ref().map(|f| f.as_ref());
         let mut result = ask(&ledger, q, opts, cb_ref)?;
 
@@ -123,7 +123,16 @@ fn execute_fleet(repo_root: &Path, q: &str, opts: &AskOptions, json: bool) -> an
 }
 
 /// Build a transcript search callback using Tantivy, if index exists.
-fn build_transcript_callback(repo_root: &Path) -> Option<Box<TranscriptSearchFn>> {
+///
+/// `label` names the project when fanning out. It must be `Some` for every
+/// fleet call: the notice below was written for a single workspace, where "the
+/// index" is unambiguous — fanned out over 16 projects an unattributed line says
+/// nothing about which one is stale, repeats once per project, and prescribes a
+/// remedy that (post-GH-414) needs the very project id it failed to mention.
+fn build_transcript_callback(
+    repo_root: &Path,
+    label: Option<&str>,
+) -> Option<Box<TranscriptSearchFn>> {
     let project_id = edda_store::project_id(repo_root);
     let index_dir = edda_store::project_dir(&project_id)
         .join("search")
@@ -135,7 +144,15 @@ fn build_transcript_callback(repo_root: &Path) -> Option<Box<TranscriptSearchFn>
     // GH-402: don't search a stale-schema index — its CJK results would be
     // silently wrong. Skip transcript search and hint the rebuild instead.
     if edda_search_fts::schema::index_is_outdated(&index_dir) {
-        eprintln!("(search index is out of date; run `edda search index` to include transcripts)");
+        match label {
+            Some(name) => eprintln!(
+                "  [{name}] search index is out of date; \
+                 run `edda search index --project {project_id}` to include its transcripts"
+            ),
+            None => eprintln!(
+                "(search index is out of date; run `edda search index` to include transcripts)"
+            ),
+        }
         return None;
     }
 

--- a/crates/edda-cli/src/fleet.rs
+++ b/crates/edda-cli/src/fleet.rs
@@ -1,0 +1,168 @@
+//! Fan-out for fleet reads (GH-407).
+//!
+//! Truth stays home: nothing is centralised. A `--fleet` read visits each
+//! project in scope, runs the same query against that project's own ledger or
+//! index, and merges the answers — tagged with where each came from.
+//!
+//! The shape is shared, the query is not: `ask` reads decisions, `search` reads
+//! a Tantivy index, `log` and `task list` read the ledger. So this owns the loop,
+//! the tagging, and the failure accounting, and takes the per-project work as a
+//! closure — the same inversion `edda-search-fts::sync` uses for its events.
+
+use edda_store::registry::ProjectEntry;
+use std::path::Path;
+
+/// One project's contribution to a fleet read.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FleetHit<T> {
+    /// The project's registered name, rendered as `[name]` beside the hit.
+    pub project: String,
+    pub item: T,
+}
+
+/// A project that could not be read.
+///
+/// These are results, not omissions. A fleet read that quietly skipped a repo
+/// would answer "nothing there" when the truth is "did not look" — the exact
+/// silent-empty failure GH-407 exists to remove, so every miss carries the
+/// project it belongs to and the reason it failed.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FleetMiss {
+    pub project: String,
+    pub reason: String,
+}
+
+/// Run `query` against every project in scope, tagging hits and collecting
+/// failures.
+///
+/// A project whose repo is absent from this machine is a miss, not an error and
+/// not a silence: a fleet ledger is legitimately read on a machine that does not
+/// have every repo checked out, and the reader still needs to know it was not
+/// looked at. That case is detected here rather than in `query`, so no caller
+/// has to remember to.
+pub fn fan_out<T, F>(scope: &[ProjectEntry], query: F) -> (Vec<FleetHit<T>>, Vec<FleetMiss>)
+where
+    F: Fn(&ProjectEntry) -> anyhow::Result<Vec<T>>,
+{
+    let mut hits = Vec::new();
+    let mut misses = Vec::new();
+
+    for entry in scope {
+        if !Path::new(&entry.path).join(".edda").is_dir() {
+            misses.push(FleetMiss {
+                project: entry.name.clone(),
+                reason: format!("repo not on this machine ({})", entry.path),
+            });
+            continue;
+        }
+        match query(entry) {
+            Ok(items) => hits.extend(items.into_iter().map(|item| FleetHit {
+                project: entry.name.clone(),
+                item,
+            })),
+            Err(e) => misses.push(FleetMiss {
+                project: entry.name.clone(),
+                reason: format!("{e}"),
+            }),
+        }
+    }
+
+    (hits, misses)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(name: &str, path: &str) -> ProjectEntry {
+        ProjectEntry {
+            project_id: format!("pid-{name}"),
+            path: path.to_string(),
+            name: name.to_string(),
+            registered_at: "2026-07-15T00:00:00Z".to_string(),
+            last_seen: "2026-07-15T00:00:00Z".to_string(),
+            group: None,
+        }
+    }
+
+    fn live_repo() -> tempfile::TempDir {
+        let d = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(d.path().join(".edda")).unwrap();
+        d
+    }
+
+    #[test]
+    fn hits_carry_the_project_they_came_from() {
+        let a = live_repo();
+        let b = live_repo();
+        let scope = vec![
+            entry("foundry", &a.path().to_string_lossy()),
+            entry("edda", &b.path().to_string_lossy()),
+        ];
+
+        let (hits, misses) = fan_out(&scope, |e| Ok(vec![format!("hit-in-{}", e.name)]));
+
+        assert!(misses.is_empty());
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].project, "foundry");
+        assert_eq!(hits[0].item, "hit-in-foundry");
+        assert_eq!(hits[1].project, "edda");
+    }
+
+    /// The core promise: a repo that is not here is reported, never skipped.
+    #[test]
+    fn an_absent_repo_is_a_reported_miss_not_a_silence() {
+        let here = live_repo();
+        let gone = live_repo();
+        let gone_path = gone.path().to_string_lossy().into_owned();
+        drop(gone);
+
+        let scope = vec![
+            entry("foundry", &here.path().to_string_lossy()),
+            entry("dazun", &gone_path),
+        ];
+
+        let (hits, misses) = fan_out(&scope, |_| Ok(vec!["x"]));
+
+        assert_eq!(hits.len(), 1, "the present repo still answers");
+        assert_eq!(misses.len(), 1, "the absent one is accounted for");
+        assert_eq!(misses[0].project, "dazun");
+        assert!(
+            misses[0].reason.contains("not on this machine"),
+            "the reason must say why: {}",
+            misses[0].reason
+        );
+    }
+
+    /// One project failing must not take the others down with it.
+    #[test]
+    fn a_failing_project_is_a_miss_and_the_rest_still_answer() {
+        let a = live_repo();
+        let b = live_repo();
+        let scope = vec![
+            entry("foundry", &a.path().to_string_lossy()),
+            entry("dazun", &b.path().to_string_lossy()),
+        ];
+
+        let (hits, misses) = fan_out(&scope, |e| {
+            if e.name == "dazun" {
+                anyhow::bail!("index not built")
+            } else {
+                Ok(vec!["found"])
+            }
+        });
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].project, "foundry");
+        assert_eq!(misses.len(), 1);
+        assert_eq!(misses[0].project, "dazun");
+        assert_eq!(misses[0].reason, "index not built");
+    }
+
+    #[test]
+    fn an_empty_scope_yields_nothing_rather_than_erroring() {
+        let (hits, misses) = fan_out(&[], |_| Ok(vec!["never"]));
+        assert!(hits.is_empty());
+        assert!(misses.is_empty());
+    }
+}

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -207,6 +207,9 @@ enum Command {
         /// Show impact analysis for override safety
         #[arg(long)]
         impact: bool,
+        /// Ask every project in the fleet, not just this workspace
+        #[arg(long)]
+        fleet: bool,
     },
     /// Chronicle synthesis - cognitive zoom across sessions
     Recap {
@@ -1053,6 +1056,7 @@ fn main() -> anyhow::Result<()> {
             all,
             branch,
             impact,
+            fleet,
         } => cmd_ask::execute(
             &repo_root,
             query.as_deref(),
@@ -1061,6 +1065,7 @@ fn main() -> anyhow::Result<()> {
             all,
             branch.as_deref(),
             impact,
+            fleet,
         ),
         Command::Recap {
             query,

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -43,6 +43,7 @@ mod cmd_task;
 mod cmd_tool_tier;
 mod cmd_user;
 mod cmd_watch;
+mod fleet;
 mod pipeline_templates;
 #[cfg(test)]
 mod test_support;

--- a/crates/edda-store/src/registry.rs
+++ b/crates/edda-store/src/registry.rs
@@ -166,6 +166,32 @@ pub fn list_group_members(repo_root: &Path) -> Vec<ProjectEntry> {
         .collect()
 }
 
+/// The projects a fleet read covers (GH-407): the cwd project's group when it
+/// has one, otherwise every registered project.
+///
+/// Differs from [`list_group_members`] in two ways that matter to a reader:
+///
+/// - **Home is included.** A fleet read reports its own workspace's hits tagged
+///   like any other; excluding it would silently omit the one repo the user is
+///   actually standing in.
+/// - **Absent repos are kept.** A project whose path is no longer on this
+///   machine stays in scope so the caller can say so per-project. Filtering it
+///   here would make the fan-out quietly incomplete, which is the same
+///   silent-omission failure the fleet read exists to remove.
+pub fn fleet_scope(repo_root: &Path) -> Vec<ProjectEntry> {
+    let pid = project_id(repo_root);
+    let reg = load_registry();
+    let group = reg.projects.get(&pid).and_then(|e| e.group.clone());
+    match group {
+        Some(g) => reg
+            .projects
+            .into_values()
+            .filter(|e| e.group.as_deref() == Some(g.as_str()))
+            .collect(),
+        None => reg.projects.into_values().collect(),
+    }
+}
+
 /// List all groups and their member projects.
 pub fn list_groups() -> std::collections::BTreeMap<String, Vec<ProjectEntry>> {
     let reg = load_registry();
@@ -298,6 +324,79 @@ mod tests {
             std::fs::create_dir_all(tmp3.path().join(".edda")).unwrap();
             register_project(tmp3.path()).unwrap();
             assert!(list_group_members(tmp3.path()).is_empty());
+        });
+    }
+
+    /// GH-407: what a `--fleet` read covers.
+    #[test]
+    fn fleet_scope_is_every_project_when_no_group_and_includes_home() {
+        with_isolated_store(|| {
+            let home = tempfile::tempdir().unwrap();
+            let other = tempfile::tempdir().unwrap();
+            std::fs::create_dir_all(home.path().join(".edda")).unwrap();
+            std::fs::create_dir_all(other.path().join(".edda")).unwrap();
+            register_project(home.path()).unwrap();
+            register_project(other.path()).unwrap();
+
+            let scope = fleet_scope(home.path());
+
+            // Home is included, unlike list_group_members: a fleet read reports
+            // its own hits tagged like anyone else's, or the output silently
+            // omits the workspace the user is standing in.
+            assert_eq!(scope.len(), 2, "no group = the whole registry");
+            assert!(scope
+                .iter()
+                .any(|e| e.project_id == project_id(home.path())));
+        });
+    }
+
+    #[test]
+    fn fleet_scope_narrows_to_the_group_when_one_is_set() {
+        with_isolated_store(|| {
+            let home = tempfile::tempdir().unwrap();
+            let peer = tempfile::tempdir().unwrap();
+            let outsider = tempfile::tempdir().unwrap();
+            for d in [&home, &peer, &outsider] {
+                std::fs::create_dir_all(d.path().join(".edda")).unwrap();
+                register_project(d.path()).unwrap();
+            }
+            set_project_group(home.path(), Some("fleet")).unwrap();
+            set_project_group(peer.path(), Some("fleet")).unwrap();
+
+            let scope = fleet_scope(home.path());
+
+            assert_eq!(scope.len(), 2, "the group, home included");
+            assert!(
+                !scope
+                    .iter()
+                    .any(|e| e.project_id == project_id(outsider.path())),
+                "a project outside the group is not in scope"
+            );
+        });
+    }
+
+    /// A repo that is not on this machine must reach the caller so it can be
+    /// reported per-project. Dropping it here would make the fan-out silently
+    /// incomplete — the same failure mode GH-407 exists to remove.
+    #[test]
+    fn fleet_scope_keeps_projects_whose_repo_is_gone() {
+        with_isolated_store(|| {
+            let home = tempfile::tempdir().unwrap();
+            std::fs::create_dir_all(home.path().join(".edda")).unwrap();
+            register_project(home.path()).unwrap();
+
+            let gone = tempfile::tempdir().unwrap();
+            std::fs::create_dir_all(gone.path().join(".edda")).unwrap();
+            register_project(gone.path()).unwrap();
+            let gone_pid = project_id(gone.path());
+            drop(gone); // the repo disappears from this machine
+
+            let scope = fleet_scope(home.path());
+
+            assert!(
+                scope.iter().any(|e| e.project_id == gone_pid),
+                "an absent repo must be visible to the caller, not filtered away"
+            );
         });
     }
 


### PR DESCRIPTION
Part of #407 — delivers the fan-out foundation and the first verb. Does **not** close it (see "What remains").

## Problem

Every read verb sees exactly one workspace: the cwd's ledger. A fleet is cross-repo by definition, and the knowledge is already split. The failure is silent — a local miss renders identically to true absence.

Reproduced from the edda repo, asking for a ruling that lives in the Foundry ledger:

```
$ edda ask "cross-repo reads federate"
No results found.
```

That is a bare "No results" for a decision that exists one repo over — the exact thing the `fleet.cross-repo-reads1` ruling forbids, and the same silent-empty shape as the CJK bug (#402).

## Fix — the same query, asked of every project in scope

```
$ edda ask "cross-repo reads federate" --fleet
── [AI Delivery Foundry] ──────────────────────────
── Decisions ──────────────────────────
  fleet.cross-repo-reads1 = truth-stays-home-reads-federate-sync-only-for-enforcement — …
```

**Live on the real registry:** 4 of 16 projects answered, 0 unreadable, whole fan-out in **0.331s**.

### `registry::fleet_scope`

The group when the cwd project has one, else the whole registry. Deliberately unlike `list_group_members` in two ways:

- **Home is included** — a fleet read tags its own workspace's hits like any other; excluding it would silently omit the repo the user is standing in.
- **Absent repos are kept, not filtered** — the caller must be able to say "did not look here". Dropping them makes the fan-out quietly incomplete, which is the failure this issue exists to remove.

### `fleet::fan_out`

Owns the loop, the tagging and the failure accounting; takes the per-project query as a closure, because `ask` reads decisions, `search` reads a Tantivy index, and `log`/`task` read the ledger. Misses are **results, not omissions**: an absent repo or a failing project is reported with its name and reason, and one project failing does not take the others down.

## A design call worth flagging

Output is **per-project sections, not one merged ranked list.**

Relevance is TF-IDF *against a corpus*. A score from the foundry ledger and one from the edda ledger are computed over different document sets and are **not comparable** — interleaving them by rank would invent an ordering that means nothing. Since the entire point of this issue is to stop read verbs implying things they have not established, a fabricated ranking would be self-defeating. Sections also keep every hit unambiguously attributed.

## #417 was a prerequisite in practice

Before that sweep the registry held 1788 entries whose repos are gone. This fan-out would have reported 1788 `repo not on this machine` misses and been slow doing it — technically correct, useless in practice. Worth knowing if this is ever backported.

## Tests

Pin the promises, not the plumbing. 199 in `edda`, 28 in `edda-store`, clippy clean at `-D warnings`.

| Test | Pins |
|---|---|
| `fleet_scope_is_every_project_when_no_group_and_includes_home` | home is not omitted |
| `fleet_scope_narrows_to_the_group_when_one_is_set` | group scoping |
| `fleet_scope_keeps_projects_whose_repo_is_gone` | absent repos reach the caller |
| `hits_carry_the_project_they_came_from` | tagging |
| `an_absent_repo_is_a_reported_miss_not_a_silence` | **the core promise** |
| `a_failing_project_is_a_miss_and_the_rest_still_answer` | isolation |

## What remains (#407 stays open)

- `search query --fleet` + the per-project "index not built" notice (acceptance 3)
- `task list --fleet --status ready` — the operator's morning board (acceptance 2)
- `log --fleet`
- Empty-result honesty without the flag: a local miss should mention fleet hits (acceptance 4)

Shipping the foundation first so each verb lands reviewable on its own rather than as one unreadable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
