### PR TITLE
feat: add portable reasoning checkpoints and deterministic memory packs

### DIFF
--- a/crates/edda-ask/src/lib.rs
+++ b/crates/edda-ask/src/lib.rs
@@ -364,7 +364,9 @@ pub fn ask(
         ledger.find_related_commits(opts.branch.as_deref(), q, &decision_event_ids, opts.limit)?;
     let related_commits = to_commit_hits(&commit_events, &decision_event_ids, q, opts.limit);
     let note_events = ledger.find_related_notes(opts.branch.as_deref(), q, opts.limit)?;
-    let related_notes = to_note_hits(&note_events, opts.limit);
+    let mut related_notes = find_checkpoint_notes(ledger, q, opts)?;
+    related_notes.extend(to_note_hits(&note_events, opts.limit));
+    related_notes.truncate(opts.limit);
 
     let conversations = match transcript_search {
         Some(search_fn) if !q.is_empty() => search_fn(q, opts.limit),
@@ -925,6 +927,66 @@ fn to_decision_hit(row: &DecisionView) -> DecisionHit {
     }
 }
 
+fn find_checkpoint_notes(
+    ledger: &Ledger,
+    query: &str,
+    opts: &AskOptions,
+) -> anyhow::Result<Vec<NoteHit>> {
+    let query = query.trim().to_lowercase();
+    let terms: Vec<&str> = query
+        .split(" or ")
+        .map(str::trim)
+        .filter(|term| !term.is_empty())
+        .collect();
+
+    let mut events = ledger.iter_events_by_type("checkpoint")?;
+    events.reverse();
+    Ok(events
+        .into_iter()
+        .filter(|event| {
+            opts.branch
+                .as_deref()
+                .is_none_or(|branch| branch == event.branch)
+        })
+        .filter(|event| {
+            opts.after
+                .as_deref()
+                .is_none_or(|after| event.ts.as_str() >= after)
+                && opts
+                    .before
+                    .as_deref()
+                    .is_none_or(|before| event.ts.as_str() <= before)
+        })
+        .filter_map(|event| {
+            let payload: edda_core::event::CheckpointPayload =
+                serde_json::from_value(event.payload.clone()).ok()?;
+            let searchable = serde_json::to_string(&payload).ok()?.to_lowercase();
+            if !terms.is_empty() && !terms.iter().any(|term| searchable.contains(term)) {
+                return None;
+            }
+            let rejected = payload
+                .rejected
+                .iter()
+                .map(|item| format!("{} — {}", item.hypothesis, item.reason))
+                .collect::<Vec<_>>();
+            let text = format!(
+                "checkpoint: hypotheses=[{}]; rejected=[{}]; open=[{}]; next={}",
+                payload.hypotheses.join(" | "),
+                rejected.join(" | "),
+                payload.open.join(" | "),
+                payload.next,
+            );
+            Some(NoteHit {
+                event_id: event.event_id,
+                text,
+                ts: event.ts,
+                branch: event.branch,
+            })
+        })
+        .take(opts.limit)
+        .collect())
+}
+
 /// Return the affected_paths carried by each decision in `result.decisions`,
 /// looked up from the ledger by event_id. Position-aligned with the input;
 /// missing/unreadable rows return empty Vec (best-effort).
@@ -948,7 +1010,9 @@ pub fn affected_paths_for_hits(ledger: &Ledger, hits: &[DecisionHit]) -> Vec<Vec
 #[cfg(test)]
 mod tests {
     use super::*;
-    use edda_core::event::{finalize_event, new_note_event};
+    use edda_core::event::{
+        finalize_event, new_checkpoint_event, new_note_event, CheckpointPayload, RejectedHypothesis,
+    };
     use edda_core::Provenance;
     use edda_ledger::ledger::{init_branches_json, init_head, init_workspace};
     use edda_ledger::paths::EddaPaths;
@@ -1064,6 +1128,32 @@ mod tests {
             hit.receipt
         );
         assert_eq!(hit.evidence_paths, vec!["dist/drill.json".to_string()]);
+    }
+
+    #[test]
+    fn ask_recalls_checkpoint_judgment_state() {
+        let (_tmp, ledger) = setup();
+        let checkpoint = CheckpointPayload {
+            hypotheses: vec!["cache invalidation is the cause".to_string()],
+            rejected: vec![RejectedHypothesis {
+                hypothesis: "database corruption".to_string(),
+                reason: "integrity check passes".to_string(),
+            }],
+            open: vec!["confirm the next rebuild".to_string()],
+            next: "run the rebuild check".to_string(),
+        };
+        let event = new_checkpoint_event("main", None, "agent", &checkpoint).unwrap();
+        ledger.append_event(&event).unwrap();
+
+        let result = ask(&ledger, "rebuild", &AskOptions::default(), None).unwrap();
+
+        assert_eq!(result.related_notes.len(), 1);
+        assert!(result.related_notes[0]
+            .text
+            .contains("next=run the rebuild check"));
+        assert!(result.related_notes[0]
+            .text
+            .contains("integrity check passes"));
     }
 
     fn make_decision(

--- a/crates/edda-bridge-claude/src/render.rs
+++ b/crates/edda-bridge-claude/src/render.rs
@@ -32,18 +32,146 @@ pub fn context_budget(cwd: &str) -> usize {
         .unwrap_or(DEFAULT_MAX_CONTEXT_CHARS)
 }
 
-/// Truncate content to fit within the char budget, preserving UTF-8 boundaries.
+/// Drop complete context sections/items to fit within the char budget.
 pub fn apply_budget(content: &str, budget: usize) -> String {
     if content.len() <= budget {
         return content.to_string();
     }
-    let cut = content.len().min(budget.saturating_sub(50));
-    let safe = content.floor_char_boundary(cut);
-    format!(
-        "{}\n\n... (truncated to {} char budget)",
-        &content[..safe],
-        budget
+
+    let items = split_budget_items(content);
+    if items.len() == 1 && items[0].title.is_none() {
+        return format!(
+            "[edda: dropped_items=1; truncated as one whole item; no partial content; {budget} char budget]\n"
+        );
+    }
+
+    let mut dropped_items = items.len();
+    let mut selected = Vec::new();
+    for _ in 0..4 {
+        selected = select_budget_items(&items, budget, dropped_items);
+        let next_dropped = items.len().saturating_sub(selected.len());
+        if next_dropped == dropped_items {
+            break;
+        }
+        dropped_items = next_dropped;
+    }
+
+    render_budget_items(
+        &items,
+        &selected,
+        items.len().saturating_sub(selected.len()),
     )
+}
+
+#[derive(Debug)]
+struct BudgetItem {
+    title: Option<String>,
+    text: String,
+    salience: usize,
+    index: usize,
+}
+
+fn split_budget_items(content: &str) -> Vec<BudgetItem> {
+    let mut boundaries = Vec::new();
+    let mut offset = 0;
+    for line in content.split_inclusive('\n') {
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if let Some(title) = trimmed.strip_prefix("## ") {
+            boundaries.push((offset, Some(title.trim().to_string())));
+        }
+        offset += line.len();
+    }
+
+    if boundaries.is_empty() {
+        return vec![BudgetItem {
+            title: None,
+            text: content.to_string(),
+            salience: 0,
+            index: 0,
+        }];
+    }
+
+    if boundaries[0].0 > 0 {
+        boundaries.insert(0, (0, None));
+    }
+
+    boundaries
+        .iter()
+        .enumerate()
+        .map(|(index, (start, title))| {
+            let end = boundaries
+                .get(index + 1)
+                .map(|(offset, _)| *offset)
+                .unwrap_or(content.len());
+            let title = title.clone();
+            BudgetItem {
+                salience: title.as_deref().map(section_salience).unwrap_or(95),
+                title,
+                text: content[*start..end].to_string(),
+                index,
+            }
+        })
+        .collect()
+}
+
+fn section_salience(title: &str) -> usize {
+    let title = title.to_ascii_lowercase();
+    if title.contains("goal") || title.contains("binding") {
+        100
+    } else if title.contains("ratified")
+        || title.contains("checkpoint")
+        || title.contains("constraint")
+    {
+        90
+    } else if title.contains("workspace") {
+        80
+    } else if title.contains("recent") {
+        60
+    } else if title.contains("doctrine") {
+        40
+    } else if title.contains("coordination") {
+        10
+    } else {
+        20
+    }
+}
+
+fn dropped_summary(dropped_items: usize) -> String {
+    format!("\n[edda: dropped_items={dropped_items} whole sections/items]\n")
+}
+
+fn render_budget_items(items: &[BudgetItem], selected: &[usize], dropped_items: usize) -> String {
+    let mut selected = selected.to_vec();
+    selected.sort_by_key(|index| items[*index].index);
+
+    let mut out = String::new();
+    for index in selected {
+        out.push_str(&items[index].text);
+        if !out.ends_with('\n') {
+            out.push('\n');
+        }
+    }
+    out.push_str(&dropped_summary(dropped_items));
+    out
+}
+
+fn select_budget_items(items: &[BudgetItem], budget: usize, dropped_items: usize) -> Vec<usize> {
+    let mut ranked: Vec<usize> = (0..items.len()).collect();
+    ranked.sort_by(|a, b| {
+        items[*b]
+            .salience
+            .cmp(&items[*a].salience)
+            .then_with(|| items[*a].index.cmp(&items[*b].index))
+    });
+
+    let mut selected = Vec::new();
+    for index in ranked {
+        selected.push(index);
+        if render_budget_items(items, &selected, dropped_items).len() > budget {
+            selected.pop();
+        }
+    }
+    selected
 }
 
 // ── Write-Back Protocol ──
@@ -257,11 +385,31 @@ mod tests {
     }
 
     #[test]
-    fn apply_budget_truncates_long_content() {
+    fn apply_budget_drops_long_content_as_one_item() {
         let content = "x".repeat(10000);
         let result = apply_budget(&content, 500);
-        assert!(result.len() <= 550);
-        assert!(result.contains("truncated"));
+        assert!(result.len() <= 500);
+        assert!(result.contains("dropped_items=1"));
+        assert!(!result.contains(&"x".repeat(100)));
+        assert!(!result.contains("truncated to 500"));
+    }
+
+    #[test]
+    fn apply_budget_keeps_schema_salient_section_and_drops_complete_items_deterministically() {
+        let content = concat!(
+            "## Coordination\nCOORDINATION_DROP_012345678901234567890123456789\n\n",
+            "## Goals\nGOAL_KEEP\n"
+        );
+
+        let first = apply_budget(content, 65);
+        let second = apply_budget(content, 65);
+
+        assert_eq!(first, second, "same input must produce the same output");
+        assert!(first.contains("## Goals"));
+        assert!(first.contains("GOAL_KEEP"));
+        assert!(!first.contains("## Coordination"));
+        assert!(!first.contains("COORDINATION_DROP"));
+        assert!(first.contains("dropped_items=1"));
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_checkpoint.rs
+++ b/crates/edda-cli/src/cmd_checkpoint.rs
@@ -1,0 +1,71 @@
+use clap::Args;
+use edda_core::event::{new_checkpoint_event, CheckpointPayload, RejectedHypothesis};
+use edda_ledger::lock::WorkspaceLock;
+use edda_ledger::Ledger;
+use std::path::Path;
+
+#[derive(Args, Debug)]
+pub struct CheckpointArgs {
+    /// Current hypotheses (repeatable)
+    #[arg(long = "hypothesis")]
+    pub hypotheses: Vec<String>,
+    /// Rejected hypothesis and reason, separated by `|` (repeatable)
+    #[arg(long = "rejected", value_name = "HYPOTHESIS|REASON")]
+    pub rejected: Vec<String>,
+    /// Open questions (repeatable)
+    #[arg(long = "open")]
+    pub open: Vec<String>,
+    /// Next checkpoint action
+    #[arg(long)]
+    pub next: String,
+    /// Author role
+    #[arg(long, default_value = "agent")]
+    pub role: String,
+}
+
+pub fn execute(repo_root: &Path, args: CheckpointArgs) -> anyhow::Result<()> {
+    let rejected = args
+        .rejected
+        .into_iter()
+        .map(|value| {
+            let (hypothesis, reason) = value
+                .split_once('|')
+                .ok_or_else(|| anyhow::anyhow!("--rejected must use HYPOTHESIS|REASON"))?;
+            if hypothesis.trim().is_empty() || reason.trim().is_empty() {
+                anyhow::bail!("--rejected requires both a hypothesis and a reason");
+            }
+            Ok(RejectedHypothesis {
+                hypothesis: hypothesis.trim().to_string(),
+                reason: reason.trim().to_string(),
+            })
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    let ledger = Ledger::open(repo_root)?;
+    let _lock = WorkspaceLock::acquire(&ledger.paths)?;
+    let branch = ledger.head_branch()?;
+    let parent_hash = ledger.last_event_hash()?;
+    let checkpoint = CheckpointPayload {
+        hypotheses: args.hypotheses,
+        rejected,
+        open: args.open,
+        next: args.next,
+    };
+    let event = new_checkpoint_event(&branch, parent_hash.as_deref(), &args.role, &checkpoint)?;
+    ledger.append_event(&event)?;
+
+    println!("Wrote CHECKPOINT {}", event.event_id);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn rejected_value_uses_one_separator() {
+        let (hypothesis, reason) = "db corruption|integrity check passes"
+            .split_once('|')
+            .unwrap();
+        assert_eq!(hypothesis, "db corruption");
+        assert_eq!(reason, "integrity check passes");
+    }
+}

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -5,6 +5,7 @@ mod cmd_branch;
 mod cmd_bridge;
 mod cmd_brief;
 mod cmd_bundle;
+mod cmd_checkpoint;
 mod cmd_commit;
 mod cmd_conduct;
 mod cmd_config;
@@ -86,6 +87,11 @@ enum Command {
         /// Tags for the note (repeatable)
         #[arg(long = "tag")]
         tags: Vec<String>,
+    },
+    /// Record a vendor-neutral reasoning checkpoint
+    Checkpoint {
+        #[command(flatten)]
+        args: cmd_checkpoint::CheckpointArgs,
     },
     /// Record a decision — agent-authored, unratified until `edda ratify` (shortcut for `bridge claude decide`)
     Decide {
@@ -998,6 +1004,7 @@ fn main() -> anyhow::Result<()> {
         } => cmd_init::execute(&repo_root, no_hooks, force_skills),
         Command::Actor { cmd } => cmd_actor::run(cmd, &repo_root),
         Command::Note { text, role, tags } => cmd_note::execute(&repo_root, &text, &role, &tags),
+        Command::Checkpoint { args } => cmd_checkpoint::execute(&repo_root, args),
         Command::Decide {
             decision,
             reason,

--- a/crates/edda-core/src/event.rs
+++ b/crates/edda-core/src/event.rs
@@ -117,6 +117,57 @@ pub fn validate_readable_payload(payload: &serde_json::Value) -> anyhow::Result<
     visit(payload, "")
 }
 
+/// A rejected hypothesis and the short, readable reason it was rejected.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct RejectedHypothesis {
+    pub hypothesis: String,
+    pub reason: String,
+}
+
+/// Vendor-neutral judgment state that can be resumed by another engine.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct CheckpointPayload {
+    pub hypotheses: Vec<String>,
+    pub rejected: Vec<RejectedHypothesis>,
+    pub open: Vec<String>,
+    pub next: String,
+}
+
+/// Create a portable reasoning checkpoint without recording vendor-native traces.
+pub fn new_checkpoint_event(
+    branch: &str,
+    parent_hash: Option<&str>,
+    role: &str,
+    checkpoint: &CheckpointPayload,
+) -> anyhow::Result<Event> {
+    let payload = serde_json::json!({
+        "role": role,
+        "tags": ["checkpoint"],
+        "hypotheses": checkpoint.hypotheses,
+        "rejected": checkpoint.rejected,
+        "open": checkpoint.open,
+        "next": checkpoint.next,
+    });
+
+    let mut event = Event {
+        event_id: new_event_id(),
+        ts: now_rfc3339(),
+        event_type: "checkpoint".to_string(),
+        branch: branch.to_string(),
+        parent_hash: parent_hash.map(|s| s.to_string()),
+        hash: String::new(),
+        payload,
+        refs: Refs::default(),
+        schema_version: SCHEMA_VERSION,
+        digests: Vec::new(),
+        event_family: None,
+        event_level: None,
+    };
+
+    finalize(&mut event)?;
+    Ok(event)
+}
+
 /// Create a new `note` event.
 pub fn new_note_event(
     branch: &str,
@@ -1081,6 +1132,33 @@ mod tests {
         assert_eq!(event.digests[0].alg, "sha256");
         assert_eq!(event.digests[0].canon, CANON_EDDA_V1);
         assert_eq!(event.digests[0].value, event.hash);
+    }
+
+    #[test]
+    fn checkpoint_event_has_vendor_neutral_judgment_state() {
+        let payload = CheckpointPayload {
+            hypotheses: vec!["cache invalidation is the cause".to_string()],
+            rejected: vec![RejectedHypothesis {
+                hypothesis: "database corruption".to_string(),
+                reason: "integrity check passes".to_string(),
+            }],
+            open: vec!["confirm the next rebuild".to_string()],
+            next: "run the rebuild check".to_string(),
+        };
+
+        let event = new_checkpoint_event("main", None, "agent", &payload).unwrap();
+
+        assert_eq!(event.event_type, "checkpoint");
+        assert_eq!(event.event_family.as_deref(), Some("signal"));
+        assert_eq!(
+            event.payload["hypotheses"][0],
+            "cache invalidation is the cause"
+        );
+        assert_eq!(
+            event.payload["rejected"][0]["reason"],
+            "integrity check passes"
+        );
+        assert_eq!(event.payload["next"], "run the rebuild check");
     }
 
     #[test]

--- a/crates/edda-core/src/event.rs
+++ b/crates/edda-core/src/event.rs
@@ -56,6 +56,67 @@ pub fn finalize_event(event: &mut Event) -> anyhow::Result<()> {
     finalize(event)
 }
 
+/// Reject vendor-native reasoning payloads at the readable ledger boundary.
+///
+/// A readable summary may be recorded as ordinary event text. If an audit
+/// trail must point at native reasoning, the event may carry a reference with
+/// both a pointer and a content hash; the native payload itself never enters
+/// the ledger.
+pub fn validate_readable_payload(payload: &serde_json::Value) -> anyhow::Result<()> {
+    fn is_reasoning_key(key: &str) -> bool {
+        let key = key.to_ascii_lowercase();
+        key.contains("reasoning") || key.contains("thinking") || key == "encrypted_content"
+    }
+
+    fn is_pointer_hash_reference(value: &serde_json::Value) -> bool {
+        let Some(object) = value.as_object() else {
+            return false;
+        };
+        let has_pointer = ["pointer", "trace_pointer", "uri"].iter().any(|key| {
+            object
+                .get(*key)
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|value| !value.is_empty())
+        });
+        let has_hash = ["hash", "content_hash", "sha256"].iter().any(|key| {
+            object
+                .get(*key)
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|value| !value.is_empty())
+        });
+        has_pointer && has_hash
+    }
+
+    fn visit(value: &serde_json::Value, path: &str) -> anyhow::Result<()> {
+        match value {
+            serde_json::Value::Object(object) => {
+                for (key, child) in object {
+                    let child_path = if path.is_empty() {
+                        key.to_string()
+                    } else {
+                        format!("{path}.{key}")
+                    };
+                    if is_reasoning_key(key) && !is_pointer_hash_reference(child) {
+                        anyhow::bail!(
+                            "raw vendor reasoning is not permitted at {child_path}; store a readable summary or a pointer plus content hash"
+                        );
+                    }
+                    visit(child, &child_path)?;
+                }
+            }
+            serde_json::Value::Array(values) => {
+                for (index, child) in values.iter().enumerate() {
+                    visit(child, &format!("{path}[{index}]"))?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    visit(payload, "")
+}
+
 /// Create a new `note` event.
 pub fn new_note_event(
     branch: &str,

--- a/crates/edda-core/src/event.rs
+++ b/crates/edda-core/src/event.rs
@@ -69,22 +69,36 @@ pub fn validate_readable_payload(payload: &serde_json::Value) -> anyhow::Result<
     }
 
     fn is_pointer_hash_reference(value: &serde_json::Value) -> bool {
-        let Some(object) = value.as_object() else {
-            return false;
-        };
-        let has_pointer = ["pointer", "trace_pointer", "uri"].iter().any(|key| {
-            object
-                .get(*key)
-                .and_then(serde_json::Value::as_str)
-                .is_some_and(|value| !value.is_empty())
-        });
-        let has_hash = ["hash", "content_hash", "sha256"].iter().any(|key| {
-            object
-                .get(*key)
-                .and_then(serde_json::Value::as_str)
-                .is_some_and(|value| !value.is_empty())
-        });
-        has_pointer && has_hash
+        fn has_pointer_hash(object: &serde_json::Map<String, serde_json::Value>) -> bool {
+            let has_pointer = ["pointer", "trace_pointer", "uri"].iter().any(|key| {
+                object
+                    .get(*key)
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|value| !value.is_empty())
+            });
+            let has_hash = ["hash", "content_hash", "sha256"].iter().any(|key| {
+                object
+                    .get(*key)
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|value| !value.is_empty())
+            });
+            has_pointer && has_hash
+        }
+
+        match value {
+            serde_json::Value::Object(object) => has_pointer_hash(object),
+            serde_json::Value::String(text) => {
+                let trimmed = text.trim_start();
+                if !matches!(trimmed.as_bytes().first(), Some(b'{' | b'[')) {
+                    return false;
+                }
+                serde_json::from_str::<serde_json::Value>(trimmed)
+                    .ok()
+                    .and_then(|parsed| parsed.as_object().map(has_pointer_hash))
+                    .unwrap_or(false)
+            }
+            _ => false,
+        }
     }
 
     fn visit(value: &serde_json::Value, path: &str) -> anyhow::Result<()> {
@@ -107,6 +121,16 @@ pub fn validate_readable_payload(payload: &serde_json::Value) -> anyhow::Result<
             serde_json::Value::Array(values) => {
                 for (index, child) in values.iter().enumerate() {
                     visit(child, &format!("{path}[{index}]"))?;
+                }
+            }
+            serde_json::Value::String(text) => {
+                let trimmed = text.trim_start();
+                if matches!(trimmed.as_bytes().first(), Some(b'{' | b'[')) {
+                    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(trimmed) {
+                        if parsed.is_object() || parsed.is_array() {
+                            visit(&parsed, path)?;
+                        }
+                    }
                 }
             }
             _ => {}

--- a/crates/edda-core/src/types.rs
+++ b/crates/edda-core/src/types.rs
@@ -94,7 +94,7 @@ pub fn authorship_tag(authority: &str) -> &'static str {
 /// Map an event_type string to its (family, level) classification.
 pub fn classify_event_type(event_type: &str) -> (Option<&'static str>, Option<&'static str>) {
     match event_type {
-        "note" => (Some(event_family::SIGNAL), Some(event_level::INFO)),
+        "note" | "checkpoint" => (Some(event_family::SIGNAL), Some(event_level::INFO)),
         "cmd" => (Some(event_family::SIGNAL), Some(event_level::TRACE)),
         "commit" => (Some(event_family::MILESTONE), Some(event_level::MILESTONE)),
         "merge" => (Some(event_family::MILESTONE), Some(event_level::MILESTONE)),

--- a/crates/edda-ledger/src/sqlite_store/events.rs
+++ b/crates/edda-ledger/src/sqlite_store/events.rs
@@ -21,7 +21,8 @@ fn validate_event_hash(event: &Event) -> anyhow::Result<()> {
 }
 
 pub(super) fn validate_event_for_append(conn: &Connection, event: &Event) -> anyhow::Result<()> {
-    edda_core::event::validate_readable_payload(&event.payload)?;
+    let event_value = serde_json::to_value(event)?;
+    edda_core::event::validate_readable_payload(&event_value)?;
 
     let current_tail: Option<String> = conn
         .query_row(

--- a/crates/edda-ledger/src/sqlite_store/events.rs
+++ b/crates/edda-ledger/src/sqlite_store/events.rs
@@ -21,6 +21,8 @@ fn validate_event_hash(event: &Event) -> anyhow::Result<()> {
 }
 
 pub(super) fn validate_event_for_append(conn: &Connection, event: &Event) -> anyhow::Result<()> {
+    edda_core::event::validate_readable_payload(&event.payload)?;
+
     let current_tail: Option<String> = conn
         .query_row(
             "SELECT hash FROM events ORDER BY rowid DESC LIMIT 1",

--- a/crates/edda-ledger/src/sqlite_store/mod.rs
+++ b/crates/edda-ledger/src/sqlite_store/mod.rs
@@ -132,6 +132,34 @@ mod tests {
     }
 
     #[test]
+    fn append_rejects_raw_vendor_reasoning_payload() {
+        let (dir, store) = tmp_db();
+        let mut event = new_note_event("main", None, "vendor", "summary", &[]).unwrap();
+        event.payload["reasoning"] = serde_json::json!({
+            "provider": "fake-vendor",
+            "encrypted_content": "fake-reasoning-payload"
+        });
+
+        let result = store.append_event(&event);
+        assert!(
+            result.is_err(),
+            "raw vendor reasoning must not cross the readable-ledger boundary"
+        );
+
+        event.payload["reasoning"] = serde_json::json!({
+            "pointer": "vendor://fake/reasoning/1",
+            "content_hash": "sha256:fake-hash"
+        });
+        assert!(
+            store.append_event(&event).is_ok(),
+            "a pointer plus content hash is readable ledger metadata"
+        );
+
+        drop(store);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn event_round_trip() {
         let (dir, store) = tmp_db();
         let e1 = new_note_event("main", None, "system", "first note", &["test".into()]).unwrap();

--- a/crates/edda-ledger/src/sqlite_store/mod.rs
+++ b/crates/edda-ledger/src/sqlite_store/mod.rs
@@ -1580,6 +1580,69 @@ mod tests {
     }
 
     #[test]
+    fn append_rejects_json_reasoning_in_provenance_note() {
+        let (dir, store) = tmp_db();
+        let mut event = new_note_event("main", None, "vendor", "readable summary", &[]).unwrap();
+        event.refs.provenance.push(Provenance {
+            target: "evt_fake_target".to_string(),
+            rel: "reviews".to_string(),
+            note: Some(
+                serde_json::json!({
+                    "thinking": {
+                        "encrypted_content": "fake-reasoning-payload"
+                    }
+                })
+                .to_string(),
+            ),
+        });
+        edda_core::event::finalize_event(&mut event).unwrap();
+
+        let result = store.append_event_strict(&event);
+        assert!(
+            result.is_err(),
+            "JSON-encoded vendor reasoning must not cross the readable-ledger boundary"
+        );
+
+        drop(store);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn append_accepts_serialized_pointer_hash_reasoning_reference() {
+        let (dir, store) = tmp_db();
+        let mut event = new_note_event("main", None, "vendor", "readable summary", &[]).unwrap();
+        event.payload["reasoning"] = serde_json::json!(serde_json::json!({
+            "pointer": "vendor://fake/reasoning/1",
+            "content_hash": "sha256:fake-hash"
+        })
+        .to_string());
+        edda_core::event::finalize_event(&mut event).unwrap();
+
+        assert!(store.append_event_strict(&event).is_ok());
+
+        drop(store);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn append_accepts_ordinary_readable_summary_text() {
+        let (dir, store) = tmp_db();
+        let event = new_note_event(
+            "main",
+            None,
+            "vendor",
+            "The agent is thinking about cache invalidation.",
+            &[],
+        )
+        .unwrap();
+
+        assert!(store.append_event_strict(&event).is_ok());
+
+        drop(store);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn append_rejects_broken_parent_hash() {
         let (dir, store) = tmp_db();
         let e1 = new_note_event("main", None, "system", "first", &[]).unwrap();

--- a/crates/edda-pack/src/lib.rs
+++ b/crates/edda-pack/src/lib.rs
@@ -283,84 +283,192 @@ fn parse_assistant_content(asst_json: &serde_json::Value) -> (Vec<String>, Vec<T
 
 // ── Pack rendering ──
 
-/// Render turns into a markdown pack string with budget truncation.
-pub fn render_pack(turns: &[Turn], metadata: &PackMetadata, budget_chars: usize) -> String {
-    let budget = if budget_chars == 0 {
+/// The stable section order for neutral memory-pack items.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PackSection {
+    Goals,
+    BindingDecisions,
+    UnratifiedDecisions,
+    OpenCheckpoints,
+    Constraints,
+    Coordination,
+    FileStateDeltas,
+    RecentTurns,
+}
+
+impl PackSection {
+    fn title(self) -> &'static str {
+        match self {
+            Self::Goals => "Goals",
+            Self::BindingDecisions => "Binding Decisions",
+            Self::UnratifiedDecisions => "Unratified Decisions",
+            Self::OpenCheckpoints => "Open Checkpoints",
+            Self::Constraints => "Constraints",
+            Self::Coordination => "Coordination",
+            Self::FileStateDeltas => "File-State Deltas",
+            Self::RecentTurns => "Recent Turns (deterministic)",
+        }
+    }
+}
+
+/// A complete, neutral item in a memory pack.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackItem {
+    pub section: PackSection,
+    pub key: String,
+    pub body: String,
+    pub salience: u64,
+}
+
+fn pack_budget(budget_chars: usize) -> usize {
+    if budget_chars == 0 {
         std::env::var("EDDA_PACK_BUDGET_CHARS")
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(DEFAULT_PACK_BUDGET_CHARS)
     } else {
         budget_chars
-    };
-
-    let mut out = String::new();
-    out.push_str("# edda memory pack (hot)\n\n");
-    out.push_str(&format!("- project_id: {}\n", metadata.project_id));
-    out.push_str(&format!("- session_id: {}\n", metadata.session_id));
-    out.push_str(&format!("- git_branch: {}\n", metadata.git_branch));
-    out.push_str(&format!("- turns: {}\n\n", turns.len()));
-    out.push_str("## Recent Turns (deterministic)\n\n");
-
-    // Render turns, newest first, truncate from oldest if over budget
-    for (i, turn) in turns.iter().enumerate() {
-        let mut section = String::new();
-        let user_preview = truncate_str(&turn.user_text, 200);
-        section.push_str(&format!("### Turn {} (newest first)\n", i + 1));
-        section.push_str(&format!("- User: {user_preview}\n"));
-
-        for tu in &turn.tool_uses {
-            let cmd_str = tu
-                .command
-                .as_deref()
-                .map(|c| format!(" `{}`", truncate_str(c, 80)))
-                .unwrap_or_default();
-            let desc_str = tu
-                .description
-                .as_deref()
-                .map(|d| format!(" ({})", truncate_str(d, 60)))
-                .unwrap_or_default();
-            let file_str = tu
-                .file_path
-                .as_deref()
-                .map(|f| format!(" file={f}"))
-                .unwrap_or_default();
-            section.push_str(&format!(
-                "  - ToolUse: {}{}{}{}\n",
-                tu.name, cmd_str, desc_str, file_str
-            ));
-        }
-
-        for text in &turn.assistant_texts {
-            let preview = truncate_str(text, 300);
-            section.push_str(&format!("  - Assistant: {preview}\n"));
-        }
-        section.push('\n');
-
-        if out.len() + section.len() > budget {
-            out.push_str(&format!(
-                "... ({} more turns truncated by budget)\n",
-                turns.len() - i
-            ));
-            break;
-        }
-        out.push_str(&section);
     }
+}
 
+fn render_pack_header(metadata: &PackMetadata, dropped_items: usize) -> String {
+    format!(
+        "# edda memory pack (hot)\n\n- project_id: {}\n- session_id: {}\n- git_branch: {}\n- turns: {}\n- dropped_items: {}\n\n",
+        metadata.project_id,
+        metadata.session_id,
+        metadata.git_branch,
+        metadata.turn_count,
+        dropped_items,
+    )
+}
+
+fn render_selected_items(
+    metadata: &PackMetadata,
+    items: &[PackItem],
+    selected: &[usize],
+    dropped_items: usize,
+) -> String {
+    let mut ordered = selected.to_vec();
+    ordered.sort_by(|a, b| {
+        items[*a]
+            .section
+            .cmp(&items[*b].section)
+            .then_with(|| items[*a].key.cmp(&items[*b].key))
+            .then_with(|| a.cmp(b))
+    });
+
+    let mut out = render_pack_header(metadata, dropped_items);
+    let mut section = None;
+    for index in ordered {
+        let item = &items[index];
+        if section != Some(item.section) {
+            out.push_str(&format!("## {}\n\n", item.section.title()));
+            section = Some(item.section);
+        }
+        out.push_str(&format!("### {}\n", item.key));
+        out.push_str(&item.body);
+        if !item.body.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push('\n');
+    }
     out
 }
 
-fn truncate_str(s: &str, max: usize) -> String {
-    if s.len() <= max {
-        s.replace('\n', " ")
-    } else {
-        // Find the last char boundary at or before `max` bytes
-        let mut end = max;
-        while end > 0 && !s.is_char_boundary(end) {
-            end -= 1;
+fn select_items(
+    metadata: &PackMetadata,
+    items: &[PackItem],
+    budget: usize,
+    dropped_items: usize,
+) -> Vec<usize> {
+    let mut ranked: Vec<usize> = (0..items.len()).collect();
+    ranked.sort_by(|a, b| {
+        items[*b]
+            .salience
+            .cmp(&items[*a].salience)
+            .then_with(|| items[*a].section.cmp(&items[*b].section))
+            .then_with(|| items[*a].key.cmp(&items[*b].key))
+            .then_with(|| a.cmp(b))
+    });
+
+    let mut selected = Vec::new();
+    for index in ranked {
+        selected.push(index);
+        if render_selected_items(metadata, items, &selected, dropped_items).len() > budget {
+            selected.pop();
         }
-        format!("{}...", s[..end].replace('\n', " "))
     }
+    selected
+}
+
+/// Render neutral items in deterministic section and salience order.
+///
+/// Items are selected by salience, with stable tie-breakers, and are either
+/// included in full or omitted. The dropped count is part of the pack header.
+pub fn render_ordered_pack(
+    items: &[PackItem],
+    metadata: &PackMetadata,
+    budget_chars: usize,
+) -> String {
+    let budget = pack_budget(budget_chars);
+    let mut dropped_items = items.len();
+    let mut selected = Vec::new();
+
+    // The count is in the header, so a digit-boundary change can affect fit.
+    for _ in 0..4 {
+        selected = select_items(metadata, items, budget, dropped_items);
+        let next_dropped = items.len() - selected.len();
+        if next_dropped == dropped_items {
+            break;
+        }
+        dropped_items = next_dropped;
+    }
+
+    render_selected_items(metadata, items, &selected, items.len() - selected.len())
+}
+
+fn render_turn_body(turn: &Turn) -> String {
+    let mut body = format!("- User: {}\n", turn.user_text);
+    for tu in &turn.tool_uses {
+        let cmd_str = tu
+            .command
+            .as_deref()
+            .map(|c| format!(" `{c}`"))
+            .unwrap_or_default();
+        let desc_str = tu
+            .description
+            .as_deref()
+            .map(|d| format!(" ({d})"))
+            .unwrap_or_default();
+        let file_str = tu
+            .file_path
+            .as_deref()
+            .map(|f| format!(" file={f}"))
+            .unwrap_or_default();
+        body.push_str(&format!(
+            "  - ToolUse: {}{}{}{}\n",
+            tu.name, cmd_str, desc_str, file_str
+        ));
+    }
+    for text in &turn.assistant_texts {
+        body.push_str(&format!("  - Assistant: {text}\n"));
+    }
+    body
+}
+
+/// Render turns into a hot pack without truncating any turn item.
+pub fn render_pack(turns: &[Turn], metadata: &PackMetadata, budget_chars: usize) -> String {
+    let items: Vec<PackItem> = turns
+        .iter()
+        .enumerate()
+        .map(|(index, turn)| PackItem {
+            section: PackSection::RecentTurns,
+            key: format!("Turn {} (newest first)", index + 1),
+            body: render_turn_body(turn),
+            salience: (turns.len() - index) as u64,
+        })
+        .collect();
+    render_ordered_pack(&items, metadata, budget_chars)
 }
 
 /// Write hot.md and hot.meta.json to the packs directory.
@@ -664,7 +772,7 @@ mod tests {
     }
 
     #[test]
-    fn render_pack_budget_truncation() {
+    fn render_pack_drops_whole_items_at_budget() {
         let turns: Vec<Turn> = (0..20)
             .map(|i| Turn {
                 user_uuid: format!("u{i}"),
@@ -686,8 +794,9 @@ mod tests {
         };
 
         let md = render_pack(&turns, &meta, 500);
-        assert!(md.contains("truncated by budget"));
-        assert!(md.len() <= 600); // some slack for the truncation message
+        assert!(md.contains("- dropped_items: "));
+        assert!(!md.contains("truncated by budget"));
+        assert!(md.len() <= 500);
     }
 
     #[test]

--- a/crates/edda-pack/src/lib.rs
+++ b/crates/edda-pack/src/lib.rs
@@ -320,6 +320,57 @@ pub struct PackItem {
     pub salience: u64,
 }
 
+/// Convert checkpoint events into neutral hot-pack items.
+pub fn checkpoint_items(events: &[edda_core::Event]) -> Vec<PackItem> {
+    events
+        .iter()
+        .rev()
+        .enumerate()
+        .filter_map(|(index, event)| {
+            let payload: edda_core::event::CheckpointPayload =
+                serde_json::from_value(event.payload.clone()).ok()?;
+            let rejected = payload
+                .rejected
+                .iter()
+                .map(|item| format!("{} — {}", item.hypothesis, item.reason))
+                .collect::<Vec<_>>();
+            let body = format!(
+                "- hypotheses: {}\n- rejected: {}\n- open: {}\n- next: {}\n",
+                payload.hypotheses.join(" | "),
+                rejected.join(" | "),
+                payload.open.join(" | "),
+                payload.next,
+            );
+            Some(PackItem {
+                section: PackSection::OpenCheckpoints,
+                key: format!("Checkpoint {}", event.event_id),
+                body,
+                salience: 90 + (events.len() - index) as u64,
+            })
+        })
+        .collect()
+}
+
+fn latest_registered_checkpoint_items(project_id: &str) -> Vec<PackItem> {
+    let Some(project) = edda_store::registry::get_project(project_id) else {
+        return Vec::new();
+    };
+    let Ok(ledger) = edda_ledger::Ledger::open(project.path) else {
+        return Vec::new();
+    };
+    let Ok(branch) = ledger.head_branch() else {
+        return Vec::new();
+    };
+    let Ok(events) = ledger.iter_events_by_type("checkpoint") else {
+        return Vec::new();
+    };
+    let events: Vec<_> = events
+        .into_iter()
+        .filter(|event| event.branch == branch)
+        .collect();
+    checkpoint_items(&events).into_iter().take(1).collect()
+}
+
 fn pack_budget(budget_chars: usize) -> usize {
     if budget_chars == 0 {
         std::env::var("EDDA_PACK_BUDGET_CHARS")
@@ -458,7 +509,7 @@ fn render_turn_body(turn: &Turn) -> String {
 
 /// Render turns into a hot pack without truncating any turn item.
 pub fn render_pack(turns: &[Turn], metadata: &PackMetadata, budget_chars: usize) -> String {
-    let items: Vec<PackItem> = turns
+    let mut items: Vec<PackItem> = turns
         .iter()
         .enumerate()
         .map(|(index, turn)| PackItem {
@@ -468,6 +519,7 @@ pub fn render_pack(turns: &[Turn], metadata: &PackMetadata, budget_chars: usize)
             salience: (turns.len() - index) as u64,
         })
         .collect();
+    items.extend(latest_registered_checkpoint_items(&metadata.project_id));
     render_ordered_pack(&items, metadata, budget_chars)
 }
 
@@ -769,6 +821,36 @@ mod tests {
         assert!(md.contains("How do I sort a list?"));
         assert!(md.contains("ToolUse: Bash"));
         assert!(md.contains("Use the sort() method."));
+    }
+
+    #[test]
+    fn checkpoint_items_join_the_hot_pack_schema() {
+        let checkpoint = edda_core::event::CheckpointPayload {
+            hypotheses: vec!["cache invalidation is the cause".to_string()],
+            rejected: vec![edda_core::event::RejectedHypothesis {
+                hypothesis: "database corruption".to_string(),
+                reason: "integrity check passes".to_string(),
+            }],
+            open: vec!["confirm the next rebuild".to_string()],
+            next: "run the rebuild check".to_string(),
+        };
+        let event =
+            edda_core::event::new_checkpoint_event("main", None, "agent", &checkpoint).unwrap();
+        let items = checkpoint_items(&[event]);
+        let meta = PackMetadata {
+            project_id: "abc".into(),
+            session_id: "s1".into(),
+            git_branch: "main".into(),
+            turn_count: 0,
+            budget_chars: 12000,
+        };
+
+        let md = render_ordered_pack(&items, &meta, 12000);
+
+        assert!(md.contains("## Open Checkpoints"));
+        assert!(md.contains("cache invalidation is the cause"));
+        assert!(md.contains("integrity check passes"));
+        assert!(md.contains("run the rebuild check"));
     }
 
     #[test]

--- a/crates/edda-search-fts/src/indexer.rs
+++ b/crates/edda-search-fts/src/indexer.rs
@@ -159,6 +159,52 @@ fn extract_event_title_body(event: &edda_core::Event) -> (String, String) {
         return (title, body);
     }
 
+    if event.event_type == "checkpoint" {
+        let strings = |key: &str| {
+            payload
+                .get(key)
+                .and_then(|value| value.as_array())
+                .map(|values| {
+                    values
+                        .iter()
+                        .filter_map(|value| value.as_str())
+                        .collect::<Vec<_>>()
+                        .join(" | ")
+                })
+                .unwrap_or_default()
+        };
+        let rejected = payload
+            .get("rejected")
+            .and_then(|value| value.as_array())
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(|value| {
+                        Some(format!(
+                            "{} — {}",
+                            value.get("hypothesis")?.as_str()?,
+                            value.get("reason")?.as_str()?
+                        ))
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" | ")
+            })
+            .unwrap_or_default();
+        let next = payload
+            .get("next")
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        return (
+            "checkpoint".to_string(),
+            format!(
+                "hypotheses: {}; rejected: {}; open: {}; next: {next}",
+                strings("hypotheses"),
+                rejected,
+                strings("open"),
+            ),
+        );
+    }
+
     // Generic: title empty, body = text field
     let text = payload.get("text").and_then(|v| v.as_str()).unwrap_or("");
     (String::new(), text.to_string())
@@ -1202,6 +1248,27 @@ mod tests {
             joined.contains("make task receipts searchable"),
             "task_intake intent must be indexed: {joined:?}"
         );
+    }
+
+    #[test]
+    fn checkpoint_judgment_state_is_searchable() {
+        let checkpoint = edda_core::event::CheckpointPayload {
+            hypotheses: vec!["cache invalidation is the cause".to_string()],
+            rejected: vec![edda_core::event::RejectedHypothesis {
+                hypothesis: "database corruption".to_string(),
+                reason: "integrity check passes".to_string(),
+            }],
+            open: vec!["confirm the next rebuild".to_string()],
+            next: "run the rebuild check".to_string(),
+        };
+        let event =
+            edda_core::event::new_checkpoint_event("main", None, "agent", &checkpoint).unwrap();
+
+        let (title, body) = extract_event_title_body(&event);
+        let searchable = format!("{title} {body}");
+        assert!(searchable.contains("cache invalidation is the cause"));
+        assert!(searchable.contains("integrity check passes"));
+        assert!(searchable.contains("run the rebuild check"));
     }
 
     #[test]

--- a/docs/architecture/consistency-contract.md
+++ b/docs/architecture/consistency-contract.md
@@ -24,6 +24,9 @@ scoping, and durability guarantees.
   acquire an exclusive `WorkspaceLock` via `.edda/LOCK` (non-blocking
   `fs2::try_lock_exclusive`). Bridge hooks retry with
   `EDDA_BRIDGE_LOCK_TIMEOUT_MS` (default 2 s).
+- **Checkpoint payload**: `hypotheses`, `rejected` (hypothesis plus one-line
+  reason), `open`, and `next`. These are readable, vendor-neutral judgment state;
+  native reasoning traces are not checkpoint fields.
 - **Entity types**: `note`, `cmd`, `commit`, `merge`, `branch_create`,
   `branch_switch`, `rebuild`, `task_intake`, `agent_phase_change`, `approval`,
   `approval_request`, `approval_policy_match`, `review_bundle`, `pr`,

--- a/docs/architecture/consistency-contract.md
+++ b/docs/architecture/consistency-contract.md
@@ -27,7 +27,7 @@ scoping, and durability guarantees.
 - **Entity types**: `note`, `cmd`, `commit`, `merge`, `branch_create`,
   `branch_switch`, `rebuild`, `task_intake`, `agent_phase_change`, `approval`,
   `approval_request`, `approval_policy_match`, `review_bundle`, `pr`,
-  `execution_event`
+  `execution_event`, `checkpoint`
 
 ### Coordination Store (`~/.edda/projects/{pid}/state/`)
 
@@ -67,6 +67,7 @@ scoping, and durability guarantees.
 | Approval / Review bundle | Ledger | Durable, hash-chained | Immediate | Rebuild from event log |
 | PR outcome | Ledger | Durable, hash-chained | Immediate | Re-ingest |
 | Execution event | Ledger | Durable, hash-chained | Immediate | Re-ingest from transcript |
+| Checkpoint | Ledger | Durable, hash-chained | Immediate | Rebuild from event log |
 | Branch metadata | Ledger (refs) | Durable | Immediate | — |
 | Heartbeat | Coordination | Ephemeral (session-scoped) | Up to 120 s stale | Stale heartbeats pruned; recreated on next hook |
 | Scope claim | Coordination | Ephemeral (session-scoped) | Re-derived on read | Compacted by GC; unclaimed on `SessionEnd` |
@@ -158,14 +159,17 @@ and future issues.
 | INV-05 | Decision source of truth is the ledger, not the coordination binding. | Coordination binding is a real-time notification, not authoritative. |
 | INV-06 | Coordination state may reference entities not yet in the ledger. | Eventual consistency — consumers must handle missing refs gracefully. |
 | INV-07 | Conductor state is workspace-local and independent of coordination. | Plan execution does not depend on peer state. |
+| INV-08 | Ledger appends MUST reject vendor-native reasoning payloads. Readable summaries are allowed; native traces may only be referenced by pointer plus content hash. | Keeps the ledger readable, auditable, and portable across vendors. |
 
 ## Contributor Guide: Adding New State
 
 When adding a new stateful feature, use this decision tree:
 
-1. **Is this a permanent project record?** (decision, note, commit, approval)
+1. **Is this a permanent project record?** (decision, note, checkpoint, commit, approval)
    - Write to the **Ledger** via `edda_ledger::Ledger::append_event()`.
    - Must be hash-chained (use `edda_core::event::new_*_event()` constructors).
+   - Record readable, vendor-neutral text only. Never append raw vendor reasoning;
+     an audit pointer is allowed only when paired with its content hash.
 
 2. **Is this real-time coordination between concurrent sessions?** (claim, binding,
    request, heartbeat)

--- a/docs/guides/claude-code.md
+++ b/docs/guides/claude-code.md
@@ -50,6 +50,11 @@ Example of what the agent receives:
 - auth.strategy: JWT (cli)
 ```
 
+Reasoning checkpoints are durable, vendor-neutral ledger records. Record one with
+`edda checkpoint --hypothesis "..." --rejected "hypothesis|reason" --open "..." --next "..."`.
+The hot pack includes the latest checkpoint under `Open Checkpoints`; budget
+degradation drops complete sections and reports the omitted-item count.
+
 View the full context snapshot at any time:
 
 ```bash


### PR DESCRIPTION
Closes #439
Closes #440
Closes #441

Summary:
- add vendor-neutral checkpoint records, CLI recording, ask/search recall, and hot-pack inclusion
- enforce the readable-ledger boundary for the full Event, including recursive JSON-looking strings in provenance notes
- preserve readable summaries and structured/serialized pointer+hash reasoning references
- make pack and host context budgeting deterministic with whole-item/section drops and visible omission counts

Verification at `79ad4b8d084cafe9dcfcc32b9c3da147ccbb7ae3`:
- TDD regression proves serialized vendor reasoning in provenance notes is rejected
- focused suites: edda-ledger 213/213; edda-core 188/188
- GitHub CI: 7/7 green on Ubuntu, macOS, and Windows
- independent verifier task #30: PASS for GH-439/440/441 and the full-event boundary
- final exact-SHA synthetic integration with PR #459 and PR #460: fmt PASS, clippy `-D warnings` PASS, default-parallel `cargo test --workspace` PASS