### PR TITLE
ci: make Windows blocking — drop continue-on-error (GH-433)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
   clippy:
     name: Clippy (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -39,7 +38,6 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What

Make Windows CI **blocking**: remove `continue-on-error` from both the clippy and test jobs. Second half of #433; the required-check flip on the ruleset follows this.

## Why

Windows was advisory on both jobs, so a genuine failure was absorbed into a green run. Proved with a live case earlier in #433:

```
run 29372955500 (a #409 intermediate commit):
  Test (windows-latest):  conclusion = failure
  overall run:            conclusion = success
```

The swallowed failure was `concurrent_writers_no_data_loss` panicking in `edda-ledger` — a crate Windows **already ran**, so this was masking a real signal, not a coverage gap.

edda's operator runs Windows. The platform where a regression bites first was the one that could not block a merge.

## Why the original justification is gone

`continue-on-error` was compensating for Windows build time (~5x slower). That has been addressed since:

- **#411** — `line-tables-only` debug trim (skips heavy PDB link)
- **#434** — crate-scoped Windows matrix (7 crates, not all 23)

Windows Test ran in **3m44s** on #434. It is no longer the outlier the escape hatch existed for.

## What this does and does not do

- **Does:** a failing Windows clippy or test job now fails the run — an unambiguous red.
- **Does not:** set the checks as *required*. That is a ruleset change (`Protect main`), applied after this merges, so that a failure is already a real red before it becomes a gate.

## Verification

This PR's own CI is the test: `pull_request` runs the head's workflow, so Windows is blocking on this very PR. If Windows is genuinely green (it was on #434, all 7 crates, real conclusion `SUCCESS`), this merges; if anything is actually broken on Windows, this PR is the first to be told so — which is the entire point.

## Note

`concurrent_writers_no_data_loss` passed 10/10 locally on Windows on current `main`, so it is a watch item (possible CI-contention flake), not a known live break. But once this merges, a flaky Windows failure *will* block — that is the intended consequence, and the fix for flakiness is to fix the test, not to hide it.

Addresses the blocking half of #433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
