### PR TITLE
test(edda-conductor): fix ETXTBSY flake in codex_app_server fake server

### DIFF
--- a/crates/edda-conductor/src/agent/codex_app_server.rs
+++ b/crates/edda-conductor/src/agent/codex_app_server.rs
@@ -519,12 +519,15 @@ mod tests {
 
     async fn wait_for_pid_exit(pid: u32) -> anyhow::Result<()> {
         tokio::time::timeout(std::time::Duration::from_secs(5), async move {
-            while process_exists(pid) {
+            loop {
+                if !process_is_alive(pid)? {
+                    return Ok(());
+                }
                 tokio::time::sleep(std::time::Duration::from_millis(25)).await;
             }
         })
         .await
-        .context("fake app-server PID did not disappear")
+        .context("fake app-server PID kept running")?
     }
 
     async fn wait_for_child_exit(child: &mut Child) -> anyhow::Result<()> {
@@ -540,24 +543,40 @@ mod tests {
         .context("fake app-server child did not exit")?
     }
 
-    fn process_exists(pid: u32) -> bool {
+    /// Reports whether `pid` is still a *running* process.
+    ///
+    /// A killed child stays in the process table as a zombie until its parent
+    /// reaps it, and dropping the client cannot reap: it hands the `Child` to
+    /// tokio's global orphan queue, drained later off SIGCHLD. So "the PID is
+    /// absent" is not something drop can guarantee -- "the process no longer
+    /// runs" is. A zombie has already terminated, so it does not count as
+    /// alive; a child that drop failed to kill still does.
+    fn process_is_alive(pid: u32) -> anyhow::Result<bool> {
         #[cfg(windows)]
         {
-            std::process::Command::new("tasklist.exe")
+            // Windows drops terminated processes from the table outright, so
+            // being listed at all already means still running.
+            let output = std::process::Command::new("tasklist.exe")
                 .args(["/FI", &format!("PID eq {pid}"), "/FO", "CSV", "/NH"])
                 .output()
-                .is_ok_and(|output| {
-                    String::from_utf8_lossy(&output.stdout).contains(&format!("\"{pid}\""))
-                })
+                .context("failed to run tasklist.exe")?;
+            Ok(String::from_utf8_lossy(&output.stdout).contains(&format!("\"{pid}\"")))
         }
         #[cfg(unix)]
         {
-            std::process::Command::new("kill")
-                .args(["-0", &pid.to_string()])
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .status()
-                .is_ok_and(|status| status.success())
+            // `kill -0` succeeds for zombies, so ask for the state instead: `ps`
+            // exits non-zero once the PID is gone, and reports `Z` (Linux) or
+            // `Z+` (macOS) while it is a terminated-but-unreaped zombie.
+            let output = std::process::Command::new("ps")
+                .args(["-o", "state=", "-p", &pid.to_string()])
+                .output()
+                .context("failed to run ps")?;
+            if !output.status.success() {
+                return Ok(false);
+            }
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let state = stdout.trim();
+            Ok(!state.is_empty() && !state.starts_with('Z'))
         }
     }
 

--- a/crates/edda-conductor/src/agent/codex_app_server.rs
+++ b/crates/edda-conductor/src/agent/codex_app_server.rs
@@ -454,14 +454,18 @@ mod tests {
 
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
-
-            let launcher = dir.path().join("fake-app-server");
-            std::fs::write(&launcher, shell_fake_script(scenario))?;
-            let mut permissions = std::fs::metadata(&launcher)?.permissions();
-            permissions.set_mode(0o755);
-            std::fs::set_permissions(&launcher, permissions)?;
-            Ok((dir, Command::new(launcher)))
+            // Feed the script to `sh` instead of exec'ing it, mirroring the
+            // PowerShell branch above. Linux `execve` fails with ETXTBSY while
+            // any process holds the target file open for writing, and in a
+            // threaded test binary a concurrent spawn elsewhere can be sitting
+            // between fork and exec holding an inherited write fd for this very
+            // file -- O_CLOEXEC only clears it at exec, not at fork. `sh` opens
+            // the script read-only, so that window cannot bite.
+            let script = dir.path().join("fake-app-server.sh");
+            std::fs::write(&script, shell_fake_script(scenario))?;
+            let mut command = Command::new("/bin/sh");
+            command.arg(script);
+            Ok((dir, command))
         }
     }
 


### PR DESCRIPTION
## Problem

CI run [32002599039](https://github.com/fagemx/edda/actions/runs/32002599039) for `main@7f5d1555b4c00e4fe6ac9a452a3c81c62289972c` failed **only** in `Test (ubuntu-latest)` (165 passed, 1 failed, 1 ignored in `edda-conductor`). PR #479, the merged head, touched only `scripts/skills/*.ps1` and docs, so this is a pre-existing Linux-only flake, not a regression from that PR.

The test name made it look like a PID-visibility problem, but the raw log shows it never reached the PID check — it failed on the very first line:

```
---- agent::codex_app_server::tests::dropping_concrete_client_makes_child_pid_disappear stdout ----
Error: failed to spawn Codex App Server

Caused by:
    Text file busy (os error 26)
```

## Root cause — ETXTBSY (commit 2, the actual fix)

The unix branch of `fake_app_server` writes `fake-app-server`, chmods it `0755`, and then `execve`s it. Linux fails `execve` with `ETXTBSY` while any process holds the target file open for writing. In a threaded test binary, a concurrent `Command::spawn` from another test can be sitting between `fork` and `exec` holding an **inherited write fd** for this very file — `O_CLOEXEC` clears it at exec, not at fork.

Whichever test happens to land inside that window loses, which is why **the failure moves between tests**: run 32002599039 hit `dropping_concrete_client_makes_child_pid_disappear`, and the first push on this branch hit `cancelling_concrete_method_makes_child_pid_disappear` with the byte-identical error.

**Fix:** feed the script to `sh` instead of exec'ing it, mirroring what the Windows branch already does with `powershell.exe -File`. `sh` opens the script read-only, so the window cannot arise — the race is removed by construction rather than retried around. The chmod is no longer needed, and the `#!/bin/sh` line is simply a comment when the script is passed as an argument.

Verified on real Linux — with a writer holding the fd open:

| | result |
|---|---|
| old: exec the script | **FAILED errno=26 Text file busy** |
| new: `/bin/sh script` | ok |

and once the writer closes, both succeed — which is precisely why the old path failed only rarely.

## Second, latent flake — zombie PIDs (commit 1)

While investigating I found a separate real hazard in the same helper, matching the failure mode the test name suggests. `wait_for_pid_exit` probed liveness with `kill -0`, which **succeeds for zombies**: `drop(server)` sends SIGKILL and hands the `Child` to tokio's *global* orphan queue, and nothing ever calls `waitpid` on it, since the drop consumes the handle. The killed child stays in the table as a zombie until that queue drains — which needs a runtime's process driver to park *and* the lazily-registered global SIGCHLD watch to fire, an event that has to cross runtimes in a parallel test binary.

`dropping_concrete_client_...` is the only pid-polling test here with no reap path; every other one reaps first via `terminate()`, `try_wait()`, or `wait_for_child_exit`. On Linux tokio 1.49 takes the `PidfdReaper` branch and never registers SIGCHLD at spawn, leaving that lazy path as the only reaper; macOS wires SIGCHLD up front; Windows evicts terminated processes outright.

The probe now asks `ps -o state=` for the state: a zombie has terminated so it no longer counts as running, while a child that drop failed to kill still does — the behavior contract is unchanged, and a genuine "drop didn't kill it" regression still fails. It also errors instead of reporting "gone" when it cannot run, so a broken environment fails loudly rather than passing vacuously.

Validated on Linux with the exact shipped logic:

| case | `process_is_alive` | probe |
|---|---|---|
| running child | **true** | rc=0, state `S` |
| zombie (SIGKILLed, unreaped) | **false** | rc=0, state `Z` |
| reaped | false | rc=1 |
| never existed | false | rc=1 |

To be clear about provenance: this one is a latent hazard I have **not** observed firing in CI. It is separable — happy to drop commit 1 if you'd rather keep the PR to the ETXTBSY fix alone.

Test-only change; no production code touched.

## Verification

- `cargo test -p edda-conductor codex_app_server` — 18 passed, 0 failed, 1 ignored
- `cargo clippy -p edda-conductor --all-targets -- -D warnings` — clean
- `cargo fmt -p edda-conductor -- --check` — clean

Windows compiles only the `#[cfg(windows)]` arms, so every `#[cfg(unix)]` / `#[cfg(not(windows))]` arm in the tests module was type-checked separately by temporarily swapping the cfg conditions and re-running clippy `-D warnings` — clean, then reverted.

The first push on this branch (commit 1 alone) is itself useful evidence: `dropping_concrete_client_makes_child_pid_disappear` **passed** on ubuntu-latest, and the ETXTBSY failure surfaced on a different test in the same binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
