### PR TITLE
feat(fleet): task list --fleet — the operator's morning board (GH-407)

### DIFF
--- a/crates/edda-cli/src/cmd_ask.rs
+++ b/crates/edda-cli/src/cmd_ask.rs
@@ -108,8 +108,11 @@ fn execute_fleet(repo_root: &Path, q: &str, opts: &AskOptions, json: bool) -> an
     // look", which is the failure this whole verb exists to remove.
     crate::fleet::print_misses(&misses);
 
-    if answered == 0 && misses.is_empty() {
-        println!("No results across {} project(s) for: {q}", scope.len());
+    if answered == 0 {
+        println!(
+            "{}",
+            crate::fleet::empty_summary("results", &format!(" for: {q}"), scope.len(), &misses)
+        );
     }
 
     Ok(())

--- a/crates/edda-cli/src/cmd_ask.rs
+++ b/crates/edda-cli/src/cmd_ask.rs
@@ -83,13 +83,11 @@ fn execute_fleet(repo_root: &Path, q: &str, opts: &AskOptions, json: bool) -> an
     });
 
     if json {
-        let payload = serde_json::json!({
-            "projects": hits.iter().map(|h| serde_json::json!({
-                "project": h.project,
-                "result": h.item,
-            })).collect::<Vec<_>>(),
-            "unavailable": crate::fleet::misses_json(&misses),
-        });
+        let projects = hits
+            .iter()
+            .map(|h| serde_json::json!({ "project": h.project, "result": h.item }))
+            .collect();
+        let payload = crate::fleet::json_envelope(projects, &misses);
         println!("{}", serde_json::to_string_pretty(&payload)?);
         return Ok(());
     }

--- a/crates/edda-cli/src/cmd_ask.rs
+++ b/crates/edda-cli/src/cmd_ask.rs
@@ -84,14 +84,11 @@ fn execute_fleet(repo_root: &Path, q: &str, opts: &AskOptions, json: bool) -> an
 
     if json {
         let payload = serde_json::json!({
-            "fleet": hits.iter().map(|h| serde_json::json!({
+            "projects": hits.iter().map(|h| serde_json::json!({
                 "project": h.project,
                 "result": h.item,
             })).collect::<Vec<_>>(),
-            "unreadable": misses.iter().map(|m| serde_json::json!({
-                "project": m.project,
-                "reason": m.reason,
-            })).collect::<Vec<_>>(),
+            "unavailable": crate::fleet::misses_json(&misses),
         });
         println!("{}", serde_json::to_string_pretty(&payload)?);
         return Ok(());
@@ -111,9 +108,7 @@ fn execute_fleet(repo_root: &Path, q: &str, opts: &AskOptions, json: bool) -> an
     // Misses are printed as results, not swallowed: a fleet read that quietly
     // skipped a repo would answer "nothing there" when the truth is "did not
     // look", which is the failure this whole verb exists to remove.
-    for miss in &misses {
-        println!("  [{}] unreadable: {}", miss.project, miss.reason);
-    }
+    crate::fleet::print_misses(&misses);
 
     if answered == 0 && misses.is_empty() {
         println!("No results across {} project(s) for: {q}", scope.len());

--- a/crates/edda-cli/src/cmd_search.rs
+++ b/crates/edda-cli/src/cmd_search.rs
@@ -156,7 +156,7 @@ fn query_fleet(
     });
 
     let mut total = 0;
-    for (project, results) in group_by_project(&hits) {
+    for (project, results) in crate::fleet::group_by_project(&hits) {
         if results.is_empty() {
             continue;
         }
@@ -178,9 +178,7 @@ fn query_fleet(
 
     // Per-project failures are results, never omissions: "did not look" must not
     // render as "nothing there".
-    for miss in &misses {
-        println!("  [{}] {}", miss.project, miss.reason);
-    }
+    crate::fleet::print_misses(&misses);
 
     if total == 0 && misses.is_empty() {
         println!(
@@ -190,21 +188,6 @@ fn query_fleet(
     }
 
     Ok(())
-}
-
-/// Collect a fan-out's hits back into per-project groups, preserving the order
-/// projects were visited in.
-fn group_by_project(
-    hits: &[crate::fleet::FleetHit<search::SearchResult>],
-) -> Vec<(String, Vec<&search::SearchResult>)> {
-    let mut out: Vec<(String, Vec<&search::SearchResult>)> = Vec::new();
-    for hit in hits {
-        match out.iter_mut().find(|(p, _)| *p == hit.project) {
-            Some((_, items)) => items.push(&hit.item),
-            None => out.push((hit.project.clone(), vec![&hit.item])),
-        }
-    }
-    out
 }
 
 /// Execute `edda search <query>` — full-text search over the Tantivy index.

--- a/crates/edda-cli/src/cmd_search.rs
+++ b/crates/edda-cli/src/cmd_search.rs
@@ -180,10 +180,15 @@ fn query_fleet(
     // render as "nothing there".
     crate::fleet::print_misses(&misses);
 
-    if total == 0 && misses.is_empty() {
+    if total == 0 {
         println!(
-            "No results across {} project(s) for: {query_str}",
-            scope.len()
+            "{}",
+            crate::fleet::empty_summary(
+                "results",
+                &format!(" for: {query_str}"),
+                scope.len(),
+                &misses
+            )
         );
     }
 

--- a/crates/edda-cli/src/cmd_task.rs
+++ b/crates/edda-cli/src/cmd_task.rs
@@ -76,6 +76,9 @@ pub enum TaskCmd {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+        /// List tasks from every project in the fleet, not just this workspace
+        #[arg(long)]
+        fleet: bool,
     },
     /// Show one task in full (user verb)
     Show {
@@ -288,6 +291,128 @@ fn do_fail(repo_root: &Path, id: u64, reason: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// One task's row, shared by the local and fleet boards so they cannot drift
+/// into two dialects of the same list.
+fn task_row(v: &TaskView) -> String {
+    let mut extras: Vec<String> = Vec::new();
+    if let Some(a) = &v.assignee {
+        extras.push(format!("assignee: {a}"));
+    }
+    if !v.after.is_empty() {
+        let deps: Vec<String> = v.after.iter().map(|d| format!("#{d}")).collect();
+        extras.push(format!("after: {}", deps.join(",")));
+    }
+    if v.attempts > 0 {
+        extras.push(format!("attempts: {}", v.attempts));
+    }
+    let extra = if extras.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", extras.join(", "))
+    };
+    format!("#{} [{}] {}{}", v.task_id, v.status, v.title, extra)
+}
+
+/// Render `task list --fleet` — the operator's morning board across every
+/// project (GH-407, acceptance 2).
+fn list_fleet(
+    repo_root: &Path,
+    assignee: Option<&str>,
+    status: Option<&str>,
+    json: bool,
+) -> anyhow::Result<()> {
+    let scope = edda_store::registry::fleet_scope(repo_root);
+    let (hits, misses) = do_list_fleet(&scope, assignee, status);
+
+    if json {
+        // Deliberately a different shape from the local `[TaskView]`, for two
+        // reasons a script cannot recover from otherwise: task ids restart at 1
+        // per repo, so a flat array would silently merge unrelated tasks under
+        // one id; and a project that could not be read has to be visible as
+        // itself, or the consumer reads "nothing ready" where the truth is
+        // "never looked".
+        let projects: Vec<_> = group_by_project(&hits)
+            .into_iter()
+            .map(|(project, tasks)| serde_json::json!({ "project": project, "tasks": tasks }))
+            .collect();
+        let unavailable: Vec<_> = misses
+            .iter()
+            .map(|m| serde_json::json!({ "project": m.project, "reason": m.reason }))
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(
+                &serde_json::json!({ "projects": projects, "unavailable": unavailable })
+            )?
+        );
+        return Ok(());
+    }
+
+    let mut total = 0;
+    for (project, tasks) in group_by_project(&hits) {
+        if tasks.is_empty() {
+            continue;
+        }
+        println!("── [{project}] ──────────────────────────");
+        for v in &tasks {
+            total += 1;
+            println!("  {}", task_row(v));
+        }
+        println!();
+    }
+
+    for miss in &misses {
+        println!("  [{}] {}", miss.project, miss.reason);
+    }
+
+    if total == 0 && misses.is_empty() {
+        let filter = match (assignee, status) {
+            (Some(a), Some(s)) => format!(" (assignee: {a}, status: {s})"),
+            (Some(a), None) => format!(" (assignee: {a})"),
+            (None, Some(s)) => format!(" (status: {s})"),
+            (None, None) => String::new(),
+        };
+        println!(
+            "No tasks on the rail across {} project(s){filter}.",
+            scope.len()
+        );
+    }
+    Ok(())
+}
+
+/// Collect a fan-out's tasks back into per-project groups, preserving the order
+/// projects were visited in.
+fn group_by_project(hits: &[crate::fleet::FleetHit<TaskView>]) -> Vec<(String, Vec<&TaskView>)> {
+    let mut out: Vec<(String, Vec<&TaskView>)> = Vec::new();
+    for hit in hits {
+        match out.iter_mut().find(|(p, _)| *p == hit.project) {
+            Some((_, items)) => items.push(&hit.item),
+            None => out.push((hit.project.clone(), vec![&hit.item])),
+        }
+    }
+    out
+}
+
+/// `task list --fleet` — the same list, read from every project's own ledger
+/// (GH-407).
+///
+/// The scope is passed in rather than looked up so this stays testable against
+/// temporary workspaces: `fleet_scope` reads the global registry, which is
+/// process-wide state, and a test that had to touch it could not run beside its
+/// neighbours.
+fn do_list_fleet(
+    scope: &[edda_store::registry::ProjectEntry],
+    assignee: Option<&str>,
+    status: Option<&str>,
+) -> (
+    Vec<crate::fleet::FleetHit<TaskView>>,
+    Vec<crate::fleet::FleetMiss>,
+) {
+    crate::fleet::fan_out(scope, |entry| {
+        do_list(Path::new(&entry.path), assignee, status)
+    })
+}
+
 fn do_list(
     repo_root: &Path,
     assignee: Option<&str>,
@@ -385,7 +510,11 @@ pub fn execute(cmd: TaskCmd, repo_root: &Path) -> anyhow::Result<()> {
             assignee,
             status,
             json,
+            fleet,
         } => {
+            if fleet {
+                return list_fleet(repo_root, assignee.as_deref(), status.as_deref(), json);
+            }
             let views = do_list(repo_root, assignee.as_deref(), status.as_deref())?;
             if json {
                 println!("{}", serde_json::to_string_pretty(&views)?);
@@ -397,23 +526,7 @@ pub fn execute(cmd: TaskCmd, repo_root: &Path) -> anyhow::Result<()> {
                 return Ok(());
             }
             for v in &views {
-                let mut extras: Vec<String> = Vec::new();
-                if let Some(a) = &v.assignee {
-                    extras.push(format!("assignee: {a}"));
-                }
-                if !v.after.is_empty() {
-                    let deps: Vec<String> = v.after.iter().map(|d| format!("#{d}")).collect();
-                    extras.push(format!("after: {}", deps.join(",")));
-                }
-                if v.attempts > 0 {
-                    extras.push(format!("attempts: {}", v.attempts));
-                }
-                let extra = if extras.is_empty() {
-                    String::new()
-                } else {
-                    format!(" ({})", extras.join(", "))
-                };
-                println!("#{} [{}] {}{}", v.task_id, v.status, v.title, extra);
+                println!("{}", task_row(v));
             }
             Ok(())
         }
@@ -466,6 +579,77 @@ pub fn execute(cmd: TaskCmd, repo_root: &Path) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fleet_entry(name: &str, path: &std::path::Path) -> edda_store::registry::ProjectEntry {
+        edda_store::registry::ProjectEntry {
+            project_id: format!("pid-{name}"),
+            path: path.to_string_lossy().into_owned(),
+            name: name.to_string(),
+            registered_at: "2026-07-16T00:00:00Z".to_string(),
+            last_seen: "2026-07-16T00:00:00Z".to_string(),
+            group: None,
+        }
+    }
+
+    /// Task ids restart at 1 in every repo, so a fleet board that did not say
+    /// where each task came from would show two unrelated "task #1" as if they
+    /// were one row of the same list. The project tag is what makes a merged
+    /// board readable at all — not decoration on top of it.
+    #[test]
+    fn fleet_list_tags_each_task_with_the_project_it_came_from() {
+        let a = temp_ws("fleet_a");
+        let b = temp_ws("fleet_b");
+        do_new(&a, &args("ship the thing", &[])).unwrap();
+        do_new(&b, &args("write the docs", &[])).unwrap();
+
+        let scope = vec![fleet_entry("edda", &a), fleet_entry("dazun", &b)];
+        let (hits, misses) = do_list_fleet(&scope, None, None);
+
+        assert!(misses.is_empty(), "both repos are live: {misses:?}");
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].project, "edda");
+        assert_eq!(hits[0].item.title, "ship the thing");
+        assert_eq!(hits[1].project, "dazun");
+        assert_eq!(hits[1].item.title, "write the docs");
+        assert_eq!(
+            hits[0].item.task_id, hits[1].item.task_id,
+            "both are task #1 in their own repo — the tag is the only thing telling them apart"
+        );
+    }
+
+    /// A filter must reach every project, not just the one being stood in.
+    #[test]
+    fn fleet_list_applies_the_status_filter_in_each_project() {
+        let a = temp_ws("fleet_ready_a");
+        let b = temp_ws("fleet_ready_b");
+        do_new(&a, &args("ready here", &[])).unwrap();
+        do_new(&b, &args("will be running", &[])).unwrap();
+        do_start(&b, 1, 3600).unwrap();
+
+        let scope = vec![fleet_entry("edda", &a), fleet_entry("dazun", &b)];
+        let (hits, _) = do_list_fleet(&scope, None, Some("ready"));
+
+        assert_eq!(hits.len(), 1, "only the un-started task is ready");
+        assert_eq!(hits[0].project, "edda");
+        assert_eq!(hits[0].item.title, "ready here");
+    }
+
+    /// A project whose ledger cannot be read is a reported miss, never a quiet
+    /// omission: "did not look" must not render as "nothing ready there".
+    #[test]
+    fn fleet_list_reports_an_unreadable_project_instead_of_dropping_it() {
+        let a = temp_ws("fleet_live");
+        do_new(&a, &args("ship the thing", &[])).unwrap();
+        let gone = std::env::temp_dir().join(format!("edda_never_here_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&gone);
+
+        let scope = vec![fleet_entry("edda", &a), fleet_entry("dazun", &gone)];
+        let (hits, misses) = do_list_fleet(&scope, None, None);
+
+        assert_eq!(hits.len(), 1, "the live repo still answers");
+        assert_eq!(misses.len(), 1, "the absent one is accounted for");
+        assert_eq!(misses[0].project, "dazun");
+    }
 
     fn temp_ws(name: &str) -> std::path::PathBuf {
         let dir = std::env::temp_dir().join(format!("edda_cmdtask_{name}_{}", std::process::id()));

--- a/crates/edda-cli/src/cmd_task.rs
+++ b/crates/edda-cli/src/cmd_task.rs
@@ -355,7 +355,7 @@ fn list_fleet(
 
     crate::fleet::print_misses(&misses);
 
-    if total == 0 && misses.is_empty() {
+    if total == 0 {
         let filter = match (assignee, status) {
             (Some(a), Some(s)) => format!(" (assignee: {a}, status: {s})"),
             (Some(a), None) => format!(" (assignee: {a})"),
@@ -363,8 +363,8 @@ fn list_fleet(
             (None, None) => String::new(),
         };
         println!(
-            "No tasks on the rail across {} project(s){filter}.",
-            scope.len()
+            "{}.",
+            crate::fleet::empty_summary("tasks on the rail", &filter, scope.len(), &misses)
         );
     }
     Ok(())

--- a/crates/edda-cli/src/cmd_task.rs
+++ b/crates/edda-cli/src/cmd_task.rs
@@ -331,25 +331,22 @@ fn list_fleet(
         // one id; and a project that could not be read has to be visible as
         // itself, or the consumer reads "nothing ready" where the truth is
         // "never looked".
-        let projects: Vec<_> = group_by_project(&hits)
+        let projects: Vec<_> = crate::fleet::group_by_project(&hits)
             .into_iter()
             .map(|(project, tasks)| serde_json::json!({ "project": project, "tasks": tasks }))
             .collect();
-        let unavailable: Vec<_> = misses
-            .iter()
-            .map(|m| serde_json::json!({ "project": m.project, "reason": m.reason }))
-            .collect();
         println!(
             "{}",
-            serde_json::to_string_pretty(
-                &serde_json::json!({ "projects": projects, "unavailable": unavailable })
-            )?
+            serde_json::to_string_pretty(&serde_json::json!({
+                "projects": projects,
+                "unavailable": crate::fleet::misses_json(&misses),
+            }))?
         );
         return Ok(());
     }
 
     let mut total = 0;
-    for (project, tasks) in group_by_project(&hits) {
+    for (project, tasks) in crate::fleet::group_by_project(&hits) {
         if tasks.is_empty() {
             continue;
         }
@@ -361,9 +358,7 @@ fn list_fleet(
         println!();
     }
 
-    for miss in &misses {
-        println!("  [{}] {}", miss.project, miss.reason);
-    }
+    crate::fleet::print_misses(&misses);
 
     if total == 0 && misses.is_empty() {
         let filter = match (assignee, status) {
@@ -378,19 +373,6 @@ fn list_fleet(
         );
     }
     Ok(())
-}
-
-/// Collect a fan-out's tasks back into per-project groups, preserving the order
-/// projects were visited in.
-fn group_by_project(hits: &[crate::fleet::FleetHit<TaskView>]) -> Vec<(String, Vec<&TaskView>)> {
-    let mut out: Vec<(String, Vec<&TaskView>)> = Vec::new();
-    for hit in hits {
-        match out.iter_mut().find(|(p, _)| *p == hit.project) {
-            Some((_, items)) => items.push(&hit.item),
-            None => out.push((hit.project.clone(), vec![&hit.item])),
-        }
-    }
-    out
 }
 
 /// `task list --fleet` — the same list, read from every project's own ledger

--- a/crates/edda-cli/src/cmd_task.rs
+++ b/crates/edda-cli/src/cmd_task.rs
@@ -331,17 +331,12 @@ fn list_fleet(
         // one id; and a project that could not be read has to be visible as
         // itself, or the consumer reads "nothing ready" where the truth is
         // "never looked".
-        let projects: Vec<_> = crate::fleet::group_by_project(&hits)
+        let projects = crate::fleet::group_by_project(&hits)
             .into_iter()
             .map(|(project, tasks)| serde_json::json!({ "project": project, "tasks": tasks }))
             .collect();
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&serde_json::json!({
-                "projects": projects,
-                "unavailable": crate::fleet::misses_json(&misses),
-            }))?
-        );
+        let payload = crate::fleet::json_envelope(projects, &misses);
+        println!("{}", serde_json::to_string_pretty(&payload)?);
         return Ok(());
     }
 

--- a/crates/edda-cli/src/fleet.rs
+++ b/crates/edda-cli/src/fleet.rs
@@ -70,6 +70,48 @@ where
     (hits, misses)
 }
 
+/// Collect a fan-out's hits back into per-project groups, preserving the order
+/// projects were visited in.
+///
+/// Generic because nothing in it is verb-specific: it is `fan_out`'s output
+/// reshaped, and every verb that fans out needs exactly this. It lives beside
+/// `fan_out` so the next one does not grow a third private copy.
+pub fn group_by_project<T>(hits: &[FleetHit<T>]) -> Vec<(String, Vec<&T>)> {
+    let mut out: Vec<(String, Vec<&T>)> = Vec::new();
+    for hit in hits {
+        match out.iter_mut().find(|(p, _)| *p == hit.project) {
+            Some((_, items)) => items.push(&hit.item),
+            None => out.push((hit.project.clone(), vec![&hit.item])),
+        }
+    }
+    out
+}
+
+/// Report the projects that did not answer, in the one form every fleet verb
+/// uses.
+///
+/// No prefix: `fan_out`'s reasons are already complete phrases, and a fixed
+/// prefix would contradict half of them — the most common miss is "repo not on
+/// this machine", which is absent, not unreadable.
+pub fn print_misses(misses: &[FleetMiss]) {
+    for miss in misses {
+        println!("  [{}] {}", miss.project, miss.reason);
+    }
+}
+
+/// The same misses for `--json`, under the one key every fleet verb uses.
+///
+/// Having one spelling matters more than which spelling won: a script reading
+/// two fleet verbs should not have to learn that one calls this `unreadable`
+/// and the other `unavailable`. `unavailable` is the word that covers both
+/// misses `fan_out` actually produces — absent *and* errored.
+pub fn misses_json(misses: &[FleetMiss]) -> Vec<serde_json::Value> {
+    misses
+        .iter()
+        .map(|m| serde_json::json!({ "project": m.project, "reason": m.reason }))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -164,5 +206,54 @@ mod tests {
         let (hits, misses) = fan_out(&[], |_| Ok(vec!["never"]));
         assert!(hits.is_empty());
         assert!(misses.is_empty());
+    }
+
+    /// Grouping preserves visit order, so a fleet read renders in registry
+    /// order rather than whatever a hash map felt like.
+    #[test]
+    fn grouping_keeps_each_project_together_in_the_order_visited() {
+        let hits = vec![
+            FleetHit {
+                project: "edda".to_string(),
+                item: "a",
+            },
+            FleetHit {
+                project: "dazun".to_string(),
+                item: "b",
+            },
+            FleetHit {
+                project: "edda".to_string(),
+                item: "c",
+            },
+        ];
+
+        let grouped = group_by_project(&hits);
+
+        assert_eq!(grouped.len(), 2, "two projects, not three rows");
+        assert_eq!(grouped[0].0, "edda");
+        assert_eq!(grouped[0].1, vec![&"a", &"c"], "non-adjacent hits regroup");
+        assert_eq!(grouped[1].0, "dazun");
+        assert_eq!(grouped[1].1, vec![&"b"]);
+    }
+
+    /// The reason is already a complete phrase, so nothing may be prepended to
+    /// it: `fan_out`'s most common miss is an absent repo, and a fixed
+    /// "unreadable:" prefix would contradict the sentence it introduces.
+    #[test]
+    fn a_miss_renders_as_project_and_reason_with_nothing_invented() {
+        let misses = vec![FleetMiss {
+            project: "dazun".to_string(),
+            reason: "repo not on this machine (D:\\gone)".to_string(),
+        }];
+
+        let json = misses_json(&misses);
+
+        assert_eq!(json.len(), 1);
+        assert_eq!(json[0]["project"], "dazun");
+        assert_eq!(json[0]["reason"], "repo not on this machine (D:\\gone)");
+        assert!(
+            json[0].get("unreadable").is_none(),
+            "the shape carries the reason, not a verdict about it"
+        );
     }
 }

--- a/crates/edda-cli/src/fleet.rs
+++ b/crates/edda-cli/src/fleet.rs
@@ -99,17 +99,29 @@ pub fn print_misses(misses: &[FleetMiss]) {
     }
 }
 
-/// The same misses for `--json`, under the one key every fleet verb uses.
+/// The `--json` body of a fleet read: what answered, and what did not.
 ///
-/// Having one spelling matters more than which spelling won: a script reading
-/// two fleet verbs should not have to learn that one calls this `unreadable`
-/// and the other `unavailable`. `unavailable` is the word that covers both
-/// misses `fan_out` actually produces — absent *and* errored.
-pub fn misses_json(misses: &[FleetMiss]) -> Vec<serde_json::Value> {
-    misses
-        .iter()
-        .map(|m| serde_json::json!({ "project": m.project, "reason": m.reason }))
-        .collect()
+/// The keys live here rather than at each call site because they are the part
+/// that actually diverged — `ask` said `unreadable` while `task` said
+/// `unavailable` for the identical array. A helper that returned only the
+/// values would leave the next verb free to invent a third spelling, which is
+/// the divergence this is meant to end.
+///
+/// Having one spelling matters more than which spelling won. `unavailable` is
+/// the word that covers both misses `fan_out` actually produces — absent *and*
+/// errored; `unreadable` only covers the second, and would contradict the
+/// commonest reason of all, "repo not on this machine".
+///
+/// `projects` is pre-built by the caller: every verb tags its rows the same
+/// way, but what hangs off each project is the verb's own business.
+pub fn json_envelope(projects: Vec<serde_json::Value>, misses: &[FleetMiss]) -> serde_json::Value {
+    serde_json::json!({
+        "projects": projects,
+        "unavailable": misses
+            .iter()
+            .map(|m| serde_json::json!({ "project": m.project, "reason": m.reason }))
+            .collect::<Vec<_>>(),
+    })
 }
 
 #[cfg(test)]
@@ -236,24 +248,29 @@ mod tests {
         assert_eq!(grouped[1].1, vec![&"b"]);
     }
 
-    /// The reason is already a complete phrase, so nothing may be prepended to
-    /// it: `fan_out`'s most common miss is an absent repo, and a fixed
-    /// "unreadable:" prefix would contradict the sentence it introduces.
+    /// Pins the key names themselves. They are the whole point of the helper —
+    /// a verb free to spell this `unreadable` is the divergence that made it
+    /// necessary — so a rename must not be able to pass quietly.
     #[test]
-    fn a_miss_renders_as_project_and_reason_with_nothing_invented() {
+    fn the_json_envelope_names_what_answered_and_what_did_not() {
         let misses = vec![FleetMiss {
             project: "dazun".to_string(),
             reason: "repo not on this machine (D:\\gone)".to_string(),
         }];
 
-        let json = misses_json(&misses);
+        let env = json_envelope(vec![serde_json::json!({ "project": "edda" })], &misses);
 
-        assert_eq!(json.len(), 1);
-        assert_eq!(json[0]["project"], "dazun");
-        assert_eq!(json[0]["reason"], "repo not on this machine (D:\\gone)");
+        assert_eq!(env["projects"][0]["project"], "edda");
+        assert_eq!(env["unavailable"][0]["project"], "dazun");
+        // Verbatim: `fan_out`'s reasons are complete phrases, and the absent
+        // repo is the case a fixed "unreadable:" prefix used to contradict.
+        assert_eq!(
+            env["unavailable"][0]["reason"],
+            "repo not on this machine (D:\\gone)"
+        );
         assert!(
-            json[0].get("unreadable").is_none(),
-            "the shape carries the reason, not a verdict about it"
+            env.get("unreadable").is_none() && env.get("fleet").is_none(),
+            "the retired spellings must not come back: {env}"
         );
     }
 }

--- a/crates/edda-cli/src/fleet.rs
+++ b/crates/edda-cli/src/fleet.rs
@@ -99,6 +99,33 @@ pub fn print_misses(misses: &[FleetMiss]) {
     }
 }
 
+/// The line a fleet read prints when it found nothing.
+///
+/// It exists because the obvious guard — `if empty && misses.is_empty()` — has
+/// the logic backwards, and all three verbs shipped with it. Suppressing the
+/// summary when something failed removes the sentence precisely when the reader
+/// most needs it: with a miss printed and no summary, "the other projects had
+/// nothing" and "the other projects were never looked at" produce identical
+/// output, which is the silence this whole verb exists to break.
+///
+/// So the count is never `scope.len()`. It is what actually answered, and the
+/// shortfall is stated rather than left for the reader to subtract.
+///
+/// `what` names the thing not found ("results", "tasks on the rail"); `tail`
+/// carries the caller's qualifier (" for: {query}") and is placed before the
+/// shortfall clause so the sentence still reads in order.
+pub fn empty_summary(what: &str, tail: &str, scope_len: usize, misses: &[FleetMiss]) -> String {
+    let answered = scope_len.saturating_sub(misses.len());
+    if misses.is_empty() {
+        format!("No {what} across {answered} project(s){tail}")
+    } else {
+        format!(
+            "No {what} in the {answered} project(s) that answered{tail}; {} could not be read (above)",
+            misses.len()
+        )
+    }
+}
+
 /// The `--json` body of a fleet read: what answered, and what did not.
 ///
 /// The keys live here rather than at each call site because they are the part
@@ -246,6 +273,35 @@ mod tests {
         assert_eq!(grouped[0].1, vec![&"a", &"c"], "non-adjacent hits regroup");
         assert_eq!(grouped[1].0, "dazun");
         assert_eq!(grouped[1].1, vec![&"b"]);
+    }
+
+    /// The line that had it backwards. A fleet read that found nothing must
+    /// say what it *did* cover, and it may never count a project it never
+    /// reached — otherwise "nothing there" and "did not look" render the same,
+    /// which is the failure the whole verb exists to remove.
+    #[test]
+    fn an_empty_fleet_read_never_counts_projects_it_could_not_reach() {
+        let plain = empty_summary("results", " for: q", 4, &[]);
+        assert_eq!(plain, "No results across 4 project(s) for: q");
+
+        let misses = vec![FleetMiss {
+            project: "yushan".to_string(),
+            reason: "index not built".to_string(),
+        }];
+        let partial = empty_summary("results", " for: q", 4, &misses);
+
+        assert!(
+            partial.contains("3 project(s) that answered"),
+            "must report the 3 it actually covered: {partial}"
+        );
+        assert!(
+            !partial.contains("across 4"),
+            "must not claim all 4 were covered when 1 never answered: {partial}"
+        );
+        assert!(
+            partial.contains("1 could not be read"),
+            "the shortfall must be accounted for, not implied: {partial}"
+        );
     }
 
     /// Pins the key names themselves. They are the whole point of the helper —


### PR DESCRIPTION
## What

`edda task list --fleet` — one board across every project in scope, each row tagged with the repo it came from. GH-407 acceptance 2, the operator's morning board.

```
edda task list --fleet --status ready
```

## Why the project tag is load-bearing

Task ids restart at 1 in every repo. An untagged merged board shows two unrelated `#1` as if they were one row of one list — so the tag is what makes the board readable at all, not decoration on top of it.

The same reasoning drives the JSON shape. `--fleet --json` groups by project and carries an `unavailable` array rather than flattening:

```json
{
  "projects": [ { "project": "edda", "tasks": [ … ] } ],
  "unavailable": [ { "project": "dazun", "reason": "repo not on this machine (…)" } ]
}
```

A flat array would silently merge unrelated tasks under one id, and a consumer could not tell *"nothing ready in dazun"* from *"dazun could not be read"* — the second is the silent-empty failure GH-407 exists to remove. It is deliberately a different shape from the local `[TaskView]`, because it answers a different question; conflating them is the same trap.

## How

- `do_list_fleet` takes the **scope as a parameter** rather than looking it up. `fleet_scope` reads the global registry — process-wide state — so an injected scope is what lets the tests run against temp workspaces without fighting their neighbours. Same inversion as `ledger_root_for`'s lookup and `sync`'s `events_after`.
- Reuses `fleet::fan_out` from #425, so absent repos and per-project failures are already accounted for as misses.
- `task_row` is extracted and shared by both boards so they cannot drift into two dialects of the same list.
- No `--project` flag exists on `task list`, so the `--project`/`--fleet` conflict fixed in #426 has no analogue here.

## Tests

Three new, each written RED first:

- `fleet_list_tags_each_task_with_the_project_it_came_from` — asserts both tasks are `#1` in their own repo, so the tag is the only thing telling them apart.
- `fleet_list_applies_the_status_filter_in_each_project` — a filter must reach every project, not just the one being stood in.
- `fleet_list_reports_an_unreadable_project_instead_of_dropping_it` — "did not look" must not render as "nothing ready there".

`203 passed; 0 failed`. clippy 0 warnings at `--all-targets` (counted, not inferred from empty output). fmt clean.

Live verification on the real fleet to follow as a comment.

Closes part of #407.
