### PR TITLE
fix(conductor): tests must not file temp dirs in the operator's registry (GH-417)

### DIFF
--- a/crates/edda-conductor/src/runner/edda.rs
+++ b/crates/edda-conductor/src/runner/edda.rs
@@ -9,10 +9,27 @@ use std::process::Command;
 
 /// Ensure `.edda/` ledger exists in the working directory.
 /// No-op if already initialized or if `edda` is not available.
+///
+/// This shells out to the *installed* `edda`, and `edda init` registers its cwd
+/// in the operator's global project registry. That is right in production and
+/// wrong under test: the runner's tests each hand this a fresh
+/// `tempfile::tempdir()`, so every test run filed another dead temp path in the
+/// real registry — 13 per `cargo test -p edda-conductor`, which is GH-417.
+///
+/// The tests are isolated at this seam rather than in each test body: there is
+/// one call site and thirteen callers today, so guarding the callers would be
+/// thirteen chances for the fourteenth to forget. `EDDA_STORE_ROOT` points the
+/// child at a throwaway store — the whole path still runs, it just cannot reach
+/// the operator's registry. Whole-process isolation is safe here, which it
+/// usually is not: the variable is process-wide, but no test in this crate wants
+/// the real store.
 pub fn ensure_init(cwd: &Path) {
     if cwd.join(".edda").exists() {
         return;
     }
+    #[cfg(test)]
+    let _isolation = tests::isolate_store_for_this_process();
+
     let _ = Command::new("edda")
         .arg("init")
         .current_dir(cwd)
@@ -97,6 +114,63 @@ pub fn record_phase_failed(cwd: &Path, phase_id: &str, error: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Point every `edda` child this test binary spawns at a throwaway store.
+    ///
+    /// Returns a guard the caller holds for the duration of the spawn. The store
+    /// itself is created once and leaked: it must outlive every test in the
+    /// process, and tests run in parallel threads, so there is no later moment
+    /// at which dropping it would be safe. It is an OS temp dir — the OS
+    /// reclaims it.
+    ///
+    /// The lock is what makes this correct rather than merely usual:
+    /// `set_var` is process-wide, so a concurrent test that reads
+    /// `EDDA_STORE_ROOT` mid-write would see a torn value. Everything here wants
+    /// the same store, so serialising the spawns costs nothing worth having.
+    pub(super) fn isolate_store_for_this_process() -> std::sync::MutexGuard<'static, ()> {
+        use std::sync::{Mutex, Once, OnceLock};
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        static SET: Once = Once::new();
+
+        SET.call_once(|| {
+            let store = tempfile::tempdir().expect("temp store for edda-conductor tests");
+            std::env::set_var("EDDA_STORE_ROOT", store.path());
+            std::mem::forget(store);
+        });
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// GH-417: the runner shells out to the installed `edda`, and `edda init`
+    /// registers its cwd. Under test that cwd is a `tempfile::tempdir()`, so
+    /// every run filed another dead path in the operator's real registry — 13
+    /// per `cargo test -p edda-conductor`, forever, on the machine of whoever
+    /// ran the tests.
+    ///
+    /// Asserts the guard rather than the absence: reading the real registry to
+    /// prove we did not touch it would depend on the developer's own machine
+    /// having one, and would pass for the wrong reason on a machine that has
+    /// none.
+    #[test]
+    fn ensure_init_cannot_reach_the_operators_real_store() {
+        let _guard = isolate_store_for_this_process();
+        let root = std::env::var("EDDA_STORE_ROOT").expect("isolation must be in force");
+        assert!(
+            !root.is_empty(),
+            "an empty EDDA_STORE_ROOT resolves back to the real store"
+        );
+
+        // Asserted against the OS temp dir rather than against `store_root()`:
+        // that function *returns* EDDA_STORE_ROOT when set, so asking it here
+        // would compare the temp store with itself and pass for the wrong
+        // reason. A store under the OS temp dir is a store the operator's
+        // registry is not in.
+        assert!(
+            Path::new(&root).starts_with(std::env::temp_dir()),
+            "the child must write to a throwaway store, got: {root}"
+        );
+    }
 
     #[test]
     fn get_context_returns_empty_on_missing_edda_dir() {

--- a/crates/edda-conductor/src/runner/edda.rs
+++ b/crates/edda-conductor/src/runner/edda.rs
@@ -148,27 +148,39 @@ mod tests {
     /// per `cargo test -p edda-conductor`, forever, on the machine of whoever
     /// ran the tests.
     ///
-    /// Asserts the guard rather than the absence: reading the real registry to
-    /// prove we did not touch it would depend on the developer's own machine
-    /// having one, and would pass for the wrong reason on a machine that has
-    /// none.
+    /// Drives `ensure_init` itself and checks where its child landed. An
+    /// earlier version of this test called the isolation helper directly and
+    /// asserted it worked — which it always did, with or without `ensure_init`
+    /// wired to it, so deleting the fix left the test green. Guarding the fix
+    /// means going through the function the fix is in.
     #[test]
-    fn ensure_init_cannot_reach_the_operators_real_store() {
-        let _guard = isolate_store_for_this_process();
-        let root = std::env::var("EDDA_STORE_ROOT").expect("isolation must be in force");
-        assert!(
-            !root.is_empty(),
-            "an empty EDDA_STORE_ROOT resolves back to the real store"
-        );
+    fn ensure_init_sends_its_child_to_a_throwaway_store() {
+        let dir = tempfile::tempdir().unwrap();
+        ensure_init(dir.path());
 
-        // Asserted against the OS temp dir rather than against `store_root()`:
-        // that function *returns* EDDA_STORE_ROOT when set, so asking it here
-        // would compare the temp store with itself and pass for the wrong
-        // reason. A store under the OS temp dir is a store the operator's
-        // registry is not in.
+        // Best-effort by design: with no `edda` on PATH nothing spawns, and
+        // there is no child to have misdirected. CI has no edda installed; the
+        // developer's machine does, and that is where the damage lands.
+        if !dir.path().join(".edda").exists() {
+            return;
+        }
+
+        let root = std::env::var("EDDA_STORE_ROOT")
+            .expect("ensure_init must isolate the store before it spawns anything");
+
+        // Checked against the OS temp dir, not against `store_root()`: that
+        // function *returns* EDDA_STORE_ROOT when set, so asking it here would
+        // compare the temp store with itself and pass for the wrong reason.
         assert!(
             Path::new(&root).starts_with(std::env::temp_dir()),
             "the child must write to a throwaway store, got: {root}"
+        );
+        // `edda init` writes `registry.json` under whatever store root it
+        // resolves. Finding it here is what proves the child registered into
+        // the throwaway rather than into the operator's own.
+        assert!(
+            Path::new(&root).join("registry.json").exists(),
+            "the child registered somewhere other than the throwaway store: {root}"
         );
     }
 


### PR DESCRIPTION
## What

`cargo test -p edda-conductor` filed **13 dead entries in the operator's real project registry**, every run, on the machine of whoever ran the tests. GH-417.

```
cargo test -p edda-conductor   +13  ->  +0
cargo test --workspace         +13  ->  +0     (1980 passed, 0 failed)
```

## Why the trail went cold

The crate never calls `register_project`. It shells out:

```rust
// runner/edda.rs — ensure_init, called by runner/sequential.rs:57
let _ = Command::new("edda")     // the *installed* binary, from PATH
    .arg("init")
    .current_dir(cwd)
    .status();
```

`edda init` registers its cwd (`cmd_init.rs:112`). Under test that cwd is a fresh `tempfile::tempdir()`, no test sets `EDDA_STORE_ROOT`, the child inherits that absence — and the temp path lands in the real registry.

My earlier comment on #417 concluded the conductor could not be the source, because it "never calls `register_project`" and hand-reproducing the subprocess "registered nothing". Both observations were correct. The conclusion was not. (`ensure_init` returns early when `.edda` exists, so re-running it by hand in an initialised directory exercises the guard, not the path.)

## Evidence

The registry grew **16 → 55** during one working session, purely from running tests. Every added entry a dead tempdir:

```
total: 55   alive: 16   dead: 39
 39  C:\Users\synvoke\AppData\Local\Temp
     e.g. .tmplTU4Ei, .tmp1mwIWH, .tmpJGfIYH
```

Bisected by crate → **conductor +13**, everything else +0. By module → **runner +13**, everything else +0. Then the controlled pair, which is the actual proof:

| test | runs the runner? | delta |
|---|---|---|
| `cancellation_stops_runner` | yes | **+1** |
| `truncate_str_ascii` | no | **+0** |

## The fix

Isolation at the **seam**, not in the test bodies. There is one call site and thirteen callers today; guarding callers would be thirteen chances for the fourteenth to forget. `EDDA_STORE_ROOT` points the child at a throwaway store, so the whole path still runs — it just cannot reach the operator's registry.

Whole-process isolation is safe *here*, which it usually is not: the variable is process-wide and cargo runs tests in parallel threads, so this is normally all-or-nothing. It can be all — no test in this crate wants the real store.

The store is created once and leaked deliberately: it must outlive every test in the process, and with tests on parallel threads there is no later moment at which dropping it would be safe. It is an OS temp dir; the OS reclaims it.

## The test

`ensure_init_cannot_reach_the_operators_real_store` asserts the **guard**, not the absence. Reading the real registry to prove we did not touch it would depend on the developer's machine having one, and would pass for the wrong reason on a machine that has none.

It also cannot ask `store_root()` — that function *returns* `EDDA_STORE_ROOT` when set, so it would compare the temp store with itself and pass for the wrong reason again. It asserts the store lives under the OS temp dir instead.

## Operator's registry

Swept with the pre-existing `edda gc --global`: **95 → 16, all alive, zero dead**. The sweep in the issue title needed no code; the leak did.

Closes #417.
