### PR TITLE
feat(edda-cli): coord-orchestrate skill + coordination-discipline naming alignment

### DIFF
--- a/crates/edda-cli/src/cmd_init.rs
+++ b/crates/edda-cli/src/cmd_init.rs
@@ -11,7 +11,10 @@ const SKILLS: &[(&str, &str)] = &[
     ("coord-handoff", include_str!("skills/coord-handoff.md")),
     ("coord-request", include_str!("skills/coord-request.md")),
     ("coord-review", include_str!("skills/coord-review.md")),
-    ("coord-orchestrate", include_str!("skills/coord-orchestrate.md")),
+    (
+        "coord-orchestrate",
+        include_str!("skills/coord-orchestrate.md"),
+    ),
 ];
 
 pub fn execute(repo_root: &Path, no_hooks: bool, force_skills: bool) -> anyhow::Result<()> {

--- a/crates/edda-cli/src/cmd_init.rs
+++ b/crates/edda-cli/src/cmd_init.rs
@@ -11,6 +11,7 @@ const SKILLS: &[(&str, &str)] = &[
     ("coord-handoff", include_str!("skills/coord-handoff.md")),
     ("coord-request", include_str!("skills/coord-request.md")),
     ("coord-review", include_str!("skills/coord-review.md")),
+    ("coord-orchestrate", include_str!("skills/coord-orchestrate.md")),
 ];
 
 pub fn execute(repo_root: &Path, no_hooks: bool, force_skills: bool) -> anyhow::Result<()> {

--- a/crates/edda-cli/src/skills/coord-orchestrate.md
+++ b/crates/edda-cli/src/skills/coord-orchestrate.md
@@ -1,0 +1,99 @@
+---
+name: coord-orchestrate
+description: Use when coordinating two or more sessions on parallel implementation work as the controller — assigning bundles, briefing workers and a verifier, adjudicating mid-flight, and closing with dual review
+---
+
+# Coordination Orchestrate
+
+You are the controller of a multi-session formation. The other coord skills
+teach a session to be a good peer (coord-sync/request/handoff/review); this
+one teaches the seat that runs the whole formation. The companion prose is
+the "Coordination discipline" section of edda's multi-agent guide.
+
+## Layers — never mixed
+
+| Layer | Carrier | Property |
+|---|---|---|
+| Truth | `edda task` / `edda decide` / issue comments | survives any session's death |
+| Doorbell | `edda request`, host cross-session messaging | may drop — never the only copy |
+| Isolation | one git worktree per work bundle | conflicts impossible, not discouraged |
+
+Core rule: **messages may drop; state may not.** Every load-bearing fact is
+fixated in the truth layer FIRST, then doorbelled.
+
+## Formation
+
+1 controller (you) + 1 read-only verifier + N workers. The verifier is
+mandatory from 2 workers up — it is the highest-leverage seat, not a wasted
+worker: your review inherits your own spec blind spots, and end-only review
+is reactive.
+
+The whole formation — you included — produces delivery candidates and
+**execution evidence**, not acceptance. A worker's `edda task done --receipt`
+proves what was done and how it was verified; sign-off belongs to whoever
+holds merge authority outside the formation, unless explicitly delegated.
+
+## Protocol
+
+1. **Decompose.** Bundle by code-chain cohesion (same chain → same worker,
+   serial). Ownership per file, per SECTION where bundles share a file.
+2. **Ledger first.** `edda task new "<bundle>" --assignee <label>` per
+   bundle. Specs live in issues, never only in messages.
+3. **Brief workers** — self-contained (they have zero context): issues to
+   read, worktree + branch command, `edda claim` label and paths, files
+   owned/forbidden, quality gates verbatim, done = PR (never merge) +
+   `edda task done --receipt` . Include the receiver tie-break verbatim
+   (see Traffic rules).
+4. **Brief the verifier — read-only, starts BEFORE code:** baseline gates on
+   main; flake hunt; observable-behavior criteria per issue; sweep for two
+   test poisons — tests asserting the behavior being removed (invert and
+   rename, never delete) and single-case tests that pass either way (demand
+   the second case).
+5. **Relay loop:** verifier intel → spot-check the load-bearing claims
+   yourself → adjudicate → fixate as issue comment → doorbell affected
+   workers. Never fixate an unverified claim.
+6. **Track without interrupting:** workers' done-bells + background poll on
+   `edda task list` / PR state + read-only peeks. "Queued" means busy — fine.
+7. **Close:** receipt on the rail → your review + verifier's adversarial
+   review, independently → the merge authority integrates.
+
+## Traffic rules (messages WILL cross)
+
+- Rulings live in the truth layer with monotonic ids (d-001, d-002, …);
+  messages carry only pointers. Numbering is the ordering.
+- Changing or accepting a deviation from a prior ruling requires a
+  SUPERSEDES entry in the same durable place, before any doorbell.
+- Receiver tie-break (verbatim in every brief): obey the highest d-NNN in
+  the ledger, not the latest message; on conflict reply with your state
+  instead of executing; never discard pushed work unless the ruling names
+  the exact commit.
+- Reviews pin a full SHA, never a PR number; the branch freezes from
+  assignment to verdict; any push voids the verdict. Report claims are
+  tagged ran-vs-read — a harness count you executed is evidence, a test
+  described in someone's message is not.
+- Code-touching instructions carry intent + basis SHA + a drift branch
+  ("if your HEAD differs, satisfy the intent and reply with your SHA").
+- Write a board line at every transition: `edda note --tag fleet-board`
+  ("<lane>@<sha> FROZEN review-pending | ..."). The confused read the
+  board, not chat history.
+
+## Doorbell vs registered letter
+
+`edda request` is a registered letter to a **role**: durable, acknowledged,
+survives session replacement — and structurally unable to wake an idle peer.
+Host cross-session messaging is the bell: it wakes, but binds to one session
+and may not exist. Both present → letter first, bell second. Terminal-only →
+letters at the peers' natural cadence. Bell-only → ring, ledger as backstop.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| All sessions implement, review at end | verifier from 2 workers up, audit before code |
+| Truth only in messages | fixate to ledger/issue, then doorbell |
+| Accepting a deviation without revoking the old ruling | SUPERSEDES in the same place, then bell |
+| Review assigned to a PR, not a SHA | pin + freeze + void-on-push |
+| Worker obeys latest message over ledger | tie-break: highest d-NNN wins, reply don't execute |
+| Controller reads worker diffs mid-flight | compressed signals only until review time |
+| Verifier fixes things | read-only, always |
+| Treating a worker receipt as acceptance | receipts are execution evidence; sign-off lives outside the formation |

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -111,16 +111,17 @@ That ack covers the messages outstanding at that moment, so a later request
 from the same peer is delivered normally. Requests left unacked for 7 days
 expire and are reported as dead letters.
 
-## Fleet discipline
+## Coordination discipline
 
 Edda's primitives — heartbeats, claims, requests — are carriers, and every
 carrier here is unreliable by design: requests deliver at the peer's next hook
 event, host cross-session messages deliver at turn boundaries, sessions die,
 and the log replays whatever was never released. Running several sessions on
 real work needs a discipline **on top of** the carriers. This one is distilled
-from a live multi-session run on this repository (the fleet that landed
-GH-442 through GH-445); every rule below exists because its absence cost that
-fleet a concrete incident.
+from a live multi-session run on this repository (the session formation that
+landed GH-442 through GH-445); every rule below exists because its absence
+cost that formation a concrete incident. The `coord-orchestrate` skill
+(installed by `edda init`) is the executable form of this section.
 
 ### Three layers, never mixed
 
@@ -172,9 +173,10 @@ harmless by pinning everything normative:
 - **Code-touching instructions carry intent + basis SHA + a drift branch**
   ("if your HEAD differs, satisfy the intent and reply with your SHA").
   Transit delay makes "current state" language false by construction.
-- **Fleet board.** The controller writes one state line at every transition
-  (per lane: SHA, frozen?, review status) — `edda note --tag fleet-board`.
-  Whoever wakes up confused reads the board, not the chat history.
+- **Coordination board.** The controller writes one state line at every
+  transition (per lane: SHA, frozen?, review status) — e.g.
+  `edda note --tag fleet-board`. Whoever wakes up confused reads the board,
+  not the chat history.
 
 ### What is edda's and what is not
 
@@ -183,7 +185,13 @@ issue comments; the doorbell can be `edda request` or the host's
 cross-session messaging; the rules survive substituting either. What edda
 adds over a bare issue tracker: local zero-network coordination, hash-chained
 auditability, task receipts that unlock successors (`edda task done
---receipt`), and cross-repo fleet queries.
+--receipt`), and cross-repo group queries.
+
+One boundary worth stating: a worker's `--receipt` is **execution evidence**
+— proof of what was done and how it was verified. It is not acceptance. The
+formation (controller and verifier included) produces delivery candidates
+and evidence; sign-off belongs to whoever holds merge authority outside it,
+unless that authority was explicitly delegated.
 
 ## Monitoring
 


### PR DESCRIPTION
Two delegated rulings applied (both recorded as shared-scope decisions in the ledger):

**New skill: `coord-orchestrate`** — the fifth member of the coord family, covering the seat the other four don't: the controller running a multi-session formation. Installed by `edda init` alongside its siblings. Content mirrors the multi-agent guide's Coordination discipline section: layer separation, mandatory verifier from 2 workers up, numbered rulings + supersession duty, receiver tie-break, SHA-pinned frozen reviews with ran-vs-read provenance, board convention, and the registered-letter-vs-doorbell distinction (per the #446 framing correction: `edda request` cannot wake an idle peer and never will; host messaging is the wake path where it exists).

**Naming + evidence alignment** (`naming.session-coordination=execution-fleet-interior`, `evidence.worker-receipt=execution-evidence-not-receipt`): the docs section drops the "Fleet" title — that term is reserved by the methodology umbrella one level up — and now states the receipt boundary explicitly: worker receipts are execution evidence; acceptance and sign-off live outside the executing formation unless explicitly delegated.

Also removes `gt444/` — an empty accidental `git init` leftover from the fleet run.

`cargo build -p edda` and cmd_init tests pass; skills are `include_str!`-embedded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)