### PR TITLE
feat(search): index task receipts so they are searchable (GH-404)

### DIFF
--- a/crates/edda-search-fts/src/indexer.rs
+++ b/crates/edda-search-fts/src/indexer.rs
@@ -105,6 +105,29 @@ fn extract_event_title_body(event: &edda_core::Event) -> (String, String) {
         return (title.to_string(), body.to_string());
     }
 
+    // task_intake: a task ingested from an external source — a GitHub issue,
+    // via `edda intake`. Named with an underscore, so it is *not* part of the
+    // `task.` family below and needs its own arm; miss it and the issue a task
+    // came from — its title and intent, the richest text any task event carries
+    // — is unsearchable (GH-404).
+    if event.event_type == "task_intake" {
+        let s = |k: &str| payload.get(k).and_then(|v| v.as_str()).unwrap_or("");
+        let arr = |k: &str| {
+            payload
+                .get(k)
+                .and_then(|v| v.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|x| x.as_str())
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                })
+                .unwrap_or_default()
+        };
+        let body = format!("{} {} {}", s("intent"), arr("labels"), arr("constraints"));
+        return (s("title").to_string(), body.trim().to_string());
+    }
+
     // Task events: the searchable payload is the receipt / reason / title, and
     // none of it lives in a `text` field — so without this branch every task
     // event indexed empty and the receipt (the fleet's record of what shipped)
@@ -1151,6 +1174,33 @@ mod tests {
         assert!(
             joined.contains("docs/plan/x.md"),
             "task.created brief_ref must be indexed: {joined:?}"
+        );
+
+        // task_intake is named with an underscore, not a dot, so a `task.`
+        // prefix check silently skips it — yet it carries the richest text of
+        // any task event (a GitHub issue's title and intent). It must index too.
+        let intake = edda_core::event::new_task_intake_event(&edda_core::event::TaskIntakeParams {
+            branch: "main".to_string(),
+            parent_hash: None,
+            source: "github".to_string(),
+            source_id: "404".to_string(),
+            source_url: "https://example/issues/404".to_string(),
+            title: "retrieval coverage and UX".to_string(),
+            intent: "make task receipts searchable".to_string(),
+            labels: vec!["P1".to_string()],
+            priority: "high".to_string(),
+            constraints: vec!["no scoring engine".to_string()],
+        })
+        .unwrap();
+        let (t, b) = extract_event_title_body(&intake);
+        let joined = format!("{t} {b}");
+        assert!(
+            joined.contains("retrieval coverage"),
+            "task_intake title must be indexed: {joined:?}"
+        );
+        assert!(
+            joined.contains("make task receipts searchable"),
+            "task_intake intent must be indexed: {joined:?}"
         );
     }
 

--- a/crates/edda-search-fts/src/indexer.rs
+++ b/crates/edda-search-fts/src/indexer.rs
@@ -105,6 +105,37 @@ fn extract_event_title_body(event: &edda_core::Event) -> (String, String) {
         return (title.to_string(), body.to_string());
     }
 
+    // Task events: the searchable payload is the receipt / reason / title, and
+    // none of it lives in a `text` field — so without this branch every task
+    // event indexed empty and the receipt (the fleet's record of what shipped)
+    // was unreachable via search (GH-404).
+    if let Some(kind) = event.event_type.strip_prefix("task.") {
+        let s = |k: &str| payload.get(k).and_then(|v| v.as_str()).unwrap_or("");
+        let id_tag = payload
+            .get("task_id")
+            .and_then(|v| v.as_u64())
+            .map(|n| format!(" #{n}"))
+            .unwrap_or_default();
+        let (title, body) = match kind {
+            "done" => {
+                let mut body = s("receipt").to_string();
+                // Evidence paths are part of "verified how" — the artifacts a
+                // reader may search by ("which task produced dist/foo").
+                if let Some(ev) = payload.get("evidence_paths").and_then(|v| v.as_array()) {
+                    for p in ev.iter().filter_map(|x| x.as_str()) {
+                        body.push(' ');
+                        body.push_str(p);
+                    }
+                }
+                (format!("task{id_tag} done"), body)
+            }
+            "failed" => (format!("task{id_tag} failed"), s("reason").to_string()),
+            "created" => (s("title").to_string(), s("brief_ref").to_string()),
+            _ => (format!("task{id_tag} {kind}"), String::new()),
+        };
+        return (title, body);
+    }
+
     // Generic: title empty, body = text field
     let text = payload.get("text").and_then(|v| v.as_str()).unwrap_or("");
     (String::new(), text.to_string())
@@ -1059,6 +1090,68 @@ mod tests {
             event_family: None,
             event_level: None,
         }
+    }
+
+    /// A task's searchable text — the receipt for `done`, the reason for
+    /// `failed`, the title and brief for `created` — must reach the indexed
+    /// body. It was being dropped: none of these events carries a `text` field,
+    /// so the generic branch indexed them empty, and `search query "<a receipt
+    /// token>"` found nothing. The receipt is the fleet's answer to "what
+    /// shipped, verified how" (GH-404).
+    #[test]
+    fn task_events_expose_their_text_to_the_index() {
+        let done = edda_core::event::new_task_done_event(
+            "main",
+            None,
+            3,
+            "ENV_LOCK guard added; 110/601 green",
+            &[],
+        )
+        .unwrap();
+        let (t, b) = extract_event_title_body(&done);
+        assert!(
+            format!("{t} {b}").contains("ENV_LOCK"),
+            "task.done receipt must be indexed, got title={t:?} body={b:?}"
+        );
+
+        let failed = edda_core::event::new_task_failed_event(
+            "main",
+            None,
+            4,
+            "flaky under windows contention",
+        )
+        .unwrap();
+        let (t, b) = extract_event_title_body(&failed);
+        assert!(
+            format!("{t} {b}").contains("flaky under windows"),
+            "task.failed reason must be indexed, got {t:?} {b:?}"
+        );
+
+        let created =
+            edda_core::event::new_task_created_event(&edda_core::event::TaskCreatedParams {
+                branch: "main",
+                parent_hash: None,
+                task_id: 5,
+                title: "wire the retrieval snippets",
+                assignee: None,
+                agent_kind: None,
+                after: &[],
+                plan_id: None,
+                work_unit_ref: None,
+                brief_ref: Some("docs/plan/x.md"),
+                idempotency_key: None,
+            })
+            .unwrap();
+        let (t, b) = extract_event_title_body(&created);
+        let joined = format!("{t} {b}");
+        assert!(
+            joined.contains("retrieval snippets"),
+            "task.created title must be indexed: {joined:?}"
+        );
+        assert!(
+            joined.contains("docs/plan/x.md"),
+            "task.created brief_ref must be indexed: {joined:?}"
+        );
     }
 
     #[test]

--- a/crates/edda-search-fts/src/schema.rs
+++ b/crates/edda-search-fts/src/schema.rs
@@ -35,9 +35,13 @@ impl IndexLock {
 }
 
 /// On-disk index schema version (GH-402). Bump whenever the tokenizer or field
-/// layout changes so a stale index is rebuilt rather than mixing tokenizations.
+/// layout changes so a stale index is rebuilt rather than mixing tokenizations
+/// — and also when *what text a document indexes* changes, since already-indexed
+/// documents keep their old body until a rebuild.
 /// v2: CJK bigram tokenizer on all full-text fields.
-pub const INDEX_VERSION: u32 = 2;
+/// v3: task.* events index their receipt/reason/title/brief instead of nothing
+///     (GH-404) — existing indexes hold empty task bodies until this rebuilds.
+pub const INDEX_VERSION: u32 = 3;
 
 fn version_file(index_dir: &Path) -> std::path::PathBuf {
     index_dir.join("edda_schema_version")


### PR DESCRIPTION
## What

Make task receipts (and reasons, and titles) searchable. First of the #404 fixes.

Live, before → after in the edda repo:

```
# before
$ edda search query "GH-401"
No results found for: GH-401          # ← but that string is verbatim in rail task #1's receipt

# after (one-time rebuild of 143 events)
$ edda search query "GH-401"
Found 1 result(s) for: GH-401
  [task.done] evt_01kxhb50wh35…
  decision-provenance «GH»«401» shipped: recorded≠ratified 全鏈…
```

## Root cause (measured, not the issue's framing)

The issue lists three gaps. Reading the code, two of them share one cause and the third is narrower than stated:

- **Task receipts unreachable (real).** `task.*` events already reach the indexer, but `extract_event_title_body` had no task branch — they fell to the generic `body = payload.text`, and no task event has a `text` field. They indexed **empty**.
- **"Search results carry no snippets" (mostly already solved).** `SnippetGenerator` already runs and both render paths already print `r.snippet`. The "bare event ids" the issue saw is an **empty body → empty snippet**, i.e. the *same* root cause. Fixing task bodies gives task hits their snippets, as the live output shows.
- **"ask unranked" (narrower than stated).** `rank_decisions_by_similarity` already does TF-IDF. That's a separate follow-up (exact-key-first), not part of this PR.

So this one change closes the receipt gap *and* the snippet gap for task hits.

## How

A `task.*` branch in the extractor:

| event | title | body |
|---|---|---|
| `task.done` | `task #N done` | receipt + evidence paths |
| `task.failed` | `task #N failed` | reason |
| `task.created` | the task title | brief_ref |

`INDEX_VERSION` 2→3 so existing indexes rebuild once and pick up the task text. Without it the fix only helps *new* events and every already-recorded receipt stays invisible — the exact thing the issue is about. The rebuild is the standard `index_is_outdated` path (GH-402/412); one-time, and the GH-403 turns-early-out keeps it from being the old ~25s.

## Tests

`task_events_expose_their_text_to_the_index` — written RED first (failed with `title="" body=""`), asserts the receipt, reason, title, and brief each reach the indexed text.

`edda-search-fts` 58 passed, `edda` bin 211 passed. clippy 0 at `--all-targets` (counted). fmt clean. Live-verified above.

## Not in this PR (the rest of #404)

- Tasks section in `edda ask` (genuinely missing — `AskResult` has no tasks field).
- Exact-key-first ranking in `ask`.

Part of #404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
