### PR TITLE
fix: reliability wave 1 redaction and test isolation

### DIFF
--- a/crates/edda-bridge-claude/src/digest/tests.rs
+++ b/crates/edda-bridge-claude/src/digest/tests.rs
@@ -11,10 +11,60 @@ use super::*;
 use std::io::Write;
 use std::sync::{MutexGuard, PoisonError};
 
-fn env_guard() -> MutexGuard<'static, ()> {
-    crate::ENV_LOCK
+struct EnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    previous_store_root: Option<std::ffi::OsString>,
+    _store_root: tempfile::TempDir,
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match self.previous_store_root.take() {
+            Some(root) => std::env::set_var("EDDA_STORE_ROOT", root),
+            None => std::env::remove_var("EDDA_STORE_ROOT"),
+        }
+    }
+}
+
+impl EnvGuard {
+    fn new(lock: MutexGuard<'static, ()>) -> Self {
+        let previous_store_root = std::env::var_os("EDDA_STORE_ROOT");
+        let store_root = tempfile::tempdir().unwrap();
+        std::env::set_var("EDDA_STORE_ROOT", store_root.path());
+        Self {
+            _lock: lock,
+            previous_store_root,
+            _store_root: store_root,
+        }
+    }
+}
+
+fn env_guard() -> EnvGuard {
+    let lock = crate::ENV_LOCK
         .lock()
-        .unwrap_or_else(PoisonError::into_inner)
+        .unwrap_or_else(PoisonError::into_inner);
+    EnvGuard::new(lock)
+}
+
+#[test]
+fn env_guard_isolates_store_root_and_restores_on_drop() {
+    let lock = crate::ENV_LOCK
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
+    let before = std::env::var_os("EDDA_STORE_ROOT");
+    let guard = EnvGuard::new(lock);
+    let inside = std::env::var_os("EDDA_STORE_ROOT");
+    assert_ne!(inside, before, "fixture needs a private store root");
+    drop(guard);
+
+    let _lock = crate::ENV_LOCK
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
+    assert_eq!(
+        std::env::var_os("EDDA_STORE_ROOT"),
+        before,
+        "fixture must restore the caller environment"
+    );
 }
 
 fn write_session_ledger(dir: &Path, lines: &[serde_json::Value]) -> std::path::PathBuf {

--- a/crates/edda-bridge-claude/src/digest/tests.rs
+++ b/crates/edda-bridge-claude/src/digest/tests.rs
@@ -9,6 +9,13 @@ use super::render::*;
 use super::*;
 
 use std::io::Write;
+use std::sync::{MutexGuard, PoisonError};
+
+fn env_guard() -> MutexGuard<'static, ()> {
+    crate::ENV_LOCK
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}
 
 fn write_session_ledger(dir: &Path, lines: &[serde_json::Value]) -> std::path::PathBuf {
     let path = dir.join("test_session.jsonl");
@@ -418,6 +425,7 @@ fn digest_hash_chain_ready() {
 fn setup_digest_workspace(tmp: &Path) -> (std::path::PathBuf, String) {
     // Create workspace
     let workspace = tmp.join("repo");
+    std::fs::create_dir_all(workspace.join(".git")).unwrap();
     let paths = edda_ledger::EddaPaths::discover(&workspace);
     edda_ledger::ledger::init_workspace(&paths).unwrap();
     edda_ledger::ledger::init_head(&paths, "main").unwrap();
@@ -442,6 +450,7 @@ fn write_store_session_ledger(project_id: &str, session_id: &str, lines: &[serde
 
 #[test]
 fn digest_writes_to_workspace_ledger() {
+    let _env = env_guard();
     let tmp = tempfile::tempdir().unwrap();
     let (workspace, project_id) = setup_digest_workspace(tmp.path());
 
@@ -476,6 +485,7 @@ fn digest_writes_to_workspace_ledger() {
 
 #[test]
 fn digest_maintains_hash_chain() {
+    let _env = env_guard();
     let tmp = tempfile::tempdir().unwrap();
     let (workspace, project_id) = setup_digest_workspace(tmp.path());
 
@@ -512,6 +522,7 @@ fn digest_maintains_hash_chain() {
 
 #[test]
 fn digest_skips_already_digested() {
+    let _env = env_guard();
     let tmp = tempfile::tempdir().unwrap();
     let (workspace, project_id) = setup_digest_workspace(tmp.path());
 
@@ -544,6 +555,7 @@ fn digest_skips_already_digested() {
 
 #[test]
 fn digest_no_reduplicate_across_sessions() {
+    let _env = env_guard();
     let tmp = tempfile::tempdir().unwrap();
     let (workspace, project_id) = setup_digest_workspace(tmp.path());
 
@@ -586,6 +598,7 @@ fn digest_no_reduplicate_across_sessions() {
 
 #[test]
 fn digest_no_workspace_records_failure() {
+    let _env = env_guard();
     let tmp = tempfile::tempdir().unwrap();
     // No workspace created — just a store
     let project_id = "fake_project_no_workspace";
@@ -618,6 +631,7 @@ fn digest_no_workspace_records_failure() {
 
 #[test]
 fn digest_permanent_failure_after_3_retries() {
+    let _env = env_guard();
     let tmp = tempfile::tempdir().unwrap();
     let project_id = "fake_project_perm_fail";
     let _ = edda_store::ensure_dirs(project_id);
@@ -652,6 +666,7 @@ fn digest_permanent_failure_after_3_retries() {
 
 #[test]
 fn digest_state_round_trip() {
+    let _env = env_guard();
     let project_id = "test_state_rt";
     // Writes to the real per-user store and, unlike its neighbours, never
     // cleaned up — so it left `projects/test_state_rt` on every developer
@@ -787,6 +802,7 @@ fn extract_exit_code_from_error_field() {
 
 #[test]
 fn digest_writes_cmd_milestones_to_workspace() {
+    let _env = env_guard();
     let tmp = tempfile::tempdir().unwrap();
     let (workspace, project_id) = setup_digest_workspace(tmp.path());
 
@@ -835,6 +851,7 @@ fn digest_writes_cmd_milestones_to_workspace() {
 
 #[test]
 fn digest_skips_cmd_milestones_when_disabled() {
+    let _env = env_guard();
     let tmp = tempfile::tempdir().unwrap();
     let (workspace, project_id) = setup_digest_workspace(tmp.path());
 
@@ -873,6 +890,7 @@ fn digest_skips_cmd_milestones_when_disabled() {
 
 #[test]
 fn manual_digest_specific_session() {
+    let _env = env_guard();
     let tmp = tempfile::tempdir().unwrap();
     let (workspace, project_id) = setup_digest_workspace(tmp.path());
 
@@ -906,6 +924,7 @@ fn manual_digest_specific_session() {
 
 #[test]
 fn prev_digest_roundtrip() {
+    let _env = env_guard();
     let pid = "test_prev_digest_rt";
     let _ = edda_store::ensure_dirs(pid);
 
@@ -947,6 +966,7 @@ fn prev_digest_roundtrip() {
 
 #[test]
 fn prev_digest_empty_tasks() {
+    let _env = env_guard();
     let pid = "test_prev_digest_empty";
     let _ = edda_store::ensure_dirs(pid);
 
@@ -971,6 +991,7 @@ fn prev_digest_empty_tasks() {
 
 #[test]
 fn prev_digest_with_decisions_and_notes() {
+    let _env = env_guard();
     let pid = "test_prev_digest_dn";
     let _ = edda_store::ensure_dirs(pid);
 
@@ -1002,6 +1023,7 @@ fn prev_digest_with_decisions_and_notes() {
 
 #[test]
 fn prev_digest_backward_compat() {
+    let _env = env_guard();
     let pid = "test_prev_digest_compat";
     let _ = edda_store::ensure_dirs(pid);
 
@@ -1130,6 +1152,7 @@ fn collect_session_ledger_extras_no_workspace() {
 
 #[test]
 fn digest_skips_empty_session() {
+    let _env = env_guard();
     let tmp = tempfile::tempdir().unwrap();
     let (workspace, project_id) = setup_digest_workspace(tmp.path());
 
@@ -1219,6 +1242,7 @@ fn digest_event_empty_notes_backward_compat() {
 
 #[test]
 fn prev_digest_has_recall_fields() {
+    let _env = env_guard();
     let pid = "test_prev_digest_recall";
     let _ = edda_store::ensure_dirs(pid);
 
@@ -1442,6 +1466,7 @@ fn passive_harvest_empty_deps_no_events() {
 
 #[test]
 fn prev_digest_has_signal_count() {
+    let _env = env_guard();
     let pid = "test_prev_digest_signal";
     let _ = std::fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = edda_store::ensure_dirs(pid);
@@ -1464,6 +1489,7 @@ fn prev_digest_has_signal_count() {
 
 #[test]
 fn prev_digest_has_tool_breakdown() {
+    let _env = env_guard();
     let pid = "test_prev_digest_tool_bd";
     let _ = std::fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = edda_store::ensure_dirs(pid);

--- a/crates/edda-bridge-claude/src/dispatch/tests.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tests.rs
@@ -1031,6 +1031,7 @@ fn write_back_protocol_contains_examples() {
 
 #[test]
 fn counter_increment_and_read() {
+    let _env = env_guard();
     let pid = "test_counter_ops";
     let sid = "sess-counter-1";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
@@ -1191,6 +1192,7 @@ fn any_active_peer(project_id: &str, session_id: &str) -> bool {
 
 #[test]
 fn no_active_peers_when_solo() {
+    let _env = env_guard();
     let pid = "test_dispatch_solo_gate";
     let _ = edda_store::ensure_dirs(pid);
     // No heartbeat files → no peers
@@ -1200,6 +1202,7 @@ fn no_active_peers_when_solo() {
 
 #[test]
 fn active_peer_seen_when_peer_heartbeat_exists() {
+    let _env = env_guard();
     let pid = "test_dispatch_peer_gate";
     let _ = edda_store::ensure_dirs(pid);
 

--- a/crates/edda-bridge-claude/src/dispatch/tests.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tests.rs
@@ -162,6 +162,7 @@ fn pre_tool_use_with_patterns() {
 
 #[test]
 fn compact_pending_flag_lifecycle() {
+    let _env = env_guard();
     // Use a unique fake project id to avoid collisions with real state
     let pid = "test_compact_pending_00";
     let _ = edda_store::ensure_dirs(pid);
@@ -432,6 +433,7 @@ fn active_plan_truncates_to_budget() {
 
 #[test]
 fn session_start_includes_signals() {
+    let _env = env_guard();
     let pid = "test_session_start_signals";
     let _ = edda_store::ensure_dirs(pid);
 
@@ -459,6 +461,7 @@ fn session_start_includes_signals() {
     let pack_dir = edda_store::project_dir(pid).join("packs");
     let _ = fs::create_dir_all(&pack_dir);
     let _ = fs::write(pack_dir.join("hot.md"), "# edda memory pack (hot)\n");
+    drop(_env);
 
     crate::with_env_guard(
         &[("EDDA_PLANS_DIR", Some("/nonexistent/plans/dir"))],
@@ -495,11 +498,13 @@ fn session_start_includes_signals() {
         },
     );
 
+    let _env = env_guard();
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }
 
 #[test]
 fn session_start_no_signals_no_extra_sections() {
+    let _env = env_guard();
     let pid = "test_session_start_no_signals";
     let _ = edda_store::ensure_dirs(pid);
 
@@ -507,6 +512,7 @@ fn session_start_no_signals_no_extra_sections() {
     let pack_dir = edda_store::project_dir(pid).join("packs");
     let _ = fs::create_dir_all(&pack_dir);
     let _ = fs::write(pack_dir.join("hot.md"), "# edda memory pack (hot)\n");
+    drop(_env);
 
     crate::with_env_guard(
         &[("EDDA_PLANS_DIR", Some("/nonexistent/plans/dir"))],
@@ -535,6 +541,7 @@ fn session_start_no_signals_no_extra_sections() {
         },
     );
 
+    let _env = env_guard();
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }
 
@@ -598,6 +605,7 @@ fn hook_result_from_option_none() {
 
 #[test]
 fn dedup_skips_identical_context() {
+    let _env = env_guard();
     let pid = "test_dedup_skip";
     let sid = "sess-dedup-1";
     let _ = edda_store::ensure_dirs(pid);
@@ -613,6 +621,7 @@ fn dedup_skips_identical_context() {
 
 #[test]
 fn dedup_injects_changed_context() {
+    let _env = env_guard();
     let pid = "test_dedup_changed";
     let sid = "sess-dedup-2";
     let _ = edda_store::ensure_dirs(pid);
@@ -627,6 +636,7 @@ fn dedup_injects_changed_context() {
 
 #[test]
 fn dedup_first_call_always_injects() {
+    let _env = env_guard();
     let pid = "test_dedup_first";
     let sid = "sess-dedup-3";
     let _ = edda_store::ensure_dirs(pid);
@@ -642,6 +652,7 @@ fn dedup_first_call_always_injects() {
 
 #[test]
 fn session_end_cleans_state() {
+    let _env = env_guard();
     let pid = "test_session_end_clean";
     let sid = "sess-end-1";
     let _ = edda_store::ensure_dirs(pid);
@@ -668,6 +679,7 @@ fn session_end_cleans_state() {
 
 #[test]
 fn session_end_warns_pending_tasks() {
+    let _env = env_guard();
     let pid = "test_session_end_warn";
     let _ = edda_store::ensure_dirs(pid);
 
@@ -699,6 +711,7 @@ fn session_end_warns_pending_tasks() {
 
 #[test]
 fn session_end_no_warning_when_all_completed() {
+    let _env = env_guard();
     let pid = "test_session_end_no_warn";
     let _ = edda_store::ensure_dirs(pid);
 
@@ -733,12 +746,14 @@ fn wrap_context_boundary_adds_markers() {
 
 #[test]
 fn session_start_output_has_boundary_markers() {
+    let _env = env_guard();
     let pid = "test_boundary_session_start";
     let _ = edda_store::ensure_dirs(pid);
 
     let pack_dir = edda_store::project_dir(pid).join("packs");
     let _ = fs::create_dir_all(&pack_dir);
     let _ = fs::write(pack_dir.join("hot.md"), "# edda memory pack (hot)\n");
+    drop(_env);
 
     crate::with_env_guard(
         &[("EDDA_PLANS_DIR", Some("/nonexistent/plans/dir"))],
@@ -761,6 +776,7 @@ fn session_start_output_has_boundary_markers() {
         },
     );
 
+    let _env = env_guard();
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }
 
@@ -874,6 +890,7 @@ fn empty_tail_preserves_existing_behavior() {
 
 #[test]
 fn post_tool_use_commit_triggers_nudge() {
+    let _env = env_guard();
     let pid = "test_nudge_commit";
     let sid = "sess-nudge-1";
     let _ = edda_store::ensure_dirs(pid);
@@ -905,6 +922,7 @@ fn post_tool_use_commit_triggers_nudge() {
 
 #[test]
 fn post_tool_use_after_decide_cooldown_still_applies() {
+    let _env = env_guard();
     let pid = "test_nudge_suppressed";
     let sid = "sess-nudge-2";
     let _ = edda_store::ensure_dirs(pid);
@@ -932,6 +950,7 @@ fn post_tool_use_after_decide_cooldown_still_applies() {
 
 #[test]
 fn post_tool_use_cooldown_suppresses() {
+    let _env = env_guard();
     let pid = "test_nudge_cooldown";
     let sid = "sess-nudge-3";
     let _ = edda_store::ensure_dirs(pid);
@@ -960,6 +979,7 @@ fn post_tool_use_cooldown_suppresses() {
 
 #[test]
 fn post_tool_use_self_record_increments_decide_count() {
+    let _env = env_guard();
     let pid = "test_nudge_selfrecord";
     let sid = "sess-nudge-4";
     let _ = edda_store::ensure_dirs(pid);
@@ -984,6 +1004,7 @@ fn post_tool_use_self_record_increments_decide_count() {
 
 #[test]
 fn session_end_cleans_nudge_state() {
+    let _env = env_guard();
     let pid = "test_nudge_cleanup";
     let sid = "sess-nudge-5";
     let _ = edda_store::ensure_dirs(pid);
@@ -1051,6 +1072,7 @@ fn counter_increment_and_read() {
 
 #[test]
 fn post_tool_use_increments_nudge_counter() {
+    let _env = env_guard();
     let pid = "test_nudge_counter";
     let sid = "sess-nudge-cnt-1";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
@@ -1086,6 +1108,7 @@ fn post_tool_use_increments_nudge_counter() {
 
 #[test]
 fn post_tool_use_increments_decide_counter() {
+    let _env = env_guard();
     let pid = "test_decide_counter";
     let sid = "sess-decide-cnt-1";
     let _ = edda_store::ensure_dirs(pid);
@@ -1102,6 +1125,7 @@ fn post_tool_use_increments_decide_counter() {
 
 #[test]
 fn session_end_cleans_recall_counters() {
+    let _env = env_guard();
     let pid = "test_counter_cleanup";
     let sid = "sess-counter-clean";
     let _ = edda_store::ensure_dirs(pid);
@@ -1124,6 +1148,7 @@ fn session_end_cleans_recall_counters() {
 
 #[test]
 fn signal_count_incremented_for_all_signals() {
+    let _env = env_guard();
     let pid = "test_signal_count_all";
     let sid = "sess-sig-cnt";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
@@ -1163,6 +1188,7 @@ fn signal_count_incremented_for_all_signals() {
 
 #[test]
 fn session_end_cleans_signal_count() {
+    let _env = env_guard();
     let pid = "test_signal_count_cleanup";
     let sid = "sess-sig-clean";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
@@ -1338,6 +1364,7 @@ fn solo_session_still_sees_bindings_via_prompt_submit() {
 
 #[test]
 fn solo_to_multi_session_transition() {
+    let _env = env_guard();
     let pid = "test_solo_multi_trans";
     // Clean slate to avoid interference from other tests
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
@@ -1438,6 +1465,7 @@ fn session_end_writes_unclaim_for_every_claimed_session() {
 
 #[test]
 fn unclaim_without_a_claim_is_a_fold_noop() {
+    let _env = env_guard();
     let pid = "test_se_unclaim_noop";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = edda_store::ensure_dirs(pid);
@@ -1455,6 +1483,7 @@ fn unclaim_without_a_claim_is_a_fold_noop() {
 
 #[test]
 fn compaction_drops_released_claims_and_never_emits_unclaim() {
+    let _env = env_guard();
     let pid = "test_se_unclaim_compaction";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = edda_store::ensure_dirs(pid);
@@ -1665,6 +1694,7 @@ fn solo_session_writes_zero_peer_count() {
 
 #[test]
 fn peer_count_cleaned_on_session_end() {
+    let _env = env_guard();
     let pid = "test_peer_count_clean";
     let _ = edda_store::ensure_dirs(pid);
     let state_dir = edda_store::project_dir(pid).join("state");
@@ -1775,6 +1805,7 @@ fn try_write_commit_event_skips_when_empty_cwd() {
 
 #[test]
 fn post_tool_use_edit_triggers_auto_claim() {
+    let _env = env_guard();
     let pid = "test_post_edit_autoclaim";
     let sid = "sess-autoclaim-1";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
@@ -1798,6 +1829,7 @@ fn post_tool_use_edit_triggers_auto_claim() {
 
 #[test]
 fn post_tool_use_write_triggers_auto_claim() {
+    let _env = env_guard();
     let pid = "test_post_write_autoclaim";
     let sid = "sess-autoclaim-2";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
@@ -1820,6 +1852,7 @@ fn post_tool_use_write_triggers_auto_claim() {
 
 #[test]
 fn post_tool_use_bash_does_not_auto_claim() {
+    let _env = env_guard();
     let pid = "test_post_bash_no_autoclaim";
     let sid = "sess-autoclaim-3";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
@@ -1842,6 +1875,7 @@ fn post_tool_use_bash_does_not_auto_claim() {
 
 #[test]
 fn pre_tool_use_request_nudge_cooldown() {
+    let _env = env_guard();
     let pid = "test_pre_req_nudge_cd";
     let sid = "sess-req-nudge-1";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
@@ -1875,6 +1909,7 @@ fn pre_tool_use_request_nudge_cooldown() {
 
 #[test]
 fn pre_tool_use_no_pending_no_nudge() {
+    let _env = env_guard();
     let pid = "test_pre_no_pending";
     let sid = "sess-req-nudge-2";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
@@ -1890,6 +1925,7 @@ fn pre_tool_use_no_pending_no_nudge() {
 
 #[test]
 fn pre_tool_use_solo_skips_counter_io() {
+    let _env = env_guard();
     let pid = "test_pre_solo_skip";
     let sid = "sess-req-nudge-3";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
@@ -1941,6 +1977,7 @@ fn write_test_heartbeat(pid: &str, sid: &str, branch: Option<&str>) {
 
 #[test]
 fn branch_guard_match_allows() {
+    let _env = env_guard();
     let pid = "test_branch_guard_match";
     let sid = "s1";
     // Write heartbeat with current branch so it matches
@@ -1967,6 +2004,7 @@ fn branch_guard_match_allows() {
 
 #[test]
 fn branch_guard_mismatch_blocks() {
+    let _env = env_guard();
     let pid = "test_branch_guard_mismatch";
     let sid = "s1";
     // Write heartbeat with a branch that won't match
@@ -1998,6 +2036,7 @@ fn branch_guard_mismatch_blocks() {
 
 #[test]
 fn branch_guard_no_heartbeat_allows() {
+    let _env = env_guard();
     let pid = "test_branch_guard_no_hb";
     let sid = "s_no_hb";
     let _ = edda_store::ensure_dirs(pid);
@@ -2022,6 +2061,7 @@ fn branch_guard_no_heartbeat_allows() {
 
 #[test]
 fn branch_guard_amend_allows() {
+    let _env = env_guard();
     let pid = "test_branch_guard_amend";
     let sid = "s1";
     write_test_heartbeat(pid, sid, Some("nonexistent-branch-xyz"));
@@ -2048,6 +2088,7 @@ fn branch_guard_amend_allows() {
 
 #[test]
 fn branch_guard_non_commit_allows() {
+    let _env = env_guard();
     let pid = "test_branch_guard_non_commit";
     let sid = "s1";
     write_test_heartbeat(pid, sid, Some("nonexistent-branch-xyz"));
@@ -2071,6 +2112,7 @@ fn branch_guard_non_commit_allows() {
 
 #[test]
 fn branch_guard_no_claimed_branch_allows() {
+    let _env = env_guard();
     // Heartbeat exists but branch is None — should allow (no claim to enforce)
     let pid = "test_branch_guard_no_claim";
     let sid = "s1";
@@ -2095,6 +2137,7 @@ fn branch_guard_no_claimed_branch_allows() {
 
 #[test]
 fn subagent_start_creates_heartbeat() {
+    let _env = env_guard();
     let pid = "test_subagent_start";
     let _ = edda_store::ensure_dirs(pid);
 
@@ -2111,6 +2154,7 @@ fn subagent_start_creates_heartbeat() {
 
 #[test]
 fn subagent_stop_removes_heartbeat() {
+    let _env = env_guard();
     let pid = "test_subagent_stop";
     let _ = edda_store::ensure_dirs(pid);
 
@@ -2131,6 +2175,7 @@ fn subagent_stop_removes_heartbeat() {
 
 #[test]
 fn subagent_stop_writes_summary_and_removes_heartbeat() {
+    let _env = env_guard();
     let tmp = tempfile::tempdir().unwrap();
     let workspace = tmp.path().to_path_buf();
     fs::create_dir(workspace.join(".git")).unwrap();
@@ -2234,6 +2279,7 @@ fn subagent_stop_writes_summary_and_removes_heartbeat() {
 
 #[test]
 fn subagent_stop_fallback_summary_when_transcript_missing() {
+    let _env = env_guard();
     let tmp = tempfile::tempdir().unwrap();
     let workspace = tmp.path().to_path_buf();
     fs::create_dir(workspace.join(".git")).unwrap();
@@ -2284,6 +2330,7 @@ fn subagent_stop_fallback_summary_when_transcript_missing() {
 
 #[test]
 fn subagent_orphan_cleanup_on_session_end() {
+    let _env = env_guard();
     let pid = "test_subagent_orphan";
     let _ = edda_store::ensure_dirs(pid);
 
@@ -2314,6 +2361,7 @@ fn subagent_orphan_cleanup_on_session_end() {
 
 #[test]
 fn subagent_start_no_agent_id_is_noop() {
+    let _env = env_guard();
     let pid = "test_subagent_no_id";
     let _ = edda_store::ensure_dirs(pid);
 
@@ -2457,6 +2505,7 @@ fn task_completed_skips_when_task_id_empty() {
 
 #[test]
 fn offlimits_disabled_by_default() {
+    let _env = env_guard();
     let pid = "test-offlimits-disabled";
     let sid = "s-self";
     let _ = edda_store::ensure_dirs(pid);
@@ -2500,6 +2549,7 @@ fn offlimits_blocks_peer_claimed_file() {
 
 #[test]
 fn offlimits_allows_own_claimed_file() {
+    let _env = env_guard();
     let pid = "test-offlimits-self";
     let sid = "s-self-own";
     let _ = edda_store::ensure_dirs(pid);
@@ -2517,6 +2567,7 @@ fn offlimits_allows_own_claimed_file() {
 
 #[test]
 fn offlimits_allows_unclaimed_file() {
+    let _env = env_guard();
     let pid = "test-offlimits-unclaimed";
     let sid = "s-self-unclaimed";
     let peer_sid = "s-peer-unclaimed";
@@ -2538,6 +2589,7 @@ fn offlimits_allows_unclaimed_file() {
 
 #[test]
 fn offlimits_skips_stale_claims() {
+    let _env = env_guard();
     let pid = "test-offlimits-stale";
     let sid = "s-self-stale";
     let stale_sid = "s-stale-peer";
@@ -2563,6 +2615,7 @@ fn offlimits_skips_stale_claims() {
 
 #[test]
 fn offlimits_ignores_repo_wide_peer_claim() {
+    let _env = env_guard();
     let pid = "test-offlimits-repo-wide";
     let sid = "s-self-wide";
     let peer_sid = "s-peer-wide";

--- a/crates/edda-bridge-claude/src/dispatch/tests.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tests.rs
@@ -1216,6 +1216,7 @@ fn active_peer_seen_when_peer_heartbeat_exists() {
 
 #[test]
 fn cross_session_binding_visible_via_user_prompt_submit() {
+    let _env = env_guard();
     let pid = "test_xsess_bind_vis";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = edda_store::ensure_dirs(pid);
@@ -1231,7 +1232,6 @@ fn cross_session_binding_visible_via_user_prompt_submit() {
     // Session A (s1) writes a binding
     crate::peers::write_binding(pid, "s1", "auth", "db.engine", "postgres");
 
-    let _eg = crate::ENV_LOCK.lock().unwrap();
     std::env::set_var("EDDA_BRIDGE_AUTO_DIGEST", "0");
     std::env::set_var("EDDA_PLANS_DIR", "/nonexistent");
     // Session B (s2) dispatches UserPromptSubmit — should see the binding
@@ -1256,7 +1256,7 @@ fn cross_session_binding_visible_via_user_prompt_submit() {
 
     std::env::remove_var("EDDA_BRIDGE_AUTO_DIGEST");
     std::env::remove_var("EDDA_PLANS_DIR");
-    drop(_eg);
+    drop(_env);
     crate::peers::remove_heartbeat(pid, "s1");
     crate::peers::remove_heartbeat(pid, "s2");
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
@@ -1265,6 +1265,7 @@ fn cross_session_binding_visible_via_user_prompt_submit() {
 
 #[test]
 fn user_prompt_submit_dedup_skips_identical_state() {
+    let _env = env_guard();
     let pid = "test_ups_dedup";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = edda_store::ensure_dirs(pid);
@@ -1275,7 +1276,6 @@ fn user_prompt_submit_dedup_skips_identical_state() {
     // Write a binding so there's something to inject
     crate::peers::write_binding(pid, "s1", "auth", "cache.backend", "redis");
 
-    let _eg = crate::ENV_LOCK.lock().unwrap();
     std::env::set_var("EDDA_BRIDGE_AUTO_DIGEST", "0");
     std::env::set_var("EDDA_PLANS_DIR", "/nonexistent");
     // First call — should produce output
@@ -1291,7 +1291,7 @@ fn user_prompt_submit_dedup_skips_identical_state() {
 
     std::env::remove_var("EDDA_BRIDGE_AUTO_DIGEST");
     std::env::remove_var("EDDA_PLANS_DIR");
-    drop(_eg);
+    drop(_env);
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = fs::remove_dir_all(&cwd);
 }
@@ -1300,6 +1300,7 @@ fn user_prompt_submit_dedup_skips_identical_state() {
 
 #[test]
 fn solo_session_still_sees_bindings_via_prompt_submit() {
+    let _env = env_guard();
     let pid = "test_solo_bind_vis";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = edda_store::ensure_dirs(pid);
@@ -1310,7 +1311,6 @@ fn solo_session_still_sees_bindings_via_prompt_submit() {
     // Write binding — no heartbeats (solo mode)
     crate::peers::write_binding(pid, "solo-s", "solo", "api.style", "GraphQL");
 
-    let _eg = crate::ENV_LOCK.lock().unwrap();
     std::env::set_var("EDDA_BRIDGE_AUTO_DIGEST", "0");
     std::env::set_var("EDDA_PLANS_DIR", "/nonexistent");
     let result = dispatch_user_prompt_submit(pid, "solo-s", "", cwd.to_str().unwrap()).unwrap();
@@ -1326,7 +1326,7 @@ fn solo_session_still_sees_bindings_via_prompt_submit() {
 
     std::env::remove_var("EDDA_BRIDGE_AUTO_DIGEST");
     std::env::remove_var("EDDA_PLANS_DIR");
-    drop(_eg);
+    drop(_env);
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = fs::remove_dir_all(&cwd);
 }
@@ -1376,10 +1376,10 @@ fn solo_to_multi_session_transition() {
 
 #[test]
 fn session_end_writes_unclaim_for_every_claimed_session() {
+    let _env = env_guard();
     let pid = "test_se_unclaim_gate";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = edda_store::ensure_dirs(pid);
-    let _eg = crate::ENV_LOCK.lock().unwrap();
     std::env::set_var("EDDA_BRIDGE_AUTO_DIGEST", "0");
     std::env::set_var("EDDA_PLANS_DIR", "/nonexistent");
 
@@ -1428,7 +1428,7 @@ fn session_end_writes_unclaim_for_every_claimed_session() {
 
     std::env::remove_var("EDDA_BRIDGE_AUTO_DIGEST");
     std::env::remove_var("EDDA_PLANS_DIR");
-    drop(_eg);
+    drop(_env);
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = fs::remove_dir_all(&cwd);
 }
@@ -1478,11 +1478,11 @@ fn compaction_drops_released_claims_and_never_emits_unclaim() {
 
 #[test]
 fn session_end_reads_counters_before_cleanup() {
+    let _env = env_guard();
     let pid = "test_se_counters";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = edda_store::ensure_dirs(pid);
     let sid = "counter-sess";
-    let _eg = crate::ENV_LOCK.lock().unwrap();
     std::env::set_var("EDDA_BRIDGE_AUTO_DIGEST", "0");
     std::env::set_var("EDDA_PLANS_DIR", "/nonexistent");
 
@@ -1523,7 +1523,7 @@ fn session_end_reads_counters_before_cleanup() {
 
     std::env::remove_var("EDDA_BRIDGE_AUTO_DIGEST");
     std::env::remove_var("EDDA_PLANS_DIR");
-    drop(_eg);
+    drop(_env);
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = fs::remove_dir_all(&cwd);
 }
@@ -1532,10 +1532,10 @@ fn session_end_reads_counters_before_cleanup() {
 
 #[test]
 fn late_peer_detection_injects_full_protocol() {
+    let _env = env_guard();
     let pid = "test_late_peer_full";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = edda_store::ensure_dirs(pid);
-    let _eg = crate::ENV_LOCK.lock().unwrap();
     std::env::set_var("EDDA_BRIDGE_AUTO_DIGEST", "0");
     std::env::set_var("EDDA_PLANS_DIR", "/nonexistent");
 
@@ -1574,7 +1574,7 @@ fn late_peer_detection_injects_full_protocol() {
 
     std::env::remove_var("EDDA_BRIDGE_AUTO_DIGEST");
     std::env::remove_var("EDDA_PLANS_DIR");
-    drop(_eg);
+    drop(_env);
     crate::peers::remove_heartbeat(pid, "peer-a");
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = fs::remove_dir_all(&cwd);
@@ -1582,10 +1582,10 @@ fn late_peer_detection_injects_full_protocol() {
 
 #[test]
 fn subsequent_prompts_use_lightweight_updates() {
+    let _env = env_guard();
     let pid = "test_late_peer_subsequent";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = edda_store::ensure_dirs(pid);
-    let _eg = crate::ENV_LOCK.lock().unwrap();
     std::env::set_var("EDDA_BRIDGE_AUTO_DIGEST", "0");
     std::env::set_var("EDDA_PLANS_DIR", "/nonexistent");
 
@@ -1618,7 +1618,7 @@ fn subsequent_prompts_use_lightweight_updates() {
 
     std::env::remove_var("EDDA_BRIDGE_AUTO_DIGEST");
     std::env::remove_var("EDDA_PLANS_DIR");
-    drop(_eg);
+    drop(_env);
     crate::peers::remove_heartbeat(pid, "peer-b");
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = fs::remove_dir_all(&cwd);
@@ -1626,10 +1626,10 @@ fn subsequent_prompts_use_lightweight_updates() {
 
 #[test]
 fn solo_session_writes_zero_peer_count() {
+    let _env = env_guard();
     let pid = "test_late_peer_solo";
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = edda_store::ensure_dirs(pid);
-    let _eg = crate::ENV_LOCK.lock().unwrap();
     std::env::set_var("EDDA_BRIDGE_AUTO_DIGEST", "0");
     std::env::set_var("EDDA_PLANS_DIR", "/nonexistent");
 
@@ -1655,7 +1655,7 @@ fn solo_session_writes_zero_peer_count() {
 
     std::env::remove_var("EDDA_BRIDGE_AUTO_DIGEST");
     std::env::remove_var("EDDA_PLANS_DIR");
-    drop(_eg);
+    drop(_env);
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = fs::remove_dir_all(&cwd);
 }
@@ -2468,6 +2468,7 @@ fn offlimits_disabled_by_default() {
 
 #[test]
 fn offlimits_blocks_peer_claimed_file() {
+    let _env = env_guard();
     let pid = "test-offlimits-blocks";
     let sid = "s-self-blocks";
     let peer_sid = "s-peer-blocks";
@@ -2581,6 +2582,7 @@ fn offlimits_ignores_repo_wide_peer_claim() {
 
 #[test]
 fn offlimits_env_var_enables_enforcement() {
+    let _env = env_guard();
     let pid = "test-offlimits-env";
     let sid = "s-self-env";
     let peer_sid = "s-peer-env";
@@ -2592,7 +2594,6 @@ fn offlimits_env_var_enables_enforcement() {
     write_peer_count(pid, sid, 1);
 
     // Enable enforcement via env var
-    let _eg = crate::ENV_LOCK.lock().unwrap();
     std::env::set_var("EDDA_ENFORCE_OFFLIMITS", "1");
 
     let raw = serde_json::json!({
@@ -2626,12 +2627,13 @@ fn offlimits_env_var_enables_enforcement() {
     );
 
     std::env::remove_var("EDDA_ENFORCE_OFFLIMITS");
-    drop(_eg);
+    drop(_env);
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }
 
 #[test]
 fn offlimits_skips_non_edit_tools() {
+    let _env = env_guard();
     let pid = "test-offlimits-bash";
     let sid = "s-self-bash";
     let peer_sid = "s-peer-bash";
@@ -2643,7 +2645,6 @@ fn offlimits_skips_non_edit_tools() {
     write_peer_count(pid, sid, 1);
 
     // Enable enforcement
-    let _eg = crate::ENV_LOCK.lock().unwrap();
     std::env::set_var("EDDA_ENFORCE_OFFLIMITS", "1");
     std::env::set_var("EDDA_CLAUDE_AUTO_APPROVE", "1");
 
@@ -2667,7 +2668,7 @@ fn offlimits_skips_non_edit_tools() {
 
     std::env::remove_var("EDDA_ENFORCE_OFFLIMITS");
     std::env::remove_var("EDDA_CLAUDE_AUTO_APPROVE");
-    drop(_eg);
+    drop(_env);
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }
 

--- a/crates/edda-bridge-claude/src/dispatch/tests.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tests.rs
@@ -1,4 +1,11 @@
 use std::fs;
+use std::sync::{MutexGuard, PoisonError};
+
+fn env_guard() -> MutexGuard<'static, ()> {
+    crate::ENV_LOCK
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}
 
 // Imports from dispatch/mod.rs
 use super::{
@@ -1045,6 +1052,7 @@ fn counter_increment_and_read() {
 fn post_tool_use_increments_nudge_counter() {
     let pid = "test_nudge_counter";
     let sid = "sess-nudge-cnt-1";
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     let _ = edda_store::ensure_dirs(pid);
 
     // First commit → nudge emitted → counter = 1
@@ -2122,6 +2130,7 @@ fn subagent_stop_removes_heartbeat() {
 fn subagent_stop_writes_summary_and_removes_heartbeat() {
     let tmp = tempfile::tempdir().unwrap();
     let workspace = tmp.path().to_path_buf();
+    fs::create_dir(workspace.join(".git")).unwrap();
     let paths = edda_ledger::EddaPaths::discover(&workspace);
     edda_ledger::ledger::init_workspace(&paths).unwrap();
     edda_ledger::ledger::init_head(&paths, "main").unwrap();
@@ -2224,6 +2233,7 @@ fn subagent_stop_writes_summary_and_removes_heartbeat() {
 fn subagent_stop_fallback_summary_when_transcript_missing() {
     let tmp = tempfile::tempdir().unwrap();
     let workspace = tmp.path().to_path_buf();
+    fs::create_dir(workspace.join(".git")).unwrap();
     let paths = edda_ledger::EddaPaths::discover(&workspace);
     edda_ledger::ledger::init_workspace(&paths).unwrap();
     edda_ledger::ledger::init_head(&paths, "main").unwrap();
@@ -2361,8 +2371,10 @@ fn is_karvi_project_detection() {
 
 #[test]
 fn task_completed_writes_coordination_event() {
+    let _env = env_guard();
     let tmp = tempfile::tempdir().unwrap();
     let workspace = tmp.path().to_path_buf();
+    fs::create_dir(workspace.join(".git")).unwrap();
     let paths = edda_ledger::EddaPaths::discover(&workspace);
     edda_ledger::ledger::init_workspace(&paths).unwrap();
     edda_ledger::ledger::init_head(&paths, "main").unwrap();
@@ -2407,8 +2419,10 @@ fn task_completed_writes_coordination_event() {
 
 #[test]
 fn task_completed_skips_when_task_id_empty() {
+    let _env = env_guard();
     let tmp = tempfile::tempdir().unwrap();
     let workspace = tmp.path().to_path_buf();
+    fs::create_dir(workspace.join(".git")).unwrap();
 
     let project_id = resolve_project_id(workspace.to_str().unwrap());
     let _ = edda_store::ensure_dirs(&project_id);
@@ -2862,6 +2876,7 @@ fn read_project_state_empty_tasks() {
 
 #[test]
 fn session_end_bg_threads_joined_zero_threads() {
+    let _env = env_guard();
     // Regression test: when no background threads are spawned (no API key),
     // the channel-based join must complete immediately without hanging.
     let pid = "test_se_bg_join_zero";

--- a/crates/edda-bridge-claude/src/redact.rs
+++ b/crates/edda-bridge-claude/src/redact.rs
@@ -20,6 +20,22 @@ static SECRET_PATTERNS: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(|| 
             Regex::new(r"\b(glpat-[a-zA-Z0-9\-]{20,})").expect("static regex"),
             "[REDACTED_GITLAB_TOKEN]",
         ),
+        // Slack bot/user tokens: xoxb-, xoxp-
+        (
+            Regex::new(r"\b(xox[bp]-[a-zA-Z0-9-]{10,})").expect("static regex"),
+            "[REDACTED_SLACK_TOKEN]",
+        ),
+        // Stripe live publishable/secret keys
+        (
+            Regex::new(r"\b(sk_live_[a-zA-Z0-9]{10,}|pk_live_[a-zA-Z0-9]{10,})")
+                .expect("static regex"),
+            "[REDACTED_STRIPE_KEY]",
+        ),
+        // npm access tokens
+        (
+            Regex::new(r"\b(npm_[a-zA-Z0-9_-]{10,})").expect("static regex"),
+            "[REDACTED_NPM_TOKEN]",
+        ),
         // AWS access key IDs: AKIA followed by 16 uppercase alphanumeric
         (
             Regex::new(r"\b(AKIA[A-Z0-9]{16})\b").expect("static regex"),
@@ -197,5 +213,15 @@ mod tests {
         let output = redact_secrets(input);
         assert!(!output.contains("sk-aaaa"));
         assert!(!output.contains("ghp_CCCC"));
+    }
+
+    #[test]
+    fn redact_slack_stripe_and_npm_tokens() {
+        let input = "xoxb-1234567890-1234567890-fakevalue npm_fake_token_1234567890 sk_live_fakevalue1234567890 pk_live_fakevalue1234567890";
+        let output = redact_secrets(input);
+        assert!(!output.contains("xoxb-"));
+        assert!(!output.contains("npm_"));
+        assert!(!output.contains("sk_live_"));
+        assert!(!output.contains("pk_live_"));
     }
 }

--- a/crates/edda-cli/src/cmd_search.rs
+++ b/crates/edda-cli/src/cmd_search.rs
@@ -628,8 +628,11 @@ mod tests {
     /// events into that project's index.
     #[test]
     fn foreign_project_uses_its_own_registered_repo() {
+        let _store = crate::test_support::isolated_store();
         let here = tempfile::tempdir().unwrap();
         let there = tempfile::tempdir().unwrap();
+        std::fs::create_dir(here.path().join(".git")).unwrap();
+        std::fs::create_dir(there.path().join(".git")).unwrap();
         std::fs::create_dir_all(there.path().join(".edda")).unwrap();
         std::fs::write(there.path().join(".edda").join("ledger.db"), b"").unwrap();
         let there_path = there.path().to_string_lossy().into_owned();

--- a/crates/edda-store/src/registry.rs
+++ b/crates/edda-store/src/registry.rs
@@ -229,17 +229,25 @@ mod tests {
     use super::*;
     /// Run a closure with `EDDA_STORE_ROOT` pointing to an isolated tempdir.
     fn with_isolated_store(f: impl FnOnce()) {
-        let _guard = crate::ENV_STORE_LOCK.lock().unwrap();
+        let _guard = crate::ENV_STORE_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let store = tempfile::tempdir().unwrap();
         std::env::set_var("EDDA_STORE_ROOT", store.path());
         f();
         std::env::remove_var("EDDA_STORE_ROOT");
     }
 
+    fn temp_repo() -> tempfile::TempDir {
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::create_dir(repo.path().join(".git")).unwrap();
+        repo
+    }
+
     #[test]
     fn register_and_list_roundtrip() {
         with_isolated_store(|| {
-            let tmp = tempfile::tempdir().unwrap();
+            let tmp = temp_repo();
             std::fs::create_dir_all(tmp.path().join(".edda")).unwrap();
 
             register_project(tmp.path()).unwrap();
@@ -253,7 +261,7 @@ mod tests {
     #[test]
     fn register_is_idempotent() {
         with_isolated_store(|| {
-            let tmp = tempfile::tempdir().unwrap();
+            let tmp = temp_repo();
             std::fs::create_dir_all(tmp.path().join(".edda")).unwrap();
 
             register_project(tmp.path()).unwrap();
@@ -273,7 +281,7 @@ mod tests {
     #[test]
     fn unregister_removes_entry() {
         with_isolated_store(|| {
-            let tmp = tempfile::tempdir().unwrap();
+            let tmp = temp_repo();
             let pid = project_id(tmp.path());
 
             register_project(tmp.path()).unwrap();
@@ -287,7 +295,7 @@ mod tests {
     #[test]
     fn set_and_get_group() {
         with_isolated_store(|| {
-            let tmp = tempfile::tempdir().unwrap();
+            let tmp = temp_repo();
             std::fs::create_dir_all(tmp.path().join(".edda")).unwrap();
             register_project(tmp.path()).unwrap();
 
@@ -304,8 +312,8 @@ mod tests {
     #[test]
     fn list_group_members_returns_peers() {
         with_isolated_store(|| {
-            let tmp1 = tempfile::tempdir().unwrap();
-            let tmp2 = tempfile::tempdir().unwrap();
+            let tmp1 = temp_repo();
+            let tmp2 = temp_repo();
             std::fs::create_dir_all(tmp1.path().join(".edda")).unwrap();
             std::fs::create_dir_all(tmp2.path().join(".edda")).unwrap();
 
@@ -320,7 +328,7 @@ mod tests {
             assert_eq!(members[0].project_id, project_id(tmp2.path()));
 
             // No group = no members
-            let tmp3 = tempfile::tempdir().unwrap();
+            let tmp3 = temp_repo();
             std::fs::create_dir_all(tmp3.path().join(".edda")).unwrap();
             register_project(tmp3.path()).unwrap();
             assert!(list_group_members(tmp3.path()).is_empty());
@@ -331,8 +339,8 @@ mod tests {
     #[test]
     fn fleet_scope_is_every_project_when_no_group_and_includes_home() {
         with_isolated_store(|| {
-            let home = tempfile::tempdir().unwrap();
-            let other = tempfile::tempdir().unwrap();
+            let home = temp_repo();
+            let other = temp_repo();
             std::fs::create_dir_all(home.path().join(".edda")).unwrap();
             std::fs::create_dir_all(other.path().join(".edda")).unwrap();
             register_project(home.path()).unwrap();
@@ -353,9 +361,9 @@ mod tests {
     #[test]
     fn fleet_scope_narrows_to_the_group_when_one_is_set() {
         with_isolated_store(|| {
-            let home = tempfile::tempdir().unwrap();
-            let peer = tempfile::tempdir().unwrap();
-            let outsider = tempfile::tempdir().unwrap();
+            let home = temp_repo();
+            let peer = temp_repo();
+            let outsider = temp_repo();
             for d in [&home, &peer, &outsider] {
                 std::fs::create_dir_all(d.path().join(".edda")).unwrap();
                 register_project(d.path()).unwrap();
@@ -381,11 +389,11 @@ mod tests {
     #[test]
     fn fleet_scope_keeps_projects_whose_repo_is_gone() {
         with_isolated_store(|| {
-            let home = tempfile::tempdir().unwrap();
+            let home = temp_repo();
             std::fs::create_dir_all(home.path().join(".edda")).unwrap();
             register_project(home.path()).unwrap();
 
-            let gone = tempfile::tempdir().unwrap();
+            let gone = temp_repo();
             std::fs::create_dir_all(gone.path().join(".edda")).unwrap();
             register_project(gone.path()).unwrap();
             let gone_pid = project_id(gone.path());
@@ -403,8 +411,8 @@ mod tests {
     #[test]
     fn list_groups_returns_all() {
         with_isolated_store(|| {
-            let tmp1 = tempfile::tempdir().unwrap();
-            let tmp2 = tempfile::tempdir().unwrap();
+            let tmp1 = temp_repo();
+            let tmp2 = temp_repo();
             std::fs::create_dir_all(tmp1.path().join(".edda")).unwrap();
             std::fs::create_dir_all(tmp2.path().join(".edda")).unwrap();
 
@@ -434,7 +442,7 @@ mod tests {
     #[test]
     fn validate_detects_stale() {
         with_isolated_store(|| {
-            let tmp = tempfile::tempdir().unwrap();
+            let tmp = temp_repo();
             std::fs::create_dir_all(tmp.path().join(".edda")).unwrap();
             register_project(tmp.path()).unwrap();
 

--- a/crates/edda-store/src/skill_registry.rs
+++ b/crates/edda-store/src/skill_registry.rs
@@ -320,7 +320,9 @@ mod tests {
 
     /// Run a closure with `EDDA_STORE_ROOT` pointing to an isolated tempdir.
     fn with_isolated_store(f: impl FnOnce()) {
-        let _guard = crate::ENV_STORE_LOCK.lock().unwrap();
+        let _guard = crate::ENV_STORE_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let store = tempfile::tempdir().unwrap();
         std::env::set_var("EDDA_STORE_ROOT", store.path());
         f();

--- a/crates/edda-store/src/user_config.rs
+++ b/crates/edda-store/src/user_config.rs
@@ -48,7 +48,9 @@ mod tests {
 
     /// Run a closure with `EDDA_STORE_ROOT` pointing to an isolated tempdir.
     fn with_isolated_store(f: impl FnOnce()) {
-        let _guard = crate::ENV_STORE_LOCK.lock().unwrap();
+        let _guard = crate::ENV_STORE_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let store = tempfile::tempdir().unwrap();
         std::env::set_var("EDDA_STORE_ROOT", store.path());
         f();


### PR DESCRIPTION
Closes #357
Closes #447
Closes #450
Closes #452

Summary:
- redact Slack, Stripe, and npm token formats
- isolate Claude digest/search/store fixtures from the real user store
- serialize all store-touching dispatch test boundaries with the existing poison-recovering guard
- keep default-parallel bridge tests deterministic without weakening coverage

Verification at `a94adc36a6c4381a775cfc23cc51a31c4e299eee`:
- GitHub CI: 7/7 green on Ubuntu, macOS, and Windows
- independent verifier task #28: PASS; 64/64 store-touching dispatch test boundaries guarded
- final exact-SHA synthetic integration with PR #460 and PR #461: fmt PASS, clippy `-D warnings` PASS, default-parallel `cargo test --workspace` PASS