### PR TITLE
docs(edda-cli): correct coord skills to match CLI reality

### DIFF
--- a/crates/edda-cli/src/skills/coord-handoff.md
+++ b/crates/edda-cli/src/skills/coord-handoff.md
@@ -64,7 +64,15 @@ Include:
 
 ### Step 5: Scope Release
 
-Unclaim happens automatically on session end via the SessionEnd hook. If you need to release scope early before ending the session, note that the unclaim will fire when the session closes.
+Where the Claude Code hooks are wired, unclaim happens automatically on
+session end via the SessionEnd hook — nothing to do.
+
+Where they are not (claims made from a bare CLI, CI, or a host without the
+bridge hooks), the claim outlives the session: there is currently no
+`edda unclaim` verb to release it by hand (GH-455). In that case, say so in
+your handoff summary — peers reading the board should know the claim is dead
+even though it still folds. Enforcement stays safe either way: every consumer
+joins claims against live heartbeats.
 
 ## Output Format
 

--- a/crates/edda-cli/src/skills/coord-request.md
+++ b/crates/edda-cli/src/skills/coord-request.md
@@ -74,7 +74,25 @@ deliberately queuing for a peer that has not started yet.
 
 ### Step 5: Verify
 
-Run `edda peers` again to confirm your requests appear in the board state.
+The send command itself is the verification: a label no active session answers
+to is an error (with the live labels listed), and a label held by several
+sessions prints a warning naming how many will see it. A clean exit with
+`Request sent to [<label>]` means the request is on the board. Do NOT check
+`edda peers` for it — that command lists sessions, not requests.
+
+### Registered letter, not doorbell
+
+`edda request` is a registered letter addressed to a **role**: it is durable,
+acknowledged, and survives the peer dying — a replacement session holding the
+same label receives it on arrival. What it can never do is **wake** anyone:
+delivery happens at the peer's next hook event, and an idle session has no
+next hook event.
+
+If your host has cross-session messaging (a way to send a message that starts
+the peer's next turn), ring after sending: fixate first (`edda request`), then
+send a short host message that only points at it ("coordination request
+pending — run `edda coord`"). Letter first, bell second — the letter is the
+truth, the bell is latency.
 
 ### Answering requests addressed to you
 

--- a/crates/edda-cli/src/skills/coord-review.md
+++ b/crates/edda-cli/src/skills/coord-review.md
@@ -30,12 +30,20 @@ Flag any significant change that lacks a recorded decision.
 
 ### Step 2: Check Unresolved Requests
 
-Run `edda peers` to see the board state including requests.
+Note the tooling boundary first: `edda peers` lists sessions only — it does
+not show requests. Requests addressed to **your** label render via
+`edda coord` (including an `Expired requests` warning line for unacked
+messages past the dead-letter horizon). There is currently no non-interactive
+command that lists the whole board's requests across all labels — the
+`edda watch` TUI panel is the only full view (a machine-readable board dump
+is proposed in GH-446).
 
-List all requests that have NOT been acknowledged:
-- Who sent them and when
-- What they are asking for
-- Whether the target agent is still active
+So review what is reachable:
+- Run `edda coord` — list unacked requests addressed to you, and treat any
+  `Expired requests` line as a WARN (someone's message aged out unanswered)
+- For requests you sent, the send-time validation already confirmed a live
+  target; unacked-by-them is not queryable today — note it as a limitation
+  in the report if it matters for this review
 
 Flag requests that are blocking work.
 


### PR DESCRIPTION
Audit of the four `edda init`-installed coord skills against the post-#448/#451 CLI surface found three instructions teaching steps that cannot work, plus one conceptual correction. All four skills stay — the family split (sync/request/handoff/review) is clean — but:

**coord-request, Step 5 (broken verification):** told agents to confirm sends via `edda peers`, which lists sessions and never shows requests. An agent following it sees nothing → concludes the send failed → double-sends. Replaced with the truth: since #451, send-time validation IS the verification (dead-letter labels error out with live labels listed; ambiguous labels warn).

**coord-request, new section (conceptual):** `edda request` is a **registered letter, not a doorbell** — durable, role-addressed (a replacement session holding the label still receives it), but structurally unable to wake an idle peer (delivery is at the next hook event; idle sessions have none). Where host cross-session messaging exists: fixate first, ring second. This corrects an overstatement in earlier planning that #451 made edda's channel a viable primary doorbell.

**coord-handoff, Step 5 (false promise):** claimed unclaim is always automatic. Only true where the SessionEnd hook is wired; hookless claims outlive the session with no release verb (#455). The skill now says so and tells the agent to flag dead claims in the handoff summary.

**coord-review, Step 2 (broken instruction + tooling gap):** also pointed at `edda peers` for requests. There is currently NO non-interactive board-wide request listing (the `edda watch` TUI panel is the only full view) — scoped the check to what `edda coord` actually shows (requests to you + the Expired-requests dead-letter WARN line) and noted the gap, which #446's `peers --json` extension should close.

Skills are `include_str!`-embedded; `cargo build -p edda` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)