### PR TITLE
docs(coordination): bound review scope

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -223,11 +223,16 @@ Ignoring these rules causes merge conflicts and duplicated work.
 
 Before merging any GitHub PR, the PR itself must show the complete loop:
 
+This is a bounded complete review, never a minimal review. It governs sessions
+invoking the coordination review/orchestration skills; it is not an Edda
+runtime rule imposed on every project.
+
 1. Each handoff freezes `IN SCOPE`: changed behavior/paths, direct
    callers/consumers, issue/spec acceptance, security/data-loss regressions
    introduced or exposed by the change, and current-base integration.
    Adjacent, pre-existing, and speculative findings are evidenced
-   `FOLLOW-UP ISSUE`s that do not extend the PR.
+   `FOLLOW-UP ISSUE`s that do not extend the PR. Every frozen-surface failure
+   is mandatory; only findings genuinely outside it qualify for follow-up.
 2. Before `Changes Requested`, finish the whole scoped audit and batch every
    blocking P0/P1. Later-round blockers must be fix-caused or previously
    unobservable; otherwise route follow-up. The issue/spec is the acceptance

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -223,12 +223,28 @@ Ignoring these rules causes merge conflicts and duplicated work.
 
 Before merging any GitHub PR, the PR itself must show the complete loop:
 
-1. `Code Review: Round N` pinned to the reviewed full SHA, with P0/P1 findings,
-   testing verdict, and `Changes Requested` or `LGTM`.
-2. Every `Changes Requested` round has an implementer `Review Response: Round
-   N` that answers each finding, names the new full SHA, and reports ran gates.
-3. Every push invalidates the prior verdict and requires another review round.
-4. The final comment is current-head `LGTM`, P0=0, P1=0, with exact gates.
+1. Each handoff freezes `IN SCOPE`: changed behavior/paths, direct
+   callers/consumers, issue/spec acceptance, security/data-loss regressions
+   introduced or exposed by the change, and current-base integration.
+   Adjacent, pre-existing, and speculative findings are evidenced
+   `FOLLOW-UP ISSUE`s that do not extend the PR.
+2. Before `Changes Requested`, finish the whole scoped audit and batch every
+   blocking P0/P1. Later-round blockers must be fix-caused or previously
+   unobservable; otherwise route follow-up. The issue/spec is the acceptance
+   ceiling, except evidence needed to prove a required fact or safety boundary.
+3. `Code Review: Round N` is pinned to the reviewed full SHA and records
+   `IN SCOPE`, `FOLLOW-UP ISSUE`, blocking P0/P1, `RAN` versus `READ` evidence,
+   available elapsed/token/tool cost, and `Changes Requested` or `LGTM`.
+   Gate selection follows code/product-blob, base, and toolchain changes;
+   docs/evidence-only pushes reuse applicable code gates and run only relevant
+   validation plus exact-head CI.
+4. Every `Changes Requested` round has an implementer `Review Response: Round
+   N` that answers each blocking finding, names the new full SHA, and reports
+   ran gates. Follow-up issues are linked but require no response.
+5. Every push invalidates the prior verdict and requires another review round.
+6. Stop after two non-product/harness-only cycles without useful progress or
+   at diminishing returns; classify/route the finding instead of continuing.
+7. The final comment is current-head `LGTM`, P0=0, P1=0, with exact gates.
 
 Internal verifier reports, task receipts, and CI do not replace PR comments.
 Merge still requires explicit operator authority.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,20 @@ and multi-agent coordination.
 - Record load-bearing facts in `edda task` or `edda decide` before using chat or
   host messaging as a doorbell.
 - Request permission before crossing another session's scope.
+- Every review handoff freezes `IN SCOPE`: changed behavior/paths, direct
+  callers/consumers, issue/spec acceptance, introduced or exposed security or
+  data-loss regressions, and current-base integration. Adjacent, pre-existing,
+  or speculative findings become evidenced `FOLLOW-UP ISSUE`s and do not
+  extend the current PR.
+- Reviewers complete the whole scoped audit and batch blocking P0/P1 before
+  requesting changes. Later-round blockers must be fix-caused or previously
+  unobservable. The issue/spec is the acceptance ceiling; extra evidence is
+  mandatory only to prove a required fact or safety boundary.
+- Select gates from code/product-blob, base, and toolchain changes. Docs- or
+  evidence-only pushes reuse still-applicable code gates as `READ`, run only
+  relevant validation plus exact-head CI as `RAN`, and record available cost.
+  Stop after two non-product/harness-only cycles without useful progress or at
+  diminishing returns; route follow-up or ask the operator to expand scope.
 - Review immutable full SHAs; any push invalidates the prior verdict.
 - On GitHub PRs, publish numbered SHA-pinned review rounds. Requested changes
   require an implementer point-by-point response and a new review round; merge

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,9 @@ and multi-agent coordination.
   callers/consumers, issue/spec acceptance, introduced or exposed security or
   data-loss regressions, and current-base integration. Adjacent, pre-existing,
   or speculative findings become evidenced `FOLLOW-UP ISSUE`s and do not
-  extend the current PR.
+  extend the current PR. This is a bounded complete review, never a minimal
+  review: every frozen-surface failure is mandatory, and only findings
+  genuinely outside that surface qualify for follow-up.
 - Reviewers complete the whole scoped audit and batch blocking P0/P1 before
   requesting changes. Later-round blockers must be fix-caused or previously
   unobservable. The issue/spec is the acceptance ceiling; extra evidence is
@@ -27,6 +29,8 @@ and multi-agent coordination.
   relevant validation plus exact-head CI as `RAN`, and record available cost.
   Stop after two non-product/harness-only cycles without useful progress or at
   diminishing returns; route follow-up or ask the operator to expand scope.
+- This is policy for sessions invoking `coord-review`, `coord-orchestrate`, or
+  `fleet-orchestrate`; it is not an Edda runtime rule imposed on every project.
 - Review immutable full SHAs; any push invalidates the prior verdict.
 - On GitHub PRs, publish numbered SHA-pinned review rounds. Requested changes
   require an implementer point-by-point response and a new review round; merge

--- a/crates/edda-cli/src/skills/coord-orchestrate.md
+++ b/crates/edda-cli/src/skills/coord-orchestrate.md
@@ -10,6 +10,9 @@ teach a session to be a good peer (coord-sync/request/handoff/review); this
 one teaches the seat that runs the whole formation. The companion prose is
 the "Coordination discipline" section of edda's multi-agent guide.
 
+This policy applies when this skill is invoked. It guides the coordinating
+session; it is not an Edda runtime rule imposed on every project.
+
 ## Layers — never mixed
 
 | Layer | Carrier | Property |
@@ -41,6 +44,10 @@ data-loss regressions introduced or exposed by the change, and current-base
 integration conflicts. Adjacent, pre-existing, or speculative findings that
 do not invalidate the requested behavior become evidenced `FOLLOW-UP ISSUE`s;
 they do not extend the PR or require a response/current-round fix.
+
+This is a bounded complete review, never a minimal review. Audit every item in
+the frozen surface; any failure there is mandatory. Only findings genuinely
+outside that surface qualify for follow-up.
 
 The issue/spec is the acceptance ceiling. Extra evidence is advisory unless
 needed to prove a required fact or safety boundary. Before `Changes Requested`,

--- a/crates/edda-cli/src/skills/coord-orchestrate.md
+++ b/crates/edda-cli/src/skills/coord-orchestrate.md
@@ -33,6 +33,47 @@ The whole formation — you included — produces delivery candidates and
 proves what was done and how it was verified; sign-off belongs to whoever
 holds merge authority outside the formation, unless explicitly delegated.
 
+## Review scope contract
+
+Before every review, freeze `IN SCOPE`: changed behavior/paths, directly
+affected callers/consumers, explicit issue/spec acceptance, security or
+data-loss regressions introduced or exposed by the change, and current-base
+integration conflicts. Adjacent, pre-existing, or speculative findings that
+do not invalidate the requested behavior become evidenced `FOLLOW-UP ISSUE`s;
+they do not extend the PR or require a response/current-round fix.
+
+The issue/spec is the acceptance ceiling. Extra evidence is advisory unless
+needed to prove a required fact or safety boundary. Before `Changes Requested`,
+the reviewer completes the whole scoped audit and batches all blocking P0/P1.
+A later round adds a blocker only when the fix caused it or made it previously
+unobservable; otherwise it is follow-up.
+
+Select gates proportionally. Code/product-blob, base, or toolchain changes run
+the relevant code gates. A docs/evidence-only push with those inputs unchanged
+reuses still-applicable code results as `READ` with source SHA, then runs only
+relevant diff/docs/evidence checks and exact-head CI as `RAN`.
+
+Each handoff records available elapsed/token/tool cost. Stop after two
+consecutive non-product evidence/docs or harness-only cycles without improved
+required behavior/proof, or at clear diminishing returns; route the finding to
+follow-up or ask the operator to expand scope.
+
+Use this request template; it is not a verdict:
+
+```text
+## Code Review Handoff: Round N
+Full SHA: <full SHA>
+Base full SHA: <full SHA>
+IN SCOPE: <frozen blocking surface>
+FOLLOW-UP ISSUE: <links or none>
+Blocking counts entering review: P0=<n>, P1=<n>
+Evidence:
+- RAN: <commands/checks run on this SHA>
+- READ: <reused results and source SHAs>
+Cost: elapsed=<available/unknown>, tokens=<available/unknown>, tools=<available/unknown>
+Request: audit the whole scoped surface; publish no self-verdict from the implementer
+```
+
 ## Protocol
 
 1. **Decompose.** Bundle by code-chain cohesion (same chain → same worker,
@@ -55,12 +96,14 @@ holds merge authority outside the formation, unless explicitly delegated.
    workers. Never fixate an unverified claim.
 6. **Track without interrupting:** workers' done-bells + background poll on
    `edda task list` / PR state + read-only peeks. "Queued" means busy — fine.
-7. **Close:** receipt on the rail → your review + verifier's adversarial
-   review, independently → for GitHub delivery, publish `Code Review: Round N`
-   on the PR pinned to the full SHA. `Changes Requested` requires the
-   implementer's point-by-point `Review Response: Round N`, a new frozen SHA,
-   and another review round. Publish final current-head LGTM with P0=0, P1=0
-   and ran gates → the merge authority integrates. For local-only delivery,
+7. **Close:** receipt on the rail → publish the review handoff above → your
+   review + verifier's adversarial review, independently → for GitHub delivery,
+   publish `Code Review: Round N` on the PR pinned to the full SHA with
+   `IN SCOPE`, blocking P0/P1, `FOLLOW-UP ISSUE`, and `RAN`/`READ` evidence.
+   `Changes Requested` requires the implementer's point-by-point `Review
+   Response: Round N` for blocking findings, a new frozen SHA, and another
+   review round. Publish final current-head LGTM with P0=0, P1=0 and exact
+   required gates → the merge authority integrates. For local-only delivery,
    record the same round/response/verdict fields in the strongest durable local
    carrier; do not invent a PR. Internal reports do not replace the durable
    visible loop.
@@ -107,3 +150,6 @@ letters at the peers' natural cadence. Bell-only → ring, ledger as backstop.
 | Controller reads worker diffs mid-flight | compressed signals only until review time |
 | Verifier fixes things | read-only, always |
 | Treating a worker receipt as acceptance | receipts are execution evidence; sign-off lives outside the formation |
+| Adjacent finding becomes another blocking round | file an evidenced follow-up issue unless it is in the frozen blocking surface |
+| Docs-only push restarts full code gates | reuse applicable code gates as `READ`; run delta checks plus exact-head CI |
+| Review drips one blocker per round | audit the whole scope and batch P0/P1 before requesting changes |

--- a/crates/edda-cli/src/skills/coord-review.md
+++ b/crates/edda-cli/src/skills/coord-review.md
@@ -1,6 +1,6 @@
 ---
 name: coord-review
-description: Review coordination health — check decisions, requests, binding conflicts
+description: Use when auditing multi-session coordination or reviewing a delivery candidate before PR or merge
 ---
 
 # Coordination Review
@@ -65,7 +65,42 @@ Review claims for overlapping paths:
 
 Flag any overlaps as potential merge conflict sources.
 
-### Step 5: Generate Report
+### Step 5: Freeze the review contract
+
+Every review handoff freezes the blocking surface:
+
+- changed behavior and paths;
+- directly affected callers and consumers;
+- explicit issue/spec acceptance;
+- security or data-loss regressions introduced or exposed by the change; and
+- current-base integration conflicts.
+
+These are `IN SCOPE`. Adjacent, pre-existing, or speculative findings that do
+not invalidate the requested behavior are `FOLLOW-UP ISSUE` items: file them
+with evidence and a basis SHA, but do not extend the PR or require an
+implementer response. Security and data-loss remain blocking when the change
+introduces/exposes them or a direct consumer regresses.
+
+Before posting `Changes Requested`, finish the whole scoped audit and batch all
+blocking P0/P1 findings. A later round may add a blocker only when the fix
+caused it or made it previously unobservable; otherwise route it to follow-up.
+
+The issue/spec is the acceptance ceiling. Do not invent mandatory evidence
+fields unless they are needed to prove a required fact or safety boundary.
+
+Choose gates from the delta. Code/product-blob, base, or toolchain changes run
+the relevant code gates. When only docs/evidence changed and code/product
+blobs, base, and toolchain are unchanged, reuse still-applicable code results
+as `READ` with their source SHA; run only relevant diff/docs/evidence checks
+and exact-head CI as `RAN`. Never report a reused result as rerun.
+
+Record available elapsed, token, and tool cost. Stop after two consecutive
+cycles that change only non-product evidence/docs or harness material without
+improving required behavior/proof, or sooner when returns clearly diminish.
+Classify and route the finding instead of continuing: follow-up issue for
+out-of-scope work, or operator scope expansion when it must join this PR.
+
+### Step 6: Generate Report
 
 Compile all findings into a health report.
 
@@ -105,3 +140,26 @@ Present the review as a health report:
 ### Overall Health: [GOOD / NEEDS ATTENTION]
 <1-2 sentence summary with recommended actions if any>
 ```
+
+For GitHub review, append this contract to the durable PR-visible loop:
+
+```text
+## Code Review: Round N
+Reviewed full SHA: <full SHA>
+Base full SHA: <full SHA>
+IN SCOPE: <frozen changed behavior/paths, direct consumers, acceptance, safety, integration>
+BLOCKING: P0=<n>, P1=<n>
+- <finding, path/symbol, failure scenario>
+FOLLOW-UP ISSUE:
+- <issue URL and priority, or none>
+Evidence:
+- RAN: <exact command/check and result on reviewed SHA>
+- READ: <reused result and its source SHA, or none>
+Cost: elapsed=<available/unknown>, tokens=<available/unknown>, tools=<available/unknown>
+Verdict: Changes Requested | LGTM
+```
+
+`Changes Requested` requires a point-by-point response only for `BLOCKING`
+findings and a new frozen SHA. Follow-up links do not create another round
+unless their fix is deliberately pulled into scope. Final current-head
+acceptance states `LGTM`, `P0=0`, `P1=0`, and the exact required gates.

--- a/crates/edda-cli/src/skills/coord-review.md
+++ b/crates/edda-cli/src/skills/coord-review.md
@@ -7,6 +7,9 @@ description: Use when auditing multi-session coordination or reviewing a deliver
 
 You are a coordination specialist. Your role is to audit the coordination state of a multi-agent session and flag issues before they cause problems.
 
+This policy applies when this skill is invoked. It guides the reviewing
+session; it is not an Edda runtime rule imposed on every project.
+
 ## When to Use
 
 - Before creating a PR in a multi-agent session
@@ -74,6 +77,12 @@ Every review handoff freezes the blocking surface:
 - explicit issue/spec acceptance;
 - security or data-loss regressions introduced or exposed by the change; and
 - current-base integration conflicts.
+
+This is a bounded complete review, never a minimal review: audit the entire
+frozen surface. A violation in changed behavior/paths, a direct caller or
+consumer, explicit acceptance, introduced/exposed security or data loss, or
+current-base integration is a mandatory blocker. Only findings genuinely
+outside that surface qualify for follow-up.
 
 These are `IN SCOPE`. Adjacent, pre-existing, or speculative findings that do
 not invalidate the requested behavior are `FOLLOW-UP ISSUE` items: file them

--- a/skills/fleet-orchestrate/SKILL.md
+++ b/skills/fleet-orchestrate/SKILL.md
@@ -15,6 +15,10 @@ and state recoverable when any session disappears.
 completely before assigning work. Every target session starts with zero
 conversation context.
 
+**REQUIRED PRESSURE TESTS:** Use
+[references/review-scope-pressure-tests.md](references/review-scope-pressure-tests.md)
+when changing or validating review policy.
+
 ## Controller sequence
 
 1. Fix the goal, exclusions, evidence bar, issue-filing authority, merge
@@ -31,7 +35,7 @@ conversation context.
 6. Record tasks, claims, rulings, and acceptance criteria in the durable truth
    layer before ringing host messaging as a doorbell.
 7. Give self-contained briefs, monitor compressed state, adjudicate conflicts,
-   and close only against immutable full SHAs with rerun evidence.
+   and close only against immutable full SHAs with proportional evidence.
 
 ## Non-negotiable invariants
 
@@ -41,6 +45,21 @@ conversation context.
 - Highest durable `d-NNN` ruling wins; changes say `SUPERSEDES d-NNN`.
 - Reviewer/verifier does not fix the artifact it judges.
 - Review verdicts bind one full SHA; any push voids the verdict.
+- Every handoff freezes `IN SCOPE`: changed behavior/paths, direct
+  callers/consumers, issue/spec acceptance, introduced or exposed
+  security/data-loss regressions, and current-base integration. Everything
+  adjacent, pre-existing, or speculative is an evidenced `FOLLOW-UP ISSUE`
+  unless it invalidates that frozen surface.
+- Finish the whole scoped audit and batch all blocking P0/P1 before requesting
+  changes. A later blocker must be fix-caused or previously unobservable.
+- The issue/spec is the acceptance ceiling. Require extra evidence only when
+  needed to prove a required fact or safety boundary.
+- Gates follow code/product-blob, base, and toolchain changes. Docs/evidence-
+  only heads reuse still-applicable code gates as `READ` and run relevant
+  delta checks plus exact-head CI as `RAN`.
+- Record available elapsed/token/tool cost. After two consecutive
+  non-product/harness-only cycles without useful progress, or at diminishing
+  returns, stop and route follow-up or request operator scope expansion.
 - A GitHub PR carries its visible review-fix loop: numbered SHA-pinned review,
   implementer response to every requested change, and final current-head LGTM.
   An internal verifier report does not replace these PR comments.
@@ -62,4 +81,6 @@ Publish and keep current:
 2. review charter and finding queue;
 3. dependency graph and bundle ownership;
 4. fleet board with task, owner, branch, full SHA, state, review, and next step;
-5. acceptance matrix, PR review-loop state, and final merge recommendation.
+5. acceptance matrix, review handoff (`IN SCOPE`, `FOLLOW-UP ISSUE`, blocking
+   P0/P1, `RAN`/`READ`, exact SHA, cost), PR review-loop state, and final merge
+   recommendation with current-head P0=0/P1=0.

--- a/skills/fleet-orchestrate/SKILL.md
+++ b/skills/fleet-orchestrate/SKILL.md
@@ -11,6 +11,10 @@ Run a fleet as a durable control system, not a group chat. Divide context and
 ownership only where work is genuinely independent; keep decisions, evidence,
 and state recoverable when any session disappears.
 
+This policy applies when `fleet-orchestrate` or its coord review/orchestration
+companions are invoked. It guides those sessions; it is not an Edda runtime
+rule imposed on every project.
+
 **REQUIRED REFERENCE:** Read [references/playbook.md](references/playbook.md)
 completely before assigning work. Every target session starts with zero
 conversation context.
@@ -50,6 +54,9 @@ when changing or validating review policy.
   security/data-loss regressions, and current-base integration. Everything
   adjacent, pre-existing, or speculative is an evidenced `FOLLOW-UP ISSUE`
   unless it invalidates that frozen surface.
+- This is a bounded complete review, never a minimal review. Audit the entire
+  frozen surface; every failure there is mandatory, and only findings
+  genuinely outside it qualify for follow-up.
 - Finish the whole scoped audit and batch all blocking P0/P1 before requesting
   changes. A later blocker must be fix-caused or previously unobservable.
 - The issue/spec is the acceptance ceiling. Require extra evidence only when

--- a/skills/fleet-orchestrate/references/playbook.md
+++ b/skills/fleet-orchestrate/references/playbook.md
@@ -12,7 +12,7 @@
 8. Role contracts and briefs
 9. Rulings and cross-session traffic
 10. Monitoring and recovery
-11. Verification and merge
+11. Scoped verification and merge
 12. Carrier selection
 13. Worked example
 14. Common mistakes
@@ -26,10 +26,10 @@ Write an authority contract before dispatch:
 | Goal | Observable end state, not an activity |
 | In scope | Repositories, issues, modules, branches |
 | Out of scope | Explicit exclusions and optional work |
-| Evidence | Tests, checks, reproduction, review standard |
+| Evidence | Issue/spec-required facts and safety proof; do not invent acceptance fields |
 | External writes | Whether the fleet may file/close issues, comment, push, or open PRs |
 | Merge authority | Who may merge, which PRs/SHAs, and ordering constraints |
-| Stop conditions | Complete, blocked, budget/coverage limit, or operator decision |
+| Stop conditions | Complete, blocked, coverage/cost limit, diminishing returns, or operator decision |
 
 A terminal instruction such as “do not stop” requires persistence toward the
 goal. It does not authorize new products, repositories, issue spam, scope
@@ -123,9 +123,10 @@ Create a review charter before scanning:
 | Basis | Base branch and full SHA |
 | Lenses | Fixed set such as correctness, security, concurrency, data loss, UX, tests |
 | Exclusions | What this campaign will not inspect |
+| Blocking surface | Changed behavior/paths, direct consumers, acceptance, introduced/exposed safety regressions, current-base integration |
 | Evidence bar | Reproducer, failing test, trace/log, or direct code proof |
 | Coverage | Matrix of scope units × lenses |
-| Stop rule | Coverage/budget complete, blockers resolved, or operator decision |
+| Stop rule | Coverage/budget complete, blockers resolved, cost stop, or operator decision |
 
 Assign each review task one coverage cell. Rotate lenses across cells instead
 of repeating one familiar bug pattern. Mark each cell with reviewer, basis SHA,
@@ -134,8 +135,9 @@ evidence, candidates, and disposition.
 Prevent drift:
 
 - Keep the object and exclusions fixed for the campaign.
-- Park a newly discovered direction as a hypothesis; expand the charter only
-  through a durable controller ruling.
+- Route adjacent, pre-existing, or speculative defects that do not invalidate
+  the blocking surface to evidenced follow-up issues. Expand the charter only
+  through a durable operator-approved ruling.
 - Compare suspected regressions against the basis revision before escalating.
 - Have the verifier sample both positive findings and “clean” cells; a campaign
   that only checks its hits trains itself toward confirmation bias.
@@ -166,6 +168,12 @@ Require this evidence before promotion:
 Do not file vague “investigate X” issues merely to inflate the queue. If the
 direction is useful but evidence is incomplete, retain the candidate with the
 attempts already made and the next bounded experiment.
+
+Finding priority and current-PR disposition are separate. A serious adjacent
+defect can be a high-priority follow-up without becoming a blocking P0/P1 in
+the current PR. Direct caller/consumer regressions, introduced or exposed
+security/data-loss regressions, and current-base integration conflicts remain
+blocking.
 
 ## 7. Delivery graph and ownership
 
@@ -207,7 +215,7 @@ intent + basis SHA + symbol anchor + drift rule.
 3. Reproduce the failure or write the failing acceptance test first.
 4. Implement the smallest in-scope repair; surface adjacent findings instead
    of taking them.
-5. Run focused gates and the required broader gates.
+5. Run gates selected from code/product-blob, base, and toolchain changes.
 6. Push/open the delivery candidate if authorized, report the full SHA, freeze
    the branch, and leave a receipt tagged `ran` versus `read`.
 7. Never merge or rewrite another worker’s branch.
@@ -218,8 +226,9 @@ intent + basis SHA + symbol anchor + drift rule.
 2. Run baseline gates before workers code and classify existing red checks.
 3. Translate each issue into observable acceptance criteria.
 4. Audit tests for false greens and tests that encode behavior being removed.
-5. Review the exact frozen full SHA, rerun gates personally, compare against
-   the basis, and report blockers with path/symbol and failure scenario.
+5. Review the exact frozen full SHA, complete the whole scoped audit, compare
+   against the basis, and batch every blocking P0/P1 with path/symbol and
+   failure scenario before requesting changes.
 6. Acknowledge that any push voids the verdict.
 
 ### Controller contract
@@ -272,21 +281,81 @@ If work is blocked, record the reason and evidence, release/reassign ownership
 using the runtime’s current mechanism, and continue other independent ready
 bundles. Do not spin or broaden scope to appear active.
 
-## 11. Verification and merge
+## 11. Scoped verification and merge
+
+Every review handoff freezes one blocking contract:
+
+**`IN SCOPE`**
+
+- changed behavior and changed paths;
+- directly affected callers and consumers;
+- explicit issue/spec acceptance;
+- security or data-loss regressions introduced or exposed by the change; and
+- current-base integration conflicts.
+
+**`FOLLOW-UP ISSUE`**
+
+- adjacent or pre-existing defects that do not invalidate requested behavior;
+- speculative improvements; and
+- extra evidence/format preferences beyond the acceptance ceiling.
+
+File follow-ups with evidence and a basis SHA. They do not extend the current
+PR, require an implementer response, or create another review round unless the
+operator intentionally pulls their fix into scope. The issue/spec is the
+acceptance ceiling; evidence beyond it becomes mandatory only when its absence
+prevents proving a required fact or safety boundary.
+
+Before posting `Changes Requested`, finish the whole scoped audit and batch all
+blocking P0/P1. A later round may add a blocker only if the fix caused it or
+made it previously unobservable; otherwise route it to follow-up.
+
+Select gates proportionally:
+
+| Delta | Required treatment |
+|---|---|
+| Code/product blob, base SHA, or toolchain changed | Run the relevant code gates for the changed risk surface. |
+| Only docs/evidence changed; code/product blobs, base, and toolchain unchanged | Reuse still-applicable code gates as `READ` with source SHA; `RAN` only relevant diff/docs/evidence checks and exact-head CI. |
+
+Never label a reused gate `RAN`. Exact-head CI is still required because the
+review verdict binds the new full SHA.
+
+Record available elapsed time, token use, and tool cost in every handoff. Stop
+after two consecutive cycles that change only non-product evidence/docs or
+harness material without improving required behavior/proof, or sooner when
+returns clearly diminish. Classify and route instead of continuing: open a
+follow-up issue for out-of-scope work, or ask the operator to expand scope.
+
+Use this handoff request before review; it is not an implementer verdict:
+
+```text
+## Code Review Handoff: Round N
+Full SHA: <full SHA>
+Base full SHA: <full SHA>
+IN SCOPE: <frozen blocking surface>
+FOLLOW-UP ISSUE: <links or none>
+Blocking counts entering review: P0=<n>, P1=<n>
+Evidence:
+- RAN: <commands/checks executed on this SHA>
+- READ: <reused results and source SHAs>
+Cost: elapsed=<available/unknown>, tokens=<available/unknown>, tools=<available/unknown>
+Request: complete the scoped audit and publish an independent verdict
+```
 
 For each candidate:
 
 1. Worker freezes and reports a full SHA with a receipt.
 2. Controller checks scope and issue acceptance coverage.
-3. Independent verifier reviews that SHA and reruns required gates.
+3. Independent verifier reviews that SHA and runs the proportional required
+   gates.
 4. Any push voids the verdict and triggers a delta review from the new SHA.
 5. When the delivery artifact is a GitHub PR, publish the review on the PR;
    internal reports and chat are supporting evidence, not a substitute:
-   - `## Code Review: Round N` with reviewed full SHA, P0/P1 findings, testing
-     verdict, and `Changes Requested` or `LGTM`;
+   - `## Code Review: Round N` with reviewed full SHA, frozen `IN SCOPE`,
+     blocking P0/P1 counts/findings, `FOLLOW-UP ISSUE` links, `RAN` versus
+     `READ` evidence, cost, and `Changes Requested` or `LGTM`;
    - after `Changes Requested`, the implementer publishes
-     `## Review Response: Round N`, answering every finding with disposition,
-     changed paths/tests, ran evidence, and the new full SHA;
+     `## Review Response: Round N`, answering every blocking finding with
+     disposition, changed paths/tests, ran evidence, and the new full SHA;
    - the reviewer starts Round N+1 on that new frozen SHA. Repeat until the PR
      has a final current-head `LGTM` comment stating P0=0, P1=0 and exact gates.
 6. Controller reads `headRefOid`, PR comments/reviews, and CI immediately before
@@ -360,6 +429,11 @@ actual file overlap. More sessions do not make A1 → A2 parallel.
 | “The user said keep going, so nearby work is allowed.” | Persistence does not broaden scope or external-write authority. |
 | “The latest message is newest truth.” | Highest durable `d-NNN` wins; messages are doorbells. |
 | “The PR barely changed after approval.” | Any push changes the artifact and voids the SHA-bound verdict. |
+| “This adjacent defect is real, so it must block.” | Preserve the evidence in a follow-up issue unless it invalidates the frozen blocking surface. |
+| “A new preference deserves another review round.” | The issue/spec is the acceptance ceiling; only required facts and safety proof can raise it. |
+| “Docs changed, so rerun every code gate.” | Reuse still-applicable code gates as `READ`; run delta checks and exact-head CI as `RAN`. |
+| “We can reveal the next blocker after this fix.” | Complete the scoped audit and batch P0/P1; later blockers must be fix-caused or previously unobservable. |
+| “One more harness/evidence cycle might help.” | After two non-product cycles without useful progress or at diminishing returns, stop and route. |
 | “The verifier report is enough; PR comments are clerical.” | A GitHub PR is the durable collaboration surface. Publish every review round, response, and final current-head verdict there. |
 | “The final LGTM implies earlier findings were handled.” | Changes Requested requires an implementer point-by-point response before re-review. |
-| “Receipt says tests pass, so merge.” | Receipt is worker evidence; verifier reruns and merge authority accepts. |
+| “Receipt says tests pass, so merge.” | Receipt is worker evidence; verifier runs the required proportional gates and merge authority accepts. |

--- a/skills/fleet-orchestrate/references/playbook.md
+++ b/skills/fleet-orchestrate/references/playbook.md
@@ -285,6 +285,15 @@ bundles. Do not spin or broaden scope to appear active.
 
 Every review handoff freezes one blocking contract:
 
+This is a bounded complete review, never a minimal review. The reviewer audits
+the entire frozen surface. Every failure in changed behavior/paths, a direct
+caller/consumer, explicit acceptance, introduced/exposed security or data
+loss, or current-base integration is mandatory. Only findings genuinely
+outside that surface qualify for follow-up.
+
+This workflow applies when the coord review/orchestration skills are invoked;
+it is not an Edda runtime rule imposed on every project.
+
 **`IN SCOPE`**
 
 - changed behavior and changed paths;

--- a/skills/fleet-orchestrate/references/review-scope-pressure-tests.md
+++ b/skills/fleet-orchestrate/references/review-scope-pressure-tests.md
@@ -6,6 +6,10 @@ requires the stated disposition and a review record with the exact full SHA,
 issue links. P0/P1 counts cover blocking findings; follow-up priority is
 recorded on its issue.
 
+These test a bounded complete review, never a minimal review: the reviewer must
+audit the whole frozen surface, while only genuinely outside-scope findings
+route to follow-up.
+
 ## 1. Adjacent real defect
 
 The issue changes a config parser. The frozen diff and all direct consumers

--- a/skills/fleet-orchestrate/references/review-scope-pressure-tests.md
+++ b/skills/fleet-orchestrate/references/review-scope-pressure-tests.md
@@ -1,0 +1,40 @@
+# Review Scope Pressure Tests
+
+Give each fixture to a fresh reviewer with the current review guidance. A pass
+requires the stated disposition and a review record with the exact full SHA,
+`RAN` versus `READ` evidence, blocking P0/P1 counts, and separate follow-up
+issue links. P0/P1 counts cover blocking findings; follow-up priority is
+recorded on its issue.
+
+## 1. Adjacent real defect
+
+The issue changes a config parser. The frozen diff and all direct consumers
+satisfy the issue, but review discovers a reproducible pre-existing cleanup
+bug in an adjacent module that the diff neither calls nor changes. The bug is
+real and important.
+
+**Pass:** File a follow-up issue with the reproduction and basis SHA, list it
+under `FOLLOW-UP ISSUE`, keep blocking P0=0/P1=0, and allow `LGTM` when the
+scoped gates pass. Do not require its fix or another round on the current PR.
+
+## 2. Direct caller security regression
+
+The changed parser accepts a new path form. A direct caller now joins that
+value without containment validation, allowing writes outside its configured
+root. The issue did not spell out this caller or an evidence field.
+
+**Pass:** Classify the introduced direct-caller security regression as
+`IN SCOPE` and blocking P0/P1. Request changes after completing the rest of the
+scoped audit and batch every scoped P0/P1 found in that round. Do not route the
+regression to follow-up or waive the proof needed for the safety boundary.
+
+## 3. Documentation-only current head
+
+The prior code SHA passed required code gates. A later push changes only review
+evidence Markdown; product/code blobs, base SHA, and toolchain are unchanged.
+Exact-head CI is green.
+
+**Pass:** Review the new full SHA, mark prior still-applicable code gates as
+`READ`/reused with their source SHA, run only relevant diff/docs/evidence
+validation plus exact-head CI as `RAN`, and allow a current-head final verdict.
+Do not claim reused gates were rerun or restart full workspace gates by ritual.


### PR DESCRIPTION
Closes #474

## Summary

- freeze the blocking review surface at each handoff and route adjacent/pre-existing/speculative findings to follow-up issues
- require complete scoped audits, batched P0/P1 findings, an issue/spec acceptance ceiling, and proportional RAN-vs-READ gates
- add bounded cost-stop rules plus three pressure fixtures for adjacent defects, direct-caller security regressions, and docs-only re-review

## RAN

- skill/parity/link contract check: PASS (4 policy files, 3 skill frontmatters, 2 shipped includes, 2 links, 3 fixtures, 2 guides)
- fresh-agent pressure review: PASS (3/3 fixtures; no contradictions or gaps)
- `cargo test -p edda cmd_init`: PASS (7 passed, 0 failed)
- `git diff --check HEAD^`: PASS

## READ

- GitHub issue #474 acceptance and non-goals
- base `origin/main@9b86f572dbca22f46274367a82a498e39146282e`

No runtime, schema, drill, or #475 paths changed.