### PR TITLE
feat(ops): schedule reconciliation and prove controller-loss recovery

### DIFF
--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -10,12 +10,14 @@ use edda_ledger::{Ledger, TaskLease};
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::AtomicU64;
 
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[cfg(test)]
 static DOORBELL_COUNT: AtomicUsize = AtomicUsize::new(0);
+static SCHEDULER_MANIFEST_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 #[cfg(test)]
 static DOORBELL_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 #[cfg(all(test, windows))]
@@ -125,7 +127,6 @@ struct SchedulerLaunchManifestV1 {
 struct PreparedSchedulerManifest {
     manifest: SchedulerLaunchManifestV1,
     bytes: Vec<u8>,
-    #[allow(dead_code)]
     digest: String,
     path: PathBuf,
 }
@@ -245,10 +246,16 @@ fn publish_scheduler_manifest(prepared: &PreparedSchedulerManifest) -> anyhow::R
     let launch_directory = directory
         .parent()
         .context("scheduler manifest path has no launch directory")?;
-    let store = launch_directory
-        .parent()
-        .context("scheduler manifest path has no store root")?;
+    let store = edda_store::store_root();
+    anyhow::ensure!(
+        scheduler_manifest_directory(&store, false)? == directory,
+        "scheduler manifest path is outside the trusted Edda store directory"
+    );
     let _lock = edda_store::lock_file(&launch_directory.join("manifest.lock"))?;
+    anyhow::ensure!(
+        scheduler_manifest_directory(&store, false)? == directory,
+        "scheduler manifest directory changed during lock acquisition"
+    );
     std::fs::create_dir_all(directory).with_context(|| {
         format!(
             "create scheduler manifest directory {}",
@@ -256,23 +263,80 @@ fn publish_scheduler_manifest(prepared: &PreparedSchedulerManifest) -> anyhow::R
         )
     })?;
     anyhow::ensure!(
-        scheduler_manifest_directory(store, true)? == directory,
+        scheduler_manifest_directory(&store, true)? == directory,
         "scheduler manifest directory changed during publication"
     );
 
     if prepared.path.exists() {
-        let loaded = load_scheduler_manifest(&prepared.path)?;
-        anyhow::ensure!(
-            loaded.manifest == prepared.manifest
-                && std::fs::read(&prepared.path)? == prepared.bytes,
-            "existing scheduler manifest does not contain the expected bytes"
-        );
+        validate_existing_scheduler_manifest(prepared)?;
         return Ok(false);
     }
 
-    edda_store::write_atomic(&prepared.path, &prepared.bytes)
-        .with_context(|| format!("publish scheduler manifest {}", prepared.path.display()))?;
-    Ok(true)
+    let sequence =
+        SCHEDULER_MANIFEST_TEMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let temp = directory.join(format!(
+        ".{}.{}.{}.tmp",
+        prepared.digest,
+        std::process::id(),
+        sequence
+    ));
+    edda_store::write_atomic(&temp, &prepared.bytes)
+        .with_context(|| format!("write scheduler manifest temporary file {}", temp.display()))?;
+    link_scheduler_manifest_noclobber(&temp, prepared)
+}
+
+fn validate_existing_scheduler_manifest(
+    prepared: &PreparedSchedulerManifest,
+) -> anyhow::Result<()> {
+    let loaded = load_scheduler_manifest(&prepared.path)?;
+    anyhow::ensure!(
+        loaded.manifest == prepared.manifest && std::fs::read(&prepared.path)? == prepared.bytes,
+        "existing scheduler manifest does not contain the expected bytes"
+    );
+    Ok(())
+}
+
+fn link_scheduler_manifest_noclobber(
+    temp: &Path,
+    prepared: &PreparedSchedulerManifest,
+) -> anyhow::Result<bool> {
+    match std::fs::hard_link(temp, &prepared.path) {
+        Ok(()) => {
+            std::fs::remove_file(temp).with_context(|| {
+                format!(
+                    "remove scheduler manifest temporary file {}",
+                    temp.display()
+                )
+            })?;
+            Ok(true)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            std::fs::remove_file(temp).with_context(|| {
+                format!(
+                    "remove scheduler manifest temporary file {}",
+                    temp.display()
+                )
+            })?;
+            validate_existing_scheduler_manifest(prepared)?;
+            Ok(false)
+        }
+        Err(error) => {
+            let cleanup = std::fs::remove_file(temp);
+            match cleanup {
+                Ok(()) => Err(error).with_context(|| {
+                    format!(
+                        "atomically publish scheduler manifest {}",
+                        prepared.path.display()
+                    )
+                }),
+                Err(cleanup_error) => anyhow::bail!(
+                    "atomically publish scheduler manifest {}: {error}; retain temporary file {} because cleanup failed: {cleanup_error}",
+                    prepared.path.display(),
+                    temp.display()
+                ),
+            }
+        }
+    }
 }
 
 fn load_scheduler_manifest(path: &Path) -> anyhow::Result<LoadedSchedulerManifest> {
@@ -444,23 +508,53 @@ struct SchedulerOutput {
     code: u32,
     stdout: String,
     stderr: String,
+    stdout_bytes: usize,
+    stderr_bytes: usize,
 }
 
 #[cfg(any(windows, test))]
 impl SchedulerOutput {
     #[cfg(test)]
     fn for_test(code: u32, stdout: &str, stderr: &str) -> Self {
+        Self::for_test_with_lengths(code, stdout, stderr, stdout.len(), stderr.len())
+    }
+
+    #[cfg(test)]
+    fn for_test_with_lengths(
+        code: u32,
+        stdout: &str,
+        stderr: &str,
+        stdout_bytes: usize,
+        stderr_bytes: usize,
+    ) -> Self {
         Self {
             code,
             stdout: stdout.into(),
             stderr: stderr.into(),
+            stdout_bytes,
+            stderr_bytes,
         }
+    }
+
+    fn xml(&self) -> anyhow::Result<&str> {
+        anyhow::ensure!(
+            self.stdout_bytes <= SCHEDULER_OUTPUT_LIMIT,
+            "scheduler Query XML is {} bytes; maximum bounded output is {}",
+            self.stdout_bytes,
+            SCHEDULER_OUTPUT_LIMIT
+        );
+        Ok(&self.stdout)
     }
 
     fn description(&self) -> String {
         format!(
-            "code=0x{:08x} ({}) stdout={:?} stderr={:?}",
-            self.code, self.code as i32, self.stdout, self.stderr
+            "code=0x{:08x} ({}) stdout_bytes={} stderr_bytes={} stdout={:?} stderr={:?}",
+            self.code,
+            self.code as i32,
+            self.stdout_bytes,
+            self.stderr_bytes,
+            self.stdout,
+            self.stderr
         )
     }
 }
@@ -665,52 +759,105 @@ fn windows_scheduler_spec(
 }
 
 #[cfg(any(windows, test))]
+fn decode_scheduler_xml_value(value: &str) -> anyhow::Result<String> {
+    let mut decoded = String::with_capacity(value.len());
+    let mut remaining = value;
+    while let Some(ampersand) = remaining.find('&') {
+        let literal = &remaining[..ampersand];
+        anyhow::ensure!(
+            !literal.contains('<'),
+            "scheduler Query XML contains nested markup"
+        );
+        decoded.push_str(literal);
+        let entity = &remaining[ampersand..];
+        let semicolon = entity
+            .find(';')
+            .context("scheduler Query XML contains an unterminated entity")?;
+        decoded.push(match &entity[..=semicolon] {
+            "&amp;" => '&',
+            "&lt;" => '<',
+            "&gt;" => '>',
+            "&quot;" => '"',
+            "&apos;" => '\'',
+            unknown => anyhow::bail!("scheduler Query XML contains unknown entity {unknown}"),
+        });
+        remaining = &entity[semicolon + 1..];
+    }
+    anyhow::ensure!(
+        !remaining.contains('<'),
+        "scheduler Query XML contains nested markup"
+    );
+    decoded.push_str(remaining);
+    Ok(decoded)
+}
+
+#[cfg(any(windows, test))]
+fn scheduler_exec_values(xml: &str) -> anyhow::Result<Vec<(String, String)>> {
+    anyhow::ensure!(
+        xml.len() <= SCHEDULER_OUTPUT_LIMIT,
+        "scheduler Query XML exceeds the bounded output limit"
+    );
+    let element = |action: &str, name: &str| -> anyhow::Result<String> {
+        let open = format!("<{name}>");
+        let close = format!("</{name}>");
+        let start = action
+            .find(&open)
+            .with_context(|| format!("scheduler Exec action has no {name}"))?;
+        let value = &action[start + open.len()..];
+        let end = value
+            .find(&close)
+            .with_context(|| format!("scheduler Exec action has unterminated {name}"))?;
+        anyhow::ensure!(
+            !value[end + close.len()..].contains(&open) && !action[..start].contains(&close),
+            "scheduler Exec action has duplicate {name}"
+        );
+        decode_scheduler_xml_value(&value[..end])
+    };
+
+    let mut actions = Vec::new();
+    let mut remaining = xml;
+    while let Some(start) = remaining.find("<Exec>") {
+        anyhow::ensure!(
+            !remaining[..start].contains("<Exec") && !remaining[..start].contains("</Exec>"),
+            "scheduler Query XML contains a malformed Exec action"
+        );
+        remaining = &remaining[start + "<Exec>".len()..];
+        let end = remaining
+            .find("</Exec>")
+            .context("scheduler Query XML contains an unterminated Exec action")?;
+        let action = &remaining[..end];
+        anyhow::ensure!(
+            !action.contains("<Exec"),
+            "scheduler Query XML contains a nested Exec action"
+        );
+        actions.push((element(action, "Command")?, element(action, "Arguments")?));
+        remaining = &remaining[end + "</Exec>".len()..];
+    }
+    anyhow::ensure!(
+        !remaining.contains("<Exec") && !remaining.contains("</Exec>"),
+        "scheduler Query XML contains a malformed Exec action"
+    );
+    Ok(actions)
+}
+
+#[cfg(any(windows, test))]
 fn scheduler_query_references_manifest(
     xml: &str,
     executable: &Path,
     manifest: &Path,
 ) -> anyhow::Result<bool> {
-    anyhow::ensure!(
-        xml.len() <= SCHEDULER_OUTPUT_LIMIT,
-        "scheduler Query XML exceeds the bounded output limit"
-    );
-    let escape = |value: &str| {
-        value
-            .replace('&', "&amp;")
-            .replace('<', "&lt;")
-            .replace('>', "&gt;")
-            .replace('"', "&quot;")
-            .replace('\'', "&apos;")
-    };
-    let command = format!(
-        "<Command>{}</Command>",
-        escape(
-            executable
-                .to_str()
-                .context("scheduler executable is not Unicode")?
-        )
-    );
+    let command = executable
+        .to_str()
+        .context("scheduler executable is not Unicode")?;
     let arguments = format!(
-        "<Arguments>{}</Arguments>",
-        escape(&format!(
-            "reconcile --scheduler-manifest {}",
-            quote_windows_argument(manifest)?
-        ))
+        "reconcile --scheduler-manifest {}",
+        quote_windows_argument(manifest)?
     );
-
-    let mut remaining = xml;
-    while let Some(start) = remaining.find("<Exec>") {
-        remaining = &remaining[start + "<Exec>".len()..];
-        let Some(end) = remaining.find("</Exec>") else {
-            anyhow::bail!("scheduler Query XML contains an unterminated Exec action");
-        };
-        let action = &remaining[..end];
-        if action.contains(&command) && action.contains(&arguments) {
-            return Ok(true);
-        }
-        remaining = &remaining[end + "</Exec>".len()..];
-    }
-    Ok(false)
+    Ok(scheduler_exec_values(xml)?
+        .iter()
+        .any(|(actual_command, actual_arguments)| {
+            actual_command == command && actual_arguments == &arguments
+        }))
 }
 
 #[cfg(any(windows, test))]
@@ -723,77 +870,61 @@ fn manifest_cleanup_decision(
         SchedulerTaskState::Missing => return Ok(ManifestCleanupDecision::RemoveNewArtifact),
         SchedulerTaskState::Present => {}
     }
-    if scheduler_query_references_manifest(&query.stdout, executable, expected_manifest)? {
+    let actions = scheduler_exec_values(query.xml()?)?;
+    let executable = executable
+        .to_str()
+        .context("scheduler executable is not Unicode")?;
+    let expected_arguments = format!(
+        "reconcile --scheduler-manifest {}",
+        quote_windows_argument(expected_manifest)?
+    );
+    if actions
+        .iter()
+        .any(|(command, arguments)| command == executable && arguments == &expected_arguments)
+    {
         return Ok(ManifestCleanupDecision::Retain);
     }
-
-    let escaped_executable = executable
-        .to_str()
-        .context("scheduler executable is not Unicode")?
-        .replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;");
-    let command = format!("<Command>{escaped_executable}</Command>");
-    let arguments_prefix = "<Arguments>reconcile --scheduler-manifest &quot;";
-    let arguments_suffix = "&quot;</Arguments>";
-    let mut remaining = query.stdout.as_str();
-    while let Some(start) = remaining.find("<Exec>") {
-        remaining = &remaining[start + "<Exec>".len()..];
-        let Some(end) = remaining.find("</Exec>") else {
-            break;
-        };
-        let action = &remaining[..end];
-        if action.contains(&command) {
-            if let Some(arguments_start) = action.find(arguments_prefix) {
-                let value = &action[arguments_start + arguments_prefix.len()..];
-                if let Some(arguments_end) = value.find(arguments_suffix) {
-                    let encoded_path = &value[..arguments_end];
-                    let trailing = &value[arguments_end + arguments_suffix.len()..];
-                    if !encoded_path.is_empty()
-                        && !encoded_path.contains(['<', '>'])
-                        && !encoded_path.contains("&quot;")
-                        && trailing.trim().is_empty()
-                    {
-                        let decoded_path = encoded_path
-                            .replace("&apos;", "'")
-                            .replace("&gt;", ">")
-                            .replace("&lt;", "<")
-                            .replace("&amp;", "&");
-                        let canonical_encoding = decoded_path
-                            .replace('&', "&amp;")
-                            .replace('<', "&lt;")
-                            .replace('>', "&gt;")
-                            .replace('"', "&quot;")
-                            .replace('\'', "&apos;");
-                        let candidate = Path::new(&decoded_path);
-                        let filename = candidate.file_name().and_then(|name| name.to_str());
-                        let trusted_filename = filename.is_some_and(|name| {
-                            name.len() == 69
-                                && name.ends_with(".json")
-                                && name[..64].bytes().all(|byte| {
-                                    byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)
-                                })
-                        });
-                        if canonical_encoding == encoded_path
-                            && windows_path_is_absolute(candidate)?
-                            && candidate.parent() == expected_manifest.parent()
-                            && candidate != expected_manifest
-                            && trusted_filename
-                        {
-                            return Ok(ManifestCleanupDecision::RemoveNewArtifact);
-                        }
-                    }
-                }
-            }
-        }
-        remaining = &remaining[end + "</Exec>".len()..];
-    }
-    anyhow::bail!(
-        "scheduler Query did not prove whether the exact task references the new manifest: {}",
+    anyhow::ensure!(
+        !actions.is_empty(),
+        "scheduler Query did not contain an Exec action: {}",
         query.description()
-    )
+    );
+
+    for (command, arguments) in actions {
+        anyhow::ensure!(
+            command == executable,
+            "scheduler Query command did not match the direct Edda executable: {}",
+            query.description()
+        );
+        let path = arguments
+            .strip_prefix("reconcile --scheduler-manifest \"")
+            .and_then(|value| value.strip_suffix('"'))
+            .context("scheduler Query Arguments were not a strict manifest command")?;
+        anyhow::ensure!(
+            !path.contains('"'),
+            "scheduler Query manifest path contains a quote"
+        );
+        let candidate = Path::new(path);
+        let trusted_filename = candidate
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(|name| name.strip_suffix(".json"))
+            .is_some_and(|digest| {
+                digest.len() == 64
+                    && digest
+                        .bytes()
+                        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+            });
+        anyhow::ensure!(
+            windows_path_is_absolute(candidate)?
+                && candidate.parent() == expected_manifest.parent()
+                && candidate != expected_manifest
+                && trusted_filename,
+            "scheduler Query did not prove a different trusted manifest path: {}",
+            query.description()
+        );
+    }
+    Ok(ManifestCleanupDecision::RemoveNewArtifact)
 }
 
 #[cfg(any(windows, test))]
@@ -862,6 +993,8 @@ fn run_schtasks(args: &[String]) -> anyhow::Result<SchedulerOutput> {
         code: signed_code as u32,
         stdout: bounded(&output.stdout),
         stderr: bounded(&output.stderr),
+        stdout_bytes: output.stdout.len(),
+        stderr_bytes: output.stderr.len(),
     })
 }
 
@@ -910,7 +1043,7 @@ fn scheduler_lifecycle(
                 )?;
                 anyhow::ensure!(
                     scheduler_query_references_manifest(
-                        &queried.stdout,
+                        queried.xml()?,
                         &executable,
                         &manifest.path,
                     )?,
@@ -2030,6 +2163,28 @@ mod tests {
     }
 
     #[test]
+    fn scheduler_manifest_atomic_link_never_replaces_a_racer() -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        let prepared = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+        let directory = prepared.path.parent().context("manifest directory")?;
+        std::fs::create_dir_all(directory)?;
+        let temp = directory.join("race.tmp");
+        edda_store::write_atomic(&temp, &prepared.bytes)?;
+        edda_store::write_atomic(&prepared.path, &prepared.bytes)?;
+
+        assert!(!link_scheduler_manifest_noclobber(&temp, &prepared)?);
+        assert!(!temp.exists());
+        assert_eq!(std::fs::read(&prepared.path)?, prepared.bytes);
+
+        std::fs::write(&prepared.path, b"racer bytes")?;
+        edda_store::write_atomic(&temp, &prepared.bytes)?;
+        assert!(link_scheduler_manifest_noclobber(&temp, &prepared).is_err());
+        assert!(!temp.exists());
+        assert_eq!(std::fs::read(&prepared.path)?, b"racer bytes");
+        Ok(())
+    }
+
+    #[test]
     fn scheduler_manifest_changed_install_retains_prior_artifact() -> anyhow::Result<()> {
         let fixture = scheduler_manifest_fixture()?;
         let old = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
@@ -2061,6 +2216,22 @@ mod tests {
     }
 
     #[test]
+    fn scheduler_manifest_publish_validates_containment_before_mutation() -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        let mut prepared =
+            prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+        let outside = fixture._root.path().join("outside-store");
+        prepared.path = outside
+            .join("scheduler-launch")
+            .join("v1")
+            .join(format!("{}.json", prepared.digest));
+
+        assert!(publish_scheduler_manifest(&prepared).is_err());
+        assert!(!outside.exists());
+        Ok(())
+    }
+
+    #[test]
     fn scheduler_query_xml_requires_exact_escaped_command_and_arguments() -> anyhow::Result<()> {
         let executable = Path::new(r"C:\Program Files\Edda & Co\edda.exe");
         let manifest = Path::new(r"C:\Store & State\scheduler-launch\v1\expected.json");
@@ -2081,6 +2252,82 @@ mod tests {
             executable,
             manifest
         )?);
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_query_scans_every_exec_before_deciding() {
+        let executable = Path::new(r"C:\edda\edda.exe");
+        let expected = Path::new(
+            r"C:\store\scheduler-launch\v1\aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json",
+        );
+        let expected_xml = r#"<Task><Actions><Exec><Command>C:\edda\edda.exe</Command><Arguments>reconcile --scheduler-manifest &quot;C:\store\scheduler-launch\v1\aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json&quot;</Arguments></Exec><Exec><Command>truncated"#;
+        assert!(scheduler_query_references_manifest(expected_xml, executable, expected).is_err());
+        let cut_open = format!(
+            "{}<Exec",
+            expected_xml.trim_end_matches("<Exec><Command>truncated")
+        );
+        assert!(scheduler_query_references_manifest(&cut_open, executable, expected).is_err());
+
+        let different_xml = expected_xml.replace(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json",
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.json",
+        );
+        assert!(manifest_cleanup_decision(
+            &SchedulerOutput::for_test(0, &different_xml, ""),
+            executable,
+            expected,
+        )
+        .is_err());
+        let different_cut_open = cut_open.replace(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json",
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.json",
+        );
+        assert!(manifest_cleanup_decision(
+            &SchedulerOutput::for_test(0, &different_cut_open, ""),
+            executable,
+            expected,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn scheduler_query_compares_decoded_xml_element_values() -> anyhow::Result<()> {
+        let executable = Path::new(r"C:\O'Brien & Sons\edda.exe");
+        let expected = Path::new(
+            r"C:\Store & State\scheduler-launch\v1\aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json",
+        );
+        let literal_xml = r#"<Task><Actions><Exec><Command>C:\O'Brien &amp; Sons\edda.exe</Command><Arguments>reconcile --scheduler-manifest "C:\Store &amp; State\scheduler-launch\v1\aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json"</Arguments></Exec></Actions></Task>"#;
+        assert!(scheduler_query_references_manifest(
+            literal_xml,
+            executable,
+            expected,
+        )?);
+
+        let named_xml = literal_xml
+            .replace("O'Brien", "O&apos;Brien")
+            .replace('"', "&quot;");
+        assert!(scheduler_query_references_manifest(
+            &named_xml, executable, expected,
+        )?);
+
+        let unknown_entity = literal_xml.replace("&amp;", "&unknown;");
+        assert!(
+            scheduler_query_references_manifest(&unknown_entity, executable, expected).is_err()
+        );
+
+        let different = literal_xml.replace(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json",
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.json",
+        );
+        assert_eq!(
+            manifest_cleanup_decision(
+                &SchedulerOutput::for_test(0, &different, ""),
+                executable,
+                expected,
+            )?,
+            ManifestCleanupDecision::RemoveNewArtifact
+        );
         Ok(())
     }
 
@@ -2698,6 +2945,31 @@ mod tests {
             assert!(error.contains(&format!("0x{code:08x}")));
             assert!(error.contains(&(code as i32).to_string()));
         }
+    }
+
+    #[test]
+    fn scheduler_query_rejects_truncated_xml_output() {
+        let output = SchedulerOutput::for_test_with_lengths(
+            0,
+            "<Task />",
+            "",
+            SCHEDULER_OUTPUT_LIMIT + 1,
+            0,
+        );
+        let error = output
+            .xml()
+            .expect_err("truncated Query XML must be rejected")
+            .to_string();
+        assert!(error.contains(&(SCHEDULER_OUTPUT_LIMIT + 1).to_string()));
+        assert!(error.contains(&SCHEDULER_OUTPUT_LIMIT.to_string()));
+        assert!(manifest_cleanup_decision(
+            &output,
+            Path::new(r"C:\edda\edda.exe"),
+            Path::new(
+                r"C:\store\scheduler-launch\v1\aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json"
+            ),
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -10,6 +10,8 @@ use edda_ledger::{Ledger, TaskLease};
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+
+#[cfg(any(windows, test))]
 use std::sync::atomic::AtomicU64;
 
 #[cfg(any(windows, test))]
@@ -20,6 +22,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[cfg(test)]
 static DOORBELL_COUNT: AtomicUsize = AtomicUsize::new(0);
+#[cfg(any(windows, test))]
 static SCHEDULER_MANIFEST_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 #[cfg(test)]
 static DOORBELL_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -129,6 +132,7 @@ struct SchedulerLaunchManifestV1 {
     lease_ttl_s: u64,
 }
 
+#[cfg(any(windows, test))]
 struct PreparedSchedulerManifest {
     manifest: SchedulerLaunchManifestV1,
     bytes: Vec<u8>,
@@ -137,6 +141,7 @@ struct PreparedSchedulerManifest {
 }
 
 struct LoadedSchedulerManifest {
+    #[cfg(any(windows, test))]
     manifest: SchedulerLaunchManifestV1,
     repo: PathBuf,
     config: ReconcileConfig,
@@ -230,12 +235,14 @@ fn validate_scheduler_manifest(
         codex_bin,
     };
     Ok(LoadedSchedulerManifest {
+        #[cfg(any(windows, test))]
         manifest,
         repo,
         config,
     })
 }
 
+#[cfg(any(windows, test))]
 fn prepare_scheduler_manifest(
     store: &Path,
     repo: &Path,
@@ -263,6 +270,7 @@ fn prepare_scheduler_manifest(
     })
 }
 
+#[cfg(any(windows, test))]
 fn publish_scheduler_manifest(prepared: &PreparedSchedulerManifest) -> anyhow::Result<bool> {
     let directory = prepared
         .path
@@ -310,6 +318,7 @@ fn publish_scheduler_manifest(prepared: &PreparedSchedulerManifest) -> anyhow::R
     link_scheduler_manifest_noclobber(&temp, prepared)
 }
 
+#[cfg(any(windows, test))]
 fn validate_existing_scheduler_manifest(
     prepared: &PreparedSchedulerManifest,
 ) -> anyhow::Result<()> {
@@ -321,6 +330,7 @@ fn validate_existing_scheduler_manifest(
     Ok(())
 }
 
+#[cfg(any(windows, test))]
 fn link_scheduler_manifest_noclobber(
     temp: &Path,
     prepared: &PreparedSchedulerManifest,
@@ -729,6 +739,21 @@ fn windows_path_is_absolute(path: &Path) -> anyhow::Result<bool> {
     Ok(unc_rooted(&value[2..]))
 }
 
+#[cfg(any(windows, test))]
+fn windows_manifest_path_components(path: &Path) -> anyhow::Result<(&str, &str)> {
+    let value = path
+        .to_str()
+        .context("scheduler manifest path is not Unicode")?;
+    let (parent, filename) = value
+        .rsplit_once(['\\', '/'])
+        .context("scheduler manifest path has no Windows parent")?;
+    anyhow::ensure!(
+        !parent.is_empty() && !filename.is_empty(),
+        "scheduler manifest path has no Windows filename"
+    );
+    Ok((parent, filename))
+}
+
 fn validate_canonical_direct_codex_target(canonical: &Path) -> anyhow::Result<()> {
     anyhow::ensure!(
         canonical.is_absolute()
@@ -1000,6 +1025,7 @@ fn manifest_cleanup_decision(
         "scheduler Query did not contain an Exec action: {}",
         query.description()
     );
+    let (expected_parent, expected_filename) = windows_manifest_path_components(expected_manifest)?;
 
     for (command, arguments) in actions {
         anyhow::ensure!(
@@ -1016,10 +1042,9 @@ fn manifest_cleanup_decision(
             "scheduler Query manifest path contains a quote"
         );
         let candidate = Path::new(path);
-        let trusted_filename = candidate
-            .file_name()
-            .and_then(|name| name.to_str())
-            .and_then(|name| name.strip_suffix(".json"))
+        let (candidate_parent, candidate_filename) = windows_manifest_path_components(candidate)?;
+        let trusted_filename = candidate_filename
+            .strip_suffix(".json")
             .is_some_and(|digest| {
                 digest.len() == 64
                     && digest
@@ -1028,8 +1053,8 @@ fn manifest_cleanup_decision(
             });
         anyhow::ensure!(
             windows_path_is_absolute(candidate)?
-                && candidate.parent() == expected_manifest.parent()
-                && candidate != expected_manifest
+                && candidate_parent == expected_parent
+                && candidate_filename != expected_filename
                 && trusted_filename,
             "scheduler Query did not prove a different trusted manifest path: {}",
             query.description()
@@ -2888,6 +2913,34 @@ mod tests {
             executable,
             manifest
         )?);
+        Ok(())
+    }
+
+    #[test]
+    fn windows_manifest_path_components_are_host_neutral() -> anyhow::Result<()> {
+        assert_eq!(
+            windows_manifest_path_components(Path::new(
+                r"C:\store\scheduler-launch\v1\manifest.json"
+            ))?,
+            (r"C:\store\scheduler-launch\v1", "manifest.json")
+        );
+        assert_eq!(
+            windows_manifest_path_components(Path::new(
+                r"\\?\C:\store\scheduler-launch\v1\manifest.json"
+            ))?,
+            (r"\\?\C:\store\scheduler-launch\v1", "manifest.json")
+        );
+        assert_eq!(
+            windows_manifest_path_components(Path::new(r"\\?\UNC\server\share\v1\manifest.json"))?,
+            (r"\\?\UNC\server\share\v1", "manifest.json")
+        );
+        assert_eq!(
+            windows_manifest_path_components(Path::new(
+                "C:/store/scheduler-launch/v1/manifest.json"
+            ))?,
+            ("C:/store/scheduler-launch/v1", "manifest.json")
+        );
+        assert!(windows_manifest_path_components(Path::new(r"C:\")).is_err());
         Ok(())
     }
 

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -955,6 +955,11 @@ fn manifest_cleanup_decision(
     }
     let xml = query.xml()?;
     let actions = scheduler_direct_exec_values(xml.as_ref())?;
+    anyhow::ensure!(
+        actions.len() == 1,
+        "scheduler Query must contain exactly one direct Exec action: {}",
+        query.description()
+    );
     let expected_arguments = format!(
         "reconcile --scheduler-manifest {}",
         quote_windows_argument(expected_manifest)?
@@ -3146,6 +3151,17 @@ mod tests {
             )?,
             ManifestCleanupDecision::RemoveNewArtifact
         );
+
+        let two_previous_actions = previous_xml.replace(
+            "</Actions>",
+            r#"<Exec><Command>C:\edda\edda.exe</Command><Arguments>reconcile --scheduler-manifest &quot;C:\store\scheduler-launch\v1\cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc.json&quot;</Arguments></Exec></Actions>"#,
+        );
+        assert!(manifest_cleanup_decision(
+            &SchedulerOutput::for_test(0, &two_previous_actions, ""),
+            executable,
+            expected,
+        )
+        .is_err());
 
         let aliased_expected_xml = expected_xml.replace(
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json",

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -7,6 +7,7 @@ use edda_core::event::{
 use edda_ledger::lock::WorkspaceLock;
 use edda_ledger::tasks::{TaskStatus, TaskView};
 use edda_ledger::{Ledger, TaskLease};
+use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -89,6 +90,213 @@ impl ReconcileConfig {
     fn test_defaults() -> Self {
         Self::defaults()
     }
+}
+
+const SCHEDULER_MANIFEST_MAX_BYTES: u64 = 16 * 1024;
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct SchedulerLaunchManifestV1 {
+    schema_version: u8,
+    project_id: String,
+    repo: PathBuf,
+    codex_bin: PathBuf,
+    max_workers: usize,
+    max_attempts: u32,
+    lease_ttl_s: u64,
+}
+
+struct PreparedSchedulerManifest {
+    manifest: SchedulerLaunchManifestV1,
+    bytes: Vec<u8>,
+    digest: String,
+    path: PathBuf,
+}
+
+struct LoadedSchedulerManifest {
+    manifest: SchedulerLaunchManifestV1,
+    repo: PathBuf,
+    config: ReconcileConfig,
+}
+
+fn scheduler_manifest_directory(store: &Path, must_exist: bool) -> anyhow::Result<PathBuf> {
+    let store = std::path::absolute(store)
+        .with_context(|| format!("resolve Edda store root {}", store.display()))?;
+    let value = store.to_str().context("Edda store root is not Unicode")?;
+    anyhow::ensure!(
+        !value.contains(['\0', '"']),
+        "Edda store root contains an unsupported character"
+    );
+    let store = if store.exists() {
+        anyhow::ensure!(store.is_dir(), "Edda store root must be a directory");
+        store
+            .canonicalize()
+            .with_context(|| format!("canonicalize Edda store root {}", store.display()))?
+    } else {
+        anyhow::ensure!(!must_exist, "Edda store root does not exist");
+        store
+    };
+    let launch = store.join("scheduler-launch");
+    if launch.exists() {
+        anyhow::ensure!(
+            launch.canonicalize()? == launch,
+            "scheduler manifest directory escapes the Edda store root"
+        );
+    }
+    let directory = launch.join("v1");
+    if directory.exists() {
+        anyhow::ensure!(
+            directory.canonicalize()? == directory,
+            "scheduler manifest directory escapes the Edda store root"
+        );
+    } else {
+        anyhow::ensure!(!must_exist, "scheduler manifest directory does not exist");
+    }
+    Ok(directory)
+}
+
+fn scheduler_manifest_digest(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+fn validate_scheduler_manifest(
+    manifest: SchedulerLaunchManifestV1,
+) -> anyhow::Result<LoadedSchedulerManifest> {
+    anyhow::ensure!(
+        manifest.schema_version == 1,
+        "unknown scheduler manifest version"
+    );
+    let repo = canonical_main_repo(&manifest.repo)?;
+    anyhow::ensure!(
+        repo == manifest.repo,
+        "scheduler manifest repository is not canonical"
+    );
+    anyhow::ensure!(
+        manifest.project_id == edda_store::project_id_for_root(&repo),
+        "scheduler manifest project id does not match repository"
+    );
+    let codex_bin = canonical_direct_codex_executable(&manifest.codex_bin, None)?;
+    anyhow::ensure!(
+        codex_bin == manifest.codex_bin,
+        "scheduler manifest Codex executable is not canonical"
+    );
+    let config = ReconcileConfig {
+        max_workers: manifest.max_workers,
+        max_attempts: manifest.max_attempts,
+        lease_ttl_s: manifest.lease_ttl_s,
+        codex_bin,
+    };
+    Ok(LoadedSchedulerManifest {
+        manifest,
+        repo,
+        config,
+    })
+}
+
+fn prepare_scheduler_manifest(
+    store: &Path,
+    repo: &Path,
+    config: &ReconcileConfig,
+) -> anyhow::Result<PreparedSchedulerManifest> {
+    let repo = canonical_main_repo(repo)?;
+    let codex_bin = canonical_direct_codex_executable(&config.codex_bin, None)?;
+    let manifest = SchedulerLaunchManifestV1 {
+        schema_version: 1,
+        project_id: edda_store::project_id_for_root(&repo),
+        repo,
+        codex_bin,
+        max_workers: config.max_workers,
+        max_attempts: config.max_attempts,
+        lease_ttl_s: config.lease_ttl_s,
+    };
+    let bytes = serde_json::to_vec(&manifest)?;
+    let digest = scheduler_manifest_digest(&bytes);
+    let path = scheduler_manifest_directory(store, false)?.join(format!("{digest}.json"));
+    Ok(PreparedSchedulerManifest {
+        manifest,
+        bytes,
+        digest,
+        path,
+    })
+}
+
+fn load_scheduler_manifest(path: &Path) -> anyhow::Result<LoadedSchedulerManifest> {
+    anyhow::ensure!(
+        path.is_absolute(),
+        "scheduler manifest path must be absolute"
+    );
+    let value = path
+        .to_str()
+        .context("scheduler manifest path is not Unicode")?;
+    anyhow::ensure!(
+        !value.contains(['\0', '"']),
+        "scheduler manifest path contains an unsupported character"
+    );
+    let filename = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .context("scheduler manifest filename is not Unicode")?;
+    let expected_digest = filename
+        .strip_suffix(".json")
+        .context("scheduler manifest filename must end in .json")?;
+    anyhow::ensure!(
+        expected_digest.len() == 64
+            && expected_digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
+        "scheduler manifest filename must contain a 64-character lowercase SHA-256 digest"
+    );
+
+    let trusted_directory = scheduler_manifest_directory(&edda_store::store_root(), true)?;
+    let source_metadata = path
+        .symlink_metadata()
+        .with_context(|| format!("inspect scheduler manifest {}", path.display()))?;
+    anyhow::ensure!(
+        source_metadata.file_type().is_file(),
+        "scheduler manifest must be a regular file"
+    );
+    anyhow::ensure!(
+        source_metadata.len() <= SCHEDULER_MANIFEST_MAX_BYTES,
+        "scheduler manifest exceeds 16 KiB"
+    );
+    let canonical = path
+        .canonicalize()
+        .with_context(|| format!("canonicalize scheduler manifest {}", path.display()))?;
+    let parent = path
+        .parent()
+        .context("scheduler manifest has no parent")?
+        .canonicalize()
+        .context("canonicalize scheduler manifest parent")?;
+    anyhow::ensure!(
+        parent == trusted_directory && canonical.parent() == Some(trusted_directory.as_path()),
+        "scheduler manifest is outside the trusted Edda store directory"
+    );
+    let metadata = canonical.metadata()?;
+    anyhow::ensure!(
+        metadata.is_file(),
+        "scheduler manifest must be a regular file"
+    );
+    anyhow::ensure!(
+        metadata.len() <= SCHEDULER_MANIFEST_MAX_BYTES,
+        "scheduler manifest exceeds 16 KiB"
+    );
+    let bytes = std::fs::read(&canonical)
+        .with_context(|| format!("read scheduler manifest {}", canonical.display()))?;
+    anyhow::ensure!(
+        bytes.len() as u64 <= SCHEDULER_MANIFEST_MAX_BYTES,
+        "scheduler manifest exceeds 16 KiB"
+    );
+    let manifest: SchedulerLaunchManifestV1 =
+        serde_json::from_slice(&bytes).context("parse scheduler launch manifest")?;
+    anyhow::ensure!(
+        serde_json::to_vec(&manifest)? == bytes,
+        "scheduler manifest JSON is not canonical"
+    );
+    anyhow::ensure!(
+        scheduler_manifest_digest(&bytes) == expected_digest,
+        "scheduler manifest digest does not match filename"
+    );
+    validate_scheduler_manifest(manifest)
 }
 
 #[derive(Clone)]
@@ -256,7 +464,6 @@ fn windows_path_is_absolute(path: &Path) -> anyhow::Result<bool> {
     Ok(unc_rooted(&value[2..]))
 }
 
-#[cfg(any(windows, test))]
 fn validate_canonical_direct_codex_target(canonical: &Path) -> anyhow::Result<()> {
     anyhow::ensure!(
         canonical.is_absolute()
@@ -271,7 +478,6 @@ fn validate_canonical_direct_codex_target(canonical: &Path) -> anyhow::Result<()
     Ok(())
 }
 
-#[cfg(any(windows, test))]
 fn canonical_direct_codex_executable(
     command: &Path,
     search_path: Option<&std::ffi::OsStr>,
@@ -1430,6 +1636,212 @@ mod tests {
             lease_ttl_s: 300,
             codex_bin: PathBuf::from(codex_bin),
         }
+    }
+
+    struct SchedulerManifestFixture {
+        _store_guard: crate::test_support::IsolatedStore,
+        _root: tempfile::TempDir,
+        store: PathBuf,
+        repo: PathBuf,
+        codex: PathBuf,
+        config: ReconcileConfig,
+    }
+
+    fn scheduler_manifest_fixture() -> anyhow::Result<SchedulerManifestFixture> {
+        let store_guard = crate::test_support::isolated_store();
+        let store = edda_store::store_root();
+        let root = tempfile::tempdir()?;
+        let repo = root.path().join("repo");
+        std::fs::create_dir(&repo)?;
+        Ledger::ensure_initialized(&repo)?;
+        let repo = repo.canonicalize()?;
+        let codex = root.path().join("codex.exe");
+        std::fs::write(&codex, b"MZ")?;
+        let codex = codex.canonicalize()?;
+        let config = ReconcileConfig {
+            max_workers: 3,
+            max_attempts: 4,
+            lease_ttl_s: 300,
+            codex_bin: codex.clone(),
+        };
+        Ok(SchedulerManifestFixture {
+            _store_guard: store_guard,
+            _root: root,
+            store,
+            repo,
+            codex,
+            config,
+        })
+    }
+
+    fn write_scheduler_manifest_candidate(store: &Path, bytes: &[u8]) -> anyhow::Result<PathBuf> {
+        use sha2::Digest;
+
+        let digest = hex::encode(sha2::Sha256::digest(bytes));
+        let path = store
+            .join("scheduler-launch")
+            .join("v1")
+            .join(format!("{digest}.json"));
+        edda_store::write_atomic(&path, bytes)?;
+        Ok(path)
+    }
+
+    #[test]
+    fn scheduler_manifest_is_canonical_content_addressed_and_strict() -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        let first = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+        let second = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+
+        assert_eq!(first.bytes, second.bytes);
+        assert_eq!(first.path, second.path);
+        assert!(first.path.ends_with(format!("{}.json", first.digest)));
+        assert!(!first.bytes.ends_with(b"\n"));
+        assert_eq!(first.manifest.schema_version, 1);
+        assert_eq!(
+            first.manifest.project_id,
+            edda_store::project_id_for_root(&fixture.repo)
+        );
+        edda_store::write_atomic(&first.path, &first.bytes)?;
+        let loaded = load_scheduler_manifest(&first.path)?;
+        assert_eq!(loaded.manifest, first.manifest);
+        assert_eq!(loaded.repo, fixture.repo);
+        assert_eq!(loaded.config.codex_bin, fixture.codex);
+        assert_eq!(loaded.config.max_workers, fixture.config.max_workers);
+        assert_eq!(loaded.config.max_attempts, fixture.config.max_attempts);
+        assert_eq!(loaded.config.lease_ttl_s, fixture.config.lease_ttl_s);
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_manifest_changed_config_changes_digest() -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        let first = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+        let mut changed = fixture.config.clone();
+        changed.max_workers += 1;
+        let second = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &changed)?;
+
+        assert_ne!(first.bytes, second.bytes);
+        assert_ne!(first.digest, second.digest);
+        assert_ne!(first.path, second.path);
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_manifest_rejects_unknown_duplicate_and_noncanonical_json() -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        let prepared = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+
+        let mut unknown_field: serde_json::Value = serde_json::from_slice(&prepared.bytes)?;
+        unknown_field
+            .as_object_mut()
+            .expect("manifest object")
+            .insert("extra".into(), true.into());
+        let path = write_scheduler_manifest_candidate(
+            &fixture.store,
+            &serde_json::to_vec(&unknown_field)?,
+        )?;
+        assert!(load_scheduler_manifest(&path).is_err());
+
+        let mut unknown_version = prepared.manifest.clone();
+        unknown_version.schema_version = 2;
+        let path = write_scheduler_manifest_candidate(
+            &fixture.store,
+            &serde_json::to_vec(&unknown_version)?,
+        )?;
+        assert!(load_scheduler_manifest(&path).is_err());
+
+        let canonical = String::from_utf8(prepared.bytes.clone())?;
+        let duplicate = canonical.replacen('{', r#"{"schema_version":1,"#, 1);
+        let path = write_scheduler_manifest_candidate(&fixture.store, duplicate.as_bytes())?;
+        assert!(load_scheduler_manifest(&path).is_err());
+
+        let mut noncanonical = prepared.bytes;
+        noncanonical.push(b'\n');
+        let path = write_scheduler_manifest_candidate(&fixture.store, &noncanonical)?;
+        assert!(load_scheduler_manifest(&path).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_manifest_rejects_oversize_and_digest_mismatch() -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        let prepared = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+
+        let oversized = vec![b' '; 16 * 1024 + 1];
+        let path = write_scheduler_manifest_candidate(&fixture.store, &oversized)?;
+        assert!(load_scheduler_manifest(&path).is_err());
+
+        let mismatch = prepared
+            .path
+            .with_file_name(format!("{}.json", "0".repeat(64)));
+        edda_store::write_atomic(&mismatch, &prepared.bytes)?;
+        assert!(load_scheduler_manifest(&mismatch).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_manifest_revalidates_project_repo_and_codex() -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        assert!(prepare_scheduler_manifest(
+            &fixture.store,
+            &fixture.repo.join("missing"),
+            &fixture.config
+        )
+        .is_err());
+        let mut invalid_codex = fixture.config.clone();
+        invalid_codex.codex_bin = fixture.repo.join("codex.cmd");
+        assert!(prepare_scheduler_manifest(&fixture.store, &fixture.repo, &invalid_codex).is_err());
+
+        let prepared = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+        let mut wrong_project = prepared.manifest.clone();
+        wrong_project.project_id = "0".repeat(32);
+        let path = write_scheduler_manifest_candidate(
+            &fixture.store,
+            &serde_json::to_vec(&wrong_project)?,
+        )?;
+        assert!(load_scheduler_manifest(&path).is_err());
+
+        edda_store::write_atomic(&prepared.path, &prepared.bytes)?;
+        std::fs::remove_file(&fixture.codex)?;
+        assert!(load_scheduler_manifest(&prepared.path).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_manifest_rejects_store_root_and_reparse_escape() -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        let prepared = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+        let outside = fixture._root.path().join("outside");
+        let escaped = outside.join(format!("{}.json", prepared.digest));
+        edda_store::write_atomic(&escaped, &prepared.bytes)?;
+        assert!(load_scheduler_manifest(&escaped).is_err());
+
+        let launch = fixture.store.join("scheduler-launch");
+        let reparse_target = fixture._root.path().join("reparse-target");
+        std::fs::create_dir(&reparse_target)?;
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&reparse_target, &launch)?;
+        #[cfg(windows)]
+        if let Err(error) = std::os::windows::fs::symlink_dir(&reparse_target, &launch) {
+            anyhow::ensure!(
+                error.raw_os_error() == Some(1314),
+                "create scheduler manifest directory symlink: {error}"
+            );
+            let output = Command::new("cmd.exe")
+                .args(["/D", "/C", "mklink", "/J"])
+                .arg(&launch)
+                .arg(&reparse_target)
+                .output()?;
+            anyhow::ensure!(
+                output.status.success(),
+                "create scheduler manifest directory junction: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        assert!(
+            prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config).is_err()
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -1040,76 +1040,255 @@ fn remove_unreferenced_scheduler_manifest(path: &Path) -> String {
 }
 
 #[cfg(any(windows, test))]
-fn scheduler_actions_xml(xml: &str) -> anyhow::Result<&str> {
+fn scheduler_direct_exec_values(xml: &str) -> anyhow::Result<Vec<(String, String)>> {
     anyhow::ensure!(
         xml.len() <= SCHEDULER_OUTPUT_LIMIT,
         "scheduler Query XML exceeds the bounded output limit"
     );
-    let xml = xml.trim();
-    let task_start = xml
-        .find("<Task")
-        .context("scheduler Query XML has no Task root")?;
-    let prefix = xml[..task_start].trim();
-    anyhow::ensure!(
-        prefix.is_empty() || (prefix.starts_with("<?xml") && prefix.ends_with("?>")),
-        "scheduler Query XML has content before the Task root"
-    );
-    anyhow::ensure!(
-        matches!(
-            xml.as_bytes().get(task_start + "<Task".len()),
-            Some(b'>') | Some(b' ' | b'\t' | b'\r' | b'\n')
-        ),
-        "scheduler Query XML has a malformed Task root"
-    );
-    let task_open_end = xml[task_start..]
-        .find('>')
-        .map(|end| task_start + end)
-        .context("scheduler Query XML has an unterminated Task root")?;
-    anyhow::ensure!(
-        !xml[task_start..=task_open_end].trim_end().ends_with("/>"),
-        "scheduler Query XML has a self-closing Task root"
-    );
-    let task_close = xml
-        .strip_suffix("</Task>")
-        .context("scheduler Query XML has an incomplete Task root")?;
-    let task_body = &task_close[task_open_end + 1..];
-    anyhow::ensure!(
-        !task_body.contains("<Task") && !task_body.contains("</Task>"),
-        "scheduler Query XML has nested or duplicate Task roots"
-    );
+    let valid_name = |name: &str| {
+        let mut bytes = name.bytes();
+        bytes
+            .next()
+            .is_some_and(|byte| byte.is_ascii_alphabetic() || matches!(byte, b'_' | b':'))
+            && bytes.all(|byte| {
+                byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b':' | b'.' | b'-')
+            })
+    };
+    let mut cursor = 0;
+    let mut stack: Vec<&str> = Vec::new();
+    let mut seen_root = false;
+    let mut seen_declaration = false;
+    let mut actions_count = 0;
+    let mut execs = Vec::new();
+    let mut command = None;
+    let mut arguments = None;
+    let mut capture: Option<(&str, String)> = None;
 
-    let actions_start = task_body
-        .find("<Actions")
-        .context("scheduler Query XML has no Actions container")?;
+    while cursor < xml.len() {
+        let start = xml[cursor..]
+            .find('<')
+            .map(|offset| cursor + offset)
+            .unwrap_or(xml.len());
+        let text = &xml[cursor..start];
+        if let Some((_, value)) = capture.as_mut() {
+            value.push_str(text);
+        } else if stack.is_empty() {
+            anyhow::ensure!(
+                text.trim().is_empty(),
+                "scheduler Query XML has text outside the Task root"
+            );
+        }
+        if start == xml.len() {
+            cursor = start;
+            break;
+        }
+
+        if xml[start..].starts_with("<!--") {
+            let comment = &xml[start + "<!--".len()..];
+            let end = comment
+                .find("-->")
+                .context("scheduler Query XML has an unterminated comment")?;
+            anyhow::ensure!(
+                !comment[..end].contains("--"),
+                "scheduler Query XML has a malformed comment"
+            );
+            cursor = start + "<!--".len() + end + "-->".len();
+            continue;
+        }
+        if xml[start..].starts_with("<?") {
+            anyhow::ensure!(
+                stack.is_empty()
+                    && !seen_root
+                    && !seen_declaration
+                    && xml[start..].starts_with("<?xml"),
+                "scheduler Query XML has an unsupported processing instruction"
+            );
+            let end = xml[start + 2..]
+                .find("?>")
+                .context("scheduler Query XML has an unterminated declaration")?;
+            seen_declaration = true;
+            cursor = start + 2 + end + 2;
+            continue;
+        }
+        anyhow::ensure!(
+            !xml[start..].starts_with("<!"),
+            "scheduler Query XML has unsupported markup"
+        );
+
+        let mut quote = None;
+        let mut end = None;
+        for (offset, character) in xml[start + 1..].char_indices() {
+            if let Some(expected) = quote {
+                anyhow::ensure!(
+                    character != '<',
+                    "scheduler Query XML has malformed tag attributes"
+                );
+                if character == expected {
+                    quote = None;
+                }
+            } else {
+                match character {
+                    '\'' | '"' => quote = Some(character),
+                    '>' => {
+                        end = Some(start + 1 + offset);
+                        break;
+                    }
+                    '<' => anyhow::bail!("scheduler Query XML has a malformed tag"),
+                    _ => {}
+                }
+            }
+        }
+        let end = end.context("scheduler Query XML has an unterminated tag")?;
+        let raw = xml[start + 1..end].trim();
+        cursor = end + 1;
+
+        if let Some(closing) = raw.strip_prefix('/') {
+            let name = closing.trim();
+            anyhow::ensure!(
+                valid_name(name) && name.len() == closing.len(),
+                "scheduler Query XML has a malformed closing tag"
+            );
+            anyhow::ensure!(
+                stack.last() == Some(&name),
+                "scheduler Query XML has mismatched element nesting"
+            );
+            if matches!(name, "Command" | "Arguments") {
+                let (kind, value) = capture
+                    .take()
+                    .context("scheduler Exec value did not close directly")?;
+                anyhow::ensure!(kind == name, "scheduler Exec values closed out of order");
+                let decoded = decode_scheduler_xml_value(&value)?;
+                if name == "Command" {
+                    command = Some(decoded);
+                } else {
+                    arguments = Some(decoded);
+                }
+            } else if name == "Exec" && stack.as_slice() == ["Task", "Actions", "Exec"] {
+                execs.push((
+                    command
+                        .take()
+                        .context("scheduler Exec action has no Command")?,
+                    arguments
+                        .take()
+                        .context("scheduler Exec action has no Arguments")?,
+                ));
+            }
+            stack.pop();
+            continue;
+        }
+
+        let (open, self_closing) = raw
+            .strip_suffix('/')
+            .map_or((raw, false), |open| (open.trim_end(), true));
+        let name_end = open.find(char::is_whitespace).unwrap_or(open.len());
+        let name = &open[..name_end];
+        anyhow::ensure!(
+            valid_name(name),
+            "scheduler Query XML has a malformed element name"
+        );
+        let mut attributes = &open[name_end..];
+        let mut attribute_names = Vec::new();
+        loop {
+            attributes = attributes.trim_start();
+            if attributes.is_empty() {
+                break;
+            }
+            let name_end = attributes
+                .find(|character: char| character.is_whitespace() || character == '=')
+                .unwrap_or(attributes.len());
+            let attribute_name = &attributes[..name_end];
+            anyhow::ensure!(
+                valid_name(attribute_name) && !attribute_names.contains(&attribute_name),
+                "scheduler Query XML has a malformed or duplicate attribute"
+            );
+            attribute_names.push(attribute_name);
+            attributes = attributes[name_end..].trim_start();
+            attributes = attributes
+                .strip_prefix('=')
+                .context("scheduler Query XML attribute has no equals sign")?
+                .trim_start();
+            let delimiter = attributes
+                .chars()
+                .next()
+                .filter(|character| matches!(character, '\'' | '"'))
+                .context("scheduler Query XML attribute value is not quoted")?;
+            attributes = &attributes[delimiter.len_utf8()..];
+            let value_end = attributes
+                .find(delimiter)
+                .context("scheduler Query XML attribute value is unterminated")?;
+            anyhow::ensure!(
+                !attributes[..value_end].contains('<'),
+                "scheduler Query XML attribute value contains markup"
+            );
+            attributes = &attributes[value_end + delimiter.len_utf8()..];
+            anyhow::ensure!(
+                attributes.is_empty() || attributes.chars().next().is_some_and(char::is_whitespace),
+                "scheduler Query XML attributes are not separated"
+            );
+        }
+
+        anyhow::ensure!(
+            capture.is_none(),
+            "scheduler Exec value contains nested markup"
+        );
+        if stack.is_empty() {
+            anyhow::ensure!(
+                !seen_root && name == "Task" && !self_closing,
+                "scheduler Query XML does not have one complete Task root"
+            );
+            seen_root = true;
+        }
+        if name == "Actions" {
+            anyhow::ensure!(
+                stack.as_slice() == ["Task"] && !self_closing,
+                "scheduler Actions container is not a direct Task child"
+            );
+            actions_count += 1;
+        } else if name == "Exec" {
+            anyhow::ensure!(
+                stack.as_slice() == ["Task", "Actions"] && !self_closing,
+                "scheduler Exec action is not a direct Actions child"
+            );
+            command = None;
+            arguments = None;
+        } else if matches!(name, "Command" | "Arguments") {
+            anyhow::ensure!(
+                stack.as_slice() == ["Task", "Actions", "Exec"],
+                "scheduler Exec value is not a direct Exec child"
+            );
+            let value = if name == "Command" {
+                &mut command
+            } else {
+                &mut arguments
+            };
+            anyhow::ensure!(
+                value.is_none(),
+                "scheduler Exec action has a duplicate {name}"
+            );
+            if self_closing {
+                *value = Some(String::new());
+            } else {
+                capture = Some((name, String::new()));
+            }
+        }
+        if !self_closing {
+            stack.push(name);
+        }
+    }
+
     anyhow::ensure!(
-        matches!(
-            task_body.as_bytes().get(actions_start + "<Actions".len()),
-            Some(b'>') | Some(b' ' | b'\t' | b'\r' | b'\n')
-        ),
-        "scheduler Query XML has a malformed Actions container"
+        cursor == xml.len(),
+        "scheduler Query XML was not fully scanned"
     );
-    let actions_open_end = task_body[actions_start..]
-        .find('>')
-        .map(|end| actions_start + end)
-        .context("scheduler Query XML has an unterminated Actions container")?;
     anyhow::ensure!(
-        !task_body[actions_start..=actions_open_end]
-            .trim_end()
-            .ends_with("/>"),
-        "scheduler Query XML has a self-closing Actions container"
+        seen_root && stack.is_empty() && capture.is_none(),
+        "scheduler Query XML has incomplete element nesting"
     );
-    let after_open = &task_body[actions_open_end + 1..];
-    let actions_close = after_open
-        .find("</Actions>")
-        .context("scheduler Query XML has an incomplete Actions container")?;
     anyhow::ensure!(
-        !task_body[..actions_start].contains("</Actions>")
-            && !after_open[..actions_close].contains("<Actions")
-            && !after_open[actions_close + "</Actions>".len()..].contains("<Actions")
-            && !after_open[actions_close + "</Actions>".len()..].contains("</Actions>"),
-        "scheduler Query XML has nested or duplicate Actions containers"
+        actions_count == 1,
+        "scheduler Query XML must have exactly one direct Actions container"
     );
-    Ok(&after_open[..actions_close])
+    Ok(execs)
 }
 
 #[cfg(any(windows, test))]
@@ -1117,12 +1296,7 @@ fn recover_scheduler_manifest_candidate(
     xml: &str,
     executable: &Path,
 ) -> anyhow::Result<Option<PathBuf>> {
-    let actions_xml = scheduler_actions_xml(xml)?;
-    let actions = scheduler_exec_values(actions_xml)?;
-    anyhow::ensure!(
-        scheduler_exec_values(xml)? == actions,
-        "scheduler Query XML has an Exec action outside its Actions container"
-    );
+    let actions = scheduler_direct_exec_values(xml)?;
     let [(command, arguments)] = actions.as_slice() else {
         return Ok(None);
     };
@@ -2667,6 +2841,10 @@ mod tests {
             xml, executable, manifest
         )?);
         assert_eq!(
+            recover_scheduler_manifest_candidate(xml, executable)?,
+            Some(manifest.to_path_buf())
+        );
+        assert_eq!(
             manifest_cleanup_decision(
                 &SchedulerOutput::for_test(0, xml, ""),
                 executable,
@@ -3311,7 +3489,11 @@ mod tests {
         edda_store::write_atomic(&prepared.path, &prepared.bytes)?;
         let project_id = edda_store::project_id_for_root(&fixture.repo);
         let (_, query_args, delete_args) = windows_scheduler_management_args(&project_id)?;
-        let xml = scheduler_manifest_xml(&fixture.codex, &prepared.path)?;
+        let xml = format!(
+            "<?xml version=\"1.0\"?>{}",
+            scheduler_manifest_xml(&fixture.codex, &prepared.path)?
+                .replace("<Actions>", "<!-- harmless scheduler comment --><Actions>")
+        );
         let outputs = [
             SchedulerOutput::for_test(0, &xml, ""),
             SchedulerOutput::for_test(0, "", ""),
@@ -3331,6 +3513,77 @@ mod tests {
 
         assert_eq!(calls, [query_args.clone(), delete_args, query_args]);
         assert!(!prepared.path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_uninstall_structural_xml_ignores_commented_matching_action() -> anyhow::Result<()>
+    {
+        let fixture = scheduler_manifest_fixture()?;
+        let prepared = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+        edda_store::write_atomic(&prepared.path, &prepared.bytes)?;
+        let xml = format!(
+            "<?xml version=\"1.0\"?>{}",
+            scheduler_manifest_xml(&fixture.codex, &prepared.path)?
+                .replace("<Actions>", "<!-- <Actions>")
+                .replace("</Actions>", "</Actions> -->")
+        );
+        let project_id = edda_store::project_id_for_root(&fixture.repo);
+        let mut outputs = [
+            SchedulerOutput::for_test(0, &xml, ""),
+            SchedulerOutput::for_test(0, "", ""),
+            SchedulerOutput::for_test(MISSING_TASK_HRESULT, "", "missing"),
+        ]
+        .into_iter();
+        let mut calls = 0;
+
+        uninstall_scheduler_task_with(&fixture.repo, &fixture.codex, &project_id, |_| {
+            calls += 1;
+            outputs.next().context("unexpected scheduler call")
+        })?;
+
+        assert_eq!(calls, 3);
+        assert!(prepared.path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_uninstall_structural_xml_rejects_malformed_unrelated_nesting() -> anyhow::Result<()>
+    {
+        for wrap in [
+            "<Settings><Unclosed></Settings>{actions}",
+            "<Unclosed>{actions}",
+        ] {
+            let fixture = scheduler_manifest_fixture()?;
+            let prepared =
+                prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+            edda_store::write_atomic(&prepared.path, &prepared.bytes)?;
+            let complete = scheduler_manifest_xml(&fixture.codex, &prepared.path)?;
+            let actions = complete
+                .strip_prefix("<Task>")
+                .and_then(|xml| xml.strip_suffix("</Task>"))
+                .context("test scheduler XML Task wrapper")?;
+            let xml = format!("<Task>{}</Task>", wrap.replace("{actions}", actions));
+            let project_id = edda_store::project_id_for_root(&fixture.repo);
+            let mut outputs = [
+                SchedulerOutput::for_test(0, &xml, ""),
+                SchedulerOutput::for_test(0, "", ""),
+                SchedulerOutput::for_test(MISSING_TASK_HRESULT, "", "missing"),
+            ]
+            .into_iter();
+            let mut calls = 0;
+
+            uninstall_scheduler_task_with(&fixture.repo, &fixture.codex, &project_id, |_| {
+                calls += 1;
+                outputs.next().context("unexpected scheduler call")
+            })?;
+
+            assert_eq!(calls, 3);
+            assert!(
+                prepared.path.exists(),
+                "wrapper {wrap:?} authorized cleanup"
+            );
+        }
         Ok(())
     }
 

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -108,8 +108,12 @@ pub fn run(repo_root: &Path, args: ReconcileArgs) -> anyhow::Result<()> {
         Some(repo) => canonical_main_repo(repo)?,
         None => repo_root.to_path_buf(),
     };
-    if args.install_scheduler || args.uninstall_scheduler {
-        return scheduler_lifecycle(&repo_root, args.install_scheduler);
+    if args.install_scheduler {
+        let config = ReconcileConfig::from_args(&args);
+        return scheduler_lifecycle(&repo_root, Some(&config));
+    }
+    if args.uninstall_scheduler {
+        return scheduler_lifecycle(&repo_root, None);
     }
     let config = ReconcileConfig::from_args(&args);
     if let Some(task_id) = args.run_task {
@@ -186,7 +190,6 @@ struct WindowsSchedulerSpec {
     task_name: String,
     create_args: Vec<String>,
     query_args: Vec<String>,
-    delete_args: Vec<String>,
 }
 
 fn canonical_main_repo(repo: &Path) -> anyhow::Result<PathBuf> {
@@ -254,10 +257,81 @@ fn windows_path_is_absolute(path: &Path) -> anyhow::Result<bool> {
 }
 
 #[cfg(any(windows, test))]
+fn canonical_direct_codex_executable(
+    command: &Path,
+    search_path: Option<&std::ffi::OsStr>,
+) -> anyhow::Result<PathBuf> {
+    let has_parent = command
+        .parent()
+        .is_some_and(|parent| !parent.as_os_str().is_empty());
+    let path = search_path
+        .map(std::ffi::OsString::from)
+        .or_else(|| std::env::var_os("PATH"));
+    let candidates = if command.is_absolute() || has_parent {
+        vec![command.to_path_buf()]
+    } else {
+        path.as_deref()
+            .map(std::env::split_paths)
+            .into_iter()
+            .flatten()
+            .map(|directory| directory.join(command))
+            .collect()
+    };
+
+    for candidate in candidates {
+        let candidate = match candidate
+            .extension()
+            .and_then(|extension| extension.to_str())
+        {
+            None => candidate.with_extension("exe"),
+            Some(extension) if extension.eq_ignore_ascii_case("exe") => candidate,
+            Some(_) => continue,
+        };
+        if !candidate.is_file() {
+            continue;
+        }
+        let canonical = candidate
+            .canonicalize()
+            .with_context(|| format!("canonicalize Codex executable {}", candidate.display()))?;
+        if canonical.is_file() {
+            return Ok(canonical);
+        }
+    }
+    anyhow::bail!(
+        "Codex executable {} must resolve to an absolute native .exe file",
+        command.display()
+    )
+}
+
+#[cfg(any(windows, test))]
+fn windows_scheduler_task_name(project_id: &str) -> anyhow::Result<String> {
+    anyhow::ensure!(
+        project_id.len() == 32
+            && project_id
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
+        "project id must be 32 lowercase hexadecimal characters"
+    );
+    Ok(format!("Edda-Reconcile-{project_id}"))
+}
+
+#[cfg(any(windows, test))]
+fn windows_scheduler_management_args(
+    project_id: &str,
+) -> anyhow::Result<(String, Vec<String>, Vec<String>)> {
+    let task_name = windows_scheduler_task_name(project_id)?;
+    let strings = |items: &[&str]| items.iter().map(|item| (*item).into()).collect();
+    let query_args = strings(&["/Query", "/TN", &task_name, "/XML", "/HRESULT"]);
+    let delete_args = strings(&["/Delete", "/TN", &task_name, "/F", "/HRESULT"]);
+    Ok((task_name, query_args, delete_args))
+}
+
+#[cfg(any(windows, test))]
 fn windows_scheduler_spec(
     exe: &Path,
     repo: &Path,
     project_id: &str,
+    config: &ReconcileConfig,
 ) -> anyhow::Result<WindowsSchedulerSpec> {
     anyhow::ensure!(
         windows_path_is_absolute(exe)?,
@@ -268,17 +342,18 @@ fn windows_scheduler_spec(
         "scheduler repository must be absolute"
     );
     anyhow::ensure!(
-        project_id.len() == 32
-            && project_id
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "project id must be 32 lowercase hexadecimal characters"
+        windows_path_is_absolute(&config.codex_bin)?,
+        "scheduler Codex executable must be absolute"
     );
-    let task_name = format!("Edda-Reconcile-{project_id}");
+    let (task_name, query_args, _) = windows_scheduler_management_args(project_id)?;
     let task_run = format!(
-        "{} reconcile --repo {}",
+        "{} reconcile --repo {} --max-workers {} --max-attempts {} --lease-ttl-s {} --codex-bin {}",
         quote_windows_argument(exe)?,
-        quote_windows_argument(repo)?
+        quote_windows_argument(repo)?,
+        config.max_workers,
+        config.max_attempts,
+        config.lease_ttl_s,
+        quote_windows_argument(&config.codex_bin)?
     );
     let strings = |items: &[&str]| items.iter().map(|item| (*item).into()).collect();
     Ok(WindowsSchedulerSpec {
@@ -286,8 +361,7 @@ fn windows_scheduler_spec(
             "/Create", "/SC", "MINUTE", "/MO", "1", "/TN", &task_name, "/TR", &task_run, "/RL",
             "LIMITED", "/F", "/HRESULT",
         ]),
-        query_args: strings(&["/Query", "/TN", &task_name, "/XML", "/HRESULT"]),
-        delete_args: strings(&["/Delete", "/TN", &task_name, "/F", "/HRESULT"]),
+        query_args,
         task_name,
     })
 }
@@ -338,19 +412,25 @@ fn run_schtasks(args: &[String]) -> anyhow::Result<SchedulerOutput> {
     })
 }
 
-fn scheduler_lifecycle(repo: &Path, install: bool) -> anyhow::Result<()> {
+fn scheduler_lifecycle(
+    repo: &Path,
+    install_config: Option<&ReconcileConfig>,
+) -> anyhow::Result<()> {
     #[cfg(not(windows))]
     {
-        let _ = (repo, install);
+        let _ = (repo, install_config);
         anyhow::bail!("Windows Task Scheduler is supported only on Windows")
     }
     #[cfg(windows)]
     {
         let repo = canonical_main_repo(repo)?;
-        let executable = std::env::current_exe()?.canonicalize()?;
-        let spec =
-            windows_scheduler_spec(&executable, &repo, &edda_store::project_id_for_root(&repo))?;
-        if install {
+        let project_id = edda_store::project_id_for_root(&repo);
+        let (task_name, query_args, delete_args) = windows_scheduler_management_args(&project_id)?;
+        if let Some(config) = install_config {
+            let executable = std::env::current_exe()?.canonicalize()?;
+            let mut config = config.clone();
+            config.codex_bin = canonical_direct_codex_executable(&config.codex_bin, None)?;
+            let spec = windows_scheduler_spec(&executable, &repo, &project_id, &config)?;
             let created = run_schtasks(&spec.create_args)
                 .with_context(|| format!("scheduler Create failed for task {}", spec.task_name))?;
             anyhow::ensure!(
@@ -375,38 +455,38 @@ fn scheduler_lifecycle(repo: &Path, install: bool) -> anyhow::Result<()> {
             return Ok(());
         }
 
-        let before = run_schtasks(&spec.query_args)
-            .with_context(|| format!("scheduler Query failed for task {}", spec.task_name))?;
+        let before = run_schtasks(&query_args)
+            .with_context(|| format!("scheduler Query failed for task {task_name}"))?;
         if classify_scheduler_query(&before)
-            .with_context(|| format!("scheduler Query failed for task {}", spec.task_name))?
+            .with_context(|| format!("scheduler Query failed for task {task_name}"))?
             == SchedulerTaskState::Missing
         {
             println!(
                 "scheduler task {} already absent for {}",
-                spec.task_name,
+                task_name,
                 repo.display()
             );
             return Ok(());
         }
-        let deleted = run_schtasks(&spec.delete_args)
-            .with_context(|| format!("scheduler Delete failed for task {}", spec.task_name))?;
+        let deleted = run_schtasks(&delete_args)
+            .with_context(|| format!("scheduler Delete failed for task {task_name}"))?;
         anyhow::ensure!(
             deleted.code == 0 || deleted.code == MISSING_TASK_HRESULT,
             "scheduler Delete failed for {}: {}",
-            spec.task_name,
+            task_name,
             deleted.description()
         );
-        let after = run_schtasks(&spec.query_args)
-            .with_context(|| format!("scheduler Query failed for task {}", spec.task_name))?;
+        let after = run_schtasks(&query_args)
+            .with_context(|| format!("scheduler Query failed for task {task_name}"))?;
         require_scheduler_state(
             &after,
             SchedulerTaskState::Missing,
             "post-Delete Query",
-            &spec.task_name,
+            &task_name,
         )?;
         println!(
             "uninstalled scheduler task {} for {}",
-            spec.task_name,
+            task_name,
             repo.display()
         );
         Ok(())
@@ -1329,6 +1409,15 @@ mod tests {
         lock.lock().unwrap_or_else(|poison| poison.into_inner())
     }
 
+    fn scheduler_config(codex_bin: &str) -> ReconcileConfig {
+        ReconcileConfig {
+            max_workers: 3,
+            max_attempts: 3,
+            lease_ttl_s: 300,
+            codex_bin: PathBuf::from(codex_bin),
+        }
+    }
+
     #[test]
     fn scheduler_cli_parses_reentry_and_rejects_conflicting_modes() {
         let parsed = SchedulerCli::try_parse_from([
@@ -1358,14 +1447,76 @@ mod tests {
             "1"
         ])
         .is_err());
+
+        let reentry = SchedulerCli::try_parse_from([
+            "test",
+            "--repo",
+            r"C:\ai projects\sample",
+            "--max-workers",
+            "2",
+            "--max-attempts",
+            "5",
+            "--lease-ttl-s",
+            "17",
+            "--codex-bin",
+            r"C:\Program Files\Codex\codex.exe",
+        ])
+        .expect("rendered scheduler re-entry arguments");
+        let config = ReconcileConfig::from_args(&reentry.args);
+        assert_eq!(config.max_workers, 2);
+        assert_eq!(config.max_attempts, 5);
+        assert_eq!(config.lease_ttl_s, 17);
+        assert_eq!(
+            config.codex_bin,
+            PathBuf::from(r"C:\Program Files\Codex\codex.exe")
+        );
+    }
+
+    #[test]
+    fn scheduler_codex_config_prefers_cli_then_environment() {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = test_lock(&ENV_LOCK);
+        let previous = std::env::var_os("EDDA_CODEX_BIN");
+        std::env::set_var("EDDA_CODEX_BIN", r"C:\environment\codex.exe");
+
+        let explicit = SchedulerCli::try_parse_from([
+            "test",
+            "--install-scheduler",
+            "--codex-bin",
+            r"C:\explicit\codex.exe",
+        ])
+        .expect("explicit Codex path");
+        assert_eq!(
+            ReconcileConfig::from_args(&explicit.args).codex_bin,
+            PathBuf::from(r"C:\explicit\codex.exe")
+        );
+
+        let inherited = SchedulerCli::try_parse_from(["test", "--install-scheduler"])
+            .expect("environment Codex path");
+        assert_eq!(
+            ReconcileConfig::from_args(&inherited.args).codex_bin,
+            PathBuf::from(r"C:\environment\codex.exe")
+        );
+
+        match previous {
+            Some(value) => std::env::set_var("EDDA_CODEX_BIN", value),
+            None => std::env::remove_var("EDDA_CODEX_BIN"),
+        }
     }
 
     #[test]
     fn scheduler_renderer_emits_exact_project_scoped_argv() -> anyhow::Result<()> {
+        let config = ReconcileConfig {
+            max_workers: 2,
+            max_attempts: 5,
+            lease_ttl_s: 17,
+            codex_bin: PathBuf::from(r"C:\Program Files\Codex\codex.exe"),
+        };
         let spec = windows_scheduler_spec(
             Path::new(r"C:\Program Files\edda\edda.exe"),
             Path::new(r"C:\ai projects\sample"),
             "0123456789abcdef0123456789abcdef",
+            &config,
         )?;
 
         assert_eq!(
@@ -1374,7 +1525,7 @@ mod tests {
         );
         assert_eq!(
             spec.create_args[8],
-            r#""C:\Program Files\edda\edda.exe" reconcile --repo "C:\ai projects\sample""#
+            r#""C:\Program Files\edda\edda.exe" reconcile --repo "C:\ai projects\sample" --max-workers 2 --max-attempts 5 --lease-ttl-s 17 --codex-bin "C:\Program Files\Codex\codex.exe""#
         );
         assert_eq!(
             spec.create_args,
@@ -1387,7 +1538,7 @@ mod tests {
                 "/TN",
                 "Edda-Reconcile-0123456789abcdef0123456789abcdef",
                 "/TR",
-                r#""C:\Program Files\edda\edda.exe" reconcile --repo "C:\ai projects\sample""#,
+                r#""C:\Program Files\edda\edda.exe" reconcile --repo "C:\ai projects\sample" --max-workers 2 --max-attempts 5 --lease-ttl-s 17 --codex-bin "C:\Program Files\Codex\codex.exe""#,
                 "/RL",
                 "LIMITED",
                 "/F",
@@ -1404,8 +1555,94 @@ mod tests {
                 "/HRESULT",
             ]
         );
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_renderer_is_stable_and_quotes_terminal_backslashes() -> anyhow::Result<()> {
+        let id = "0123456789abcdef0123456789abcdef";
+        let config = ReconcileConfig {
+            max_workers: 3,
+            max_attempts: 3,
+            lease_ttl_s: 300,
+            codex_bin: PathBuf::from(r"C:\Codex\codex.exe"),
+        };
+        let first = windows_scheduler_spec(
+            Path::new(r"C:\edda\edda.exe"),
+            Path::new(r"C:\repo\"),
+            id,
+            &config,
+        )?;
+        let second = windows_scheduler_spec(
+            Path::new(r"C:\edda\edda.exe"),
+            Path::new(r"C:\repo\"),
+            id,
+            &config,
+        )?;
+
+        assert_eq!(first.create_args, second.create_args);
         assert_eq!(
-            spec.delete_args,
+            first.create_args[8],
+            r#""C:\edda\edda.exe" reconcile --repo "C:\repo\\" --max-workers 3 --max-attempts 3 --lease-ttl-s 300 --codex-bin "C:\Codex\codex.exe""#
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_codex_resolver_requires_a_canonical_direct_exe() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let native = dir.path().join("codex.exe");
+        std::fs::write(&native, b"MZ")?;
+        let shim = dir.path().join("codex.cmd");
+        std::fs::write(&shim, b"@echo off")?;
+        let search_path = std::env::join_paths([dir.path()])?;
+
+        assert_eq!(
+            canonical_direct_codex_executable(Path::new("codex"), Some(&search_path))?,
+            native.canonicalize()?
+        );
+        assert_eq!(
+            canonical_direct_codex_executable(&native, None)?,
+            native.canonicalize()?
+        );
+        assert!(canonical_direct_codex_executable(&shim, None).is_err());
+        assert!(
+            canonical_direct_codex_executable(Path::new("missing-codex"), Some(&search_path))
+                .is_err()
+        );
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn scheduler_codex_resolver_finds_this_hosts_native_codex_exe() -> anyhow::Result<()> {
+        let resolved = canonical_direct_codex_executable(Path::new("codex"), None)?;
+        assert!(resolved.is_absolute());
+        assert!(resolved.is_file());
+        assert!(resolved
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("exe")));
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_uninstall_target_does_not_require_a_codex_executable() -> anyhow::Result<()> {
+        let (task_name, query_args, delete_args) =
+            windows_scheduler_management_args("0123456789abcdef0123456789abcdef")?;
+        assert_eq!(task_name, "Edda-Reconcile-0123456789abcdef0123456789abcdef");
+        assert_eq!(
+            query_args,
+            [
+                "/Query",
+                "/TN",
+                "Edda-Reconcile-0123456789abcdef0123456789abcdef",
+                "/XML",
+                "/HRESULT",
+            ]
+        );
+        assert_eq!(
+            delete_args,
             [
                 "/Delete",
                 "/TN",
@@ -1413,22 +1650,6 @@ mod tests {
                 "/F",
                 "/HRESULT",
             ]
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn scheduler_renderer_is_stable_and_quotes_terminal_backslashes() -> anyhow::Result<()> {
-        let id = "0123456789abcdef0123456789abcdef";
-        let first =
-            windows_scheduler_spec(Path::new(r"C:\edda\edda.exe"), Path::new(r"C:\repo\"), id)?;
-        let second =
-            windows_scheduler_spec(Path::new(r"C:\edda\edda.exe"), Path::new(r"C:\repo\"), id)?;
-
-        assert_eq!(first.create_args, second.create_args);
-        assert_eq!(
-            first.create_args[8],
-            r#""C:\edda\edda.exe" reconcile --repo "C:\repo\\""#
         );
         Ok(())
     }
@@ -1461,29 +1682,41 @@ mod tests {
     fn scheduler_renderer_rejects_ambiguous_inputs() {
         let executable = Path::new(r"C:\edda\edda.exe");
         let repository = Path::new(r"C:\repo");
+        let config = scheduler_config(r"C:\Codex\codex.exe");
         for id in [
             "0123456789abcdef0123456789abcde",
             "0123456789ABCDEF0123456789ABCDEF",
             "0123456789abcdef0123456789abcde*",
         ] {
-            assert!(windows_scheduler_spec(executable, repository, id).is_err());
+            assert!(windows_scheduler_spec(executable, repository, id, &config).is_err());
         }
         assert!(windows_scheduler_spec(
             executable,
             Path::new("C:\\repo\"quoted"),
-            "0123456789abcdef0123456789abcdef"
+            "0123456789abcdef0123456789abcdef",
+            &config
         )
         .is_err());
         assert!(windows_scheduler_spec(
             Path::new("edda.exe"),
             repository,
-            "0123456789abcdef0123456789abcdef"
+            "0123456789abcdef0123456789abcdef",
+            &config
         )
         .is_err());
         assert!(windows_scheduler_spec(
             executable,
             Path::new("repo"),
-            "0123456789abcdef0123456789abcdef"
+            "0123456789abcdef0123456789abcdef",
+            &config
+        )
+        .is_err());
+        let relative_codex = scheduler_config("codex.exe");
+        assert!(windows_scheduler_spec(
+            executable,
+            repository,
+            "0123456789abcdef0123456789abcdef",
+            &relative_codex
         )
         .is_err());
     }
@@ -1497,7 +1730,8 @@ mod tests {
         assert!(windows_scheduler_spec(
             Path::new(r"C:\edda\edda.exe"),
             Path::new(&invalid),
-            "0123456789abcdef0123456789abcdef"
+            "0123456789abcdef0123456789abcdef",
+            &scheduler_config(r"C:\Codex\codex.exe")
         )
         .is_err());
     }
@@ -1558,7 +1792,8 @@ mod tests {
     #[cfg(not(windows))]
     #[test]
     fn scheduler_lifecycle_is_explicitly_unsupported_off_windows() {
-        let error = scheduler_lifecycle(Path::new("/tmp/repo"), true)
+        let config = scheduler_config("/tmp/codex.exe");
+        let error = scheduler_lifecycle(Path::new("/tmp/repo"), Some(&config))
             .expect_err("non-Windows scheduler must fail")
             .to_string();
         assert!(error.contains("supported only on Windows"));

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -12,6 +12,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::AtomicU64;
 
+#[cfg(any(windows, test))]
+use std::borrow::Cow;
+
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -506,6 +509,7 @@ enum ManifestCleanupDecision {
 #[cfg(any(windows, test))]
 struct SchedulerOutput {
     code: u32,
+    stdout_raw: Vec<u8>,
     stdout: String,
     stderr: String,
     stdout_bytes: usize,
@@ -527,23 +531,96 @@ impl SchedulerOutput {
         stdout_bytes: usize,
         stderr_bytes: usize,
     ) -> Self {
+        Self::for_test_bytes_with_lengths(
+            code,
+            stdout.as_bytes(),
+            stderr.as_bytes(),
+            stdout_bytes,
+            stderr_bytes,
+        )
+    }
+
+    #[cfg(test)]
+    fn for_test_bytes(code: u32, stdout: &[u8], stderr: &[u8]) -> Self {
+        Self::for_test_bytes_with_lengths(code, stdout, stderr, stdout.len(), stderr.len())
+    }
+
+    #[cfg(test)]
+    fn for_test_bytes_with_stdout_len(
+        code: u32,
+        stdout: &[u8],
+        stderr: &[u8],
+        stdout_bytes: usize,
+    ) -> Self {
+        Self::for_test_bytes_with_lengths(code, stdout, stderr, stdout_bytes, stderr.len())
+    }
+
+    #[cfg(test)]
+    fn for_test_bytes_with_lengths(
+        code: u32,
+        stdout: &[u8],
+        stderr: &[u8],
+        stdout_bytes: usize,
+        stderr_bytes: usize,
+    ) -> Self {
+        let stdout_raw = stdout[..stdout.len().min(SCHEDULER_OUTPUT_LIMIT)].to_vec();
         Self {
             code,
-            stdout: stdout.into(),
-            stderr: stderr.into(),
+            stdout: String::from_utf8_lossy(&stdout_raw).into_owned(),
+            stdout_raw,
+            stderr: String::from_utf8_lossy(&stderr[..stderr.len().min(SCHEDULER_OUTPUT_LIMIT)])
+                .into_owned(),
             stdout_bytes,
             stderr_bytes,
         }
     }
 
-    fn xml(&self) -> anyhow::Result<&str> {
+    fn xml(&self) -> anyhow::Result<Cow<'_, str>> {
         anyhow::ensure!(
             self.stdout_bytes <= SCHEDULER_OUTPUT_LIMIT,
             "scheduler Query XML is {} bytes; maximum bounded output is {}",
             self.stdout_bytes,
             SCHEDULER_OUTPUT_LIMIT
         );
-        Ok(&self.stdout)
+        let bytes = self.stdout_raw.as_slice();
+        anyhow::ensure!(
+            !bytes.starts_with(&[0x00, 0x00, 0xfe, 0xff])
+                && !bytes.starts_with(&[0xff, 0xfe, 0x00, 0x00]),
+            "scheduler Query XML uses an unsupported UTF-32 encoding"
+        );
+        let decode_utf16 = |encoded: &[u8], little_endian: bool| -> anyhow::Result<String> {
+            anyhow::ensure!(
+                encoded.len().is_multiple_of(2),
+                "scheduler Query XML contains odd-length UTF-16"
+            );
+            let units = encoded
+                .chunks_exact(2)
+                .map(|bytes| {
+                    if little_endian {
+                        u16::from_le_bytes([bytes[0], bytes[1]])
+                    } else {
+                        u16::from_be_bytes([bytes[0], bytes[1]])
+                    }
+                })
+                .collect::<Vec<_>>();
+            String::from_utf16(&units).context("scheduler Query XML contains malformed UTF-16")
+        };
+        if let Some(encoded) = bytes.strip_prefix(&[0xff, 0xfe]) {
+            return Ok(Cow::Owned(decode_utf16(encoded, true)?));
+        }
+        if let Some(encoded) = bytes.strip_prefix(&[0xfe, 0xff]) {
+            return Ok(Cow::Owned(decode_utf16(encoded, false)?));
+        }
+        if bytes.starts_with(&[0x3c, 0x00, 0x3f, 0x00]) {
+            return Ok(Cow::Owned(decode_utf16(bytes, true)?));
+        }
+        if bytes.starts_with(&[0x00, 0x3c, 0x00, 0x3f]) {
+            return Ok(Cow::Owned(decode_utf16(bytes, false)?));
+        }
+        let utf8 = bytes.strip_prefix(&[0xef, 0xbb, 0xbf]).unwrap_or(bytes);
+        Ok(Cow::Borrowed(
+            std::str::from_utf8(utf8).context("scheduler Query XML is not valid UTF-8")?,
+        ))
     }
 
     fn description(&self) -> String {
@@ -881,7 +958,8 @@ fn manifest_cleanup_decision(
         SchedulerTaskState::Missing => return Ok(ManifestCleanupDecision::RemoveNewArtifact),
         SchedulerTaskState::Present => {}
     }
-    let actions = scheduler_exec_values(query.xml()?)?;
+    let xml = query.xml()?;
+    let actions = scheduler_exec_values(xml.as_ref())?;
     let executable = executable
         .to_str()
         .context("scheduler executable is not Unicode")?;
@@ -997,13 +1075,14 @@ fn run_schtasks(args: &[String]) -> anyhow::Result<SchedulerOutput> {
         .status
         .code()
         .context("schtasks.exe terminated by signal")?;
-    let bounded = |bytes: &[u8]| {
-        String::from_utf8_lossy(&bytes[..bytes.len().min(SCHEDULER_OUTPUT_LIMIT)]).into_owned()
-    };
+    let bounded = |bytes: &[u8]| bytes[..bytes.len().min(SCHEDULER_OUTPUT_LIMIT)].to_vec();
+    let stdout_raw = bounded(&output.stdout);
+    let stderr_raw = bounded(&output.stderr);
     Ok(SchedulerOutput {
         code: signed_code as u32,
-        stdout: bounded(&output.stdout),
-        stderr: bounded(&output.stderr),
+        stdout: String::from_utf8_lossy(&stdout_raw).into_owned(),
+        stdout_raw,
+        stderr: String::from_utf8_lossy(&stderr_raw).into_owned(),
         stdout_bytes: output.stdout.len(),
         stderr_bytes: output.stderr.len(),
     })
@@ -1054,7 +1133,7 @@ fn scheduler_lifecycle(
                 )?;
                 anyhow::ensure!(
                     scheduler_query_references_manifest(
-                        queried.xml()?,
+                        queried.xml()?.as_ref(),
                         &executable,
                         &manifest.path,
                     )?,
@@ -2070,6 +2149,26 @@ mod tests {
         PathBuf::from(format!(r"C:\{}.json", "x".repeat(target - fixed)))
     }
 
+    fn scheduler_xml_utf16_bytes(xml: &str, little_endian: bool, bom: bool) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        if bom {
+            bytes.extend_from_slice(if little_endian {
+                &[0xff, 0xfe]
+            } else {
+                &[0xfe, 0xff]
+            });
+        }
+        for unit in xml.encode_utf16() {
+            let encoded = if little_endian {
+                unit.to_le_bytes()
+            } else {
+                unit.to_be_bytes()
+            };
+            bytes.extend_from_slice(&encoded);
+        }
+        bytes
+    }
+
     struct SchedulerManifestFixture {
         _store_guard: crate::test_support::IsolatedStore,
         _root: tempfile::TempDir,
@@ -3019,6 +3118,73 @@ mod tests {
             ),
         )
         .is_err());
+    }
+
+    #[test]
+    fn scheduler_query_decodes_raw_utf16_xml_with_non_ascii_paths() -> anyhow::Result<()> {
+        let executable = Path::new(r"C:\工具\Edda\edda.exe");
+        let manifest = Path::new(
+            r"C:\儲存\scheduler-launch\v1\aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json",
+        );
+        let xml = r#"<?xml version="1.0" encoding="UTF-16"?><Task><Actions><Exec><Command>C:\工具\Edda\edda.exe</Command><Arguments>reconcile --scheduler-manifest &quot;C:\儲存\scheduler-launch\v1\aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json&quot;</Arguments></Exec></Actions></Task>"#;
+
+        let utf8_xml = xml.replace("UTF-16", "UTF-8");
+        for bytes in [
+            utf8_xml.as_bytes().to_vec(),
+            [b"\xef\xbb\xbf", utf8_xml.as_bytes()].concat(),
+        ] {
+            let output = SchedulerOutput::for_test_bytes(0, &bytes, b"");
+            let decoded = output.xml()?;
+            assert!(scheduler_query_references_manifest(
+                decoded.as_ref(),
+                executable,
+                manifest,
+            )?);
+        }
+        for (little_endian, bom) in [(true, true), (false, true), (true, false), (false, false)] {
+            let bytes = scheduler_xml_utf16_bytes(xml, little_endian, bom);
+            let output = SchedulerOutput::for_test_bytes(0, &bytes, b"");
+            let decoded = output.xml()?;
+            assert!(scheduler_query_references_manifest(
+                decoded.as_ref(),
+                executable,
+                manifest,
+            )?);
+            assert_eq!(
+                manifest_cleanup_decision(&output, executable, manifest)?,
+                ManifestCleanupDecision::Retain
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_query_rejects_malformed_raw_xml_but_keeps_diagnostics_lossy() {
+        for bytes in [
+            vec![0xff, 0xfe, b'<'],
+            vec![0xff, 0xfe, 0x00, 0xd8],
+            vec![0x00, 0x00, 0xfe, 0xff],
+            vec![0x80, 0x81],
+        ] {
+            assert!(SchedulerOutput::for_test_bytes(0, &bytes, b"")
+                .xml()
+                .is_err());
+        }
+
+        let overflow = SchedulerOutput::for_test_bytes_with_stdout_len(
+            0,
+            b"<Task />",
+            b"",
+            SCHEDULER_OUTPUT_LIMIT + 1,
+        );
+        assert!(overflow.xml().is_err());
+
+        let localized = SchedulerOutput::for_test_bytes(MISSING_TASK_HRESULT, b"", &[0xff]);
+        assert_eq!(
+            classify_scheduler_query(&localized).expect("non-XML diagnostics stay lossy"),
+            SchedulerTaskState::Missing
+        );
+        assert!(localized.description().contains('\u{fffd}'));
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -25,6 +25,8 @@ static SCHEDULER_MANIFEST_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 static DOORBELL_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 #[cfg(all(test, windows))]
 static FAKE_CODEX_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+#[cfg(all(test, windows))]
+const FAKE_CODEX_STARTUP_BUDGET: std::time::Duration = std::time::Duration::from_secs(30);
 #[cfg(test)]
 thread_local! {
     static FAIL_NEXT_STARTED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
@@ -4183,7 +4185,8 @@ mod tests {
         deny: std::path::PathBuf,
     ) -> std::thread::JoinHandle<anyhow::Result<()>> {
         std::thread::spawn(move || {
-            for _ in 0..200 {
+            let deadline = std::time::Instant::now() + FAKE_CODEX_STARTUP_BUDGET;
+            while std::time::Instant::now() < deadline {
                 if challenge.exists() {
                     let view = Ledger::open(&repo)?
                         .task_views()?
@@ -5269,7 +5272,8 @@ mod tests {
         let runner =
             std::thread::spawn(move || run_task(&runner_repo, 1, 1, &runner_config, false));
 
-        for _ in 0..100 {
+        let session_deadline = std::time::Instant::now() + FAKE_CODEX_STARTUP_BUDGET;
+        while std::time::Instant::now() < session_deadline {
             if ledger
                 .task_events()?
                 .iter()
@@ -5318,7 +5322,7 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn fake_runner_resumes_the_current_attempt_session_before_turn() -> anyhow::Result<()> {
+    fn fake_runner_resumes_current_attempt_after_slow_startup_before_turn() -> anyhow::Result<()> {
         let _fake = test_lock(&FAKE_CODEX_LOCK);
         let dir = tempfile::tempdir()?;
         let repo = dir.path().join("repo");
@@ -5342,6 +5346,8 @@ mod tests {
         std::env::set_var("EDDA_FAKE_DENY", &deny);
         let observer =
             allow_fake_turn_after_durable_session(repo.clone(), 2, 1, challenge, allow, deny);
+
+        std::thread::sleep(std::time::Duration::from_millis(2_100));
 
         let run_result = run_task(&repo, 2, 1, &config, false);
         let observer_result = observer.join();
@@ -5409,7 +5415,8 @@ Write-Line '{"id":2,"result":{"thread":{"id":"fake-thread"}}}'
 Read-Line
 if ($env:EDDA_FAKE_CHALLENGE) {
   New-Item -ItemType File -Force -Path $env:EDDA_FAKE_CHALLENGE | Out-Null
-  for ($i = 0; $i -lt 200; $i++) {
+  $startupDeadline = [System.DateTime]::UtcNow.AddMilliseconds(STARTUP_BUDGET_MS)
+  while ([System.DateTime]::UtcNow -lt $startupDeadline) {
     if (Test-Path $env:EDDA_FAKE_ALLOW) { break }
     if (Test-Path $env:EDDA_FAKE_DENY) { exit 7 }
     Start-Sleep -Milliseconds 10
@@ -5421,6 +5428,10 @@ EVENTS
 Write-Line '{"id":3,"result":{"turn":{"id":"fake-turn"}}}'
 "#
             .replace("DELAY", &delay_s.to_string())
+            .replace(
+                "STARTUP_BUDGET_MS",
+                &FAKE_CODEX_STARTUP_BUDGET.as_millis().to_string(),
+            )
             .replace("LOGFILE", &log.to_string_lossy().replace("'", "''"))
             .replace(
                 "EVENTS",

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -53,6 +53,22 @@ pub struct ReconcileArgs {
     run_task: Option<u64>,
     #[arg(long, hide = true)]
     attempt: Option<u32>,
+    #[arg(
+        long,
+        hide = true,
+        conflicts_with_all = [
+            "install_scheduler",
+            "uninstall_scheduler",
+            "repo",
+            "codex_bin",
+            "run_task",
+            "attempt",
+            "max_workers",
+            "max_attempts",
+            "lease_ttl_s"
+        ]
+    )]
+    scheduler_manifest: Option<PathBuf>,
 }
 
 #[derive(Clone)]
@@ -92,11 +108,8 @@ impl ReconcileConfig {
     }
 }
 
-// Task 2 removes these temporary allowances when it wires the private Task 1 surface.
-#[allow(dead_code)]
 const SCHEDULER_MANIFEST_MAX_BYTES: u64 = 16 * 1024;
 
-#[allow(dead_code)]
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 struct SchedulerLaunchManifestV1 {
@@ -109,22 +122,25 @@ struct SchedulerLaunchManifestV1 {
     lease_ttl_s: u64,
 }
 
-#[allow(dead_code)]
 struct PreparedSchedulerManifest {
+    // Task 3 consumes these fields when it publishes immutable manifests.
+    #[allow(dead_code)]
     manifest: SchedulerLaunchManifestV1,
+    #[allow(dead_code)]
     bytes: Vec<u8>,
+    #[allow(dead_code)]
     digest: String,
     path: PathBuf,
 }
 
-#[allow(dead_code)]
 struct LoadedSchedulerManifest {
+    // Task 3 consumes the payload when verifying existing artifacts.
+    #[allow(dead_code)]
     manifest: SchedulerLaunchManifestV1,
     repo: PathBuf,
     config: ReconcileConfig,
 }
 
-#[allow(dead_code)]
 fn scheduler_manifest_directory(store: &Path, must_exist: bool) -> anyhow::Result<PathBuf> {
     let store = std::path::absolute(store)
         .with_context(|| format!("resolve Edda store root {}", store.display()))?;
@@ -161,12 +177,10 @@ fn scheduler_manifest_directory(store: &Path, must_exist: bool) -> anyhow::Resul
     Ok(directory)
 }
 
-#[allow(dead_code)]
 fn scheduler_manifest_digest(bytes: &[u8]) -> String {
     hex::encode(Sha256::digest(bytes))
 }
 
-#[allow(dead_code)]
 fn validate_scheduler_manifest(
     manifest: SchedulerLaunchManifestV1,
 ) -> anyhow::Result<LoadedSchedulerManifest> {
@@ -201,7 +215,6 @@ fn validate_scheduler_manifest(
     })
 }
 
-#[allow(dead_code)]
 fn prepare_scheduler_manifest(
     store: &Path,
     repo: &Path,
@@ -229,7 +242,6 @@ fn prepare_scheduler_manifest(
     })
 }
 
-#[allow(dead_code)]
 fn load_scheduler_manifest(path: &Path) -> anyhow::Result<LoadedSchedulerManifest> {
     anyhow::ensure!(
         path.is_absolute(),
@@ -322,9 +334,17 @@ struct PersistOutcome {
 }
 
 pub fn run(repo_root: &Path, args: ReconcileArgs) -> anyhow::Result<()> {
-    let repo_root = match args.repo.as_deref() {
-        Some(repo) => canonical_main_repo(repo)?,
-        None => repo_root.to_path_buf(),
+    let scheduler_manifest = args
+        .scheduler_manifest
+        .as_deref()
+        .map(load_scheduler_manifest)
+        .transpose()?;
+    let repo_root = match scheduler_manifest.as_ref() {
+        Some(loaded) => loaded.repo.clone(),
+        None => match args.repo.as_deref() {
+            Some(repo) => canonical_main_repo(repo)?,
+            None => repo_root.to_path_buf(),
+        },
     };
     if args.install_scheduler {
         let config = ReconcileConfig::from_args(&args);
@@ -333,7 +353,9 @@ pub fn run(repo_root: &Path, args: ReconcileArgs) -> anyhow::Result<()> {
     if args.uninstall_scheduler {
         return scheduler_lifecycle(&repo_root, None);
     }
-    let config = ReconcileConfig::from_args(&args);
+    let config = scheduler_manifest
+        .map(|loaded| loaded.config)
+        .unwrap_or_else(|| ReconcileConfig::from_args(&args));
     if let Some(task_id) = args.run_task {
         let attempt = args
             .attempt
@@ -557,34 +579,40 @@ fn windows_scheduler_management_args(
 }
 
 #[cfg(any(windows, test))]
-fn windows_scheduler_spec(
+fn render_scheduler_task_run(
     exe: &Path,
-    repo: &Path,
-    project_id: &str,
-    config: &ReconcileConfig,
-) -> anyhow::Result<WindowsSchedulerSpec> {
+    manifest_path: &Path,
+    task_name: &str,
+) -> anyhow::Result<String> {
     anyhow::ensure!(
         windows_path_is_absolute(exe)?,
         "scheduler executable must be absolute"
     );
     anyhow::ensure!(
-        windows_path_is_absolute(repo)?,
-        "scheduler repository must be absolute"
+        windows_path_is_absolute(manifest_path)?,
+        "scheduler manifest path must be absolute"
     );
-    anyhow::ensure!(
-        windows_path_is_absolute(&config.codex_bin)?,
-        "scheduler Codex executable must be absolute"
-    );
-    let (task_name, query_args, _) = windows_scheduler_management_args(project_id)?;
     let task_run = format!(
-        "{} reconcile --repo {} --max-workers {} --max-attempts {} --lease-ttl-s {} --codex-bin {}",
+        "{} reconcile --scheduler-manifest {}",
         quote_windows_argument(exe)?,
-        quote_windows_argument(repo)?,
-        config.max_workers,
-        config.max_attempts,
-        config.lease_ttl_s,
-        quote_windows_argument(&config.codex_bin)?
+        quote_windows_argument(manifest_path)?,
     );
+    let units = task_run.encode_utf16().count();
+    anyhow::ensure!(
+        units <= 261,
+        "scheduler task {task_name} /TR is {units} UTF-16 code units; maximum is 261"
+    );
+    Ok(task_run)
+}
+
+#[cfg(any(windows, test))]
+fn windows_scheduler_spec(
+    exe: &Path,
+    manifest_path: &Path,
+    project_id: &str,
+) -> anyhow::Result<WindowsSchedulerSpec> {
+    let (task_name, query_args, _) = windows_scheduler_management_args(project_id)?;
+    let task_run = render_scheduler_task_run(exe, manifest_path, &task_name)?;
     let strings = |items: &[&str]| items.iter().map(|item| (*item).into()).collect();
     Ok(WindowsSchedulerSpec {
         create_args: strings(&[
@@ -660,7 +688,8 @@ fn scheduler_lifecycle(
             let executable = std::env::current_exe()?.canonicalize()?;
             let mut config = config.clone();
             config.codex_bin = canonical_direct_codex_executable(&config.codex_bin, None)?;
-            let spec = windows_scheduler_spec(&executable, &repo, &project_id, &config)?;
+            let manifest = prepare_scheduler_manifest(&edda_store::store_root(), &repo, &config)?;
+            let spec = windows_scheduler_spec(&executable, &manifest.path, &project_id)?;
             let created = run_schtasks(&spec.create_args)
                 .with_context(|| format!("scheduler Create failed for task {}", spec.task_name))?;
             anyhow::ensure!(
@@ -1639,6 +1668,7 @@ mod tests {
         lock.lock().unwrap_or_else(|poison| poison.into_inner())
     }
 
+    #[cfg(not(windows))]
     fn scheduler_config(codex_bin: &str) -> ReconcileConfig {
         ReconcileConfig {
             max_workers: 3,
@@ -1646,6 +1676,13 @@ mod tests {
             lease_ttl_s: 300,
             codex_bin: PathBuf::from(codex_bin),
         }
+    }
+
+    fn manifest_path_for_task_run_utf16_len(target: usize) -> PathBuf {
+        let fixed = r#""C:\e.exe" reconcile --scheduler-manifest "C:\.json""#
+            .encode_utf16()
+            .count();
+        PathBuf::from(format!(r"C:\{}.json", "x".repeat(target - fixed)))
     }
 
     struct SchedulerManifestFixture {
@@ -1860,7 +1897,9 @@ mod tests {
     }
 
     #[test]
-    fn scheduler_cli_parses_reentry_and_rejects_conflicting_modes() {
+    fn scheduler_cli_parses_manifest_reentry_and_rejects_conflicting_modes() {
+        use clap::CommandFactory;
+
         let parsed = SchedulerCli::try_parse_from([
             "test",
             "--repo",
@@ -1889,28 +1928,33 @@ mod tests {
         ])
         .is_err());
 
-        let reentry = SchedulerCli::try_parse_from([
-            "test",
-            "--repo",
-            r"C:\ai projects\sample",
-            "--max-workers",
-            "2",
-            "--max-attempts",
-            "5",
-            "--lease-ttl-s",
-            "17",
-            "--codex-bin",
-            r"C:\Program Files\Codex\codex.exe",
-        ])
-        .expect("rendered scheduler re-entry arguments");
-        let config = ReconcileConfig::from_args(&reentry.args);
-        assert_eq!(config.max_workers, 2);
-        assert_eq!(config.max_attempts, 5);
-        assert_eq!(config.lease_ttl_s, 17);
+        let manifest = r"C:\store\scheduler-launch\v1\0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.json";
+        let reentry = SchedulerCli::try_parse_from(["test", "--scheduler-manifest", manifest])
+            .expect("manifest scheduler re-entry arguments");
         assert_eq!(
-            config.codex_bin,
-            PathBuf::from(r"C:\Program Files\Codex\codex.exe")
+            reentry.args.scheduler_manifest.as_deref(),
+            Some(Path::new(manifest))
         );
+        assert!(!SchedulerCli::command()
+            .render_long_help()
+            .to_string()
+            .contains("--scheduler-manifest"));
+
+        for conflict in [
+            &["--install-scheduler"][..],
+            &["--uninstall-scheduler"][..],
+            &["--repo", r"C:\repo"][..],
+            &["--codex-bin", r"C:\codex.exe"][..],
+            &["--run-task", "7"][..],
+            &["--attempt", "1"][..],
+            &["--max-workers", "2"][..],
+            &["--max-attempts", "5"][..],
+            &["--lease-ttl-s", "17"][..],
+        ] {
+            let mut args = vec!["test", "--scheduler-manifest", manifest];
+            args.extend_from_slice(conflict);
+            assert!(SchedulerCli::try_parse_from(args).is_err(), "{conflict:?}");
+        }
     }
 
     #[test]
@@ -1947,17 +1991,13 @@ mod tests {
 
     #[test]
     fn scheduler_renderer_emits_exact_project_scoped_argv() -> anyhow::Result<()> {
-        let config = ReconcileConfig {
-            max_workers: 2,
-            max_attempts: 5,
-            lease_ttl_s: 17,
-            codex_bin: PathBuf::from(r"C:\Program Files\Codex\codex.exe"),
-        };
+        let manifest = Path::new(
+            r"C:\Users\alice\AppData\Roaming\edda\scheduler-launch\v1\0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.json",
+        );
         let spec = windows_scheduler_spec(
             Path::new(r"C:\Program Files\edda\edda.exe"),
-            Path::new(r"C:\ai projects\sample"),
+            manifest,
             "0123456789abcdef0123456789abcdef",
-            &config,
         )?;
 
         assert_eq!(
@@ -1966,7 +2006,7 @@ mod tests {
         );
         assert_eq!(
             spec.create_args[8],
-            r#""C:\Program Files\edda\edda.exe" reconcile --repo "C:\ai projects\sample" --max-workers 2 --max-attempts 5 --lease-ttl-s 17 --codex-bin "C:\Program Files\Codex\codex.exe""#
+            r#""C:\Program Files\edda\edda.exe" reconcile --scheduler-manifest "C:\Users\alice\AppData\Roaming\edda\scheduler-launch\v1\0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.json""#
         );
         assert_eq!(
             spec.create_args,
@@ -1979,7 +2019,7 @@ mod tests {
                 "/TN",
                 "Edda-Reconcile-0123456789abcdef0123456789abcdef",
                 "/TR",
-                r#""C:\Program Files\edda\edda.exe" reconcile --repo "C:\ai projects\sample" --max-workers 2 --max-attempts 5 --lease-ttl-s 17 --codex-bin "C:\Program Files\Codex\codex.exe""#,
+                r#""C:\Program Files\edda\edda.exe" reconcile --scheduler-manifest "C:\Users\alice\AppData\Roaming\edda\scheduler-launch\v1\0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.json""#,
                 "/RL",
                 "LIMITED",
                 "/F",
@@ -2002,31 +2042,78 @@ mod tests {
     #[test]
     fn scheduler_renderer_is_stable_and_quotes_terminal_backslashes() -> anyhow::Result<()> {
         let id = "0123456789abcdef0123456789abcdef";
-        let config = ReconcileConfig {
-            max_workers: 3,
-            max_attempts: 3,
-            lease_ttl_s: 300,
-            codex_bin: PathBuf::from(r"C:\Codex\codex.exe"),
-        };
         let first = windows_scheduler_spec(
             Path::new(r"C:\edda\edda.exe"),
-            Path::new(r"C:\repo\"),
+            Path::new(r"C:\manifest\"),
             id,
-            &config,
         )?;
         let second = windows_scheduler_spec(
             Path::new(r"C:\edda\edda.exe"),
-            Path::new(r"C:\repo\"),
+            Path::new(r"C:\manifest\"),
             id,
-            &config,
         )?;
 
         assert_eq!(first.create_args, second.create_args);
         assert_eq!(
             first.create_args[8],
-            r#""C:\edda\edda.exe" reconcile --repo "C:\repo\\" --max-workers 3 --max-attempts 3 --lease-ttl-s 300 --codex-bin "C:\Codex\codex.exe""#
+            r#""C:\edda\edda.exe" reconcile --scheduler-manifest "C:\manifest\\""#
         );
         Ok(())
+    }
+
+    #[test]
+    fn scheduler_manifest_renderer_fits_the_preserved_356_unit_fixture() -> anyhow::Result<()> {
+        let executable =
+            Path::new(r"\\?\C:\ai_agent\edda-target-gh466-drill-20260816T163456Z\debug\edda.exe");
+        let repository = r"\\?\C:\ai_agent\edda-drills\20260816T163456Z\repo";
+        let codex = r"\\?\C:\Users\synvoke\AppData\Roaming\npm\node_modules\@openai\codex\node_modules\@openai\codex-win32-x64\vendor\x86_64-pc-windows-msvc\bin\codex.exe";
+        let old = format!(
+            "{} reconcile --repo \"{repository}\" --max-workers 1 --max-attempts 3 --lease-ttl-s 120 --codex-bin \"{codex}\"",
+            quote_windows_argument(executable)?,
+        );
+        assert_eq!(old.encode_utf16().count(), 356);
+
+        let manifest = Path::new(
+            r"\\?\C:\Users\synvoke\AppData\Roaming\edda\scheduler-launch\v1\0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.json",
+        );
+        let rendered = render_scheduler_task_run(
+            executable,
+            manifest,
+            "Edda-Reconcile-75ab49a9590f5e1105b928c63a3c0be5",
+        )?;
+        assert_eq!(rendered.encode_utf16().count(), 238);
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_manifest_renderer_enforces_utf16_limit() -> anyhow::Result<()> {
+        let task_name = "Edda-Reconcile-0123456789abcdef0123456789abcdef";
+        let accepted_path = manifest_path_for_task_run_utf16_len(261);
+        let accepted =
+            render_scheduler_task_run(Path::new(r"C:\e.exe"), &accepted_path, task_name)?;
+        assert_eq!(accepted.encode_utf16().count(), 261);
+
+        let rejected_path = manifest_path_for_task_run_utf16_len(262);
+        let error = render_scheduler_task_run(Path::new(r"C:\e.exe"), &rejected_path, task_name)
+            .expect_err("262 UTF-16 units must fail")
+            .to_string();
+        assert!(error.contains("262"));
+        assert!(error.contains("261"));
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_manifest_renderer_counts_surrogate_pairs_as_two_utf16_units() {
+        let task_name = "Edda-Reconcile-0123456789abcdef0123456789abcdef";
+        let ascii = manifest_path_for_task_run_utf16_len(261);
+        let with_pair = PathBuf::from(ascii.to_string_lossy().replacen('x', "😀", 1));
+        let unbounded = format!(
+            r#""C:\e.exe" reconcile --scheduler-manifest "{}""#,
+            with_pair.display()
+        );
+        assert_eq!(unbounded.chars().count(), 261);
+        assert_eq!(unbounded.encode_utf16().count(), 262);
+        assert!(render_scheduler_task_run(Path::new(r"C:\e.exe"), &with_pair, task_name).is_err());
     }
 
     #[test]
@@ -2141,42 +2228,30 @@ mod tests {
     #[test]
     fn scheduler_renderer_rejects_ambiguous_inputs() {
         let executable = Path::new(r"C:\edda\edda.exe");
-        let repository = Path::new(r"C:\repo");
-        let config = scheduler_config(r"C:\Codex\codex.exe");
+        let manifest = Path::new(r"C:\manifest.json");
         for id in [
             "0123456789abcdef0123456789abcde",
             "0123456789ABCDEF0123456789ABCDEF",
             "0123456789abcdef0123456789abcde*",
         ] {
-            assert!(windows_scheduler_spec(executable, repository, id, &config).is_err());
+            assert!(windows_scheduler_spec(executable, manifest, id).is_err());
         }
         assert!(windows_scheduler_spec(
             executable,
-            Path::new("C:\\repo\"quoted"),
+            Path::new("C:\\manifest\"quoted.json"),
             "0123456789abcdef0123456789abcdef",
-            &config
         )
         .is_err());
         assert!(windows_scheduler_spec(
             Path::new("edda.exe"),
-            repository,
+            manifest,
             "0123456789abcdef0123456789abcdef",
-            &config
         )
         .is_err());
         assert!(windows_scheduler_spec(
             executable,
-            Path::new("repo"),
+            Path::new("manifest.json"),
             "0123456789abcdef0123456789abcdef",
-            &config
-        )
-        .is_err());
-        let relative_codex = scheduler_config("codex.exe");
-        assert!(windows_scheduler_spec(
-            executable,
-            repository,
-            "0123456789abcdef0123456789abcdef",
-            &relative_codex
         )
         .is_err());
     }
@@ -2191,7 +2266,6 @@ mod tests {
             Path::new(r"C:\edda\edda.exe"),
             Path::new(&invalid),
             "0123456789abcdef0123456789abcdef",
-            &scheduler_config(r"C:\Codex\codex.exe")
         )
         .is_err());
     }
@@ -2295,32 +2369,33 @@ mod tests {
     }
 
     #[test]
-    fn scheduler_repo_reentry_runs_against_the_explicit_repo_from_an_unrelated_root(
+    fn scheduler_manifest_reentry_runs_against_its_repo_from_an_unrelated_root(
     ) -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let repo = dir.path().join("scheduled repo");
-        let unrelated = dir.path().join("unrelated cwd");
-        std::fs::create_dir(&repo)?;
+        let mut fixture = scheduler_manifest_fixture()?;
+        fixture.config.max_workers = 0;
+        fixture.config.max_attempts = 1;
+        let unrelated = fixture._root.path().join("unrelated cwd");
         std::fs::create_dir(&unrelated)?;
-        init_git(&repo)?;
-        Ledger::ensure_initialized(&repo)?;
-        let ledger = Ledger::open(&repo)?;
+        let ledger = Ledger::open(&fixture.repo)?;
         create_task(&ledger, 91, &["src/scheduled.rs".into()])?;
         append_started(&ledger, 91, 1, 1)?;
         ledger.upsert_task_lease(&lease(91, 1, "2026-08-16T00:00:00Z"))?;
+        let prepared = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+        edda_store::write_atomic(&prepared.path, &prepared.bytes)?;
 
         run(
             &unrelated,
             ReconcileArgs {
-                max_workers: 0,
-                max_attempts: 1,
+                max_workers: 3,
+                max_attempts: 3,
                 lease_ttl_s: 300,
                 codex_bin: None,
                 install_scheduler: false,
                 uninstall_scheduler: false,
-                repo: Some(repo.canonicalize()?),
+                repo: None,
                 run_task: None,
                 attempt: None,
+                scheduler_manifest: Some(prepared.path),
             },
         )?;
 

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -148,15 +148,7 @@ fn scheduler_manifest_directory(store: &Path, must_exist: bool) -> anyhow::Resul
         !value.contains(['\0', '"']),
         "Edda store root contains an unsupported character"
     );
-    let store = if store.exists() {
-        anyhow::ensure!(store.is_dir(), "Edda store root must be a directory");
-        store
-            .canonicalize()
-            .with_context(|| format!("canonicalize Edda store root {}", store.display()))?
-    } else {
-        anyhow::ensure!(!must_exist, "Edda store root does not exist");
-        store
-    };
+    let store = prospective_canonical_store_root(&store, must_exist)?;
     let launch = store.join("scheduler-launch");
     if launch.exists() {
         anyhow::ensure!(
@@ -174,6 +166,34 @@ fn scheduler_manifest_directory(store: &Path, must_exist: bool) -> anyhow::Resul
         anyhow::ensure!(!must_exist, "scheduler manifest directory does not exist");
     }
     Ok(directory)
+}
+
+fn prospective_canonical_store_root(store: &Path, must_exist: bool) -> anyhow::Result<PathBuf> {
+    let mut missing = Vec::new();
+    let mut existing = store;
+    while !existing.exists() {
+        missing.push(
+            existing
+                .file_name()
+                .context("Edda store root has no existing ancestor")?
+                .to_os_string(),
+        );
+        existing = existing
+            .parent()
+            .context("Edda store root has no existing ancestor")?;
+    }
+    anyhow::ensure!(existing.is_dir(), "Edda store root must be a directory");
+    anyhow::ensure!(
+        !must_exist || missing.is_empty(),
+        "Edda store root does not exist"
+    );
+    let mut canonical = existing
+        .canonicalize()
+        .with_context(|| format!("canonicalize Edda store root {}", existing.display()))?;
+    for component in missing.iter().rev() {
+        canonical.push(component);
+    }
+    Ok(canonical)
 }
 
 fn scheduler_manifest_digest(bytes: &[u8]) -> String {
@@ -2585,6 +2605,32 @@ mod tests {
         lock.lock().unwrap_or_else(|poison| poison.into_inner())
     }
 
+    static CODEX_BIN_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct CodexBinEnvGuard {
+        previous: Option<std::ffi::OsString>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl Drop for CodexBinEnvGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var("EDDA_CODEX_BIN", value),
+                None => std::env::remove_var("EDDA_CODEX_BIN"),
+            }
+        }
+    }
+
+    fn codex_bin_env_guard(value: &str) -> CodexBinEnvGuard {
+        let lock = test_lock(&CODEX_BIN_ENV_LOCK);
+        let previous = std::env::var_os("EDDA_CODEX_BIN");
+        std::env::set_var("EDDA_CODEX_BIN", value);
+        CodexBinEnvGuard {
+            previous,
+            _lock: lock,
+        }
+    }
+
     #[cfg(not(windows))]
     fn scheduler_config(codex_bin: &str) -> ReconcileConfig {
         ReconcileConfig {
@@ -2722,6 +2768,26 @@ mod tests {
         std::fs::write(&prepared.path, b"different")?;
         assert!(publish_scheduler_manifest(&prepared).is_err());
         assert_eq!(std::fs::read(&prepared.path)?, b"different");
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_manifest_first_publish_from_absent_store_root_is_loadable() -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        std::fs::remove_dir_all(&fixture.store)?;
+        assert!(!fixture.store.exists());
+
+        let prepared = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+        assert!(publish_scheduler_manifest(&prepared)?);
+        assert_eq!(
+            prepared.path.parent(),
+            Some(scheduler_manifest_directory(&fixture.store, true)?.as_path())
+        );
+        assert_eq!(
+            load_scheduler_manifest(&prepared.path)?.manifest,
+            prepared.manifest
+        );
+        assert!(!publish_scheduler_manifest(&prepared)?);
         Ok(())
     }
 
@@ -3220,10 +3286,7 @@ mod tests {
 
     #[test]
     fn scheduler_codex_config_prefers_cli_then_environment() {
-        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _guard = test_lock(&ENV_LOCK);
-        let previous = std::env::var_os("EDDA_CODEX_BIN");
-        std::env::set_var("EDDA_CODEX_BIN", r"C:\environment\codex.exe");
+        let _environment = codex_bin_env_guard(r"C:\environment\codex.exe");
 
         let explicit = SchedulerCli::try_parse_from([
             "test",
@@ -3243,11 +3306,18 @@ mod tests {
             ReconcileConfig::from_args(&inherited.args).codex_bin,
             PathBuf::from(r"C:\environment\codex.exe")
         );
+    }
 
-        match previous {
-            Some(value) => std::env::set_var("EDDA_CODEX_BIN", value),
-            None => std::env::remove_var("EDDA_CODEX_BIN"),
-        }
+    #[test]
+    fn scheduler_codex_environment_guard_restores_after_unwind() {
+        let previous = std::env::var_os("EDDA_CODEX_BIN");
+        let result = std::panic::catch_unwind(|| {
+            let _environment = codex_bin_env_guard(r"C:\environment\codex.exe");
+            panic!("test unwind");
+        });
+
+        assert!(result.is_err());
+        assert_eq!(std::env::var_os("EDDA_CODEX_BIN"), previous);
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -92,8 +92,11 @@ impl ReconcileConfig {
     }
 }
 
+// Task 2 removes these temporary allowances when it wires the private Task 1 surface.
+#[allow(dead_code)]
 const SCHEDULER_MANIFEST_MAX_BYTES: u64 = 16 * 1024;
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 struct SchedulerLaunchManifestV1 {
@@ -106,6 +109,7 @@ struct SchedulerLaunchManifestV1 {
     lease_ttl_s: u64,
 }
 
+#[allow(dead_code)]
 struct PreparedSchedulerManifest {
     manifest: SchedulerLaunchManifestV1,
     bytes: Vec<u8>,
@@ -113,12 +117,14 @@ struct PreparedSchedulerManifest {
     path: PathBuf,
 }
 
+#[allow(dead_code)]
 struct LoadedSchedulerManifest {
     manifest: SchedulerLaunchManifestV1,
     repo: PathBuf,
     config: ReconcileConfig,
 }
 
+#[allow(dead_code)]
 fn scheduler_manifest_directory(store: &Path, must_exist: bool) -> anyhow::Result<PathBuf> {
     let store = std::path::absolute(store)
         .with_context(|| format!("resolve Edda store root {}", store.display()))?;
@@ -155,10 +161,12 @@ fn scheduler_manifest_directory(store: &Path, must_exist: bool) -> anyhow::Resul
     Ok(directory)
 }
 
+#[allow(dead_code)]
 fn scheduler_manifest_digest(bytes: &[u8]) -> String {
     hex::encode(Sha256::digest(bytes))
 }
 
+#[allow(dead_code)]
 fn validate_scheduler_manifest(
     manifest: SchedulerLaunchManifestV1,
 ) -> anyhow::Result<LoadedSchedulerManifest> {
@@ -193,6 +201,7 @@ fn validate_scheduler_manifest(
     })
 }
 
+#[allow(dead_code)]
 fn prepare_scheduler_manifest(
     store: &Path,
     repo: &Path,
@@ -220,6 +229,7 @@ fn prepare_scheduler_manifest(
     })
 }
 
+#[allow(dead_code)]
 fn load_scheduler_manifest(path: &Path) -> anyhow::Result<LoadedSchedulerManifest> {
     anyhow::ensure!(
         path.is_absolute(),
@@ -1809,13 +1819,18 @@ mod tests {
 
     #[test]
     fn scheduler_manifest_rejects_store_root_and_reparse_escape() -> anyhow::Result<()> {
-        let fixture = scheduler_manifest_fixture()?;
-        let prepared = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
-        let outside = fixture._root.path().join("outside");
-        let escaped = outside.join(format!("{}.json", prepared.digest));
-        edda_store::write_atomic(&escaped, &prepared.bytes)?;
-        assert!(load_scheduler_manifest(&escaped).is_err());
+        {
+            let fixture = scheduler_manifest_fixture()?;
+            let prepared =
+                prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+            std::fs::create_dir_all(fixture.store.join("scheduler-launch").join("v1"))?;
+            let outside = fixture._root.path().join("outside");
+            let escaped = outside.join(format!("{}.json", prepared.digest));
+            edda_store::write_atomic(&escaped, &prepared.bytes)?;
+            assert!(load_scheduler_manifest(&escaped).is_err());
+        }
 
+        let fixture = scheduler_manifest_fixture()?;
         let launch = fixture.store.join("scheduler-launch");
         let reparse_target = fixture._root.path().join("reparse-target");
         std::fs::create_dir(&reparse_target)?;

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -2631,6 +2631,11 @@ mod tests {
         }
     }
 
+    fn codex_bin_env() -> Option<std::ffi::OsString> {
+        let _lock = test_lock(&CODEX_BIN_ENV_LOCK);
+        std::env::var_os("EDDA_CODEX_BIN")
+    }
+
     #[cfg(not(windows))]
     fn scheduler_config(codex_bin: &str) -> ReconcileConfig {
         ReconcileConfig {
@@ -3310,14 +3315,14 @@ mod tests {
 
     #[test]
     fn scheduler_codex_environment_guard_restores_after_unwind() {
-        let previous = std::env::var_os("EDDA_CODEX_BIN");
+        let previous = codex_bin_env();
         let result = std::panic::catch_unwind(|| {
             let _environment = codex_bin_env_guard(r"C:\environment\codex.exe");
             panic!("test unwind");
         });
 
         assert!(result.is_err());
-        assert_eq!(std::env::var_os("EDDA_CODEX_BIN"), previous);
+        assert_eq!(codex_bin_env(), previous);
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -123,10 +123,7 @@ struct SchedulerLaunchManifestV1 {
 }
 
 struct PreparedSchedulerManifest {
-    // Task 3 consumes these fields when it publishes immutable manifests.
-    #[allow(dead_code)]
     manifest: SchedulerLaunchManifestV1,
-    #[allow(dead_code)]
     bytes: Vec<u8>,
     #[allow(dead_code)]
     digest: String,
@@ -134,8 +131,6 @@ struct PreparedSchedulerManifest {
 }
 
 struct LoadedSchedulerManifest {
-    // Task 3 consumes the payload when verifying existing artifacts.
-    #[allow(dead_code)]
     manifest: SchedulerLaunchManifestV1,
     repo: PathBuf,
     config: ReconcileConfig,
@@ -240,6 +235,44 @@ fn prepare_scheduler_manifest(
         digest,
         path,
     })
+}
+
+fn publish_scheduler_manifest(prepared: &PreparedSchedulerManifest) -> anyhow::Result<bool> {
+    let directory = prepared
+        .path
+        .parent()
+        .context("scheduler manifest path has no version directory")?;
+    let launch_directory = directory
+        .parent()
+        .context("scheduler manifest path has no launch directory")?;
+    let store = launch_directory
+        .parent()
+        .context("scheduler manifest path has no store root")?;
+    let _lock = edda_store::lock_file(&launch_directory.join("manifest.lock"))?;
+    std::fs::create_dir_all(directory).with_context(|| {
+        format!(
+            "create scheduler manifest directory {}",
+            directory.display()
+        )
+    })?;
+    anyhow::ensure!(
+        scheduler_manifest_directory(store, true)? == directory,
+        "scheduler manifest directory changed during publication"
+    );
+
+    if prepared.path.exists() {
+        let loaded = load_scheduler_manifest(&prepared.path)?;
+        anyhow::ensure!(
+            loaded.manifest == prepared.manifest
+                && std::fs::read(&prepared.path)? == prepared.bytes,
+            "existing scheduler manifest does not contain the expected bytes"
+        );
+        return Ok(false);
+    }
+
+    edda_store::write_atomic(&prepared.path, &prepared.bytes)
+        .with_context(|| format!("publish scheduler manifest {}", prepared.path.display()))?;
+    Ok(true)
 }
 
 fn load_scheduler_manifest(path: &Path) -> anyhow::Result<LoadedSchedulerManifest> {
@@ -389,7 +422,7 @@ pub fn run(repo_root: &Path, args: ReconcileArgs) -> anyhow::Result<()> {
 
 #[cfg(any(windows, test))]
 const MISSING_TASK_HRESULT: u32 = 0x8007_0002;
-#[cfg(windows)]
+#[cfg(any(windows, test))]
 const SCHEDULER_OUTPUT_LIMIT: usize = 4096;
 
 #[cfg(any(windows, test))]
@@ -397,6 +430,13 @@ const SCHEDULER_OUTPUT_LIMIT: usize = 4096;
 enum SchedulerTaskState {
     Present,
     Missing,
+}
+
+#[cfg(any(windows, test))]
+#[derive(Debug, Eq, PartialEq)]
+enum ManifestCleanupDecision {
+    RemoveNewArtifact,
+    Retain,
 }
 
 #[cfg(any(windows, test))]
@@ -625,6 +665,161 @@ fn windows_scheduler_spec(
 }
 
 #[cfg(any(windows, test))]
+fn scheduler_query_references_manifest(
+    xml: &str,
+    executable: &Path,
+    manifest: &Path,
+) -> anyhow::Result<bool> {
+    anyhow::ensure!(
+        xml.len() <= SCHEDULER_OUTPUT_LIMIT,
+        "scheduler Query XML exceeds the bounded output limit"
+    );
+    let escape = |value: &str| {
+        value
+            .replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
+            .replace('"', "&quot;")
+            .replace('\'', "&apos;")
+    };
+    let command = format!(
+        "<Command>{}</Command>",
+        escape(
+            executable
+                .to_str()
+                .context("scheduler executable is not Unicode")?
+        )
+    );
+    let arguments = format!(
+        "<Arguments>{}</Arguments>",
+        escape(&format!(
+            "reconcile --scheduler-manifest {}",
+            quote_windows_argument(manifest)?
+        ))
+    );
+
+    let mut remaining = xml;
+    while let Some(start) = remaining.find("<Exec>") {
+        remaining = &remaining[start + "<Exec>".len()..];
+        let Some(end) = remaining.find("</Exec>") else {
+            anyhow::bail!("scheduler Query XML contains an unterminated Exec action");
+        };
+        let action = &remaining[..end];
+        if action.contains(&command) && action.contains(&arguments) {
+            return Ok(true);
+        }
+        remaining = &remaining[end + "</Exec>".len()..];
+    }
+    Ok(false)
+}
+
+#[cfg(any(windows, test))]
+fn manifest_cleanup_decision(
+    query: &SchedulerOutput,
+    executable: &Path,
+    expected_manifest: &Path,
+) -> anyhow::Result<ManifestCleanupDecision> {
+    match classify_scheduler_query(query)? {
+        SchedulerTaskState::Missing => return Ok(ManifestCleanupDecision::RemoveNewArtifact),
+        SchedulerTaskState::Present => {}
+    }
+    if scheduler_query_references_manifest(&query.stdout, executable, expected_manifest)? {
+        return Ok(ManifestCleanupDecision::Retain);
+    }
+
+    let escaped_executable = executable
+        .to_str()
+        .context("scheduler executable is not Unicode")?
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;");
+    let command = format!("<Command>{escaped_executable}</Command>");
+    let arguments_prefix = "<Arguments>reconcile --scheduler-manifest &quot;";
+    let arguments_suffix = "&quot;</Arguments>";
+    let mut remaining = query.stdout.as_str();
+    while let Some(start) = remaining.find("<Exec>") {
+        remaining = &remaining[start + "<Exec>".len()..];
+        let Some(end) = remaining.find("</Exec>") else {
+            break;
+        };
+        let action = &remaining[..end];
+        if action.contains(&command) {
+            if let Some(arguments_start) = action.find(arguments_prefix) {
+                let value = &action[arguments_start + arguments_prefix.len()..];
+                if let Some(arguments_end) = value.find(arguments_suffix) {
+                    let encoded_path = &value[..arguments_end];
+                    let trailing = &value[arguments_end + arguments_suffix.len()..];
+                    if !encoded_path.is_empty()
+                        && !encoded_path.contains(['<', '>'])
+                        && !encoded_path.contains("&quot;")
+                        && trailing.trim().is_empty()
+                    {
+                        let decoded_path = encoded_path
+                            .replace("&apos;", "'")
+                            .replace("&gt;", ">")
+                            .replace("&lt;", "<")
+                            .replace("&amp;", "&");
+                        let canonical_encoding = decoded_path
+                            .replace('&', "&amp;")
+                            .replace('<', "&lt;")
+                            .replace('>', "&gt;")
+                            .replace('"', "&quot;")
+                            .replace('\'', "&apos;");
+                        let candidate = Path::new(&decoded_path);
+                        let filename = candidate.file_name().and_then(|name| name.to_str());
+                        let trusted_filename = filename.is_some_and(|name| {
+                            name.len() == 69
+                                && name.ends_with(".json")
+                                && name[..64].bytes().all(|byte| {
+                                    byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)
+                                })
+                        });
+                        if canonical_encoding == encoded_path
+                            && windows_path_is_absolute(candidate)?
+                            && candidate.parent() == expected_manifest.parent()
+                            && candidate != expected_manifest
+                            && trusted_filename
+                        {
+                            return Ok(ManifestCleanupDecision::RemoveNewArtifact);
+                        }
+                    }
+                }
+            }
+        }
+        remaining = &remaining[end + "</Exec>".len()..];
+    }
+    anyhow::bail!(
+        "scheduler Query did not prove whether the exact task references the new manifest: {}",
+        query.description()
+    )
+}
+
+#[cfg(any(windows, test))]
+fn remove_unreferenced_scheduler_manifest(path: &Path) -> String {
+    let removal = (|| -> anyhow::Result<()> {
+        let launch_directory = path
+            .parent()
+            .and_then(Path::parent)
+            .context("scheduler manifest path has no launch directory")?;
+        let _lock = edda_store::lock_file(&launch_directory.join("manifest.lock"))?;
+        std::fs::remove_file(path)
+            .with_context(|| format!("remove unreferenced scheduler manifest {}", path.display()))
+    })();
+    match removal {
+        Ok(()) => format!(
+            "new scheduler manifest removed after exact-task Query proved it unreferenced: {}",
+            path.display()
+        ),
+        Err(error) => format!(
+            "new scheduler manifest retained because exact-file cleanup failed for {}: {error:#}",
+            path.display()
+        ),
+    }
+}
+
+#[cfg(any(windows, test))]
 fn classify_scheduler_query(output: &SchedulerOutput) -> anyhow::Result<SchedulerTaskState> {
     match output.code {
         0 => Ok(SchedulerTaskState::Present),
@@ -690,22 +885,68 @@ fn scheduler_lifecycle(
             config.codex_bin = canonical_direct_codex_executable(&config.codex_bin, None)?;
             let manifest = prepare_scheduler_manifest(&edda_store::store_root(), &repo, &config)?;
             let spec = windows_scheduler_spec(&executable, &manifest.path, &project_id)?;
-            let created = run_schtasks(&spec.create_args)
-                .with_context(|| format!("scheduler Create failed for task {}", spec.task_name))?;
-            anyhow::ensure!(
-                created.code == 0,
-                "scheduler Create failed for {}: {}",
-                spec.task_name,
-                created.description()
-            );
-            let queried = run_schtasks(&spec.query_args)
-                .with_context(|| format!("scheduler Query failed for task {}", spec.task_name))?;
-            require_scheduler_state(
-                &queried,
-                SchedulerTaskState::Present,
-                "post-Create Query",
-                &spec.task_name,
-            )?;
+            let artifact_created = publish_scheduler_manifest(&manifest)?;
+            let install = (|| -> anyhow::Result<()> {
+                let created = run_schtasks(&spec.create_args).with_context(|| {
+                    format!("scheduler Create failed for task {}", spec.task_name)
+                })?;
+                anyhow::ensure!(
+                    created.code == 0,
+                    "scheduler Create failed for {}: {}",
+                    spec.task_name,
+                    created.description()
+                );
+                let queried = run_schtasks(&spec.query_args).with_context(|| {
+                    format!(
+                        "scheduler post-Create Query failed for task {}",
+                        spec.task_name
+                    )
+                })?;
+                require_scheduler_state(
+                    &queried,
+                    SchedulerTaskState::Present,
+                    "post-Create Query",
+                    &spec.task_name,
+                )?;
+                anyhow::ensure!(
+                    scheduler_query_references_manifest(
+                        &queried.stdout,
+                        &executable,
+                        &manifest.path,
+                    )?,
+                    "scheduler post-Create Query returned a different command for task {}: {}",
+                    spec.task_name,
+                    queried.description()
+                );
+                Ok(())
+            })();
+            if let Err(install_error) = install {
+                let cleanup = match run_schtasks(&spec.query_args) {
+                    Ok(query) if !artifact_created => format!(
+                        "existing scheduler manifest retained after exact-task cleanup Query: {}",
+                        query.description()
+                    ),
+                    Ok(query) => {
+                        match manifest_cleanup_decision(&query, &executable, &manifest.path) {
+                            Ok(ManifestCleanupDecision::RemoveNewArtifact) => {
+                                remove_unreferenced_scheduler_manifest(&manifest.path)
+                            }
+                            Ok(ManifestCleanupDecision::Retain) => format!(
+                                "new scheduler manifest retained because the exact task references it: {}",
+                                query.description()
+                            ),
+                            Err(error) => format!(
+                                "new scheduler manifest retained because cleanup was uncertain: {error:#}"
+                            ),
+                        }
+                    }
+                    Err(error) => format!(
+                        "{} scheduler manifest retained because cleanup Query failed for task {}: {error:#}",
+                        if artifact_created { "new" } else { "existing" }, spec.task_name
+                    ),
+                };
+                anyhow::bail!("{install_error:#}; {cleanup}");
+            }
             println!(
                 "installed scheduler task {} for {}",
                 spec.task_name,
@@ -1770,6 +2011,174 @@ mod tests {
         assert_ne!(first.bytes, second.bytes);
         assert_ne!(first.digest, second.digest);
         assert_ne!(first.path, second.path);
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_manifest_publish_reuses_identical_bytes_without_replacing() -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        let prepared = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+
+        assert!(publish_scheduler_manifest(&prepared)?);
+        assert!(!publish_scheduler_manifest(&prepared)?);
+        assert_eq!(std::fs::read(&prepared.path)?, prepared.bytes);
+
+        std::fs::write(&prepared.path, b"different")?;
+        assert!(publish_scheduler_manifest(&prepared).is_err());
+        assert_eq!(std::fs::read(&prepared.path)?, b"different");
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_manifest_changed_install_retains_prior_artifact() -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        let old = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+        assert!(publish_scheduler_manifest(&old)?);
+
+        let mut changed = fixture.config.clone();
+        changed.max_attempts += 1;
+        let new = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &changed)?;
+        assert_ne!(old.path, new.path);
+        assert!(publish_scheduler_manifest(&new)?);
+        assert_eq!(std::fs::read(&old.path)?, old.bytes);
+        assert_eq!(std::fs::read(&new.path)?, new.bytes);
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_manifest_write_failure_precedes_scheduler_cleanup() -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        let prepared = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+        std::fs::create_dir_all(fixture.store.join("scheduler-launch"))?;
+        std::fs::write(
+            fixture.store.join("scheduler-launch").join("v1"),
+            b"blocked",
+        )?;
+
+        assert!(publish_scheduler_manifest(&prepared).is_err());
+        assert!(!prepared.path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_query_xml_requires_exact_escaped_command_and_arguments() -> anyhow::Result<()> {
+        let executable = Path::new(r"C:\Program Files\Edda & Co\edda.exe");
+        let manifest = Path::new(r"C:\Store & State\scheduler-launch\v1\expected.json");
+        let xml = r#"<Task><Actions><Exec><Command>C:\Program Files\Edda &amp; Co\edda.exe</Command><Arguments>reconcile --scheduler-manifest &quot;C:\Store &amp; State\scheduler-launch\v1\expected.json&quot;</Arguments></Exec></Actions></Task>"#;
+        assert!(scheduler_query_references_manifest(
+            xml, executable, manifest
+        )?);
+
+        let wrong_arguments = xml.replace("expected.json&quot;", "expected.json&quot; --extra");
+        assert!(!scheduler_query_references_manifest(
+            &wrong_arguments,
+            executable,
+            manifest
+        )?);
+        let wrong_command = xml.replace("edda.exe</Command>", "other.exe</Command>");
+        assert!(!scheduler_query_references_manifest(
+            &wrong_command,
+            executable,
+            manifest
+        )?);
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_manifest_cleanup_requires_proved_non_reference() -> anyhow::Result<()> {
+        let executable = Path::new(r"C:\edda\edda.exe");
+        let expected = Path::new(
+            r"C:\store\scheduler-launch\v1\aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json",
+        );
+        let missing = SchedulerOutput::for_test(MISSING_TASK_HRESULT, "", "missing");
+        assert_eq!(
+            manifest_cleanup_decision(&missing, executable, expected)?,
+            ManifestCleanupDecision::RemoveNewArtifact
+        );
+
+        let expected_xml = r#"<Task><Actions><Exec><Command>C:\edda\edda.exe</Command><Arguments>reconcile --scheduler-manifest &quot;C:\store\scheduler-launch\v1\aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json&quot;</Arguments></Exec></Actions></Task>"#;
+        assert_eq!(
+            manifest_cleanup_decision(
+                &SchedulerOutput::for_test(0, expected_xml, ""),
+                executable,
+                expected,
+            )?,
+            ManifestCleanupDecision::Retain
+        );
+
+        let previous_xml = expected_xml.replace(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json",
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.json",
+        );
+        assert_eq!(
+            manifest_cleanup_decision(
+                &SchedulerOutput::for_test(0, &previous_xml, ""),
+                executable,
+                expected,
+            )?,
+            ManifestCleanupDecision::RemoveNewArtifact
+        );
+
+        let aliased_expected_xml = expected_xml.replace(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json",
+            "&#97;aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json",
+        );
+        let non_content_addressed_xml = expected_xml.replace(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json",
+            "previous.json",
+        );
+        let different_directory_xml = previous_xml.replace(
+            r"C:\store\scheduler-launch\v1",
+            r"C:\other\scheduler-launch\v1",
+        );
+        for uncertain in [
+            SchedulerOutput::for_test(5, "", "access denied"),
+            SchedulerOutput::for_test(0, "<Task />", ""),
+            SchedulerOutput::for_test(0, &aliased_expected_xml, ""),
+            SchedulerOutput::for_test(0, &non_content_addressed_xml, ""),
+            SchedulerOutput::for_test(0, &different_directory_xml, ""),
+            SchedulerOutput::for_test(
+                0,
+                r#"<Task><Actions><Exec><Command>C:\other.exe</Command><Arguments>reconcile --scheduler-manifest &quot;C:\store\scheduler-launch\v1\bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.json&quot;</Arguments></Exec></Actions></Task>"#,
+                "",
+            ),
+        ] {
+            assert!(manifest_cleanup_decision(&uncertain, executable, expected).is_err());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_manifest_cleanup_failure_retains_original_error_first() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let manifest = root
+            .path()
+            .join("scheduler-launch")
+            .join("v1")
+            .join(format!("{}.json", "a".repeat(64)));
+        std::fs::create_dir_all(&manifest)?;
+
+        let cleanup = remove_unreferenced_scheduler_manifest(&manifest);
+        let combined = format!("scheduler Create failed; {cleanup}");
+        assert!(manifest.is_dir());
+        assert!(cleanup.contains("retained"));
+        assert!(combined.starts_with("scheduler Create failed;"));
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_preflight_failure_creates_no_manifest_directory() -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        let _prepared = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+        let rejected_path = manifest_path_for_task_run_utf16_len(262);
+
+        assert!(render_scheduler_task_run(
+            Path::new(r"C:\e.exe"),
+            &rejected_path,
+            "Edda-Reconcile-0123456789abcdef0123456789abcdef",
+        )
+        .is_err());
+        assert!(!fixture.store.join("scheduler-launch").exists());
         Ok(())
     }
 

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -1229,6 +1229,10 @@ fn scheduler_direct_exec_values(xml: &str) -> anyhow::Result<Vec<(String, String
             capture.is_none(),
             "scheduler Exec value contains nested markup"
         );
+        anyhow::ensure!(
+            stack.as_slice() != ["Task", "Actions"] || name == "Exec",
+            "scheduler Actions contains a non-Exec direct child"
+        );
         if stack.is_empty() {
             anyhow::ensure!(
                 !seen_root && name == "Task" && !self_closing,
@@ -2953,6 +2957,30 @@ mod tests {
             manifest,
         )
         .is_err());
+
+        let com_handler = quoted.replace(
+            "</Actions>",
+            "<ComHandler><ClassId>00000000-0000-0000-0000-000000000000</ClassId><Data>ignored</Data></ComHandler></Actions>",
+        );
+        assert!(scheduler_query_references_manifest(&com_handler, executable, manifest).is_err());
+        assert!(recover_scheduler_manifest_candidate(&com_handler, executable).is_err());
+        assert!(manifest_cleanup_decision(
+            &SchedulerOutput::for_test(0, &com_handler, ""),
+            executable,
+            manifest,
+        )
+        .is_err());
+
+        let harmless_comment = quoted.replace("<Exec>", "<!-- harmless --><Exec>");
+        assert!(scheduler_query_references_manifest(
+            &harmless_comment,
+            executable,
+            manifest,
+        )?);
+        assert_eq!(
+            recover_scheduler_manifest_candidate(&harmless_comment, executable)?,
+            Some(manifest.to_path_buf())
+        );
 
         let commented_match = quoted.replace("<Exec>", "<!-- <Exec>").replace(
             "</Exec>",

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -1040,6 +1040,127 @@ fn remove_unreferenced_scheduler_manifest(path: &Path) -> String {
 }
 
 #[cfg(any(windows, test))]
+fn recover_scheduler_manifest_candidate(
+    xml: &str,
+    executable: &Path,
+) -> anyhow::Result<Option<PathBuf>> {
+    let actions = scheduler_exec_values(xml)?;
+    let [(command, arguments)] = actions.as_slice() else {
+        return Ok(None);
+    };
+    if command
+        != executable
+            .to_str()
+            .context("scheduler executable is not Unicode")?
+    {
+        return Ok(None);
+    }
+    let Some(value) = arguments
+        .strip_prefix("reconcile --scheduler-manifest \"")
+        .and_then(|value| value.strip_suffix('"'))
+    else {
+        return Ok(None);
+    };
+    let candidate = PathBuf::from(value);
+    if !candidate.is_absolute()
+        || format!(
+            "reconcile --scheduler-manifest {}",
+            quote_windows_argument(&candidate)?
+        ) != *arguments
+    {
+        return Ok(None);
+    }
+    Ok(Some(candidate))
+}
+
+#[cfg(any(windows, test))]
+fn remove_trusted_scheduler_manifest(path: &Path, repo: &Path, project_id: &str) -> String {
+    let removal = (|| -> anyhow::Result<()> {
+        let store = edda_store::store_root();
+        let directory = scheduler_manifest_directory(&store, true)?;
+        let launch_directory = directory
+            .parent()
+            .context("scheduler manifest path has no launch directory")?;
+        let _lock = edda_store::lock_file(&launch_directory.join("manifest.lock"))?;
+        anyhow::ensure!(
+            scheduler_manifest_directory(&store, true)? == directory,
+            "scheduler manifest directory changed during uninstall"
+        );
+        let loaded = load_scheduler_manifest(path)?;
+        anyhow::ensure!(
+            loaded.repo == repo && loaded.manifest.project_id == project_id,
+            "scheduler manifest does not belong to the exact task project"
+        );
+        std::fs::remove_file(path)
+            .with_context(|| format!("remove trusted scheduler manifest {}", path.display()))
+    })();
+    match removal {
+        Ok(()) => format!(
+            "removed trusted scheduler manifest after exact-task absence proof: {}",
+            path.display()
+        ),
+        Err(error) => format!(
+            "scheduler manifest retained because exact-file validation or removal failed for {}: {error:#}",
+            path.display()
+        ),
+    }
+}
+
+#[cfg(any(windows, test))]
+fn uninstall_scheduler_task_with(
+    repo: &Path,
+    executable: &Path,
+    project_id: &str,
+    mut run: impl FnMut(&[String]) -> anyhow::Result<SchedulerOutput>,
+) -> anyhow::Result<String> {
+    let (task_name, query_args, delete_args) = windows_scheduler_management_args(project_id)?;
+    let before =
+        run(&query_args).with_context(|| format!("scheduler Query failed for task {task_name}"))?;
+    if classify_scheduler_query(&before)
+        .with_context(|| format!("scheduler Query failed for task {task_name}"))?
+        == SchedulerTaskState::Missing
+    {
+        return Ok(format!(
+            "scheduler task {} already absent for {}",
+            task_name,
+            repo.display()
+        ));
+    }
+    let candidate = before
+        .xml()
+        .and_then(|xml| recover_scheduler_manifest_candidate(xml.as_ref(), executable));
+    let deleted = run(&delete_args)
+        .with_context(|| format!("scheduler Delete failed for task {task_name}"))?;
+    anyhow::ensure!(
+        deleted.code == 0 || deleted.code == MISSING_TASK_HRESULT,
+        "scheduler Delete failed for {}: {}",
+        task_name,
+        deleted.description()
+    );
+    let after =
+        run(&query_args).with_context(|| format!("scheduler Query failed for task {task_name}"))?;
+    require_scheduler_state(
+        &after,
+        SchedulerTaskState::Missing,
+        "post-Delete Query",
+        &task_name,
+    )?;
+    let cleanup = match candidate {
+        Ok(Some(path)) => remove_trusted_scheduler_manifest(&path, repo, project_id),
+        Ok(None) => "scheduler manifest retained because the exact task did not prove one strict direct manifest command".into(),
+        Err(error) => format!(
+            "scheduler manifest retained because the pre-Delete Query was not trustworthy: {error:#}"
+        ),
+    };
+    Ok(format!(
+        "uninstalled scheduler task {} for {}; {}",
+        task_name,
+        repo.display(),
+        cleanup
+    ))
+}
+
+#[cfg(any(windows, test))]
 fn classify_scheduler_query(output: &SchedulerOutput) -> anyhow::Result<SchedulerTaskState> {
     match output.code {
         0 => Ok(SchedulerTaskState::Present),
@@ -1101,7 +1222,6 @@ fn scheduler_lifecycle(
     {
         let repo = canonical_main_repo(repo)?;
         let project_id = edda_store::project_id_for_root(&repo);
-        let (task_name, query_args, delete_args) = windows_scheduler_management_args(&project_id)?;
         if let Some(config) = install_config {
             let executable = std::env::current_exe()?.canonicalize()?;
             let mut config = config.clone();
@@ -1178,39 +1298,10 @@ fn scheduler_lifecycle(
             return Ok(());
         }
 
-        let before = run_schtasks(&query_args)
-            .with_context(|| format!("scheduler Query failed for task {task_name}"))?;
-        if classify_scheduler_query(&before)
-            .with_context(|| format!("scheduler Query failed for task {task_name}"))?
-            == SchedulerTaskState::Missing
-        {
-            println!(
-                "scheduler task {} already absent for {}",
-                task_name,
-                repo.display()
-            );
-            return Ok(());
-        }
-        let deleted = run_schtasks(&delete_args)
-            .with_context(|| format!("scheduler Delete failed for task {task_name}"))?;
-        anyhow::ensure!(
-            deleted.code == 0 || deleted.code == MISSING_TASK_HRESULT,
-            "scheduler Delete failed for {}: {}",
-            task_name,
-            deleted.description()
-        );
-        let after = run_schtasks(&query_args)
-            .with_context(|| format!("scheduler Query failed for task {task_name}"))?;
-        require_scheduler_state(
-            &after,
-            SchedulerTaskState::Missing,
-            "post-Delete Query",
-            &task_name,
-        )?;
+        let executable = std::env::current_exe()?.canonicalize()?;
         println!(
-            "uninstalled scheduler task {} for {}",
-            task_name,
-            repo.display()
+            "{}",
+            uninstall_scheduler_task_with(&repo, &executable, &project_id, run_schtasks)?
         );
         Ok(())
     }
@@ -3002,6 +3093,205 @@ mod tests {
                 "/HRESULT",
             ]
         );
+        Ok(())
+    }
+
+    fn scheduler_manifest_xml(executable: &Path, manifest: &Path) -> anyhow::Result<String> {
+        let escape = |value: &str| {
+            value
+                .replace('&', "&amp;")
+                .replace('<', "&lt;")
+                .replace('>', "&gt;")
+                .replace('"', "&quot;")
+                .replace('\'', "&apos;")
+        };
+        Ok(format!(
+            "<Task><Actions><Exec><Command>{}</Command><Arguments>{}</Arguments></Exec></Actions></Task>",
+            escape(executable.to_str().context("test executable path")?),
+            escape(&format!(
+                "reconcile --scheduler-manifest {}",
+                quote_windows_argument(manifest)?
+            )),
+        ))
+    }
+
+    #[test]
+    fn scheduler_uninstall_removes_only_a_trusted_exact_manifest_after_absence(
+    ) -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        let prepared = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+        edda_store::write_atomic(&prepared.path, &prepared.bytes)?;
+        let project_id = edda_store::project_id_for_root(&fixture.repo);
+        let (_, query_args, delete_args) = windows_scheduler_management_args(&project_id)?;
+        let xml = scheduler_manifest_xml(&fixture.codex, &prepared.path)?;
+        let outputs = [
+            SchedulerOutput::for_test(0, &xml, ""),
+            SchedulerOutput::for_test(0, "", ""),
+            SchedulerOutput::for_test(MISSING_TASK_HRESULT, "", "missing"),
+        ];
+        let mut calls = Vec::new();
+        let mut outputs = outputs.into_iter();
+
+        uninstall_scheduler_task_with(&fixture.repo, &fixture.codex, &project_id, |args| {
+            assert!(
+                prepared.path.exists(),
+                "artifact removed before absence proof"
+            );
+            calls.push(args.to_vec());
+            outputs.next().context("unexpected scheduler call")
+        })?;
+
+        assert_eq!(calls, [query_args.clone(), delete_args, query_args]);
+        assert!(!prepared.path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_uninstall_malformed_query_retains_artifacts_but_removes_task() -> anyhow::Result<()>
+    {
+        let fixture = scheduler_manifest_fixture()?;
+        let prepared = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+        edda_store::write_atomic(&prepared.path, &prepared.bytes)?;
+        let project_id = edda_store::project_id_for_root(&fixture.repo);
+        let mut outputs = [
+            SchedulerOutput::for_test(0, "<Task><Exec", ""),
+            SchedulerOutput::for_test(0, "", ""),
+            SchedulerOutput::for_test(MISSING_TASK_HRESULT, "", "missing"),
+        ]
+        .into_iter();
+        let mut calls = 0;
+
+        uninstall_scheduler_task_with(&fixture.repo, &fixture.codex, &project_id, |_| {
+            calls += 1;
+            outputs.next().context("unexpected scheduler call")
+        })?;
+
+        assert_eq!(calls, 3);
+        assert!(prepared.path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_uninstall_untrusted_manifest_does_not_block_task_removal() -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        let prepared = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+        edda_store::write_atomic(&prepared.path, &prepared.bytes)?;
+        let mut wrong_project = prepared.manifest.clone();
+        wrong_project.project_id = "0".repeat(32);
+        let untrusted = write_scheduler_manifest_candidate(
+            &fixture.store,
+            &serde_json::to_vec(&wrong_project)?,
+        )?;
+        let xml = scheduler_manifest_xml(&fixture.codex, &untrusted)?;
+        let project_id = edda_store::project_id_for_root(&fixture.repo);
+        let mut outputs = [
+            SchedulerOutput::for_test(0, &xml, ""),
+            SchedulerOutput::for_test(0, "", ""),
+            SchedulerOutput::for_test(MISSING_TASK_HRESULT, "", "missing"),
+        ]
+        .into_iter();
+        let mut calls = 0;
+
+        uninstall_scheduler_task_with(&fixture.repo, &fixture.codex, &project_id, |_| {
+            calls += 1;
+            outputs.next().context("unexpected scheduler call")
+        })?;
+
+        assert_eq!(calls, 3);
+        assert!(untrusted.exists());
+        assert!(prepared.path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_uninstall_never_sweeps_unproven_artifacts() -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        let prepared = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+        edda_store::write_atomic(&prepared.path, &prepared.bytes)?;
+        let project_id = edda_store::project_id_for_root(&fixture.repo);
+        let (_, query_args, _) = windows_scheduler_management_args(&project_id)?;
+        let mut calls = Vec::new();
+
+        uninstall_scheduler_task_with(&fixture.repo, &fixture.codex, &project_id, |args| {
+            calls.push(args.to_vec());
+            Ok(SchedulerOutput::for_test(
+                MISSING_TASK_HRESULT,
+                "",
+                "missing",
+            ))
+        })?;
+
+        assert_eq!(calls, [query_args]);
+        assert!(prepared.path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_uninstall_missing_codex_retains_manifest_without_blocking_task_removal(
+    ) -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        let prepared = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+        edda_store::write_atomic(&prepared.path, &prepared.bytes)?;
+        let xml = scheduler_manifest_xml(&fixture.codex, &prepared.path)?;
+        std::fs::remove_file(&fixture.codex)?;
+        let project_id = edda_store::project_id_for_root(&fixture.repo);
+        let mut outputs = [
+            SchedulerOutput::for_test(0, &xml, ""),
+            SchedulerOutput::for_test(0, "", ""),
+            SchedulerOutput::for_test(MISSING_TASK_HRESULT, "", "missing"),
+        ]
+        .into_iter();
+
+        uninstall_scheduler_task_with(&fixture.repo, &fixture.codex, &project_id, |_| {
+            outputs.next().context("unexpected scheduler call")
+        })?;
+
+        assert!(prepared.path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_uninstall_delete_race_accepts_only_missing_hresult() -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        let project_id = edda_store::project_id_for_root(&fixture.repo);
+        let xml = "<Task><Actions /></Task>";
+        for (delete_code, succeeds) in [(MISSING_TASK_HRESULT, true), (0x8007_0005, false)] {
+            let mut outputs = [
+                SchedulerOutput::for_test(0, xml, ""),
+                SchedulerOutput::for_test(delete_code, "", "delete detail"),
+                SchedulerOutput::for_test(MISSING_TASK_HRESULT, "", "missing"),
+            ]
+            .into_iter();
+            let result =
+                uninstall_scheduler_task_with(&fixture.repo, &fixture.codex, &project_id, |_| {
+                    outputs.next().context("unexpected scheduler call")
+                });
+            assert_eq!(result.is_ok(), succeeds, "delete code 0x{delete_code:08x}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_uninstall_post_delete_uncertainty_retains_manifest() -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        let prepared = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+        edda_store::write_atomic(&prepared.path, &prepared.bytes)?;
+        let project_id = edda_store::project_id_for_root(&fixture.repo);
+        let xml = scheduler_manifest_xml(&fixture.codex, &prepared.path)?;
+        let mut outputs = [
+            SchedulerOutput::for_test(0, &xml, ""),
+            SchedulerOutput::for_test(0, "", ""),
+            SchedulerOutput::for_test(0, &xml, "still present"),
+        ]
+        .into_iter();
+
+        assert!(
+            uninstall_scheduler_task_with(&fixture.repo, &fixture.codex, &project_id, |_| outputs
+                .next()
+                .context("unexpected scheduler call"),)
+            .is_err()
+        );
+        assert!(prepared.path.exists());
         Ok(())
     }
 

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -916,63 +916,11 @@ fn decode_scheduler_xml_value(value: &str) -> anyhow::Result<String> {
 }
 
 #[cfg(any(windows, test))]
-fn contains_scheduler_exec_candidate(xml: &str) -> bool {
-    xml.match_indices("<Exec").any(|(start, _)| {
-        matches!(
-            xml.as_bytes().get(start + "<Exec".len()),
-            None | Some(b'>' | b'/') | Some(b' ' | b'\t' | b'\r' | b'\n')
-        )
-    })
-}
-
-#[cfg(any(windows, test))]
-fn scheduler_exec_values(xml: &str) -> anyhow::Result<Vec<(String, String)>> {
-    anyhow::ensure!(
-        xml.len() <= SCHEDULER_OUTPUT_LIMIT,
-        "scheduler Query XML exceeds the bounded output limit"
-    );
-    let element = |action: &str, name: &str| -> anyhow::Result<String> {
-        let open = format!("<{name}>");
-        let close = format!("</{name}>");
-        let start = action
-            .find(&open)
-            .with_context(|| format!("scheduler Exec action has no {name}"))?;
-        let value = &action[start + open.len()..];
-        let end = value
-            .find(&close)
-            .with_context(|| format!("scheduler Exec action has unterminated {name}"))?;
-        anyhow::ensure!(
-            !value[end + close.len()..].contains(&open) && !action[..start].contains(&close),
-            "scheduler Exec action has duplicate {name}"
-        );
-        decode_scheduler_xml_value(&value[..end])
-    };
-
-    let mut actions = Vec::new();
-    let mut remaining = xml;
-    while let Some(start) = remaining.find("<Exec>") {
-        anyhow::ensure!(
-            !contains_scheduler_exec_candidate(&remaining[..start])
-                && !remaining[..start].contains("</Exec>"),
-            "scheduler Query XML contains a malformed Exec action"
-        );
-        remaining = &remaining[start + "<Exec>".len()..];
-        let end = remaining
-            .find("</Exec>")
-            .context("scheduler Query XML contains an unterminated Exec action")?;
-        let action = &remaining[..end];
-        anyhow::ensure!(
-            !contains_scheduler_exec_candidate(action),
-            "scheduler Query XML contains a nested Exec action"
-        );
-        actions.push((element(action, "Command")?, element(action, "Arguments")?));
-        remaining = &remaining[end + "</Exec>".len()..];
-    }
-    anyhow::ensure!(
-        !contains_scheduler_exec_candidate(remaining) && !remaining.contains("</Exec>"),
-        "scheduler Query XML contains a malformed Exec action"
-    );
-    Ok(actions)
+fn scheduler_command_matches_executable(command: &str, executable: &Path) -> anyhow::Result<bool> {
+    let expected = executable
+        .to_str()
+        .context("scheduler executable is not Unicode")?;
+    Ok(command == expected || command == quote_windows_argument(executable)?)
 }
 
 #[cfg(any(windows, test))]
@@ -981,18 +929,18 @@ fn scheduler_query_references_manifest(
     executable: &Path,
     manifest: &Path,
 ) -> anyhow::Result<bool> {
-    let command = executable
-        .to_str()
-        .context("scheduler executable is not Unicode")?;
     let arguments = format!(
         "reconcile --scheduler-manifest {}",
         quote_windows_argument(manifest)?
     );
-    Ok(scheduler_exec_values(xml)?
-        .iter()
-        .any(|(actual_command, actual_arguments)| {
-            actual_command == command && actual_arguments == &arguments
-        }))
+    let actions = scheduler_direct_exec_values(xml)?;
+    let [(command, actual_arguments)] = actions.as_slice() else {
+        return Ok(false);
+    };
+    Ok(
+        scheduler_command_matches_executable(command, executable)?
+            && actual_arguments == &arguments,
+    )
 }
 
 #[cfg(any(windows, test))]
@@ -1006,19 +954,17 @@ fn manifest_cleanup_decision(
         SchedulerTaskState::Present => {}
     }
     let xml = query.xml()?;
-    let actions = scheduler_exec_values(xml.as_ref())?;
-    let executable = executable
-        .to_str()
-        .context("scheduler executable is not Unicode")?;
+    let actions = scheduler_direct_exec_values(xml.as_ref())?;
     let expected_arguments = format!(
         "reconcile --scheduler-manifest {}",
         quote_windows_argument(expected_manifest)?
     );
-    if actions
-        .iter()
-        .any(|(command, arguments)| command == executable && arguments == &expected_arguments)
-    {
-        return Ok(ManifestCleanupDecision::Retain);
+    if let [(command, arguments)] = actions.as_slice() {
+        if scheduler_command_matches_executable(command, executable)?
+            && arguments == &expected_arguments
+        {
+            return Ok(ManifestCleanupDecision::Retain);
+        }
     }
     anyhow::ensure!(
         !actions.is_empty(),
@@ -1029,7 +975,7 @@ fn manifest_cleanup_decision(
 
     for (command, arguments) in actions {
         anyhow::ensure!(
-            command == executable,
+            scheduler_command_matches_executable(&command, executable)?,
             "scheduler Query command did not match the direct Edda executable: {}",
             query.description()
         );
@@ -1347,11 +1293,7 @@ fn recover_scheduler_manifest_candidate(
     let [(command, arguments)] = actions.as_slice() else {
         return Ok(None);
     };
-    if command
-        != executable
-            .to_str()
-            .context("scheduler executable is not Unicode")?
-    {
+    if !scheduler_command_matches_executable(command, executable)? {
         return Ok(None);
     }
     let Some(value) = arguments
@@ -2913,6 +2855,114 @@ mod tests {
             executable,
             manifest
         )?);
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_query_accepts_exact_windows_quoted_executable_only() -> anyhow::Result<()> {
+        let executable = Path::new(r"\\?\C:\Program Files\Edda\edda.exe");
+        let manifest = Path::new(r"C:\Store\scheduler-launch\v1\expected.json");
+        let arguments = r#"reconcile --scheduler-manifest &quot;C:\Store\scheduler-launch\v1\expected.json&quot;"#;
+        let xml = |command: &str| {
+            format!(
+                "<Task><Actions><Exec><Command>{command}</Command><Arguments>{arguments}</Arguments></Exec></Actions></Task>"
+            )
+        };
+
+        let quoted = xml(r#"&quot;\\?\C:\Program Files\Edda\edda.exe&quot;"#);
+        assert!(scheduler_query_references_manifest(
+            &quoted, executable, manifest
+        )?);
+        assert_eq!(
+            recover_scheduler_manifest_candidate(&quoted, executable)?,
+            Some(manifest.to_path_buf())
+        );
+        assert_eq!(
+            manifest_cleanup_decision(
+                &SchedulerOutput::for_test(0, &quoted, ""),
+                executable,
+                manifest,
+            )?,
+            ManifestCleanupDecision::Retain
+        );
+
+        let literal_quoted = xml(r#""\\?\C:\Program Files\Edda\edda.exe""#);
+        assert!(scheduler_query_references_manifest(
+            &literal_quoted,
+            executable,
+            manifest,
+        )?);
+
+        for rejected in [
+            r#"&quot;\\?\C:\Program Files\Edda\edda.exe&quot; --extra"#,
+            r#"&quot;\\?\C:\Program Files\Edda\edda.exe"#,
+            r#"&quot;&quot;\\?\C:\Program Files\Edda\edda.exe&quot;&quot;"#,
+            r#" &quot;\\?\C:\Program Files\Edda\edda.exe&quot;"#,
+            r#"&quot;\\?\C:\Program Files\Edda\edda.exe&quot; "#,
+            r#"&quot;C:\other\edda.exe&quot;"#,
+            r#"cmd.exe /c &quot;\\?\C:\Program Files\Edda\edda.exe&quot;"#,
+            r#"&quot;\\?\C:\Program Files\Edda\edda.exe&quot; &quot;C:\other.exe&quot;"#,
+        ] {
+            let rejected = xml(rejected);
+            assert!(!scheduler_query_references_manifest(
+                &rejected, executable, manifest
+            )?);
+            assert_eq!(
+                recover_scheduler_manifest_candidate(&rejected, executable)?,
+                None
+            );
+            assert!(manifest_cleanup_decision(
+                &SchedulerOutput::for_test(0, &rejected, ""),
+                executable,
+                manifest,
+            )
+            .is_err());
+        }
+
+        let entity_trick = xml(r#"&#34;\\?\C:\Program Files\Edda\edda.exe&#34;"#);
+        assert!(scheduler_query_references_manifest(&entity_trick, executable, manifest).is_err());
+        assert!(recover_scheduler_manifest_candidate(&entity_trick, executable).is_err());
+        assert!(manifest_cleanup_decision(
+            &SchedulerOutput::for_test(0, &entity_trick, ""),
+            executable,
+            manifest,
+        )
+        .is_err());
+
+        let extra_exec = quoted.replace(
+            "</Actions>",
+            "<Exec><Command>cmd.exe</Command><Arguments>/c exit</Arguments></Exec></Actions>",
+        );
+        assert!(!scheduler_query_references_manifest(
+            &extra_exec,
+            executable,
+            manifest,
+        )?);
+        assert_eq!(
+            recover_scheduler_manifest_candidate(&extra_exec, executable)?,
+            None
+        );
+        assert!(manifest_cleanup_decision(
+            &SchedulerOutput::for_test(0, &extra_exec, ""),
+            executable,
+            manifest,
+        )
+        .is_err());
+
+        let commented_match = quoted.replace("<Exec>", "<!-- <Exec>").replace(
+            "</Exec>",
+            "</Exec> --><Exec><Command>cmd.exe</Command><Arguments>/c exit</Arguments></Exec>",
+        );
+        assert!(
+            scheduler_query_references_manifest(&commented_match, executable, manifest).is_err()
+        );
+        assert!(recover_scheduler_manifest_candidate(&commented_match, executable).is_err());
+        assert!(manifest_cleanup_decision(
+            &SchedulerOutput::for_test(0, &commented_match, ""),
+            executable,
+            manifest,
+        )
+        .is_err());
         Ok(())
     }
 

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -1361,7 +1361,7 @@ fn recover_scheduler_manifest_candidate(
         return Ok(None);
     };
     let candidate = PathBuf::from(value);
-    if !candidate.is_absolute()
+    if !windows_path_is_absolute(&candidate)?
         || format!(
             "reconcile --scheduler-manifest {}",
             quote_windows_argument(&candidate)?

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -1361,7 +1361,7 @@ fn recover_scheduler_manifest_candidate(
         return Ok(None);
     };
     let candidate = PathBuf::from(value);
-    if !windows_path_is_absolute(&candidate)?
+    if !(candidate.is_absolute() || windows_path_is_absolute(&candidate)?)
         || format!(
             "reconcile --scheduler-manifest {}",
             quote_windows_argument(&candidate)?

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -257,6 +257,21 @@ fn windows_path_is_absolute(path: &Path) -> anyhow::Result<bool> {
 }
 
 #[cfg(any(windows, test))]
+fn validate_canonical_direct_codex_target(canonical: &Path) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        canonical.is_absolute()
+            && canonical.is_file()
+            && canonical
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("exe")),
+        "canonical Codex executable {} must be an absolute native .exe file",
+        canonical.display()
+    );
+    Ok(())
+}
+
+#[cfg(any(windows, test))]
 fn canonical_direct_codex_executable(
     command: &Path,
     search_path: Option<&std::ffi::OsStr>,
@@ -293,9 +308,8 @@ fn canonical_direct_codex_executable(
         let canonical = candidate
             .canonicalize()
             .with_context(|| format!("canonicalize Codex executable {}", candidate.display()))?;
-        if canonical.is_file() {
-            return Ok(canonical);
-        }
+        validate_canonical_direct_codex_target(&canonical)?;
+        return Ok(canonical);
     }
     anyhow::bail!(
         "Codex executable {} must resolve to an absolute native .exe file",
@@ -1613,16 +1627,35 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(windows)]
     #[test]
-    fn scheduler_codex_resolver_finds_this_hosts_native_codex_exe() -> anyhow::Result<()> {
-        let resolved = canonical_direct_codex_executable(Path::new("codex"), None)?;
-        assert!(resolved.is_absolute());
-        assert!(resolved.is_file());
-        assert!(resolved
-            .extension()
-            .and_then(|extension| extension.to_str())
-            .is_some_and(|extension| extension.eq_ignore_ascii_case("exe")));
+    fn scheduler_codex_resolver_revalidates_the_canonical_target_extension() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let native = dir.path().join("codex.exe");
+        std::fs::write(&native, b"MZ")?;
+        let shim = dir.path().join("codex.cmd");
+        std::fs::write(&shim, b"@echo off")?;
+
+        validate_canonical_direct_codex_target(&native.canonicalize()?)?;
+        let error = validate_canonical_direct_codex_target(&shim.canonicalize()?)
+            .expect_err("a canonical .cmd target must not be schedulable");
+        assert!(error
+            .to_string()
+            .contains("must be an absolute native .exe file"));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scheduler_codex_resolver_rejects_exe_alias_to_cmd_target() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let shim = dir.path().join("codex.cmd");
+        std::fs::write(&shim, b"#!/bin/sh")?;
+        let alias = dir.path().join("codex.exe");
+        std::os::unix::fs::symlink(&shim, &alias)?;
+
+        let error = canonical_direct_codex_executable(&alias, None)
+            .expect_err("an .exe alias to a .cmd target must not be schedulable");
+        assert!(error.to_string().contains("absolute native .exe file"));
         Ok(())
     }
 

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -194,10 +194,11 @@ fn canonical_main_repo(repo: &Path) -> anyhow::Result<PathBuf> {
     let repo = repo
         .canonicalize()
         .with_context(|| format!("canonicalize repository {}", repo.display()))?;
-    edda_core::git::resolve_git_root(&repo)
-        .unwrap_or(repo)
+    anyhow::ensure!(repo.is_dir(), "--repo must name a directory");
+    edda_ledger::EddaPaths::find_root(&repo)
+        .context("--repo must name an initialized Edda workspace")?
         .canonicalize()
-        .context("canonicalize main repository")
+        .context("canonicalize Edda workspace root")
 }
 
 #[cfg(any(windows, test))]
@@ -216,13 +217,56 @@ fn quote_windows_argument(path: &Path) -> anyhow::Result<String> {
 }
 
 #[cfg(any(windows, test))]
+fn windows_path_is_absolute(path: &Path) -> anyhow::Result<bool> {
+    let value = path.to_str().context("scheduler path is not Unicode")?;
+    let bytes = value.as_bytes();
+    let separator = |byte| matches!(byte, b'\\' | b'/');
+    let drive_rooted = |candidate: &[u8]| {
+        candidate.len() >= 3
+            && candidate[0].is_ascii_alphabetic()
+            && candidate[1] == b':'
+            && separator(candidate[2])
+    };
+    let unc_rooted = |candidate: &str| {
+        let mut parts = candidate.split(['\\', '/']);
+        parts.next().is_some_and(|part| !part.is_empty())
+            && parts.next().is_some_and(|part| !part.is_empty())
+    };
+
+    if drive_rooted(bytes) {
+        return Ok(true);
+    }
+    if bytes.len() < 2 || !separator(bytes[0]) || !separator(bytes[1]) {
+        return Ok(false);
+    }
+    if bytes.len() >= 4 && bytes[2] == b'?' && separator(bytes[3]) {
+        let rest = &value[4..];
+        if drive_rooted(rest.as_bytes()) {
+            return Ok(true);
+        }
+        let rest_bytes = rest.as_bytes();
+        return Ok(rest_bytes.len() >= 4
+            && rest_bytes[..3].eq_ignore_ascii_case(b"UNC")
+            && separator(rest_bytes[3])
+            && unc_rooted(&rest[4..]));
+    }
+    Ok(unc_rooted(&value[2..]))
+}
+
+#[cfg(any(windows, test))]
 fn windows_scheduler_spec(
     exe: &Path,
     repo: &Path,
     project_id: &str,
 ) -> anyhow::Result<WindowsSchedulerSpec> {
-    anyhow::ensure!(exe.is_absolute(), "scheduler executable must be absolute");
-    anyhow::ensure!(repo.is_absolute(), "scheduler repository must be absolute");
+    anyhow::ensure!(
+        windows_path_is_absolute(exe)?,
+        "scheduler executable must be absolute"
+    );
+    anyhow::ensure!(
+        windows_path_is_absolute(repo)?,
+        "scheduler repository must be absolute"
+    );
     anyhow::ensure!(
         project_id.len() == 32
             && project_id
@@ -257,6 +301,23 @@ fn classify_scheduler_query(output: &SchedulerOutput) -> anyhow::Result<Schedule
     }
 }
 
+#[cfg(any(windows, test))]
+fn require_scheduler_state(
+    output: &SchedulerOutput,
+    expected: SchedulerTaskState,
+    operation: &str,
+    task_name: &str,
+) -> anyhow::Result<()> {
+    let actual = classify_scheduler_query(output)
+        .with_context(|| format!("scheduler {operation} failed for task {task_name}"))?;
+    anyhow::ensure!(
+        actual == expected,
+        "scheduler {operation} expected {expected:?} for task {task_name}, got {actual:?}: {}",
+        output.description()
+    );
+    Ok(())
+}
+
 #[cfg(windows)]
 fn run_schtasks(args: &[String]) -> anyhow::Result<SchedulerOutput> {
     let output = Command::new("schtasks.exe")
@@ -287,7 +348,8 @@ fn scheduler_lifecycle(repo: &Path, install: bool) -> anyhow::Result<()> {
     {
         let repo = canonical_main_repo(repo)?;
         let executable = std::env::current_exe()?.canonicalize()?;
-        let spec = windows_scheduler_spec(&executable, &repo, &edda_store::project_id(&repo))?;
+        let spec =
+            windows_scheduler_spec(&executable, &repo, &edda_store::project_id_for_root(&repo))?;
         if install {
             let created = run_schtasks(&spec.create_args)
                 .with_context(|| format!("scheduler Create failed for task {}", spec.task_name))?;
@@ -299,14 +361,12 @@ fn scheduler_lifecycle(repo: &Path, install: bool) -> anyhow::Result<()> {
             );
             let queried = run_schtasks(&spec.query_args)
                 .with_context(|| format!("scheduler Query failed for task {}", spec.task_name))?;
-            anyhow::ensure!(
-                classify_scheduler_query(&queried).with_context(|| format!(
-                    "scheduler Query failed for task {}",
-                    spec.task_name
-                ))? == SchedulerTaskState::Present,
-                "scheduler task {} missing after Create",
-                spec.task_name
-            );
+            require_scheduler_state(
+                &queried,
+                SchedulerTaskState::Present,
+                "post-Create Query",
+                &spec.task_name,
+            )?;
             println!(
                 "installed scheduler task {} for {}",
                 spec.task_name,
@@ -338,13 +398,12 @@ fn scheduler_lifecycle(repo: &Path, install: bool) -> anyhow::Result<()> {
         );
         let after = run_schtasks(&spec.query_args)
             .with_context(|| format!("scheduler Query failed for task {}", spec.task_name))?;
-        anyhow::ensure!(
-            classify_scheduler_query(&after)
-                .with_context(|| format!("scheduler Query failed for task {}", spec.task_name))?
-                == SchedulerTaskState::Missing,
-            "scheduler task {} remains after Delete",
-            spec.task_name
-        );
+        require_scheduler_state(
+            &after,
+            SchedulerTaskState::Missing,
+            "post-Delete Query",
+            &spec.task_name,
+        )?;
         println!(
             "uninstalled scheduler task {} for {}",
             spec.task_name,
@@ -1375,6 +1434,30 @@ mod tests {
     }
 
     #[test]
+    fn scheduler_windows_absolute_paths_are_host_neutral() -> anyhow::Result<()> {
+        for path in [
+            r"C:\edda\edda.exe",
+            "C:/edda/edda.exe",
+            r"\\server\share\edda.exe",
+            r"\\?\C:\edda\edda.exe",
+            r"\\?\UNC\server\share\edda.exe",
+        ] {
+            assert!(windows_path_is_absolute(Path::new(path))?, "{path}");
+        }
+        for path in [
+            "edda.exe",
+            r"C:edda.exe",
+            r"\edda.exe",
+            r"\\server",
+            r"\\?\C:edda.exe",
+            r"\\?\UNC\server",
+        ] {
+            assert!(!windows_path_is_absolute(Path::new(path))?, "{path}");
+        }
+        Ok(())
+    }
+
+    #[test]
     fn scheduler_renderer_rejects_ambiguous_inputs() {
         let executable = Path::new(r"C:\edda\edda.exe");
         let repository = Path::new(r"C:\repo");
@@ -1440,6 +1523,38 @@ mod tests {
         }
     }
 
+    #[test]
+    fn scheduler_expected_state_mismatch_preserves_bounded_process_output() {
+        let task_name = "Edda-Reconcile-0123456789abcdef0123456789abcdef";
+        let missing = SchedulerOutput::for_test(MISSING_TASK_HRESULT, "", "missing detail");
+        let install_error = require_scheduler_state(
+            &missing,
+            SchedulerTaskState::Present,
+            "post-Create Query",
+            task_name,
+        )
+        .expect_err("Create verification must reject missing")
+        .to_string();
+        assert!(install_error.contains("post-Create Query"));
+        assert!(install_error.contains(task_name));
+        assert!(install_error.contains("0x80070002"));
+        assert!(install_error.contains("missing detail"));
+
+        let present = SchedulerOutput::for_test(0, "present xml", "");
+        let uninstall_error = require_scheduler_state(
+            &present,
+            SchedulerTaskState::Missing,
+            "post-Delete Query",
+            task_name,
+        )
+        .expect_err("Delete verification must reject present")
+        .to_string();
+        assert!(uninstall_error.contains("post-Delete Query"));
+        assert!(uninstall_error.contains(task_name));
+        assert!(uninstall_error.contains("0x00000000"));
+        assert!(uninstall_error.contains("present xml"));
+    }
+
     #[cfg(not(windows))]
     #[test]
     fn scheduler_lifecycle_is_explicitly_unsupported_off_windows() {
@@ -1456,8 +1571,18 @@ mod tests {
         let dir = tempfile::tempdir()?;
         assert!(canonical_main_repo(&dir.path().join("missing")).is_err());
 
+        let parent = dir.path().join("parent git");
+        std::fs::create_dir(&parent)?;
+        init_git(&parent)?;
+        assert!(canonical_main_repo(&parent).is_err());
+        let nested = parent.join("nested edda");
+        std::fs::create_dir(&nested)?;
+        Ledger::ensure_initialized(&nested)?;
+        assert_eq!(canonical_main_repo(&nested)?, nested.canonicalize()?);
+
         let repo = dir.path().join("repo");
         std::fs::create_dir_all(repo.join(".git").join("worktrees").join("scheduler"))?;
+        Ledger::ensure_initialized(&repo)?;
         let worktree = dir.path().join("linked worktree");
         std::fs::create_dir_all(&worktree)?;
         let gitdir = repo.join(".git").join("worktrees").join("scheduler");
@@ -1471,6 +1596,43 @@ mod tests {
             edda_store::project_id(&worktree),
             edda_store::project_id(&repo)
         );
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_repo_reentry_runs_against_the_explicit_repo_from_an_unrelated_root(
+    ) -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let repo = dir.path().join("scheduled repo");
+        let unrelated = dir.path().join("unrelated cwd");
+        std::fs::create_dir(&repo)?;
+        std::fs::create_dir(&unrelated)?;
+        init_git(&repo)?;
+        Ledger::ensure_initialized(&repo)?;
+        let ledger = Ledger::open(&repo)?;
+        create_task(&ledger, 91, &["src/scheduled.rs".into()])?;
+        append_started(&ledger, 91, 1, 1)?;
+        ledger.upsert_task_lease(&lease(91, 1, "2026-08-16T00:00:00Z"))?;
+
+        run(
+            &unrelated,
+            ReconcileArgs {
+                max_workers: 0,
+                max_attempts: 1,
+                lease_ttl_s: 300,
+                codex_bin: None,
+                install_scheduler: false,
+                uninstall_scheduler: false,
+                repo: Some(repo.canonicalize()?),
+                run_task: None,
+                attempt: None,
+            },
+        )?;
+
+        let view = ledger.task_views()?.remove(0);
+        assert_eq!(view.status, TaskStatus::Failed);
+        assert_eq!(view.failure_reason.as_deref(), Some("retry-cap-exhausted"));
+        assert!(!unrelated.join(".edda").exists());
         Ok(())
     }
 

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -792,6 +792,16 @@ fn decode_scheduler_xml_value(value: &str) -> anyhow::Result<String> {
 }
 
 #[cfg(any(windows, test))]
+fn contains_scheduler_exec_candidate(xml: &str) -> bool {
+    xml.match_indices("<Exec").any(|(start, _)| {
+        matches!(
+            xml.as_bytes().get(start + "<Exec".len()),
+            None | Some(b'>' | b'/') | Some(b' ' | b'\t' | b'\r' | b'\n')
+        )
+    })
+}
+
+#[cfg(any(windows, test))]
 fn scheduler_exec_values(xml: &str) -> anyhow::Result<Vec<(String, String)>> {
     anyhow::ensure!(
         xml.len() <= SCHEDULER_OUTPUT_LIMIT,
@@ -818,7 +828,8 @@ fn scheduler_exec_values(xml: &str) -> anyhow::Result<Vec<(String, String)>> {
     let mut remaining = xml;
     while let Some(start) = remaining.find("<Exec>") {
         anyhow::ensure!(
-            !remaining[..start].contains("<Exec") && !remaining[..start].contains("</Exec>"),
+            !contains_scheduler_exec_candidate(&remaining[..start])
+                && !remaining[..start].contains("</Exec>"),
             "scheduler Query XML contains a malformed Exec action"
         );
         remaining = &remaining[start + "<Exec>".len()..];
@@ -827,14 +838,14 @@ fn scheduler_exec_values(xml: &str) -> anyhow::Result<Vec<(String, String)>> {
             .context("scheduler Query XML contains an unterminated Exec action")?;
         let action = &remaining[..end];
         anyhow::ensure!(
-            !action.contains("<Exec"),
+            !contains_scheduler_exec_candidate(action),
             "scheduler Query XML contains a nested Exec action"
         );
         actions.push((element(action, "Command")?, element(action, "Arguments")?));
         remaining = &remaining[end + "</Exec>".len()..];
     }
     anyhow::ensure!(
-        !remaining.contains("<Exec") && !remaining.contains("</Exec>"),
+        !contains_scheduler_exec_candidate(remaining) && !remaining.contains("</Exec>"),
         "scheduler Query XML contains a malformed Exec action"
     );
     Ok(actions)
@@ -2256,6 +2267,39 @@ mod tests {
     }
 
     #[test]
+    fn scheduler_query_ignores_execution_time_limit_setting() -> anyhow::Result<()> {
+        let executable = Path::new(r"C:\Program Files\Edda\edda.exe");
+        let manifest = Path::new(
+            r"C:\Store\scheduler-launch\v1\aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json",
+        );
+        let xml = r#"<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <Settings>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>C:\Program Files\Edda\edda.exe</Command>
+      <Arguments>reconcile --scheduler-manifest &quot;C:\Store\scheduler-launch\v1\aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json&quot;</Arguments>
+    </Exec>
+  </Actions>
+</Task>"#;
+
+        assert!(scheduler_query_references_manifest(
+            xml, executable, manifest
+        )?);
+        assert_eq!(
+            manifest_cleanup_decision(
+                &SchedulerOutput::for_test(0, xml, ""),
+                executable,
+                manifest,
+            )?,
+            ManifestCleanupDecision::Retain
+        );
+        Ok(())
+    }
+
+    #[test]
     fn scheduler_query_scans_every_exec_before_deciding() {
         let executable = Path::new(r"C:\edda\edda.exe");
         let expected = Path::new(
@@ -2268,6 +2312,11 @@ mod tests {
             expected_xml.trim_end_matches("<Exec><Command>truncated")
         );
         assert!(scheduler_query_references_manifest(&cut_open, executable, expected).is_err());
+        let self_closing = format!(
+            "{}<Exec/>",
+            expected_xml.trim_end_matches("<Exec><Command>truncated")
+        );
+        assert!(scheduler_query_references_manifest(&self_closing, executable, expected).is_err());
 
         let different_xml = expected_xml.replace(
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json",

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -1040,11 +1040,89 @@ fn remove_unreferenced_scheduler_manifest(path: &Path) -> String {
 }
 
 #[cfg(any(windows, test))]
+fn scheduler_actions_xml(xml: &str) -> anyhow::Result<&str> {
+    anyhow::ensure!(
+        xml.len() <= SCHEDULER_OUTPUT_LIMIT,
+        "scheduler Query XML exceeds the bounded output limit"
+    );
+    let xml = xml.trim();
+    let task_start = xml
+        .find("<Task")
+        .context("scheduler Query XML has no Task root")?;
+    let prefix = xml[..task_start].trim();
+    anyhow::ensure!(
+        prefix.is_empty() || (prefix.starts_with("<?xml") && prefix.ends_with("?>")),
+        "scheduler Query XML has content before the Task root"
+    );
+    anyhow::ensure!(
+        matches!(
+            xml.as_bytes().get(task_start + "<Task".len()),
+            Some(b'>') | Some(b' ' | b'\t' | b'\r' | b'\n')
+        ),
+        "scheduler Query XML has a malformed Task root"
+    );
+    let task_open_end = xml[task_start..]
+        .find('>')
+        .map(|end| task_start + end)
+        .context("scheduler Query XML has an unterminated Task root")?;
+    anyhow::ensure!(
+        !xml[task_start..=task_open_end].trim_end().ends_with("/>"),
+        "scheduler Query XML has a self-closing Task root"
+    );
+    let task_close = xml
+        .strip_suffix("</Task>")
+        .context("scheduler Query XML has an incomplete Task root")?;
+    let task_body = &task_close[task_open_end + 1..];
+    anyhow::ensure!(
+        !task_body.contains("<Task") && !task_body.contains("</Task>"),
+        "scheduler Query XML has nested or duplicate Task roots"
+    );
+
+    let actions_start = task_body
+        .find("<Actions")
+        .context("scheduler Query XML has no Actions container")?;
+    anyhow::ensure!(
+        matches!(
+            task_body.as_bytes().get(actions_start + "<Actions".len()),
+            Some(b'>') | Some(b' ' | b'\t' | b'\r' | b'\n')
+        ),
+        "scheduler Query XML has a malformed Actions container"
+    );
+    let actions_open_end = task_body[actions_start..]
+        .find('>')
+        .map(|end| actions_start + end)
+        .context("scheduler Query XML has an unterminated Actions container")?;
+    anyhow::ensure!(
+        !task_body[actions_start..=actions_open_end]
+            .trim_end()
+            .ends_with("/>"),
+        "scheduler Query XML has a self-closing Actions container"
+    );
+    let after_open = &task_body[actions_open_end + 1..];
+    let actions_close = after_open
+        .find("</Actions>")
+        .context("scheduler Query XML has an incomplete Actions container")?;
+    anyhow::ensure!(
+        !task_body[..actions_start].contains("</Actions>")
+            && !after_open[..actions_close].contains("<Actions")
+            && !after_open[actions_close + "</Actions>".len()..].contains("<Actions")
+            && !after_open[actions_close + "</Actions>".len()..].contains("</Actions>"),
+        "scheduler Query XML has nested or duplicate Actions containers"
+    );
+    Ok(&after_open[..actions_close])
+}
+
+#[cfg(any(windows, test))]
 fn recover_scheduler_manifest_candidate(
     xml: &str,
     executable: &Path,
 ) -> anyhow::Result<Option<PathBuf>> {
-    let actions = scheduler_exec_values(xml)?;
+    let actions_xml = scheduler_actions_xml(xml)?;
+    let actions = scheduler_exec_values(actions_xml)?;
+    anyhow::ensure!(
+        scheduler_exec_values(xml)? == actions,
+        "scheduler Query XML has an Exec action outside its Actions container"
+    );
     let [(command, arguments)] = actions.as_slice() else {
         return Ok(None);
     };
@@ -1074,6 +1152,99 @@ fn recover_scheduler_manifest_candidate(
 }
 
 #[cfg(any(windows, test))]
+fn claim_and_remove_scheduler_manifest_under_lock(
+    path: &Path,
+    quarantine: &Path,
+    expected_bytes: &[u8],
+    repo: &Path,
+    project_id: &str,
+) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        path.parent() == quarantine.parent(),
+        "scheduler manifest quarantine must be in the same directory"
+    );
+    anyhow::ensure!(
+        !quarantine.exists(),
+        "scheduler manifest quarantine already exists"
+    );
+    std::fs::rename(path, quarantine).with_context(|| {
+        format!(
+            "atomically claim scheduler manifest {} as {}",
+            path.display(),
+            quarantine.display()
+        )
+    })?;
+
+    let revalidation = (|| -> anyhow::Result<()> {
+        let trusted_directory = scheduler_manifest_directory(&edda_store::store_root(), true)?;
+        let source_metadata = quarantine.symlink_metadata().with_context(|| {
+            format!(
+                "inspect scheduler manifest quarantine {}",
+                quarantine.display()
+            )
+        })?;
+        anyhow::ensure!(
+            source_metadata.file_type().is_file(),
+            "scheduler manifest quarantine must be a regular file"
+        );
+        anyhow::ensure!(
+            source_metadata.len() <= SCHEDULER_MANIFEST_MAX_BYTES,
+            "scheduler manifest quarantine exceeds 16 KiB"
+        );
+        let canonical = quarantine.canonicalize().with_context(|| {
+            format!(
+                "canonicalize scheduler manifest quarantine {}",
+                quarantine.display()
+            )
+        })?;
+        let parent = quarantine
+            .parent()
+            .context("scheduler manifest quarantine has no parent")?
+            .canonicalize()
+            .context("canonicalize scheduler manifest quarantine parent")?;
+        anyhow::ensure!(
+            parent == trusted_directory && canonical.parent() == Some(trusted_directory.as_path()),
+            "scheduler manifest quarantine is outside the trusted Edda store directory"
+        );
+        let bytes = std::fs::read(&canonical).with_context(|| {
+            format!("read scheduler manifest quarantine {}", canonical.display())
+        })?;
+        anyhow::ensure!(
+            bytes.len() as u64 <= SCHEDULER_MANIFEST_MAX_BYTES,
+            "scheduler manifest quarantine exceeds 16 KiB"
+        );
+        anyhow::ensure!(
+            bytes == expected_bytes,
+            "scheduler manifest entry changed before the atomic quarantine claim"
+        );
+        let manifest: SchedulerLaunchManifestV1 = serde_json::from_slice(&bytes)
+            .context("parse quarantined scheduler launch manifest")?;
+        anyhow::ensure!(
+            serde_json::to_vec(&manifest)? == bytes,
+            "scheduler manifest quarantine JSON is not canonical"
+        );
+        let loaded = validate_scheduler_manifest(manifest)?;
+        anyhow::ensure!(
+            loaded.repo == repo && loaded.manifest.project_id == project_id,
+            "scheduler manifest quarantine does not belong to the exact task project"
+        );
+        Ok(())
+    })();
+    if let Err(error) = revalidation {
+        anyhow::bail!(
+            "retain quarantine {} because the claimed scheduler manifest failed revalidation: {error:#}",
+            quarantine.display()
+        );
+    }
+    std::fs::remove_file(quarantine).with_context(|| {
+        format!(
+            "retain quarantine {} because exact-file removal failed",
+            quarantine.display()
+        )
+    })
+}
+
+#[cfg(any(windows, test))]
 fn remove_trusted_scheduler_manifest(path: &Path, repo: &Path, project_id: &str) -> String {
     let removal = (|| -> anyhow::Result<()> {
         let store = edda_store::store_root();
@@ -1091,8 +1262,25 @@ fn remove_trusted_scheduler_manifest(path: &Path, repo: &Path, project_id: &str)
             loaded.repo == repo && loaded.manifest.project_id == project_id,
             "scheduler manifest does not belong to the exact task project"
         );
-        std::fs::remove_file(path)
-            .with_context(|| format!("remove trusted scheduler manifest {}", path.display()))
+        let expected_bytes = serde_json::to_vec(&loaded.manifest)?;
+        let filename = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .context("scheduler manifest filename is not Unicode")?;
+        let sequence =
+            SCHEDULER_MANIFEST_TEMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let quarantine = directory.join(format!(
+            ".{filename}.{}.{}.uninstall-quarantine",
+            std::process::id(),
+            sequence
+        ));
+        claim_and_remove_scheduler_manifest_under_lock(
+            path,
+            &quarantine,
+            &expected_bytes,
+            repo,
+            project_id,
+        )
     })();
     match removal {
         Ok(()) => format!(
@@ -3147,6 +3335,35 @@ mod tests {
     }
 
     #[test]
+    fn scheduler_manifest_quarantine_revalidates_the_claimed_entry_before_removal(
+    ) -> anyhow::Result<()> {
+        let fixture = scheduler_manifest_fixture()?;
+        let prepared = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+        edda_store::write_atomic(&prepared.path, &prepared.bytes)?;
+        let loaded = load_scheduler_manifest(&prepared.path)?;
+        let expected_bytes = serde_json::to_vec(&loaded.manifest)?;
+        let project_id = edda_store::project_id_for_root(&fixture.repo);
+        let quarantine = prepared.path.with_file_name("swap-test.quarantine");
+        std::fs::write(&prepared.path, b"replacement")?;
+
+        let error = claim_and_remove_scheduler_manifest_under_lock(
+            &prepared.path,
+            &quarantine,
+            &expected_bytes,
+            &fixture.repo,
+            &project_id,
+        )
+        .expect_err("a replacement must be retained after the atomic claim")
+        .to_string();
+
+        assert!(!prepared.path.exists());
+        assert!(quarantine.exists());
+        assert_eq!(std::fs::read(&quarantine)?, b"replacement");
+        assert!(error.contains("retain quarantine"));
+        Ok(())
+    }
+
+    #[test]
     fn scheduler_uninstall_malformed_query_retains_artifacts_but_removes_task() -> anyhow::Result<()>
     {
         let fixture = scheduler_manifest_fixture()?;
@@ -3168,6 +3385,42 @@ mod tests {
 
         assert_eq!(calls, 3);
         assert!(prepared.path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_uninstall_truncated_outer_xml_retains_manifest_but_removes_task(
+    ) -> anyhow::Result<()> {
+        for ending in ["", "</Actions>", "</Task>"] {
+            let fixture = scheduler_manifest_fixture()?;
+            let prepared =
+                prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+            edda_store::write_atomic(&prepared.path, &prepared.bytes)?;
+            let complete = scheduler_manifest_xml(&fixture.codex, &prepared.path)?;
+            let body = complete
+                .strip_suffix("</Actions></Task>")
+                .context("test scheduler XML suffix")?;
+            let xml = format!("{body}{ending}");
+            let project_id = edda_store::project_id_for_root(&fixture.repo);
+            let mut outputs = [
+                SchedulerOutput::for_test(0, &xml, ""),
+                SchedulerOutput::for_test(0, "", ""),
+                SchedulerOutput::for_test(MISSING_TASK_HRESULT, "", "missing"),
+            ]
+            .into_iter();
+            let mut calls = 0;
+
+            uninstall_scheduler_task_with(&fixture.repo, &fixture.codex, &project_id, |_| {
+                calls += 1;
+                outputs.next().context("unexpected scheduler call")
+            })?;
+
+            assert_eq!(calls, 3);
+            assert!(
+                prepared.path.exists(),
+                "ending {ending:?} authorized cleanup"
+            );
+        }
         Ok(())
     }
 

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -36,6 +36,18 @@ pub struct ReconcileArgs {
     lease_ttl_s: u64,
     #[arg(long)]
     codex_bin: Option<PathBuf>,
+    #[arg(
+        long,
+        conflicts_with_all = ["uninstall_scheduler", "run_task", "attempt"]
+    )]
+    install_scheduler: bool,
+    #[arg(
+        long,
+        conflicts_with_all = ["install_scheduler", "run_task", "attempt"]
+    )]
+    uninstall_scheduler: bool,
+    #[arg(long, hide = true)]
+    repo: Option<PathBuf>,
     #[arg(long, hide = true)]
     run_task: Option<u64>,
     #[arg(long, hide = true)]
@@ -92,24 +104,31 @@ struct PersistOutcome {
 }
 
 pub fn run(repo_root: &Path, args: ReconcileArgs) -> anyhow::Result<()> {
+    let repo_root = match args.repo.as_deref() {
+        Some(repo) => canonical_main_repo(repo)?,
+        None => repo_root.to_path_buf(),
+    };
+    if args.install_scheduler || args.uninstall_scheduler {
+        return scheduler_lifecycle(&repo_root, args.install_scheduler);
+    }
     let config = ReconcileConfig::from_args(&args);
     if let Some(task_id) = args.run_task {
         let attempt = args
             .attempt
             .context("--run-task requires hidden --attempt")?;
-        return run_task(repo_root, task_id, attempt, &config, true);
+        return run_task(&repo_root, task_id, attempt, &config, true);
     }
     if args.attempt.is_some() {
         anyhow::bail!("--attempt is valid only with hidden --run-task");
     }
-    let persisted = persist_reconciliation(repo_root, &config)?;
+    let persisted = persist_reconciliation(&repo_root, &config)?;
     let plans = persisted.plans;
     let executable = std::env::current_exe()?;
     let executables = vec![executable; plans.len()];
-    let (launched, mut errors) = launch_plans_with(repo_root, plans, &config, &executables);
+    let (launched, mut errors) = launch_plans_with(&repo_root, plans, &config, &executables);
     errors.extend(persisted.errors);
     for plan in launched {
-        notify_started(repo_root, &plan.task);
+        notify_started(&repo_root, &plan.task);
         println!(
             "dispatched task #{} attempt {} in {}",
             plan.task.task_id,
@@ -121,6 +140,217 @@ pub fn run(repo_root: &Path, args: ReconcileArgs) -> anyhow::Result<()> {
         Ok(())
     } else {
         anyhow::bail!(errors.join("\n"));
+    }
+}
+
+#[cfg(any(windows, test))]
+const MISSING_TASK_HRESULT: u32 = 0x8007_0002;
+#[cfg(windows)]
+const SCHEDULER_OUTPUT_LIMIT: usize = 4096;
+
+#[cfg(any(windows, test))]
+#[derive(Debug, Eq, PartialEq)]
+enum SchedulerTaskState {
+    Present,
+    Missing,
+}
+
+#[cfg(any(windows, test))]
+struct SchedulerOutput {
+    code: u32,
+    stdout: String,
+    stderr: String,
+}
+
+#[cfg(any(windows, test))]
+impl SchedulerOutput {
+    #[cfg(test)]
+    fn for_test(code: u32, stdout: &str, stderr: &str) -> Self {
+        Self {
+            code,
+            stdout: stdout.into(),
+            stderr: stderr.into(),
+        }
+    }
+
+    fn description(&self) -> String {
+        format!(
+            "code=0x{:08x} ({}) stdout={:?} stderr={:?}",
+            self.code, self.code as i32, self.stdout, self.stderr
+        )
+    }
+}
+
+#[cfg(any(windows, test))]
+struct WindowsSchedulerSpec {
+    task_name: String,
+    create_args: Vec<String>,
+    query_args: Vec<String>,
+    delete_args: Vec<String>,
+}
+
+fn canonical_main_repo(repo: &Path) -> anyhow::Result<PathBuf> {
+    anyhow::ensure!(repo.is_absolute(), "--repo must be absolute");
+    let repo = repo
+        .canonicalize()
+        .with_context(|| format!("canonicalize repository {}", repo.display()))?;
+    edda_core::git::resolve_git_root(&repo)
+        .unwrap_or(repo)
+        .canonicalize()
+        .context("canonicalize main repository")
+}
+
+#[cfg(any(windows, test))]
+fn quote_windows_argument(path: &Path) -> anyhow::Result<String> {
+    let value = path.to_str().context("scheduler path is not Unicode")?;
+    anyhow::ensure!(
+        !value.contains(['\0', '"']),
+        "scheduler path contains an unsupported character"
+    );
+    let trailing_backslashes = value
+        .bytes()
+        .rev()
+        .take_while(|byte| *byte == b'\\')
+        .count();
+    Ok(format!("\"{value}{}\"", "\\".repeat(trailing_backslashes)))
+}
+
+#[cfg(any(windows, test))]
+fn windows_scheduler_spec(
+    exe: &Path,
+    repo: &Path,
+    project_id: &str,
+) -> anyhow::Result<WindowsSchedulerSpec> {
+    anyhow::ensure!(exe.is_absolute(), "scheduler executable must be absolute");
+    anyhow::ensure!(repo.is_absolute(), "scheduler repository must be absolute");
+    anyhow::ensure!(
+        project_id.len() == 32
+            && project_id
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
+        "project id must be 32 lowercase hexadecimal characters"
+    );
+    let task_name = format!("Edda-Reconcile-{project_id}");
+    let task_run = format!(
+        "{} reconcile --repo {}",
+        quote_windows_argument(exe)?,
+        quote_windows_argument(repo)?
+    );
+    let strings = |items: &[&str]| items.iter().map(|item| (*item).into()).collect();
+    Ok(WindowsSchedulerSpec {
+        create_args: strings(&[
+            "/Create", "/SC", "MINUTE", "/MO", "1", "/TN", &task_name, "/TR", &task_run, "/RL",
+            "LIMITED", "/F", "/HRESULT",
+        ]),
+        query_args: strings(&["/Query", "/TN", &task_name, "/XML", "/HRESULT"]),
+        delete_args: strings(&["/Delete", "/TN", &task_name, "/F", "/HRESULT"]),
+        task_name,
+    })
+}
+
+#[cfg(any(windows, test))]
+fn classify_scheduler_query(output: &SchedulerOutput) -> anyhow::Result<SchedulerTaskState> {
+    match output.code {
+        0 => Ok(SchedulerTaskState::Present),
+        MISSING_TASK_HRESULT => Ok(SchedulerTaskState::Missing),
+        _ => anyhow::bail!("scheduler query failed: {}", output.description()),
+    }
+}
+
+#[cfg(windows)]
+fn run_schtasks(args: &[String]) -> anyhow::Result<SchedulerOutput> {
+    let output = Command::new("schtasks.exe")
+        .args(args)
+        .output()
+        .context("launch schtasks.exe")?;
+    let signed_code = output
+        .status
+        .code()
+        .context("schtasks.exe terminated by signal")?;
+    let bounded = |bytes: &[u8]| {
+        String::from_utf8_lossy(&bytes[..bytes.len().min(SCHEDULER_OUTPUT_LIMIT)]).into_owned()
+    };
+    Ok(SchedulerOutput {
+        code: signed_code as u32,
+        stdout: bounded(&output.stdout),
+        stderr: bounded(&output.stderr),
+    })
+}
+
+fn scheduler_lifecycle(repo: &Path, install: bool) -> anyhow::Result<()> {
+    #[cfg(not(windows))]
+    {
+        let _ = (repo, install);
+        anyhow::bail!("Windows Task Scheduler is supported only on Windows")
+    }
+    #[cfg(windows)]
+    {
+        let repo = canonical_main_repo(repo)?;
+        let executable = std::env::current_exe()?.canonicalize()?;
+        let spec = windows_scheduler_spec(&executable, &repo, &edda_store::project_id(&repo))?;
+        if install {
+            let created = run_schtasks(&spec.create_args)
+                .with_context(|| format!("scheduler Create failed for task {}", spec.task_name))?;
+            anyhow::ensure!(
+                created.code == 0,
+                "scheduler Create failed for {}: {}",
+                spec.task_name,
+                created.description()
+            );
+            let queried = run_schtasks(&spec.query_args)
+                .with_context(|| format!("scheduler Query failed for task {}", spec.task_name))?;
+            anyhow::ensure!(
+                classify_scheduler_query(&queried).with_context(|| format!(
+                    "scheduler Query failed for task {}",
+                    spec.task_name
+                ))? == SchedulerTaskState::Present,
+                "scheduler task {} missing after Create",
+                spec.task_name
+            );
+            println!(
+                "installed scheduler task {} for {}",
+                spec.task_name,
+                repo.display()
+            );
+            return Ok(());
+        }
+
+        let before = run_schtasks(&spec.query_args)
+            .with_context(|| format!("scheduler Query failed for task {}", spec.task_name))?;
+        if classify_scheduler_query(&before)
+            .with_context(|| format!("scheduler Query failed for task {}", spec.task_name))?
+            == SchedulerTaskState::Missing
+        {
+            println!(
+                "scheduler task {} already absent for {}",
+                spec.task_name,
+                repo.display()
+            );
+            return Ok(());
+        }
+        let deleted = run_schtasks(&spec.delete_args)
+            .with_context(|| format!("scheduler Delete failed for task {}", spec.task_name))?;
+        anyhow::ensure!(
+            deleted.code == 0 || deleted.code == MISSING_TASK_HRESULT,
+            "scheduler Delete failed for {}: {}",
+            spec.task_name,
+            deleted.description()
+        );
+        let after = run_schtasks(&spec.query_args)
+            .with_context(|| format!("scheduler Query failed for task {}", spec.task_name))?;
+        anyhow::ensure!(
+            classify_scheduler_query(&after)
+                .with_context(|| format!("scheduler Query failed for task {}", spec.task_name))?
+                == SchedulerTaskState::Missing,
+            "scheduler task {} remains after Delete",
+            spec.task_name
+        );
+        println!(
+            "uninstalled scheduler task {} for {}",
+            spec.task_name,
+            repo.display()
+        );
+        Ok(())
     }
 }
 
@@ -1026,11 +1256,222 @@ fn read_brief(repo_root: &Path, reference: &str) -> anyhow::Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
     use edda_ledger::tasks::{TaskStatus, TaskView};
     use edda_ledger::TaskLease;
 
+    #[derive(Parser)]
+    struct SchedulerCli {
+        #[command(flatten)]
+        args: ReconcileArgs,
+    }
+
     fn test_lock(lock: &std::sync::Mutex<()>) -> std::sync::MutexGuard<'_, ()> {
         lock.lock().unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    #[test]
+    fn scheduler_cli_parses_reentry_and_rejects_conflicting_modes() {
+        let parsed = SchedulerCli::try_parse_from([
+            "test",
+            "--repo",
+            r"C:\ai projects\sample",
+            "--install-scheduler",
+        ])
+        .expect("scheduler arguments");
+        assert_eq!(
+            parsed.args.repo.as_deref(),
+            Some(Path::new(r"C:\ai projects\sample"))
+        );
+        assert!(parsed.args.install_scheduler);
+        assert!(SchedulerCli::try_parse_from([
+            "test",
+            "--install-scheduler",
+            "--uninstall-scheduler"
+        ])
+        .is_err());
+        assert!(SchedulerCli::try_parse_from([
+            "test",
+            "--install-scheduler",
+            "--run-task",
+            "7",
+            "--attempt",
+            "1"
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn scheduler_renderer_emits_exact_project_scoped_argv() -> anyhow::Result<()> {
+        let spec = windows_scheduler_spec(
+            Path::new(r"C:\Program Files\edda\edda.exe"),
+            Path::new(r"C:\ai projects\sample"),
+            "0123456789abcdef0123456789abcdef",
+        )?;
+
+        assert_eq!(
+            spec.task_name,
+            "Edda-Reconcile-0123456789abcdef0123456789abcdef"
+        );
+        assert_eq!(
+            spec.create_args[8],
+            r#""C:\Program Files\edda\edda.exe" reconcile --repo "C:\ai projects\sample""#
+        );
+        assert_eq!(
+            spec.create_args,
+            [
+                "/Create",
+                "/SC",
+                "MINUTE",
+                "/MO",
+                "1",
+                "/TN",
+                "Edda-Reconcile-0123456789abcdef0123456789abcdef",
+                "/TR",
+                r#""C:\Program Files\edda\edda.exe" reconcile --repo "C:\ai projects\sample""#,
+                "/RL",
+                "LIMITED",
+                "/F",
+                "/HRESULT",
+            ]
+        );
+        assert_eq!(
+            spec.query_args,
+            [
+                "/Query",
+                "/TN",
+                "Edda-Reconcile-0123456789abcdef0123456789abcdef",
+                "/XML",
+                "/HRESULT",
+            ]
+        );
+        assert_eq!(
+            spec.delete_args,
+            [
+                "/Delete",
+                "/TN",
+                "Edda-Reconcile-0123456789abcdef0123456789abcdef",
+                "/F",
+                "/HRESULT",
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_renderer_is_stable_and_quotes_terminal_backslashes() -> anyhow::Result<()> {
+        let id = "0123456789abcdef0123456789abcdef";
+        let first =
+            windows_scheduler_spec(Path::new(r"C:\edda\edda.exe"), Path::new(r"C:\repo\"), id)?;
+        let second =
+            windows_scheduler_spec(Path::new(r"C:\edda\edda.exe"), Path::new(r"C:\repo\"), id)?;
+
+        assert_eq!(first.create_args, second.create_args);
+        assert_eq!(
+            first.create_args[8],
+            r#""C:\edda\edda.exe" reconcile --repo "C:\repo\\""#
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn scheduler_renderer_rejects_ambiguous_inputs() {
+        let executable = Path::new(r"C:\edda\edda.exe");
+        let repository = Path::new(r"C:\repo");
+        for id in [
+            "0123456789abcdef0123456789abcde",
+            "0123456789ABCDEF0123456789ABCDEF",
+            "0123456789abcdef0123456789abcde*",
+        ] {
+            assert!(windows_scheduler_spec(executable, repository, id).is_err());
+        }
+        assert!(windows_scheduler_spec(
+            executable,
+            Path::new("C:\\repo\"quoted"),
+            "0123456789abcdef0123456789abcdef"
+        )
+        .is_err());
+        assert!(windows_scheduler_spec(
+            Path::new("edda.exe"),
+            repository,
+            "0123456789abcdef0123456789abcdef"
+        )
+        .is_err());
+        assert!(windows_scheduler_spec(
+            executable,
+            Path::new("repo"),
+            "0123456789abcdef0123456789abcdef"
+        )
+        .is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn scheduler_renderer_rejects_non_unicode_paths() {
+        use std::os::windows::ffi::OsStringExt;
+
+        let invalid = std::ffi::OsString::from_wide(&[b'C' as u16, b':' as u16, 0xd800]);
+        assert!(windows_scheduler_spec(
+            Path::new(r"C:\edda\edda.exe"),
+            Path::new(&invalid),
+            "0123456789abcdef0123456789abcdef"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn scheduler_query_classifier_accepts_only_success_and_verified_missing_hresult() {
+        let present = SchedulerOutput::for_test(0, "xml", "");
+        assert_eq!(
+            classify_scheduler_query(&present).expect("present"),
+            SchedulerTaskState::Present
+        );
+        let missing = SchedulerOutput::for_test(MISSING_TASK_HRESULT, "", "missing");
+        assert_eq!(
+            classify_scheduler_query(&missing).expect("missing"),
+            SchedulerTaskState::Missing
+        );
+        for code in [5, 0x8007_0005, 0xdead_beef] {
+            let error = classify_scheduler_query(&SchedulerOutput::for_test(code, "", "failure"))
+                .expect_err("non-missing failures remain errors")
+                .to_string();
+            assert!(error.contains(&format!("0x{code:08x}")));
+            assert!(error.contains(&(code as i32).to_string()));
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn scheduler_lifecycle_is_explicitly_unsupported_off_windows() {
+        let error = scheduler_lifecycle(Path::new("/tmp/repo"), true)
+            .expect_err("non-Windows scheduler must fail")
+            .to_string();
+        assert!(error.contains("supported only on Windows"));
+    }
+
+    #[test]
+    fn scheduler_repo_reentry_requires_absolute_existing_path_and_resolves_main_worktree(
+    ) -> anyhow::Result<()> {
+        assert!(canonical_main_repo(Path::new("relative/repo")).is_err());
+        let dir = tempfile::tempdir()?;
+        assert!(canonical_main_repo(&dir.path().join("missing")).is_err());
+
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(repo.join(".git").join("worktrees").join("scheduler"))?;
+        let worktree = dir.path().join("linked worktree");
+        std::fs::create_dir_all(&worktree)?;
+        let gitdir = repo.join(".git").join("worktrees").join("scheduler");
+        std::fs::write(
+            worktree.join(".git"),
+            format!("gitdir: {}", gitdir.canonicalize()?.display()),
+        )?;
+
+        assert_eq!(canonical_main_repo(&worktree)?, repo.canonicalize()?);
+        assert_eq!(
+            edda_store::project_id(&worktree),
+            edda_store::project_id(&repo)
+        );
+        Ok(())
     }
 
     #[cfg(windows)]

--- a/crates/edda-store/src/lib.rs
+++ b/crates/edda-store/src/lib.rs
@@ -16,7 +16,12 @@ use std::path::{Path, PathBuf};
 pub fn project_id(repo_root_or_cwd: &Path) -> String {
     let resolved = edda_core::git::resolve_git_root(repo_root_or_cwd)
         .unwrap_or_else(|| repo_root_or_cwd.to_path_buf());
-    let normalized = normalize_path(&resolved);
+    project_id_for_root(&resolved)
+}
+
+/// Compute a deterministic project ID from an already-resolved authoritative root.
+pub fn project_id_for_root(root: &Path) -> String {
+    let normalized = normalize_path(root);
     let hash = blake3::hash(normalized.as_bytes());
     hash.to_hex()[..32].to_string()
 }
@@ -114,6 +119,20 @@ mod tests {
         assert_eq!(id1, id2);
         assert_eq!(id1.len(), 32);
         assert!(id1.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn project_id_for_root_does_not_follow_an_unrelated_ancestor_git_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let parent = tmp.path().join("parent");
+        let nested = parent.join("nested-edda");
+        fs::create_dir_all(parent.join(".git")).unwrap();
+        fs::create_dir_all(&nested).unwrap();
+
+        let nested_id = project_id_for_root(&nested);
+        assert_eq!(nested_id, project_id_for_root(&nested));
+        assert_ne!(nested_id, project_id(&nested));
+        assert_eq!(project_id(&nested), project_id(&parent));
     }
 
     #[test]

--- a/docs/plan/task-rail/P2_DRILL_2026-08-16.md
+++ b/docs/plan/task-rail/P2_DRILL_2026-08-16.md
@@ -1,18 +1,108 @@
 # Task Rail P2 controller-loss drill — 2026-08-16
 
-> Status: **RAN: RED / EXACT-TASK CLEANUP PASS / BLOCKED.** A fresh preserved
-> rerun at Round 6 reviewed SHA
-> `3a26ff989c8be0a577435f4e5b6bbee4d22280bb` proved the local exact-name
-> missing result, then stopped at the first install: `schtasks.exe` created the
-> exact task, but Edda rejected the task's returned Query XML because its
-> `<Command>` contained the quoted canonical executable. The exact task was
-> uninstalled and a final exact-name query again returned `0x80070002`. The
-> lifecycle did not reach reinstall/idempotence, and D1–D8 were not started.
-> Prior incomplete/RED runs remain documented below. A subsequent local product
-> fix exists at `69140a065c937bcbf74dd9196422cc087729af43`, directly on the
-> reviewed parent, but it has not received a new immutable review or passed a
-> live lifecycle rerun. Task #50 therefore stays running; the fix is not drill
-> acceptance evidence and no future PASS is implied here.
+> Status: **RAN: RED / LIFECYCLE PASS / D1 PRODUCT PATH PASS BUT EVIDENCE
+> HARNESS RED / D2–D8 NOT RUN / EXACT-TASK CLEANUP PASS / BLOCKED.** The fresh
+> Round 8 run proved the complete exact-name Scheduler lifecycle and exercised
+> a native-Codex two-step DAG through controller loss and scheduled successor
+> completion. It is not accepted: the corrected controller-launch capture
+> process observed killed-process exit `-1` and then failed while converting it
+> to `UInt32`, so it did not emit the required final signed-plus-hex transition
+> artifact. Per the bounded stop contract, no second workaround/retry and no
+> D2–D8 followed. Task #50 stays running and no PASS is implied.
+
+## Fresh Round 8 run — `20260817T021129Z`
+
+Status: **RAN: RED / STOPPED AFTER D1 EVIDENCE-HARNESS FAILURE**
+
+### Frozen authority and run identity
+
+| Field | RAN / READ evidence |
+|---|---|
+| Drill-authority full SHA | clean local HEAD, tracking ref, remote branch, and PR #473 head all `14901f54282212a85842f1aa82765fbf6e81254a` |
+| Review / CI | [Code Review Round 8](https://github.com/fagemx/edda/pull/473#issuecomment-5310977062), LGTM for drills only, P0=0/P1=0; Actions `31986212945`, 7/7 PASS |
+| Authoritative Task #47 runbook | copied before action to `C:\ai_agent\edda-drills\20260817T021129Z\raw\task47-authoritative-runbook.txt`; 12,416 bytes; SHA-256 `CA3A89E592BD6F06F98195C1AACEB81BA94EA535042CBF1C411528CF849FE418`; captured by `006-runbook-sha256.*` |
+| Fresh preserved root | `C:\ai_agent\edda-drills\20260817T021129Z`; prior roots were not changed |
+| Isolated target / TEMP | `C:\ai_agent\edda-target-gh466-drill-20260817T021129Z`; `C:\ai_agent\edda-temp-gh466-drill-20260817T021129Z` |
+| Exact Edda | release build from the reviewed source, `edda 0.3.0`; SHA-256 `8EBD88588D8A0891E918EBCE180B9667C19B83386D3EEAC94258DC827702E4CA`; `007-build-exact-edda-release.*`, `008-edda-version.*` |
+| Direct native Codex | `codex-cli 0.147.0`; vendor `codex.exe` SHA-256 `935A1911ED2556E4FFCEC995F4886AC2AC425863BA26FED264DF62E30272AD9D`; direct `--version` and login status were run |
+| Disposable repo / initial HEAD / D1-retry basis | `C:\ai_agent\edda-drills\20260817T021129Z\repo with spaces`; `6e09f764b67426d54b7c82339429a065a41ba9de`; retry basis `0ede43ca010c622815c860787866ee4f9578793e` |
+| Project / exact Scheduler task | `5977ad81e49ff1137edc0c658f09495c` / `Edda-Reconcile-5977ad81e49ff1137edc0c658f09495c` |
+| Raw command carrier | `raw/manifest.jsonl`; direct `ProcessStartInfo.ArgumentList` capture records literal argv, cwd, UTC, PID, signed/hex exit, bounded stdout/stderr hashes, permission disposition, and requested path snapshots |
+
+The copied Codex selector first retained a failed WindowsApps-only search, then
+accepted the explicit already-known vendor candidate. The first runbook copy
+self-check also retained a Windows PowerShell `Get-FileHash` availability
+failure before direct `certutil.exe` captured the required hash. These occurred
+before Scheduler/PID action and are disclosed setup evidence, not product
+results.
+
+### Exact missing-HRESULT lifecycle — RAN: PASS
+
+Every Scheduler command addressed only the exact task above. No enumeration,
+wildcard, prefix query/delete, principal change, shell wrapper, elevation,
+password, or permission approval occurred.
+
+| Step | Result / raw artifact |
+|---|---|
+| Pre-query | exact `/Query /TN <exact> /XML /HRESULT` returned signed `-2147024894`, `0x80070002`; `025-lifecycle-pre-query-missing.*` |
+| Install 1 | exact reviewed Edda with repo, native Codex, `1/3/15` limits returned `0`; `026-lifecycle-install-1.*` |
+| Query / trust inspection | one direct `Exec`, `PT1M`, `InteractiveToken`, current-user SID, no forbidden principal/shell shape; content-addressed manifest SHA-256 `ADE4C6A3C8B8186B2DF6282AC2043786B7C8844F3209651997BBFBFBC5531D52`; `027`–`031` |
+| Reinstall | returned `0`, reused the same task, command, arguments, manifest path, bytes, hash, and unchanged artifact mtime; `032`–`036` |
+| Uninstall 1 / absence | returned `0`, removed the exact task and its proved manifest; exact post-query returned `0x80070002`; `037`–`038` |
+| Uninstall 2 / final absence | idempotent return `0`; exact final query returned `0x80070002`; `039`–`040` |
+
+### D1 first pair — RAN: PRODUCT PATH PASS / HARNESS-NONACCEPTING
+
+Tasks #1 and #2 each completed once with native Codex, receipts, clean commit
+worktrees, and scheduled successor dispatch. They are not acceptance evidence.
+Two capture defects delayed the exact controller PID stop until
+`2026-08-17T02:41:11Z`, after task #2 had already started. The immutable
+disclosure is `raw/d1-attempt1-harness-nonaccepting.json` (SHA-256
+`A239095D45874E9410292914DE10F6858438DE965E87E63704B4746E648DDD64`).
+The exact task was then uninstalled and `073-d1-attempt1-exact-query-missing.*`
+again proved `0x80070002` before the single corrected retry.
+
+### D1 corrected pair — RAN: PRODUCT PATH PASS / EVIDENCE RED / NOT ACCEPTED
+
+The corrected launch plan and its three helper hashes were captured before the
+process launch in `083-d1-retry-controller-launch-plan.*`; a fresh exact query
+proved Scheduler absence in `084-d1-retry-pre-query-missing.*`. New tasks and
+nonces were used:
+
+| Event | Durable result |
+|---|---|
+| Task A | #3 attempt 1; started `02:45:46.109514Z`; session `01a00d9c-6033-7073-b1a1-ec610c6d991d`; done `02:47:39.7562956Z`; commit `1b2ac8305b5bb805783445d5d46617263b4c9c23`; evidence SHA-256 `994B371D1083096B3AD8B0AA2DA8B9E0DE695EFB62B235BC229CC902A16465E4` |
+| Controller loss | launch record `controller-task-3-start.json`; exact PID `23460`, creation `02:45:45.317792Z`, executable/full argv/task/attempt/worktree proved; exact stop at `02:46:17.4639967Z`; no task #4 start existed; `d1-retry-controller-stop.json` SHA-256 `3BEE7E11F765323CCB207F36F04C15C5AB7BE3134A8CBC43D3F65D73510297FC` |
+| Post-loss Scheduler | exact verbose query recorded successful post-loss ticks; task #4 started only by the `02:48:01.4670888Z` tick; `088`, `090`, `094` |
+| Task B | #4 attempt 1; session `01a00d9e-75b1-7a73-ae47-70958175ecae`; done `02:49:49.767762Z`; receipt contains task #3 receipt; commit `45a7a02e529a91f5a1f255487d16a0f3d07ce731`; evidence SHA-256 `1B3216717F61710FA5A83A7D90A5EB21AD0984673602CA1A8A4D5369E3507B3D` |
+| Final product state | task list/events, Scheduler XML/verbose, Git worktrees/refs, both worktree HEAD/status records, evidence hashes, and read-only SQLite events/leases are preserved in `092`–`108` |
+
+This otherwise successful product path is **not accepted**. After PID `23460`
+was killed, the corrected `start-held-controller.ps1` observed process exit
+`-1` but failed while formatting it as `[uint32]`. It therefore returned exit
+1 with `Cannot convert value "-1" to type "System.UInt32"` and did not emit the
+required final artifact containing both signed and hex exit forms. The start
+and ownership/stop artifacts are intact, but they do not substitute for that
+missing transition record. `raw/d1-retry-evidence-harness-red.json` records the
+stop verdict; its task-#4 session transcription is corrected without rewriting
+the original by `raw/d1-retry-evidence-harness-red-correction.json`, whose
+authority is `092-d1-retry-final-task-list.stdout.txt`.
+
+Per the controller's one-retry stop rule, no further harness change or D1 retry
+was attempted. D2–D8 are **NOT RUN**. Exact Edda uninstall returned `0`, and
+`103-d1-retry-final-query-missing.*` proved final signed `-2147024894` /
+`0x80070002`. Native runners ended naturally. The repo, ledger, local commits,
+worktrees, dirty/untracked state, and all raw artifacts remain preserved; no
+reset, clean, forced checkout, worktree removal, branch deletion, push, PR
+mutation, merge, broad process action, or permission approval occurred.
+
+Task #50 remains running. A later authorized run must start from a newly
+reviewed immutable head or separately accepted drill-only evidence carrier and
+must prove D1 completely before D2–D8 may resume.
+
+## Prior Round 6 evidence
+
+The earlier incomplete/RED runs remain below unchanged.
 
 ## Fresh Round 6 rerun — `20260816T233003Z`
 

--- a/docs/plan/task-rail/P2_DRILL_2026-08-16.md
+++ b/docs/plan/task-rail/P2_DRILL_2026-08-16.md
@@ -1,18 +1,77 @@
 # Task Rail P2 controller-loss drill — 2026-08-16
 
-> Status: **RAN: RED / LIFECYCLE PASS / D1 PRODUCT PATH PASS BUT EVIDENCE
-> HARNESS RED / D2–D8 NOT RUN / EXACT-TASK CLEANUP PASS / BLOCKED.** The fresh
-> Round 8 run proved the complete exact-name Scheduler lifecycle and exercised
-> a native-Codex two-step DAG through controller loss and scheduled successor
-> completion. It is not accepted: the corrected controller-launch capture
-> process observed killed-process exit `-1` and then failed while converting it
-> to `UInt32`, so it did not emit the required final signed-plus-hex transition
-> artifact. Per the bounded stop contract, no second workaround/retry and no
-> D2–D8 followed. Task #50 stays running and no PASS is implied.
+> Status: **RAN: PASS / LIFECYCLE PASS / D1–D8 PASS / EXACT-TASK CLEANUP
+> PASS.** The issue-level evidence is accepted at reviewed product SHA
+> `14901f54282212a85842f1aa82765fbf6e81254a`. Task #82 independently accepted
+> corrected D1 with P0=0/P1=0; D2–D8 then ran against the same reviewed Edda
+> binary and are reconciled below. Historical RED checkpoints remain intact.
 
-## Fresh Round 8 run — `20260817T021129Z`
+## Final issue-level reconciliation — 2026-08-17
+
+Status: **RAN: PASS**. This section supersedes the top-level verdict of the
+historical stop record below; it does not rewrite or delete that record.
+
+### Authority and final boundaries
+
+| Field | Final evidence |
+|---|---|
+| Reviewed source / product | `14901f54282212a85842f1aa82765fbf6e81254a`; exact release `edda.exe` SHA-256 `8EBD88588D8A0891E918EBCE180B9667C19B83386D3EEAC94258DC827702E4CA` |
+| Native Codex | `codex-cli 0.147.0`; SHA-256 `935A1911ED2556E4FFCEC995F4886AC2AC425863BA26FED264DF62E30272AD9D` |
+| Preserved run / raw carrier | `C:\ai_agent\edda-drills\20260817T021129Z`; `raw/manifest.jsonl` contains literal argv, cwd, UTC, PID/exit, hashes, and permission disposition |
+| D1–D5 repo | `C:\ai_agent\edda-drills\20260817T021129Z\repo with spaces`; project `5977ad81e49ff1137edc0c658f09495c` |
+| D6–D8 isolated repo | `C:\ai_agent\edda-drills\20260817T021129Z\repo d6-d8 isolated`; project `8f14082dec8ccdf48a6f6728f8e6d3cf`; same reviewed binaries; `199`–`207` |
+| Scheduler final state | old project exact query `126` and isolated-project exact queries `206`, `247` all returned signed `-2147024894` / `0x80070002`; no enumeration or wildcard action |
+
+Issue #466 requires recorded drills, not one shared ledger. D6–D8 use the
+fresh isolated repo because a later `max-attempts=3` controller correctly made
+older tasks that had been terminal only under smaller drill-local caps eligible
+again. The contaminated shared-repo commands and events are preserved in
+`189`–`197d`; no history was removed or rewritten, and no further reconcile ran
+there. D2 acceptance remains pinned to its immutable cap-2 checkpoint
+`136`–`139`.
+
+### Drill verdicts
+
+| Drill | Verdict | RAN evidence |
+|---|---|---|
+| D1 — scheduled controller loss | **PASS / independently accepted** | Task #82 receipt: P0=0, P1=0, no blocking evidence gap. Corrected tasks #3/#4, native sessions `01a00d9c-6033-7073-b1a1-ec610c6d991d` / `01a00d9e-75b1-7a73-ae47-70958175ecae`, exact controller PID `23460` stopped before any #4 start, later Scheduler tick started #4, both receipts/commits/hashes present; `d1-retry-controller-stop.json`, `092`–`108`. The missing duplicate UInt32 formatting of killed exit `-1` is explicitly nonblocking at issue level. |
+| D2 — pre-session runner loss | **PASS** | Task #5 attempts 1/2 only at checkpoint; no `task.session`; exact runner PIDs `46924` / `52564` passed executable/full-argv/task/attempt/lease/worktree gates, were individually stopped, and their verified descendants exited naturally. One reconcile created exactly one attempt 2; bounded terminal state and empty leases; `128`–`139`, `d2-attempt1-runner-stop.json`, `d2-attempt2-runner-stop.json`. |
+| D3 — dirty native resume | **PASS** | Task #6 attempt 1, native thread `01a00dc3-8a88-7c61-a48a-52c0a7375867`; exact runner PID `62348` stopped after session and dirty/untracked capture. After natural expiry one reconcile resumed the same attempt/thread. Tracked SHA-256 `F6C7A0A3B8899F1D98CE6F5AE43C958C8708747735218E1331510125D51EF500` and untracked SHA-256 `4F5E3B13D8911CBAC70C7AC318B747D04459967E93352D892AEE24E7273052A3` remained unchanged; `143`–`154`. |
+| D4 — concurrent reconcilers | **PASS** | Corrected task #8: controller PID `65044` interval `03:36:51.4727066Z`–`03:36:51.8449118Z` overlapped PID `86460` interval `03:36:51.4993328Z`–`03:36:51.8566272Z`; only controller A dispatched. Exactly one start/session/lease/runner existed; `160`–`167`, `d4-retry-controllers-final.json`. Invalid task #7 attempt `155`–`159` is retained: the first harness queried WMI before launching B, so it never exercised concurrency and does not count. |
+| D5 — live overlapping claim | **PASS** | Tasks #9/#10; live session `gh466-d5-20260817T021129Z`, configured TTL 120 seconds, claim `src/shared/b/**`. #9 terminated and freed its slot, heartbeat was touched, and a second reconcile still left #10 ready with attempts 0 and zero starts. Explicit unclaim plus heartbeat removal preceded #10's single normal fixture run; `168`–`187`. |
+| D6 — bounded no-receipt retry | **PASS** | Fresh isolated task #1 under consistent cap 3: each attempt 1/2/3 had exactly one start, session, current lease, exact runner, and `ended-without-receipt`; exactly two requeues. Fourth same-config reconcile `216` produced no output, no attempt 4, and no runner; leases empty; `199`–`221`, `d6-isolated-attempt{1,2,3}-gate.json`. |
+| D7 — stale verifier SHA | **PASS** | Owned branch/worktree preserved commit A `d256a3b436a2f0cb0f14f846d3174c048c7bc2f2`, verifier task #2 receipt `LGTM P0=0 P1=0` pinned to full A, then authorized local commit B `a9f180d56a37d1553512ac195427f16825660338`. A is an ancestor of B, `A..B` is nonempty, and `HEAD == B != A`; stale verdict assertion `235`; full carrier `222`–`240`. |
+| D8 — controller reconstruction | **PASS** | Controller PID `98052` produced a canonical 6,000-byte board SHA-256 `99113A25387D4BFA29E36DF75600C4D03BAC53C63031B7F1F5576772A8A13188` from ledger/task and Git surfaces, then waited. Exact PID/executable/creation/full-argv/output-hash gate stopped only that PID (`244`). Fresh PID `48912`, given only the script plus Edda/repo/output arguments and no prior board/chat/env input, reproduced byte-identical content; `241`–`248`, `d8-byte-identity.json`. |
+
+### Disclosed non-product harness records
+
+- Fake App Server modes passed an offline protocol self-test before dispatch;
+  `125`. No fake log contains a permission request.
+- D4's first harness launch (`155`–`159`) never launched controller B and is
+  not counted. The one authorized retry passed after an offline launch-order
+  self-test (`160`).
+- The first shared-repo D6 setup (`189`–`197d`) reused a larger retry cap and
+  reactivated older failed tasks. Those events are invalid drill contamination,
+  not a product failure or D2 retroactive failure. The isolated rerun is the D6
+  acceptance carrier.
+- D8 stop attempts `242` and `243` refused before any process action because
+  PowerShell JSON timestamp formatting/parsing changed only the representation
+  of the already-matched creation instant. `244` compares the same UTC
+  `DateTime` identity while retaining PID, executable, complete command line,
+  repo, output, and board-hash gates; it stopped the same PID.
+
+Across accepted drills there was no reset, clean, forced checkout, destructive
+worktree removal, branch deletion, permission approval, scheduler wildcard or
+enumeration, broad process kill, push, PR mutation, or merge. Dirty/untracked
+D3 bytes and all fixture worktrees, commits, refs, ledgers, logs, and raw
+artifacts remain preserved.
+
+## Fresh Round 8 initial stop record — `20260817T021129Z`
 
 Status: **RAN: RED / STOPPED AFTER D1 EVIDENCE-HARNESS FAILURE**
+
+This is the immutable historical checkpoint before Task #82's proportional D1
+acceptance and the authorized D2–D8 continuation reconciled above.
 
 ### Frozen authority and run identity
 

--- a/docs/plan/task-rail/P2_DRILL_2026-08-16.md
+++ b/docs/plan/task-rail/P2_DRILL_2026-08-16.md
@@ -1,9 +1,11 @@
 # Task Rail P2 controller-loss drill — 2026-08-16
 
-> Status: **BLOCKED — implementation code review required before machine
-> mutation.** This file is the pre-drill evidence skeleton. No scheduler task
-> was queried, created, run, or deleted; no process was terminated; no drill
-> result is claimed.
+> Status: **PARTIAL RAN / BLOCKED.** The exact-name missing-HRESULT
+> lifecycle passed at reviewed SHA `2150318f52301870f7dc976139b0af7105a0fcb9`.
+> D1 then exposed a scheduler re-entry product defect and stopped RED. D1 is
+> incomplete and D2–D8 were not started. The scheduler task was removed; one
+> fully identified controller PID was terminated, while an unbound child was
+> deliberately not terminated because it did not meet the identity boundary.
 
 ## Fixed safety boundary
 
@@ -20,79 +22,157 @@
   scheduler XML, ledger rows, session/receipt evidence, Git refs/status, and
   before/after file hashes. Label source inspection `READ` and execution `RAN`.
 
-## Frozen implementation gate
+## Frozen implementation gate and run identity
 
 | Field | Evidence |
 |---|---|
-| Reviewed full SHA | PENDING |
-| PR current-head LGTM | PENDING |
-| P0 / P1 | PENDING |
-| `cargo fmt --check` | PENDING |
-| `cargo clippy --workspace --all-targets -- -D warnings` | PENDING |
-| `cargo test --workspace --no-fail-fast` | PENDING |
-| Exact-head GitHub Actions | PENDING |
+| Reviewed full SHA used for the drill | `2150318f52301870f7dc976139b0af7105a0fcb9` |
+| Round 2 current-head LGTM | [P0=0 / P1=0](https://github.com/fagemx/edda/pull/473#issuecomment-5308042562) |
+| Local required gates | fmt, workspace clippy, scheduler, serial edda, and serial workspace tests: PASS |
+| Exact-head GitHub Actions | [run 31953396279](https://github.com/fagemx/edda/actions/runs/31953396279): 7/7 PASS |
+| Exact binary | `C:\ai_agent\edda-target-gh466-drill\debug\edda.exe` |
+| Binary SHA-256 | `ECE94BF3062EB2DA33B6B349A2C117CF3762D58E3D083B2623D04B09E985F584` |
+| Disposable repository | `C:\ai_agent\edda-drills\20260816T150212Z` |
+| Repository Git identity | initial `a7b0e5a6ac9f463382a9eaa4910fb70e156bb6f5`; D1 briefs `5c2315de409f5e724e6933cc57d361762d7df254` |
+| Project / exact task | `cdfebec7ac488ab471223e055e60f664` / `Edda-Reconcile-cdfebec7ac488ab471223e055e60f664` |
+| Windows identity | `DESKTOP-4T5S030\synvoke`; Windows NT `10.0.26200.0` |
 
-No section below may change from `BLOCKED` until the reviewed SHA is immutable
-and the PR contains the required SHA-pinned LGTM round.
+The D1 failure required a code correction. SHA
+`06ea4348ab9503119b91781eb6464951e73cb5a0` preserves the selected Codex binary
+and reconcile limits in `/TR`, but [Round 3](https://github.com/fagemx/edda/pull/473#issuecomment-5308289342)
+requested three P1 corrections. Actions run `31955711284` passed 6/7 and failed
+only the host-installation-dependent Windows test. No drill resumed at that
+SHA; a new immutable SHA and review are required before D1 may restart.
 
 ## Missing-task HRESULT lifecycle proof
 
-Status: **BLOCKED**
+Status: **RAN: PASS**
 
-Record the exact disposable repo, project/task id, binary path/hash/SHA,
-Windows user/context, and UTC start. Query only the exact task before Create,
-after Create, after Delete, and during a second idempotent uninstall. Preserve
-signed decimal and `u32` hex process codes plus bounded stdout/stderr and XML.
-The pre-create and post-delete missing codes must match. Only that observed code
-may classify absence; access denied and arbitrary failures remain errors.
+Only the exact task name above was addressed. Each absence query used
+`schtasks.exe /Query /TN <exact-task> /XML /HRESULT`; create/delete used the
+reviewed direct-argument lifecycle, without enumeration, wildcard, shell,
+elevation, password, or unrelated scheduler access.
+
+| Step | Observed result |
+|---|---|
+| Pre-create exact query | signed `-2147024894`, `u32 0x80070002`, bounded missing-task stderr |
+| First install | success; exact query returned XML |
+| Second install | success and idempotent; exact query returned the same XML |
+| First uninstall | success; post-delete query returned `-2147024894` / `0x80070002` |
+| Second uninstall | reported already absent; final exact query again returned `-2147024894` / `0x80070002` |
+
+The XML identified only the exact task, used `InteractiveToken`, `PT1M`, and
+`LIMITED`, and contained the exact reviewed `edda.exe` plus canonical repo in
+`/TR`; it contained no `SYSTEM`, `HIGHEST`, password, or shell wrapper. Thus
+only the observed `0x80070002` is classified as absence; arbitrary failures and
+access denied remain errors.
 
 ## D1 — scheduled two-step DAG with controller loss
 
-Status: **BLOCKED**. Required: scheduled successor completion after terminating
-only the verified controller PID; preserve scheduler Last Run/Result, ledger
-sequence, current session, receipts, worktree, and SHAs.
+Status: **RAN: RED / BLOCKED**. The intended successor-completion assertion was
+not reached. Tasks were created at Git `5c2315de409f5e724e6933cc57d361762d7df254`:
+
+- task #1 `D1 step 1`, scope `evidence/d1-step1.txt`;
+- task #2 `D1 scheduled successor`, dependent on #1, scope
+  `evidence/d1-step2.txt`.
+
+The exact scheduler task was installed at `2026-08-16T15:07:09Z` and fired
+naturally. The append-only ledger records:
+
+| Attempt | Started UTC | Failed UTC | Result |
+|---|---|---|---|
+| 1 | `15:08:04.7674383Z` | `15:08:06.0337642Z` | `runner-failed: Codex App Server spawn: failed to spawn Codex App Server: program not found` |
+| 2 | `15:08:07.0358955Z` | `15:08:07.5590169Z` | same runner failure |
+| 3 | `15:08:08.7753531Z` | `15:08:09.4677973Z` | same runner failure |
+| 4 (manual bounded check) | `15:08:42.7996651Z` | `15:08:43.3164378Z` | `retry-cap-exhausted` |
+
+Attempts 1–3 preserved separate worktrees under
+`C:\ai_agent\edda-drills\.edda-worktrees\20260816T150212Z-task-1-attempt-{1,2,3}`.
+No `task.session` was written, task #1 never completed, and dependent task #2
+remained blocked.
+
+Root cause: the reviewed scheduler `/TR` persisted only `edda.exe reconcile
+--repo <repo>`. Scheduler lifecycle returned before `ReconcileConfig` was
+materialized, so it dropped `--codex-bin`, max workers/attempts, and lease TTL.
+With `EDDA_CODEX_BIN` unset, scheduled re-entry selected bare `codex`; the
+no-shell App Server spawn could not execute the extensionless npm shim although
+a native `codex.exe` existed at the explicit path.
+
+### Controller-loss and process boundary evidence
+
+- The first controller launch failed on argument quoting with `unexpected
+  argument 'D1'`; this failed start is preserved in
+  `runtime/d1-controller.stderr.log` and was not hidden.
+- The corrected controller was native Codex PID `47556`. Before termination,
+  its executable and complete command line matched task #1, attempt 1, and
+  worktree
+  `C:\ai_agent\edda-drills\.edda-worktrees\20260816T150212Z-task-1-attempt-1`.
+  Only PID `47556` was terminated and it was verified gone at
+  `2026-08-16T15:09:43Z`.
+- Command-runner PID `93096` and its PowerShell sleep child were not terminated:
+  their command lines did not carry both task and worktree identity. They were
+  left to expire naturally. No name-wide termination was used.
+- Controller stdout/stderr and runner logs remain under `runtime/`; exact task
+  events remain in `.edda/ledger.db`. The disposable repository and all three
+  worktrees are preserved.
+
+After RED, the exact scheduler task was uninstalled at
+`2026-08-16T15:09:17Z`; its exact-name query returned the verified absence code
+`0x80070002`. No product code was patched under the drill task, and no further
+drill began.
 
 ## D2 — death before session binding
 
-Status: **BLOCKED**. Required: terminate the verified runner after started +
-lease but before session; after natural expiry prove exactly one replacement
-attempt and no duplicate start.
+Status: **BLOCKED / NOT RUN**. Required: terminate the verified runner after
+started + lease but before session; after natural expiry prove exactly one
+replacement attempt and no duplicate start.
 
 ## D3 — death after binding and mid-change
 
-Status: **BLOCKED**. Required: preserve pre-kill commits, dirty paths, untracked
-paths, and hashes; prove same-attempt resume or a deterministic separate
-replacement worktree without losing a byte.
+Status: **BLOCKED / NOT RUN**. Required: preserve pre-kill commits, dirty paths,
+untracked paths, and hashes; prove same-attempt resume or a deterministic
+separate replacement worktree without losing a byte.
 
 ## D4 — concurrent reconcilers
 
-Status: **BLOCKED**. Required: two concurrent real PIDs/timestamps/output and
-exactly one current attempt, lease, and runner.
+Status: **BLOCKED / NOT RUN**. Required: two concurrent real PIDs/timestamps/
+output and exactly one current attempt, lease, and runner.
 
 ## D5 — scope/live-claim exclusion
 
-Status: **BLOCKED**. Required: overlapping task remains ready/blocked with no
-started event while the real claim is live; stale claims expire naturally.
+Status: **BLOCKED / NOT RUN**. Required: overlapping task remains ready/blocked
+with no started event while the real claim is live; stale claims expire
+naturally.
 
 ## D6 — no receipt and bounded retry
 
-Status: **BLOCKED**. Required: each attempt records turn, failure, requeue, and
-lease lifecycle; after the cap, one extra reconcile produces no later start.
+Status: **BLOCKED / NOT RUN**. Required: each attempt records turn, failure,
+requeue, and lease lifecycle; after the cap, one extra reconcile produces no
+later start.
 
 ## D7 — verdict invalidation
 
-Status: **BLOCKED**. Required: preserve SHA A verdict, authorized local commit
-B, and the exact A..B diff proving the A verdict is invalid for B.
+Status: **BLOCKED / NOT RUN**. Required: preserve SHA A verdict, authorized
+local commit B, and the exact A..B diff proving the A verdict is invalid for B.
 
 ## D8 — fresh-controller reconstruction
 
-Status: **BLOCKED**. Required: after terminating only the verified controller,
-reconstruct normalized board/ledger/Git state from durable state alone and
-compare deterministically without chat or transcript evidence.
+Status: **BLOCKED / NOT RUN**. Required: after terminating only the verified
+controller, reconstruct normalized board/ledger/Git state from durable state
+alone and compare deterministically without chat or transcript evidence.
 
 ## Cleanup and release verdict
 
-Status: **BLOCKED**. Preserve before/after exact-name queries, prove the drill
-task is absent, prove identified terminated PIDs are gone, and prove unrelated
-scheduler/process/Git state was untouched. P2 remains not release-accepted
-unless all eight drills and the missing-HRESULT proof are `RAN: PASS`.
+Status: **PARTIAL CLEANUP PASS / RELEASE BLOCKED**.
+
+- The only scheduler task touched was the computed exact task; it is absent by
+  exact-name `0x80070002` query.
+- The sole authorized terminated PID, `47556`, is gone. PID `93096` and its
+  child were deliberately left alone because their identity was insufficient;
+  they were allowed to expire naturally.
+- The disposable repo, dirty ledger/log evidence, Git refs, and attempt
+  worktrees remain preserved. No unrelated scheduler, process, or Git state was
+  queried or mutated.
+
+P2 is not release-accepted: D1 must be rerun from a newly reviewed immutable
+head, and D1–D8 must all reach `RAN: PASS` before release.

--- a/docs/plan/task-rail/P2_DRILL_2026-08-16.md
+++ b/docs/plan/task-rail/P2_DRILL_2026-08-16.md
@@ -1,0 +1,98 @@
+# Task Rail P2 controller-loss drill — 2026-08-16
+
+> Status: **BLOCKED — implementation code review required before machine
+> mutation.** This file is the pre-drill evidence skeleton. No scheduler task
+> was queried, created, run, or deleted; no process was terminated; no drill
+> result is claimed.
+
+## Fixed safety boundary
+
+- Use one disposable isolated repository and its exact computed
+  `Edda-Reconcile-<32-lowercase-hex-project-id>` task only.
+- Never enumerate or delete by wildcard/prefix; never use `SYSTEM`, `HIGHEST`,
+  passwords, shell wrappers, or name-wide process termination.
+- Before terminating a process, record and match its PID, executable, complete
+  command line, task id, attempt, and worktree. Terminate only that PID.
+- Never run `git reset`, `git clean`, forced checkout, destructive worktree
+  removal, branch deletion, permission auto-approval, push, or merge during a
+  drill.
+- Preserve exact commands, UTC timestamps, bounded stdout/stderr, exit codes,
+  scheduler XML, ledger rows, session/receipt evidence, Git refs/status, and
+  before/after file hashes. Label source inspection `READ` and execution `RAN`.
+
+## Frozen implementation gate
+
+| Field | Evidence |
+|---|---|
+| Reviewed full SHA | PENDING |
+| PR current-head LGTM | PENDING |
+| P0 / P1 | PENDING |
+| `cargo fmt --check` | PENDING |
+| `cargo clippy --workspace --all-targets -- -D warnings` | PENDING |
+| `cargo test --workspace --no-fail-fast` | PENDING |
+| Exact-head GitHub Actions | PENDING |
+
+No section below may change from `BLOCKED` until the reviewed SHA is immutable
+and the PR contains the required SHA-pinned LGTM round.
+
+## Missing-task HRESULT lifecycle proof
+
+Status: **BLOCKED**
+
+Record the exact disposable repo, project/task id, binary path/hash/SHA,
+Windows user/context, and UTC start. Query only the exact task before Create,
+after Create, after Delete, and during a second idempotent uninstall. Preserve
+signed decimal and `u32` hex process codes plus bounded stdout/stderr and XML.
+The pre-create and post-delete missing codes must match. Only that observed code
+may classify absence; access denied and arbitrary failures remain errors.
+
+## D1 — scheduled two-step DAG with controller loss
+
+Status: **BLOCKED**. Required: scheduled successor completion after terminating
+only the verified controller PID; preserve scheduler Last Run/Result, ledger
+sequence, current session, receipts, worktree, and SHAs.
+
+## D2 — death before session binding
+
+Status: **BLOCKED**. Required: terminate the verified runner after started +
+lease but before session; after natural expiry prove exactly one replacement
+attempt and no duplicate start.
+
+## D3 — death after binding and mid-change
+
+Status: **BLOCKED**. Required: preserve pre-kill commits, dirty paths, untracked
+paths, and hashes; prove same-attempt resume or a deterministic separate
+replacement worktree without losing a byte.
+
+## D4 — concurrent reconcilers
+
+Status: **BLOCKED**. Required: two concurrent real PIDs/timestamps/output and
+exactly one current attempt, lease, and runner.
+
+## D5 — scope/live-claim exclusion
+
+Status: **BLOCKED**. Required: overlapping task remains ready/blocked with no
+started event while the real claim is live; stale claims expire naturally.
+
+## D6 — no receipt and bounded retry
+
+Status: **BLOCKED**. Required: each attempt records turn, failure, requeue, and
+lease lifecycle; after the cap, one extra reconcile produces no later start.
+
+## D7 — verdict invalidation
+
+Status: **BLOCKED**. Required: preserve SHA A verdict, authorized local commit
+B, and the exact A..B diff proving the A verdict is invalid for B.
+
+## D8 — fresh-controller reconstruction
+
+Status: **BLOCKED**. Required: after terminating only the verified controller,
+reconstruct normalized board/ledger/Git state from durable state alone and
+compare deterministically without chat or transcript evidence.
+
+## Cleanup and release verdict
+
+Status: **BLOCKED**. Preserve before/after exact-name queries, prove the drill
+task is absent, prove identified terminated PIDs are gone, and prove unrelated
+scheduler/process/Git state was untouched. P2 remains not release-accepted
+unless all eight drills and the missing-HRESULT proof are `RAN: PASS`.

--- a/docs/plan/task-rail/P2_DRILL_2026-08-16.md
+++ b/docs/plan/task-rail/P2_DRILL_2026-08-16.md
@@ -1,11 +1,13 @@
 # Task Rail P2 controller-loss drill — 2026-08-16
 
-> Status: **PARTIAL RAN / BLOCKED.** The exact-name missing-HRESULT
-> lifecycle passed at reviewed SHA `2150318f52301870f7dc976139b0af7105a0fcb9`.
-> D1 then exposed a scheduler re-entry product defect and stopped RED. D1 is
-> incomplete and D2–D8 were not started. The scheduler task was removed; one
-> fully identified controller PID was terminated, while an unbound child was
-> deliberately not terminated because it did not meet the identity boundary.
+> Status: **PARTIAL RAN / EVIDENCE INCOMPLETE / BLOCKED.** The exact-name
+> missing-HRESULT lifecycle and part of D1 were executed at reviewed SHA
+> `2150318f52301870f7dc976139b0af7105a0fcb9`, but the lifecycle raw transcript
+> was not persisted. D1 then exposed a scheduler re-entry product defect and
+> stopped RED. Ledger events and controller logs survive; scheduler and process
+> observations survive only as summaries. Therefore neither the lifecycle nor
+> D1 is acceptance proof, D2–D8 were not started, and an authorized rerun from a
+> newly reviewed head is required.
 
 ## Fixed safety boundary
 
@@ -46,38 +48,39 @@ SHA; a new immutable SHA and review are required before D1 may restart.
 
 ## Missing-task HRESULT lifecycle proof
 
-Status: **RAN: PASS**
+Status: **RAN: EVIDENCE INCOMPLETE / BLOCKED**
 
-Only the exact task name above was addressed. Each absence query used
-`schtasks.exe /Query /TN <exact-task> /XML /HRESULT`; create/delete used the
-reviewed direct-argument lifecycle, without enumeration, wildcard, shell,
-elevation, password, or unrelated scheduler access.
+The executor reported that only the exact task name above was addressed and
+that pre-create, post-delete, and final absence queries returned signed
+`-2147024894` / `u32 0x80070002`. It also reported two successful idempotent
+installs, two uninstalls, and XML using `InteractiveToken`, `PT1M`, and
+`LIMITED`, without `SYSTEM`, `HIGHEST`, a password, or a shell wrapper.
 
-| Step | Observed result |
-|---|---|
-| Pre-create exact query | signed `-2147024894`, `u32 0x80070002`, bounded missing-task stderr |
-| First install | success; exact query returned XML |
-| Second install | success and idempotent; exact query returned the same XML |
-| First uninstall | success; post-delete query returned `-2147024894` / `0x80070002` |
-| Second uninstall | reported already absent; final exact query again returned `-2147024894` / `0x80070002` |
+Those observations are not accepted as proof. The preserved disposable repo
+contains no raw lifecycle artifact with:
 
-The XML identified only the exact task, used `InteractiveToken`, `PT1M`, and
-`LIMITED`, and contained the exact reviewed `edda.exe` plus canonical repo in
-`/TR`; it contained no `SYSTEM`, `HIGHEST`, password, or shell wrapper. Thus
-only the observed `0x80070002` is classified as absence; arbitrary failures and
-access denied remain errors.
+- the exact command argv and cwd for each lifecycle step;
+- per-step UTC, process exit code, and bounded stdout/stderr;
+- the successful exact-name Query XML before and after replacement;
+- a raw final exact-name absence query tying cleanup to the observed HRESULT.
+
+The prior `RAN: PASS` label is withdrawn. The lifecycle must be rerun after a
+new immutable-head review, with every field above durably captured before task
+deletion.
 
 ## D1 — scheduled two-step DAG with controller loss
 
-Status: **RAN: RED / BLOCKED**. The intended successor-completion assertion was
-not reached. Tasks were created at Git `5c2315de409f5e724e6933cc57d361762d7df254`:
+Status: **RAN: RED / EVIDENCE INCOMPLETE / BLOCKED**. The intended
+successor-completion assertion was not reached. Tasks were created at Git
+`5c2315de409f5e724e6933cc57d361762d7df254`:
 
 - task #1 `D1 step 1`, scope `evidence/d1-step1.txt`;
 - task #2 `D1 scheduled successor`, dependent on #1, scope
   `evidence/d1-step2.txt`.
 
-The exact scheduler task was installed at `2026-08-16T15:07:09Z` and fired
-naturally. The append-only ledger records:
+The executor reported that the exact scheduler task was installed at
+`2026-08-16T15:07:09Z` and fired naturally. Independently, the preserved
+append-only ledger records:
 
 | Attempt | Started UTC | Failed UTC | Result |
 |---|---|---|---|
@@ -100,26 +103,31 @@ a native `codex.exe` existed at the explicit path.
 
 ### Controller-loss and process boundary evidence
 
-- The first controller launch failed on argument quoting with `unexpected
-  argument 'D1'`; this failed start is preserved in
-  `runtime/d1-controller.stderr.log` and was not hidden.
-- The corrected controller was native Codex PID `47556`. Before termination,
-  its executable and complete command line matched task #1, attempt 1, and
-  worktree
-  `C:\ai_agent\edda-drills\.edda-worktrees\20260816T150212Z-task-1-attempt-1`.
-  Only PID `47556` was terminated and it was verified gone at
-  `2026-08-16T15:09:43Z`.
-- Command-runner PID `93096` and its PowerShell sleep child were not terminated:
-  their command lines did not carry both task and worktree identity. They were
-  left to expire naturally. No name-wide termination was used.
-- Controller stdout/stderr and runner logs remain under `runtime/`; exact task
-  events remain in `.edda/ledger.db`. The disposable repository and all three
-  worktrees are preserved.
+The preserved raw evidence is limited to `.edda/ledger.db`, Git refs/worktrees,
+and the files under `runtime/`. It proves the task events above and preserves
+the first controller quoting failure, `unexpected argument 'D1'`, plus the
+corrected controller's bounded stdout/stderr. It does not contain:
 
-After RED, the exact scheduler task was uninstalled at
-`2026-08-16T15:09:17Z`; its exact-name query returned the verified absence code
-`0x80070002`. No product code was patched under the drill task, and no further
-drill began.
+- the D1 scheduler Query XML, Last Run/Result, exact `/TR`, account/logon mode,
+  or config/permission disposition;
+- raw scheduler install/query/uninstall commands, cwd, UTC, exit codes, and
+  bounded stdout/stderr;
+- the pre-termination process inventory and complete command line used to bind
+  PID, task, attempt, executable, and worktree;
+- the exact PID termination command/result, post-termination absence check, or
+  evidence that the deliberately preserved child expired naturally.
+
+The executor summary reports that native Codex PID `47556` matched task #1,
+attempt 1, and worktree
+`C:\ai_agent\edda-drills\.edda-worktrees\20260816T150212Z-task-1-attempt-1`;
+that only PID `47556` was terminated and was gone at
+`2026-08-16T15:09:43Z`; and that PID `93096` plus its PowerShell sleep child
+were not terminated because they lacked task/worktree identity. It also reports
+that the exact scheduler task was uninstalled at `2026-08-16T15:09:17Z` and an
+exact-name query returned `0x80070002`. These are retained as disclosed run
+notes, not accepted proof.
+
+No product code was patched under the drill task, and no further drill began.
 
 ## D2 — death before session binding
 
@@ -163,16 +171,19 @@ alone and compare deterministically without chat or transcript evidence.
 
 ## Cleanup and release verdict
 
-Status: **PARTIAL CLEANUP PASS / RELEASE BLOCKED**.
+Status: **CLEANUP REPORTED / EVIDENCE INCOMPLETE / RELEASE BLOCKED**.
 
-- The only scheduler task touched was the computed exact task; it is absent by
-  exact-name `0x80070002` query.
-- The sole authorized terminated PID, `47556`, is gone. PID `93096` and its
-  child were deliberately left alone because their identity was insufficient;
-  they were allowed to expire naturally.
+- The executor reported that only the computed exact task was touched and that
+  its final exact-name query returned `0x80070002`; the raw query artifact is
+  absent.
+- The executor reported PID `47556` gone and PID `93096` plus its child left to
+  expire naturally; the raw process snapshots and final orphan check are
+  absent.
 - The disposable repo, dirty ledger/log evidence, Git refs, and attempt
-  worktrees remain preserved. No unrelated scheduler, process, or Git state was
-  queried or mutated.
+  worktrees remain preserved. The executor reported no unrelated scheduler,
+  process, or Git mutation, but the preserved artifacts do not independently
+  prove that negative.
 
-P2 is not release-accepted: D1 must be rerun from a newly reviewed immutable
-head, and D1–D8 must all reach `RAN: PASS` before release.
+P2 is not release-accepted: the lifecycle and D1 must be rerun from a newly
+reviewed immutable head with durable raw artifacts, and D1–D8 must all reach
+accepted `RAN: PASS` before release.

--- a/docs/plan/task-rail/P2_DRILL_2026-08-16.md
+++ b/docs/plan/task-rail/P2_DRILL_2026-08-16.md
@@ -1,13 +1,80 @@
 # Task Rail P2 controller-loss drill — 2026-08-16
 
-> Status: **PARTIAL RAN / EVIDENCE INCOMPLETE / BLOCKED.** The exact-name
-> missing-HRESULT lifecycle and part of D1 were executed at reviewed SHA
-> `2150318f52301870f7dc976139b0af7105a0fcb9`, but the lifecycle raw transcript
-> was not persisted. D1 then exposed a scheduler re-entry product defect and
-> stopped RED. Ledger events and controller logs survive; scheduler and process
-> observations survive only as summaries. Therefore neither the lifecycle nor
-> D1 is acceptance proof, D2–D8 were not started, and an authorized rerun from a
-> newly reviewed head is required.
+> Status: **RAN: RED / EXACT-TASK CLEANUP PASS / BLOCKED.** A fresh preserved
+> rerun at Round 6 reviewed SHA
+> `3a26ff989c8be0a577435f4e5b6bbee4d22280bb` proved the local exact-name
+> missing result, then stopped at the first install: `schtasks.exe` created the
+> exact task, but Edda rejected the task's returned Query XML because its
+> `<Command>` contained the quoted canonical executable. The exact task was
+> uninstalled and a final exact-name query again returned `0x80070002`. The
+> lifecycle did not reach reinstall/idempotence, and D1–D8 were not started.
+> Prior incomplete/RED runs remain documented below. A subsequent local product
+> fix exists at `69140a065c937bcbf74dd9196422cc087729af43`, directly on the
+> reviewed parent, but it has not received a new immutable review or passed a
+> live lifecycle rerun. Task #50 therefore stays running; the fix is not drill
+> acceptance evidence and no future PASS is implied here.
+
+## Fresh Round 6 rerun — `20260816T233003Z`
+
+Status: **RAN: RED / STOPPED AT FIRST INSTALL**
+
+### Frozen authority and run identity
+
+| Field | RAN evidence |
+|---|---|
+| Drill-authority full SHA | local, remote branch, and PR head all `3a26ff989c8be0a577435f4e5b6bbee4d22280bb`; clean source status before the run |
+| Review / CI | [Code Review Round 6](https://github.com/fagemx/edda/pull/473#issuecomment-5310200169), P0=0/P1=0; Actions `31977395218`, 7/7 PASS |
+| Subsequent local fix — not reviewed or rerun | `69140a065c937bcbf74dd9196422cc087729af43`, parent `3a26ff989c8be0a577435f4e5b6bbee4d22280bb`; addresses the quoted scheduler command comparison, but has no new immutable review or live lifecycle/D1–D8 evidence |
+| Authoritative Task #47 runbook | `C:\ai_agent\edda-drills\20260816T233003Z\raw\task47-authoritative-runbook.txt`; 12,416 bytes; SHA-256 `CA3A89E592BD6F06F98195C1AACEB81BA94EA535042CBF1C411528CF849FE418` |
+| Fresh preserved root | `C:\ai_agent\edda-drills\20260816T233003Z` |
+| Isolated build target / TEMP | `C:\ai_agent\edda-target-gh466-drill-20260816T233003Z`; `C:\ai_agent\edda-temp-gh466-drill-20260816T233003Z` |
+| Exact Edda binary | `C:\ai_agent\edda-target-gh466-drill-20260816T233003Z\debug\edda.exe`; `edda 0.3.0`; SHA-256 `F7E7C2599609C05BA9E4D353E8E14404C3CCC3670213C20E8F876E48978A7EE6` |
+| Direct native Codex | `C:\Users\synvoke\AppData\Roaming\npm\node_modules\@openai\codex\node_modules\@openai\codex-win32-x64\vendor\x86_64-pc-windows-msvc\bin\codex.exe`; `codex-cli 0.147.0`; SHA-256 `935A1911ED2556E4FFCEC995F4886AC2AC425863BA26FED264DF62E30272AD9D` |
+| Disposable repository / HEAD | `C:\ai_agent\edda-drills\20260816T233003Z\repo with spaces`; `5192278da55b687007dfbc18e830b7fc443b34dd` |
+| Project / exact task | `727badef3f8e0267c0dcab09388937be` / `Edda-Reconcile-727badef3f8e0267c0dcab09388937be` |
+| Host identity | `DESKTOP-4T5S030\synvoke`; Windows `10.0.26200`; captured at `raw/024-host-identity.*` |
+| Command evidence manifest | `C:\ai_agent\edda-drills\20260816T233003Z\raw\manifest.jsonl`; every captured child records literal argv, cwd, UTC start/end, PID, signed/hex exit, bounded stdout/stderr hashes, file snapshots, and permission disposition |
+
+The capture harness initially recorded two setup-only failures before any
+scheduler or PID action: an array-binding self-test and unsupported
+`New-Item -LiteralPath`. Both artifacts are retained; the harness was corrected
+and rerun successfully. Native Codex selection also retained the inaccessible
+WindowsApps candidate before selecting and directly executing the vendor
+binary. These are disclosed setup evidence, not product results.
+
+### Missing-HRESULT lifecycle RED
+
+All scheduler operations addressed only the exact task above. No enumeration,
+wildcard, prefix query/delete, principal change, shell wrapper, permission
+approval, or PID termination occurred.
+
+| Step | Literal command / result | Raw artifact |
+|---|---|---|
+| Pre-Query | `schtasks.exe /Query /TN Edda-Reconcile-727badef3f8e0267c0dcab09388937be /XML /HRESULT` → signed `-2147024894`, `0x80070002` | `raw/027-lifecycle-pre-query-missing.meta.json` SHA-256 `8EBDD51C6FE7AA41DFAFC7B4042A59F3481FB6E7360030C819490BB49F2F7C47`; stderr SHA-256 `E4C99E16DF130A5146F7234FF24E4D6ECD7E53C655D4A89074C872F8C041B27D` |
+| Install 1 | exact Edda `reconcile --repo <repo> --max-workers 1 --max-attempts 3 --lease-ttl-s 15 --codex-bin <native.exe> --install-scheduler` → exit `1` | `raw/028-lifecycle-install-1.meta.json` SHA-256 `FC5B4ECF1211E5BD5A5DDB77B57F63B54D4118A7169D1851DA26B4BE410056EF`; stderr SHA-256 `4FEE60C621085BA6D1332380E8D4002649F375945238FBEC5A4C305D4C3EC51B` |
+| Exact post-RED Query XML | exact `/Query /TN <exact> /XML /HRESULT` → exit `0`; one-minute `PT1M`, `InteractiveToken`, exact current-user SID, direct manifest-only action | `raw/029-red-exact-query-xml.stdout.txt` SHA-256 `B5116140E1F35D8B9C2BC8CC3EE556343A759DEC84AF00B9D0D97A99BD037C59` |
+| Exact verbose Query | exact `/Query /TN <exact> /V /FO LIST /HRESULT` → exit `0`; Last Run was the never-run placeholder, Last Result `267011`, current user, interactive logon, exact `/TR` | `raw/030-red-exact-query-verbose.stdout.txt` SHA-256 `C1AD43A272C3A0E44837208E5B6462852F3AC3028EB9937F90BB62FFDDE1ED02` |
+| Raw launch manifest | exact XML-referenced immutable file copied byte-for-byte before cleanup; schema/project/repo/Codex and `1/3/15` limits preserved | `raw/lifecycle-install-1.manifest.json`; 377 bytes; SHA-256 `A3EC23BD3C71EEA947467784D60831A793713DC2C089B5B0F6367C2B04E5EEA2` |
+| Exact uninstall | exact Edda `reconcile --repo <repo> --uninstall-scheduler` → exit `0`; task deleted; manifest conservatively retained because strict command recovery failed | `raw/032-red-exact-uninstall.meta.json` SHA-256 `DD06A1158E580B0F396B5DD2ED8A95088F6F92A70F8EA9C1F2610AF371D5B2B8`; stdout SHA-256 `D1BC11F625E70F34C8CEDFBFC3653A0A271F1CCB88A756CEA332F6C930466D52` |
+| Final exact Query | same exact-name `/XML /HRESULT` → signed `-2147024894`, `0x80070002` | `raw/033-red-final-query-missing.meta.json` SHA-256 `0066C357922C3F1AD817B4CA0BC286971D5D0134E5668BEB03E3AF467B48654B`; stderr SHA-256 `E4C99E16DF130A5146F7234FF24E4D6ECD7E53C655D4A89074C872F8C041B27D` |
+
+Root cause: the installed action's Query XML returned
+`<Command>"\\?\C:\...\edda.exe"</Command>`. Edda compared that literal quoted
+value with the unquoted canonical executable and reported `scheduler
+post-Create Query returned a different command`. Its cleanup check rejected
+the same strict shape, so the content-addressed manifest was intentionally
+retained rather than deleted under uncertainty. This is a product RED, not a
+permission or machine-policy failure.
+
+Per the stop contract, reinstall, lifecycle idempotence, the second uninstall,
+and D1–D8 were not run. No product workaround or patch was attempted. The
+disposable root, raw XML/verbose output, raw manifest, Git/Edda state, and
+command transcript remain preserved.
+
+The later local fix commit
+`69140a065c937bcbf74dd9196422cc087729af43` does not change this recorded
+result. It was not the binary exercised by this run and, as of this handoff,
+has not passed a new SHA-pinned review or authorized live scheduler lifecycle.
 
 ## Fixed safety boundary
 
@@ -24,7 +91,7 @@
   scheduler XML, ledger rows, session/receipt evidence, Git refs/status, and
   before/after file hashes. Label source inspection `READ` and execution `RAN`.
 
-## Frozen implementation gate and run identity
+## Prior `2150318f` attempt gate and run identity
 
 | Field | Evidence |
 |---|---|

--- a/docs/plan/task-rail/TASK_RAIL_V1.md
+++ b/docs/plan/task-rail/TASK_RAIL_V1.md
@@ -1,7 +1,9 @@
 # Task Rail v1: ledger-driven multi-agent handoff（conductor 升級案）
 
-> Status: **P1 implemented**（2026-07-14:`task.*` 事件 + 投影 + CLI 動詞 + Stop-hook nudge;
-> 驗收 drill 通過,存證 [P1_DRILL_2026-07-14.md](P1_DRILL_2026-07-14.md);P2+ 未動工）
+> Status: **P1 implemented; P2 implementation under review**（2026-07-14:`task.*`
+> 事件 + 投影 + CLI 動詞 + Stop-hook nudge;P1 驗收存證
+> [P1_DRILL_2026-07-14.md](P1_DRILL_2026-07-14.md)。P2 release gate 尚未通過，
+> 見 [P2_DRILL_2026-08-16.md](P2_DRILL_2026-08-16.md)）
 > Repo: `C:\ai_agent\edda`
 > Language: **Rust**（ACP client 以 Rust 重寫語義,不是搬 JS 碼)
 > 參考實作: `C:\ai_agent\bryti\adapters\session-acp.js`（ACP 傳輸層,已 live-verified）
@@ -138,7 +140,8 @@ edda task list / edda task show 13
 edda plan run release.md          # conductor DAG 糖衣(topo 已有)
 edda plan status                  # 一眼看整條 pipeline 卡在哪
 edda reconcile                    # 兜底掃描(排程器目標,亦可手跑)
-edda reconcile --install-scheduler  # 註冊 schtasks / cron
+edda reconcile --install-scheduler  # Windows: 註冊專案限定的 schtasks
+edda reconcile --uninstall-scheduler # Windows: 只移除該專案的精確 task 名稱
 ```
 
 Hooks(edda 已有的裝置直接沿用):
@@ -166,6 +169,14 @@ Hooks(edda 已有的裝置直接沿用):
 | **P2** | `edda reconcile` + 租約 + `--install-scheduler` | 中途 kill 掉執行者,N 分鐘內任務被重排並完成;冪等鍵擋住重複副作用 |
 | **P3** | ACP runner(spawn-on-finish + brief 注入 + 續跑) | A done → B 經 ACP 自起,無人介入;F7 剝除在巢狀 session 實測;win32 實測;`session/load` 續跑 drill 至少一個 agent 通過 |
 | **P4** | plan DAG 糖衣 + `edda watch` task board | 3 步驟 × 3 種 agent 的 pipeline 在 watch TUI 全程可視 |
+
+P2 的 Windows 排程器只是每分鐘喚醒同一個 one-shot reconciler；不新增
+daemon 或第二份狀態。安裝/移除必須由 operator 明確呼叫，採目前使用者的
+`LIMITED` context，task 名稱固定為
+`Edda-Reconcile-<32-lowercase-hex-project-id>`。重裝以 `/F` 更新同一名稱，
+移除先查詢再只刪除該精確名稱；兩者都不會殺掉正在執行的 process。
+八個 real-process drills 與 missing-task HRESULT 的本機證明未完成前，P2
+仍是 **not release-accepted**。
 
 護欄(全期適用):auto-spawn 是 **opt-in**,每小時 spawn 上限 + 每任務
 attempt 上限——沿用 edda「LLM 花費一律 budget-capped」哲學。

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -288,9 +288,10 @@ directly under the current user with `LIMITED`; it does not use `SYSTEM`,
 Each project uses the exact name `Edda-Reconcile-<32-lowercase-hex-project-id>`.
 Install uses `/F`, so repeating it replaces only that name. Uninstall queries
 and deletes only that exact name and is idempotent; it never terminates a
-running reconciler or worker. The scheduled command contains absolute,
-canonical executable and main-repository paths, so linked worktrees share one
-task and execution does not depend on the scheduler's working directory.
+running reconciler or worker. The compact scheduled command contains canonical
+Edda and manifest paths; the repository path lives in the validated manifest,
+so linked worktrees share one task and execution does not depend on the
+scheduler's working directory.
 
 Scheduler lifecycle is Windows-only. A local exact-name missing-task HRESULT
 lifecycle run reported the expected signed and hexadecimal result codes, but

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -292,9 +292,10 @@ running reconciler or worker. The scheduled command contains absolute,
 canonical executable and main-repository paths, so linked worktrees share one
 task and execution does not depend on the scheduler's working directory.
 
-Scheduler lifecycle is Windows-only. The controller-loss release drills and
-the locally observed missing-task HRESULT are recorded in
-[`P2_DRILL_2026-08-16.md`](../plan/task-rail/P2_DRILL_2026-08-16.md).
+Scheduler lifecycle is Windows-only. The still-pending controller-loss drills
+and local missing-task HRESULT proof contract are tracked in
+[`P2_DRILL_2026-08-16.md`](../plan/task-rail/P2_DRILL_2026-08-16.md); they remain
+`BLOCKED` until the required reviewed implementation gate.
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -258,6 +258,44 @@ Launch the real-time TUI showing active sessions, events, and coordination state
 edda watch
 ```
 
+### `edda reconcile`
+
+Recover unfinished Task Rail attempts and dispatch ready work. The ledger,
+claims, leases, attempts, and receipts remain authoritative; reconciliation is
+safe to invoke repeatedly.
+
+```bash
+edda reconcile
+edda reconcile --install-scheduler
+edda reconcile --uninstall-scheduler
+```
+
+| Option | Description |
+|--------|-------------|
+| `--max-workers N` | Maximum concurrent workers (default: 3) |
+| `--max-attempts N` | Retry cap per task (default: 3) |
+| `--lease-ttl-s N` | Runner lease lifetime in seconds (default: 300) |
+| `--codex-bin PATH` | Codex executable used for runners |
+| `--install-scheduler` | On Windows, create or replace this project's one-minute scheduler task |
+| `--uninstall-scheduler` | On Windows, remove this project's exact scheduler task if present |
+
+The lifecycle flags are explicit machine mutations and never run from
+`edda init` or ordinary reconciliation. They are mutually exclusive and return
+without dispatching workers. Windows registration calls `schtasks.exe`
+directly under the current user with `LIMITED`; it does not use `SYSTEM`,
+`HIGHEST`, a password, shell wrapper, or background daemon.
+
+Each project uses the exact name `Edda-Reconcile-<32-lowercase-hex-project-id>`.
+Install uses `/F`, so repeating it replaces only that name. Uninstall queries
+and deletes only that exact name and is idempotent; it never terminates a
+running reconciler or worker. The scheduled command contains absolute,
+canonical executable and main-repository paths, so linked worktrees share one
+task and execution does not depend on the scheduler's working directory.
+
+Scheduler lifecycle is Windows-only. The controller-loss release drills and
+the locally observed missing-task HRESULT are recorded in
+[`P2_DRILL_2026-08-16.md`](../plan/task-rail/P2_DRILL_2026-08-16.md).
+
 ---
 
 ## Branches & drafts

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -292,10 +292,13 @@ running reconciler or worker. The scheduled command contains absolute,
 canonical executable and main-repository paths, so linked worktrees share one
 task and execution does not depend on the scheduler's working directory.
 
-Scheduler lifecycle is Windows-only. The still-pending controller-loss drills
-and local missing-task HRESULT proof contract are tracked in
-[`P2_DRILL_2026-08-16.md`](../plan/task-rail/P2_DRILL_2026-08-16.md); they remain
-`BLOCKED` until the required reviewed implementation gate.
+Scheduler lifecycle is Windows-only. A local exact-name missing-task HRESULT
+lifecycle run reported the expected signed and hexadecimal result codes, but
+its raw command, output, and Query XML artifacts were not preserved. D1 stopped
+`RED / BLOCKED` on a scheduler re-entry defect, and D2–D8 were not run. The
+incomplete evidence and rerun requirements are tracked in
+[`P2_DRILL_2026-08-16.md`](../plan/task-rail/P2_DRILL_2026-08-16.md); neither the
+lifecycle nor the controller-loss drills are release-accepted.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-17-scheduler-launch-manifest.md
+++ b/docs/superpowers/plans/2026-08-17-scheduler-launch-manifest.md
@@ -1,0 +1,326 @@
+# Scheduler Launch Manifest Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace GH-466's overlong Windows Task Scheduler `/TR` command with a validated, immutable, machine-local launch manifest while preserving the exact-task and direct-execution safety model.
+
+**Architecture:** Keep all production work in `cmd_reconcile.rs`. Install serializes one versioned launch payload, addresses it by SHA-256 under the existing Edda user store, and schedules `edda reconcile --scheduler-manifest <absolute-path>`. Scheduled re-entry validates the artifact before ledger access; lifecycle cleanup is exact-task-only and retains artifacts whenever ownership is uncertain.
+
+**Tech Stack:** Rust, Clap, Serde/serde_json, sha2/hex, existing `edda_store::{store_root, lock_file, write_atomic}`, `std::process::Command`, Windows `schtasks.exe`.
+
+## Global Constraints
+
+- Follow `docs/superpowers/specs/2026-08-17-scheduler-launch-manifest-design.md` and ratified decision `gh466.scheduler-launch-config`.
+- Modify product code only in `crates/edda-cli/src/cmd_reconcile.rs`; no Cargo, crate, trait, daemon, shell, XML-registration, principal, or dependency change.
+- `/TR` stays direct native execution and must be at most 261 UTF-16 code units before any filesystem or scheduler mutation.
+- Use one exact `Edda-Reconcile-<32 lowercase hex>` task; never enumerate, prefix-match, wildcard-delete, pre-delete, or kill processes.
+- Manifest validation fails before ledger access or Codex launch. Unknown or uncertain artifacts are retained.
+- No scheduler/PID/drill action occurs during implementation. A fresh immutable-head review must pass before Task #50 resumes.
+
+---
+
+## File map
+
+- Modify and test: `crates/edda-cli/src/cmd_reconcile.rs` — CLI mode, manifest schema/canonical bytes, trust validation, renderer, lifecycle, and focused tests.
+- Read only: `crates/edda-store/src/lib.rs` — reuse `store_root`, `lock_file`, and `write_atomic`; do not change its API.
+- Read only until the later drill receipt: `docs/plan/task-rail/P2_DRILL_2026-08-16.md`.
+
+### Task 1: Canonical manifest model and trust boundary
+
+**Files:**
+- Modify/Test: `crates/edda-cli/src/cmd_reconcile.rs`
+
+**Interfaces:**
+- Produces `SchedulerLaunchManifestV1`, `PreparedSchedulerManifest`, `prepare_scheduler_manifest`, and `load_scheduler_manifest` for later tasks.
+- Reuses `canonical_main_repo`, `canonical_direct_codex_executable`, `edda_store::project_id_for_root`, `sha2`, and `hex`.
+
+- [ ] **Step 1: Add failing canonicalization and rejection tests**
+
+Add focused tests covering deterministic compact bytes/digest/path, changed config changing digest, unknown/duplicate/noncanonical JSON, oversize input, digest mismatch, wrong project id, invalid repo/Codex, and store-root/reparse escape. Use `tempfile` only from the existing dev-dependency and serialize environment mutation under the existing test lock pattern.
+
+```rust
+#[test]
+fn scheduler_manifest_is_canonical_content_addressed_and_strict() -> anyhow::Result<()> {
+    let fixture = scheduler_manifest_fixture()?;
+    let first = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+    let second = prepare_scheduler_manifest(&fixture.store, &fixture.repo, &fixture.config)?;
+    assert_eq!(first.bytes, second.bytes);
+    assert_eq!(first.path, second.path);
+    assert!(first.path.ends_with(format!("{}.json", first.digest)));
+    assert_eq!(load_scheduler_manifest(&first.path)?.manifest, first.manifest);
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run RED**
+
+Run:
+
+```text
+cargo test -p edda scheduler_manifest_ --no-fail-fast -- --test-threads=1
+```
+
+Expected: compile failure for the missing manifest types/functions.
+
+- [ ] **Step 3: Implement the minimal typed schema and canonical bytes**
+
+Define these private types in `cmd_reconcile.rs`; do not add a generic config module:
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct SchedulerLaunchManifestV1 {
+    schema_version: u8,
+    project_id: String,
+    repo: PathBuf,
+    codex_bin: PathBuf,
+    max_workers: usize,
+    max_attempts: u32,
+    lease_ttl_s: u64,
+}
+
+struct PreparedSchedulerManifest {
+    manifest: SchedulerLaunchManifestV1,
+    bytes: Vec<u8>,
+    digest: String,
+    path: PathBuf,
+}
+
+struct LoadedSchedulerManifest {
+    manifest: SchedulerLaunchManifestV1,
+    repo: PathBuf,
+    config: ReconcileConfig,
+}
+```
+
+Use declaration order plus `serde_json::to_vec` for the exact compact byte form. Hash those bytes with `Sha256`, require a 64-lowercase-hex filename, cap reads at 16 KiB using metadata before `std::fs::read`, reserialize and compare exact bytes, and validate canonical repo/project/Codex through existing helpers. Resolve the prospective store root to an absolute path in memory; after the directory exists, canonicalize it and reject any parent mismatch or reparse escape.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+Run the focused command from Step 2; expected all `scheduler_manifest_` tests PASS. Then:
+
+```text
+git add crates/edda-cli/src/cmd_reconcile.rs
+git commit -m "feat(task-rail): validate scheduler launch manifests"
+```
+
+### Task 2: Compact hidden re-entry and UTF-16 renderer
+
+**Files:**
+- Modify/Test: `crates/edda-cli/src/cmd_reconcile.rs`
+
+**Interfaces:**
+- Consumes `LoadedSchedulerManifest` from Task 1.
+- Changes `windows_scheduler_spec(exe, manifest_path, project_id)` to render the compact direct command.
+
+- [ ] **Step 1: Add failing CLI, renderer, and boundary tests**
+
+Cover hidden `--scheduler-manifest`, conflicts with lifecycle/repo/Codex/run-task/attempt/explicit limits, unrelated-cwd re-entry, the preserved real 356-unit fixture now fitting, exact 261 acceptance, exact 262 rejection, and a surrogate-pair case proving UTF-16 rather than byte/character counting.
+
+```rust
+#[test]
+fn scheduler_manifest_renderer_enforces_utf16_limit() -> anyhow::Result<()> {
+    let accepted = render_scheduler_task_run(&path_with_utf16_len(261))?;
+    assert_eq!(accepted.encode_utf16().count(), 261);
+    let error = render_scheduler_task_run(&path_with_utf16_len(262))
+        .expect_err("262 UTF-16 units must fail")
+        .to_string();
+    assert!(error.contains("262"));
+    assert!(error.contains("261"));
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run RED**
+
+Run:
+
+```text
+cargo test -p edda scheduler_ --no-fail-fast -- --test-threads=1
+```
+
+Expected: missing CLI field/renderer and old full-config `/TR` assertions fail.
+
+- [ ] **Step 3: Implement the compact mode without a second reconcile path**
+
+Add only one hidden option:
+
+```rust
+#[arg(long, hide = true)]
+scheduler_manifest: Option<PathBuf>,
+```
+
+Declare Clap conflicts listed in the spec. In `run`, load and validate the manifest first, select its repo and `ReconcileConfig`, then continue through the existing ordinary one-shot persistence/launch path. Do not duplicate the planner or runner code.
+
+Render exactly:
+
+```rust
+let task_run = format!(
+    "{} reconcile --scheduler-manifest {}",
+    quote_windows_argument(exe)?,
+    quote_windows_argument(manifest_path)?,
+);
+let units = task_run.encode_utf16().count();
+anyhow::ensure!(
+    units <= 261,
+    "scheduler task {task_name} /TR is {units} UTF-16 code units; maximum is 261"
+);
+```
+
+Keep the exact ordered Create/Query/Delete scheduler vectors and `LIMITED` run level unchanged.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+Run the focused scheduler suite; expected all scheduler tests PASS. Then:
+
+```text
+git add crates/edda-cli/src/cmd_reconcile.rs
+git commit -m "fix(task-rail): shorten scheduler reentry"
+```
+
+### Task 3: Atomic install/reinstall and exact verification
+
+**Files:**
+- Modify/Test: `crates/edda-cli/src/cmd_reconcile.rs`
+
+**Interfaces:**
+- Consumes `PreparedSchedulerManifest` and the compact `WindowsSchedulerSpec`.
+- Produces small pure helpers for exact Query XML verification and cleanup decisions; no scheduler trait or injectable production abstraction.
+
+- [ ] **Step 1: Add failing lifecycle/fault tests**
+
+Test identical reinstall reuse, changed config producing a new immutable path, existing-file exact-byte verification, no-replace behavior, write/Create/post-Create-Query failure decisions, exact Query XML matching Command+Arguments, and no mutation marker when validation/preflight fails.
+
+```rust
+#[test]
+fn scheduler_install_failure_never_overwrites_prior_manifest() -> anyhow::Result<()> {
+    let old = prepared_manifest_with_attempts(3)?;
+    let new = prepared_manifest_with_attempts(5)?;
+    assert_ne!(old.path, new.path);
+    assert_eq!(
+        manifest_cleanup_decision(&missing_scheduler_output(), &new.path)?,
+        ManifestCleanupDecision::RemoveNewArtifact
+    );
+    assert_eq!(std::fs::read(&old.path)?, old.bytes);
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run RED**
+
+Run:
+
+```text
+cargo test -p edda scheduler_ --no-fail-fast -- --test-threads=1
+```
+
+Expected: missing publish/XML/cleanup helpers.
+
+- [ ] **Step 3: Implement the minimum lifecycle sequencing**
+
+Before mutation, prepare and validate manifest bytes/path/spec and finish UTF-16 preflight. Then acquire `store_root/scheduler-launch/manifest.lock`, create `v1`, and either validate an identical existing artifact or call existing `edda_store::write_atomic` once. Record whether this attempt created the file.
+
+Create the exact task with `/F`, query the exact task with `/XML /HRESULT`, and require bounded XML to contain the exact XML-escaped `<Command>` and `<Arguments>` values. On failure, query only the exact task and remove only a newly created manifest whose non-reference is proved; uncertainty retains it and is included in the error.
+
+Use two private pure helpers rather than an abstraction:
+
+```rust
+enum ManifestCleanupDecision { RemoveNewArtifact, Retain }
+
+fn scheduler_query_references_manifest(
+    xml: &str,
+    executable: &Path,
+    manifest: &Path,
+) -> anyhow::Result<bool>;
+
+fn manifest_cleanup_decision(
+    query: &SchedulerOutput,
+    expected_manifest: &Path,
+) -> anyhow::Result<ManifestCleanupDecision>;
+```
+
+- [ ] **Step 4: Run GREEN and commit**
+
+Run scheduler tests and `cargo test -p edda cmd_reconcile --no-fail-fast -- --test-threads=1`; expected PASS. Then:
+
+```text
+git add crates/edda-cli/src/cmd_reconcile.rs
+git commit -m "fix(task-rail): persist scheduler launch manifests"
+```
+
+### Task 4: Conservative uninstall and full verification
+
+**Files:**
+- Modify/Test: `crates/edda-cli/src/cmd_reconcile.rs`
+
+**Interfaces:**
+- Consumes strict Query XML recognition from Task 3.
+- Leaves Task #50 and `P2_DRILL_2026-08-16.md` untouched until review approval.
+
+- [ ] **Step 1: Add failing uninstall tests**
+
+Cover present exact task with trusted manifest, malformed/untrusted XML retaining artifacts while still removing the exact task, already-missing task doing no sweep, missing Codex not blocking uninstall, delete race using only the accepted missing HRESULT, and post-delete uncertainty retaining artifacts.
+
+```rust
+#[test]
+fn scheduler_uninstall_never_sweeps_unproven_artifacts() -> anyhow::Result<()> {
+    let unrelated = scheduler_manifest_fixture_for_other_project()?;
+    let candidate = recover_manifest_candidate("<malformed>", &expected_task())?;
+    assert!(candidate.is_none());
+    assert!(unrelated.path.exists());
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run RED, implement, and run GREEN**
+
+Run the focused scheduler suite; expected new tests fail. Implement exact-task Query/Delete/post-Query first. Recover one candidate only from the strict direct-command shape; after absence is proved, delete it under the store lock only after full path/schema/digest/project validation. Never enumerate or sweep the manifest directory. Rerun scheduler and serial `cmd_reconcile`; expected PASS.
+
+- [ ] **Step 3: Run all required gates**
+
+Run separately with a fresh isolated TEMP/target where appropriate:
+
+```text
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test -p edda scheduler_ --no-fail-fast -- --test-threads=1
+cargo test -p edda cmd_reconcile --no-fail-fast -- --test-threads=1
+cargo test --workspace --no-fail-fast -- --test-threads=1
+git diff --check 8d0f71a016d5a0d4122adc59907afa8f6c768388..HEAD
+```
+
+Expected: all commands PASS; disclose any first-run flake and require an exact isolated rerun instead of hiding it.
+
+- [ ] **Step 4: Commit, push, and request immutable review**
+
+```text
+git add crates/edda-cli/src/cmd_reconcile.rs
+git commit -m "fix(task-rail): clean exact scheduler manifests"
+git push origin codex/gh-466-scheduler
+```
+
+Post `Review Response: Launch Manifest RED` containing the real 356-unit root cause, commit list, RED/GREEN evidence, exact full SHA, and gates. Post `Code Review Handoff: Round 6`; do not self-author a verdict. Freeze the branch.
+
+### Task 5: Independent current-head acceptance and drill restart
+
+**Files:**
+- Review only: complete `38c31bad15c4df55cfcc04b0f630bc3dddbb3e58..HEAD` range.
+- Later drill-only update: `docs/plan/task-rail/P2_DRILL_2026-08-16.md`.
+
+**Interfaces:**
+- Verifier publishes PR-visible `Code Review: Round 6` with P0/P1 counts and exact-head CI.
+- Task #50 resumes only after P0=0/P1=0 LGTM.
+
+- [ ] **Step 1: Run immutable independent review**
+
+Verifier checks the full range, ratified decision/spec/plan, amended S2/S4/S5/S14, manifest trust/fault matrix, all local gates, and exact-head GitHub Actions. Any push invalidates the verdict.
+
+- [ ] **Step 2: Restart Task #50 only after LGTM**
+
+Create a new preserved run directory. Build/hash the reviewed binary, capture raw argv/cwd/UTC/exit/stdout/stderr/XML/PID evidence, prove the missing-HRESULT lifecycle and the prior 356-unit fixture from scratch, then run D1 and serial D2-D8. Any product RED stops drills and creates a separately scoped fix/review round. No merge without explicit operator authority.
+
+## Plan self-review
+
+- Spec coverage: schema, digest/path trust, UTF-16 boundary, compact re-entry, install/reinstall/failure/uninstall, amended matrix, gates, immutable review, and drill restart are each mapped above.
+- Placeholder scan: every step contains concrete commands, expected outcomes, and named interfaces.
+- Type consistency: Task 2 consumes Task 1's loaded manifest; Tasks 3-4 share the exact Query XML and cleanup helpers; Task 5 consumes the frozen implementation SHA only.

--- a/docs/superpowers/plans/2026-08-17-scheduler-launch-manifest.md
+++ b/docs/superpowers/plans/2026-08-17-scheduler-launch-manifest.md
@@ -47,6 +47,7 @@ fn scheduler_manifest_is_canonical_content_addressed_and_strict() -> anyhow::Res
     assert_eq!(first.bytes, second.bytes);
     assert_eq!(first.path, second.path);
     assert!(first.path.ends_with(format!("{}.json", first.digest)));
+    edda_store::write_atomic(&first.path, &first.bytes)?;
     assert_eq!(load_scheduler_manifest(&first.path)?.manifest, first.manifest);
     Ok(())
 }
@@ -198,7 +199,7 @@ fn scheduler_install_failure_never_overwrites_prior_manifest() -> anyhow::Result
     let new = prepared_manifest_with_attempts(5)?;
     assert_ne!(old.path, new.path);
     assert_eq!(
-        manifest_cleanup_decision(&missing_scheduler_output(), &new.path)?,
+        manifest_cleanup_decision(&missing_scheduler_output(), &scheduler_exe(), &new.path)?,
         ManifestCleanupDecision::RemoveNewArtifact
     );
     assert_eq!(std::fs::read(&old.path)?, old.bytes);
@@ -235,6 +236,7 @@ fn scheduler_query_references_manifest(
 
 fn manifest_cleanup_decision(
     query: &SchedulerOutput,
+    executable: &Path,
     expected_manifest: &Path,
 ) -> anyhow::Result<ManifestCleanupDecision>;
 ```

--- a/docs/superpowers/specs/2026-08-17-scheduler-launch-manifest-design.md
+++ b/docs/superpowers/specs/2026-08-17-scheduler-launch-manifest-design.md
@@ -1,0 +1,186 @@
+# Scheduler launch manifest design
+
+**Status:** Approved design for GH-466; not an implementation or drill receipt
+
+**Ratified decision:** `gh466.scheduler-launch-config=machine-local-content-addressed-manifest`
+
+**Observed blocker:** the fresh Windows lifecycle run rendered a 356-UTF-16-code-unit
+`/TR`; `schtasks.exe /Create` rejected it because `/TR` may not exceed 261.
+
+## Scope and constraints
+
+Replace the long scheduler command with a direct Edda invocation that names one
+immutable machine-local manifest. The ledger remains truth; the scheduled task
+is only a one-minute doorbell.
+
+The implementation must keep these GH-466 constraints:
+
+- one exact `Edda-Reconcile-<32-lowercase-hex-project-id>` task;
+- direct `edda.exe` and `schtasks.exe` execution, with no shell, wrapper, daemon,
+  XML registration, new dependency, principal change, or task enumeration;
+- canonical main-repository identity, a canonical native Codex `.exe`, and the
+  existing `max-workers`, `max-attempts`, and `lease-ttl-s` semantics;
+- fail closed before any file or scheduler mutation when validation or the
+  `/TR` length preflight fails.
+
+## Manifest and command
+
+The manifest location is:
+
+```text
+<canonical edda_store::store_root()>/scheduler-launch/v1/<sha256>.json
+```
+
+`<sha256>` is the full 64-character lowercase SHA-256 of the exact manifest
+bytes. Version 1 uses compact UTF-8 JSON with a fixed field order and no trailing
+newline:
+
+```json
+{"schema_version":1,"project_id":"<32hex>","repo":"<canonical absolute root>","codex_bin":"<canonical absolute native .exe>","max_workers":3,"max_attempts":3,"lease_ttl_s":300}
+```
+
+There is no timestamp or mutable `current` pointer, so reinstalling identical
+configuration produces the same bytes, digest, and path. The manifest contains
+no credentials or session state.
+
+The installed `/TR` is exactly this shape:
+
+```text
+"<canonical absolute edda.exe>" reconcile --scheduler-manifest "<canonical absolute manifest>"
+```
+
+`--scheduler-manifest` is hidden and is the sole configuration source on this
+re-entry path. It conflicts with scheduler install/uninstall, `--repo`,
+`--codex-bin`, `--run-task`, `--attempt`, and explicitly supplied reconcile
+limits. It does not dispatch during install.
+
+The renderer uses the existing Windows argument quoting rules. Before creating
+a directory or file and before invoking `schtasks.exe`, install renders the full
+`/TR` and requires `task_run.encode_utf16().count() <= 261`. The count excludes
+the terminating NUL. A 262-code-unit command is an error naming the observed and
+maximum lengths; no shortening, lossy conversion, relative path, or fallback
+transport is allowed.
+
+## Trust and schema validation
+
+Both install and scheduled re-entry validate the same typed version-1 payload.
+Re-entry additionally performs all checks before opening the ledger or launching
+Codex:
+
+1. Require an absolute Unicode manifest path with no NUL or quote.
+2. Canonicalize the file and its parent. The parent must equal the canonical
+   `store_root()/scheduler-launch/v1`; symlink or reparse escape is rejected.
+3. Require a regular file no larger than 16 KiB and a filename exactly
+   `<64-lowercase-hex>.json`.
+4. Read bounded bytes, parse a `deny_unknown_fields` version-1 struct, serialize
+   it back to the canonical byte form, and require byte-for-byte equality.
+5. Recompute SHA-256 and require it to equal the filename. Unknown versions,
+   unknown fields, duplicate/noncanonical JSON, and digest mismatch fail closed.
+6. Validate `repo` through the existing authoritative `EddaPaths::find_root`
+   and canonical-main-root logic. Recompute `project_id_for_root(repo)` and
+   require both the payload id and exact task name to match.
+7. Revalidate `codex_bin` with the existing absolute, canonical, regular native
+   `.exe` checks. Parse the three numeric fields into their existing Rust types
+   and apply the same reconcile semantics; the manifest must not introduce a
+   second set of limits.
+
+The trust boundary is the current user's canonical Edda store. A manifest from
+another directory is rejected even when its digest is internally consistent.
+Changing any field creates a different artifact rather than mutating one in
+place.
+
+## Lifecycle and cleanup
+
+### Install and reinstall
+
+1. Canonicalize and validate Edda, repo, Codex, project id, config, store root,
+   canonical manifest bytes, prospective path, and the complete `/TR` in memory.
+2. Perform the UTF-16 preflight. Until it passes, make no filesystem or scheduler
+   mutation.
+3. Acquire one store-local `scheduler-launch/manifest.lock`, using the existing
+   Edda file-lock helper. Create the version directory and atomically publish a
+   missing content-addressed file with the existing atomic-write helper. If it
+   already exists, never rewrite it; accept it only after the complete trust
+   checks and exact-byte comparison pass.
+4. Run the unchanged exact `/Create ... /F /HRESULT` vector and then the exact
+   `/Query ... /XML /HRESULT`. Success requires the query to show the rendered
+   direct manifest command for the exact task.
+5. Reinstalling the same configuration reuses one artifact. A successful
+   changed-config reinstall retains the prior immutable artifact: a previously
+   triggered invocation may still need it, and exact-task-only policy forbids a
+   machine-wide reference scan.
+
+There is no pre-delete, suffix task, task-list scan, or content-directory sweep.
+
+### Failure
+
+- A manifest write failure occurs before scheduler mutation.
+- After a Create or post-Create Query failure, query only the exact task again.
+  Remove a manifest created by this attempt only when that query proves the task
+  missing or proves its strict command references a different manifest.
+- If scheduler state, XML, path trust, or artifact ownership is uncertain,
+  retain the artifact and report the exact operation/task plus bounded scheduler
+  output. Never delete the task or a prior manifest merely to make rollback look
+  clean.
+
+### Uninstall
+
+Query the exact task first and, when present, recover a manifest candidate only
+from its bounded XML's strict direct-command shape. This narrow extraction adds
+no shell, XML-registration path, or generic parser abstraction; failure to prove
+the exact shape simply disables artifact deletion. Delete the exact task,
+accept only the locally proved missing HRESULT race, and require an exact
+post-Delete Query to show absence. After absence is proved, delete the recovered
+artifact under the store lock only if it passes all path, schema, digest, and
+project-id checks. Missing, malformed, or untrusted artifact state does not
+block exact-task removal and is retained for manual inspection. An
+already-missing task is success and performs no artifact sweep.
+
+This is intentionally conservative: bounded orphan files are preferable to
+deleting an artifact whose ownership is not proved. General garbage collection
+is outside GH-466.
+
+## Acceptance-matrix amendments
+
+These rows replace the corresponding rows in the Task 4 verifier matrix; all
+other rows remain in force.
+
+| Row | Replacement |
+|---|---|
+| S2 — absolute re-entry | `/TR` contains a hidden absolute `--scheduler-manifest` path. The validated manifest contains the canonical authoritative repo root. Re-entry from an unrelated cwd targets that root; invalid manifest/repo paths fail before ledger access. |
+| S4 — quoting | The single `/TR` string quotes only the canonical Edda executable and canonical manifest path. Spaces and terminal backslashes round-trip; quotes, NUL, non-Unicode input, and length over 261 UTF-16 code units are rejected. Repo and Codex paths are not repeated in `/TR`. |
+| S5 — exact create argv | The ordered vector remains `/Create /SC MINUTE /MO 1 /TN <exact-name> /TR <single-direct-manifest-command> /RL LIMITED /F /HRESULT`. No principal option, shell, wrapper, XML registration, or extra scheduler option is added. |
+| S14 — minimal scope | Expected product work remains `crates/edda-cli/src/cmd_reconcile.rs`, using existing `edda_store::store_root`, `lock_file`, `write_atomic`, `sha2`, Serde, and standard-library file APIs. `main.rs`, Cargo files, a generic scheduler/config layer, a new crate, and a new dependency remain out of scope unless a new reviewed scope decision proves them unavoidable. |
+
+## Tests and gates
+
+Implementation starts with focused failing tests for:
+
+- the preserved 356-code-unit configuration rendering through a manifest at
+  no more than 261, plus exact 261-accept and 262-reject/no-mutation boundaries;
+- deterministic canonical bytes/digest/path, identical reinstall reuse, changed
+  config producing a new digest, and no-replace immutability;
+- unknown version/field, duplicate or noncanonical JSON, oversize input, digest
+  mismatch, store-root escape, symlink/reparse escape, wrong project id, invalid
+  repo, and Codex `.exe` disappearance or alias-to-non-`.exe`;
+- exact `/Create`, Query, and Delete argv; unrelated-cwd re-entry; install not
+  dispatching; strict uninstall-command recovery; failure retention/cleanup;
+  reinstall reuse/retention; idempotent uninstall; and untrusted artifacts being
+  retained.
+
+Required gates are the focused scheduler and CLI suites, `cargo fmt --check`,
+`cargo clippy --workspace --all-targets -- -D warnings`,
+`cargo test --workspace`, and exact-head GitHub Actions.
+
+## Drill restart boundary
+
+The lifecycle RED in `C:\ai_agent\edda-drills\20260816T163456Z` is preserved;
+it is not a PASS and D1-D8 did not start. No scheduler or PID drill resumes from
+this design commit.
+
+After implementation, all gates, and a PR-visible numbered review with
+current-head LGTM (P0=0, P1=0), restart Task #50 in a new preserved run
+directory with a fresh exact-head binary and raw capture artifacts. Prove the
+missing-HRESULT lifecycle from scratch, then D1, and only after each accepted boundary continue
+serially through D2-D8. Any product RED stops drills and returns to a separately
+scoped fix and review round.


### PR DESCRIPTION
## What changed
- add Windows-only `edda reconcile --install-scheduler` and `--uninstall-scheduler`
- schedule the accepted one-shot reconciler every minute with exact project-scoped native `schtasks.exe` arguments
- add hidden absolute `--repo` re-entry, linked-worktree main-root identity, Windows argument quoting, strict missing-HRESULT classification, and focused tests
- add the P2 drill evidence skeleton and update Task Rail/CLI documentation

## Why
A reconciler cannot recover controller loss unless an external doorbell wakes it. The Windows Task Scheduler is the smallest native wake-up mechanism; the ledger remains the only source of truth.

## Safety / current phase
This PR is deliberately draft. No real scheduler query/create/delete, process termination, or recovery drill has run yet. `P2_DRILL_2026-08-16.md` records every drill as BLOCKED until this frozen implementation receives an independent SHA-pinned code review. The locally observed missing-task HRESULT and all eight real-process drills will be added in later review rounds; each push invalidates the prior verdict.

## Validation run
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-fail-fast` (isolated TEMP; 0 failed)
- `cargo test -p edda scheduler_ --no-fail-fast` (7 passed)

Closes #466