### PR TITLE
feat(fleet): search query --fleet with per-project index notices (GH-407)

### DIFF
--- a/crates/edda-cli/src/cmd_search.rs
+++ b/crates/edda-cli/src/cmd_search.rs
@@ -41,6 +41,9 @@ pub enum SearchCmd {
         /// Maximum results (default: 20)
         #[arg(long, default_value_t = 20)]
         limit: usize,
+        /// Search every project in the fleet, not just this workspace
+        #[arg(long)]
+        fleet: bool,
     },
     /// Show full content of a specific turn
     Show {
@@ -70,6 +73,7 @@ pub fn run_cmd(cmd: SearchCmd, repo_root: &Path) -> anyhow::Result<()> {
             event_type,
             exact,
             limit,
+            fleet,
         } => {
             let pid = project.as_deref().unwrap_or(&default_pid);
             query(
@@ -81,6 +85,7 @@ pub fn run_cmd(cmd: SearchCmd, repo_root: &Path) -> anyhow::Result<()> {
                 event_type.as_deref(),
                 exact,
                 limit,
+                fleet,
             )
         }
         SearchCmd::Show { turn, project } => {
@@ -91,6 +96,110 @@ pub fn run_cmd(cmd: SearchCmd, repo_root: &Path) -> anyhow::Result<()> {
 }
 
 // ── Command Implementations ──
+
+/// `edda search query --fleet` — the same search, run against every project's
+/// own index (GH-407).
+///
+/// Never builds. A cold build costs ~25s (GH-403), and doing that for each of N
+/// projects because someone asked a question would be a trap — so a project
+/// without a usable index reports why, per project, and the others still answer.
+/// That reporting is not extra machinery: `fan_out` turns each error into an
+/// attributed line, which is exactly the notice acceptance 3 asks for.
+#[allow(clippy::too_many_arguments)]
+fn query_fleet(
+    repo_root: &Path,
+    query_str: &str,
+    session_id: Option<&str>,
+    doc_type: Option<&str>,
+    event_type: Option<&str>,
+    exact: bool,
+    limit: usize,
+) -> anyhow::Result<()> {
+    let scope = edda_store::registry::fleet_scope(repo_root);
+
+    let (hits, misses) = crate::fleet::fan_out(&scope, |entry| {
+        let index_dir = project_dir(&entry.project_id)
+            .join("search")
+            .join("tantivy");
+        if !index_dir.exists() {
+            anyhow::bail!(
+                "index not built — run `edda search index --project {}`",
+                entry.project_id
+            );
+        }
+        if schema::index_is_outdated(&index_dir) {
+            anyhow::bail!(
+                "index schema is outdated — run `edda search index --project {}`",
+                entry.project_id
+            );
+        }
+        let Some(index) = schema::open_index(&index_dir) else {
+            anyhow::bail!(
+                "index could not be opened — run `edda search index --project {}` to rebuild",
+                entry.project_id
+            );
+        };
+        let opts = search::SearchOptions {
+            project_id: Some(&entry.project_id),
+            session_id,
+            doc_type,
+            event_type,
+            exact,
+        };
+        search::search(&index, query_str, &opts, limit)
+    });
+
+    let mut total = 0;
+    for (project, results) in group_by_project(&hits) {
+        if results.is_empty() {
+            continue;
+        }
+        println!("── [{project}] ──────────────────────────");
+        for r in &results {
+            total += 1;
+            let label = if r.doc_type == "event" {
+                format!("[{}]", r.event_type)
+            } else {
+                "[turn]".to_string()
+            };
+            println!("  {} {} ts={}", label, r.doc_id, r.ts);
+            if !r.snippet.is_empty() {
+                println!("     {}", r.snippet.replace('\n', " "));
+            }
+        }
+        println!();
+    }
+
+    // Per-project failures are results, never omissions: "did not look" must not
+    // render as "nothing there".
+    for miss in &misses {
+        println!("  [{}] {}", miss.project, miss.reason);
+    }
+
+    if total == 0 && misses.is_empty() {
+        println!(
+            "No results across {} project(s) for: {query_str}",
+            scope.len()
+        );
+    }
+
+    Ok(())
+}
+
+/// Collect a fan-out's hits back into per-project groups, preserving the order
+/// projects were visited in.
+fn group_by_project(
+    hits: &[crate::fleet::FleetHit<search::SearchResult>],
+) -> Vec<(String, Vec<&search::SearchResult>)> {
+    let mut out: Vec<(String, Vec<&search::SearchResult>)> = Vec::new();
+    for hit in hits {
+        match out.iter_mut().find(|(p, _)| *p == hit.project) {
+            Some((_, items)) => items.push(&hit.item),
+            None => out.push((hit.project.clone(), vec![&hit.item])),
+        }
+    }
+    out
+}
 
 /// Execute `edda search <query>` — full-text search over the Tantivy index.
 #[allow(clippy::too_many_arguments)]
@@ -103,7 +212,13 @@ pub fn query(
     event_type: Option<&str>,
     exact: bool,
     limit: usize,
+    fleet: bool,
 ) -> anyhow::Result<()> {
+    if fleet {
+        return query_fleet(
+            repo_root, query_str, session_id, doc_type, event_type, exact, limit,
+        );
+    }
     let proj_dir = project_dir(project_id);
     let index_dir = proj_dir.join("search").join("tantivy");
 

--- a/crates/edda-cli/src/cmd_search.rs
+++ b/crates/edda-cli/src/cmd_search.rs
@@ -42,7 +42,13 @@ pub enum SearchCmd {
         #[arg(long, default_value_t = 20)]
         limit: usize,
         /// Search every project in the fleet, not just this workspace
-        #[arg(long)]
+        ///
+        /// Contradicts `--project`, which names exactly one. Rejected at parse
+        /// time rather than resolved by precedence: either choice would be a
+        /// guess about which flag was meant, and answering a question the user
+        /// did not ask — quietly — is the failure this whole verb exists to
+        /// remove (GH-407).
+        #[arg(long, conflicts_with = "project")]
         fleet: bool,
     },
     /// Show full content of a specific turn
@@ -548,6 +554,34 @@ fn extract_message_text(json: &serde_json::Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `--project` and `--fleet` are contradictory, so one has to lose. Losing
+    /// silently is the trap: the reader asked about one project, got sixteen,
+    /// and was told nothing — a read verb answering a question nobody asked,
+    /// which is the failure GH-407 exists to remove. Rejecting at parse time
+    /// says so before any project is touched.
+    ///
+    /// Worth a test because `conflicts_with` takes an arg id as a *string*: a
+    /// typo, or a later rename of the `project` field, silently stops enforcing
+    /// and the bug returns exactly as quietly as it arrived.
+    #[test]
+    fn project_and_fleet_are_rejected_rather_than_one_silently_winning() {
+        use clap::Parser;
+        #[derive(Parser)]
+        struct W {
+            #[command(subcommand)]
+            cmd: SearchCmd,
+        }
+
+        let err = W::try_parse_from(["edda", "query", "x", "--project", "abc", "--fleet"])
+            .err()
+            .expect("asking for one project and every project at once must not be accepted");
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+
+        // …and neither flag alone is disturbed.
+        assert!(W::try_parse_from(["edda", "query", "x", "--fleet"]).is_ok());
+        assert!(W::try_parse_from(["edda", "query", "x", "--project", "abc"]).is_ok());
+    }
 
     /// The registry must not even be consulted for the project we are standing
     /// in — that is the overwhelmingly common case and it must not depend on


### PR DESCRIPTION
Part of #407 — delivers acceptance 3. Does not close it (see "What remains").

Follows #425, which landed `fleet_scope` + `fan_out` + `ask --fleet`.

## What this adds

`search query --fleet` — the same search, run against every project's **own** index, tagged with its home.

Live from the edda repo, searching a CJK term that only exists elsewhere:

```
$ edda search query "權威事實" --fleet
── [AI Delivery Foundry] ──────────────────────────
  [note] evt_01kxh47tz… ts=2026-07-14T20:14:06Z
     供掃。起因:外部評論指出投影把機器推論洗成«權威事實»。…
── [edda] ──────────────────────────
  [note] evt_01kxkaxn7… ts=2026-07-15T16:49:21Z

  [dazun]  index not built — run `edda search index --project 10bfe3f9…`
  [yushan] index not built — run `edda search index --project 97f7c3be…`
```

**0.180s** across 16 projects.

That output is four of tonight's fixes compounding: #410's CJK tokenizer makes the term findable at all, #403's auto-index keeps those indexes current, #414 makes the prescribed remedy actually work from another repo, and #425's fan-out ties them together.

## Acceptance 3, demonstrated

> A project whose search index is missing shows an explicit per-project notice in `search query --fleet`

Two notices above, each naming its project and carrying a command that runs from anywhere.

## The notice needed no new machinery

`fan_out` already turns a per-project error into an attributed line, so `bail!` *is* the notice. That also disposes of the landmine found while reviewing #425:

`cmd_search.rs`'s `"Search index could not be opened. Run \`edda search index\` to rebuild."` is the same anonymous shape just fixed in `ask` — it would have repeated unattributed, once per project, the moment this fanned out. The fleet path carries the project id in every message. The single-workspace path keeps its original wording, where naming the project would be noise.

## `--fleet` never builds

A cold build costs ~25s (measured in #403). Doing that for each of N projects because someone asked a question would be a trap that turns one question into a multi-minute stall. So an unusable index reports why and the others still answer — which is also what makes the notice above possible instead of a hang.

## Grouped, not merged

Same reasoning recorded in `cmd_ask`: relevance is TF-IDF against a corpus, so scores from different indexes are not comparable, and interleaving them by rank would invent an ordering. The whole point of this issue is to stop read verbs implying things they have not established.

## Tests

199 in `edda`, clippy clean at `-D warnings`. The fan-out's promises are pinned by #425's unit tests (`an_absent_repo_is_a_reported_miss_not_a_silence`, `a_failing_project_is_a_miss_and_the_rest_still_answer`); this verb is CLI glue that prints, in a file whose test module covers the pure logic (`ledger_root_for`), so it is verified by the live run above — recorded here rather than asserted in-process.

## What remains (#407 stays open)

- `task list --fleet --status ready` — the operator's morning board (acceptance 2)
- `log --fleet`
- Empty-result honesty without the flag (acceptance 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
