### PR TITLE
test(drill): add reusable process capture harness

### DIFF
--- a/docs/plan/task-rail/DRILL_CAPTURE.md
+++ b/docs/plan/task-rail/DRILL_CAPTURE.md
@@ -1,0 +1,87 @@
+# Drill process capture
+
+Use `scripts/drill/capture.ps1` for real-process drill evidence. It uses only
+PowerShell and .NET, starts children with `ProcessStartInfo.ArgumentList`, and
+never kills a process.
+
+Run the offline gate first:
+
+```powershell
+pwsh -NoProfile -File scripts/drill/self-test.ps1
+```
+
+The test uses disposable files and local child shells only. It does not invoke
+Edda, Scheduler, Codex, a network, PID termination, or a repository command.
+
+## Single process
+
+```powershell
+. ./scripts/drill/capture.ps1
+$capture = Invoke-DrillCapture `
+    -CaptureId 'D1-controller' `
+    -Owner 'task-84-attempt-1' `
+    -Executable 'C:\absolute\path\controller.exe' `
+    -WorkingDirectory 'C:\absolute\path\fresh drill repo' `
+    -ArgumentList @('reconcile', '--max-workers', '1') `
+    -OutputDirectory 'C:\absolute\path\raw'
+```
+
+`CaptureId`, `Owner`, literal executable, and existing cwd are required before
+the child can start. Treat PID plus process creation time, executable, argv,
+cwd, and owner as the ownership tuple; PID alone never authorizes a process
+action.
+
+Each stage is a new atomically renamed file. Existing stage files are never
+overwritten:
+
+- `*.00-planned.json` is durable before any child starts.
+- `*.10-started.json` records PID and the OS creation-time query. A fast exit is
+  recorded as `exited_before_identity_query_recovered` or
+  `exited_before_identity_query_unavailable`, not treated as missing evidence.
+- `*.stdout.txt` and `*.stderr.txt` are bounded; the terminal record carries
+  total characters, truncation, and .NET SHA-256 hashes.
+- `*.20-terminal.json` retains owner, timing, signed exit, identity, and output
+  evidence.
+- `*.30-optional*.json` is written only after the required terminal record.
+  UInt32 hex is optional metadata and is converted from the Int32 bytes, so a
+  signed `-1` is safe without making hex an acceptance requirement.
+
+An optional formatter may be supplied with `-OptionalMetadata`. If it throws,
+the terminal record remains intact and the helper records an
+`OPTIONAL_METADATA` failure.
+
+## Concurrent processes
+
+Pass all child specifications to one call:
+
+```powershell
+$result = Invoke-DrillCaptureSet -SetId 'D4-controllers' -Spec @(
+    @{ capture_id='A'; owner='task-84'; executable=$exe; cwd=$repo; argv=$argv },
+    @{ capture_id='B'; owner='task-84'; executable=$exe; cwd=$repo; argv=$argv }
+) -OutputDirectory $raw
+```
+
+The helper writes every planned record, launches every child, and only then
+queries either identity. The set terminal record proves overlap when the
+latest OS process start is earlier than the earliest OS process exit. Missing
+OS interval data or `overlap=false` is not concurrency proof.
+
+## Receipt classification
+
+Use one exact label for every non-pass result:
+
+| Label | Meaning and action |
+| --- | --- |
+| `PRODUCT_RED` | Trustworthy evidence contradicts product acceptance; stop the product path. |
+| `SAFETY_RED` | Ownership, cleanup, or another safety invariant is not proven; stop before any PID action. |
+| `HARNESS_RED` | Required capture or evidence failed; do not relabel it as product RED. |
+| `OPTIONAL_METADATA` | Nonessential formatting or redundant metadata failed; it is nonblocking when planned, started, and terminal ownership/timing evidence remains. |
+
+## Phase isolation
+
+Default to a fresh disposable repository and ledger for each drill phase when
+planner state can affect the result. In particular, do not reuse a ledger when
+earlier terminal attempts, failed tasks, leases, or stale heartbeats can change
+later `max-attempts`, capacity, or eligibility checks. Preserve each phase's
+repo/ledger as evidence, but start the next contaminated phase from a fresh
+pair.

--- a/scripts/drill/capture.ps1
+++ b/scripts/drill/capture.ps1
@@ -1,0 +1,338 @@
+$ErrorActionPreference = 'Stop'
+$script:DrillUtf8 = [Text.UTF8Encoding]::new($false)
+$script:DrillClassifications = @('PASS', 'PRODUCT_RED', 'SAFETY_RED', 'HARNESS_RED')
+
+function ConvertTo-DrillExitHex {
+    param([Parameter(Mandatory = $true)][int32]$ExitCode)
+    $bits = [BitConverter]::ToUInt32([BitConverter]::GetBytes($ExitCode), 0)
+    '0x{0:X8}' -f $bits
+}
+
+function Get-DrillSha256 {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    $stream = [IO.File]::OpenRead($Path)
+    $sha = [Security.Cryptography.SHA256]::Create()
+    try { ([BitConverter]::ToString($sha.ComputeHash($stream))).Replace('-', '') }
+    finally {
+        $sha.Dispose()
+        $stream.Dispose()
+    }
+}
+
+function Write-DrillAtomicNewText {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [AllowEmptyString()][Parameter(Mandatory = $true)][string]$Text
+    )
+    $temporary = "$Path.$([guid]::NewGuid().ToString('N')).tmp"
+    try {
+        [IO.File]::WriteAllText($temporary, $Text, $script:DrillUtf8)
+        [IO.File]::Move($temporary, $Path)
+    }
+    finally {
+        if ([IO.File]::Exists($temporary)) { [IO.File]::Delete($temporary) }
+    }
+}
+
+function Write-DrillRecord {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)]$Record
+    )
+    $json = $Record | ConvertTo-Json -Depth 12 -Compress
+    Write-DrillAtomicNewText -Path $Path -Text ($json + [Environment]::NewLine)
+}
+
+function Get-DrillSpecValue {
+    param($Spec, [Parameter(Mandatory = $true)][string]$Name)
+    if ($Spec -is [Collections.IDictionary]) { return $Spec[$Name] }
+    $Spec.$Name
+}
+
+function Assert-DrillSpec {
+    param([Parameter(Mandatory = $true)]$Spec)
+    $captureId = [string](Get-DrillSpecValue $Spec 'capture_id')
+    $owner = [string](Get-DrillSpecValue $Spec 'owner')
+    $executable = [string](Get-DrillSpecValue $Spec 'executable')
+    $cwd = [string](Get-DrillSpecValue $Spec 'cwd')
+    $classification = [string](Get-DrillSpecValue $Spec 'classification')
+    if ([string]::IsNullOrWhiteSpace($captureId)) { throw 'capture_id is required before process start' }
+    if ([string]::IsNullOrWhiteSpace($owner)) { throw 'owner is required before process start' }
+    if ([string]::IsNullOrWhiteSpace($executable)) { throw 'executable is required before process start' }
+    if ([string]::IsNullOrWhiteSpace($cwd)) { throw 'cwd is required before process start' }
+    if (-not [IO.File]::Exists($executable)) { throw "executable must be a literal file before process start: $executable" }
+    if (-not [IO.Directory]::Exists($cwd)) { throw "cwd must exist before process start: $cwd" }
+    if ([string]::IsNullOrWhiteSpace($classification)) { $classification = 'PASS' }
+    if ($classification -notin $script:DrillClassifications) { throw "invalid drill classification: $classification" }
+    [pscustomobject]@{
+        capture_id = $captureId
+        safe_id = $captureId -replace '[^A-Za-z0-9._-]', '_'
+        owner = $owner
+        executable = [IO.Path]::GetFullPath($executable)
+        cwd = [IO.Path]::GetFullPath($cwd)
+        argv = @((Get-DrillSpecValue $Spec 'argv'))
+        classification = $classification
+    }
+}
+
+function Get-DrillBoundedText {
+    param([AllowNull()][string]$Text, [Parameter(Mandatory = $true)][int]$MaxChars)
+    if ($null -eq $Text) { $Text = '' }
+    $length = $Text.Length
+    [ordered]@{
+        text = if ($length -le $MaxChars) { $Text } else { $Text.Substring(0, $MaxChars) }
+        total_chars = $length
+        truncated = $length -gt $MaxChars
+    }
+}
+
+function Get-DrillProcessIdentity {
+    param([Parameter(Mandatory = $true)][Diagnostics.Process]$Process)
+    $exitedBeforeQuery = $Process.HasExited
+    try {
+        [ordered]@{
+            process_creation_utc = $Process.StartTime.ToUniversalTime().ToString('o')
+            identity_status = if ($exitedBeforeQuery) { 'exited_before_identity_query_recovered' } else { 'captured' }
+            identity_error = $null
+        }
+    }
+    catch {
+        [ordered]@{
+            process_creation_utc = $null
+            identity_status = if ($exitedBeforeQuery) { 'exited_before_identity_query_unavailable' } else { 'identity_query_failed' }
+            identity_error = $_.Exception.Message
+        }
+    }
+}
+
+function Invoke-DrillCaptureSet {
+    param(
+        [Parameter(Mandatory = $true)][string]$SetId,
+        [Parameter(Mandatory = $true)][object[]]$Spec,
+        [Parameter(Mandatory = $true)][string]$OutputDirectory,
+        [ValidateRange(1, 1048576)][int]$MaxChars = 65536,
+        [scriptblock]$OptionalMetadata
+    )
+
+    if ([string]::IsNullOrWhiteSpace($SetId)) { throw 'SetId is required before process start' }
+    if ($Spec.Count -eq 0) { throw 'at least one process spec is required' }
+    $validated = @($Spec | ForEach-Object { Assert-DrillSpec $_ })
+    $safeIds = @($validated.safe_id)
+    if (($safeIds | Select-Object -Unique).Count -ne $safeIds.Count) { throw 'capture IDs collide after filename sanitization' }
+
+    [IO.Directory]::CreateDirectory($OutputDirectory) | Out-Null
+    $setSafeId = $SetId -replace '[^A-Za-z0-9._-]', '_'
+    $destinations = @()
+    foreach ($item in $validated) {
+        foreach ($suffix in @('00-planned.json', '10-started.json', '20-terminal.json', '30-optional.json', '30-optional-error.json', 'stdout.txt', 'stderr.txt')) {
+            $destinations += Join-Path $OutputDirectory "$($item.safe_id).$suffix"
+        }
+    }
+    $overlapPath = Join-Path $OutputDirectory "$setSafeId.20-overlap.json"
+    $destinations += $overlapPath
+    foreach ($path in $destinations) {
+        if ([IO.File]::Exists($path)) { throw "append-only capture destination already exists: $path" }
+    }
+
+    $states = @()
+    foreach ($item in $validated) {
+        $planned = [ordered]@{
+            schema = 'edda-drill-process-v1'
+            phase = 'planned'
+            capture_id = $item.capture_id
+            owner = $item.owner
+            executable = $item.executable
+            argv = @($item.argv)
+            cwd = $item.cwd
+            utc_planned = [DateTimeOffset]::UtcNow.ToString('o')
+        }
+        Write-DrillRecord -Path (Join-Path $OutputDirectory "$($item.safe_id).00-planned.json") -Record $planned
+        $states += [pscustomobject]@{
+            spec = $item
+            planned = $planned
+            process = $null
+            stdout_task = $null
+            stderr_task = $null
+            utc_start = $null
+            process_id = $null
+            process_creation_utc = $null
+            identity_status = 'not_started'
+            identity_error = $null
+            start_error = $null
+        }
+    }
+
+    # Launch every child before asking the OS for either child's identity.
+    foreach ($state in $states) {
+        $state.utc_start = [DateTimeOffset]::UtcNow.ToString('o')
+        try {
+            $psi = [Diagnostics.ProcessStartInfo]::new()
+            $psi.FileName = $state.spec.executable
+            $psi.WorkingDirectory = $state.spec.cwd
+            $psi.UseShellExecute = $false
+            $psi.CreateNoWindow = $true
+            $psi.RedirectStandardOutput = $true
+            $psi.RedirectStandardError = $true
+            $psi.StandardOutputEncoding = $script:DrillUtf8
+            $psi.StandardErrorEncoding = $script:DrillUtf8
+            foreach ($argument in $state.spec.argv) { [void]$psi.ArgumentList.Add([string]$argument) }
+            $process = [Diagnostics.Process]::new()
+            $process.StartInfo = $psi
+            [void]$process.Start()
+            $state.process = $process
+            $state.process_id = $process.Id
+            $state.stdout_task = $process.StandardOutput.ReadToEndAsync()
+            $state.stderr_task = $process.StandardError.ReadToEndAsync()
+        }
+        catch {
+            $state.start_error = $_.Exception.ToString()
+            $state.identity_status = 'start_failed'
+        }
+    }
+
+    foreach ($state in $states) {
+        if ($null -ne $state.process) {
+            $identity = Get-DrillProcessIdentity -Process $state.process
+            $state.process_creation_utc = $identity.process_creation_utc
+            $state.identity_status = $identity.identity_status
+            $state.identity_error = $identity.identity_error
+        }
+        $started = [ordered]@{
+            schema = 'edda-drill-process-v1'
+            phase = 'started'
+            capture_id = $state.spec.capture_id
+            owner = $state.spec.owner
+            executable = $state.spec.executable
+            argv = @($state.spec.argv)
+            cwd = $state.spec.cwd
+            utc_start = $state.utc_start
+            pid = $state.process_id
+            process_creation_utc = $state.process_creation_utc
+            identity_status = $state.identity_status
+            identity_error = $state.identity_error
+            start_error = $state.start_error
+        }
+        Write-DrillRecord -Path (Join-Path $OutputDirectory "$($state.spec.safe_id).10-started.json") -Record $started
+    }
+
+    $terminals = @()
+    $optionalRecords = @()
+    foreach ($state in $states) {
+        $stdoutText = ''
+        $stderrText = if ($state.start_error) { $state.start_error } else { '' }
+        $exitSigned = $null
+        $processExitUtc = $null
+        if ($null -ne $state.process) {
+            $state.process.WaitForExit()
+            $stdoutText = $state.stdout_task.GetAwaiter().GetResult()
+            $stderrText = $state.stderr_task.GetAwaiter().GetResult()
+            $exitSigned = [int32]$state.process.ExitCode
+            try { $processExitUtc = $state.process.ExitTime.ToUniversalTime().ToString('o') } catch { $processExitUtc = $null }
+        }
+        $utcEnd = [DateTimeOffset]::UtcNow.ToString('o')
+        $stdout = Get-DrillBoundedText -Text $stdoutText -MaxChars $MaxChars
+        $stderr = Get-DrillBoundedText -Text $stderrText -MaxChars $MaxChars
+        $stdoutPath = Join-Path $OutputDirectory "$($state.spec.safe_id).stdout.txt"
+        $stderrPath = Join-Path $OutputDirectory "$($state.spec.safe_id).stderr.txt"
+        Write-DrillAtomicNewText -Path $stdoutPath -Text $stdout.text
+        Write-DrillAtomicNewText -Path $stderrPath -Text $stderr.text
+        $stdout.path = $stdoutPath
+        $stdout.sha256 = Get-DrillSha256 -Path $stdoutPath
+        $stderr.path = $stderrPath
+        $stderr.sha256 = Get-DrillSha256 -Path $stderrPath
+        $terminal = [ordered]@{
+            schema = 'edda-drill-process-v1'
+            phase = 'terminal'
+            classification = $state.spec.classification
+            capture_id = $state.spec.capture_id
+            owner = $state.spec.owner
+            executable = $state.spec.executable
+            argv = @($state.spec.argv)
+            cwd = $state.spec.cwd
+            utc_start = $state.utc_start
+            process_creation_utc = $state.process_creation_utc
+            utc_end = $utcEnd
+            process_exit_utc = $processExitUtc
+            pid = $state.process_id
+            identity_status = $state.identity_status
+            identity_error = $state.identity_error
+            exit_signed = $exitSigned
+            start_error = $state.start_error
+            stdout = $stdout
+            stderr = $stderr
+        }
+        Write-DrillRecord -Path (Join-Path $OutputDirectory "$($state.spec.safe_id).20-terminal.json") -Record $terminal
+        $terminals += $terminal
+
+        try {
+            $metadata = if ($OptionalMetadata) { & $OptionalMetadata $terminal } else { $null }
+            $optional = [ordered]@{
+                schema = 'edda-drill-process-v1'
+                phase = 'optional'
+                classification = 'OPTIONAL_METADATA'
+                status = 'captured'
+                capture_id = $state.spec.capture_id
+                exit_u32_hex = if ($null -eq $exitSigned) { $null } else { ConvertTo-DrillExitHex -ExitCode $exitSigned }
+                metadata = $metadata
+            }
+            Write-DrillRecord -Path (Join-Path $OutputDirectory "$($state.spec.safe_id).30-optional.json") -Record $optional
+        }
+        catch {
+            $optional = [ordered]@{
+                schema = 'edda-drill-process-v1'
+                phase = 'optional'
+                classification = 'OPTIONAL_METADATA'
+                status = 'failed'
+                capture_id = $state.spec.capture_id
+                error = $_.Exception.Message
+            }
+            Write-DrillRecord -Path (Join-Path $OutputDirectory "$($state.spec.safe_id).30-optional-error.json") -Record $optional
+        }
+        $optionalRecords += $optional
+    }
+
+    $intervals = @($terminals | Where-Object { $_.process_creation_utc -and $_.process_exit_utc })
+    $latestStart = $null
+    $earliestExit = $null
+    $overlap = $false
+    if ($intervals.Count -ge 2) {
+        $latestStart = @($intervals | ForEach-Object { [DateTimeOffset]::ParseExact($_.process_creation_utc, 'o', [Globalization.CultureInfo]::InvariantCulture) } | Sort-Object)[-1]
+        $earliestExit = @($intervals | ForEach-Object { [DateTimeOffset]::ParseExact($_.process_exit_utc, 'o', [Globalization.CultureInfo]::InvariantCulture) } | Sort-Object)[0]
+        $overlap = $latestStart -lt $earliestExit
+    }
+    $overlapRecord = [ordered]@{
+        schema = 'edda-drill-overlap-v1'
+        phase = 'terminal'
+        set_id = $SetId
+        capture_ids = @($terminals.capture_id)
+        overlap = $overlap
+        latest_start_utc = if ($null -eq $latestStart) { $null } else { $latestStart.ToString('o') }
+        earliest_exit_utc = if ($null -eq $earliestExit) { $null } else { $earliestExit.ToString('o') }
+    }
+    Write-DrillRecord -Path $overlapPath -Record $overlapRecord
+    [pscustomobject]@{ Terminals = $terminals; Optional = $optionalRecords; Overlap = $overlapRecord }
+}
+
+function Invoke-DrillCapture {
+    param(
+        [Parameter(Mandatory = $true)][string]$CaptureId,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Owner,
+        [Parameter(Mandatory = $true)][string]$Executable,
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [string[]]$ArgumentList = @(),
+        [Parameter(Mandatory = $true)][string]$OutputDirectory,
+        [ValidateSet('PASS', 'PRODUCT_RED', 'SAFETY_RED', 'HARNESS_RED')][string]$Classification = 'PASS',
+        [ValidateRange(1, 1048576)][int]$MaxChars = 65536,
+        [scriptblock]$OptionalMetadata
+    )
+    $spec = @{
+        capture_id = $CaptureId
+        owner = $Owner
+        executable = $Executable
+        cwd = $WorkingDirectory
+        argv = @($ArgumentList)
+        classification = $Classification
+    }
+    $result = Invoke-DrillCaptureSet -SetId $CaptureId -Spec @($spec) -OutputDirectory $OutputDirectory -MaxChars $MaxChars -OptionalMetadata $OptionalMetadata
+    [pscustomobject]@{ Terminal = @($result.Terminals)[0]; Optional = @($result.Optional)[0] }
+}

--- a/scripts/drill/self-test.ps1
+++ b/scripts/drill/self-test.ps1
@@ -1,0 +1,125 @@
+param()
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'capture.ps1')
+
+function Assert-Drill([bool]$Condition, [string]$Message) {
+    if (-not $Condition) { throw "self-test: $Message" }
+}
+
+$utf8 = [Text.UTF8Encoding]::new($false)
+$testRoot = Join-Path ([IO.Path]::GetTempPath()) "edda drill self-test $([guid]::NewGuid().ToString('N'))"
+$unicodeRoot = Join-Path $testRoot '路徑 with spaces'
+$pwsh = (Get-Command pwsh -ErrorAction Stop).Source
+$childScript = Join-Path $unicodeRoot 'child probe.ps1'
+
+try {
+    [IO.Directory]::CreateDirectory($unicodeRoot) | Out-Null
+    [IO.File]::WriteAllText($childScript, @'
+param([string]$Mode, [string]$Text)
+[Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
+[Console]::InputEncoding = [Text.UTF8Encoding]::new($false)
+if ($Mode -eq 'slow') { Start-Sleep -Milliseconds 700 }
+if ($Mode -eq 'noisy') {
+    [Console]::Out.Write(('o' * 80))
+    [Console]::Error.Write(('e' * 80))
+    exit 7
+}
+[Console]::Out.Write("$($PWD.Path)|$Text")
+'@, $utf8)
+
+    Assert-Drill ((ConvertTo-DrillExitHex -ExitCode -1) -eq '0xFFFFFFFF') 'negative exit conversion lost Int32 bits'
+
+    $fastDir = Join-Path $unicodeRoot 'fast result'
+    $fast = Invoke-DrillCapture `
+        -CaptureId 'fast' `
+        -Owner 'self-test' `
+        -Executable $pwsh `
+        -WorkingDirectory $unicodeRoot `
+        -ArgumentList @('-NoProfile', '-File', $childScript, '-Mode', 'fast', '-Text', 'hello 世界 with spaces') `
+        -OutputDirectory $fastDir
+    Assert-Drill ($fast.Terminal.exit_signed -eq 0) 'fast child exit was not captured'
+    Assert-Drill ($fast.Terminal.pid -gt 0) 'fast child PID is missing'
+    Assert-Drill ($fast.Terminal.owner -eq 'self-test') 'ownership field is missing'
+    Assert-Drill ($fast.Terminal.cwd -eq $unicodeRoot) 'cwd was not recorded exactly'
+    Assert-Drill ($fast.Terminal.stdout.text -eq "$unicodeRoot|hello 世界 with spaces") "ArgumentList or non-ASCII path was altered: '$($fast.Terminal.stdout.text)'"
+    Assert-Drill (Test-Path -LiteralPath (Join-Path $fastDir 'fast.00-planned.json')) 'planned record was not preserved'
+    Assert-Drill (Test-Path -LiteralPath (Join-Path $fastDir 'fast.20-terminal.json')) 'terminal record was not preserved'
+
+    $startText = $fast.Terminal.utc_start
+    $endText = $fast.Terminal.utc_end
+    $start = [DateTimeOffset]::ParseExact($startText, 'o', [Globalization.CultureInfo]::InvariantCulture)
+    $end = [DateTimeOffset]::ParseExact($endText, 'o', [Globalization.CultureInfo]::InvariantCulture)
+    Assert-Drill ($start.Offset -eq [TimeSpan]::Zero -and $end.Offset -eq [TimeSpan]::Zero) 'timestamps are not UTC round-trippable'
+    $jsonRoundTrip = @{ utc_start = $startText; utc_end = $endText } | ConvertTo-Json -Compress | ConvertFrom-Json
+    Assert-Drill ($jsonRoundTrip.utc_start -eq $startText -and $jsonRoundTrip.utc_end -eq $endText) 'JSON timestamp round-trip changed the value'
+
+    $noisy = Invoke-DrillCapture `
+        -CaptureId 'bounded' `
+        -Owner 'self-test' `
+        -Executable $pwsh `
+        -WorkingDirectory $unicodeRoot `
+        -ArgumentList @('-NoProfile', '-File', $childScript, '-Mode', 'noisy') `
+        -OutputDirectory (Join-Path $unicodeRoot 'bounded result') `
+        -MaxChars 32
+    Assert-Drill ($noisy.Terminal.exit_signed -eq 7) 'signed exit was not retained'
+    Assert-Drill ($noisy.Terminal.stdout.truncated -and $noisy.Terminal.stderr.truncated) 'output was not bounded'
+    Assert-Drill ($noisy.Terminal.stdout.text.Length -eq 32 -and $noisy.Terminal.stderr.text.Length -eq 32) 'bounded output length is wrong'
+    Assert-Drill ($noisy.Terminal.stdout.sha256 -eq (Get-DrillSha256 -Path $noisy.Terminal.stdout.path)) 'stdout hash mismatch'
+    Assert-Drill ($noisy.Terminal.stderr.sha256 -eq (Get-DrillSha256 -Path $noisy.Terminal.stderr.path)) 'stderr hash mismatch'
+
+    $concurrentDir = Join-Path $unicodeRoot 'concurrent result'
+    $specs = @(
+        @{ capture_id = 'A'; owner = 'self-test'; executable = $pwsh; cwd = $unicodeRoot; argv = @('-NoProfile', '-File', $childScript, '-Mode', 'slow', '-Text', 'A') },
+        @{ capture_id = 'B'; owner = 'self-test'; executable = $pwsh; cwd = $unicodeRoot; argv = @('-NoProfile', '-File', $childScript, '-Mode', 'slow', '-Text', 'B') }
+    )
+    $concurrent = Invoke-DrillCaptureSet -SetId 'overlap' -Spec $specs -OutputDirectory $concurrentDir
+    Assert-Drill ($concurrent.Overlap.overlap) 'two-process OS intervals did not overlap'
+    Assert-Drill ($concurrent.Overlap.latest_start_utc -lt $concurrent.Overlap.earliest_exit_utc) 'overlap proof interval is invalid'
+    Assert-Drill (($concurrent.Terminals | Where-Object { -not $_.process_creation_utc }).Count -eq 0) 'slow-process creation time is missing'
+
+    $fastExitSpecs = @(
+        @{ capture_id = 'gone'; owner = 'self-test'; executable = $env:ComSpec; cwd = $unicodeRoot; argv = @('/d', '/c', 'exit 0') },
+        @{ capture_id = 'delay'; owner = 'self-test'; executable = $pwsh; cwd = $unicodeRoot; argv = @('-NoProfile', '-File', $childScript, '-Mode', 'slow', '-Text', 'delay') }
+    )
+    $fastExit = Invoke-DrillCaptureSet -SetId 'fast-exit' -Spec $fastExitSpecs -OutputDirectory (Join-Path $unicodeRoot 'fast exit result')
+    $gone = $fastExit.Terminals | Where-Object capture_id -eq 'gone'
+    Assert-Drill ($gone.exit_signed -eq 0) 'process exiting before identity query was not completed honestly'
+    $identityProbe = [Diagnostics.Process]::Start($env:ComSpec, '/d /c exit 0')
+    $identityProbe.WaitForExit()
+    $exitedIdentity = Get-DrillProcessIdentity -Process $identityProbe
+    Assert-Drill ($exitedIdentity.identity_status -match '^exited_before_identity_query') 'fast exit was not identified honestly'
+
+    $optionalDir = Join-Path $unicodeRoot 'optional failure result'
+    $optional = Invoke-DrillCapture `
+        -CaptureId 'optional' `
+        -Owner 'self-test' `
+        -Executable $env:ComSpec `
+        -WorkingDirectory $unicodeRoot `
+        -ArgumentList @('/d', '/c', 'exit 0') `
+        -OutputDirectory $optionalDir `
+        -OptionalMetadata { throw 'deliberate optional formatter failure' }
+    Assert-Drill ($optional.Terminal.pid -gt 0 -and $optional.Terminal.utc_start -and $optional.Terminal.utc_end) 'optional failure erased ownership or timing'
+    Assert-Drill ($optional.Optional.classification -eq 'OPTIONAL_METADATA') 'optional failure classification is wrong'
+    Assert-Drill (Test-Path -LiteralPath (Join-Path $optionalDir 'optional.20-terminal.json')) 'optional failure erased terminal record'
+
+    $marker = Join-Path $unicodeRoot 'must-not-run.txt'
+    $requiredFailed = $false
+    try {
+        Invoke-DrillCapture `
+            -CaptureId 'required-failure' `
+            -Owner '' `
+            -Executable $pwsh `
+            -WorkingDirectory $unicodeRoot `
+            -ArgumentList @('-NoProfile', '-Command', "[IO.File]::WriteAllText('$marker','ran')") `
+            -OutputDirectory (Join-Path $unicodeRoot 'required failure result') | Out-Null
+    }
+    catch { $requiredFailed = $true }
+    Assert-Drill $requiredFailed 'missing required ownership did not fail'
+    Assert-Drill (-not (Test-Path -LiteralPath $marker)) 'required ownership failure acted on a PID'
+
+    [pscustomobject]@{ status = 'PASS'; checks = 8; root = $testRoot }
+}
+finally {
+    if (Test-Path -LiteralPath $testRoot) { Remove-Item -LiteralPath $testRoot -Recurse -Force }
+}


### PR DESCRIPTION
Closes #475

## What changed

- adds a reusable PowerShell process-capture helper under `scripts/drill/`
- writes immutable planned, started, terminal, and optional records with direct `ProcessStartInfo.ArgumentList`, OS process intervals, signed exits, bounded output, and .NET SHA-256
- launches every concurrent child before either identity query and persists overlap proof
- adds an offline self-test for negative-exit conversion, fast exit, overlap, Unicode/space paths, timestamp round-trip, optional-metadata failure, required-owner preflight, and bounded hashed output
- documents receipt classification and fresh repo/ledger isolation between contaminating drill phases

## Why

The GH-466 drills repeatedly stopped on one-off evidence-script defects. This keeps harness failures distinct from product failures without changing Edda runtime behavior.

## TDD evidence

- RED: `pwsh -NoProfile -File scripts/drill/self-test.ps1` exited 1 because `capture.ps1` was absent
- GREEN: the same command exits 0 with `PASS 8`

## Validation

- `pwsh -NoProfile -File scripts/drill/self-test.ps1`
- PowerShell parser check for both scripts
- `git diff --cached --check`
- no Cargo/workspace/CI gates run (proportional non-product scope)

## Scope

Exact head: `fba0c3455307bf656e7317ee99abd385e06588dd`

Only:
- `scripts/drill/capture.ps1`
- `scripts/drill/self-test.ps1`
- `docs/plan/task-rail/DRILL_CAPTURE.md`
