### PR TITLE
fix(bridge-claude): ack requests per message, validate and expire targets

### DIFF
--- a/crates/edda-bridge-claude/src/peers/board.rs
+++ b/crates/edda-bridge-claude/src/peers/board.rs
@@ -1,9 +1,11 @@
 use std::fs;
 
+use super::helpers::parse_rfc3339_to_epoch;
 use super::{
-    coordination_path, BindingEntry, BoardState, ClaimEntry, CoordEvent, CoordEventType,
-    RequestAckEntry, RequestEntry, SubagentCompletedEntry,
+    coordination_path, request_ttl_secs, BindingEntry, BoardState, ClaimEntry, CoordEvent,
+    CoordEventType, RequestAckEntry, RequestEntry, SubagentCompletedEntry,
 };
+use crate::parse::now_rfc3339;
 
 // ── Board State Computation ──
 
@@ -73,7 +75,14 @@ pub fn compute_board_state(project_id: &str) -> BoardState {
                     .to_string();
                 let to_label = event.payload["to_label"].as_str().unwrap_or("").to_string();
                 let message = event.payload["message"].as_str().unwrap_or("").to_string();
+                // Pre-GH-442 requests have no id; synthesize a stable one from
+                // the fields that already identify the event on disk.
+                let id = event.payload["id"]
+                    .as_str()
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| format!("legacy:{}:{}", event.session_id, event.ts));
                 requests.push(RequestEntry {
+                    id,
                     from_session: event.session_id,
                     from_label,
                     to_label,
@@ -86,9 +95,18 @@ pub fn compute_board_state(project_id: &str) -> BoardState {
                     .as_str()
                     .unwrap_or("")
                     .to_string();
+                let request_ids: Vec<String> = event.payload["request_ids"]
+                    .as_array()
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                            .collect()
+                    })
+                    .unwrap_or_default();
                 request_acks.push(RequestAckEntry {
                     acker_session: event.session_id,
                     from_label,
+                    request_ids,
                     ts: event.ts,
                 });
             }
@@ -158,6 +176,74 @@ pub fn compute_board_state(project_id: &str) -> BoardState {
     }
 }
 
+// ── Request Delivery Rules ──
+
+/// Current wall clock as epoch seconds, on the same coarse scale the peers
+/// module uses for every other event timestamp.
+fn now_epoch() -> u64 {
+    parse_rfc3339_to_epoch(&now_rfc3339()).unwrap_or(0)
+}
+
+/// True when `session_id` has acknowledged this specific request.
+///
+/// Acks name the request ids they cover (GH-442), so acking one message from a
+/// peer no longer suppresses that peer's later messages. Legacy acks carry no
+/// ids; they fall back to label matching bounded by timestamp, so they can only
+/// suppress requests that already existed when the ack was written.
+fn is_acked(board: &BoardState, request: &RequestEntry, session_id: &str) -> bool {
+    board.request_acks.iter().any(|a| {
+        if a.acker_session != session_id {
+            return false;
+        }
+        if a.request_ids.is_empty() {
+            a.from_label == request.from_label
+                && parse_rfc3339_to_epoch(&a.ts).unwrap_or(0)
+                    >= parse_rfc3339_to_epoch(&request.ts).unwrap_or(0)
+        } else {
+            a.request_ids.iter().any(|id| id == &request.id)
+        }
+    })
+}
+
+/// True when an unacked request has aged past the dead-letter horizon.
+/// An unparseable timestamp never expires — losing a message is worse than
+/// keeping a stale one.
+fn is_expired(request: &RequestEntry, now: u64, ttl: u64) -> bool {
+    match parse_rfc3339_to_epoch(&request.ts) {
+        Some(ts) => now.saturating_sub(ts) > ttl,
+        None => false,
+    }
+}
+
+/// Split the unacked requests addressed to `my_label` into `(live, expired)`.
+///
+/// The single place delivery is decided: every renderer and the pending-request
+/// nudge go through here, so they cannot drift apart on what counts as acked.
+pub fn partition_requests_for_session<'a>(
+    board: &'a BoardState,
+    session_id: &str,
+    my_label: &str,
+) -> (Vec<&'a RequestEntry>, Vec<&'a RequestEntry>) {
+    if my_label.is_empty() {
+        return (Vec::new(), Vec::new());
+    }
+    let now = now_epoch();
+    let ttl = request_ttl_secs();
+    let mut live = Vec::new();
+    let mut expired = Vec::new();
+    for r in board.requests.iter().filter(|r| r.to_label == my_label) {
+        if is_acked(board, r, session_id) {
+            continue;
+        }
+        if is_expired(r, now, ttl) {
+            expired.push(r);
+        } else {
+            live.push(r);
+        }
+    }
+    (live, expired)
+}
+
 /// Compact coordination.jsonl: compute current state and return as JSONL lines.
 /// Used by GC to shrink the append-only log.
 pub fn compute_board_state_for_compaction(project_id: &str) -> Vec<String> {
@@ -195,12 +281,20 @@ pub fn compute_board_state_for_compaction(project_id: &str) -> Vec<String> {
         }
     }
 
-    for request in &board.requests {
+    // Requests and acks past the dead-letter horizon are dropped rather than
+    // carried forward forever (GH-443). An ack is never older than the request
+    // it answers, so TTL-ing both on the same horizon cannot resurrect a
+    // request by outliving its ack.
+    let now = now_epoch();
+    let ttl = request_ttl_secs();
+
+    for request in board.requests.iter().filter(|r| !is_expired(r, now, ttl)) {
         let event = CoordEvent {
             ts: request.ts.clone(),
             session_id: request.from_session.clone(),
             event_type: CoordEventType::Request,
             payload: serde_json::json!({
+                "id": request.id,
                 "from_label": request.from_label,
                 "to_label": request.to_label,
                 "message": request.message,
@@ -211,13 +305,18 @@ pub fn compute_board_state_for_compaction(project_id: &str) -> Vec<String> {
         }
     }
 
-    for ack in &board.request_acks {
+    for ack in board.request_acks.iter().filter(|a| {
+        parse_rfc3339_to_epoch(&a.ts)
+            .map(|ts| now.saturating_sub(ts) <= ttl)
+            .unwrap_or(true)
+    }) {
         let event = CoordEvent {
             ts: ack.ts.clone(),
             session_id: ack.acker_session.clone(),
             event_type: CoordEventType::RequestAck,
             payload: serde_json::json!({
                 "from_label": ack.from_label,
+                "request_ids": ack.request_ids,
             }),
         };
         if let Ok(line) = serde_json::to_string(&event) {

--- a/crates/edda-bridge-claude/src/peers/heartbeat.rs
+++ b/crates/edda-bridge-claude/src/peers/heartbeat.rs
@@ -4,11 +4,11 @@ use std::io::Write;
 use crate::parse::now_rfc3339;
 use crate::signals::SessionSignals;
 
-use super::board::compute_board_state;
-use super::helpers::auto_label;
+use super::board::{compute_board_state, partition_requests_for_session};
+use super::helpers::{auto_label, parse_rfc3339_to_epoch, session_label_from_board};
 use super::{
-    coordination_path, detect_git_branch_in, env_label, heartbeat_path, BindingConflict,
-    CoordEvent, CoordEventType, SessionHeartbeat,
+    coordination_path, detect_git_branch_in, env_label, heartbeat_path, stale_secs,
+    BindingConflict, CoordEvent, CoordEventType, SessionHeartbeat,
 };
 
 // ── Heartbeat Write/Read ──
@@ -273,36 +273,122 @@ pub fn write_binding(project_id: &str, session_id: &str, label: &str, key: &str,
     append_coord_event(project_id, &event);
 }
 
-/// Write a cross-agent request event.
+/// Write a cross-agent request event. Returns the request id.
+///
+/// Every request carries its own id so an ack can name the message it answers
+/// rather than the peer that sent it (GH-442).
 pub fn write_request(
     project_id: &str,
     session_id: &str,
     from_label: &str,
     to_label: &str,
     message: &str,
-) {
+) -> String {
+    let id = ulid::Ulid::new().to_string();
     let event = CoordEvent {
         ts: now_rfc3339(),
         session_id: session_id.to_string(),
         event_type: CoordEventType::Request,
         payload: serde_json::json!({
+            "id": id,
             "from_label": from_label,
             "to_label": to_label,
             "message": message,
         }),
     };
     append_coord_event(project_id, &event);
+    id
 }
 
 /// Write a request acknowledgement event.
+///
+/// Resolves which of `from_label`'s messages are actually outstanding for this
+/// session and records their ids, so the ack retires exactly those messages and
+/// nothing that arrives afterwards.
 pub fn write_request_ack(project_id: &str, session_id: &str, from_label: &str) {
+    let board = compute_board_state(project_id);
+    let my_label = session_label_from_board(&board, project_id, session_id);
+    let (live, _expired) = partition_requests_for_session(&board, session_id, &my_label);
+    let request_ids: Vec<String> = live
+        .iter()
+        .filter(|r| r.from_label == from_label)
+        .map(|r| r.id.clone())
+        .collect();
+
     let event = CoordEvent {
         ts: now_rfc3339(),
         session_id: session_id.to_string(),
         event_type: CoordEventType::RequestAck,
-        payload: serde_json::json!({ "from_label": from_label }),
+        // No resolvable pending message (unidentified session, or an ack for
+        // something already retired): fall back to a label-scoped ack, which
+        // board state bounds by timestamp so it cannot swallow future messages.
+        payload: serde_json::json!({
+            "from_label": from_label,
+            "request_ids": request_ids,
+        }),
     };
     append_coord_event(project_id, &event);
+}
+
+/// Resolve a request target label to the active sessions that would receive it.
+///
+/// Returns the session ids of every non-stale session whose claim label or
+/// heartbeat label matches. Zero means the message is a dead letter — usually a
+/// typo; more than one means the label is ambiguous and the message will land in
+/// several inboxes (GH-443).
+pub fn resolve_request_targets(project_id: &str, to_label: &str) -> Vec<String> {
+    if to_label.is_empty() {
+        return Vec::new();
+    }
+    let state_dir = edda_store::project_dir(project_id).join("state");
+    let entries = match fs::read_dir(&state_dir) {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+    let board = compute_board_state(project_id);
+    let stale_threshold = stale_secs();
+    let now = parse_rfc3339_to_epoch(&now_rfc3339()).unwrap_or(0);
+
+    let mut targets = Vec::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !name.starts_with("session.") || !name.ends_with(".json") {
+            continue;
+        }
+        let hb: SessionHeartbeat = match fs::read_to_string(entry.path())
+            .ok()
+            .and_then(|c| serde_json::from_str(&c).ok())
+        {
+            Some(h) => h,
+            None => continue,
+        };
+
+        // Sub-agents can't touch their heartbeat while running; match the
+        // extended threshold peer discovery already uses for them.
+        let effective_threshold = if hb.parent_session_id.is_some() {
+            stale_threshold * 15
+        } else {
+            stale_threshold
+        };
+        let age = now.saturating_sub(parse_rfc3339_to_epoch(&hb.last_heartbeat).unwrap_or(0));
+        if age > effective_threshold {
+            continue;
+        }
+
+        // Claim wins over heartbeat, matching how a session resolves the label
+        // it answers to — otherwise a claimed session looks reachable under a
+        // stale heartbeat label it no longer reads.
+        let effective_label = board
+            .claims
+            .iter()
+            .find(|c| c.session_id == hb.session_id)
+            .map(|c| c.label.as_str())
+            .unwrap_or(hb.label.as_str());
+        if effective_label == to_label {
+            targets.push(hb.session_id);
+        }
+    }
+    targets
 }
 
 /// Data describing a completed sub-agent's work output.

--- a/crates/edda-bridge-claude/src/peers/helpers.rs
+++ b/crates/edda-bridge-claude/src/peers/helpers.rs
@@ -1,38 +1,34 @@
-use super::board::compute_board_state;
+use super::board::{compute_board_state, partition_requests_for_session};
 use super::heartbeat::read_heartbeat;
-use super::RequestEntry;
+use super::{BoardState, RequestEntry};
 use crate::signals::SessionSignals;
+
+/// Resolve a session's coordination label: an explicit claim wins, the
+/// heartbeat label is the fallback, `""` means unidentified.
+pub fn session_label_from_board(board: &BoardState, project_id: &str, session_id: &str) -> String {
+    board
+        .claims
+        .iter()
+        .find(|c| c.session_id == session_id)
+        .map(|c| c.label.clone())
+        .or_else(|| read_heartbeat(project_id, session_id).map(|hb| hb.label))
+        .unwrap_or_default()
+}
+
+/// Same as [`session_label_from_board`] for callers that have no board yet.
+pub fn resolve_session_label(project_id: &str, session_id: &str) -> String {
+    let board = compute_board_state(project_id);
+    session_label_from_board(&board, project_id, session_id)
+}
 
 pub(crate) fn pending_requests_for_session(
     project_id: &str,
     session_id: &str,
 ) -> Vec<RequestEntry> {
     let board = compute_board_state(project_id);
-
-    // Resolve my label from claim or heartbeat
-    let my_label: String = board
-        .claims
-        .iter()
-        .find(|c| c.session_id == session_id)
-        .map(|c| c.label.clone())
-        .or_else(|| read_heartbeat(project_id, session_id).map(|hb| hb.label))
-        .unwrap_or_default();
-
-    if my_label.is_empty() {
-        return Vec::new();
-    }
-
-    board
-        .requests
-        .into_iter()
-        .filter(|r| r.to_label == my_label)
-        .filter(|r| {
-            !board
-                .request_acks
-                .iter()
-                .any(|a| a.from_label == r.from_label && a.acker_session == session_id)
-        })
-        .collect()
+    let my_label = session_label_from_board(&board, project_id, session_id);
+    let (live, _expired) = partition_requests_for_session(&board, session_id, &my_label);
+    live.into_iter().cloned().collect()
 }
 
 // ── Helpers ──

--- a/crates/edda-bridge-claude/src/peers/mod.rs
+++ b/crates/edda-bridge-claude/src/peers/mod.rs
@@ -14,6 +14,19 @@ pub fn stale_secs() -> u64 {
         .unwrap_or(120)
 }
 
+/// Dead-letter horizon: unacked requests older than this are expired.
+///
+/// Requests are addressed by label, and a label can go away — the session
+/// ended, the scope was renamed, the sender typo'd it. Without a horizon those
+/// requests sit in `coordination.jsonl` forever: invisible to every renderer,
+/// preserved by every compaction. Default 7 days.
+pub fn request_ttl_secs() -> u64 {
+    std::env::var("EDDA_REQUEST_TTL_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(7 * 24 * 60 * 60)
+}
+
 /// Maximum chars for the coordination protocol section.
 fn protocol_budget() -> usize {
     std::env::var("EDDA_PEERS_BUDGET_CHARS")
@@ -116,6 +129,10 @@ pub struct BindingEntry {
 /// A cross-agent request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RequestEntry {
+    /// Stable per-message identity, so an ack can name the message it answers.
+    /// Requests written before GH-442 carry no id on disk and are given a
+    /// synthetic `legacy:{session}:{ts}` one on read.
+    pub id: String,
     pub from_session: String,
     pub from_label: String,
     pub to_label: String,
@@ -128,6 +145,10 @@ pub struct RequestEntry {
 pub struct RequestAckEntry {
     pub acker_session: String,
     pub from_label: String,
+    /// Ids of the requests this ack covers. Empty for legacy acks written
+    /// before GH-442, which fall back to `from_label` + timestamp matching.
+    #[serde(default)]
+    pub request_ids: Vec<String>,
     pub ts: String,
 }
 
@@ -227,7 +248,9 @@ mod render_fleet;
 
 // Re-export public items to preserve API
 pub(crate) use autoclaim::{maybe_auto_claim, maybe_auto_claim_file, remove_autoclaim_state};
-pub use board::{compute_board_state, compute_board_state_for_compaction};
+pub use board::{
+    compute_board_state, compute_board_state_for_compaction, partition_requests_for_session,
+};
 pub use discovery::{discover_active_peers, discover_all_sessions, infer_session_id};
 pub(crate) use heartbeat::{
     cleanup_subagent_heartbeats, ensure_heartbeat_exists, read_heartbeat, resolve_teammate_session,
@@ -235,11 +258,13 @@ pub(crate) use heartbeat::{
     write_subagent_heartbeat, write_task_completed, write_teammate_idle, SubagentReport,
 };
 pub use heartbeat::{
-    find_binding_conflict, remove_heartbeat, touch_heartbeat, write_binding, write_claim,
-    write_heartbeat_minimal, write_request, write_request_ack, write_unclaim,
+    find_binding_conflict, remove_heartbeat, resolve_request_targets, touch_heartbeat,
+    write_binding, write_claim, write_heartbeat_minimal, write_request, write_request_ack,
+    write_unclaim,
 };
 pub use helpers::format_age;
 pub(crate) use helpers::{format_peer_suffix, pending_requests_for_session};
+pub use helpers::{resolve_session_label, session_label_from_board};
 pub(crate) use render_coord::{render_coord_diff, render_peer_updates_with};
 pub use render_coord::{render_coordination_protocol, render_coordination_protocol_with};
 pub use render_fleet::fleet_section;

--- a/crates/edda-bridge-claude/src/peers/render_coord.rs
+++ b/crates/edda-bridge-claude/src/peers/render_coord.rs
@@ -154,11 +154,20 @@ pub fn render_coordination_protocol_with(
 
     // My scope + L2 command instructions
     if let Some(claim) = my_claim {
-        lines.push(format!(
-            "Your scope: **{}** ({})",
-            claim.label,
-            claim.paths.join(", ")
-        ));
+        // A claim with no paths is a presence signal, not a scope. Rendering it
+        // as `Your scope: **main** ()` reads as a bug; say what is missing.
+        if claim.paths.is_empty() {
+            lines.push(format!(
+                "Your scope: **{}** (no paths claimed yet — `edda claim \"{}\" --paths \"src/...\"`)",
+                claim.label, claim.label
+            ));
+        } else {
+            lines.push(format!(
+                "Your scope: **{}** ({})",
+                claim.label,
+                claim.paths.join(", ")
+            ));
+        }
     } else {
         // No claim yet — provide actionable nudge with specific suggestion
         let suggested = suggest_claim_command(my_label, &my_heartbeat);
@@ -258,7 +267,7 @@ pub fn render_coordination_protocol_with(
     if !expired_requests.is_empty() {
         let senders = distinct_senders(&expired_requests);
         lines.push(format!(
-            "### Expired requests (unacked, aged out): {} from {}",
+            "### WARN: {} expired request(s) — unacked past the horizon, from {}",
             expired_requests.len(),
             senders.join(", ")
         ));

--- a/crates/edda-bridge-claude/src/peers/render_coord.rs
+++ b/crates/edda-bridge-claude/src/peers/render_coord.rs
@@ -1,10 +1,12 @@
 use crate::signals::FileEditCount;
 
 use super::autoclaim::derive_scope_from_files;
-use super::board::compute_board_state;
+use super::board::{compute_board_state, partition_requests_for_session};
 use super::discovery::discover_active_peers;
 use super::heartbeat::read_heartbeat;
-use super::helpers::{self, format_age, format_peer_suffix, truncate_to_budget};
+use super::helpers::{
+    self, format_age, format_peer_suffix, session_label_from_board, truncate_to_budget,
+};
 use super::{
     protocol_budget, BoardState, PeerSummary, RequestEntry, SessionHeartbeat, PEER_UPDATES_BUDGET,
 };
@@ -16,6 +18,12 @@ use super::{
 /// - Multi-session: full protocol (peers, claims, bindings, commits, requests).
 /// - Solo with bindings: "## Binding Decisions" section only.
 /// - Solo without bindings: returns None.
+///
+/// Rendering is delivery, not acknowledgement (GH-442). This used to auto-ack
+/// everything it rendered, which meant a compacted context, a crashed turn, or
+/// a model that simply skipped the block all counted as "handled" — and the
+/// sender could not tell the difference. Requests now stay pending until an
+/// explicit `edda request-ack` or the dead-letter horizon.
 pub fn render_coordination_protocol(
     project_id: &str,
     session_id: &str,
@@ -23,43 +31,7 @@ pub fn render_coordination_protocol(
 ) -> Option<String> {
     let peers = discover_active_peers(project_id, session_id);
     let board = compute_board_state(project_id);
-
-    // Resolve my label to identify which requests are "to me"
-    let my_label: String = board
-        .claims
-        .iter()
-        .find(|c| c.session_id == session_id)
-        .map(|c| c.label.clone())
-        .or_else(|| read_heartbeat(project_id, session_id).map(|hb| hb.label))
-        .unwrap_or_default();
-
-    // Collect unacked requests addressed to me (before rendering)
-    let unacked_from_labels: Vec<String> = if !my_label.is_empty() {
-        board
-            .requests
-            .iter()
-            .filter(|r| r.to_label == my_label)
-            .filter(|r| {
-                !board
-                    .request_acks
-                    .iter()
-                    .any(|a| a.from_label == r.from_label && a.acker_session == session_id)
-            })
-            .map(|r| r.from_label.clone())
-            .collect()
-    } else {
-        Vec::new()
-    };
-
-    let result = render_coordination_protocol_with(&peers, &board, project_id, session_id);
-
-    // Auto-ack: the agent has now "seen" these requests at SessionStart.
-    // Write ack events so they won't appear in subsequent renders.
-    for from_label in &unacked_from_labels {
-        super::heartbeat::write_request_ack(project_id, session_id, from_label);
-    }
-
-    result
+    render_coordination_protocol_with(&peers, &board, project_id, session_id)
 }
 
 /// Generate a suggested `edda claim` command based on available session context.
@@ -116,6 +88,17 @@ pub(super) fn suggest_claim_command(label: &str, heartbeat: &Option<SessionHeart
     } else {
         "`edda claim \"<your-task>\" --paths \"<your-scope>/*\"`".to_string()
     }
+}
+
+/// Distinct sender labels in first-seen order, for compact summary lines.
+fn distinct_senders(requests: &[&RequestEntry]) -> Vec<String> {
+    let mut seen: Vec<String> = Vec::new();
+    for r in requests {
+        if !seen.iter().any(|s| s == &r.from_label) {
+            seen.push(r.from_label.clone());
+        }
+    }
+    seen
 }
 
 /// Render full coordination protocol using pre-computed peers and board state.
@@ -258,24 +241,27 @@ pub fn render_coordination_protocol_with(
         }
     }
 
-    // Requests to me (using resolved my_label from claim or heartbeat fallback)
-    // Filter out already-acked requests so stale entries don't accumulate.
-    let my_requests: Vec<&RequestEntry> = board
-        .requests
-        .iter()
-        .filter(|r| r.to_label == my_label && !my_label.is_empty())
-        .filter(|r| {
-            !board
-                .request_acks
-                .iter()
-                .any(|a| a.from_label == r.from_label && a.acker_session == session_id)
-        })
-        .collect();
+    // Requests to me (using resolved my_label from claim or heartbeat fallback).
+    let (my_requests, expired_requests) =
+        partition_requests_for_session(board, session_id, my_label);
     if !my_requests.is_empty() {
         lines.push("### Requests to you".to_string());
         for r in my_requests.iter().take(3) {
             lines.push(format!("- Agent {}: \"{}\"", r.from_label, r.message));
         }
+        // The ack is the only signal the sender gets that this was handled.
+        lines.push("Ack when handled: `edda request-ack \"<peer-label>\"`".to_string());
+    }
+
+    // Dead letters: aged out unacked. Surfaced rather than silently dropped so
+    // a label that nobody answers is visible to whoever is looking (GH-443).
+    if !expired_requests.is_empty() {
+        let senders = distinct_senders(&expired_requests);
+        lines.push(format!(
+            "### Expired requests (unacked, aged out): {} from {}",
+            expired_requests.len(),
+            senders.join(", ")
+        ));
     }
 
     let result = lines.join("\n");
@@ -369,27 +355,8 @@ pub(crate) fn render_peer_updates_with(
     }
 
     // Requests to current session (claim label → heartbeat label fallback)
-    let my_claim = board.claims.iter().find(|c| c.session_id == session_id);
-    let my_heartbeat = read_heartbeat(project_id, session_id);
-    let my_label: &str = if let Some(claim) = my_claim {
-        claim.label.as_str()
-    } else if let Some(ref hb) = my_heartbeat {
-        hb.label.as_str()
-    } else {
-        ""
-    };
-    // Filter out acked requests so stale entries don't appear in peer updates.
-    let my_requests: Vec<&RequestEntry> = board
-        .requests
-        .iter()
-        .filter(|r| r.to_label == my_label && !my_label.is_empty())
-        .filter(|r| {
-            !board
-                .request_acks
-                .iter()
-                .any(|a| a.from_label == r.from_label && a.acker_session == session_id)
-        })
-        .collect();
+    let my_label = session_label_from_board(board, project_id, session_id);
+    let (my_requests, _expired) = partition_requests_for_session(board, session_id, &my_label);
     if !my_requests.is_empty() {
         for r in my_requests.iter().take(2) {
             lines.push(format!(

--- a/crates/edda-bridge-claude/src/peers/tests.rs
+++ b/crates/edda-bridge-claude/src/peers/tests.rs
@@ -283,17 +283,24 @@ fn full_lifecycle_multi_session() {
     assert!(proto.contains("4")); // 3 peers + self = 4 agents
     assert!(proto.contains("JWT RS256"));
 
-    // s2 sees peer updates (lightweight) — check BEFORE render_coordination_protocol
-    // because render_coordination_protocol auto-acks displayed requests.
+    // s2 sees peer updates (lightweight)
     let updates = render_peer_updates(pid, "s2").unwrap();
     assert!(updates.contains("Peers"));
     assert!(updates.contains("Export BillingPlan"));
 
-    // Verify s2 sees the request at SessionStart (auto-acks it)
+    // Verify s2 sees the request at SessionStart. Rendering does not ack it
+    // (GH-442) — the request survives until s2 explicitly acknowledges.
     let proto_s2 = render_coordination_protocol(pid, "s2", ".").unwrap();
     assert!(proto_s2.contains("Export BillingPlan type"));
+    assert!(
+        render_peer_updates(pid, "s2")
+            .unwrap()
+            .contains("Export BillingPlan"),
+        "rendering is delivery, not acknowledgement — request must still show"
+    );
 
-    // After auto-ack, peer updates should no longer show the request
+    // After an explicit ack, peer updates should no longer show the request
+    write_request_ack(pid, "s2", "api");
     let updates_after = render_peer_updates(pid, "s2").unwrap();
     assert!(
         !updates_after.contains("Export BillingPlan"),
@@ -2591,5 +2598,189 @@ fn teammate_idle_writes_coord_event_and_updates_phase() {
     // Cleanup
     remove_heartbeat(pid, teammate_sid);
     let _ = fs::remove_file(coordination_path(pid));
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+// ── GH-442 / GH-443: per-message ack identity, target validation, TTL ──
+
+/// Append a raw Request event with a caller-chosen timestamp, bypassing
+/// `write_request`. Used to age a request past the TTL horizon.
+fn append_request_at(pid: &str, ts: &str, from_session: &str, from_label: &str, to_label: &str) {
+    let event = CoordEvent {
+        ts: ts.to_string(),
+        session_id: from_session.to_string(),
+        event_type: CoordEventType::Request,
+        payload: serde_json::json!({
+            "id": format!("req-{ts}"),
+            "from_label": from_label,
+            "to_label": to_label,
+            "message": "aged request",
+        }),
+    };
+    append_coord_event(pid, &event);
+}
+
+#[test]
+fn second_request_from_same_peer_survives_first_ack() {
+    let pid = "test_gh442_second_request";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    write_claim(pid, "s1", "auth", &["src/auth/*".into()]);
+    write_request(pid, "s2", "billing", "auth", "request A");
+    write_request_ack(pid, "s1", "billing");
+
+    // Same peer sends a second, distinct request after the first was acked.
+    write_request(pid, "s2", "billing", "auth", "request B");
+
+    let pending = pending_requests_for_session(pid, "s1");
+    assert_eq!(
+        pending.len(),
+        1,
+        "only the unacked second request should be pending, got: {pending:?}"
+    );
+    assert_eq!(pending[0].message, "request B");
+
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn render_does_not_auto_ack_requests() {
+    let pid = "test_gh442_no_auto_ack";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"), ".");
+    write_claim(pid, "s1", "auth", &["src/auth/*".into()]);
+    write_request(pid, "s2", "billing", "auth", "Need AuthToken export");
+
+    let rendered = render_coordination_protocol(pid, "s1", ".").unwrap_or_default();
+    assert!(
+        rendered.contains("Need AuthToken export"),
+        "request should render: {rendered}"
+    );
+
+    // Rendering is delivery, not acknowledgement: the request stays pending
+    // until an explicit `edda request-ack`.
+    let pending = pending_requests_for_session(pid, "s1");
+    assert_eq!(
+        pending.len(),
+        1,
+        "rendering must not auto-ack — request should still be pending"
+    );
+
+    write_request_ack(pid, "s1", "billing");
+    assert!(
+        pending_requests_for_session(pid, "s1").is_empty(),
+        "explicit ack should clear the request"
+    );
+
+    remove_heartbeat(pid, "s1");
+    remove_heartbeat(pid, "s2");
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn resolve_request_targets_matches_only_live_labels() {
+    let pid = "test_gh443_resolve_targets";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"), ".");
+    write_claim(pid, "s1", "auth", &["src/auth/*".into()]);
+
+    assert_eq!(
+        resolve_request_targets(pid, "auth"),
+        vec!["s1".to_string()],
+        "an active session holding the label should resolve"
+    );
+    assert!(
+        resolve_request_targets(pid, "aut").is_empty(),
+        "a typo'd label must resolve to nobody"
+    );
+
+    remove_heartbeat(pid, "s1");
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn resolve_request_targets_reports_ambiguous_labels() {
+    let pid = "test_gh443_ambiguous_targets";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("auth"), ".");
+
+    let mut targets = resolve_request_targets(pid, "auth");
+    targets.sort();
+    assert_eq!(
+        targets,
+        vec!["s1".to_string(), "s2".to_string()],
+        "duplicate labels must both surface so the sender can be warned"
+    );
+
+    remove_heartbeat(pid, "s1");
+    remove_heartbeat(pid, "s2");
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn expired_requests_are_not_pending_and_are_compacted_away() {
+    let pid = "test_gh443_request_ttl";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    write_claim(pid, "s1", "auth", &["src/auth/*".into()]);
+    append_request_at(pid, "2020-01-01T00:00:00Z", "s2", "ghost", "auth");
+    write_request(pid, "s2", "billing", "auth", "fresh request");
+
+    let pending = pending_requests_for_session(pid, "s1");
+    assert_eq!(
+        pending.len(),
+        1,
+        "the aged dead letter must not be delivered, got: {pending:?}"
+    );
+    assert_eq!(pending[0].message, "fresh request");
+
+    let lines = compute_board_state_for_compaction(pid);
+    assert!(
+        !lines.iter().any(|l| l.contains("aged request")),
+        "compaction must drop expired requests instead of preserving them forever"
+    );
+    assert!(
+        lines.iter().any(|l| l.contains("fresh request")),
+        "compaction must keep live requests"
+    );
+
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn render_surfaces_expired_requests_as_warning() {
+    let pid = "test_gh443_expired_warning";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("auth"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"), ".");
+    write_claim(pid, "s1", "auth", &["src/auth/*".into()]);
+    append_request_at(pid, "2020-01-01T00:00:00Z", "s2", "ghost", "auth");
+
+    let peers = discover_active_peers(pid, "s1");
+    let board = compute_board_state(pid);
+    let rendered = render_coordination_protocol_with(&peers, &board, pid, "s1").unwrap_or_default();
+    assert!(
+        rendered.contains("Expired requests"),
+        "expired unacked requests should be surfaced, not silently hidden: {rendered}"
+    );
+    assert!(
+        !rendered.contains("aged request"),
+        "expired request bodies should not be rendered as live requests: {rendered}"
+    );
+
+    remove_heartbeat(pid, "s1");
+    remove_heartbeat(pid, "s2");
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }

--- a/crates/edda-bridge-claude/src/peers/tests.rs
+++ b/crates/edda-bridge-claude/src/peers/tests.rs
@@ -2855,3 +2855,80 @@ fn render_pathless_claim_says_what_is_missing() {
     remove_heartbeat(pid, "s2");
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }
+
+/// A timestamp `secs` in the past, in the same format `now_rfc3339` produces.
+/// Lets a test place events at known distances without touching the clock or
+/// any env var.
+fn ts_secs_ago(secs: i64) -> String {
+    (time::OffsetDateTime::now_utc() - time::Duration::seconds(secs))
+        .format(&time::format_description::well_known::Rfc3339)
+        .expect("RFC3339 formatting")
+}
+
+/// Append a Request exactly as pre-GH-442 edda wrote it: no `id` field.
+fn append_legacy_request(pid: &str, ts: &str, from_label: &str, to_label: &str, message: &str) {
+    let event = CoordEvent {
+        ts: ts.to_string(),
+        session_id: "s2".to_string(),
+        event_type: CoordEventType::Request,
+        payload: serde_json::json!({
+            "from_label": from_label,
+            "to_label": to_label,
+            "message": message,
+        }),
+    };
+    append_coord_event(pid, &event);
+}
+
+/// Append a RequestAck exactly as pre-GH-442 edda wrote it: `from_label` only.
+fn append_legacy_ack(pid: &str, ts: &str, acker_session: &str, from_label: &str) {
+    let event = CoordEvent {
+        ts: ts.to_string(),
+        session_id: acker_session.to_string(),
+        event_type: CoordEventType::RequestAck,
+        payload: serde_json::json!({ "from_label": from_label }),
+    };
+    append_coord_event(pid, &event);
+}
+
+#[test]
+fn legacy_ackless_id_log_survives_compaction_without_swallowing_later_requests() {
+    let pid = "test_gh442_legacy_compaction";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    // A log written entirely by the pre-fix binary: no request ids, no
+    // request_ids on the ack. Only the timestamps separate the messages.
+    write_claim(pid, "s1", "auth", &["src/auth/*".into()]);
+    append_legacy_request(pid, &ts_secs_ago(30), "billing", "auth", "legacy request A");
+    append_legacy_ack(pid, &ts_secs_ago(20), "s1", "billing");
+    append_legacy_request(pid, &ts_secs_ago(10), "billing", "auth", "legacy request B");
+
+    let expect_only_b = |stage: &str| {
+        let pending = pending_requests_for_session(pid, "s1");
+        assert_eq!(
+            pending.len(),
+            1,
+            "{stage}: the ack predates B, so only A is retired, got: {pending:?}"
+        );
+        assert_eq!(pending[0].message, "legacy request B", "{stage}");
+    };
+    expect_only_b("before compaction");
+
+    // Compaction rewrites every event through the current serializer. A legacy
+    // ack comes back with an empty `request_ids`, which must keep it on the
+    // timestamp-bounded path rather than promoting it to "acks nothing" or
+    // demoting it to "acks everything from this peer".
+    let lines = compute_board_state_for_compaction(pid);
+    fs::write(coordination_path(pid), format!("{}\n", lines.join("\n"))).unwrap();
+    expect_only_b("after compaction");
+
+    let board = compute_board_state(pid);
+    assert_eq!(board.request_acks.len(), 1, "the ack survives compaction");
+    assert!(
+        board.request_acks[0].request_ids.is_empty(),
+        "a legacy ack must not gain fabricated ids during compaction"
+    );
+
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}

--- a/crates/edda-bridge-claude/src/peers/tests.rs
+++ b/crates/edda-bridge-claude/src/peers/tests.rs
@@ -1940,22 +1940,38 @@ fn compaction_preserves_request_acks() {
         "acked request should not be pending"
     );
 
+    // The same peer sends a second message after the first was acked. A single
+    // request/ack pair cannot tell per-label from per-message matching, so the
+    // round-trip below has to carry two.
+    write_request(pid, "s2", "billing", "auth", "Export InvoiceTotal");
+
     // Compact
     let lines = compute_board_state_for_compaction(pid);
-    assert_eq!(lines.len(), 3, "claim + request + ack = 3 lines");
+    assert_eq!(
+        lines.len(),
+        4,
+        "claim + 2 requests + ack = 4 lines, got: {lines:?}"
+    );
 
     // Write compacted back
     let path = coordination_path(pid);
     let content = lines.join("\n");
     fs::write(&path, format!("{content}\n")).unwrap();
 
-    // After compaction: ack should still exist
+    // After compaction: ack should still exist, and the unacked set must be
+    // unchanged. Compaction re-serializes from board state, so an identity
+    // field missing there is silently stripped and this bug comes back.
     let board_after = compute_board_state(pid);
     assert_eq!(board_after.request_acks.len(), 1);
     let pending_after = pending_requests_for_session(pid, "s1");
-    assert!(
-        pending_after.is_empty(),
-        "acked request should still not be pending after compaction"
+    assert_eq!(
+        pending_after.len(),
+        1,
+        "compaction must preserve which message was acked, got: {pending_after:?}"
+    );
+    assert_eq!(
+        pending_after[0].message, "Export InvoiceTotal",
+        "the acked message stays acked; the later one stays pending"
     );
 
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
@@ -2374,6 +2390,21 @@ fn render_coordination_filters_acked_requests() {
         "acked request should be filtered out: {text}"
     );
 
+    // The same peer sends a second message. One request/ack pair renders the
+    // same either way, so only this second message proves the ack was matched
+    // per message rather than per sender.
+    write_request(pid, "s2", "billing", "auth", "Also export RefreshToken");
+    let board = compute_board_state(pid);
+    let text = render_coordination_protocol_with(&peers, &board, pid, "s1").unwrap();
+    assert!(
+        text.contains("Also export RefreshToken"),
+        "a later request from an already-acked peer must still render: {text}"
+    );
+    assert!(
+        !text.contains("Need AuthToken export"),
+        "the acked message must stay acked: {text}"
+    );
+
     remove_heartbeat(pid, "s1");
     remove_heartbeat(pid, "s2");
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
@@ -2411,6 +2442,18 @@ fn peer_updates_filters_acked_requests() {
     assert!(
         !text.contains("Export BillingPlan"),
         "acked request should be filtered from peer updates: {text}"
+    );
+
+    // Second message from the same peer — the case a per-label ack swallows.
+    write_request(pid, "s2", "billing", "auth", "Export BillingCycle");
+    let text = render_peer_updates(pid, "s1").unwrap();
+    assert!(
+        text.contains("Export BillingCycle"),
+        "a later request from an already-acked peer must still surface: {text}"
+    );
+    assert!(
+        !text.contains("Export BillingPlan"),
+        "the acked message must stay acked: {text}"
     );
 
     remove_heartbeat(pid, "s1");
@@ -2772,12 +2815,40 @@ fn render_surfaces_expired_requests_as_warning() {
     let board = compute_board_state(pid);
     let rendered = render_coordination_protocol_with(&peers, &board, pid, "s1").unwrap_or_default();
     assert!(
-        rendered.contains("Expired requests"),
-        "expired unacked requests should be surfaced, not silently hidden: {rendered}"
+        rendered.contains("WARN") && rendered.contains("expired request"),
+        "expired unacked requests should be surfaced as a warning, not silently hidden: {rendered}"
     );
     assert!(
         !rendered.contains("aged request"),
         "expired request bodies should not be rendered as live requests: {rendered}"
+    );
+
+    remove_heartbeat(pid, "s1");
+    remove_heartbeat(pid, "s2");
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn render_pathless_claim_says_what_is_missing() {
+    let pid = "test_pathless_claim_render";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    write_heartbeat(pid, "s1", &SessionSignals::default(), Some("main"), ".");
+    write_heartbeat(pid, "s2", &SessionSignals::default(), Some("billing"), ".");
+    // A presence-only claim: label, no paths (GH-444/445 branch fallback).
+    write_claim(pid, "s1", "main", &[]);
+
+    let peers = discover_active_peers(pid, "s1");
+    let board = compute_board_state(pid);
+    let rendered = render_coordination_protocol_with(&peers, &board, pid, "s1").unwrap_or_default();
+    assert!(
+        !rendered.contains("**main** ()"),
+        "an empty path list must not render as a broken-looking empty scope: {rendered}"
+    );
+    assert!(
+        rendered.contains("no paths claimed yet"),
+        "a pathless claim should say what is missing: {rendered}"
     );
 
     remove_heartbeat(pid, "s1");

--- a/crates/edda-cli/src/cmd_bridge.rs
+++ b/crates/edda-cli/src/cmd_bridge.rs
@@ -143,6 +143,9 @@ pub enum BridgeClaudeCmd {
         /// Session ID (auto-inferred from active heartbeats if omitted)
         #[arg(long)]
         session: Option<String>,
+        /// Send even when no active session answers to the target label
+        #[arg(long)]
+        force: bool,
     },
     /// Render write-back protocol (static teaching text)
     RenderWriteback,
@@ -316,7 +319,8 @@ pub fn run_bridge(cmd: BridgeCmd, repo_root: &Path) -> anyhow::Result<()> {
                 to,
                 message,
                 session,
-            } => request(repo_root, &to, &message, session.as_deref()),
+                force,
+            } => request(repo_root, &to, &message, session.as_deref(), force),
             BridgeClaudeCmd::RenderWriteback => render_writeback(),
             BridgeClaudeCmd::RenderWorkspace { budget } => render_workspace(repo_root, budget),
             BridgeClaudeCmd::RenderCoordination { session } => {
@@ -889,18 +893,61 @@ pub fn ratify(
 }
 
 /// `edda bridge claude request <to> <message>` — send cross-agent request
+///
+/// The target is a free-string label, so a typo used to be indistinguishable
+/// from a delivered message (GH-443). Resolve it against live sessions first:
+/// nobody listening is an error unless `--force`, and an ambiguous label is a
+/// warning, because the message really will land in several inboxes.
 pub fn request(
     repo_root: &Path,
     to: &str,
     message: &str,
     cli_session: Option<&str>,
+    force: bool,
 ) -> anyhow::Result<()> {
     let project_id = edda_store::project_id(repo_root);
     let (session_id, from_label) = resolve_session_id(cli_session, &project_id, "cli");
 
+    let targets = edda_bridge_claude::peers::resolve_request_targets(&project_id, to);
+    if targets.is_empty() && !force {
+        let active = active_labels(&project_id);
+        let known = if active.is_empty() {
+            "no sessions are currently active".to_string()
+        } else {
+            format!("active labels: {}", active.join(", "))
+        };
+        anyhow::bail!(
+            "no active session answers to '{to}' — {known}\n\
+             check the label, or pass --force to queue the request for a peer that has not started yet"
+        );
+    }
+    if targets.len() > 1 {
+        eprintln!(
+            "warning: '{to}' matches {} active sessions — every one of them will see this request",
+            targets.len()
+        );
+    }
+
     edda_bridge_claude::peers::write_request(&project_id, &session_id, &from_label, to, message);
-    println!("Request sent to [{to}]: \"{message}\"");
+    if targets.is_empty() {
+        println!("Request queued for [{to}] (no active session): \"{message}\"");
+    } else {
+        println!("Request sent to [{to}]: \"{message}\"");
+    }
     Ok(())
+}
+
+/// Labels of every currently active session, for "did you mean" diagnostics.
+fn active_labels(project_id: &str) -> Vec<String> {
+    let stale = edda_bridge_claude::peers::stale_secs();
+    let mut labels: Vec<String> = edda_bridge_claude::peers::discover_all_sessions(project_id)
+        .into_iter()
+        .filter(|p| p.age_secs <= stale && !p.label.is_empty())
+        .map(|p| p.label)
+        .collect();
+    labels.sort();
+    labels.dedup();
+    labels
 }
 
 /// `edda request-ack <from>` — acknowledge a pending request
@@ -1967,5 +2014,44 @@ mod tests {
         std::env::set_var("EDDA_HOOK_TIMEOUT_MS", "5000");
         assert_eq!(hook_timeout_ms(), 5000);
         std::env::remove_var("EDDA_HOOK_TIMEOUT_MS");
+    }
+
+    // ── Request target validation (GH-443) ──
+
+    #[test]
+    fn request_to_unknown_label_is_rejected_unless_forced() {
+        let _store = crate::test_support::isolated_store();
+        let repo = tempfile::tempdir().expect("tempdir");
+        let pid = edda_store::project_id(repo.path());
+        let _ = edda_store::ensure_dirs(&pid);
+        edda_bridge_claude::peers::write_heartbeat_minimal(&pid, "s-auth", "auth", ".");
+
+        let err = request(repo.path(), "aut", "hi", Some("s-cli"), false)
+            .expect_err("a typo'd label must not silently succeed");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("no active session answers to 'aut'"),
+            "error should name the unreachable label: {msg}"
+        );
+        assert!(
+            msg.contains("auth"),
+            "error should list the labels that do exist: {msg}"
+        );
+
+        // --force is the escape hatch for a peer that has not started yet.
+        request(repo.path(), "aut", "hi", Some("s-cli"), true).expect("--force should send anyway");
+        // A live label needs no escape hatch.
+        request(repo.path(), "auth", "hi", Some("s-cli"), false).expect("live label should send");
+
+        let board = edda_bridge_claude::peers::compute_board_state(&pid);
+        assert_eq!(board.requests.len(), 2, "both sent requests are recorded");
+        assert!(
+            !board.requests[0].id.is_empty(),
+            "every request carries an id"
+        );
+        assert_ne!(
+            board.requests[0].id, board.requests[1].id,
+            "ids must be distinct per message"
+        );
     }
 }

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -165,6 +165,9 @@ enum Command {
         /// Session ID (auto-inferred from active heartbeats if omitted)
         #[arg(long)]
         session: Option<String>,
+        /// Send even when no active session answers to the target label
+        #[arg(long)]
+        force: bool,
     },
     /// Acknowledge a pending request from another session
     #[command(name = "request-ack")]
@@ -721,6 +724,9 @@ enum BridgeClaudeCmd {
         /// Session ID (auto-inferred from active heartbeats if omitted)
         #[arg(long)]
         session: Option<String>,
+        /// Send even when no active session answers to the target label
+        #[arg(long)]
+        force: bool,
     },
     /// Render write-back protocol (static teaching text)
     RenderWriteback,
@@ -1034,7 +1040,8 @@ fn main() -> anyhow::Result<()> {
             to,
             message,
             session,
-        } => cmd_bridge::request(&repo_root, &to, &message, session.as_deref()),
+            force,
+        } => cmd_bridge::request(&repo_root, &to, &message, session.as_deref(), force),
         Command::RequestAck { from, session } => {
             cmd_bridge::request_ack(&repo_root, &from, session.as_deref())
         }

--- a/crates/edda-cli/src/skills/coord-request.md
+++ b/crates/edda-cli/src/skills/coord-request.md
@@ -68,9 +68,26 @@ Examples:
 - `edda request "billing" "[need]: Export BillingPlan type from your crate so I can reference it"`
 - `edda request "api" "[info]: Added new error variant ApiError::RateLimit — you may want to handle it"`
 
+If the send fails with "no active session answers to ...", the label is wrong —
+check `edda peers` for the live labels. Only pass `--force` when you are
+deliberately queuing for a peer that has not started yet.
+
 ### Step 5: Verify
 
 Run `edda peers` again to confirm your requests appear in the board state.
+
+### Answering requests addressed to you
+
+Requests you receive stay pending until you acknowledge them — being shown the
+message does not clear it, and the sender has no other signal that it landed.
+Once you have acted on a peer's request:
+
+```bash
+edda request-ack "<their-label>"
+```
+
+This retires only what is outstanding now, so a later message from that same
+peer still reaches you.
 
 ## Output Format
 

--- a/crates/edda-cli/src/tui/ui.rs
+++ b/crates/edda-cli/src/tui/ui.rs
@@ -273,11 +273,20 @@ fn render_requests(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
             // Match the ack to this specific message, not merely to its sender —
             // otherwise every later request from a peer inherits the first ack.
             let is_acked = app.board.request_acks.iter().any(|a| {
-                if a.request_ids.is_empty() {
-                    a.from_label == r.from_label && a.ts >= r.ts
-                } else {
-                    a.request_ids.iter().any(|id| id == &r.id)
+                if !a.request_ids.is_empty() {
+                    return a.request_ids.iter().any(|id| id == &r.id);
                 }
+                // Legacy ack, no ids. Sender and timestamp alone are not enough:
+                // an ack written by some third session for its own mail from the
+                // same peer would show a phantom [ack] here. Require the acker to
+                // actually be the addressee.
+                a.from_label == r.from_label
+                    && a.ts >= r.ts
+                    && app
+                        .board
+                        .claims
+                        .iter()
+                        .any(|c| c.session_id == a.acker_session && c.label == r.to_label)
             });
             let msg = truncate_str(&r.message, 40);
             let line = if is_acked {

--- a/crates/edda-cli/src/tui/ui.rs
+++ b/crates/edda-cli/src/tui/ui.rs
@@ -270,11 +270,15 @@ fn render_requests(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         .requests
         .iter()
         .map(|r| {
-            let is_acked = app
-                .board
-                .request_acks
-                .iter()
-                .any(|a| a.from_label == r.from_label);
+            // Match the ack to this specific message, not merely to its sender —
+            // otherwise every later request from a peer inherits the first ack.
+            let is_acked = app.board.request_acks.iter().any(|a| {
+                if a.request_ids.is_empty() {
+                    a.from_label == r.from_label && a.ts >= r.ts
+                } else {
+                    a.request_ids.iter().any(|id| id == &r.id)
+                }
+            });
             let msg = truncate_str(&r.message, 40);
             let line = if is_acked {
                 format!(" [ack] {} → {}: {msg}", r.from_label, r.to_label)

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -97,7 +97,19 @@ Agents can send requests to each other:
 edda request "billing" "Please expose the invoice total as a public method"
 ```
 
-The target agent sees the request at its next prompt.
+The target agent sees the request at its next prompt. If no active session
+answers to `billing`, the send fails rather than silently going nowhere — pass
+`--force` to queue it for a peer that has not started yet.
+
+The request keeps appearing until the receiving agent acknowledges it:
+
+```bash
+edda request-ack "auth"
+```
+
+That ack covers the messages outstanding at that moment, so a later request
+from the same peer is delivered normally. Requests left unacked for 7 days
+expire and are reported as dead letters.
 
 ## Monitoring
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -223,10 +223,32 @@ edda request <TO> <MESSAGE> [OPTIONS]
 | `TO` | Target session label |
 | `MESSAGE` | Request message |
 | `--session ID` | Session ID (auto-inferred) |
+| `--force` | Send even when no active session answers to `TO` |
 
 ```bash
 edda request "billing" "Please expose invoice total as a public method"
 ```
+
+`TO` is resolved against active sessions before the request is recorded. A
+label nobody answers to is an error — usually a typo — and `--force` queues it
+anyway for a peer that has not started yet. A label held by more than one
+session is a warning: all of them will see the message.
+
+Unacked requests expire after 7 days (`EDDA_REQUEST_TTL_SECS`), after which
+they are reported as expired and dropped by the next `edda gc`.
+
+### `edda request-ack`
+
+Acknowledge requests from a peer.
+
+```bash
+edda request-ack <FROM>
+```
+
+Rendering a request into an agent's context is delivery, not acknowledgement:
+the request keeps appearing until it is acked here, and the ack covers only the
+messages outstanding at that moment — later ones from the same peer still
+arrive.
 
 ### `edda watch`
 


### PR DESCRIPTION
Fixes #442
Fixes #443

## The bug

`edda request` is the only peer-to-peer messaging primitive, and it silently dropped every request after the first one from a given peer. Two defects in the same code chain:

**(a) Auto-ack on render.** `render_coordination_protocol` wrote `RequestAck` events for everything it had just rendered. A compacted context, a crashed turn, or a model that skipped the block all counted as "handled", and the sender had no way to tell delivery from handling.

**(b) Acks keyed by `from_label`.** The ack payload named only the peer, so the ack for message A matched message B from that same peer and suppressed it permanently.

On the send side, `write_request` took a free-string label with no validation, no uniqueness check, and no expiry — a typo'd label produced "request sent", and the dead letter survived every compaction forever.

## What changed

**Per-message identity (GH-442).** Requests carry a ULID. `edda request-ack <from>` resolves what is actually outstanding for this session and records those ids, so an ack retires exactly the messages it saw and nothing that arrives later.

**Rendering is delivery, not acknowledgement (GH-442).** The auto-ack is gone. A request keeps appearing until an explicit `edda request-ack` or until it expires, and the render now carries the ack instruction so the receiving agent knows how to clear it. An ack in the log now genuinely means an agent acted.

**One place decides delivery.** `board::partition_requests_for_session` returns `(live, expired)` and is shared by both renderers, the pending-request nudge, and the ack writer. Previously four call sites each open-coded the same filter — which is how the renderers and the nudge could disagree about what had been seen.

**Target validation (GH-443).** `edda request` resolves the label against non-stale heartbeats + claims first. Zero matches is an error listing the labels that do exist; more than one is a warning, because the message really will land in several inboxes.

**TTL and dead letters (GH-443).** Unacked requests expire after 7 days (`EDDA_REQUEST_TTL_SECS`). Expired ones are surfaced in the coordination render as `### Expired requests (unacked, aged out)` rather than hidden, and compaction drops them instead of preserving them forever.

## Trade-offs

- **Typo is an error, not a warning.** The issue offered "warn (or require `--force`)". Warning-and-send keeps the exact failure mode being fixed — identical feedback whether or not anyone is listening. But sending to a peer that has not booted yet is a legitimate fleet pattern, so `--force` keeps it available and the error message says so. If this proves annoying in practice, downgrading to a warning is a one-line change.
- **ULID over `ack.ts >= request.ts`.** The issue suggested timestamp comparison as an alternative. Rejected: `now_rfc3339` collides within a second, so a request sent in the same second as an ack would be wrongly suppressed — the original bug at finer granularity. Timestamp comparison is kept only as the fallback for legacy acks that carry no ids, where it is strictly better than the unbounded label match it replaces.
- **Requests now persist until acked.** They no longer vanish after one render. This is the point — the sender needs a real signal — but it does mean an agent that never acks will keep seeing the request until the TTL. The render caps at 3 requests and the section is inside the existing char budget.

## Backward compatibility

Existing `coordination.jsonl` files keep working. Requests without an `id` get a synthetic `legacy:{session}:{ts}` one on read; acks without `request_ids` fall back to `from_label` matching **bounded by timestamp**, so a legacy ack can only retire requests that already existed when it was written — it can no longer swallow future messages.

## Files outside the original claim

The three claimed files (`render_coord.rs`, `heartbeat.rs`, `board.rs`) could not carry the fix alone:

- `peers/mod.rs` — `RequestEntry`/`RequestAckEntry` gain fields; TTL config.
- `peers/helpers.rs` — `pending_requests_for_session` had defect (b) verbatim; the nudge is one of the two channels the issue names. Also gained the shared label resolver that three sites had duplicated.
- `edda-cli/cmd_bridge.rs`, `main.rs` — `--force` and target validation for GH-443.
- `edda-cli/tui/ui.rs` — `edda watch` marked requests `[ack]` by sender label, the same defect on a display surface.
- `docs/reference/cli.md`, `docs/guides/multi-agent.md`, `skills/coord-request.md` — the ack is now load-bearing, so the docs and the skill that teach `edda request` have to teach `edda request-ack` too.

`cmd_gc.rs` needed no change: compaction goes through `compute_board_state_for_compaction`, where the TTL now applies.

Noticed in passing, **not** changed: `main.rs` declares dead duplicates of `BridgeCmd`/`BridgeClaudeCmd` that shadow nothing — the live definitions are in `cmd_bridge.rs`. I kept the dead copy in sync rather than let it drift further; deleting it is separate work.

## Verification

- New failing-first tests, in `peers/tests.rs` unless noted:
  - `second_request_from_same_peer_survives_first_ack` — reproduces (b)
  - `render_does_not_auto_ack_requests` — reproduces (a)
  - `resolve_request_targets_matches_only_live_labels` / `..._reports_ambiguous_labels`
  - `expired_requests_are_not_pending_and_are_compacted_away`
  - `render_surfaces_expired_requests_as_warning`
  - `cmd_bridge::tests::request_to_unknown_label_is_rejected_unless_forced`
- `full_lifecycle_multi_session` updated: it asserted the auto-ack contract this PR removes.
- `cargo fmt --check` clean, `cargo clippy --workspace --all-targets` zero warnings, `cargo test -p edda-bridge-claude peers::` 113/113.
- `cargo test --workspace` on this branch fails the same pre-existing, environment-dependent tests that fail on `main` at the merge base (shared-store parallel isolation in `digest::`, `registry::`, `skill_registry::`, `cmd_search::foreign_project_uses_its_own_registered_repo`) — 8 failures here vs 28 on `main` in the same run. None involve peers/requests, and they pass single-threaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
