### PR TITLE
fix(bridge-claude): repo-wide auto-claims and orphan claims (GH-444, GH-445)

### DIFF
--- a/crates/edda-bridge-claude/src/dispatch/mod.rs
+++ b/crates/edda-bridge-claude/src/dispatch/mod.rs
@@ -95,47 +95,6 @@ pub(crate) fn render_write_back_protocol(_cwd: &str) -> Option<String> {
     Some(render::writeback())
 }
 
-// ── L2 Solo Gate ──
-
-/// Check if any non-stale peer session heartbeats exist (excluding current session).
-/// Used to skip all L2 I/O when running solo.
-fn has_active_peers(project_id: &str, session_id: &str) -> bool {
-    let state_dir = edda_store::project_dir(project_id).join("state");
-    let stale_threshold: u64 = std::env::var("EDDA_PEER_STALE_SECS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(120);
-    let entries = match fs::read_dir(&state_dir) {
-        Ok(e) => e,
-        Err(_) => return false,
-    };
-    let now = std::time::SystemTime::now();
-    for entry in entries.flatten() {
-        let name = entry.file_name().to_string_lossy().to_string();
-        if !name.starts_with("session.") || !name.ends_with(".json") {
-            continue;
-        }
-        let sid = name
-            .strip_prefix("session.")
-            .and_then(|s| s.strip_suffix(".json"))
-            .unwrap_or("");
-        if sid.is_empty() || sid == session_id {
-            continue;
-        }
-        // Check file modification time as a lightweight staleness check
-        // (avoids parsing JSON — just stat the file)
-        if let Ok(meta) = entry.metadata() {
-            if let Ok(modified) = meta.modified() {
-                let age = now.duration_since(modified).unwrap_or_default();
-                if age.as_secs() <= stale_threshold {
-                    return true;
-                }
-            }
-        }
-    }
-    false
-}
-
 // ── Hook dispatch ──
 
 /// Main hook entrypoint: parse stdin, dispatch by hook_event_name.
@@ -235,16 +194,10 @@ pub fn hook_entrypoint_from_stdin(stdin: &str) -> anyhow::Result<HookResult> {
             Ok(HookResult::empty())
         }
         "SessionEnd" => {
-            // Solo gate: only used to skip coordination log writes (write_unclaim).
-            // Computed here (not at top) so non-SessionEnd hooks avoid the dir scan (#83).
-            let peers_active = !session_id.is_empty() && has_active_peers(&project_id, &session_id);
-            dispatch_session_end(
-                &project_id,
-                &session_id,
-                &transcript_path,
-                &cwd,
-                peers_active,
-            )
+            // The solo gate used to live here, to skip the write_unclaim on
+            // coordination.jsonl. It orphaned claims instead (#445) — cleanup is
+            // now unconditional, so the peer scan is gone with it.
+            dispatch_session_end(&project_id, &session_id, &transcript_path, &cwd)
         }
         "SubagentStart" => {
             // Inject peer context BEFORE writing heartbeat so the sub-agent

--- a/crates/edda-bridge-claude/src/dispatch/session.rs
+++ b/crates/edda-bridge-claude/src/dispatch/session.rs
@@ -622,6 +622,14 @@ pub(super) fn run_postmortem(project_id: &str, session_id: &str, cwd: &str) {
     );
 }
 
+/// True if the coordination board still folds a claim for this session.
+fn session_holds_claim(project_id: &str, session_id: &str) -> bool {
+    crate::peers::compute_board_state(project_id)
+        .claims
+        .iter()
+        .any(|c| c.session_id == session_id)
+}
+
 /// Remove session-scoped state files that are no longer needed.
 pub(super) fn cleanup_session_state(project_id: &str, session_id: &str, peers_active: bool) {
     let state_dir = edda_store::project_dir(project_id).join("state");
@@ -650,7 +658,13 @@ pub(super) fn cleanup_session_state(project_id: &str, session_id: &str, peers_ac
     crate::peers::cleanup_subagent_heartbeats(project_id, session_id);
     // Peer heartbeat + unclaim (L2 — keep remove_heartbeat unconditional as idempotent cleanup)
     crate::peers::remove_heartbeat(project_id, session_id);
-    if peers_active {
+    // Release the claim whenever this session still holds one. Gating on
+    // `peers_active` alone orphaned every solo session's claim in
+    // coordination.jsonl: compaction preserves claims, so `edda gc` never
+    // reclaimed them and the board fold carried them forever (#445).
+    // `peers_active` stays as the cheap path — with peers around, the claim
+    // write is the norm, so skip the board read.
+    if peers_active || session_holds_claim(project_id, session_id) {
         crate::peers::write_unclaim(project_id, session_id);
     }
     // NOTE: The following state files are intentionally NOT deleted here — they

--- a/crates/edda-bridge-claude/src/dispatch/session.rs
+++ b/crates/edda-bridge-claude/src/dispatch/session.rs
@@ -262,7 +262,6 @@ pub(super) fn dispatch_session_end(
     session_id: &str,
     transcript_path: &str,
     cwd: &str,
-    peers_active: bool,
 ) -> anyhow::Result<HookResult> {
     // 1. Final ingest so signals are up-to-date
     ingest_and_build_pack(project_id, session_id, transcript_path, cwd);
@@ -414,7 +413,7 @@ pub(super) fn dispatch_session_end(
     notify_session_end(project_id, cwd, session_id);
 
     // 3. Clean up session-scoped state files
-    cleanup_session_state(project_id, session_id, peers_active);
+    cleanup_session_state(project_id, session_id);
 
     // 4. Collect warnings (pending tasks)
     if let Some(warning) = collect_session_end_warnings(project_id) {
@@ -622,16 +621,8 @@ pub(super) fn run_postmortem(project_id: &str, session_id: &str, cwd: &str) {
     );
 }
 
-/// True if the coordination board still folds a claim for this session.
-fn session_holds_claim(project_id: &str, session_id: &str) -> bool {
-    crate::peers::compute_board_state(project_id)
-        .claims
-        .iter()
-        .any(|c| c.session_id == session_id)
-}
-
 /// Remove session-scoped state files that are no longer needed.
-pub(super) fn cleanup_session_state(project_id: &str, session_id: &str, peers_active: bool) {
+pub(super) fn cleanup_session_state(project_id: &str, session_id: &str) {
     let state_dir = edda_store::project_dir(project_id).join("state");
     // Dedup hash (Step 2)
     let _ = fs::remove_file(state_dir.join(format!("inject_hash.{session_id}")));
@@ -658,15 +649,12 @@ pub(super) fn cleanup_session_state(project_id: &str, session_id: &str, peers_ac
     crate::peers::cleanup_subagent_heartbeats(project_id, session_id);
     // Peer heartbeat + unclaim (L2 — keep remove_heartbeat unconditional as idempotent cleanup)
     crate::peers::remove_heartbeat(project_id, session_id);
-    // Release the claim whenever this session still holds one. Gating on
-    // `peers_active` alone orphaned every solo session's claim in
-    // coordination.jsonl: compaction preserves claims, so `edda gc` never
+    // Unconditional, for the same reason remove_heartbeat is: an Unclaim with no
+    // matching claim is a no-op in the fold, and compaction drops both halves.
+    // Gating this on active peers orphaned every solo session's claim in
+    // coordination.jsonl — compaction preserves claims, so `edda gc` never
     // reclaimed them and the board fold carried them forever (#445).
-    // `peers_active` stays as the cheap path — with peers around, the claim
-    // write is the norm, so skip the board read.
-    if peers_active || session_holds_claim(project_id, session_id) {
-        crate::peers::write_unclaim(project_id, session_id);
-    }
+    crate::peers::write_unclaim(project_id, session_id);
     // NOTE: The following state files are intentionally NOT deleted here — they
     // persist across sessions to provide continuity context at the next SessionStart:
     //   - active_tasks.json  → L1 narrative shows previous session's final task state

--- a/crates/edda-bridge-claude/src/dispatch/tests.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tests.rs
@@ -2,11 +2,10 @@ use std::fs;
 
 // Imports from dispatch/mod.rs
 use super::{
-    apply_context_budget, context_budget, has_active_peers, hook_entrypoint_from_stdin,
-    increment_counter, is_same_as_last_inject, mark_nudge_sent, read_counter,
-    render_workspace_section, render_write_back_protocol, set_compact_pending,
-    take_compact_pending, wrap_context_boundary, write_inject_hash, write_peer_count, HookResult,
-    EDDA_BOUNDARY_END, EDDA_BOUNDARY_START,
+    apply_context_budget, context_budget, hook_entrypoint_from_stdin, increment_counter,
+    is_same_as_last_inject, mark_nudge_sent, read_counter, render_workspace_section,
+    render_write_back_protocol, set_compact_pending, take_compact_pending, wrap_context_boundary,
+    write_inject_hash, write_peer_count, HookResult, EDDA_BOUNDARY_END, EDDA_BOUNDARY_START,
 };
 // Imports from sub-modules
 use super::events::{
@@ -646,7 +645,7 @@ fn session_end_cleans_state() {
     fs::write(state_dir.join(format!("inject_hash.{sid}")), "abcd").unwrap();
     fs::write(state_dir.join("compact_pending"), "1").unwrap();
 
-    cleanup_session_state(pid, sid, false);
+    cleanup_session_state(pid, sid);
 
     assert!(
         !state_dir.join(format!("inject_hash.{sid}")).exists(),
@@ -987,7 +986,7 @@ fn session_end_cleans_nudge_state() {
     let state_dir = edda_store::project_dir(pid).join("state");
     assert!(state_dir.join(format!("nudge_ts.{sid}")).exists());
 
-    cleanup_session_state(pid, sid, false);
+    cleanup_session_state(pid, sid);
 
     assert!(!state_dir.join(format!("nudge_ts.{sid}")).exists());
 
@@ -1106,7 +1105,7 @@ fn session_end_cleans_recall_counters() {
     assert!(state_dir.join(format!("nudge_count.{sid}")).exists());
     assert!(state_dir.join(format!("decide_count.{sid}")).exists());
 
-    cleanup_session_state(pid, sid, false);
+    cleanup_session_state(pid, sid);
 
     assert!(!state_dir.join(format!("nudge_count.{sid}")).exists());
     assert!(!state_dir.join(format!("decide_count.{sid}")).exists());
@@ -1165,36 +1164,42 @@ fn session_end_cleans_signal_count() {
     let state_dir = edda_store::project_dir(pid).join("state");
     assert!(state_dir.join(format!("signal_count.{sid}")).exists());
 
-    cleanup_session_state(pid, sid, false);
+    cleanup_session_state(pid, sid);
 
     assert!(!state_dir.join(format!("signal_count.{sid}")).exists());
 
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }
 
+/// True if any non-stale peer heartbeat exists (excluding `session_id`).
+///
+/// The dispatch layer used to carry its own mtime-based copy of this
+/// (`has_active_peers`), read only by the SessionEnd solo gate that #445
+/// removed. The peers layer owns liveness now; these tests assert the same
+/// behaviour against it.
+fn any_active_peer(project_id: &str, session_id: &str) -> bool {
+    !crate::peers::discover_active_peers(project_id, session_id).is_empty()
+}
+
 #[test]
-fn has_active_peers_false_when_solo() {
+fn no_active_peers_when_solo() {
     let pid = "test_dispatch_solo_gate";
     let _ = edda_store::ensure_dirs(pid);
     // No heartbeat files → no peers
-    assert!(!has_active_peers(pid, "my-session"));
+    assert!(!any_active_peer(pid, "my-session"));
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }
 
 #[test]
-fn has_active_peers_true_when_peer_exists() {
+fn active_peer_seen_when_peer_heartbeat_exists() {
     let pid = "test_dispatch_peer_gate";
     let _ = edda_store::ensure_dirs(pid);
-    let state_dir = edda_store::project_dir(pid).join("state");
-    let _ = fs::create_dir_all(&state_dir);
 
-    // Create a fresh peer heartbeat file
-    let peer_path = state_dir.join("session.peer-session.json");
-    fs::write(&peer_path, r#"{"session_id":"peer-session"}"#).unwrap();
+    crate::peers::write_heartbeat_minimal(pid, "peer-session", "peer", ".");
 
-    assert!(has_active_peers(pid, "my-session"));
+    assert!(any_active_peer(pid, "my-session"));
     // Own session should be excluded
-    assert!(!has_active_peers(pid, "peer-session"));
+    assert!(!any_active_peer(pid, "peer-session"));
 
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }
@@ -1330,30 +1335,31 @@ fn solo_to_multi_session_transition() {
     let _ = fs::create_dir_all(&state_dir);
 
     // Phase 1: Only own heartbeat → solo (no active peers)
-    let own_hb = state_dir.join("session.s1.json");
-    fs::write(&own_hb, r#"{"session_id":"s1"}"#).unwrap();
+    crate::peers::write_heartbeat_minimal(pid, "s1", "mine", ".");
     assert!(
-        !has_active_peers(pid, "s1"),
+        !any_active_peer(pid, "s1"),
         "should be solo with only own heartbeat"
     );
 
     // Phase 2: Peer appears → multi-session
-    let peer_hb = state_dir.join("session.s2.json");
-    fs::write(&peer_hb, r#"{"session_id":"s2"}"#).unwrap();
+    crate::peers::write_heartbeat_minimal(pid, "s2", "peer", ".");
     assert!(
-        has_active_peers(pid, "s1"),
+        any_active_peer(pid, "s1"),
         "should detect peer after heartbeat written"
     );
 
-    // Phase 3: Peer goes stale → back to solo
-    // Sleep to ensure file mtime is in the past, then set threshold to 0
-    std::thread::sleep(std::time::Duration::from_millis(1100));
-    crate::with_env_guard(&[("EDDA_PEER_STALE_SECS", Some("0"))], || {
-        assert!(
-            !has_active_peers(pid, "s1"),
-            "peer should be stale after threshold=0 with old mtime"
-        );
-    });
+    // Phase 3: Peer goes stale → back to solo.
+    // Age the peer's heartbeat directly instead of sleeping and overriding
+    // EDDA_PEER_STALE_SECS — env mutation is what makes this suite flake (#447).
+    let peer_hb = state_dir.join("session.s2.json");
+    let mut hb: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&peer_hb).unwrap()).unwrap();
+    hb["last_heartbeat"] = serde_json::json!("2020-01-01T00:00:00+00:00");
+    fs::write(&peer_hb, serde_json::to_string(&hb).unwrap()).unwrap();
+    assert!(
+        !any_active_peer(pid, "s1"),
+        "peer with an ancient heartbeat should read as stale"
+    );
 
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }
@@ -1378,7 +1384,7 @@ fn session_end_writes_unclaim_for_every_claimed_session() {
 
     // #445: a session that ends solo still has to release its claim, otherwise the
     // claim stays in coordination.jsonl forever (compaction preserves all claims).
-    let _ = dispatch_session_end(pid, "s1", "", cwd.to_str().unwrap(), false);
+    let _ = dispatch_session_end(pid, "s1", "", cwd.to_str().unwrap());
 
     let coord_path = edda_store::project_dir(pid)
         .join("state")
@@ -1400,16 +1406,17 @@ fn session_end_writes_unclaim_for_every_claimed_session() {
         "claim must be gone from the board fold, not orphaned"
     );
 
-    // Write fresh claim for s3 and end with peers_active=true — SHOULD write unclaim
+    // Same with a peer alive (s2 still holds its claim) — unchanged behaviour.
     crate::peers::write_claim(pid, "s3", "infra", &["infra/main.tf".into()]);
-    let _ = dispatch_session_end(pid, "s3", "", cwd.to_str().unwrap(), true);
+    crate::peers::write_heartbeat_minimal(pid, "s2", "billing", ".");
+    let _ = dispatch_session_end(pid, "s3", "", cwd.to_str().unwrap());
 
     let content2 = fs::read_to_string(&coord_path).unwrap_or_default();
     let unclaim_s3 = content2
         .lines()
         .filter(|l| l.contains("\"unclaim\"") && l.contains("s3"))
         .count();
-    assert!(unclaim_s3 > 0, "should have unclaim when peers_active=true");
+    assert!(unclaim_s3 > 0, "should have unclaim with a peer alive too");
 
     std::env::remove_var("EDDA_BRIDGE_AUTO_DIGEST");
     std::env::remove_var("EDDA_PLANS_DIR");
@@ -1419,21 +1426,43 @@ fn session_end_writes_unclaim_for_every_claimed_session() {
 }
 
 #[test]
-fn session_end_skips_unclaim_when_nothing_was_claimed() {
-    let pid = "test_se_unclaim_noise";
+fn unclaim_without_a_claim_is_a_fold_noop() {
+    let pid = "test_se_unclaim_noop";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = edda_store::ensure_dirs(pid);
 
-    // Solo session that never claimed anything: releasing nothing is pure log noise.
-    cleanup_session_state(pid, "s-noclaim", false);
+    // A peer's claim must survive an unrelated session releasing nothing.
+    crate::peers::write_claim(pid, "s-peer", "billing", &["src/bill.rs".into()]);
+    cleanup_session_state(pid, "s-noclaim");
 
-    let coord_path = edda_store::project_dir(pid)
-        .join("state")
-        .join("coordination.jsonl");
-    let content = fs::read_to_string(&coord_path).unwrap_or_default();
+    let board = crate::peers::compute_board_state(pid);
+    assert_eq!(board.claims.len(), 1, "unclaim must not disturb the fold");
+    assert_eq!(board.claims[0].session_id, "s-peer");
+
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn compaction_drops_released_claims_and_never_emits_unclaim() {
+    let pid = "test_se_unclaim_compaction";
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    let _ = edda_store::ensure_dirs(pid);
+
+    // Solo session claims, then ends: claim + unclaim both sit in the log.
+    crate::peers::write_claim(pid, "s-solo", "auth", &["src/auth.rs".into()]);
+    cleanup_session_state(pid, "s-solo");
+
+    // #445 relies on compaction self-healing: `edda gc` rewrites the log from the
+    // folded state, which carries neither the released claim nor its unclaim, so
+    // the pair costs nothing long-term. Verified, not assumed.
+    let lines = crate::peers::compute_board_state_for_compaction(pid);
     assert!(
-        !content.contains("\"unclaim\""),
-        "no claim to release → no unclaim event, got: {content}"
+        !lines.iter().any(|l| l.contains("\"unclaim\"")),
+        "compaction must not re-emit unclaim events, got: {lines:?}"
+    );
+    assert!(
+        !lines.iter().any(|l| l.contains("s-solo")),
+        "released claim must not survive compaction, got: {lines:?}"
     );
 
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
@@ -1467,7 +1496,7 @@ fn session_end_reads_counters_before_cleanup() {
     assert!(state_dir.join(format!("signal_count.{sid}")).exists());
 
     // SessionEnd should read counters then clean them up
-    let result = dispatch_session_end(pid, sid, "", cwd.to_str().unwrap(), false);
+    let result = dispatch_session_end(pid, sid, "", cwd.to_str().unwrap());
     assert!(result.is_ok(), "session_end should not error");
 
     // Counter files should be cleaned up
@@ -1634,7 +1663,7 @@ fn peer_count_cleaned_on_session_end() {
     fs::write(state_dir.join(format!("peer_count.{sid}")), "2").unwrap();
     assert!(state_dir.join(format!("peer_count.{sid}")).exists());
 
-    cleanup_session_state(pid, sid, false);
+    cleanup_session_state(pid, sid);
 
     assert!(
         !state_dir.join(format!("peer_count.{sid}")).exists(),
@@ -2253,7 +2282,7 @@ fn subagent_orphan_cleanup_on_session_end() {
     crate::peers::write_subagent_heartbeat(pid, "sub-2", "parent-sess", "sub:Plan", ".");
 
     // Run cleanup (what SessionEnd does)
-    cleanup_session_state(pid, "parent-sess", false);
+    cleanup_session_state(pid, "parent-sess");
 
     // All sub-agent heartbeats should be cleaned up
     assert!(
@@ -2849,7 +2878,7 @@ fn session_end_bg_threads_joined_zero_threads() {
     // Use a short join timeout to catch hangs quickly
     std::env::set_var("EDDA_BG_JOIN_TIMEOUT_SECS", "1");
 
-    let result = dispatch_session_end(pid, "s1", "", cwd.path().to_str().unwrap(), false);
+    let result = dispatch_session_end(pid, "s1", "", cwd.path().to_str().unwrap());
     assert!(
         result.is_ok(),
         "dispatch_session_end should succeed with zero bg threads"

--- a/crates/edda-bridge-claude/src/dispatch/tests.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tests.rs
@@ -1358,10 +1358,10 @@ fn solo_to_multi_session_transition() {
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }
 
-// ── Issue #148 Gap 7: SessionEnd unclaim gating ──
+// ── Issue #148 Gap 7 / #445: SessionEnd unclaim gating ──
 
 #[test]
-fn session_end_unclaim_only_with_active_peers() {
+fn session_end_writes_unclaim_for_every_claimed_session() {
     let pid = "test_se_unclaim_gate";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = edda_store::ensure_dirs(pid);
@@ -1376,10 +1376,10 @@ fn session_end_unclaim_only_with_active_peers() {
     crate::peers::write_claim(pid, "s1", "auth", &["src/auth.rs".into()]);
     crate::peers::write_claim(pid, "s2", "billing", &["src/bill.rs".into()]);
 
-    // SessionEnd with peers_active=false — should NOT write unclaim
+    // #445: a session that ends solo still has to release its claim, otherwise the
+    // claim stays in coordination.jsonl forever (compaction preserves all claims).
     let _ = dispatch_session_end(pid, "s1", "", cwd.to_str().unwrap(), false);
 
-    // Read coordination.jsonl and check no unclaim for s1
     let coord_path = edda_store::project_dir(pid)
         .join("state")
         .join("coordination.jsonl");
@@ -1388,7 +1388,17 @@ fn session_end_unclaim_only_with_active_peers() {
         .lines()
         .filter(|l| l.contains("\"unclaim\"") && l.contains("s1"))
         .count();
-    assert_eq!(unclaim_count, 0, "no unclaim when peers_active=false");
+    assert_eq!(
+        unclaim_count, 1,
+        "solo session must still release its claim"
+    );
+    assert!(
+        !crate::peers::compute_board_state(pid)
+            .claims
+            .iter()
+            .any(|c| c.session_id == "s1"),
+        "claim must be gone from the board fold, not orphaned"
+    );
 
     // Write fresh claim for s3 and end with peers_active=true — SHOULD write unclaim
     crate::peers::write_claim(pid, "s3", "infra", &["infra/main.tf".into()]);
@@ -1406,6 +1416,27 @@ fn session_end_unclaim_only_with_active_peers() {
     drop(_eg);
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = fs::remove_dir_all(&cwd);
+}
+
+#[test]
+fn session_end_skips_unclaim_when_nothing_was_claimed() {
+    let pid = "test_se_unclaim_noise";
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    let _ = edda_store::ensure_dirs(pid);
+
+    // Solo session that never claimed anything: releasing nothing is pure log noise.
+    cleanup_session_state(pid, "s-noclaim", false);
+
+    let coord_path = edda_store::project_dir(pid)
+        .join("state")
+        .join("coordination.jsonl");
+    let content = fs::read_to_string(&coord_path).unwrap_or_default();
+    assert!(
+        !content.contains("\"unclaim\""),
+        "no claim to release → no unclaim event, got: {content}"
+    );
+
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }
 
 #[test]
@@ -2478,6 +2509,28 @@ fn offlimits_skips_stale_claims() {
     assert!(
         result.is_none(),
         "should not block on claims from stale/missing peers"
+    );
+
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn offlimits_ignores_repo_wide_peer_claim() {
+    let pid = "test-offlimits-repo-wide";
+    let sid = "s-self-wide";
+    let peer_sid = "s-peer-wide";
+    let _ = edda_store::ensure_dirs(pid);
+
+    // #444: legacy branch-fallback auto-claims (and any deliberate repo-wide claim)
+    // would otherwise hard-block every Edit/Write from every peer.
+    crate::peers::write_heartbeat_minimal(pid, peer_sid, "main", ".");
+    crate::peers::write_claim(pid, peer_sid, "main", &["**/*".into()]);
+    write_peer_count(pid, sid, 1);
+
+    let result = check_offlimits(pid, sid, "crates/edda-store/src/lib.rs");
+    assert!(
+        result.is_none(),
+        "a repo-wide claim must not gate peer writes, got {result:?}"
     );
 
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));

--- a/crates/edda-bridge-claude/src/dispatch/tools.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tools.rs
@@ -236,6 +236,15 @@ pub(super) fn check_offlimits(
         if !active_sids.contains(claim.session_id.as_str()) {
             continue;
         }
+        // Skip repo-wide claims (#444). A claim on everything can't express a
+        // coordination boundary — enforcing it blocks every peer write, which
+        // reads as "enforcement is broken". Pre-#444 logs still carry `**/*`
+        // branch-fallback auto-claims, and those sessions keep heartbeating
+        // after an upgrade, so the guard is load-bearing beyond the fallback fix.
+        // Such claims still render in the protocol and on the board, advisory-only.
+        if claim.paths.iter().any(|p| p == "**/*") {
+            continue;
+        }
 
         for glob_pattern in &claim.paths {
             if let Ok(glob) = Glob::new(glob_pattern) {

--- a/crates/edda-bridge-claude/src/peers/autoclaim.rs
+++ b/crates/edda-bridge-claude/src/peers/autoclaim.rs
@@ -5,7 +5,7 @@ use crate::signals::{FileEditCount, SessionSignals};
 
 use super::board::compute_board_state;
 use super::heartbeat::write_claim;
-use super::{autoclaim_state_path, detect_git_branch_in, AutoClaimState};
+use super::{autoclaim_state_path, AutoClaimState};
 
 // ── Auto-Claim ──
 
@@ -139,22 +139,16 @@ pub(crate) fn maybe_auto_claim(
         return;
     }
 
-    // 2. Derive scope from edited files, fallback to git branch
-    let (label, paths) = match derive_scope_from_files(&signals.files_modified, Some(cwd)) {
-        Some(v) => v,
-        None => {
-            // No file edits yet (fresh session) — use the git branch as a fallback
-            // label so the peer is visible in `edda watch` immediately (#128).
-            //
-            // This records *presence*, not scope: the session hasn't touched
-            // anything yet, so it claims no paths. Claiming `**/*` here matched
-            // every file under `enforce_offlimits` and hard-blocked every peer's
-            // Edit/Write for as long as the fresh session's heartbeat lived (#444).
-            match detect_git_branch_in(cwd) {
-                Some(branch) => (branch, Vec::new()),
-                None => return,
-            }
-        }
+    // 2. Derive scope from edited files.
+    //
+    // A fresh session with no edits has no scope to claim, so it claims nothing.
+    // This used to fall back to `(branch, ["**/*"])` for `edda watch` visibility
+    // (#128), but that glob matched every file: under `enforce_offlimits` one
+    // idle session hard-blocked every peer's Edit/Write (#444). Branch presence
+    // now rides on the heartbeat label instead (`write_heartbeat`), which is
+    // where `edda watch` and request delivery already look.
+    let Some((label, paths)) = derive_scope_from_files(&signals.files_modified, Some(cwd)) else {
+        return;
     };
 
     // 3. Dedup: skip if scope unchanged from last auto-claim

--- a/crates/edda-bridge-claude/src/peers/autoclaim.rs
+++ b/crates/edda-bridge-claude/src/peers/autoclaim.rs
@@ -143,10 +143,15 @@ pub(crate) fn maybe_auto_claim(
     let (label, paths) = match derive_scope_from_files(&signals.files_modified, Some(cwd)) {
         Some(v) => v,
         None => {
-            // No file edits yet (fresh session) — use git branch as fallback label
-            // so the peer is visible in `edda watch` immediately (#128)
+            // No file edits yet (fresh session) — use the git branch as a fallback
+            // label so the peer is visible in `edda watch` immediately (#128).
+            //
+            // This records *presence*, not scope: the session hasn't touched
+            // anything yet, so it claims no paths. Claiming `**/*` here matched
+            // every file under `enforce_offlimits` and hard-blocked every peer's
+            // Edit/Write for as long as the fresh session's heartbeat lived (#444).
             match detect_git_branch_in(cwd) {
-                Some(branch) => (branch, vec!["**/*".to_string()]),
+                Some(branch) => (branch, Vec::new()),
                 None => return,
             }
         }

--- a/crates/edda-bridge-claude/src/peers/heartbeat.rs
+++ b/crates/edda-bridge-claude/src/peers/heartbeat.rs
@@ -29,10 +29,24 @@ pub(crate) fn write_heartbeat(
         .map(|h| h.started_at)
         .unwrap_or_else(|| now.clone());
 
+    let branch = detect_git_branch_in(cwd);
+
     let derived_label = label
         .map(|s| s.to_string())
         .or_else(env_label)
-        .unwrap_or_else(|| auto_label(signals, Some(cwd)));
+        .unwrap_or_else(|| {
+            let auto = auto_label(signals, Some(cwd));
+            if auto.is_empty() {
+                // Fresh session: no edits yet, so `auto_label` is empty. Fall back
+                // to the git branch so the peer stays identifiable in `edda watch`
+                // and can still receive `edda request` (#128). This is a presence
+                // signal on the heartbeat — never a scope claim, which is what
+                // used to block every peer under enforce_offlimits (#444).
+                branch.clone().unwrap_or_default()
+            } else {
+                auto
+            }
+        });
 
     let heartbeat = SessionHeartbeat {
         session_id: session_id.to_string(),
@@ -55,7 +69,7 @@ pub(crate) fn write_heartbeat(
             .take(3)
             .map(|c| format!("{} {}", &c.hash[..7.min(c.hash.len())], c.message))
             .collect(),
-        branch: detect_git_branch_in(cwd),
+        branch,
         current_phase: crate::agent_phase::read_phase_state(project_id, session_id)
             .map(|ps| ps.phase.to_string()),
         parent_session_id: None,

--- a/crates/edda-bridge-claude/src/peers/tests.rs
+++ b/crates/edda-bridge-claude/src/peers/tests.rs
@@ -1330,6 +1330,86 @@ fn auto_claim_updates_on_scope_change() {
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }
 
+// ── #444: the branch fallback is a presence signal, not a scope claim ──
+
+/// Create a git repo in a temp dir sitting on `branch` with one commit,
+/// so `detect_git_branch_in` can resolve HEAD.
+fn git_repo_on_branch(branch: &str) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    for args in [
+        vec!["init"],
+        vec!["config", "user.email", "test@test.com"],
+        vec!["config", "user.name", "Test"],
+        vec!["commit", "--allow-empty", "-m", "init"],
+        vec!["checkout", "-b", branch],
+    ] {
+        let _ = std::process::Command::new("git")
+            .args(&args)
+            .current_dir(tmp.path())
+            .output();
+    }
+    tmp
+}
+
+#[test]
+fn auto_claim_branch_fallback_claims_no_paths() {
+    let pid = "test_autoclaim_branch_fallback";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    let repo = git_repo_on_branch("fallback-branch");
+    // Fresh session: no file edits yet, so scope derivation falls back to the branch.
+    let signals = SessionSignals::default();
+
+    maybe_auto_claim(pid, "s1", &signals, repo.path().to_str().unwrap());
+
+    let board = compute_board_state(pid);
+    let claim = board
+        .claims
+        .iter()
+        .find(|c| c.session_id == "s1")
+        .expect("branch fallback should still register presence under the branch label");
+    assert_eq!(claim.label, "fallback-branch");
+    assert!(
+        claim.paths.is_empty(),
+        "branch fallback must claim no scope (it would block every peer write \
+         under enforce_offlimits), got {:?}",
+        claim.paths
+    );
+
+    remove_autoclaim_state(pid, "s1");
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn auto_claim_replaces_branch_fallback_once_files_are_edited() {
+    let pid = "test_autoclaim_fallback_upgrade";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    let repo = git_repo_on_branch("fallback-upgrade");
+    let cwd = repo.path().to_str().unwrap();
+
+    maybe_auto_claim(pid, "s1", &SessionSignals::default(), cwd);
+
+    let signals = SessionSignals {
+        files_modified: vec![FileEditCount {
+            path: "crates/edda-store/src/lib.rs".into(),
+            count: 3,
+        }],
+        ..Default::default()
+    };
+    maybe_auto_claim(pid, "s1", &signals, cwd);
+
+    let board = compute_board_state(pid);
+    let claim = board.claims.iter().find(|c| c.session_id == "s1").unwrap();
+    assert_eq!(claim.label, "edda-store");
+    assert_eq!(claim.paths, vec!["crates/edda-store/*"]);
+
+    remove_autoclaim_state(pid, "s1");
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
 #[test]
 fn auto_claim_cleanup_removes_state_file() {
     let pid = "test_autoclaim_cleanup";

--- a/crates/edda-bridge-claude/src/peers/tests.rs
+++ b/crates/edda-bridge-claude/src/peers/tests.rs
@@ -1352,29 +1352,26 @@ fn git_repo_on_branch(branch: &str) -> tempfile::TempDir {
 }
 
 #[test]
-fn auto_claim_branch_fallback_claims_no_paths() {
+fn auto_claim_writes_no_claim_for_a_fresh_session() {
     let pid = "test_autoclaim_branch_fallback";
     let _ = edda_store::ensure_dirs(pid);
     let _ = fs::remove_file(coordination_path(pid));
 
     let repo = git_repo_on_branch("fallback-branch");
-    // Fresh session: no file edits yet, so scope derivation falls back to the branch.
-    let signals = SessionSignals::default();
-
-    maybe_auto_claim(pid, "s1", &signals, repo.path().to_str().unwrap());
+    // Fresh session: no file edits yet, so there is no scope to claim. This used
+    // to claim `(branch, ["**/*"])`, which blocked every peer under enforcement.
+    maybe_auto_claim(
+        pid,
+        "s1",
+        &SessionSignals::default(),
+        repo.path().to_str().unwrap(),
+    );
 
     let board = compute_board_state(pid);
-    let claim = board
-        .claims
-        .iter()
-        .find(|c| c.session_id == "s1")
-        .expect("branch fallback should still register presence under the branch label");
-    assert_eq!(claim.label, "fallback-branch");
     assert!(
-        claim.paths.is_empty(),
-        "branch fallback must claim no scope (it would block every peer write \
-         under enforce_offlimits), got {:?}",
-        claim.paths
+        board.claims.is_empty(),
+        "a session that edited nothing must claim nothing, got {:?}",
+        board.claims
     );
 
     remove_autoclaim_state(pid, "s1");
@@ -1382,7 +1379,7 @@ fn auto_claim_branch_fallback_claims_no_paths() {
 }
 
 #[test]
-fn auto_claim_replaces_branch_fallback_once_files_are_edited() {
+fn auto_claim_starts_claiming_once_files_are_edited() {
     let pid = "test_autoclaim_fallback_upgrade";
     let _ = edda_store::ensure_dirs(pid);
     let _ = fs::remove_file(coordination_path(pid));
@@ -1407,6 +1404,93 @@ fn auto_claim_replaces_branch_fallback_once_files_are_edited() {
     assert_eq!(claim.paths, vec!["crates/edda-store/*"]);
 
     remove_autoclaim_state(pid, "s1");
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn heartbeat_label_falls_back_to_git_branch_for_a_fresh_session() {
+    let pid = "test_hb_branch_label";
+    let _ = edda_store::ensure_dirs(pid);
+
+    let repo = git_repo_on_branch("presence-branch");
+    // No edits → `auto_label` is empty, so the branch carries the identity.
+    write_heartbeat(
+        pid,
+        "s1",
+        &SessionSignals::default(),
+        None,
+        repo.path().to_str().unwrap(),
+    );
+
+    let hb = read_heartbeat(pid, "s1").expect("heartbeat written");
+    assert_eq!(
+        hb.label, "presence-branch",
+        "fresh session must stay identifiable in `edda watch` without a claim"
+    );
+
+    remove_heartbeat(pid, "s1");
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn fresh_session_receives_requests_addressed_to_its_branch() {
+    let pid = "test_hb_branch_request";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    let repo = git_repo_on_branch("request-branch");
+    let cwd = repo.path().to_str().unwrap();
+
+    // Peer, and a fresh session that has claimed nothing.
+    write_heartbeat(pid, "s-peer", &SessionSignals::default(), Some("auth"), ".");
+    write_heartbeat(pid, "s-fresh", &SessionSignals::default(), None, cwd);
+    maybe_auto_claim(pid, "s-fresh", &SessionSignals::default(), cwd);
+
+    write_request(
+        pid,
+        "s-peer",
+        "auth",
+        "request-branch",
+        "rebase before you push",
+    );
+
+    let pending = pending_requests_for_session(pid, "s-fresh");
+    assert_eq!(
+        pending.len(),
+        1,
+        "branch-addressed request must reach a session with no claim, got {pending:?}"
+    );
+    assert_eq!(pending[0].message, "rebase before you push");
+
+    remove_heartbeat(pid, "s-peer");
+    remove_heartbeat(pid, "s-fresh");
+    remove_autoclaim_state(pid, "s-fresh");
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn two_fresh_sessions_on_one_branch_do_not_block_each_other() {
+    let pid = "test_two_fresh_no_block";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    let repo = git_repo_on_branch("shared-branch");
+    let cwd = repo.path().to_str().unwrap();
+
+    write_heartbeat(pid, "s1", &SessionSignals::default(), None, cwd);
+    write_heartbeat(pid, "s2", &SessionSignals::default(), None, cwd);
+    maybe_auto_claim(pid, "s1", &SessionSignals::default(), cwd);
+    maybe_auto_claim(pid, "s2", &SessionSignals::default(), cwd);
+
+    // Both are visible to each other, and neither has claimed any path — the
+    // mutual deadlock in #444 came from both claiming `**/*`.
+    assert_eq!(discover_active_peers(pid, "s1").len(), 1);
+    assert!(compute_board_state(pid).claims.is_empty());
+
+    remove_heartbeat(pid, "s1");
+    remove_heartbeat(pid, "s2");
+    remove_autoclaim_state(pid, "s1");
+    remove_autoclaim_state(pid, "s2");
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }
 


### PR DESCRIPTION
Both bugs are claim-lifecycle bugs in the Claude bridge, so they land together. Route for GH-444 follows the controller/verifier ruling (presence signal on the heartbeat); see "How this landed" at the bottom for what changed from the first push.

## GH-444 — branch-fallback auto-claim claimed `**/*`

`maybe_auto_claim` fell back to `(branch, ["**/*"])` when a session had no edits yet, so the peer would show up in `edda watch` (#128). Under `enforce_offlimits` that glob matches every file, so one idle session hard-blocked every peer's `Edit`/`Write` until its heartbeat went stale.

**Fix — presence moves to the heartbeat.** The branch name reaches `edda watch` and my-label resolution today *only* through that claim: `auto_label` (`peers/helpers.rs:76-79`) returns `""` for a session with no edits, and `write_claim` never touches the heartbeat. So `write_heartbeat` now falls back to the git branch when `auto_label` yields nothing, and `maybe_auto_claim` emits no claim at all for a session that has edited nothing. Nothing is left for enforcement to match, and identity lives where every consumer already looks:

- TUI peer list reads `hb.label` (`discovery.rs:79`) → non-empty, so `active_peers()` (`edda-cli/src/tui/app.rs:110`) no longer hides the session after 120s. The old `**/*` claim never fixed this — the claim only populated the Claims panel.
- My-label resolution and request delivery already fall back to the heartbeat (`render_coord.rs:33`, `helpers.rs:18`), so `edda request "<branch>"` keeps landing.

**Also kept: `check_offlimits` skips any claim containing `**/*`.** Not redundant with the fallback removal — `coordination.jsonl` is append-only, so sessions that claimed `**/*` before the upgrade keep folding into the board and keep blocking peers until they end. Without the guard the deadlock survives the fix.

**Trade-off, as flagged in the issue:** a deliberate `edda claim "x" --paths "**/*"` no longer hard-blocks peers. It still renders in the coordination protocol and on the board, so it stays advisory. A claim on everything can't express a coordination *boundary* anyway, and its enforcement failure mode is indistinguishable from enforcement being broken. Honouring explicit repo-wide claims would need provenance on `ClaimEntry` (auto vs manual) plus a `board.rs` fold change — out of scope here.

## GH-445 — solo sessions never wrote `Unclaim`

`cleanup_session_state` wrote `Unclaim` only when `peers_active`. A session ending solo left its claim in `coordination.jsonl` with no terminator, and since compaction preserves every claim, `edda gc` never reclaimed it.

**Fix:** write it unconditionally, for the same reason `remove_heartbeat` is unconditional. That leaves `peers_active` unused, so it is removed along the caller chain — `cleanup_session_state`, `dispatch_session_end`, and the `SessionEnd` arm — which also retires dispatch's private mtime-based `has_active_peers` (its only non-test caller was that gate). Its three tests now assert the same liveness behaviour against `discover_active_peers`, which owns liveness for the peers layer.

`remove_heartbeat` → `write_unclaim` ordering is unchanged.

## Same bug elsewhere (not touched)

`edda-bridge-codex`, `-cursor`, `-hermes`, and `-openclaw` each carry their own `cleanup_session_state` with the identical `if peers_active` gate, so GH-445 reproduces in all four. Outside this PR's claimed scope — worth a follow-up issue.

## Verification

Against the stated acceptance criteria:

| Criterion | Test |
|---|---|
| Fresh session claims nothing | `auto_claim_writes_no_claim_for_a_fresh_session` |
| Claiming resumes on first edit | `auto_claim_starts_claiming_once_files_are_edited` |
| Fresh session stays visible with a non-empty label | `heartbeat_label_falls_back_to_git_branch_for_a_fresh_session` |
| `edda request "<branch>"` still delivers | `fresh_session_receives_requests_addressed_to_its_branch` (plus the pre-existing `request_delivered_via_heartbeat_label_no_claim`) |
| Two fresh sessions on one branch don't block each other | `two_fresh_sessions_on_one_branch_do_not_block_each_other` |
| A real claim still blocks under enforcement | `offlimits_blocks_peer_claimed_file` (unchanged, still green) |
| Legacy `**/*` claims don't block | `offlimits_ignores_repo_wide_peer_claim` |
| Solo end releases the claim, board no longer lists it | `session_end_writes_unclaim_for_every_claimed_session` (the reversed-and-renamed `session_end_unclaim_only_with_active_peers`, whose `assert_eq!(unclaim_count, 0)` encoded the bug) |
| Unclaim with no claim is a fold no-op | `unclaim_without_a_claim_is_a_fold_noop` |
| GC compaction self-heals — verified, not assumed | `compaction_drops_released_claims_and_never_emits_unclaim` |

Gates: `cargo fmt --check` clean, `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets` clean, `cargo test -p edda-bridge-claude --lib -- --test-threads=1` 557/557.

Per the fleet test convention, everything ran with `--test-threads=1`; no new test mutates the environment. `solo_to_multi_session_transition` now ages a heartbeat timestamp directly instead of sleeping 1.1s and overriding `EDDA_PEER_STALE_SECS`, removing one env mutation from the suite (GH-447).

Unrelated pre-existing failures on this machine, reproduced on unmodified `main`: `edda-cli cmd_search::tests::foreign_project_uses_its_own_registered_repo` fails even in isolation; `edda-store` registry/skill_registry/user_config tests fail only under parallel execution and pass with `--test-threads=1`. Some `edda-bridge-claude` digest tests also flake under machine load (three consecutive serial runs of this branch gave 7, 1, then 0 failures; a serial run of clean `main` gave 0) — they pass in isolation and this branch touches nothing they read.

## How this landed

The first push recorded the fallback as a zero-path claim, keeping the branch label on the claim event. That preserved label resolution and request delivery but still used a claim to mean "present", and left the TUI's 120s hide in place. The verifier's route — put the label on the heartbeat, emit no claim — is strictly better, and this branch now does that.

Fixes #444
Fixes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)
