### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,14 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal --component rustfmt
       - run: cargo fmt --check
+      - run: sh -n install.sh
+      - name: Verify installer latest-version stdout
+        shell: bash
+        run: |
+          source <(awk '/^main\(\)/ { exit } { print }' install.sh)
+          VERSION=""
+          download_to_stdout() { printf '%s\n' '{"tag_name":"v0.0.0"}'; }
+          test "$(resolve_version)" = "v0.0.0"
 
   clippy:
     name: Clippy (${{ matrix.os }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,26 @@ jobs:
       - name: Get tag
         id: tag
         run: echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+      - name: Prepare release notes
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          release_notes="$(awk -v heading="## [$version]" '
+            { sub(/\r$/, "") }
+            index($0, heading) == 1 { capture = 1; next }
+            capture && /^## \[/ { exit }
+            capture { print }
+          ' CHANGELOG.md)"
+          if [ -z "$release_notes" ]; then
+            echo "::error::CHANGELOG.md has no section for $version"
+            exit 1
+          fi
+          printf '%s\n' "$release_notes" > "$RUNNER_TEMP/release-notes.md"
       - name: Create draft release
-        run: gh release create "$GITHUB_REF_NAME" --draft --verify-tag --title "$GITHUB_REF_NAME" --generate-notes
+        run: >-
+          gh release create "$GITHUB_REF_NAME" --draft --verify-tag
+          --title "$GITHUB_REF_NAME" --generate-notes
+          --notes "$(cat "$RUNNER_TEMP/release-notes.md")"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-16
+
 ### Added
 
 - **Decision provenance** (`edda ratify`) — decisions are now *recorded ≠ ratified*. Every `edda decide` is tagged `authority=agent` (or `system`), never operator; the background decision extractor is tagged `agent` too, and any write that omits authority projects as `unknown` (never the old `human` default). Operator authority is conferred only by a separate, append-only `decision_ratify` event via `edda ratify <key> [--by] [--note]`, so the hash chain can no longer launder machine inference into authoritative fact. The SessionStart decision pack now splits into **Ratified Decisions** (binding) and **Unratified Decisions** (recorded, not binding), with authorship tags; the coordination view and the `coord-sync`/`coord-review` skills were reworded to stop calling broadcasts "binding". Ratified-state is derived from event insertion order (rowid), never stored, and keyed per decision event (a re-decided key must be re-ratified; branch- and import-safe). `--by` is recorded for audit but self-asserted (identity enforcement is a policy-layer concern). Spec: [GH-401](https://github.com/fagemx/edda/issues/401). Existing decisions render as unratified until ratified — a deliberate clean sweep, not a regression. Existing installs: re-run `edda init --force` once to refresh the reworded coordination skills (this overwrites local edits to the `coord-*` skill files)
 - **Task rail P1** (`edda task`) — hash-chained `task.*` event family, derived status/readiness projection (never stored), CLI verbs `new/start/done/fail/list/show` (done requires a receipt and reports which successors became ready), Stop-hook nudge for newly-ready assigned tasks, and task-rail verbs taught in the write-back protocol. Spec: `docs/plan/task-rail/TASK_RAIL_V1.md` §3–§7; acceptance drill: `docs/plan/task-rail/P1_DRILL_2026-07-14.md`. Existing installs: re-run `edda init` (or `edda bridge claude install`) once to register the new `Stop` hook
+- **Portable reasoning checkpoints** (`edda checkpoint`) — vendor-neutral hypothesis, rejection, open-question, and next-action records are hash-chained, searchable through `edda ask`, and included in deterministic hot packs with section-aware budget degradation
+- **Fleet-wide reads** — `edda ask --fleet`, `edda search query --fleet`, `edda log --fleet`, and `edda task list --fleet` fan out across the configured project scope, tag results by project, and report unreachable projects instead of silently treating them as empty; hot packs can also surface sibling-project rulings and queues
+- **Incremental full-text indexing** — turn and event cursors avoid full rescans, SessionEnd hooks keep the index current, task receipts are searchable, and the CJK bigram tokenizer supports queries longer than two characters
+- **Coordination operations** — the installed `coord-orchestrate` skill and multi-agent discipline guide are joined by hardened peer lifecycle, task-board, notification, TUI, and policy surfaces across supported bridges
+- **Richer `edda ask` output** — active task receipts now appear alongside decisions, notes, and related history
+
+### Changed
+
+- Windows Clippy and platform-sensitive tests are now blocking CI; the derived Windows crate set includes conductor and transcript coverage while trimming debug information to keep linking practical
 
 ### Fixed
 
 - `edda bundle create` and `edda pair new/revoke/revoke-all` appended chain events without the workspace lock — a concurrent locked writer could interleave and fork the hash chain (two events claiming the same parent). Now serialized like every other writer
 - Latent env-var race between `resolve_session_id_tiers` and the `decide()` tests under the parallel test runner (serialized with `ENV_LOCK`, same pattern as edda-bridge-claude)
+- Search index safety: an empty ledger no longer erases a populated index, cross-project indexing uses the registered project's own repository, and metadata cursors advance only after the Tantivy commit succeeds
+- Coordination requests now acknowledge individual messages, validate and expire targets, avoid treating repo-wide claims as editable scopes, and clean orphaned claims on lifecycle boundaries
+- Glob-scoped decision staleness checks now inspect the directory and its matching files, so in-place edits are detected instead of treating the glob as a literal path
+- Bridge secret redaction and test-store isolation were expanded to prevent sensitive output leakage and writes into an operator's real registry during tests
+- `controls_suggest` fixtures now use a thread-local temporary store without mutating `EDDA_STORE_ROOT`, eliminating Windows test races without touching persistent user data
+- `install.sh` now sends latest-release progress to stderr so its default version lookup captures only the tag and builds a valid asset URL
 
 ## [0.2.1] - 2026-07-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "edda"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "edda-aggregate"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "edda-ask"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "edda-bridge-claude"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "edda-bridge-codex"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "edda-bridge-cursor"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "edda-bridge-hermes"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "edda-bridge-openclaw"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "edda-chronicle"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "edda-conductor"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "edda-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "globset",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "edda-derive"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "edda-index"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "edda-store",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "edda-ingestion"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "edda-ledger"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "edda-mcp"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "edda-ask",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "edda-notify"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "edda-ledger",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "edda-pack"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "edda-postmortem"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "edda-search-fts"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "edda-serve"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "edda-store"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "edda-transcript"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "edda-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fagemx/edda"

--- a/crates/edda-aggregate/Cargo.toml
+++ b/crates/edda-aggregate/Cargo.toml
@@ -10,9 +10,9 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.2.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.2.0" }
-edda-store = { path = "../edda-store", version = "0.2.0" }
+edda-core = { path = "../edda-core", version = "0.3.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.3.0" }
+edda-store = { path = "../edda-store", version = "0.3.0" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-ask/Cargo.toml
+++ b/crates/edda-ask/Cargo.toml
@@ -10,8 +10,8 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-ledger = { path = "../edda-ledger", version = "0.2.0" }
-edda-core = { path = "../edda-core", version = "0.2.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.3.0" }
+edda-core = { path = "../edda-core", version = "0.3.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/edda-bridge-claude/Cargo.toml
+++ b/crates/edda-bridge-claude/Cargo.toml
@@ -10,17 +10,17 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-aggregate = { path = "../edda-aggregate", version = "0.2.0" }
-edda-core = { path = "../edda-core", version = "0.2.0" }
-edda-store = { path = "../edda-store", version = "0.2.0" }
-edda-transcript = { path = "../edda-transcript", version = "0.2.0" }
-edda-index = { path = "../edda-index", version = "0.2.0" }
-edda-pack = { path = "../edda-pack", version = "0.2.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.2.0" }
-edda-search-fts = { path = "../edda-search-fts", version = "0.2.0" }
-edda-notify = { path = "../edda-notify", version = "0.2.0" }
-edda-postmortem = { path = "../edda-postmortem", version = "0.2.0" }
-edda-derive = { path = "../edda-derive", version = "0.2.0" }
+edda-aggregate = { path = "../edda-aggregate", version = "0.3.0" }
+edda-core = { path = "../edda-core", version = "0.3.0" }
+edda-store = { path = "../edda-store", version = "0.3.0" }
+edda-transcript = { path = "../edda-transcript", version = "0.3.0" }
+edda-index = { path = "../edda-index", version = "0.3.0" }
+edda-pack = { path = "../edda-pack", version = "0.3.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.3.0" }
+edda-search-fts = { path = "../edda-search-fts", version = "0.3.0" }
+edda-notify = { path = "../edda-notify", version = "0.3.0" }
+edda-postmortem = { path = "../edda-postmortem", version = "0.3.0" }
+edda-derive = { path = "../edda-derive", version = "0.3.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/edda-bridge-claude/src/controls_suggest.rs
+++ b/crates/edda-bridge-claude/src/controls_suggest.rs
@@ -325,8 +325,23 @@ pub fn load_rules() -> Vec<ThresholdRule> {
 
 // ── Storage Helpers ──
 
-fn patches_dir(project_id: &str) -> PathBuf {
+#[cfg(test)]
+thread_local! {
+    static TEST_STORE_ROOT: std::cell::RefCell<Option<PathBuf>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+fn controls_project_dir(project_id: &str) -> PathBuf {
+    #[cfg(test)]
+    if let Some(root) = TEST_STORE_ROOT.with(|root| root.borrow().clone()) {
+        return root.join("projects").join(project_id);
+    }
+
     edda_store::project_dir(project_id)
+}
+
+fn patches_dir(project_id: &str) -> PathBuf {
+    controls_project_dir(project_id)
         .join("state")
         .join("controls_patches")
 }
@@ -336,7 +351,7 @@ fn patch_path(project_id: &str, patch_id: &str) -> PathBuf {
 }
 
 fn audit_log_path(project_id: &str) -> PathBuf {
-    edda_store::project_dir(project_id)
+    controls_project_dir(project_id)
         .join("state")
         .join("controls_patch_audit.jsonl")
 }
@@ -395,15 +410,51 @@ fn cooldown_cutoff(now: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{MutexGuard, PoisonError};
-
     use super::*;
     use edda_aggregate::quality::{ModelQuality, QualityReport};
 
-    fn store_guard() -> MutexGuard<'static, ()> {
-        crate::ENV_LOCK
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
+    struct StoreGuard {
+        _store_root: tempfile::TempDir,
+    }
+
+    impl Drop for StoreGuard {
+        fn drop(&mut self) {
+            TEST_STORE_ROOT.with(|root| {
+                root.replace(None);
+            });
+        }
+    }
+
+    impl StoreGuard {
+        fn new() -> Self {
+            let store_root = tempfile::tempdir().unwrap();
+            TEST_STORE_ROOT.with(|root| {
+                assert!(
+                    root.borrow().is_none(),
+                    "test store guard must not be nested"
+                );
+                root.replace(Some(store_root.path().to_path_buf()));
+            });
+            Self {
+                _store_root: store_root,
+            }
+        }
+    }
+
+    fn store_guard() -> StoreGuard {
+        StoreGuard::new()
+    }
+
+    #[test]
+    fn store_guard_isolates_storage_without_mutating_process_env() {
+        let before_env = std::env::var_os("EDDA_STORE_ROOT");
+        let default_path = edda_store::project_dir("test_controls_guard");
+        let guard = store_guard();
+        let isolated_path = controls_project_dir("test_controls_guard");
+        assert_ne!(isolated_path, default_path, "fixture needs a private store");
+        assert_eq!(std::env::var_os("EDDA_STORE_ROOT"), before_env);
+        drop(guard);
+        assert_eq!(controls_project_dir("test_controls_guard"), default_path);
     }
 
     fn make_report(success_rate: f64, total_steps: u64, cost: f64) -> QualityReport {
@@ -480,8 +531,6 @@ mod tests {
     fn crud_roundtrip() {
         let _store = store_guard();
         let pid = "test_controls_crud";
-        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
-        let _ = edda_store::ensure_dirs(pid);
 
         let patch = ControlsPatch {
             patch_id: "cpatch_crud1".to_string(),
@@ -504,17 +553,12 @@ mod tests {
 
         let pending = list_patches(pid, Some(&PatchStatus::Pending)).unwrap();
         assert_eq!(pending.len(), 1);
-
-        // Cleanup
-        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     }
 
     #[test]
     fn approve_and_dismiss_transitions() {
         let _store = store_guard();
         let pid = "test_controls_transitions";
-        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
-        let _ = edda_store::ensure_dirs(pid);
 
         // Approve path
         let p1 = ControlsPatch {
@@ -558,17 +602,12 @@ mod tests {
 
         // Cannot dismiss again
         assert!(dismiss_patch(pid, "cpatch_trans2", None).is_err());
-
-        // Cleanup
-        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     }
 
     #[test]
     fn mark_applied_requires_approved() {
         let _store = store_guard();
         let pid = "test_controls_applied";
-        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
-        let _ = edda_store::ensure_dirs(pid);
 
         let p1 = ControlsPatch {
             patch_id: "cpatch_app1".to_string(),
@@ -591,17 +630,12 @@ mod tests {
         let applied = mark_applied(pid, "cpatch_app1").unwrap();
         assert_eq!(applied.status, PatchStatus::Applied);
         assert!(applied.applied_at.is_some());
-
-        // Cleanup
-        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     }
 
     #[test]
     fn audit_log_records_actions() {
         let _store = store_guard();
         let pid = "test_controls_audit";
-        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
-        let _ = edda_store::ensure_dirs(pid);
 
         let patch = ControlsPatch {
             patch_id: "cpatch_audit1".to_string(),
@@ -623,9 +657,6 @@ mod tests {
         assert_eq!(lines.len(), 2);
         assert!(lines[0].contains("created"));
         assert!(lines[1].contains("approved"));
-
-        // Cleanup
-        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     }
 
     #[test]

--- a/crates/edda-bridge-claude/src/controls_suggest.rs
+++ b/crates/edda-bridge-claude/src/controls_suggest.rs
@@ -395,8 +395,16 @@ fn cooldown_cutoff(now: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{MutexGuard, PoisonError};
+
     use super::*;
     use edda_aggregate::quality::{ModelQuality, QualityReport};
+
+    fn store_guard() -> MutexGuard<'static, ()> {
+        crate::ENV_LOCK
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+    }
 
     fn make_report(success_rate: f64, total_steps: u64, cost: f64) -> QualityReport {
         QualityReport {
@@ -457,6 +465,7 @@ mod tests {
 
     #[test]
     fn suggest_returns_patch_when_triggered() {
+        let _store = store_guard();
         let report = make_report(0.30, 20, 2.0);
         let rules = default_rules();
         let result = suggest_controls_patch("test_suggest_some", &report, &rules, None).unwrap();
@@ -469,7 +478,9 @@ mod tests {
 
     #[test]
     fn crud_roundtrip() {
+        let _store = store_guard();
         let pid = "test_controls_crud";
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
         let _ = edda_store::ensure_dirs(pid);
 
         let patch = ControlsPatch {
@@ -500,7 +511,9 @@ mod tests {
 
     #[test]
     fn approve_and_dismiss_transitions() {
+        let _store = store_guard();
         let pid = "test_controls_transitions";
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
         let _ = edda_store::ensure_dirs(pid);
 
         // Approve path
@@ -552,7 +565,9 @@ mod tests {
 
     #[test]
     fn mark_applied_requires_approved() {
+        let _store = store_guard();
         let pid = "test_controls_applied";
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
         let _ = edda_store::ensure_dirs(pid);
 
         let p1 = ControlsPatch {
@@ -583,7 +598,9 @@ mod tests {
 
     #[test]
     fn audit_log_records_actions() {
+        let _store = store_guard();
         let pid = "test_controls_audit";
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
         let _ = edda_store::ensure_dirs(pid);
 
         let patch = ControlsPatch {

--- a/crates/edda-bridge-codex/Cargo.toml
+++ b/crates/edda-bridge-codex/Cargo.toml
@@ -10,13 +10,13 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.2.0" }
-edda-store = { path = "../edda-store", version = "0.2.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.2.0" }
-edda-pack = { path = "../edda-pack", version = "0.2.0" }
-edda-postmortem = { path = "../edda-postmortem", version = "0.2.0" }
-edda-derive = { path = "../edda-derive", version = "0.2.0" }
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.2.0" }
+edda-core = { path = "../edda-core", version = "0.3.0" }
+edda-store = { path = "../edda-store", version = "0.3.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.3.0" }
+edda-pack = { path = "../edda-pack", version = "0.3.0" }
+edda-postmortem = { path = "../edda-postmortem", version = "0.3.0" }
+edda-derive = { path = "../edda-derive", version = "0.3.0" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.3.0" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-bridge-cursor/Cargo.toml
+++ b/crates/edda-bridge-cursor/Cargo.toml
@@ -10,10 +10,10 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.2.0" }
-edda-pack = { path = "../edda-pack", version = "0.2.0" }
-edda-postmortem = { path = "../edda-postmortem", version = "0.2.0" }
-edda-store = { path = "../edda-store", version = "0.2.0" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.3.0" }
+edda-pack = { path = "../edda-pack", version = "0.3.0" }
+edda-postmortem = { path = "../edda-postmortem", version = "0.3.0" }
+edda-store = { path = "../edda-store", version = "0.3.0" }
 anyhow.workspace = true
 dirs.workspace = true
 serde.workspace = true

--- a/crates/edda-bridge-hermes/Cargo.toml
+++ b/crates/edda-bridge-hermes/Cargo.toml
@@ -10,13 +10,13 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.2.0" }
-edda-store = { path = "../edda-store", version = "0.2.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.2.0" }
-edda-pack = { path = "../edda-pack", version = "0.2.0" }
-edda-postmortem = { path = "../edda-postmortem", version = "0.2.0" }
-edda-derive = { path = "../edda-derive", version = "0.2.0" }
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.2.0" }
+edda-core = { path = "../edda-core", version = "0.3.0" }
+edda-store = { path = "../edda-store", version = "0.3.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.3.0" }
+edda-pack = { path = "../edda-pack", version = "0.3.0" }
+edda-postmortem = { path = "../edda-postmortem", version = "0.3.0" }
+edda-derive = { path = "../edda-derive", version = "0.3.0" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.3.0" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-bridge-openclaw/Cargo.toml
+++ b/crates/edda-bridge-openclaw/Cargo.toml
@@ -10,11 +10,11 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.2.0" }
-edda-store = { path = "../edda-store", version = "0.2.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.2.0" }
-edda-derive = { path = "../edda-derive", version = "0.2.0" }
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.2.0" }
+edda-core = { path = "../edda-core", version = "0.3.0" }
+edda-store = { path = "../edda-store", version = "0.3.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.3.0" }
+edda-derive = { path = "../edda-derive", version = "0.3.0" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.3.0" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-chronicle/Cargo.toml
+++ b/crates/edda-chronicle/Cargo.toml
@@ -10,13 +10,13 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.2.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.2.0" }
-edda-store = { path = "../edda-store", version = "0.2.0" }
-edda-transcript = { path = "../edda-transcript", version = "0.2.0" }
-edda-index = { path = "../edda-index", version = "0.2.0" }
-edda-search-fts = { path = "../edda-search-fts", version = "0.2.0" }
-edda-aggregate = { path = "../edda-aggregate", version = "0.2.0" }
+edda-core = { path = "../edda-core", version = "0.3.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.3.0" }
+edda-store = { path = "../edda-store", version = "0.3.0" }
+edda-transcript = { path = "../edda-transcript", version = "0.3.0" }
+edda-index = { path = "../edda-index", version = "0.3.0" }
+edda-search-fts = { path = "../edda-search-fts", version = "0.3.0" }
+edda-aggregate = { path = "../edda-aggregate", version = "0.3.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/edda-cli/Cargo.toml
+++ b/crates/edda-cli/Cargo.toml
@@ -14,27 +14,27 @@ name = "edda"
 path = "src/main.rs"
 
 [dependencies]
-edda-aggregate = { path = "../edda-aggregate", version = "0.2.0" }
-edda-ask = { path = "../edda-ask", version = "0.2.0" }
-edda-chronicle = { path = "../edda-chronicle", version = "0.2.0" }
-edda-core = { path = "../edda-core", version = "0.2.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.2.0" }
-edda-derive = { path = "../edda-derive", version = "0.2.0" }
-edda-store = { path = "../edda-store", version = "0.2.0" }
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.2.0" }
-edda-bridge-codex = { path = "../edda-bridge-codex", version = "0.2.0" }
-edda-bridge-cursor = { path = "../edda-bridge-cursor", version = "0.2.0" }
-edda-bridge-hermes = { path = "../edda-bridge-hermes", version = "0.2.0" }
-edda-bridge-openclaw = { path = "../edda-bridge-openclaw", version = "0.2.0" }
-edda-transcript = { path = "../edda-transcript", version = "0.2.0" }
-edda-index = { path = "../edda-index", version = "0.2.0" }
-edda-pack = { path = "../edda-pack", version = "0.2.0" }
-edda-mcp = { path = "../edda-mcp", version = "0.2.0" }
-edda-serve = { path = "../edda-serve", version = "0.2.0" }
-edda-notify = { path = "../edda-notify", version = "0.2.0" }
-edda-postmortem = { path = "../edda-postmortem", version = "0.2.0" }
-edda-search-fts = { path = "../edda-search-fts", version = "0.2.0" }
-edda-conductor = { path = "../edda-conductor", version = "0.2.0" }
+edda-aggregate = { path = "../edda-aggregate", version = "0.3.0" }
+edda-ask = { path = "../edda-ask", version = "0.3.0" }
+edda-chronicle = { path = "../edda-chronicle", version = "0.3.0" }
+edda-core = { path = "../edda-core", version = "0.3.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.3.0" }
+edda-derive = { path = "../edda-derive", version = "0.3.0" }
+edda-store = { path = "../edda-store", version = "0.3.0" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.3.0" }
+edda-bridge-codex = { path = "../edda-bridge-codex", version = "0.3.0" }
+edda-bridge-cursor = { path = "../edda-bridge-cursor", version = "0.3.0" }
+edda-bridge-hermes = { path = "../edda-bridge-hermes", version = "0.3.0" }
+edda-bridge-openclaw = { path = "../edda-bridge-openclaw", version = "0.3.0" }
+edda-transcript = { path = "../edda-transcript", version = "0.3.0" }
+edda-index = { path = "../edda-index", version = "0.3.0" }
+edda-pack = { path = "../edda-pack", version = "0.3.0" }
+edda-mcp = { path = "../edda-mcp", version = "0.3.0" }
+edda-serve = { path = "../edda-serve", version = "0.3.0" }
+edda-notify = { path = "../edda-notify", version = "0.3.0" }
+edda-postmortem = { path = "../edda-postmortem", version = "0.3.0" }
+edda-search-fts = { path = "../edda-search-fts", version = "0.3.0" }
+edda-conductor = { path = "../edda-conductor", version = "0.3.0" }
 ratatui = { version = "0.29", optional = true }
 crossterm = { version = "0.28", optional = true }
 clap.workspace = true

--- a/crates/edda-conductor/Cargo.toml
+++ b/crates/edda-conductor/Cargo.toml
@@ -10,7 +10,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-store = { path = "../edda-store", version = "0.2.0" }
+edda-store = { path = "../edda-store", version = "0.3.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/edda-derive/Cargo.toml
+++ b/crates/edda-derive/Cargo.toml
@@ -10,8 +10,8 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.2.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.2.0" }
+edda-core = { path = "../edda-core", version = "0.3.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.3.0" }
 anyhow.workspace = true
 time.workspace = true
 serde.workspace = true

--- a/crates/edda-index/Cargo.toml
+++ b/crates/edda-index/Cargo.toml
@@ -10,7 +10,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-store = { path = "../edda-store", version = "0.2.0" }
+edda-store = { path = "../edda-store", version = "0.3.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/edda-ingestion/Cargo.toml
+++ b/crates/edda-ingestion/Cargo.toml
@@ -10,8 +10,8 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.2.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.2.0" }
+edda-core = { path = "../edda-core", version = "0.3.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.3.0" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-ledger/Cargo.toml
+++ b/crates/edda-ledger/Cargo.toml
@@ -10,7 +10,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.2.0" }
+edda-core = { path = "../edda-core", version = "0.3.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/edda-mcp/Cargo.toml
+++ b/crates/edda-mcp/Cargo.toml
@@ -10,10 +10,10 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-ask = { path = "../edda-ask", version = "0.2.0" }
-edda-core = { path = "../edda-core", version = "0.2.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.2.0" }
-edda-derive = { path = "../edda-derive", version = "0.2.0" }
+edda-ask = { path = "../edda-ask", version = "0.3.0" }
+edda-core = { path = "../edda-core", version = "0.3.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.3.0" }
+edda-derive = { path = "../edda-derive", version = "0.3.0" }
 rmcp = { version = "0.16", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 anyhow.workspace = true

--- a/crates/edda-notify/Cargo.toml
+++ b/crates/edda-notify/Cargo.toml
@@ -10,7 +10,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-ledger = { path = "../edda-ledger", version = "0.2.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.3.0" }
 ureq = "3"
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-pack/Cargo.toml
+++ b/crates/edda-pack/Cargo.toml
@@ -10,10 +10,10 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.2.0" }
-edda-store = { path = "../edda-store", version = "0.2.0" }
-edda-index = { path = "../edda-index", version = "0.2.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.2.0" }
+edda-core = { path = "../edda-core", version = "0.3.0" }
+edda-store = { path = "../edda-store", version = "0.3.0" }
+edda-index = { path = "../edda-index", version = "0.3.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.3.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/edda-postmortem/Cargo.toml
+++ b/crates/edda-postmortem/Cargo.toml
@@ -10,8 +10,8 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.2.0" }
-edda-store = { path = "../edda-store", version = "0.2.0" }
+edda-core = { path = "../edda-core", version = "0.3.0" }
+edda-store = { path = "../edda-store", version = "0.3.0" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-search-fts/Cargo.toml
+++ b/crates/edda-search-fts/Cargo.toml
@@ -10,9 +10,9 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-store = { path = "../edda-store", version = "0.2.0" }
-edda-index = { path = "../edda-index", version = "0.2.0" }
-edda-core = { path = "../edda-core", version = "0.2.0" }
+edda-store = { path = "../edda-store", version = "0.3.0" }
+edda-index = { path = "../edda-index", version = "0.3.0" }
+edda-core = { path = "../edda-core", version = "0.3.0" }
 tantivy = { version = "0.25", default-features = false, features = ["mmap", "lz4-compression"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 fs2 = "0.4"

--- a/crates/edda-serve/Cargo.toml
+++ b/crates/edda-serve/Cargo.toml
@@ -10,14 +10,14 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-ask = { path = "../edda-ask", version = "0.2.0" }
-edda-core = { path = "../edda-core", version = "0.2.0" }
-edda-derive = { path = "../edda-derive", version = "0.2.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.2.0" }
-edda-aggregate = { path = "../edda-aggregate", version = "0.2.0" }
-edda-store = { path = "../edda-store", version = "0.2.0" }
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.2.0" }
-edda-ingestion = { path = "../edda-ingestion", version = "0.2.0" }
+edda-ask = { path = "../edda-ask", version = "0.3.0" }
+edda-core = { path = "../edda-core", version = "0.3.0" }
+edda-derive = { path = "../edda-derive", version = "0.3.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.3.0" }
+edda-aggregate = { path = "../edda-aggregate", version = "0.3.0" }
+edda-store = { path = "../edda-store", version = "0.3.0" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.3.0" }
+edda-ingestion = { path = "../edda-ingestion", version = "0.3.0" }
 axum = "0.8"
 tracing = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "time"] }

--- a/crates/edda-store/Cargo.toml
+++ b/crates/edda-store/Cargo.toml
@@ -10,7 +10,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.2.0" }
+edda-core = { path = "../edda-core", version = "0.3.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/edda-transcript/Cargo.toml
+++ b/crates/edda-transcript/Cargo.toml
@@ -10,7 +10,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-store = { path = "../edda-store", version = "0.2.0" }
+edda-store = { path = "../edda-store", version = "0.3.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -26,11 +26,11 @@ Available targets:
 
 | Platform | Target |
 |----------|--------|
-| Linux x86_64 | `edda-x86_64-unknown-linux-gnu.tar.gz` |
-| Linux ARM64 | `edda-aarch64-unknown-linux-gnu.tar.gz` |
-| macOS x86_64 | `edda-x86_64-apple-darwin.tar.gz` |
-| macOS ARM64 | `edda-aarch64-apple-darwin.tar.gz` |
-| Windows x86_64 | `edda-x86_64-pc-windows-msvc.zip` |
+| Linux x86_64 | `edda-v<VERSION>-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux ARM64 | `edda-v<VERSION>-aarch64-unknown-linux-gnu.tar.gz` |
+| macOS x86_64 | `edda-v<VERSION>-x86_64-apple-darwin.tar.gz` |
+| macOS ARM64 | `edda-v<VERSION>-aarch64-apple-darwin.tar.gz` |
+| Windows x86_64 | `edda-v<VERSION>-x86_64-pc-windows-msvc.zip` |
 
 Each archive contains the `edda` binary, and a SHA256 checksum sidecar file.
 

--- a/install.sh
+++ b/install.sh
@@ -126,7 +126,7 @@ resolve_version() {
         return
     fi
 
-    say "Fetching latest release..."
+    say "Fetching latest release..." >&2
     _api_url="https://api.github.com/repos/${REPO}/releases/latest"
     _response="$(download_to_stdout "$_api_url")" || err "failed to fetch latest release from GitHub API"
 


### PR DESCRIPTION
## Summary

- bump all 23 workspace packages and internal dependency requirements to 0.3.0
- publish a complete v0.3.0 changelog and prepend its upgrade notes to GitHub Releases
- fix latest-version resolution in install.sh and add a CI regression check
- isolate controls_suggest storage fixtures with a thread-local temporary store
- correct documented release asset names

## Verification

- cargo fmt --check
- cargo clippy --workspace --all-targets
- cargo test --workspace
- cargo test -p edda-bridge-claude -- --test-threads=16 (573 passed)
- cargo build --release -p edda
- target/release/edda.exe --version (edda 0.3.0)
- sh -n install.sh
- default installer version-resolution smoke test with stubbed GitHub response
- GitHub Actions YAML parse and v0.3.0 release-notes extraction check