### PR TITLE
ci: derive the Windows crate list from its criterion, add edda-conductor + edda-transcript (GH-433)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,16 +48,25 @@ jobs:
             args: --workspace
           - os: macos-latest
             args: --workspace
-          # Windows is non-blocking (continue-on-error) and its build/link is
-          # ~5x slower, so it runs only the platform-divergent crates
-          # (filesystem paths, file locks, process spawn, mmap) instead of all
-          # 23. Linux/macOS keep full-workspace coverage.
+          # Windows build/link is ~5x slower, so it runs only the crates whose
+          # behaviour actually diverges by platform instead of all 23.
+          # Linux/macOS keep full-workspace coverage.
+          #
+          # Each crate below earns its place against a concrete criterion; the
+          # list is derived from these, not curated, so it cannot silently drift
+          # from the rule (it did — GH-433 caught edda-conductor and
+          # edda-transcript missing while the comment named their criteria):
+          #   process spawn (Command::new):  edda, edda-bridge-claude, edda-conductor
+          #   file locks (fs2):              edda-store, edda-ledger, edda-search-fts, edda-transcript
+          #   mmap (tantivy):                edda-search-fts
           - os: windows-latest
             args: >-
               -p edda-store
               -p edda-ledger
               -p edda-search-fts
+              -p edda-transcript
               -p edda-bridge-claude
+              -p edda-conductor
               -p edda
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What

Fixes the coverage half of #433: the Windows CI matrix now runs the crates its own comment said it should. Derived from the stated criteria, not hand-curated.

## The bug in the old matrix

The comment named four selection criteria — process spawn, file locks, mmap, filesystem paths — then listed 5 crates. Deriving from the criteria instead of trusting the list turns up two matches that were absent:

| criterion | crates that match | was in list? |
|---|---|---|
| process spawn (`Command::new`) | edda, edda-bridge-claude, **edda-conductor** | conductor **no** |
| file locks (`fs2`) | edda-store, edda-ledger, edda-search-fts, **edda-transcript** | transcript **no** |
| mmap (`tantivy`) | edda-search-fts | yes |

`edda-conductor` has **7** files calling `Command::new` — the most spawn-heavy crate in the workspace — and the comment named "process spawn" as a criterion. It was the crate most obviously in scope and the one omitted.

## Why it mattered

`edda-conductor` is where GH-417 lived: `cargo test` filed 13 dead temp dirs into the operator's real registry, every run, on Windows. Fixed in #432. Its regression guard, `ensure_init_sends_its_child_to_a_throwaway_store`, **had never run on Windows CI** — the platform the bug was found on. It is also the most platform-sensitive kind of test there is: it spawns a subprocess and asserts where the child wrote.

## The fix

Add `edda-conductor` and `edda-transcript`, and rewrite the comment to list each crate against the criterion it satisfies, so the list is read off the rule rather than maintained beside it. That is how it drifted: a curated list and a stated rule with nothing tying them together.

## Verification

- Both added crates green on a **real Windows machine** before commit: conductor **148**, transcript **21**.
- The exact folded-scalar command CI will run, reconstructed and compiled with `--no-run`: `Finished`, all 7 crate names resolve.
- Windows test count **1059 → 1228** (+16%). conductor is logic-heavy and fast (6.6s), not the slow-linking kind that motivated the trim.

## Deliberately not in this PR

- **`continue-on-error` on Windows** (lines 28, 42): a policy call — should Windows block a merge on the operator's own platform? Left for the operator to decide, per #433.
- **The `line-tables-only` debug trim from #411**: sound, stays.
- **The open question** in #433 — whether `gh pr checks` reports a *failing* `continue-on-error` job as `pass` — is unresolved. It needs a deliberately-failing Windows job to observe, which does not belong on this branch. Still worth settling: if it masks, every "CI green" merge gate in this repo is weaker than it reads.

Addresses the coverage part of #433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
