### PR TITLE
fix(skills): own fleet-orchestrate global distribution

### DIFF
--- a/docs/guides/fleet-skill-distribution.md
+++ b/docs/guides/fleet-skill-distribution.md
@@ -44,13 +44,23 @@ when Git or relevant history is unavailable, a differing target is classified
 `locally-modified`. Historical comparison folds CRLF to LF only for valid
 UTF-8 text, covering Git checkout normalization while retaining exact matching
 for binary files. Marked installs always use their exact recorded byte digest.
+Their marker also binds that digest to a canonical identity derived from the
+Git root lineage plus repository-relative skill path, with the absolute path as
+the fail-safe identity when Git is unavailable. A marker from another identity
+is `locally-modified`, not stale.
 
 Sync stages the complete canonical tree in a unique sibling directory, checks
-manifest parity, then renames it into place. The adjacent
+manifest parity, then revalidates the target immediately before the first
+rename. A target changed since classification is refused unless `-Force` is
+explicit, in which case the changed bytes become the reported backup.
+Canonical and target paths are rejected if either contains the other. The
+adjacent
 `fleet-orchestrate.edda-provenance.json` marker records the canonical and
 installed digests without changing the installed directory manifest. A
 locally modified target is refused unless `-Force` is explicit; forced sync
 renames the previous directory to a reported sibling backup before installing.
+If transient-backup cleanup fails after promotion, the complete new target
+stays live and the result reports the remaining backup and cleanup error.
 
 Fixture callers can override `-CanonicalPath`, `-CodexPath`, and `-ClaudePath`.
 `-StagingPath` is limited to one target and must name a unique

--- a/docs/guides/fleet-skill-distribution.md
+++ b/docs/guides/fleet-skill-distribution.md
@@ -1,0 +1,67 @@
+# Fleet skill distribution
+
+The repository directory `skills/fleet-orchestrate/` is the sole canonical
+source. Global installation is explicit: ordinary `edda init`, including its
+skill setup, does not copy or update `fleet-orchestrate` in a user's profile.
+
+On Windows, inspect both supported installs without writing anything:
+
+```powershell
+pwsh -NoProfile -File scripts/skills/sync-fleet-orchestrate.ps1 `
+  -Action Status -Target All
+```
+
+The defaults are:
+
+- Codex: `%USERPROFILE%\.agents\skills\fleet-orchestrate`
+- Claude: `%USERPROFILE%\.claude\skills\fleet-orchestrate`
+
+Use `-Target Codex`, `-Target Claude`, or `-Target All`. `Status` never writes.
+`Sync -DryRun` reports the intended operation without writing, and `-Json`
+returns an array of structured results suitable for release checks:
+
+```powershell
+pwsh -NoProfile -File scripts/skills/sync-fleet-orchestrate.ps1 `
+  -Action Sync -Target All -DryRun -Json
+
+pwsh -NoProfile -File scripts/skills/sync-fleet-orchestrate.ps1 `
+  -Action Sync -Target All
+```
+
+Each target is classified before mutation:
+
+- `missing`: no installed directory exists;
+- `current`: its complete manifest equals canonical;
+- `stale`: its bytes match the recorded installed digest or an exact historical
+  canonical tree in the current Git repository;
+- `locally-modified`: no trusted provenance or historical canonical match
+  proves that replacement is safe.
+
+The manifest sorts every relative file path ordinally and records its byte
+length and a .NET SHA-256. The script does not depend on `Get-FileHash`.
+Repository history is read only for safe bootstrap of older unmarked installs;
+when Git or relevant history is unavailable, a differing target is classified
+`locally-modified`. Historical comparison folds CRLF to LF only for valid
+UTF-8 text, covering Git checkout normalization while retaining exact matching
+for binary files. Marked installs always use their exact recorded byte digest.
+
+Sync stages the complete canonical tree in a unique sibling directory, checks
+manifest parity, then renames it into place. The adjacent
+`fleet-orchestrate.edda-provenance.json` marker records the canonical and
+installed digests without changing the installed directory manifest. A
+locally modified target is refused unless `-Force` is explicit; forced sync
+renames the previous directory to a reported sibling backup before installing.
+
+Fixture callers can override `-CanonicalPath`, `-CodexPath`, and `-ClaudePath`.
+`-StagingPath` is limited to one target and must name a unique
+`fleet-orchestrate.edda-staging-*` sibling; the self-test uses it only to prove
+that staging failure preserves the existing target.
+
+Run the offline acceptance check with:
+
+```powershell
+pwsh -NoProfile -File scripts/skills/self-test-fleet-orchestrate-sync.ps1
+```
+
+The test creates only temporary fixtures, including a tiny local Git history;
+it never reads from or syncs to the real Codex or Claude install directories.

--- a/scripts/skills/self-test-fleet-orchestrate-sync.ps1
+++ b/scripts/skills/self-test-fleet-orchestrate-sync.ps1
@@ -148,6 +148,74 @@ try {
     Assert-True ((Get-FixtureDigest $codex) -eq $oldDigest) 'dry-run preserves target bytes'
     Assert-True (($beforeDryRun -join '|') -eq ($afterDryRun -join '|')) 'dry-run creates no sibling files'
 
+    $env:EDDA_FLEET_SYNC_TEST_ROOT = $fixtureRoot
+    $env:EDDA_FLEET_SYNC_TEST_FAULT = 'TargetChanged'
+    try {
+        $boundaryRefused = Invoke-SyncTool (@('-Action', 'Sync', '-Target', 'Codex') + $common)
+    }
+    finally {
+        Remove-Item Env:EDDA_FLEET_SYNC_TEST_FAULT, Env:EDDA_FLEET_SYNC_TEST_ROOT -ErrorAction SilentlyContinue
+    }
+    Assert-True ($boundaryRefused.ExitCode -ne 0) 'mutation-boundary change is refused without Force'
+    Assert-True ($boundaryRefused.Data[0].Operation -eq 'Refused') 'mutation-boundary refusal is reported'
+    $changedBeforeForce = [IO.File]::ReadAllText((Join-Path $codex 'SKILL.md'))
+
+    $env:EDDA_FLEET_SYNC_TEST_ROOT = $fixtureRoot
+    $env:EDDA_FLEET_SYNC_TEST_FAULT = 'TargetChanged'
+    try {
+        $boundaryForced = Invoke-SyncTool (@('-Action', 'Sync', '-Target', 'Codex', '-Force') + $common)
+    }
+    finally {
+        Remove-Item Env:EDDA_FLEET_SYNC_TEST_FAULT, Env:EDDA_FLEET_SYNC_TEST_ROOT -ErrorAction SilentlyContinue
+    }
+    Assert-True ($boundaryForced.ExitCode -eq 0) 'Force accepts a mutation-boundary change'
+    Assert-True (Test-Path -LiteralPath $boundaryForced.Data[0].BackupPath -PathType Container) 'Force preserves a mutation-boundary backup'
+    $expectedChangedBytes = $changedBeforeForce + "`nTEST BOUNDARY MUTATION`n"
+    Assert-True ([IO.File]::ReadAllText((Join-Path $boundaryForced.Data[0].BackupPath 'SKILL.md')) -eq $expectedChangedBytes) 'Force backup preserves the changed bytes'
+
+    $canonicalBeforeOverlap = Get-FixtureDigest $canonical
+    $targetBelowCanonical = Join-Path $canonical 'nested target'
+    $belowResult = Invoke-SyncTool @('-Action', 'Sync', '-Target', 'Codex', '-CanonicalPath', $canonical, '-CodexPath', $targetBelowCanonical, '-Json')
+    Assert-True ($belowResult.ExitCode -ne 0) 'target below canonical is rejected'
+    Assert-True (-not (Test-Path -LiteralPath $targetBelowCanonical)) 'target-below-canonical rejection writes nothing'
+    Assert-True ((Get-FixtureDigest $canonical) -eq $canonicalBeforeOverlap) 'target-below-canonical rejection preserves canonical'
+
+    $targetAboveCanonical = Join-Path $fixtureRoot 'ancestor target'
+    $canonicalBelowTarget = Join-Path $targetAboveCanonical 'canonical child'
+    Copy-FixtureTree $canonical $canonicalBelowTarget
+    $aboveBefore = Get-FixtureDigest $targetAboveCanonical
+    $aboveResult = Invoke-SyncTool @('-Action', 'Sync', '-Target', 'Codex', '-Force', '-CanonicalPath', $canonicalBelowTarget, '-CodexPath', $targetAboveCanonical, '-Json')
+    Assert-True ($aboveResult.ExitCode -ne 0) 'canonical below target is rejected'
+    Assert-True ((Get-FixtureDigest $targetAboveCanonical) -eq $aboveBefore) 'canonical-below-target rejection writes nothing'
+    Assert-True (Test-Path -LiteralPath $canonicalBelowTarget -PathType Container) 'canonical-below-target rejection preserves canonical'
+
+    $claudeBeforeStageMove = Get-FixtureDigest $claude
+    $env:EDDA_FLEET_SYNC_TEST_ROOT = $fixtureRoot
+    $env:EDDA_FLEET_SYNC_TEST_FAULT = 'StageMove'
+    try {
+        $stageMoveFailure = Invoke-SyncTool (@('-Action', 'Sync', '-Target', 'Claude') + $common)
+    }
+    finally {
+        Remove-Item Env:EDDA_FLEET_SYNC_TEST_FAULT, Env:EDDA_FLEET_SYNC_TEST_ROOT -ErrorAction SilentlyContinue
+    }
+    Assert-True ($stageMoveFailure.ExitCode -ne 0) 'stage move failure is reported'
+    Assert-True (Test-Path -LiteralPath $claude -PathType Container) 'stage move failure leaves a live target'
+    Assert-True ((Get-FixtureDigest $claude) -eq $claudeBeforeStageMove) 'stage move failure restores the complete old target'
+
+    $env:EDDA_FLEET_SYNC_TEST_ROOT = $fixtureRoot
+    $env:EDDA_FLEET_SYNC_TEST_FAULT = 'Cleanup'
+    try {
+        $cleanupFailure = Invoke-SyncTool (@('-Action', 'Sync', '-Target', 'Claude') + $common)
+    }
+    finally {
+        Remove-Item Env:EDDA_FLEET_SYNC_TEST_FAULT, Env:EDDA_FLEET_SYNC_TEST_ROOT -ErrorAction SilentlyContinue
+    }
+    Assert-True ($cleanupFailure.ExitCode -ne 0) 'cleanup failure is reported'
+    Assert-True ($cleanupFailure.Data[0].Operation -eq 'CleanupFailed') 'cleanup failure has a distinct operation'
+    Assert-True ((Get-FixtureDigest $claude) -eq $canonicalDigest) 'cleanup failure leaves the complete new target live'
+    Assert-True (Test-Path -LiteralPath $cleanupFailure.Data[0].BackupPath -PathType Container) 'cleanup failure reports the remaining backup'
+    Assert-True ($cleanupFailure.Data[0].Error.Contains('injected cleanup failure')) 'cleanup error is explicit'
+
     $syncAll = Invoke-SyncTool (@('-Action', 'Sync', '-Target', 'All') + $common)
     Assert-True ($syncAll.ExitCode -eq 0) 'normal sync succeeds for both targets'
     Assert-True ($syncAll.Data.Count -eq 2) 'all returns both target results'
@@ -160,6 +228,19 @@ try {
         Assert-True ($result.Status -eq 'current') 'post-sync status is current'
         Assert-True ($result.MarkerCurrent -eq $true) 'post-sync provenance is current'
     }
+
+    $otherCanonical = Join-Path $repo 'other/fleet-orchestrate'
+    Copy-FixtureTree $canonical $otherCanonical
+    & git -C $repo add --all
+    & git -C $repo commit --quiet -m 'other canonical lineage path'
+    $beforeForeignCanonical = Get-FixtureDigest $codex
+    $foreignArgs = @('-CanonicalPath', $otherCanonical, '-CodexPath', $codex, '-Json')
+    $foreignStatus = Invoke-SyncTool (@('-Action', 'Status', '-Target', 'Codex') + $foreignArgs)
+    Assert-True ($foreignStatus.Data[0].Status -eq 'locally-modified') 'marker from another canonical identity is locally modified'
+    $foreignRefused = Invoke-SyncTool (@('-Action', 'Sync', '-Target', 'Codex') + $foreignArgs)
+    Assert-True ($foreignRefused.ExitCode -ne 0) 'another canonical identity is refused without Force'
+    Assert-True ($foreignRefused.Data[0].Operation -eq 'Refused') 'another canonical refusal is reported'
+    Assert-True ((Get-FixtureDigest $codex) -eq $beforeForeignCanonical) 'another canonical refusal preserves target bytes'
 
     Add-Content -LiteralPath (Join-Path $codex 'SKILL.md') -Value 'local edit' -Encoding utf8
     $modifiedDigest = Get-FixtureDigest $codex

--- a/scripts/skills/self-test-fleet-orchestrate-sync.ps1
+++ b/scripts/skills/self-test-fleet-orchestrate-sync.ps1
@@ -1,0 +1,211 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$ToolPath = Join-Path $PSScriptRoot 'sync-fleet-orchestrate.ps1'
+$Utf8NoBom = [Text.UTF8Encoding]::new($false)
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+
+    if (-not $Condition) {
+        throw "ASSERTION FAILED: $Message"
+    }
+}
+
+function Write-FixtureFile {
+    param([string]$Path, [string]$Content)
+
+    [IO.Directory]::CreateDirectory([IO.Path]::GetDirectoryName($Path)) | Out-Null
+    [IO.File]::WriteAllText($Path, $Content, $Utf8NoBom)
+}
+
+function Copy-FixtureTree {
+    param([string]$Source, [string]$Destination)
+
+    [IO.Directory]::CreateDirectory($Destination) | Out-Null
+    foreach ($file in Get-ChildItem -LiteralPath $Source -Recurse -File) {
+        $relative = [IO.Path]::GetRelativePath($Source, $file.FullName)
+        $copy = Join-Path $Destination $relative
+        [IO.Directory]::CreateDirectory([IO.Path]::GetDirectoryName($copy)) | Out-Null
+        [IO.File]::WriteAllBytes($copy, [IO.File]::ReadAllBytes($file.FullName))
+    }
+}
+
+function Get-FixtureDigest {
+    param([string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        return $null
+    }
+
+    $lines = [Collections.Generic.List[string]]::new()
+    foreach ($file in Get-ChildItem -LiteralPath $Path -Recurse -File) {
+        $relative = [IO.Path]::GetRelativePath($Path, $file.FullName).Replace('\', '/')
+        $bytes = [IO.File]::ReadAllBytes($file.FullName)
+        $sha = [Security.Cryptography.SHA256]::Create()
+        try {
+            $hash = [Convert]::ToHexString($sha.ComputeHash($bytes)).ToLowerInvariant()
+        }
+        finally {
+            $sha.Dispose()
+        }
+        $lines.Add("$relative`t$($bytes.Length)`t$hash")
+    }
+    $sorted = $lines.ToArray()
+    [Array]::Sort($sorted, [StringComparer]::Ordinal)
+    $manifestBytes = $Utf8NoBom.GetBytes(($sorted -join "`n") + "`n")
+    $manifestSha = [Security.Cryptography.SHA256]::Create()
+    try {
+        return [Convert]::ToHexString($manifestSha.ComputeHash($manifestBytes)).ToLowerInvariant()
+    }
+    finally {
+        $manifestSha.Dispose()
+    }
+}
+
+function Invoke-SyncTool {
+    param([string[]]$Arguments)
+
+    $output = & (Get-Process -Id $PID).Path -NoProfile -NonInteractive -File $ToolPath @Arguments 2>&1 | Out-String
+    $exitCode = $LASTEXITCODE
+    $data = $null
+    if ($output.Trim()) {
+        try {
+            $data = ConvertFrom-Json $output
+        }
+        catch {
+            throw "Tool did not return JSON. Exit=$exitCode Output=$output"
+        }
+    }
+    [pscustomobject]@{ ExitCode = $exitCode; Data = @($data); Raw = $output }
+}
+
+function Remove-FixtureTree {
+    param([string]$Path, [string]$FixtureRoot)
+
+    $fullPath = [IO.Path]::GetFullPath($Path)
+    $fullRoot = [IO.Path]::GetFullPath($FixtureRoot).TrimEnd('\') + '\'
+    if (-not [string]::Equals($fullPath.TrimEnd('\'), $fullRoot.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase) -and
+        -not $fullPath.StartsWith($fullRoot, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing fixture cleanup outside $fullRoot"
+    }
+    if (Test-Path -LiteralPath $fullPath) {
+        Remove-Item -LiteralPath $fullPath -Recurse -Force
+    }
+}
+
+Assert-True (Test-Path -LiteralPath $ToolPath -PathType Leaf) 'sync tool exists'
+
+$fixtureRoot = Join-Path ([IO.Path]::GetTempPath()) "edda fleet sync 測試 $([guid]::NewGuid().ToString('N'))"
+[IO.Directory]::CreateDirectory($fixtureRoot) | Out-Null
+
+try {
+    $repo = Join-Path $fixtureRoot 'tiny history repo'
+    $canonical = Join-Path $repo 'skills/fleet-orchestrate'
+    $codex = Join-Path $fixtureRoot 'Codex 安裝/skills/fleet-orchestrate'
+    $claude = Join-Path $fixtureRoot 'Claude install/skills/fleet-orchestrate'
+    [IO.Directory]::CreateDirectory($repo) | Out-Null
+
+    & git -C $repo init --quiet
+    & git -C $repo config user.email 'fixture@example.invalid'
+    & git -C $repo config user.name 'Fixture'
+    & git -C $repo config core.autocrlf false
+    Write-FixtureFile (Join-Path $canonical 'SKILL.md') "# Fleet Orchestrate`n`nOld policy fixture.`n"
+    Write-FixtureFile (Join-Path $canonical 'agents/openai.yaml') "name: fleet-orchestrate`n"
+    Write-FixtureFile (Join-Path $canonical 'references/playbook.md') "# Old playbook`n"
+    & git -C $repo add --all
+    & git -C $repo commit --quiet -m 'old canonical'
+    Copy-FixtureTree $canonical $codex
+    Copy-FixtureTree $canonical $claude
+    foreach ($install in @($codex, $claude)) {
+        $agentFile = Join-Path $install 'agents/openai.yaml'
+        $checkoutText = [IO.File]::ReadAllText($agentFile).Replace("`n", "`r`n")
+        [IO.File]::WriteAllText($agentFile, $checkoutText, $Utf8NoBom)
+    }
+    $oldDigest = Get-FixtureDigest $codex
+
+    Write-FixtureFile (Join-Path $canonical 'SKILL.md') "# Fleet Orchestrate`n`nThis is a bounded complete review, never a minimal review.`n"
+    Write-FixtureFile (Join-Path $canonical 'references/playbook.md') "# Current playbook`n`nBounded scope.`n"
+    Write-FixtureFile (Join-Path $canonical 'references/review-scope-pressure-tests.md') "# Pressure tests`n"
+    & git -C $repo add --all
+    & git -C $repo commit --quiet -m 'current canonical'
+    $canonicalDigest = Get-FixtureDigest $canonical
+
+    $common = @('-CanonicalPath', $canonical, '-CodexPath', $codex, '-ClaudePath', $claude, '-Json')
+
+    $status = Invoke-SyncTool (@('-Action', 'Status', '-Target', 'Codex') + $common)
+    Assert-True ($status.ExitCode -eq 0) 'status succeeds for historical install'
+    Assert-True ($status.Data[0].Status -eq 'stale') 'old unmarked canonical copy is stale'
+    Assert-True ((Get-FixtureDigest $codex) -eq $oldDigest) 'status writes nothing'
+    Assert-True (-not (Test-Path -LiteralPath "$codex.edda-provenance.json")) 'status does not create provenance'
+
+    $beforeDryRun = @(Get-ChildItem -LiteralPath ([IO.Path]::GetDirectoryName($codex)) -Force | ForEach-Object Name | Sort-Object)
+    $dryRun = Invoke-SyncTool (@('-Action', 'Sync', '-Target', 'Codex', '-DryRun') + $common)
+    $afterDryRun = @(Get-ChildItem -LiteralPath ([IO.Path]::GetDirectoryName($codex)) -Force | ForEach-Object Name | Sort-Object)
+    Assert-True ($dryRun.ExitCode -eq 0) 'dry-run succeeds'
+    Assert-True ($dryRun.Data[0].Operation -eq 'WouldSync') 'dry-run reports intended sync'
+    Assert-True ((Get-FixtureDigest $codex) -eq $oldDigest) 'dry-run preserves target bytes'
+    Assert-True (($beforeDryRun -join '|') -eq ($afterDryRun -join '|')) 'dry-run creates no sibling files'
+
+    $syncAll = Invoke-SyncTool (@('-Action', 'Sync', '-Target', 'All') + $common)
+    Assert-True ($syncAll.ExitCode -eq 0) 'normal sync succeeds for both targets'
+    Assert-True ($syncAll.Data.Count -eq 2) 'all returns both target results'
+    Assert-True ((Get-FixtureDigest $codex) -eq $canonicalDigest) 'Codex target has exact parity'
+    Assert-True ((Get-FixtureDigest $claude) -eq $canonicalDigest) 'Claude target has exact parity'
+    $boundedReviewText = 'This is a bounded complete review, never a minimal review.'
+    Assert-True ((Get-Content -Raw -LiteralPath (Join-Path $codex 'SKILL.md')).Contains($boundedReviewText)) 'Codex load sees bounded review text'
+    Assert-True ((Get-Content -Raw -LiteralPath (Join-Path $claude 'SKILL.md')).Contains($boundedReviewText)) 'Claude load sees bounded review text'
+    foreach ($result in $syncAll.Data) {
+        Assert-True ($result.Status -eq 'current') 'post-sync status is current'
+        Assert-True ($result.MarkerCurrent -eq $true) 'post-sync provenance is current'
+    }
+
+    Add-Content -LiteralPath (Join-Path $codex 'SKILL.md') -Value 'local edit' -Encoding utf8
+    $modifiedDigest = Get-FixtureDigest $codex
+    $modified = Invoke-SyncTool (@('-Action', 'Status', '-Target', 'Codex') + $common)
+    Assert-True ($modified.Data[0].Status -eq 'locally-modified') 'changed marked target is locally modified'
+    $refused = Invoke-SyncTool (@('-Action', 'Sync', '-Target', 'Codex') + $common)
+    Assert-True ($refused.ExitCode -ne 0) 'normal sync refuses local modifications'
+    Assert-True ($refused.Data[0].Operation -eq 'Refused') 'refusal is reported'
+    Assert-True ((Get-FixtureDigest $codex) -eq $modifiedDigest) 'refused sync preserves target bytes'
+
+    $forced = Invoke-SyncTool (@('-Action', 'Sync', '-Target', 'Codex', '-Force') + $common)
+    Assert-True ($forced.ExitCode -eq 0) 'forced sync succeeds'
+    Assert-True ($forced.Data[0].Status -eq 'current') 'forced sync reports current'
+    Assert-True ((Get-FixtureDigest $codex) -eq $canonicalDigest) 'forced sync restores parity'
+    Assert-True (Test-Path -LiteralPath $forced.Data[0].BackupPath -PathType Container) 'forced sync reports a preserved backup'
+    Assert-True ((Get-FixtureDigest $forced.Data[0].BackupPath) -eq $modifiedDigest) 'forced backup preserves modified bytes'
+
+    Remove-FixtureTree $claude $fixtureRoot
+    Remove-Item -LiteralPath "$claude.edda-provenance.json" -Force
+    $missing = Invoke-SyncTool (@('-Action', 'Status', '-Target', 'Claude') + $common)
+    Assert-True ($missing.Data[0].Status -eq 'missing') 'absent target is missing'
+    $missingSync = Invoke-SyncTool (@('-Action', 'Sync', '-Target', 'Claude') + $common)
+    Assert-True ($missingSync.ExitCode -eq 0) 'missing target sync succeeds'
+    Assert-True ((Get-FixtureDigest $claude) -eq $canonicalDigest) 'missing target reaches parity'
+
+    $outsideCanonical = Join-Path $fixtureRoot '沒有 git canonical'
+    $outsideTarget = Join-Path $fixtureRoot 'unmarked custom target'
+    Copy-FixtureTree $canonical $outsideCanonical
+    Copy-FixtureTree $canonical $outsideTarget
+    Add-Content -LiteralPath (Join-Path $outsideTarget 'SKILL.md') -Value 'unknown old tree' -Encoding utf8
+    $noHistory = Invoke-SyncTool @('-Action', 'Status', '-Target', 'Codex', '-CanonicalPath', $outsideCanonical, '-CodexPath', $outsideTarget, '-Json')
+    Assert-True ($noHistory.ExitCode -eq 0) 'status survives unavailable history'
+    Assert-True ($noHistory.Data[0].Status -eq 'locally-modified') 'unavailable history fails safe as locally modified'
+
+    Add-Content -LiteralPath (Join-Path $canonical 'SKILL.md') -Value 'next canonical' -Encoding utf8
+    & git -C $repo add --all
+    & git -C $repo commit --quiet -m 'next canonical'
+    $beforeStageFailure = Get-FixtureDigest $codex
+    $blockedStage = Join-Path ([IO.Path]::GetDirectoryName($codex)) 'fleet-orchestrate.edda-staging-fixed-fixture'
+    Write-FixtureFile $blockedStage 'blocks staging directory creation'
+    $stageFailure = Invoke-SyncTool (@('-Action', 'Sync', '-Target', 'Codex', '-StagingPath', $blockedStage) + $common)
+    Assert-True ($stageFailure.ExitCode -ne 0) 'staging failure is reported'
+    Assert-True ((Get-FixtureDigest $codex) -eq $beforeStageFailure) 'staging failure retains the target'
+
+    Write-Output 'PASS: fleet-orchestrate sync self-test'
+}
+finally {
+    Remove-FixtureTree $fixtureRoot $fixtureRoot
+}

--- a/scripts/skills/sync-fleet-orchestrate.ps1
+++ b/scripts/skills/sync-fleet-orchestrate.ps1
@@ -27,6 +27,15 @@ function Get-FullPath {
     [IO.Path]::GetFullPath($Path).TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
 }
 
+function Test-IsSameOrDescendantPath {
+    param([string]$Path, [string]$Ancestor)
+
+    $fullPath = Get-FullPath $Path
+    $fullAncestor = Get-FullPath $Ancestor
+    [string]::Equals($fullPath, $fullAncestor, [StringComparison]::OrdinalIgnoreCase) -or
+        $fullPath.StartsWith($fullAncestor + [IO.Path]::DirectorySeparatorChar, [StringComparison]::OrdinalIgnoreCase)
+}
+
 function Get-Sha256Hex {
     param([byte[]]$Bytes)
 
@@ -195,33 +204,63 @@ function Test-HistoricalCanonical {
     $false
 }
 
+function Get-CanonicalIdentity {
+    param([string]$Canonical)
+
+    try {
+        $repoRoot = Get-FullPath (Invoke-GitText $Canonical @('rev-parse', '--show-toplevel'))
+        $relative = [IO.Path]::GetRelativePath($repoRoot, $Canonical).Replace('\', '/')
+        if ($relative -eq '..' -or $relative.StartsWith('../', [StringComparison]::Ordinal)) { throw 'canonical is outside repository' }
+        [string[]]$roots = (Invoke-GitText $repoRoot @('rev-list', '--max-parents=0', 'HEAD')).Split("`n", [StringSplitOptions]::RemoveEmptyEntries)
+        if ($roots.Count -eq 0) { throw 'repository has no root commit' }
+        [Array]::Sort($roots, [StringComparer]::Ordinal)
+        $basis = "git`n$relative`n$($roots -join "`n")"
+    }
+    catch {
+        $basis = "path`n$(Get-FullPath $Canonical)"
+    }
+    Get-Sha256Hex $Utf8NoBom.GetBytes($basis)
+}
+
 function Get-Marker {
     param([string]$MarkerPath)
 
     if (-not (Test-Path -LiteralPath $MarkerPath -PathType Leaf)) {
-        return [pscustomobject]@{ Exists = $false; Valid = $false; Schema = $null; CanonicalDigest = $null; InstalledDigest = $null }
+        return [pscustomobject]@{ Exists = $false; Valid = $false; Schema = $null; CanonicalIdentity = $null; CanonicalDigest = $null; InstalledDigest = $null }
     }
     try {
         $data = Get-Content -Raw -LiteralPath $MarkerPath | ConvertFrom-Json
         $schema = $data.PSObject.Properties['Schema']
+        $canonicalIdentity = $data.PSObject.Properties['CanonicalIdentity']
         $canonicalDigest = $data.PSObject.Properties['CanonicalDigest']
         $installedDigest = $data.PSObject.Properties['InstalledDigest']
-        $valid = $null -ne $schema -and $null -ne $canonicalDigest -and $null -ne $installedDigest -and $schema.Value -eq 1
+        $valid = $null -ne $schema -and $null -ne $canonicalIdentity -and $null -ne $canonicalDigest -and
+            $null -ne $installedDigest -and $schema.Value -eq 2
         [pscustomobject]@{
             Exists = $true
             Valid = $valid
             Schema = if ($null -ne $schema) { $schema.Value } else { $null }
+            CanonicalIdentity = if ($null -ne $canonicalIdentity) { $canonicalIdentity.Value } else { $null }
             CanonicalDigest = if ($null -ne $canonicalDigest) { $canonicalDigest.Value } else { $null }
             InstalledDigest = if ($null -ne $installedDigest) { $installedDigest.Value } else { $null }
         }
     }
     catch {
-        [pscustomobject]@{ Exists = $true; Valid = $false; Schema = $null; CanonicalDigest = $null; InstalledDigest = $null }
+        [pscustomobject]@{ Exists = $true; Valid = $false; Schema = $null; CanonicalIdentity = $null; CanonicalDigest = $null; InstalledDigest = $null }
     }
 }
 
+function Get-OptionalFileDigest {
+    param([string]$Path)
+
+    if (Test-Path -LiteralPath $Path -PathType Leaf) {
+        return Get-Sha256Hex ([IO.File]::ReadAllBytes($Path))
+    }
+    $null
+}
+
 function Get-TargetState {
-    param([string]$Name, [string]$Path, [object]$CanonicalManifest, [string]$Canonical)
+    param([string]$Name, [string]$Path, [object]$CanonicalManifest, [string]$Canonical, [string]$CanonicalIdentity)
 
     $fullPath = Get-FullPath $Path
     $markerPath = "$fullPath.edda-provenance.json"
@@ -229,20 +268,25 @@ function Get-TargetState {
         return [pscustomobject]@{
             Target = $Name; Path = $fullPath; MarkerPath = $markerPath; Status = 'missing'
             Digest = $null; CanonicalDigest = $CanonicalManifest.Digest; MarkerCurrent = $false
+            MarkerDigest = Get-OptionalFileDigest $markerPath
         }
     }
 
     $manifest = Get-DirectoryManifest $fullPath
     $marker = Get-Marker $markerPath
-    $markerCurrent = $marker.Valid -and
+    $markerBelongs = $marker.Valid -and $marker.CanonicalIdentity -eq $CanonicalIdentity
+    $markerCurrent = $markerBelongs -and
         $marker.CanonicalDigest -eq $CanonicalManifest.Digest -and
         $marker.InstalledDigest -eq $manifest.Digest
 
-    if ($manifest.Digest -eq $CanonicalManifest.Digest) {
+    if ($marker.Exists -and -not $markerBelongs) {
+        $status = 'locally-modified'
+    }
+    elseif ($manifest.Digest -eq $CanonicalManifest.Digest) {
         $status = 'current'
     }
     elseif ($marker.Exists) {
-        $status = if ($marker.Valid -and $marker.InstalledDigest -eq $manifest.Digest) { 'stale' } else { 'locally-modified' }
+        $status = if ($markerBelongs -and $marker.InstalledDigest -eq $manifest.Digest) { 'stale' } else { 'locally-modified' }
     }
     elseif (Test-HistoricalCanonical $Canonical $manifest) {
         $status = 'stale'
@@ -254,6 +298,7 @@ function Get-TargetState {
     [pscustomobject]@{
         Target = $Name; Path = $fullPath; MarkerPath = $markerPath; Status = $status
         Digest = $manifest.Digest; CanonicalDigest = $CanonicalManifest.Digest; MarkerCurrent = $markerCurrent
+        MarkerDigest = Get-OptionalFileDigest $markerPath
     }
 }
 
@@ -281,7 +326,7 @@ function Assert-UniqueSibling {
 }
 
 function Write-Provenance {
-    param([object]$State, [string]$Canonical, [string]$Digest)
+    param([object]$State, [string]$Canonical, [string]$CanonicalIdentity, [string]$Digest)
 
     $markerPath = Get-FullPath $State.MarkerPath
     if (-not [string]::Equals($markerPath, "$($State.Path).edda-provenance.json", [StringComparison]::OrdinalIgnoreCase)) {
@@ -290,7 +335,8 @@ function Write-Provenance {
     $temporary = Join-Path ([IO.Path]::GetDirectoryName($State.Path)) "$([IO.Path]::GetFileName($State.Path)).edda-staging-marker-$([guid]::NewGuid().ToString('N'))"
     Assert-UniqueSibling $temporary $State.Path staging
     $payload = [ordered]@{
-        Schema = 1
+        Schema = 2
+        CanonicalIdentity = $CanonicalIdentity
         CanonicalDigest = $Digest
         InstalledDigest = $Digest
         CanonicalPath = $Canonical
@@ -325,8 +371,32 @@ function Copy-ToStage {
     }
 }
 
+function Invoke-TestFault {
+    param([string]$Name, [string]$TargetPath)
+
+    if ($env:EDDA_FLEET_SYNC_TEST_FAULT -ne $Name) { return }
+    if (-not $env:EDDA_FLEET_SYNC_TEST_ROOT) { throw 'Test fault requires EDDA_FLEET_SYNC_TEST_ROOT' }
+    $root = Get-FullPath $env:EDDA_FLEET_SYNC_TEST_ROOT
+    $targetFull = Get-FullPath $TargetPath
+    $rootPrefix = $root + [IO.Path]::DirectorySeparatorChar
+    if (-not $targetFull.StartsWith($rootPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw 'Test fault target is outside EDDA_FLEET_SYNC_TEST_ROOT'
+    }
+    if ($Name -eq 'TargetChanged') {
+        [IO.File]::AppendAllText((Join-Path $targetFull 'SKILL.md'), "`nTEST BOUNDARY MUTATION`n", $Utf8NoBom)
+    }
+    elseif ($Name -eq 'StageMove') {
+        throw 'injected stage move failure'
+    }
+    elseif ($Name -eq 'Cleanup') {
+        $firstFile = Get-ChildItem -LiteralPath $targetFull -Recurse -File | Sort-Object FullName | Select-Object -First 1
+        if ($null -ne $firstFile) { [IO.File]::Delete($firstFile.FullName) }
+        throw 'injected cleanup failure after partial backup deletion'
+    }
+}
+
 function Install-Target {
-    param([object]$State, [string]$Canonical, [object]$CanonicalManifest, [bool]$KeepBackup, [string]$RequestedStage)
+    param([object]$State, [string]$Canonical, [string]$CanonicalIdentity, [object]$CanonicalManifest, [bool]$ForceInstall, [string]$RequestedStage)
 
     Assert-TargetPath $State.Path $State.Path
     $parent = [IO.Path]::GetDirectoryName($State.Path)
@@ -341,43 +411,64 @@ function Install-Target {
 
     $stageCreated = $false
     $oldTarget = $null
-    $swapped = $false
+    $oldRenamed = $false
+    $newTargetLive = $false
     try {
         Copy-ToStage $Canonical $CanonicalManifest $stage
         $stageCreated = $true
+        Invoke-TestFault 'TargetChanged' $State.Path
+        $currentState = Get-TargetState $State.Target $State.Path $CanonicalManifest $Canonical $CanonicalIdentity
+        $targetChanged = $currentState.Status -ne $State.Status -or
+            $currentState.Digest -ne $State.Digest -or
+            $currentState.MarkerDigest -ne $State.MarkerDigest
+        if ($targetChanged -and -not $ForceInstall) {
+            $exception = [InvalidOperationException]::new('Target changed after classification; use -Force to preserve a backup and replace it.')
+            $exception.Data['Operation'] = 'Refused'
+            throw $exception
+        }
+        $keepBackup = ($State.Status -eq 'locally-modified') -or $targetChanged
         if (Test-Path -LiteralPath $State.Path -PathType Container) {
-            $kind = if ($KeepBackup) { 'backup' } else { 'backup-transient' }
+            $kind = if ($keepBackup) { 'backup' } else { 'backup-transient' }
             $oldTarget = Join-Path $parent "$([IO.Path]::GetFileName($State.Path)).edda-$kind-$([guid]::NewGuid().ToString('N'))"
             Assert-UniqueSibling $oldTarget $State.Path backup
             [IO.Directory]::Move($State.Path, $oldTarget)
+            $oldRenamed = $true
         }
+        Invoke-TestFault 'StageMove' $State.Path
         [IO.Directory]::Move($stage, $State.Path)
         $stageCreated = $false
-        $swapped = $true
-        Write-Provenance $State $Canonical $CanonicalManifest.Digest
+        $newTargetLive = $true
+        Write-Provenance $State $Canonical $CanonicalIdentity $CanonicalManifest.Digest
 
         $installed = Get-DirectoryManifest $State.Path
         $marker = Get-Marker $State.MarkerPath
         if ($installed.Digest -ne $CanonicalManifest.Digest -or -not $marker.Valid -or
-            $marker.CanonicalDigest -ne $CanonicalManifest.Digest -or $marker.InstalledDigest -ne $installed.Digest) {
+            $marker.CanonicalIdentity -ne $CanonicalIdentity -or $marker.CanonicalDigest -ne $CanonicalManifest.Digest -or
+            $marker.InstalledDigest -ne $installed.Digest) {
             throw 'Post-sync parity or provenance verification failed'
         }
-        if ($null -ne $oldTarget -and -not $KeepBackup) {
+        if ($null -ne $oldTarget -and -not $keepBackup) {
             Assert-UniqueSibling $oldTarget $State.Path backup
-            [IO.Directory]::Delete($oldTarget, $true)
-            $oldTarget = $null
+            try {
+                Invoke-TestFault 'Cleanup' $oldTarget
+                [IO.Directory]::Delete($oldTarget, $true)
+                $oldTarget = $null
+            }
+            catch {
+                return [pscustomobject]@{ BackupPath = $oldTarget; CleanupError = $_.Exception.Message }
+            }
         }
-        return $oldTarget
+        return [pscustomobject]@{ BackupPath = $oldTarget; CleanupError = $null }
     }
     catch {
-        if ($swapped -and $null -ne $oldTarget -and (Test-Path -LiteralPath $oldTarget -PathType Container)) {
-            if (Test-Path -LiteralPath $State.Path -PathType Container) {
-                Assert-UniqueSibling $stage $State.Path staging
-                [IO.Directory]::Move($State.Path, $stage)
-                $stageCreated = $true
-            }
+        if ($oldRenamed -and -not $newTargetLive -and
+            $null -ne $oldTarget -and (Test-Path -LiteralPath $oldTarget -PathType Container) -and
+            -not (Test-Path -LiteralPath $State.Path)) {
             [IO.Directory]::Move($oldTarget, $State.Path)
             $oldTarget = $null
+        }
+        elseif ($newTargetLive -and $null -ne $oldTarget -and (Test-Path -LiteralPath $oldTarget -PathType Container)) {
+            $_.Exception.Data['BackupPath'] = $oldTarget
         }
         throw
     }
@@ -416,6 +507,7 @@ try {
     }
     $canonicalManifest = Get-DirectoryManifest $canonical
     if ($canonicalManifest.Entries.Count -eq 0) { throw "Canonical skill directory is empty: $canonical" }
+    $canonicalIdentity = Get-CanonicalIdentity $canonical
 
     $selected = switch ($Target) {
         'Codex' { @([pscustomobject]@{ Name = 'Codex'; Path = $CodexPath }) }
@@ -431,10 +523,11 @@ try {
 
     $states = foreach ($item in $selected) {
         $fullTarget = Get-FullPath $item.Path
-        if ([string]::Equals($canonical, $fullTarget, [StringComparison]::OrdinalIgnoreCase)) {
-            throw "Canonical and target paths must differ: $canonical"
+        if ((Test-IsSameOrDescendantPath $fullTarget $canonical) -or
+            (Test-IsSameOrDescendantPath $canonical $fullTarget)) {
+            throw "Canonical and target paths must not overlap: canonical=$canonical target=$fullTarget"
         }
-        Get-TargetState $item.Name $fullTarget $canonicalManifest $canonical
+        Get-TargetState $item.Name $fullTarget $canonicalManifest $canonical $canonicalIdentity
     }
 
     foreach ($state in $states) {
@@ -456,23 +549,35 @@ try {
 
         try {
             $backup = $null
+            $operationError = $null
             if ($state.Status -eq 'current') {
-                Write-Provenance $state $canonical $canonicalManifest.Digest
+                Write-Provenance $state $canonical $canonicalIdentity $canonicalManifest.Digest
                 $operation = if ($state.MarkerCurrent) { 'None' } else { 'Marked' }
             }
             else {
-                $backup = Install-Target $state $canonical $canonicalManifest ($state.Status -eq 'locally-modified') $StagingPath
-                $operation = 'Synced'
+                $installResult = Install-Target $state $canonical $canonicalIdentity $canonicalManifest $Force $StagingPath
+                $backup = $installResult.BackupPath
+                if ($installResult.CleanupError) {
+                    $operation = 'CleanupFailed'
+                    $operationError = $installResult.CleanupError
+                    $exitCode = 1
+                }
+                else {
+                    $operation = 'Synced'
+                    $operationError = $null
+                }
             }
-            $current = Get-TargetState $state.Target $state.Path $canonicalManifest $canonical
+            $current = Get-TargetState $state.Target $state.Path $canonicalManifest $canonical $canonicalIdentity
             if ($current.Status -ne 'current' -or -not $current.MarkerCurrent) {
                 throw 'Post-sync target is not current'
             }
-            $results += New-Result $current $operation $previousStatus $backup $null
+            $results += New-Result $current $operation $previousStatus $backup $operationError
         }
         catch {
-            $failed = Get-TargetState $state.Target $state.Path $canonicalManifest $canonical
-            $results += New-Result $failed 'Failed' $previousStatus $null $_.Exception.Message
+            $failed = Get-TargetState $state.Target $state.Path $canonicalManifest $canonical $canonicalIdentity
+            $failedOperation = if ($_.Exception.Data.Contains('Operation')) { $_.Exception.Data['Operation'] } else { 'Failed' }
+            $failedBackup = if ($_.Exception.Data.Contains('BackupPath')) { $_.Exception.Data['BackupPath'] } else { $null }
+            $results += New-Result $failed $failedOperation $previousStatus $failedBackup $_.Exception.Message
             $exitCode = 1
         }
     }

--- a/scripts/skills/sync-fleet-orchestrate.ps1
+++ b/scripts/skills/sync-fleet-orchestrate.ps1
@@ -1,0 +1,495 @@
+[CmdletBinding()]
+param(
+    [ValidateSet('Status', 'Sync')]
+    [string]$Action = 'Status',
+
+    [ValidateSet('Codex', 'Claude', 'All')]
+    [string]$Target = 'All',
+
+    [switch]$DryRun,
+    [switch]$Force,
+    [switch]$Json,
+
+    [string]$CanonicalPath = (Join-Path $PSScriptRoot '../../skills/fleet-orchestrate'),
+    [string]$CodexPath = (Join-Path $env:USERPROFILE '.agents/skills/fleet-orchestrate'),
+    [string]$ClaudePath = (Join-Path $env:USERPROFILE '.claude/skills/fleet-orchestrate'),
+
+    [string]$StagingPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$Utf8NoBom = [Text.UTF8Encoding]::new($false)
+
+function Get-FullPath {
+    param([string]$Path)
+
+    [IO.Path]::GetFullPath($Path).TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
+}
+
+function Get-Sha256Hex {
+    param([byte[]]$Bytes)
+
+    $sha = [Security.Cryptography.SHA256]::Create()
+    try {
+        [Convert]::ToHexString($sha.ComputeHash($Bytes)).ToLowerInvariant()
+    }
+    finally {
+        $sha.Dispose()
+    }
+}
+
+function Get-HistoricalComparisonBytes {
+    param([byte[]]$Bytes)
+
+    if ([Array]::IndexOf($Bytes, [byte]0) -ge 0) { return $Bytes }
+    try {
+        $strictUtf8 = [Text.UTF8Encoding]::new($false, $true)
+        $text = $strictUtf8.GetString($Bytes)
+        if (-not $text.Contains("`r`n")) { return $Bytes }
+        $Utf8NoBom.GetBytes($text.Replace("`r`n", "`n"))
+    }
+    catch {
+        $Bytes
+    }
+}
+
+function New-Manifest {
+    param([object[]]$Entries)
+
+    $byPath = [Collections.Generic.Dictionary[string, object]]::new([StringComparer]::Ordinal)
+    foreach ($entry in $Entries) {
+        $byPath.Add($entry.RelativePath, $entry)
+    }
+    [string[]]$paths = $byPath.Keys
+    [Array]::Sort($paths, [StringComparer]::Ordinal)
+    $sorted = foreach ($path in $paths) { $byPath[$path] }
+    $lines = foreach ($entry in $sorted) {
+        $encodedPath = [Convert]::ToBase64String($Utf8NoBom.GetBytes($entry.RelativePath))
+        "$encodedPath`t$($entry.Length)`t$($entry.Sha256)"
+    }
+    $historicalLines = foreach ($entry in $sorted) {
+        $encodedPath = [Convert]::ToBase64String($Utf8NoBom.GetBytes($entry.RelativePath))
+        "$encodedPath`t$($entry.HistoricalLength)`t$($entry.HistoricalSha256)"
+    }
+    $serialized = if ($lines.Count -gt 0) { ($lines -join "`n") + "`n" } else { '' }
+    $historicalSerialized = if ($historicalLines.Count -gt 0) { ($historicalLines -join "`n") + "`n" } else { '' }
+    [pscustomobject]@{
+        Entries          = @($sorted)
+        Digest           = Get-Sha256Hex $Utf8NoBom.GetBytes($serialized)
+        HistoricalDigest = Get-Sha256Hex $Utf8NoBom.GetBytes($historicalSerialized)
+    }
+}
+
+function Get-DirectoryManifest {
+    param([string]$Path)
+
+    $entries = foreach ($file in Get-ChildItem -LiteralPath $Path -Recurse -File -Force) {
+        $relative = [IO.Path]::GetRelativePath($Path, $file.FullName).Replace('\', '/')
+        $bytes = [IO.File]::ReadAllBytes($file.FullName)
+        $historicalBytes = Get-HistoricalComparisonBytes $bytes
+        [pscustomobject]@{
+            RelativePath     = $relative
+            Length           = [long]$bytes.Length
+            Sha256           = Get-Sha256Hex $bytes
+            HistoricalLength = [long]$historicalBytes.Length
+            HistoricalSha256 = Get-Sha256Hex $historicalBytes
+        }
+    }
+    New-Manifest @($entries)
+}
+
+function Invoke-GitBytes {
+    param([string]$WorkingDirectory, [string[]]$Arguments)
+
+    $startInfo = [Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = 'git'
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $startInfo.CreateNoWindow = $true
+    $startInfo.ArgumentList.Add('-C')
+    $startInfo.ArgumentList.Add($WorkingDirectory)
+    foreach ($argument in $Arguments) {
+        $startInfo.ArgumentList.Add($argument)
+    }
+
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    try {
+        if (-not $process.Start()) {
+            throw 'git did not start'
+        }
+        $stderr = $process.StandardError.ReadToEndAsync()
+        $output = [IO.MemoryStream]::new()
+        try {
+            $process.StandardOutput.BaseStream.CopyTo($output)
+            $process.WaitForExit()
+            $errorText = $stderr.GetAwaiter().GetResult()
+            if ($process.ExitCode -ne 0) {
+                throw "git exited $($process.ExitCode): $errorText"
+            }
+            $output.ToArray()
+        }
+        finally {
+            $output.Dispose()
+        }
+    }
+    finally {
+        $process.Dispose()
+    }
+}
+
+function Invoke-GitText {
+    param([string]$WorkingDirectory, [string[]]$Arguments)
+
+    $Utf8NoBom.GetString((Invoke-GitBytes $WorkingDirectory $Arguments)).Trim()
+}
+
+function Get-GitTreeManifest {
+    param([string]$RepoRoot, [string]$Commit, [string]$CanonicalRelativePath)
+
+    $treeBytes = Invoke-GitBytes $RepoRoot @('ls-tree', '-r', '-z', '--full-tree', $Commit, '--', $CanonicalRelativePath)
+    $records = $Utf8NoBom.GetString($treeBytes).Split([char]0, [StringSplitOptions]::RemoveEmptyEntries)
+    $entries = foreach ($record in $records) {
+        $tab = $record.IndexOf("`t", [StringComparison]::Ordinal)
+        if ($tab -lt 0) { continue }
+        $header = $record.Substring(0, $tab).Split(' ', [StringSplitOptions]::RemoveEmptyEntries)
+        if ($header.Count -lt 3 -or $header[1] -ne 'blob') { continue }
+        $repoPath = $record.Substring($tab + 1).Replace('\', '/')
+        $relative = $repoPath.Substring($CanonicalRelativePath.Length).TrimStart('/')
+        $content = Invoke-GitBytes $RepoRoot @('cat-file', 'blob', $header[2])
+        $historicalContent = Get-HistoricalComparisonBytes $content
+        [pscustomobject]@{
+            RelativePath     = $relative
+            Length           = [long]$content.Length
+            Sha256           = Get-Sha256Hex $content
+            HistoricalLength = [long]$historicalContent.Length
+            HistoricalSha256 = Get-Sha256Hex $historicalContent
+        }
+    }
+    if (@($entries).Count -eq 0) { return $null }
+    New-Manifest @($entries)
+}
+
+function Test-HistoricalCanonical {
+    param([string]$Canonical, [object]$TargetManifest)
+
+    try {
+        $repoRoot = Get-FullPath (Invoke-GitText $Canonical @('rev-parse', '--show-toplevel'))
+        $relative = [IO.Path]::GetRelativePath($repoRoot, $Canonical).Replace('\', '/')
+        if ($relative -eq '..' -or $relative.StartsWith('../', [StringComparison]::Ordinal)) {
+            return $false
+        }
+        $history = Invoke-GitText $repoRoot @('log', '--format=%H', '--all', '--', $relative)
+        foreach ($commit in $history.Split("`n", [StringSplitOptions]::RemoveEmptyEntries)) {
+            $manifest = Get-GitTreeManifest $repoRoot $commit.Trim() $relative
+            if ($null -ne $manifest -and $manifest.HistoricalDigest -eq $TargetManifest.HistoricalDigest) {
+                return $true
+            }
+        }
+    }
+    catch {
+        # No usable repository history means the target is not safe to overwrite.
+    }
+    $false
+}
+
+function Get-Marker {
+    param([string]$MarkerPath)
+
+    if (-not (Test-Path -LiteralPath $MarkerPath -PathType Leaf)) {
+        return [pscustomobject]@{ Exists = $false; Valid = $false; Schema = $null; CanonicalDigest = $null; InstalledDigest = $null }
+    }
+    try {
+        $data = Get-Content -Raw -LiteralPath $MarkerPath | ConvertFrom-Json
+        $schema = $data.PSObject.Properties['Schema']
+        $canonicalDigest = $data.PSObject.Properties['CanonicalDigest']
+        $installedDigest = $data.PSObject.Properties['InstalledDigest']
+        $valid = $null -ne $schema -and $null -ne $canonicalDigest -and $null -ne $installedDigest -and $schema.Value -eq 1
+        [pscustomobject]@{
+            Exists = $true
+            Valid = $valid
+            Schema = if ($null -ne $schema) { $schema.Value } else { $null }
+            CanonicalDigest = if ($null -ne $canonicalDigest) { $canonicalDigest.Value } else { $null }
+            InstalledDigest = if ($null -ne $installedDigest) { $installedDigest.Value } else { $null }
+        }
+    }
+    catch {
+        [pscustomobject]@{ Exists = $true; Valid = $false; Schema = $null; CanonicalDigest = $null; InstalledDigest = $null }
+    }
+}
+
+function Get-TargetState {
+    param([string]$Name, [string]$Path, [object]$CanonicalManifest, [string]$Canonical)
+
+    $fullPath = Get-FullPath $Path
+    $markerPath = "$fullPath.edda-provenance.json"
+    if (-not (Test-Path -LiteralPath $fullPath -PathType Container)) {
+        return [pscustomobject]@{
+            Target = $Name; Path = $fullPath; MarkerPath = $markerPath; Status = 'missing'
+            Digest = $null; CanonicalDigest = $CanonicalManifest.Digest; MarkerCurrent = $false
+        }
+    }
+
+    $manifest = Get-DirectoryManifest $fullPath
+    $marker = Get-Marker $markerPath
+    $markerCurrent = $marker.Valid -and
+        $marker.CanonicalDigest -eq $CanonicalManifest.Digest -and
+        $marker.InstalledDigest -eq $manifest.Digest
+
+    if ($manifest.Digest -eq $CanonicalManifest.Digest) {
+        $status = 'current'
+    }
+    elseif ($marker.Exists) {
+        $status = if ($marker.Valid -and $marker.InstalledDigest -eq $manifest.Digest) { 'stale' } else { 'locally-modified' }
+    }
+    elseif (Test-HistoricalCanonical $Canonical $manifest) {
+        $status = 'stale'
+    }
+    else {
+        $status = 'locally-modified'
+    }
+
+    [pscustomobject]@{
+        Target = $Name; Path = $fullPath; MarkerPath = $markerPath; Status = $status
+        Digest = $manifest.Digest; CanonicalDigest = $CanonicalManifest.Digest; MarkerCurrent = $markerCurrent
+    }
+}
+
+function Assert-TargetPath {
+    param([string]$Candidate, [string]$Requested)
+
+    if (-not [string]::Equals((Get-FullPath $Candidate), (Get-FullPath $Requested), [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Mutation path is not the exact requested target: $Candidate"
+    }
+}
+
+function Assert-UniqueSibling {
+    param([string]$Candidate, [string]$Requested, [ValidateSet('staging', 'backup')][string]$Kind)
+
+    $candidateFull = Get-FullPath $Candidate
+    $requestedFull = Get-FullPath $Requested
+    $parent = [IO.Path]::GetDirectoryName($requestedFull)
+    $candidateParent = [IO.Path]::GetDirectoryName($candidateFull)
+    $prefix = [IO.Path]::GetFileName($requestedFull) + ".edda-$Kind-"
+    if (-not [string]::Equals($parent, $candidateParent, [StringComparison]::OrdinalIgnoreCase) -or
+        -not [IO.Path]::GetFileName($candidateFull).StartsWith($prefix, [StringComparison]::Ordinal) -or
+        [IO.Path]::GetFileName($candidateFull).Length -le $prefix.Length) {
+        throw "Mutation path is not a unique $Kind sibling of the requested target: $Candidate"
+    }
+}
+
+function Write-Provenance {
+    param([object]$State, [string]$Canonical, [string]$Digest)
+
+    $markerPath = Get-FullPath $State.MarkerPath
+    if (-not [string]::Equals($markerPath, "$($State.Path).edda-provenance.json", [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Invalid provenance path: $markerPath"
+    }
+    $temporary = Join-Path ([IO.Path]::GetDirectoryName($State.Path)) "$([IO.Path]::GetFileName($State.Path)).edda-staging-marker-$([guid]::NewGuid().ToString('N'))"
+    Assert-UniqueSibling $temporary $State.Path staging
+    $payload = [ordered]@{
+        Schema = 1
+        CanonicalDigest = $Digest
+        InstalledDigest = $Digest
+        CanonicalPath = $Canonical
+        SyncedAtUtc = [DateTimeOffset]::UtcNow.ToString('O')
+    } | ConvertTo-Json -Compress
+    try {
+        [IO.File]::WriteAllText($temporary, $payload + "`n", $Utf8NoBom)
+        [IO.File]::Move($temporary, $markerPath, $true)
+    }
+    finally {
+        if (Test-Path -LiteralPath $temporary -PathType Leaf) { [IO.File]::Delete($temporary) }
+    }
+}
+
+function Copy-ToStage {
+    param([string]$Canonical, [object]$CanonicalManifest, [string]$Stage)
+
+    [IO.Directory]::CreateDirectory($Stage) | Out-Null
+    foreach ($entry in $CanonicalManifest.Entries) {
+        $source = Join-Path $Canonical $entry.RelativePath
+        $destination = Get-FullPath (Join-Path $Stage $entry.RelativePath)
+        $stagePrefix = (Get-FullPath $Stage) + [IO.Path]::DirectorySeparatorChar
+        if (-not $destination.StartsWith($stagePrefix, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Canonical relative path escapes staging: $($entry.RelativePath)"
+        }
+        [IO.Directory]::CreateDirectory([IO.Path]::GetDirectoryName($destination)) | Out-Null
+        [IO.File]::WriteAllBytes($destination, [IO.File]::ReadAllBytes($source))
+    }
+    $stagedManifest = Get-DirectoryManifest $Stage
+    if ($stagedManifest.Digest -ne $CanonicalManifest.Digest) {
+        throw "Staging parity failed: expected $($CanonicalManifest.Digest), got $($stagedManifest.Digest)"
+    }
+}
+
+function Install-Target {
+    param([object]$State, [string]$Canonical, [object]$CanonicalManifest, [bool]$KeepBackup, [string]$RequestedStage)
+
+    Assert-TargetPath $State.Path $State.Path
+    $parent = [IO.Path]::GetDirectoryName($State.Path)
+    if (-not (Test-Path -LiteralPath $parent -PathType Container)) {
+        throw "Target parent does not exist: $parent"
+    }
+    $stage = if ($RequestedStage) { Get-FullPath $RequestedStage } else {
+        Join-Path $parent "$([IO.Path]::GetFileName($State.Path)).edda-staging-$([guid]::NewGuid().ToString('N'))"
+    }
+    Assert-UniqueSibling $stage $State.Path staging
+    if (Test-Path -LiteralPath $stage) { throw "Staging path already exists: $stage" }
+
+    $stageCreated = $false
+    $oldTarget = $null
+    $swapped = $false
+    try {
+        Copy-ToStage $Canonical $CanonicalManifest $stage
+        $stageCreated = $true
+        if (Test-Path -LiteralPath $State.Path -PathType Container) {
+            $kind = if ($KeepBackup) { 'backup' } else { 'backup-transient' }
+            $oldTarget = Join-Path $parent "$([IO.Path]::GetFileName($State.Path)).edda-$kind-$([guid]::NewGuid().ToString('N'))"
+            Assert-UniqueSibling $oldTarget $State.Path backup
+            [IO.Directory]::Move($State.Path, $oldTarget)
+        }
+        [IO.Directory]::Move($stage, $State.Path)
+        $stageCreated = $false
+        $swapped = $true
+        Write-Provenance $State $Canonical $CanonicalManifest.Digest
+
+        $installed = Get-DirectoryManifest $State.Path
+        $marker = Get-Marker $State.MarkerPath
+        if ($installed.Digest -ne $CanonicalManifest.Digest -or -not $marker.Valid -or
+            $marker.CanonicalDigest -ne $CanonicalManifest.Digest -or $marker.InstalledDigest -ne $installed.Digest) {
+            throw 'Post-sync parity or provenance verification failed'
+        }
+        if ($null -ne $oldTarget -and -not $KeepBackup) {
+            Assert-UniqueSibling $oldTarget $State.Path backup
+            [IO.Directory]::Delete($oldTarget, $true)
+            $oldTarget = $null
+        }
+        return $oldTarget
+    }
+    catch {
+        if ($swapped -and $null -ne $oldTarget -and (Test-Path -LiteralPath $oldTarget -PathType Container)) {
+            if (Test-Path -LiteralPath $State.Path -PathType Container) {
+                Assert-UniqueSibling $stage $State.Path staging
+                [IO.Directory]::Move($State.Path, $stage)
+                $stageCreated = $true
+            }
+            [IO.Directory]::Move($oldTarget, $State.Path)
+            $oldTarget = $null
+        }
+        throw
+    }
+    finally {
+        if ($stageCreated -and (Test-Path -LiteralPath $stage -PathType Container)) {
+            Assert-UniqueSibling $stage $State.Path staging
+            [IO.Directory]::Delete($stage, $true)
+        }
+    }
+}
+
+function New-Result {
+    param([object]$State, [string]$Operation, [string]$PreviousStatus, [string]$BackupPath, [string]$ErrorMessage)
+
+    [pscustomobject][ordered]@{
+        Target = $State.Target
+        Path = $State.Path
+        Status = $State.Status
+        PreviousStatus = $PreviousStatus
+        Operation = $Operation
+        CanonicalDigest = $State.CanonicalDigest
+        InstalledDigest = $State.Digest
+        MarkerPath = $State.MarkerPath
+        MarkerCurrent = $State.MarkerCurrent
+        BackupPath = $BackupPath
+        Error = $ErrorMessage
+    }
+}
+
+$results = @()
+$exitCode = 0
+try {
+    $canonical = Get-FullPath $CanonicalPath
+    if (-not (Test-Path -LiteralPath $canonical -PathType Container)) {
+        throw "Canonical skill directory does not exist: $canonical"
+    }
+    $canonicalManifest = Get-DirectoryManifest $canonical
+    if ($canonicalManifest.Entries.Count -eq 0) { throw "Canonical skill directory is empty: $canonical" }
+
+    $selected = switch ($Target) {
+        'Codex' { @([pscustomobject]@{ Name = 'Codex'; Path = $CodexPath }) }
+        'Claude' { @([pscustomobject]@{ Name = 'Claude'; Path = $ClaudePath }) }
+        'All' {
+            @(
+                [pscustomobject]@{ Name = 'Codex'; Path = $CodexPath }
+                [pscustomobject]@{ Name = 'Claude'; Path = $ClaudePath }
+            )
+        }
+    }
+    if ($StagingPath -and $selected.Count -ne 1) { throw '-StagingPath requires a single target' }
+
+    $states = foreach ($item in $selected) {
+        $fullTarget = Get-FullPath $item.Path
+        if ([string]::Equals($canonical, $fullTarget, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Canonical and target paths must differ: $canonical"
+        }
+        Get-TargetState $item.Name $fullTarget $canonicalManifest $canonical
+    }
+
+    foreach ($state in $states) {
+        $previousStatus = $state.Status
+        if ($Action -eq 'Status') {
+            $results += New-Result $state 'None' $previousStatus $null $null
+            continue
+        }
+        if ($state.Status -eq 'locally-modified' -and -not $Force) {
+            $results += New-Result $state 'Refused' $previousStatus $null 'Use -Force to preserve a backup and replace this locally modified target.'
+            $exitCode = 1
+            continue
+        }
+        if ($DryRun) {
+            $operation = if ($state.Status -eq 'current') { if ($state.MarkerCurrent) { 'None' } else { 'WouldMark' } } else { 'WouldSync' }
+            $results += New-Result $state $operation $previousStatus $null $null
+            continue
+        }
+
+        try {
+            $backup = $null
+            if ($state.Status -eq 'current') {
+                Write-Provenance $state $canonical $canonicalManifest.Digest
+                $operation = if ($state.MarkerCurrent) { 'None' } else { 'Marked' }
+            }
+            else {
+                $backup = Install-Target $state $canonical $canonicalManifest ($state.Status -eq 'locally-modified') $StagingPath
+                $operation = 'Synced'
+            }
+            $current = Get-TargetState $state.Target $state.Path $canonicalManifest $canonical
+            if ($current.Status -ne 'current' -or -not $current.MarkerCurrent) {
+                throw 'Post-sync target is not current'
+            }
+            $results += New-Result $current $operation $previousStatus $backup $null
+        }
+        catch {
+            $failed = Get-TargetState $state.Target $state.Path $canonicalManifest $canonical
+            $results += New-Result $failed 'Failed' $previousStatus $null $_.Exception.Message
+            $exitCode = 1
+        }
+    }
+}
+catch {
+    $results = @([pscustomobject][ordered]@{
+        Target = $Target; Path = $null; Status = 'error'; PreviousStatus = $null; Operation = 'Failed'
+        CanonicalDigest = $null; InstalledDigest = $null; MarkerPath = $null; MarkerCurrent = $false
+        BackupPath = $null; Error = $_.Exception.Message
+    })
+    $exitCode = 1
+}
+
+if ($Json) {
+    ConvertTo-Json -InputObject @($results) -Depth 5 -Compress
+}
+else {
+    $results
+}
+exit $exitCode


### PR DESCRIPTION
## Summary
- add an explicit Windows PowerShell Status/Sync surface for Codex, Claude, or both
- classify complete-directory installs as missing, current, stale, or locally modified using exact provenance and Git-history bootstrap
- stage and verify replacements, preserve forced backups, and document explicit distribution outside `edda init`

## Root cause
`skills/fleet-orchestrate/**` was canonical but had no owner for user-level distribution, so merged policy changes could leave both global installs stale.

## Validation
- RAN: `pwsh -NoProfile -File scripts/skills/self-test-fleet-orchestrate-sync.ps1`
- RAN: PowerShell parser validation for both scripts
- RAN: staged diff/link/scope check for the three issue-owned files
- RAN (read-only diagnostic): live Status classified both existing global installs as stale

No Cargo/workspace gates were run because this changes only the explicit PowerShell/docs distribution surface. No real global install was synced.

Closes #478