### PR TITLE
feat(fleet): a local miss asks the fleet before reporting absence (GH-407)

### DIFF
--- a/crates/edda-cli/src/cmd_ask.rs
+++ b/crates/edda-cli/src/cmd_ask.rs
@@ -50,11 +50,40 @@ pub fn execute(
 
     if json {
         println!("{}", serde_json::to_string_pretty(&result)?);
-    } else {
-        print!("{}", format_human(&result));
+        return Ok(());
     }
 
+    let body = format_human(&result);
+    if body.trim().is_empty() {
+        // Printing nothing at all was the worst form of the silent miss: it did
+        // not even claim absence, it just ended. A workspace with no decisions
+        // yet — a sibling repo, a fresh clone — is exactly where the fleet's
+        // answer lives, and exactly where the old behaviour said least.
+        println!("No results for: {q}");
+        if let Some(hint) = fleet_hint_for_ask(repo_root, q, &opts) {
+            println!("{hint}");
+        }
+        return Ok(());
+    }
+    print!("{body}");
+
     Ok(())
+}
+
+/// Ask the rest of the fleet whether a local miss is really absence (GH-407,
+/// acceptance 4).
+fn fleet_hint_for_ask(repo_root: &Path, q: &str, opts: &AskOptions) -> Option<String> {
+    if q.trim().is_empty() {
+        return None; // no question was asked; there is nothing to look for elsewhere
+    }
+    let scope = edda_store::registry::fleet_scope(repo_root);
+    let home = edda_store::project_id(repo_root);
+    crate::fleet::elsewhere_hint(&scope, &home, "result", |entry| {
+        let root = Path::new(&entry.path);
+        let ledger = Ledger::open(root)?;
+        let result = ask(&ledger, q, opts, None)?;
+        Ok(result.decisions.len() + result.timeline.len())
+    })
 }
 
 /// `edda ask --fleet` — the same question, asked of every project in scope.

--- a/crates/edda-cli/src/cmd_ask.rs
+++ b/crates/edda-cli/src/cmd_ask.rs
@@ -53,19 +53,15 @@ pub fn execute(
         return Ok(());
     }
 
-    let body = format_human(&result);
-    if body.trim().is_empty() {
-        // Printing nothing at all was the worst form of the silent miss: it did
-        // not even claim absence, it just ended. A workspace with no decisions
-        // yet — a sibling repo, a fresh clone — is exactly where the fleet's
-        // answer lives, and exactly where the old behaviour said least.
-        println!("No results for: {q}");
+    // Emptiness is counted, not detected from the rendering: `format_human`
+    // prints its own "No results found." for an empty result, so asking whether
+    // the render is blank is a question that is never answered yes.
+    print!("{}", format_human(&result));
+    if hit_count(&result) == 0 {
         if let Some(hint) = fleet_hint_for_ask(repo_root, q, &opts) {
             println!("{hint}");
         }
-        return Ok(());
     }
-    print!("{body}");
 
     Ok(())
 }
@@ -141,15 +137,18 @@ fn execute_fleet(repo_root: &Path, q: &str, opts: &AskOptions, json: bool) -> an
         return Ok(());
     }
 
+    // Counted, not detected from the rendering: `format_human` prints its own
+    // "No results found." for an empty result, so a blank-body test never fires
+    // and every project — including the silent ones — got a section header and a
+    // line saying it had nothing.
     let mut answered = 0;
     for hit in &hits {
-        let body = format_human(&hit.item);
-        if body.trim().is_empty() {
+        if hit_count(&hit.item) == 0 {
             continue;
         }
         answered += 1;
         println!("── [{}] ──────────────────────────", hit.project);
-        print!("{body}");
+        print!("{}", format_human(&hit.item));
     }
 
     // Misses are printed as results, not swallowed: a fleet read that quietly
@@ -259,6 +258,36 @@ mod tests {
             hit_count(&r),
             1,
             "a note-only hit must not probe as absence"
+        );
+    }
+
+    /// The contract three branches were built on, and none of them checked.
+    ///
+    /// `format_human` prints its own "No results found." for an empty result, so
+    /// `body.trim().is_empty()` is a question that is never answered yes. That
+    /// one wrong assumption shipped three dead branches across three PRs — the
+    /// local hint, `--fleet`'s empty-project skip, and `--fleet`'s empty summary
+    /// — each of which read correctly and never ran. Emptiness is counted here,
+    /// never inferred from the rendering.
+    #[test]
+    fn an_empty_result_still_renders_text_so_emptiness_must_be_counted() {
+        let empty = edda_ask::AskResult {
+            query: "q".to_string(),
+            input_type: "keyword".to_string(),
+            decisions: Vec::new(),
+            timeline: Vec::new(),
+            related_commits: Vec::new(),
+            related_notes: Vec::new(),
+            conversations: Vec::new(),
+            dependents: Vec::new(),
+            override_risk: None,
+        };
+
+        assert_eq!(hit_count(&empty), 0, "nothing was found");
+        assert!(
+            !format_human(&empty).trim().is_empty(),
+            "the render is NOT blank — it says 'No results found.' — so any \
+             branch gated on a blank body is dead code"
         );
     }
 }

--- a/crates/edda-cli/src/cmd_ask.rs
+++ b/crates/edda-cli/src/cmd_ask.rs
@@ -70,8 +70,27 @@ pub fn execute(
     Ok(())
 }
 
+/// Everything `format_human` would render as a hit.
+///
+/// The count has to span every collection, not the obvious two: a project whose
+/// only hit is a commit or a transcript turn must not probe as empty, or the
+/// hint reports absence where `--fleet` finds answers — the very failure this
+/// hint exists to remove, one level down.
+fn hit_count(r: &edda_ask::AskResult) -> usize {
+    r.decisions.len()
+        + r.timeline.len()
+        + r.related_commits.len()
+        + r.related_notes.len()
+        + r.conversations.len()
+        + r.dependents.len()
+}
+
 /// Ask the rest of the fleet whether a local miss is really absence (GH-407,
 /// acceptance 4).
+///
+/// Probes exactly as `execute_fleet` reads, transcript callback included. A line
+/// that says "rerun with --fleet" is a promise about what that command will
+/// show, so anything the probe declines to look at is a promise it cannot keep.
 fn fleet_hint_for_ask(repo_root: &Path, q: &str, opts: &AskOptions) -> Option<String> {
     if q.trim().is_empty() {
         return None; // no question was asked; there is nothing to look for elsewhere
@@ -81,8 +100,9 @@ fn fleet_hint_for_ask(repo_root: &Path, q: &str, opts: &AskOptions) -> Option<St
     crate::fleet::elsewhere_hint(&scope, &home, "result", |entry| {
         let root = Path::new(&entry.path);
         let ledger = Ledger::open(root)?;
-        let result = ask(&ledger, q, opts, None)?;
-        Ok(result.decisions.len() + result.timeline.len())
+        let cb = build_transcript_callback(root, Some(&entry.name));
+        let cb_ref: Option<&TranscriptSearchFn> = cb.as_ref().map(|f| f.as_ref());
+        Ok(hit_count(&ask(&ledger, q, opts, cb_ref)?))
     })
 }
 
@@ -203,4 +223,42 @@ fn build_transcript_callback(
             })
             .collect()
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The probe decides whether the fleet gets mentioned at all, so it has to
+    /// count every kind of hit `format_human` renders. Counting only the obvious
+    /// two made a project whose hit was a note or a transcript turn probe as
+    /// empty, which reports absence where `--fleet` finds answers — the exact
+    /// failure the hint exists to remove, one level down.
+    #[test]
+    fn a_hit_of_any_kind_counts_not_just_decisions_and_timeline() {
+        let mut r = edda_ask::AskResult {
+            query: "q".to_string(),
+            input_type: "keyword".to_string(),
+            decisions: Vec::new(),
+            timeline: Vec::new(),
+            related_commits: Vec::new(),
+            related_notes: Vec::new(),
+            conversations: Vec::new(),
+            dependents: Vec::new(),
+            override_risk: None,
+        };
+        assert_eq!(hit_count(&r), 0, "an empty result is empty");
+
+        r.related_notes.push(edda_ask::NoteHit {
+            event_id: "evt_1".to_string(),
+            ts: "2026-07-16T00:00:00Z".to_string(),
+            text: "the answer is here".to_string(),
+            branch: "main".to_string(),
+        });
+        assert_eq!(
+            hit_count(&r),
+            1,
+            "a note-only hit must not probe as absence"
+        );
+    }
 }

--- a/crates/edda-cli/src/cmd_log.rs
+++ b/crates/edda-cli/src/cmd_log.rs
@@ -67,6 +67,11 @@ pub fn execute(params: &LogParams<'_>) -> anyhow::Result<()> {
 
     if matched.is_empty() {
         println!("No events match the filter.");
+        if !params.json {
+            if let Some(hint) = fleet_hint_for_filter(params) {
+                println!("{hint}");
+            }
+        }
         return Ok(());
     }
 
@@ -82,6 +87,20 @@ pub fn execute(params: &LogParams<'_>) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// Ask the rest of the fleet whether a local miss is really absence (GH-407,
+/// acceptance 4).
+fn fleet_hint_for_filter(params: &LogParams<'_>) -> Option<String> {
+    let scope = edda_store::registry::fleet_scope(params.repo_root);
+    let home = edda_store::project_id(params.repo_root);
+    crate::fleet::elsewhere_hint(&scope, &home, "event", |entry| {
+        Ok(collect_matching(&LogParams {
+            repo_root: Path::new(&entry.path),
+            ..*params
+        })?
+        .len())
+    })
 }
 
 /// `edda log --fleet` — the same log, read from every project's own ledger

--- a/crates/edda-cli/src/cmd_search.rs
+++ b/crates/edda-cli/src/cmd_search.rs
@@ -195,6 +195,38 @@ fn query_fleet(
     Ok(())
 }
 
+/// Ask the rest of the fleet whether a local miss is really absence (GH-407,
+/// acceptance 4).
+///
+/// Never builds an index to answer this: a project without one reports that it
+/// could not be checked, which is true and costs nothing, whereas a ~25s build
+/// (GH-403) triggered by someone else's miss would be a trap.
+fn fleet_hint_for_query(
+    repo_root: &Path,
+    project_id: &str,
+    query_str: &str,
+    opts: &search::SearchOptions<'_>,
+    limit: usize,
+) -> Option<String> {
+    let scope = edda_store::registry::fleet_scope(repo_root);
+    crate::fleet::elsewhere_hint(&scope, project_id, "result", |entry| {
+        let index_dir = project_dir(&entry.project_id)
+            .join("search")
+            .join("tantivy");
+        if !index_dir.exists() || schema::index_is_outdated(&index_dir) {
+            anyhow::bail!("no usable index");
+        }
+        let Some(index) = schema::open_index(&index_dir) else {
+            anyhow::bail!("index could not be opened");
+        };
+        let per_project = search::SearchOptions {
+            project_id: Some(&entry.project_id),
+            ..*opts
+        };
+        Ok(search::search(&index, query_str, &per_project, limit)?.len())
+    })
+}
+
 /// Execute `edda search <query>` — full-text search over the Tantivy index.
 #[allow(clippy::too_many_arguments)]
 pub fn query(
@@ -266,6 +298,9 @@ pub fn query(
 
     if results.is_empty() {
         println!("No results found for: {query_str}");
+        if let Some(hint) = fleet_hint_for_query(repo_root, project_id, query_str, &opts, limit) {
+            println!("{hint}");
+        }
         print_watermark(repo_root, &proj_dir, project_id);
         return Ok(());
     }

--- a/crates/edda-cli/src/cmd_task.rs
+++ b/crates/edda-cli/src/cmd_task.rs
@@ -313,6 +313,20 @@ fn task_row(v: &TaskView) -> String {
     format!("#{} [{}] {}{}", v.task_id, v.status, v.title, extra)
 }
 
+/// Ask the rest of the fleet whether an empty local rail is really an empty
+/// rail (GH-407, acceptance 4).
+fn fleet_hint_for_list(
+    repo_root: &Path,
+    assignee: Option<&str>,
+    status: Option<&str>,
+) -> Option<String> {
+    let scope = edda_store::registry::fleet_scope(repo_root);
+    let home = edda_store::project_id(repo_root);
+    crate::fleet::elsewhere_hint(&scope, &home, "task", |entry| {
+        Ok(do_list(Path::new(&entry.path), assignee, status)?.len())
+    })
+}
+
 /// Render `task list --fleet` — the operator's morning board across every
 /// project (GH-407, acceptance 2).
 fn list_fleet(
@@ -499,6 +513,11 @@ pub fn execute(cmd: TaskCmd, repo_root: &Path) -> anyhow::Result<()> {
             }
             if views.is_empty() {
                 println!("No tasks on the rail.");
+                if let Some(hint) =
+                    fleet_hint_for_list(repo_root, assignee.as_deref(), status.as_deref())
+                {
+                    println!("{hint}");
+                }
                 println!("Create one: edda task new \"title\" --assignee <label>");
                 return Ok(());
             }

--- a/crates/edda-cli/src/fleet.rs
+++ b/crates/edda-cli/src/fleet.rs
@@ -126,6 +126,68 @@ pub fn empty_summary(what: &str, tail: &str, scope_len: usize, misses: &[FleetMi
     }
 }
 
+/// Ask the rest of the fleet before a local read reports absence (GH-407,
+/// acceptance 4).
+///
+/// This is the point of the issue rather than a flourish on it. Every read verb
+/// sees one workspace, so `No results` has always meant "not in this repo" while
+/// reading as "nowhere" — and the knowledge is genuinely split across repos, so
+/// the reading is routinely wrong. A bare miss may only stay bare once the fleet
+/// has been asked and had nothing to add.
+///
+/// Returns `None` in exactly that case: the caller's own message is then true,
+/// and the hint exists to correct a lie, not to decorate a fact.
+///
+/// The home project is skipped — it is the one that just missed, and probing it
+/// again would report its own silence back as news. A project that cannot be
+/// probed is named rather than counted as empty, for the same reason its
+/// `--fleet` miss is: not looking is not the same as finding nothing.
+///
+/// The scope is injected rather than looked up so this stays testable without
+/// the global registry, which is process-wide state.
+pub fn elsewhere_hint<F>(
+    scope: &[ProjectEntry],
+    home_project_id: &str,
+    what: &str,
+    count_in: F,
+) -> Option<String>
+where
+    F: Fn(&ProjectEntry) -> anyhow::Result<usize>,
+{
+    let mut found: Vec<String> = Vec::new();
+    let mut unchecked: Vec<String> = Vec::new();
+
+    for entry in scope {
+        if entry.project_id == home_project_id {
+            continue;
+        }
+        if !Path::new(&entry.path).join(".edda").is_dir() {
+            continue; // absent repos are not news on a local miss
+        }
+        match count_in(entry) {
+            Ok(0) => {}
+            Ok(n) => found.push(format!("{n} {what}(s) in [{}]", entry.name)),
+            Err(_) => unchecked.push(format!("[{}]", entry.name)),
+        }
+    }
+
+    if found.is_empty() && unchecked.is_empty() {
+        return None;
+    }
+
+    let mut parts = String::new();
+    if !found.is_empty() {
+        parts.push_str(&found.join(", "));
+    }
+    if !unchecked.is_empty() {
+        if !parts.is_empty() {
+            parts.push_str("; ");
+        }
+        parts.push_str(&format!("{} could not be checked", unchecked.join(", ")));
+    }
+    Some(format!("  {parts} — rerun with --fleet"))
+}
+
 /// The `--json` body of a fleet read: what answered, and what did not.
 ///
 /// The keys live here rather than at each call site because they are the part
@@ -273,6 +335,109 @@ mod tests {
         assert_eq!(grouped[0].1, vec![&"a", &"c"], "non-adjacent hits regroup");
         assert_eq!(grouped[1].0, "dazun");
         assert_eq!(grouped[1].1, vec![&"b"]);
+    }
+
+    /// The point of the whole issue: a workspace that found nothing must not
+    /// imply the fleet found nothing. Without this, "not here" and "nowhere"
+    /// are the same sentence.
+    #[test]
+    fn a_local_miss_names_the_projects_that_do_have_hits() {
+        let (a, b, c) = (live_repo(), live_repo(), live_repo());
+        let scope = vec![
+            entry("edda", &a.path().to_string_lossy()),
+            entry("foundry", &b.path().to_string_lossy()),
+            entry("dazun", &c.path().to_string_lossy()),
+        ];
+
+        let hint = elsewhere_hint(&scope, "pid-edda", "result", |e| {
+            Ok(match e.name.as_str() {
+                "foundry" => 3,
+                _ => 1,
+            })
+        })
+        .expect("hits elsewhere must be reported");
+
+        assert!(hint.contains("3 result(s) in [foundry]"), "{hint}");
+        assert!(hint.contains("1 result(s) in [dazun]"), "{hint}");
+        assert!(hint.contains("--fleet"), "must say how to see them: {hint}");
+    }
+
+    /// The home project is the one that just missed. Probing it again would
+    /// report its own silence back as news.
+    #[test]
+    fn the_workspace_that_already_missed_is_not_probed_again() {
+        let (a, b) = (live_repo(), live_repo());
+        let scope = vec![
+            entry("edda", &a.path().to_string_lossy()),
+            entry("foundry", &b.path().to_string_lossy()),
+        ];
+
+        let hint = elsewhere_hint(&scope, "pid-edda", "result", |e| {
+            assert_ne!(e.name, "edda", "the home project must not be re-asked");
+            Ok(2)
+        })
+        .expect("foundry has hits");
+
+        assert!(hint.contains("[foundry]"), "{hint}");
+        assert!(!hint.contains("[edda]"), "{hint}");
+    }
+
+    /// When the fleet really is empty, the bare message is true and must stay
+    /// bare — the hint corrects a lie, it does not decorate a fact.
+    #[test]
+    fn nothing_is_added_when_the_fleet_has_nothing_either() {
+        let (a, b) = (live_repo(), live_repo());
+        let scope = vec![
+            entry("edda", &a.path().to_string_lossy()),
+            entry("foundry", &b.path().to_string_lossy()),
+        ];
+
+        assert_eq!(
+            elsewhere_hint(&scope, "pid-edda", "result", |_| Ok(0)),
+            None
+        );
+    }
+
+    /// A project that exists but could not answer is not evidence of absence.
+    #[test]
+    fn a_project_that_could_not_be_probed_is_said_so_not_counted_as_empty() {
+        let (a, b) = (live_repo(), live_repo());
+        let scope = vec![
+            entry("edda", &a.path().to_string_lossy()),
+            entry("foundry", &b.path().to_string_lossy()),
+        ];
+
+        let hint = elsewhere_hint(&scope, "pid-edda", "result", |_| {
+            anyhow::bail!("index not built")
+        })
+        .expect("an unprobed project must not render as an empty one");
+
+        assert!(hint.contains("[foundry]"), "{hint}");
+        assert!(hint.contains("could not be checked"), "{hint}");
+    }
+
+    /// A repo that is not on this machine cannot be probed and is not news: the
+    /// operator knows what they have checked out, `--fleet` reports it anyway,
+    /// and "rerun with --fleet" would not make it appear. Silence here is the
+    /// one case that is not a lie.
+    #[test]
+    fn a_repo_absent_from_this_machine_is_left_out_of_the_hint() {
+        let a = live_repo();
+        let gone = live_repo();
+        let gone_path = gone.path().to_string_lossy().into_owned();
+        drop(gone);
+
+        let scope = vec![
+            entry("edda", &a.path().to_string_lossy()),
+            entry("dazun", &gone_path),
+        ];
+
+        assert_eq!(
+            elsewhere_hint(&scope, "pid-edda", "result", |_| panic!(
+                "an absent repo must not be probed"
+            )),
+            None
+        );
     }
 
     /// The line that had it backwards. A fleet read that found nothing must


### PR DESCRIPTION
## What

Acceptance 4, and the reason #407 exists: **a local miss asks the fleet before reporting absence.**

Live, from the edda repo, for a term that lives in sibling repos:

```
$ edda log --keyword "desk-operator"
No events match the filter.
  9 event(s) in [AI Delivery Foundry], 1 event(s) in [dazun] — rerun with --fleet

$ edda search query "desk-operator"
No results found for: desk-operator
  8 result(s) in [AI Delivery Foundry], 1 result(s) in [dazun]; [yushan] could not be checked — rerun with --fleet
```

Every read verb sees one workspace, so `No results` has always meant *"not in this repo"* while reading as *"nowhere"*. The issue's own framing: knowledge really is split across repos, so that reading was routinely wrong, and *"the split-brain is invisible because a local miss renders exactly like true absence."*

A bare miss may now only stay bare once the fleet has been asked and had nothing to add. `elsewhere_hint` returns `None` in exactly that case — verified: `log --keyword "zzz-nowhere-in-any-repo-9999"` prints the bare message with no hint, because the hint corrects lies rather than decorating facts.

## The `ask` story, corrected

> **An earlier version of this description claimed `ask` "printed nothing at all" on an empty result. That was wrong, and I had not checked it.** It prints `No results found.`, from `edda-ask/src/lib.rs:830`. The correction matters because everything I first built for `ask` was gated on that false belief.

`format_human` renders its own message for an empty result, so `body.trim().is_empty()` is a question that is **never answered yes**. One wrong assumption, three dead branches, across three PRs — each read correctly, none ever ran:

| branch | shipped in | symptom |
|---|---|---|
| local fleet hint | this PR | `ask` never mentioned the fleet, while `[AI Delivery Foundry]` held 8 hits for the same term |
| `--fleet` empty-project skip | #425 (merged) | every silent project got a header and a line saying it had nothing |
| `--fleet` empty summary | #427 (merged) | `answered` counted the silent projects, so `answered == 0` was unreachable |

All three now use `hit_count`, which the probe needed anyway. `ask` has **one** definition of empty, shared by both ends of the probe.

## Two silences are deliberate, and tested

- **The home project is skipped.** It is the one that just missed; re-probing it would report its own silence back as news.
- **A repo absent from this machine is left out.** It cannot be probed, `rerun with --fleet` would not make it appear, and `--fleet` reports it anyway. A project that *exists* but fails to answer is named — that one might have hits once its index is built. `a_repo_absent_from_this_machine_is_left_out_of_the_hint` uses `panic!` as the probe body, so it asserts the absent repo is never *reached*, not merely absent from the output.

## Cost

`search`'s probe **never builds an index**. A ~25s cold build (GH-403) triggered by someone else's miss would be a trap; it reports `could not be checked` instead — true and free. All probes are read-only and only run on a miss.

The counts are capped by `--limit`, which is correct here rather than an undercount: `--limit` is *per project* under `--fleet` (#428), so the hint reports exactly what the command it recommends will show.

## How

One helper in `fleet.rs`, scope injected so tests never touch the global registry:

```rust
pub fn elsewhere_hint<F>(scope: &[ProjectEntry], home_project_id: &str, what: &str, count_in: F) -> Option<String>
```

Four call sites: `cmd_search.rs`, `cmd_log.rs`, `cmd_task.rs`, `cmd_ask.rs`. No hint can reach a `--json` stream — `ask` and `task list` return on `json` before the empty branch, `log` guards with `!params.json`, and `search` has no `--json`.

## Tests

`216 passed; 0 failed`. clippy **0** at `--all-targets` (counted, not inferred from empty output). fmt clean.

Seven new, each RED first. The two that exist because of what went wrong:

- `a_hit_of_any_kind_counts_not_just_decisions_and_timeline` — `AskResult` has six hit collections; the probe counted two, so a commit-only or transcript-only hit probed as absence.
- `an_empty_result_still_renders_text_so_emptiness_must_be_counted` — pins the contract all three dead branches depended on and none checked: an empty result counts **zero**, and its render is **not blank**.

Every finding in this review came from running the verb. The diff read fine three times, and 215 tests passed throughout, because every test injected its own notion of a hit and not one of them ever called `format_human`.

Closes #407.
