### PR TITLE
docs(coordination): verification cost discipline — ladder, lanes, receipts

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -130,14 +130,27 @@ cargo test --workspace
 ### Verification ladder
 
 Verify once per frozen SHA; cite that result everywhere else. Full workspace
-gates are expensive (23 crates; 8–13 GB of build output per target directory)
-and GitHub CI already runs them on three operating systems for every push.
+gates are expensive (23 crates; 8–13 GB of build output per target directory),
+and CI already re-runs most of them independently on every push.
+
+**Know exactly what CI does and does not cover** (`.github/workflows/ci.yml`):
+
+| CI job | Coverage |
+|---|---|
+| Format | `cargo fmt --check` |
+| Clippy | `cargo clippy --workspace --all-targets` on Linux, macOS **and** Windows |
+| Test (Linux, macOS) | `cargo test --workspace` — all 23 crates |
+| Test (Windows) | **only 7 crates** — `edda-store`, `edda-ledger`, `edda-search-fts`, `edda-transcript`, `edda-bridge-claude`, `edda-conductor`, `edda` (Windows build/link is ~5x slower; the subset is derived from process-spawn, file-lock, and mmap criteria — GH-433) |
+
+So a **Windows-specific risk in any of the other 16 crates is not covered by
+CI**. That is a stated reason for the verifier to run it locally, and it is why
+the L1 receipt from a Windows workstation is load-bearing rather than redundant.
 
 | Level | When | Run |
 |---|---|---|
 | L0 iterate | while editing | `cargo fmt --all --check`; `cargo clippy -p <crate> --all-targets -- -D warnings`; `cargo test -p <crate>` for each touched crate |
 | L1 freeze | once per frozen full SHA, clean tree, before push / PR update | `cargo fmt --all --check`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo test --workspace`, with `CARGO_INCREMENTAL=0`; record the result together with the full SHA (gate receipt) |
-| L2 review | verifier, once per frozen full SHA | READ the L1 receipt and exact-head CI; RAN only focused or adversarial checks they do not cover. A full local rerun needs a stated reason: no receipt, red or absent CI, or grounds to distrust the receipt. Deterministically red CI already blocks the SHA — audit and request changes instead of spending a full run |
+| L2 review | verifier, once per frozen full SHA | READ the L1 receipt and exact-head CI; RAN only focused or adversarial checks they do not cover — **including Windows behavior in any crate outside the CI Windows subset above**. A full local rerun needs a stated reason: no receipt, red or absent CI, grounds to distrust the receipt, or coverage CI genuinely lacks. Deterministically red CI already blocks the SHA — audit and request changes instead of spending a full run; if the red is environmental, re-run only the failed job |
 | L3 pre-merge | merge authority | READ exact-head CI and the final current-head LGTM; RAN only a merge check against the current base. A draft/ready, label, or status flip is not a push — nothing reruns |
 
 Docs-only changes (no code/product blob, `Cargo.lock`, or toolchain change)
@@ -146,15 +159,21 @@ run no Cargo gate locally; exact-head CI is the gate.
 ### Build lanes
 
 - Never create ad-hoc `CARGO_TARGET_DIR`s per round, per SHA, or per
-  timestamp. Build output is disposable cache, but unbounded copies are not:
-  twelve such directories reached ~194 GB on one workstation.
+  timestamp. Build output is disposable cache, but unbounded copies are not: an
+  audit of one workstation counted 15 such directories and ~194 GB, with a
+  single directory at 12.79 GB.
 - Solo work uses the worktree's default `target/`.
+- **Lane root** is `%LOCALAPPDATA%\fleet-workstation\lanes` unless
+  `FLEET_LANE_ROOT` is set or the brief names a different absolute path. A lane
+  is always `<lane-root>\<lane-name>` — resolve it from that rule, never invent
+  a path.
 - Fleet sessions build only in the lane named in their brief — one of
   `worker-1`, `worker-2`, `verifier`, `verifier-2` — for their whole lifetime.
-  Where the workstation lane tool is installed, run gates through it
-  (`lane.ps1 -Lane <assigned> -Gate focused|freeze`); without it, set
-  `CARGO_TARGET_DIR` only to `<lane-root>\<assigned-lane>` from the brief and
-  reuse it every round.
+  The workstation lane tool (`lane.ps1 -Lane <assigned> -Gate focused|freeze`)
+  is not shipped yet; until it is, set `CARGO_TARGET_DIR` to
+  `<lane-root>\<assigned-lane>` yourself and reuse it every round. If your brief
+  names no lane and you are running gates for a fleet, ask the controller for
+  one rather than creating a directory.
 - Verifier lanes and every L1 run set `CARGO_INCREMENTAL=0`.
 - Deleting lane build output is authorized and non-destructive; deleting
   worktrees, branches, or sources is not. Stop and report instead of building
@@ -168,10 +187,17 @@ cargo fmt --check
 cargo clippy -p <touched crate> --all-targets -- -D warnings
 cargo test -p <touched crate>
 
-# Before freezing a SHA for push / PR update (L1 — once per frozen SHA)
-cargo clippy --workspace --all-targets -- -D warnings   # CI uses -Dwarnings
-cargo test --workspace
+# Before freezing a SHA for push / PR update (L1 — once per frozen SHA,
+# clean tree, incremental off). Record the result with the full SHA.
+cargo fmt --all --check
+CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets -- -D warnings
+CARGO_INCREMENTAL=0 cargo test --workspace
+# then record the gate receipt: full SHA, gate set, toolchain, lane, result
 ```
+
+The L1 block is the ladder's L1 row — keep the two identical. Skipping the
+receipt is not a shortcut: without it the reviewer has nothing to READ and must
+run the whole set again, which is the cost this ladder exists to remove.
 
 ## Commit Conventions
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -142,9 +142,12 @@ and CI already re-runs most of them independently on every push.
 | Test (Linux, macOS) | `cargo test --workspace` — all 23 crates |
 | Test (Windows) | **only 7 crates** — `edda-store`, `edda-ledger`, `edda-search-fts`, `edda-transcript`, `edda-bridge-claude`, `edda-conductor`, `edda` (Windows build/link is ~5x slower; the subset is derived from process-spawn, file-lock, and mmap criteria — GH-433) |
 
-So a **Windows-specific risk in any of the other 16 crates is not covered by
-CI**. That is a stated reason for the verifier to run it locally, and it is why
-the L1 receipt from a Windows workstation is load-bearing rather than redundant.
+So on Windows every crate is still **compiled and linted** (Clippy is
+workspace-wide on all three OSes), but **only those 7 crates have their tests
+run**. A Windows-specific *runtime* defect in the other 16 — a path, a file
+lock, a spawned process, a temp directory — is caught by no CI job. That is a
+stated reason for the verifier to run it locally, and it is why the L1 receipt
+from a Windows workstation is load-bearing rather than redundant.
 
 | Level | When | Run |
 |---|---|---|
@@ -163,10 +166,11 @@ run no Cargo gate locally; exact-head CI is the gate.
   audit of one workstation counted 15 such directories and ~194 GB, with a
   single directory at 12.79 GB.
 - Solo work uses the worktree's default `target/`.
-- **Lane root** is `%LOCALAPPDATA%\fleet-workstation\lanes` unless
-  `FLEET_LANE_ROOT` is set or the brief names a different absolute path. A lane
-  is always `<lane-root>\<lane-name>` — resolve it from that rule, never invent
-  a path.
+- **Lane root** is the `LOCALAPPDATA` directory plus `\fleet-workstation\lanes`
+  — `$env:LOCALAPPDATA\fleet-workstation\lanes` in PowerShell,
+  `$LOCALAPPDATA/fleet-workstation/lanes` in Git Bash — unless `FLEET_LANE_ROOT`
+  is set or the brief names a different absolute path. A lane is always
+  `<lane-root>\<lane-name>`; resolve it from that rule, never invent a path.
 - Fleet sessions build only in the lane named in their brief — one of
   `worker-1`, `worker-2`, `verifier`, `verifier-2` — for their whole lifetime.
   The workstation lane tool (`lane.ps1 -Lane <assigned> -Gate focused|freeze`)
@@ -190,9 +194,20 @@ cargo test -p <touched crate>
 # Before freezing a SHA for push / PR update (L1 — once per frozen SHA,
 # clean tree, incremental off). Record the result with the full SHA.
 cargo fmt --all --check
-CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets -- -D warnings
-CARGO_INCREMENTAL=0 cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
 # then record the gate receipt: full SHA, gate set, toolchain, lane, result
+```
+
+Set `CARGO_INCREMENTAL=0` in the environment for the whole L1 run — not as an
+inline prefix, which only POSIX shells accept:
+
+```powershell
+$env:CARGO_INCREMENTAL = "0"   # PowerShell
+```
+
+```bash
+export CARGO_INCREMENTAL=0     # bash / Git Bash
 ```
 
 The L1 block is the ladder's L1 row — keep the two identical. Skipping the

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -112,14 +112,14 @@ pub use types::*;
 ## Testing Standards
 
 ```bash
-# Run all tests
-cargo test --workspace
-
-# Run tests for single crate
+# Run tests for a single crate (default while iterating)
 cargo test -p edda-core
 
-# Run specific test
+# Run a specific test
 cargo test -p edda-core test_name
+
+# Run all tests (once per frozen SHA — see Verification ladder)
+cargo test --workspace
 ```
 
 - **Unit tests**: In `#[cfg(test)] mod tests` within source files
@@ -127,12 +127,50 @@ cargo test -p edda-core test_name
 - **No mocking internal crates** — use real SQLite via `tempfile`
 - See `edda-core/src/types.rs:261-667` for test patterns
 
+### Verification ladder
+
+Verify once per frozen SHA; cite that result everywhere else. Full workspace
+gates are expensive (23 crates; 8–13 GB of build output per target directory)
+and GitHub CI already runs them on three operating systems for every push.
+
+| Level | When | Run |
+|---|---|---|
+| L0 iterate | while editing | `cargo fmt --all --check`; `cargo clippy -p <crate> --all-targets -- -D warnings`; `cargo test -p <crate>` for each touched crate |
+| L1 freeze | once per frozen full SHA, clean tree, before push / PR update | `cargo fmt --all --check`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo test --workspace`, with `CARGO_INCREMENTAL=0`; record the result together with the full SHA (gate receipt) |
+| L2 review | verifier, once per frozen full SHA | READ the L1 receipt and exact-head CI; RAN only focused or adversarial checks they do not cover. A full local rerun needs a stated reason: no receipt, red or absent CI, or grounds to distrust the receipt |
+| L3 pre-merge | merge authority | READ exact-head CI and the final current-head LGTM; RAN only a merge check against the current base. A draft/ready, label, or status flip is not a push — nothing reruns |
+
+Docs-only changes (no code/product blob, `Cargo.lock`, or toolchain change)
+run no Cargo gate locally; exact-head CI is the gate.
+
+### Build lanes
+
+- Never create ad-hoc `CARGO_TARGET_DIR`s per round, per SHA, or per
+  timestamp. Build output is disposable cache, but unbounded copies are not:
+  twelve such directories reached ~194 GB on one workstation.
+- Solo work uses the worktree's default `target/`.
+- Fleet sessions build only in the lane named in their brief — one of
+  `worker-1`, `worker-2`, `verifier`, `verifier-2` — for their whole lifetime.
+  Where the workstation lane tool is installed, run gates through it
+  (`lane.ps1 -Lane <assigned> -Gate focused|freeze`); without it, set
+  `CARGO_TARGET_DIR` only to `<lane-root>\<assigned-lane>` from the brief and
+  reuse it every round.
+- Verifier lanes and every L1 run set `CARGO_INCREMENTAL=0`.
+- Deleting lane build output is authorized and non-destructive; deleting
+  worktrees, branches, or sources is not. Stop and report instead of building
+  when the lane pool exceeds 50 GB.
+
 ## Pre-commit Checklist
 
 ```bash
-cargo fmt --check      # Format check
-cargo clippy           # Lint (CI uses -Dwarnings)
-cargo test --workspace # All tests
+# Before every commit (L0 — touched crates only)
+cargo fmt --check
+cargo clippy -p <touched crate> --all-targets -- -D warnings
+cargo test -p <touched crate>
+
+# Before freezing a SHA for push / PR update (L1 — once per frozen SHA)
+cargo clippy --workspace --all-targets -- -D warnings   # CI uses -Dwarnings
+cargo test --workspace
 ```
 
 ## Commit Conventions
@@ -256,3 +294,21 @@ Merge still requires explicit operator authority.
 
 For local-only delivery, record the same round/response/verdict fields in the
 strongest durable local carrier; do not invent a PR.
+
+### Verification cost
+
+Rules regulate cost and reclamation, not only evidence:
+
+- Verify once per frozen SHA on the ladder above. READ recorded gate results
+  and exact-head CI before any RAN, and state the reason whenever you rerun a
+  recorded gate.
+- Every worker/verifier brief names a build lane, a verification budget (L0
+  while iterating; L1 once per frozen SHA), and cleanup authority (lane build
+  cache is disposable; worktrees, branches, and sources are never deleted).
+- One verifier identity per PR: rounds resume the same session and lane; a
+  replacement reads receipts and CI before running anything.
+- Over-verification — a second RAN for an already-recorded SHA without a
+  reason, workspace gates for a docs-only push, an ad-hoc target directory —
+  is a process finding: record it in the handoff cost line, route it as a
+  `FOLLOW-UP ISSUE`, correct the next brief. It does not block a product-green
+  PR.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -137,7 +137,7 @@ and GitHub CI already runs them on three operating systems for every push.
 |---|---|---|
 | L0 iterate | while editing | `cargo fmt --all --check`; `cargo clippy -p <crate> --all-targets -- -D warnings`; `cargo test -p <crate>` for each touched crate |
 | L1 freeze | once per frozen full SHA, clean tree, before push / PR update | `cargo fmt --all --check`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo test --workspace`, with `CARGO_INCREMENTAL=0`; record the result together with the full SHA (gate receipt) |
-| L2 review | verifier, once per frozen full SHA | READ the L1 receipt and exact-head CI; RAN only focused or adversarial checks they do not cover. A full local rerun needs a stated reason: no receipt, red or absent CI, or grounds to distrust the receipt |
+| L2 review | verifier, once per frozen full SHA | READ the L1 receipt and exact-head CI; RAN only focused or adversarial checks they do not cover. A full local rerun needs a stated reason: no receipt, red or absent CI, or grounds to distrust the receipt. Deterministically red CI already blocks the SHA — audit and request changes instead of spending a full run |
 | L3 pre-merge | merge authority | READ exact-head CI and the final current-head LGTM; RAN only a merge check against the current base. A draft/ready, label, or status flip is not a push — nothing reruns |
 
 Docs-only changes (no code/product blob, `Cargo.lock`, or toolchain change)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,9 @@ and multi-agent coordination.
 - Verify once per frozen SHA on the ladder in `.claude/CLAUDE.md`: focused
   crate gates while iterating (L0); the full workspace set once per frozen full
   SHA with a recorded receipt (L1); reviewers READ that receipt and exact-head
-  CI and RAN only what they do not cover (L2); nothing reruns on a draft,
-  label, or status flip (L3). State the reason whenever you rerun a recorded
-  gate.
+  CI and RAN only what they do not cover (L2); a draft, label, or status flip
+  is not a push, so nothing reruns (L3). State the reason whenever you rerun a
+  recorded gate.
 - Build only in the lane your brief assigns (`worker-1`, `worker-2`,
   `verifier`, `verifier-2`). Never create ad-hoc `CARGO_TARGET_DIR`s per round,
   SHA, or timestamp; solo work uses the worktree's default `target/`. Lane

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,11 @@ and multi-agent coordination.
   SHA with a recorded receipt (L1); reviewers READ that receipt and exact-head
   CI and RAN only what they do not cover (L2); a draft, label, or status flip
   is not a push, so nothing reruns (L3). State the reason whenever you rerun a
-  recorded gate.
+  recorded gate. Know what this repository's CI actually covers — Windows tests
+  only a 7-crate subset — and treat a real gap as a legitimate reason to RAN.
+  Deterministically red CI already blocks the SHA: audit and request changes
+  instead of spending a full run; re-run only the failed job when the red is
+  environmental.
 - Build only in the lane your brief assigns (`worker-1`, `worker-2`,
   `verifier`, `verifier-2`). Never create ad-hoc `CARGO_TARGET_DIR`s per round,
   SHA, or timestamp; solo work uses the worktree's default `target/`. Lane

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,17 @@ and multi-agent coordination.
   relevant validation plus exact-head CI as `RAN`, and record available cost.
   Stop after two non-product/harness-only cycles without useful progress or at
   diminishing returns; route follow-up or ask the operator to expand scope.
+- Verify once per frozen SHA on the ladder in `.claude/CLAUDE.md`: focused
+  crate gates while iterating (L0); the full workspace set once per frozen full
+  SHA with a recorded receipt (L1); reviewers READ that receipt and exact-head
+  CI and RAN only what they do not cover (L2); nothing reruns on a draft,
+  label, or status flip (L3). State the reason whenever you rerun a recorded
+  gate.
+- Build only in the lane your brief assigns (`worker-1`, `worker-2`,
+  `verifier`, `verifier-2`). Never create ad-hoc `CARGO_TARGET_DIR`s per round,
+  SHA, or timestamp; solo work uses the worktree's default `target/`. Lane
+  build cache is disposable; worktrees, branches, and sources are not. Stop and
+  report when the lane pool exceeds 50 GB.
 - This is policy for sessions invoking `coord-review`, `coord-orchestrate`, or
   `fleet-orchestrate`; it is not an Edda runtime rule imposed on every project.
 - Review immutable full SHAs; any push invalidates the prior verdict.
@@ -45,4 +56,6 @@ and multi-agent coordination.
 
 - Preserve unrelated user changes.
 - Use `codex/` branch names for Codex-created branches unless directed otherwise.
-- Run the checks required by `.claude/CLAUDE.md` before claiming completion.
+- Run the checks required by `.claude/CLAUDE.md` at the ladder level that
+  matches your change before claiming completion; docs-only changes rely on
+  exact-head CI and run no Cargo gate locally.

--- a/crates/edda-cli/src/skills/coord-orchestrate.md
+++ b/crates/edda-cli/src/skills/coord-orchestrate.md
@@ -64,10 +64,13 @@ Verify once per frozen artifact. The implementer runs the full gate set once
 per frozen full SHA in the assigned build lane and records a gate receipt (SHA,
 gate set, toolchain, lane, result). The reviewer READs that receipt and
 exact-head CI, RANs only focused or adversarial checks they do not cover, and
-states the reason for any full rerun (no receipt, red or absent CI, or grounds
-to distrust the receipt). Focused gates on touched units while iterating, never
-the full set per edit. A status, label, or draft flip is not a push and reruns
-nothing.
+states the reason for any full rerun (no receipt, red or absent CI, grounds to
+distrust the receipt, or coverage the project's CI genuinely lacks — know that
+gap before you cite CI as independent evidence). Deterministically red CI
+already blocks the artifact: audit and request changes rather than spending a
+full run, and re-run only the failed job when the red is environmental. Focused
+gates on touched units while iterating, never the full set per edit. A status,
+label, or draft flip is not a push and reruns nothing.
 
 Each handoff records available elapsed/token/tool cost. Stop after two
 consecutive non-product evidence/docs or harness-only cycles without improved
@@ -106,10 +109,13 @@ Request: audit the whole scoped surface; publish no self-verdict from the implem
 3. **Brief workers** — self-contained (they have zero context): issues to
    read, worktree + branch command, `edda claim` label and paths, files
    owned/forbidden, quality gates verbatim, assigned build lane from the fixed
-   pool, verification budget (focused gates on touched units while iterating;
-   the full gate set once per frozen SHA with a receipt; READ receipts before
-   any RAN), cleanup authority (lane build cache is disposable; worktrees,
-   branches, and sources are never deleted), done = GitHub PR when available,
+   pool **with its absolute lane root** (a worker who cannot resolve
+   `<lane root>/<lane name>` will invent a directory — the exact failure the
+   lane rule exists to prevent), verification budget (focused gates on touched
+   units while iterating; the full gate set once per frozen SHA with a receipt;
+   READ receipts before any RAN), cleanup authority (lane build cache is
+   disposable; worktrees, branches, and sources are never deleted), done =
+   GitHub PR when available,
    otherwise a frozen local branch plus durable review carrier (never invent a
    PR); never merge + `edda task done --receipt`. Include the receiver tie-break
    verbatim (see Traffic rules).

--- a/crates/edda-cli/src/skills/coord-orchestrate.md
+++ b/crates/edda-cli/src/skills/coord-orchestrate.md
@@ -60,10 +60,24 @@ the relevant code gates. A docs/evidence-only push with those inputs unchanged
 reuses still-applicable code results as `READ` with source SHA, then runs only
 relevant diff/docs/evidence checks and exact-head CI as `RAN`.
 
+Verify once per frozen artifact. The implementer runs the full gate set once
+per frozen full SHA in the assigned build lane and records a gate receipt (SHA,
+gate set, toolchain, lane, result). The reviewer READs that receipt and
+exact-head CI, RANs only focused or adversarial checks they do not cover, and
+states the reason for any full rerun (no receipt, red or absent CI, or grounds
+to distrust the receipt). Focused gates on touched units while iterating, never
+the full set per edit. A status, label, or draft flip is not a push and reruns
+nothing.
+
 Each handoff records available elapsed/token/tool cost. Stop after two
 consecutive non-product evidence/docs or harness-only cycles without improved
 required behavior/proof, or at clear diminishing returns; route the finding to
 follow-up or ask the operator to expand scope.
+
+Over-verification is a process finding, not a product blocker: a second RAN
+for an already-receipted SHA without a reason, full gates for a docs-only push,
+or an ad-hoc build directory goes into the cost line, routes as a `FOLLOW-UP
+ISSUE`, and corrects the next brief.
 
 Use this request template; it is not a verdict:
 
@@ -77,6 +91,8 @@ Blocking counts entering review: P0=<n>, P1=<n>
 Evidence:
 - RAN: <commands/checks run on this SHA>
 - READ: <reused results and source SHAs>
+- Lane: <assigned build lane>
+- Receipt: <gate receipt for this SHA (SHA, gate set, toolchain, lane, result), or none>
 Cost: elapsed=<available/unknown>, tokens=<available/unknown>, tools=<available/unknown>
 Request: audit the whole scoped surface; publish no self-verdict from the implementer
 ```
@@ -89,15 +105,23 @@ Request: audit the whole scoped surface; publish no self-verdict from the implem
    bundle. Specs live in issues, never only in messages.
 3. **Brief workers** — self-contained (they have zero context): issues to
    read, worktree + branch command, `edda claim` label and paths, files
-   owned/forbidden, quality gates verbatim, done = GitHub PR when available,
+   owned/forbidden, quality gates verbatim, assigned build lane from the fixed
+   pool, verification budget (focused gates on touched units while iterating;
+   the full gate set once per frozen SHA with a receipt; READ receipts before
+   any RAN), cleanup authority (lane build cache is disposable; worktrees,
+   branches, and sources are never deleted), done = GitHub PR when available,
    otherwise a frozen local branch plus durable review carrier (never invent a
    PR); never merge + `edda task done --receipt`. Include the receiver tie-break
    verbatim (see Traffic rules).
-4. **Brief the verifier — read-only, starts BEFORE code:** baseline gates on
-   main; flake hunt; observable-behavior criteria per issue; sweep for two
-   test poisons — tests asserting the behavior being removed (invert and
-   rename, never delete) and single-case tests that pass either way (demand
-   the second case).
+4. **Brief the verifier — read-only, starts BEFORE code:** baseline on the
+   basis SHA by READing exact-head CI and any existing gate receipt, RANning
+   only what they do not cover in the assigned verifier lane, and classifying
+   existing red checks; flake hunt; observable-behavior criteria per issue;
+   sweep for two test poisons — tests asserting the behavior being removed
+   (invert and rename, never delete) and single-case tests that pass either
+   way (demand the second case). One verifier identity per delivery
+   candidate: rounds resume the same session and lane; a replacement reads
+   receipts and CI before running anything.
 5. **Relay loop:** verifier intel → spot-check the load-bearing claims
    yourself → adjudicate → fixate as issue comment → doorbell affected
    workers. Never fixate an unverified claim.
@@ -160,3 +184,6 @@ letters at the peers' natural cadence. Bell-only → ring, ledger as backstop.
 | Adjacent finding becomes another blocking round | file an evidenced follow-up issue unless it is in the frozen blocking surface |
 | Docs-only push restarts full code gates | reuse applicable code gates as `READ`; run delta checks plus exact-head CI |
 | Review drips one blocker per round | audit the whole scope and batch P0/P1 before requesting changes |
+| Fresh verifier reruns every gate "to be safe" | READ the frozen SHA's receipt and exact-head CI; RAN only what they do not cover, or state the reason |
+| New build directory per round, SHA, or timestamp | one assigned lane per session for its lifetime; lane cache is disposable, sources are not |
+| Status/label/draft flip treated as a push | not a push; nothing reruns |

--- a/crates/edda-cli/src/skills/coord-review.md
+++ b/crates/edda-cli/src/skills/coord-review.md
@@ -107,11 +107,16 @@ Verify once per frozen artifact. When the implementer's gate receipt (SHA,
 gate set, toolchain, lane, result) matches the reviewed SHA and exact-head CI
 is green, cite both as `READ` and RAN only the focused or adversarial checks
 they do not cover. A full local rerun requires a stated reason: no receipt,
-red or absent CI, or grounds to distrust the receipt. When exact-head CI is
-deterministically red the artifact is already blocked — finish the scoped
-audit and request changes rather than spending a full run that cannot change
-the verdict. Run in your assigned build lane; never create an ad-hoc build
-directory. A status, label, or draft flip is not a push and reruns nothing.
+red or absent CI, grounds to distrust the receipt, or coverage the project's CI
+genuinely lacks — establish what CI actually runs before citing it as
+independent evidence, because a partial matrix is a real gap, not a formality.
+When exact-head CI is deterministically red the artifact is already blocked —
+finish the scoped audit and request changes rather than spending a full run
+that cannot change the verdict; when the red is environmental, re-run only the
+failed job. Run in the build lane your brief assigns, resolving it as
+`<lane root>/<lane name>`; never create an ad-hoc build directory. Outside a
+fleet, with no lane assigned, use the repository's own default build directory.
+A status, label, or draft flip is not a push and reruns nothing.
 
 Record available elapsed, token, and tool cost. Stop after two consecutive
 cycles that change only non-product evidence/docs or harness material without

--- a/crates/edda-cli/src/skills/coord-review.md
+++ b/crates/edda-cli/src/skills/coord-review.md
@@ -103,11 +103,24 @@ blobs, base, and toolchain are unchanged, reuse still-applicable code results
 as `READ` with their source SHA; run only relevant diff/docs/evidence checks
 and exact-head CI as `RAN`. Never report a reused result as rerun.
 
+Verify once per frozen artifact. When the implementer's gate receipt (SHA,
+gate set, toolchain, lane, result) matches the reviewed SHA and exact-head CI
+is green, cite both as `READ` and RAN only the focused or adversarial checks
+they do not cover. A full local rerun requires a stated reason: no receipt,
+red or absent CI, or grounds to distrust the receipt. Run in your assigned
+build lane; never create an ad-hoc build directory. A status, label, or draft
+flip is not a push and reruns nothing.
+
 Record available elapsed, token, and tool cost. Stop after two consecutive
 cycles that change only non-product evidence/docs or harness material without
 improving required behavior/proof, or sooner when returns clearly diminish.
 Classify and route the finding instead of continuing: follow-up issue for
 out-of-scope work, or operator scope expansion when it must join this PR.
+
+Over-verification you find in the implementer's evidence — a second RAN for
+an already-receipted SHA without a reason, full gates for a docs-only push, an
+ad-hoc build directory — is a process finding: note it in the cost line, route
+it as a `FOLLOW-UP ISSUE`, and do not block a product-green PR on it.
 
 ### Step 6: Generate Report
 
@@ -164,6 +177,8 @@ FOLLOW-UP ISSUE:
 Evidence:
 - RAN: <exact command/check and result on reviewed SHA>
 - READ: <reused result and its source SHA, or none>
+- Lane: <build lane used, or n/a for docs-only>
+- Receipt: <implementer gate receipt cited (SHA, gate set, toolchain, lane, result), or none>
 Cost: elapsed=<available/unknown>, tokens=<available/unknown>, tools=<available/unknown>
 Verdict: Changes Requested | LGTM
 ```

--- a/crates/edda-cli/src/skills/coord-review.md
+++ b/crates/edda-cli/src/skills/coord-review.md
@@ -107,9 +107,11 @@ Verify once per frozen artifact. When the implementer's gate receipt (SHA,
 gate set, toolchain, lane, result) matches the reviewed SHA and exact-head CI
 is green, cite both as `READ` and RAN only the focused or adversarial checks
 they do not cover. A full local rerun requires a stated reason: no receipt,
-red or absent CI, or grounds to distrust the receipt. Run in your assigned
-build lane; never create an ad-hoc build directory. A status, label, or draft
-flip is not a push and reruns nothing.
+red or absent CI, or grounds to distrust the receipt. When exact-head CI is
+deterministically red the artifact is already blocked — finish the scoped
+audit and request changes rather than spending a full run that cannot change
+the verdict. Run in your assigned build lane; never create an ad-hoc build
+directory. A status, label, or draft flip is not a push and reruns nothing.
 
 Record available elapsed, token, and tool cost. Stop after two consecutive
 cycles that change only non-product evidence/docs or harness material without

--- a/docs/superpowers/plans/2026-08-18-verification-cost-discipline-pr1-edda-policy.md
+++ b/docs/superpowers/plans/2026-08-18-verification-cost-discipline-pr1-edda-policy.md
@@ -968,6 +968,33 @@ Expected: the PR shows the handoff comment; CI runs on the exact head; no local 
 
 ---
 
+## Round 1 review amendments (2026-08-18)
+
+The text blocks above are the plan as executed at `738c5ce`. An independent
+review of that SHA returned `Changes Requested` with P0=0, P1=4, and the fixes
+changed wording this plan quotes verbatim. This plan is kept as the execution
+record; the **spec is the living contract**. What changed:
+
+1. **CI coverage stated accurately.** The ladder's justification claimed CI runs
+   full workspace gates on three operating systems. It does not: Windows tests
+   only a 7-crate subset (`.github/workflows/ci.yml`, GH-433). `.claude/CLAUDE.md`
+   now carries a CI coverage table, L2 names the uncovered surface as a
+   legitimate reason to RAN, and spec §1/§4.1 match.
+2. **Deterministic-red clause distributed to all six carriers** (it had landed
+   in three), and pressure fixture 7 — which still demanded a full run for red
+   CI — split into fixture 7 (deterministic → do not run) and fixture 8
+   (environmental → re-run the failed job, then the full set once).
+3. **Pre-commit L1 block aligned with the ladder's L1 row**: `cargo fmt --all
+   --check`, `CARGO_INCREMENTAL=0`, and the gate receipt were missing from the
+   checklist, so a worker following it would freeze without a receipt — which
+   hands L2 a reason to run everything again and cancels the saving.
+4. **Lane root defined.** `<lane-root>` appeared in the fallback instruction but
+   in no brief template. `.claude/CLAUDE.md` now gives the concrete default,
+   `playbook.md` and `coord-orchestrate.md` require the absolute root in the
+   brief, and `coord-review.md` states the solo default.
+
+New fixture 9 covers the CI-coverage-gap case that no fixture exercised.
+
 ## Post-merge (outside this plan, listed so nobody forgets)
 
 1. `scripts/skills/sync-fleet-orchestrate.ps1` to propagate `skills/fleet-orchestrate/*` to fleet-playbook / user skills (see `docs/guides/fleet-skill-distribution.md`).

--- a/docs/superpowers/plans/2026-08-18-verification-cost-discipline-pr1-edda-policy.md
+++ b/docs/superpowers/plans/2026-08-18-verification-cost-discipline-pr1-edda-policy.md
@@ -1,0 +1,975 @@
+# Verification Cost Discipline — PR-1 (edda policy) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Put the verification ladder, build-lane rules, gate receipts, and brake authority into every edda policy carrier so a zero-context session verifies once per frozen SHA in an assigned lane instead of cold-building the workspace per round.
+
+**Architecture:** Docs-only change to six policy carriers plus the pressure-test fixtures. Shipped skills (`crates/edda-cli/src/skills/*.md`, embedded by `include_str!` in `cmd_init.rs`) and `skills/fleet-orchestrate/*` stay carrier-neutral (no Cargo words); `.claude/CLAUDE.md` carries the Cargo L0–L3 commands; `AGENTS.md` is the Codex entry pointer. Spec: `docs/superpowers/specs/2026-08-18-verification-cost-discipline-design.md` (§4.1–§4.5, §6 A1/A4).
+
+**Tech Stack:** Markdown, git, `rg`/`grep` for consistency checks, one fresh agent session per dry-run pressure test. No Cargo invocation anywhere in this plan.
+
+## Global Constraints
+
+- Branch `docs/verification-cost-discipline` in worktree `C:\ai_agent\edda\.claude\worktrees\verification-cost-discipline`, based on `origin/main 7f5d1555b4c00e4fe6ac9a452a3c81c62289972c`. Do not touch the `codex/fleet-orchestrate-skill` checkout at `C:\ai_agent\edda` (stale, has another session's uncommitted diff).
+- Docs-only: run **no** `cargo` command and create **no** `CARGO_TARGET_DIR`. Exact-head CI is the gate (spec §5 slice 1). No skill-content unit test exists (`cmd_init.rs` tests only check files are scaffolded), so nothing else needs local execution.
+- Shipped skills and `skills/fleet-orchestrate/*` must contain no `cargo`, `CARGO_`, or `-p <crate>` text (spec §4.5, A1). Say "assigned build lane", "focused gates on touched units", "full gate set", "gate receipt".
+- Every carrier states all four ideas: verify once per frozen SHA / READ receipt + exact-head CI before RAN / assigned lane, never ad-hoc / status flip is not a push (spec A1).
+- Lane allowlist and thresholds are exactly `worker-1`, `worker-2`, `verifier`, `verifier-2`; warn 35 GB, refuse 50 GB (spec §8). `.claude/CLAUDE.md` and `AGENTS.md` state them as rules; shipped skills and the playbook say "the fixed pool named in the brief" (pressure-test fixtures may use the names as examples).
+- Delete nothing on disk. Do not edit `docs/guides/multi-agent.md` (not a carrier in the spec) or `crates/edda-cli/src/cmd_init.rs`.
+- Commit format `docs(<scope>): <description>` with the trailer `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`. One commit per task. Files are LF in the index; keep them LF.
+- Every push voids prior review; the PR needs the visible review-fix loop from `.claude/CLAUDE.md` before merge. This plan ends at "PR open with handoff comment", not at merge.
+
+---
+
+## File map
+
+| File | Responsibility in PR-1 |
+|---|---|
+| `.claude/CLAUDE.md` | Cargo instantiation of the ladder, build lanes, split checklist, cost subsection under coordination |
+| `AGENTS.md` | Codex entry: two bullets + checklist wording |
+| `crates/edda-cli/src/skills/coord-orchestrate.md` | Controller brief fields, verifier brief, review scope contract additions, handoff template lines, mistakes rows |
+| `crates/edda-cli/src/skills/coord-review.md` | Reviewer READ-before-RAN paragraph, process-finding routing, Round N template lines |
+| `skills/fleet-orchestrate/SKILL.md` | Two invariants, brief fields in the sequence, board/matrix fields |
+| `skills/fleet-orchestrate/references/playbook.md` | Brief template, worker/verifier/controller contracts, gate table rows, receipt paragraph, mistakes rows |
+| `skills/fleet-orchestrate/references/review-scope-pressure-tests.md` | Fixtures 4–7 for spec A4 (i)–(iv) |
+| `docs/superpowers/plans/2026-08-18-verification-cost-discipline-pr1-edda-policy.md` | This plan (already committed with the spec branch) |
+
+---
+
+### Task 1: `.claude/CLAUDE.md` — ladder, lanes, checklist, cost subsection
+
+**Files:**
+- Modify: `.claude/CLAUDE.md:112-137` (Testing Standards + Pre-commit Checklist)
+- Modify: `.claude/CLAUDE.md` end of `### PR review-fix loop` (after the line `strongest durable local carrier; do not invent a PR.`)
+
+**Interfaces:**
+- Produces: level names `L0 iterate`, `L1 freeze`, `L2 review`, `L3 pre-merge`; lane names `worker-1`, `worker-2`, `verifier`, `verifier-2`; the phrase "verify once per frozen SHA"; ceiling `50 GB`. Every later task quotes these exactly.
+
+- [ ] **Step 1: Replace the Testing Standards and Pre-commit Checklist sections**
+
+Find this exact block (lines 112–137):
+
+````markdown
+## Testing Standards
+
+```bash
+# Run all tests
+cargo test --workspace
+
+# Run tests for single crate
+cargo test -p edda-core
+
+# Run specific test
+cargo test -p edda-core test_name
+```
+
+- **Unit tests**: In `#[cfg(test)] mod tests` within source files
+- **No integration tests directory** currently — tests are inline
+- **No mocking internal crates** — use real SQLite via `tempfile`
+- See `edda-core/src/types.rs:261-667` for test patterns
+
+## Pre-commit Checklist
+
+```bash
+cargo fmt --check      # Format check
+cargo clippy           # Lint (CI uses -Dwarnings)
+cargo test --workspace # All tests
+```
+````
+
+Replace it with:
+
+````markdown
+## Testing Standards
+
+```bash
+# Run tests for a single crate (default while iterating)
+cargo test -p edda-core
+
+# Run a specific test
+cargo test -p edda-core test_name
+
+# Run all tests (once per frozen SHA — see Verification ladder)
+cargo test --workspace
+```
+
+- **Unit tests**: In `#[cfg(test)] mod tests` within source files
+- **No integration tests directory** currently — tests are inline
+- **No mocking internal crates** — use real SQLite via `tempfile`
+- See `edda-core/src/types.rs:261-667` for test patterns
+
+### Verification ladder
+
+Verify once per frozen SHA; cite that result everywhere else. Full workspace
+gates are expensive (23 crates; 8–13 GB of build output per target directory)
+and GitHub CI already runs them on three operating systems for every push.
+
+| Level | When | Run |
+|---|---|---|
+| L0 iterate | while editing | `cargo fmt --all --check`; `cargo clippy -p <crate> --all-targets -- -D warnings`; `cargo test -p <crate>` for each touched crate |
+| L1 freeze | once per frozen full SHA, clean tree, before push / PR update | `cargo fmt --all --check`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo test --workspace`, with `CARGO_INCREMENTAL=0`; record the result together with the full SHA (gate receipt) |
+| L2 review | verifier, once per frozen full SHA | READ the L1 receipt and exact-head CI; RAN only focused or adversarial checks they do not cover. A full local rerun needs a stated reason: no receipt, red or absent CI, or grounds to distrust the receipt |
+| L3 pre-merge | merge authority | READ exact-head CI and the final current-head LGTM; RAN only a merge check against the current base. A draft/ready, label, or status flip is not a push — nothing reruns |
+
+Docs-only changes (no code/product blob, `Cargo.lock`, or toolchain change)
+run no Cargo gate locally; exact-head CI is the gate.
+
+### Build lanes
+
+- Never create ad-hoc `CARGO_TARGET_DIR`s per round, per SHA, or per
+  timestamp. Build output is disposable cache, but unbounded copies are not:
+  twelve such directories reached ~194 GB on one workstation.
+- Solo work uses the worktree's default `target/`.
+- Fleet sessions build only in the lane named in their brief — one of
+  `worker-1`, `worker-2`, `verifier`, `verifier-2` — for their whole lifetime.
+  Where the workstation lane tool is installed, run gates through it
+  (`lane.ps1 -Lane <assigned> -Gate focused|freeze`); without it, set
+  `CARGO_TARGET_DIR` only to `<lane-root>\<assigned-lane>` from the brief and
+  reuse it every round.
+- Verifier lanes and every L1 run set `CARGO_INCREMENTAL=0`.
+- Deleting lane build output is authorized and non-destructive; deleting
+  worktrees, branches, or sources is not. Stop and report instead of building
+  when the lane pool exceeds 50 GB.
+
+## Pre-commit Checklist
+
+```bash
+# Before every commit (L0 — touched crates only)
+cargo fmt --check
+cargo clippy -p <touched crate> --all-targets -- -D warnings
+cargo test -p <touched crate>
+
+# Before freezing a SHA for push / PR update (L1 — once per frozen SHA)
+cargo clippy --workspace --all-targets -- -D warnings   # CI uses -Dwarnings
+cargo test --workspace
+```
+````
+
+- [ ] **Step 2: Append the cost subsection to the coordination section**
+
+Find the last lines of `### PR review-fix loop`:
+
+```markdown
+For local-only delivery, record the same round/response/verdict fields in the
+strongest durable local carrier; do not invent a PR.
+```
+
+Append immediately after them:
+
+```markdown
+
+### Verification cost
+
+Rules regulate cost and reclamation, not only evidence:
+
+- Verify once per frozen SHA on the ladder above. READ recorded gate results
+  and exact-head CI before any RAN, and state the reason whenever you rerun a
+  recorded gate.
+- Every worker/verifier brief names a build lane, a verification budget (L0
+  while iterating; L1 once per frozen SHA), and cleanup authority (lane build
+  cache is disposable; worktrees, branches, and sources are never deleted).
+- One verifier identity per PR: rounds resume the same session and lane; a
+  replacement reads receipts and CI before running anything.
+- Over-verification — a second RAN for an already-recorded SHA without a
+  reason, workspace gates for a docs-only push, an ad-hoc target directory —
+  is a process finding: record it in the handoff cost line, route it as a
+  `FOLLOW-UP ISSUE`, correct the next brief. It does not block a product-green
+  PR.
+```
+
+- [ ] **Step 3: Verify the file**
+
+Run in the worktree:
+
+```bash
+grep -c "L0 iterate\|L1 freeze\|L2 review\|L3 pre-merge" .claude/CLAUDE.md
+grep -n "worker-1\|verifier-2\|50 GB\|Verification cost\|not a push" .claude/CLAUDE.md
+grep -c "<!-- edda:coordination -->" .claude/CLAUDE.md
+```
+
+Expected: first command prints `4` or more; second prints one line per pattern (at least five lines); third prints `1` (marker untouched, so `edda init` still detects the section).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/CLAUDE.md
+git commit -m "docs(claude-md): add verification ladder, build lanes, and cost rules" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `AGENTS.md` — Codex entry bullets
+
+**Files:**
+- Modify: `AGENTS.md` (`## Multi-session work` list and `## Repository safety` list)
+
+**Interfaces:**
+- Consumes: level names and lane names from Task 1.
+
+- [ ] **Step 1: Insert two bullets after the gate-selection bullet**
+
+Find this bullet (it ends with `route follow-up or ask the operator to expand scope.`):
+
+```markdown
+- Select gates from code/product-blob, base, and toolchain changes. Docs- or
+  evidence-only pushes reuse still-applicable code gates as `READ`, run only
+  relevant validation plus exact-head CI as `RAN`, and record available cost.
+  Stop after two non-product/harness-only cycles without useful progress or at
+  diminishing returns; route follow-up or ask the operator to expand scope.
+```
+
+Insert immediately after it:
+
+```markdown
+- Verify once per frozen SHA on the ladder in `.claude/CLAUDE.md`: focused
+  crate gates while iterating (L0); the full workspace set once per frozen full
+  SHA with a recorded receipt (L1); reviewers READ that receipt and exact-head
+  CI and RAN only what they do not cover (L2); nothing reruns on a draft,
+  label, or status flip (L3). State the reason whenever you rerun a recorded
+  gate.
+- Build only in the lane your brief assigns (`worker-1`, `worker-2`,
+  `verifier`, `verifier-2`). Never create ad-hoc `CARGO_TARGET_DIR`s per round,
+  SHA, or timestamp; solo work uses the worktree's default `target/`. Lane
+  build cache is disposable; worktrees, branches, and sources are not. Stop and
+  report when the lane pool exceeds 50 GB.
+```
+
+- [ ] **Step 2: Reword the completion-check bullet**
+
+Find:
+
+```markdown
+- Run the checks required by `.claude/CLAUDE.md` before claiming completion.
+```
+
+Replace with:
+
+```markdown
+- Run the checks required by `.claude/CLAUDE.md` at the ladder level that
+  matches your change before claiming completion; docs-only changes rely on
+  exact-head CI and run no Cargo gate locally.
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -n "Verify once per frozen SHA\|worker-1\|ladder level\|50 GB" AGENTS.md
+```
+
+Expected: four lines.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "docs(agents): point Codex at the verification ladder and build lanes" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `coord-orchestrate.md` — controller brief, verifier brief, contract, template, mistakes
+
+**Files:**
+- Modify: `crates/edda-cli/src/skills/coord-orchestrate.md:58-66` (review scope contract gate/cost paragraphs)
+- Modify: `crates/edda-cli/src/skills/coord-orchestrate.md:77-80` (handoff template Evidence)
+- Modify: `crates/edda-cli/src/skills/coord-orchestrate.md:90-100` (Protocol steps 3–4)
+- Modify: `crates/edda-cli/src/skills/coord-orchestrate.md:148-162` (Common mistakes table)
+
+**Interfaces:**
+- Produces: template lines `- Lane:` and `- Receipt:`; the phrase "gate receipt (SHA, gate set, toolchain, lane, result)". Task 4 and Task 6 reuse both verbatim.
+- Constraint: no Cargo words in this file.
+
+- [ ] **Step 1: Extend the review scope contract**
+
+Find:
+
+```markdown
+Select gates proportionally. Code/product-blob, base, or toolchain changes run
+the relevant code gates. A docs/evidence-only push with those inputs unchanged
+reuses still-applicable code results as `READ` with source SHA, then runs only
+relevant diff/docs/evidence checks and exact-head CI as `RAN`.
+```
+
+Append immediately after it (blank line between paragraphs):
+
+```markdown
+
+Verify once per frozen artifact. The implementer runs the full gate set once
+per frozen full SHA in the assigned build lane and records a gate receipt (SHA,
+gate set, toolchain, lane, result). The reviewer READs that receipt and
+exact-head CI, RANs only focused or adversarial checks they do not cover, and
+states the reason for any full rerun (no receipt, red or absent CI, or grounds
+to distrust the receipt). Focused gates on touched units while iterating, never
+the full set per edit. A status, label, or draft flip is not a push and reruns
+nothing.
+```
+
+Then find:
+
+```markdown
+Each handoff records available elapsed/token/tool cost. Stop after two
+consecutive non-product evidence/docs or harness-only cycles without improved
+required behavior/proof, or at clear diminishing returns; route the finding to
+follow-up or ask the operator to expand scope.
+```
+
+Append immediately after it:
+
+```markdown
+
+Over-verification is a process finding, not a product blocker: a second RAN
+for an already-receipted SHA without a reason, full gates for a docs-only push,
+or an ad-hoc build directory goes into the cost line, routes as a `FOLLOW-UP
+ISSUE`, and corrects the next brief.
+```
+
+- [ ] **Step 2: Add lane and receipt lines to the handoff template**
+
+Find inside the ```` ```text ```` block:
+
+```text
+- RAN: <commands/checks run on this SHA>
+- READ: <reused results and source SHAs>
+```
+
+Replace with:
+
+```text
+- RAN: <commands/checks run on this SHA>
+- READ: <reused results and source SHAs>
+- Lane: <assigned build lane>
+- Receipt: <gate receipt for this SHA (SHA, gate set, toolchain, lane, result), or none>
+```
+
+- [ ] **Step 3: Rewrite Protocol steps 3 and 4**
+
+Find:
+
+```markdown
+3. **Brief workers** — self-contained (they have zero context): issues to
+   read, worktree + branch command, `edda claim` label and paths, files
+   owned/forbidden, quality gates verbatim, done = GitHub PR when available,
+   otherwise a frozen local branch plus durable review carrier (never invent a
+   PR); never merge + `edda task done --receipt`. Include the receiver tie-break
+   verbatim (see Traffic rules).
+4. **Brief the verifier — read-only, starts BEFORE code:** baseline gates on
+   main; flake hunt; observable-behavior criteria per issue; sweep for two
+   test poisons — tests asserting the behavior being removed (invert and
+   rename, never delete) and single-case tests that pass either way (demand
+   the second case).
+```
+
+Replace with:
+
+```markdown
+3. **Brief workers** — self-contained (they have zero context): issues to
+   read, worktree + branch command, `edda claim` label and paths, files
+   owned/forbidden, quality gates verbatim, assigned build lane from the fixed
+   pool, verification budget (focused gates on touched units while iterating;
+   the full gate set once per frozen SHA with a receipt; READ receipts before
+   any RAN), cleanup authority (lane build cache is disposable; worktrees,
+   branches, and sources are never deleted), done = GitHub PR when available,
+   otherwise a frozen local branch plus durable review carrier (never invent a
+   PR); never merge + `edda task done --receipt`. Include the receiver tie-break
+   verbatim (see Traffic rules).
+4. **Brief the verifier — read-only, starts BEFORE code:** baseline on the
+   basis SHA by READing exact-head CI and any existing gate receipt, RANning
+   only what they do not cover in the assigned verifier lane, and classifying
+   existing red checks; flake hunt; observable-behavior criteria per issue;
+   sweep for two test poisons — tests asserting the behavior being removed
+   (invert and rename, never delete) and single-case tests that pass either
+   way (demand the second case). One verifier identity per delivery
+   candidate: rounds resume the same session and lane; a replacement reads
+   receipts and CI before running anything.
+```
+
+- [ ] **Step 4: Add three rows to the Common mistakes table**
+
+Find the last row:
+
+```markdown
+| Review drips one blocker per round | audit the whole scope and batch P0/P1 before requesting changes |
+```
+
+Append after it:
+
+```markdown
+| Fresh verifier reruns every gate "to be safe" | READ the frozen SHA's receipt and exact-head CI; RAN only what they do not cover, or state the reason |
+| New build directory per round, SHA, or timestamp | one assigned lane per session for its lifetime; lane cache is disposable, sources are not |
+| Status/label/draft flip treated as a push | not a push; nothing reruns |
+```
+
+- [ ] **Step 5: Verify carrier-neutral wording**
+
+```bash
+grep -c "gate receipt\|assigned build lane\|not a push\|Verify once per frozen" crates/edda-cli/src/skills/coord-orchestrate.md
+grep -n -i "cargo\|CARGO_\| -p " crates/edda-cli/src/skills/coord-orchestrate.md
+```
+
+Expected: first prints `4` or more; second prints nothing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/edda-cli/src/skills/coord-orchestrate.md
+git commit -m "docs(coordination): brief build lanes and verify-once in coord-orchestrate" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: `coord-review.md` — reviewer READ-before-RAN, process finding, template
+
+**Files:**
+- Modify: `crates/edda-cli/src/skills/coord-review.md:100-110`
+- Modify: `crates/edda-cli/src/skills/coord-review.md:164-166` (Round N template Evidence)
+
+**Interfaces:**
+- Consumes: `- Lane:` / `- Receipt:` lines and "gate receipt (SHA, gate set, toolchain, lane, result)" from Task 3, verbatim.
+
+- [ ] **Step 1: Add the verify-once paragraph after the delta paragraph**
+
+Find:
+
+```markdown
+Choose gates from the delta. Code/product-blob, base, or toolchain changes run
+the relevant code gates. When only docs/evidence changed and code/product
+blobs, base, and toolchain are unchanged, reuse still-applicable code results
+as `READ` with their source SHA; run only relevant diff/docs/evidence checks
+and exact-head CI as `RAN`. Never report a reused result as rerun.
+```
+
+Append immediately after it:
+
+```markdown
+
+Verify once per frozen artifact. When the implementer's gate receipt (SHA,
+gate set, toolchain, lane, result) matches the reviewed SHA and exact-head CI
+is green, cite both as `READ` and RAN only the focused or adversarial checks
+they do not cover. A full local rerun requires a stated reason: no receipt,
+red or absent CI, or grounds to distrust the receipt. Run in your assigned
+build lane; never create an ad-hoc build directory. A status, label, or draft
+flip is not a push and reruns nothing.
+```
+
+- [ ] **Step 2: Add the process-finding paragraph after the cost paragraph**
+
+Find:
+
+```markdown
+Record available elapsed, token, and tool cost. Stop after two consecutive
+cycles that change only non-product evidence/docs or harness material without
+improving required behavior/proof, or sooner when returns clearly diminish.
+Classify and route the finding instead of continuing: follow-up issue for
+out-of-scope work, or operator scope expansion when it must join this PR.
+```
+
+Append immediately after it:
+
+```markdown
+
+Over-verification you find in the implementer's evidence — a second RAN for
+an already-receipted SHA without a reason, full gates for a docs-only push, an
+ad-hoc build directory — is a process finding: note it in the cost line, route
+it as a `FOLLOW-UP ISSUE`, and do not block a product-green PR on it.
+```
+
+- [ ] **Step 3: Extend the Round N template**
+
+Find inside the ```` ```text ```` block:
+
+```text
+- RAN: <exact command/check and result on reviewed SHA>
+- READ: <reused result and its source SHA, or none>
+```
+
+Replace with:
+
+```text
+- RAN: <exact command/check and result on reviewed SHA>
+- READ: <reused result and its source SHA, or none>
+- Lane: <build lane used, or n/a for docs-only>
+- Receipt: <implementer gate receipt cited (SHA, gate set, toolchain, lane, result), or none>
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+grep -c "Verify once per frozen\|gate receipt\|assigned\|not a push\|process finding" crates/edda-cli/src/skills/coord-review.md
+grep -n -i "cargo\|CARGO_\| -p " crates/edda-cli/src/skills/coord-review.md
+```
+
+Expected: first prints `5` or more; second prints nothing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/edda-cli/src/skills/coord-review.md
+git commit -m "docs(coordination): read receipts before rerunning gates in coord-review" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: `skills/fleet-orchestrate/SKILL.md` — invariants and controller output
+
+**Files:**
+- Modify: `skills/fleet-orchestrate/SKILL.md:41-42` (controller sequence step 7)
+- Modify: `skills/fleet-orchestrate/SKILL.md:67-69` (invariants)
+- Modify: `skills/fleet-orchestrate/SKILL.md:90-93` (minimum controller output)
+
+**Interfaces:**
+- Consumes: wording from Tasks 3–4. Constraint: no Cargo words.
+
+- [ ] **Step 1: Extend controller sequence step 7**
+
+Find:
+
+```markdown
+7. Give self-contained briefs, monitor compressed state, adjudicate conflicts,
+   and close only against immutable full SHAs with proportional evidence.
+```
+
+Replace with:
+
+```markdown
+7. Give self-contained briefs (including assigned build lane, verification
+   budget, and cleanup authority), monitor compressed state, adjudicate
+   conflicts, and close only against immutable full SHAs with proportional
+   evidence.
+```
+
+- [ ] **Step 2: Add two invariants**
+
+Find:
+
+```markdown
+- Record available elapsed/token/tool cost. After two consecutive
+  non-product/harness-only cycles without useful progress, or at diminishing
+  returns, stop and route follow-up or request operator scope expansion.
+```
+
+Append immediately after it:
+
+```markdown
+- Verify once per frozen artifact: the full gate set runs once per frozen
+  full SHA in an assigned build lane and leaves a gate receipt (SHA, gate set,
+  toolchain, lane, result); reviewers READ that receipt and exact-head CI and
+  RAN only what they do not cover, stating the reason for any full rerun. A
+  status, label, or draft flip is not a push.
+- Build environments are bounded: one assigned lane per session for its
+  lifetime from a fixed pool named in the brief, never per round, SHA, or
+  timestamp; lane build cache is disposable, worktrees and sources are not;
+  over the pool ceiling the fleet stops and reports instead of building.
+```
+
+- [ ] **Step 3: Extend the minimum controller output**
+
+Find:
+
+```markdown
+4. fleet board with task, owner, branch, full SHA, state, review, and next step;
+5. acceptance matrix, review handoff (`IN SCOPE`, `FOLLOW-UP ISSUE`, blocking
+   P0/P1, `RAN`/`READ`, exact SHA, cost), PR review-loop state, and final merge
+   recommendation with current-head P0=0/P1=0.
+```
+
+Replace with:
+
+```markdown
+4. fleet board with task, owner, branch, full SHA, state, review, build lane,
+   and next step;
+5. acceptance matrix, review handoff (`IN SCOPE`, `FOLLOW-UP ISSUE`, blocking
+   P0/P1, `RAN`/`READ`, lane, gate receipt, exact SHA, cost), PR review-loop
+   state, and final merge recommendation with current-head P0=0/P1=0.
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+grep -c "Verify once per frozen\|gate receipt\|assigned build lane\|not a push" skills/fleet-orchestrate/SKILL.md
+grep -n -i "cargo\|CARGO_\| -p " skills/fleet-orchestrate/SKILL.md
+```
+
+Expected: first prints `4` or more; second prints nothing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/fleet-orchestrate/SKILL.md
+git commit -m "docs(fleet): add verify-once and bounded build lane invariants" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: `playbook.md` — brief template, contracts, gate table, mistakes
+
+**Files:**
+- Modify: `skills/fleet-orchestrate/references/playbook.md:193-202` (bundle brief block)
+- Modify: `skills/fleet-orchestrate/references/playbook.md:211-240` (§8 contracts)
+- Modify: `skills/fleet-orchestrate/references/playbook.md:321-329` (§11 gate table and paragraph)
+- Modify: `skills/fleet-orchestrate/references/playbook.md:445-448` (§14 table end)
+
+**Interfaces:**
+- Consumes: wording from Tasks 3–5. Constraint: no Cargo words.
+
+- [ ] **Step 1: Extend the bundle brief block**
+
+Find inside the ```` ```text ```` block in §7:
+
+```text
+Test-first acceptance criteria and exact gates
+Drift rule: if HEAD differs, satisfy intent against HEAD and report full SHA
+```
+
+Replace with:
+
+```text
+Test-first acceptance criteria and exact gates
+Build lane: <assigned name from the fixed pool>
+Verification budget: focused gates on touched units while iterating; the full
+  gate set once per frozen full SHA with a gate receipt; READ receipts and
+  exact-head CI before any RAN
+Cleanup authority: lane build cache is disposable; worktrees, branches, and
+  sources are never deleted
+Drift rule: if HEAD differs, satisfy intent against HEAD and report full SHA
+```
+
+- [ ] **Step 2: Rewrite the worker, verifier, and controller contracts**
+
+Find:
+
+```markdown
+5. Run gates selected from code/product-blob, base, and toolchain changes.
+6. Push/open the delivery candidate if authorized, report the full SHA, freeze
+   the branch, and leave a receipt tagged `ran` versus `read`.
+```
+
+Replace with:
+
+```markdown
+5. Run focused gates on touched units while iterating; run the full gate set
+   once on the frozen full SHA in the assigned build lane and record the gate
+   receipt (SHA, gate set, toolchain, lane, result). Never build in an ad-hoc
+   directory.
+6. Push/open the delivery candidate if authorized, report the full SHA, freeze
+   the branch, and leave a receipt tagged `ran` versus `read` that cites the
+   gate receipt.
+```
+
+Find:
+
+```markdown
+2. Run baseline gates before workers code and classify existing red checks.
+```
+
+Replace with:
+
+```markdown
+2. Establish the baseline once on the basis SHA before workers code: READ
+   exact-head CI and any existing gate receipt, RAN only what they do not
+   cover in the assigned verifier lane, and classify existing red checks.
+```
+
+Find:
+
+```markdown
+5. Review the exact frozen full SHA, complete the whole scoped audit, compare
+   against the basis, and batch every blocking P0/P1 with path/symbol and
+   failure scenario before requesting changes.
+6. Acknowledge that any push voids the verdict.
+```
+
+Replace with:
+
+```markdown
+5. Review the exact frozen full SHA, complete the whole scoped audit, compare
+   against the basis, and batch every blocking P0/P1 with path/symbol and
+   failure scenario before requesting changes. READ the frozen SHA's gate
+   receipt and exact-head CI; RAN only focused or adversarial checks they do
+   not cover, and state the reason for any full rerun.
+6. Acknowledge that any push voids the verdict; a status, label, or draft flip
+   is not a push and reruns nothing.
+7. Keep one verifier identity per delivery candidate: rounds resume the same
+   session and lane; a replacement reads receipts and CI before running
+   anything.
+```
+
+Find:
+
+```markdown
+4. Never reinterpret a receipt as acceptance.
+```
+
+Replace with:
+
+```markdown
+4. Never reinterpret a receipt as acceptance.
+5. Assign build lanes from the fixed pool, put the verification budget and
+   cleanup authority in every brief, and route over-verification (a second RAN
+   for an already-receipted SHA without a reason, full gates for a docs-only
+   push, an ad-hoc build directory) as a process finding — cost line,
+   `FOLLOW-UP ISSUE`, corrected brief — never as a reason to block a
+   product-green candidate.
+```
+
+- [ ] **Step 3: Extend the §11 gate table and add the receipt paragraph**
+
+Find:
+
+```markdown
+| Only docs/evidence changed; code/product blobs, base, and toolchain unchanged | Reuse still-applicable code gates as `READ` with source SHA; `RAN` only relevant diff/docs/evidence checks and exact-head CI. |
+
+Never label a reused gate `RAN`. Exact-head CI is still required because the
+review verdict binds the new full SHA.
+```
+
+Replace with:
+
+```markdown
+| Only docs/evidence changed; code/product blobs, base, and toolchain unchanged | Reuse still-applicable code gates as `READ` with source SHA; `RAN` only relevant diff/docs/evidence checks and exact-head CI. |
+| Code changed; a gate receipt for this exact SHA, gate set, and toolchain exists and exact-head CI is green | READ the receipt and CI; `RAN` only focused or adversarial checks they do not cover. Full rerun only with a stated reason (no receipt, red or absent CI, grounds to distrust the receipt). |
+| Status, label, or draft flip without a push | Not a new artifact; nothing reruns. |
+
+Never label a reused gate `RAN`. Exact-head CI is still required because the
+review verdict binds the new full SHA.
+
+Verify once per frozen artifact. The implementer's full gate run leaves a gate
+receipt (SHA, gate set, toolchain, lane, result); the reviewer cites it. Runs
+happen in the assigned build lane, never in an ad-hoc directory.
+Over-verification found in evidence is a process finding — cost line,
+`FOLLOW-UP ISSUE`, corrected brief — not a product blocker.
+```
+
+- [ ] **Step 4: Extend the §14 table**
+
+Find the last row:
+
+```markdown
+| “Receipt says tests pass, so merge.” | Receipt is worker evidence; verifier runs the required proportional gates and merge authority accepts. |
+```
+
+Replace with:
+
+```markdown
+| “Receipt says tests pass, so merge.” | Receipt is worker evidence; the verifier READs it against exact-head CI, RANs what they do not cover, and merge authority accepts. |
+| “A fresh session should build in its own directory to be safe.” | Use the assigned lane; lanes are the isolation. Ad-hoc build directories are forbidden. |
+| “The verifier must rerun everything to be independent.” | Exact-head CI and the gate receipt are independent evidence; RAN only what they do not cover, or state the reason. |
+| “The PR flipped to ready, so rerun the gates.” | Not a push; nothing reruns. |
+| “Cleanup is destructive, so leave every build directory.” | Lane build cache is disposable by design; worktrees, branches, and sources are not. |
+```
+
+- [ ] **Step 5: Verify**
+
+```bash
+grep -c "gate receipt\|assigned build lane\|not a push\|Verify once per frozen\|Build lane:" skills/fleet-orchestrate/references/playbook.md
+grep -n -i "cargo\|CARGO_\| -p " skills/fleet-orchestrate/references/playbook.md
+```
+
+Expected: first prints `8` or more; second prints nothing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/fleet-orchestrate/references/playbook.md
+git commit -m "docs(fleet): brief lanes, receipts, and verify-once in the playbook" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: pressure-test fixtures 4–7
+
+**Files:**
+- Modify: `skills/fleet-orchestrate/references/review-scope-pressure-tests.md` (append after fixture 3)
+
+**Interfaces:**
+- Produces: fixtures `4`–`7` used by Task 8's dry runs and by future review-policy changes (SKILL.md already says these tests are REQUIRED when changing review policy).
+
+- [ ] **Step 1: Append four fixtures**
+
+Append at the end of the file (after the fixture 3 `**Pass:**` paragraph):
+
+```markdown
+
+## 4. Frozen SHA with receipt and green CI
+
+The implementer froze full SHA `X`, ran the full gate set once in lane
+`worker-1`, and recorded the gate receipt (SHA, gate set, toolchain, lane,
+result). Exact-head CI is green on `X`. The reviewer's brief assigns lane
+`verifier`.
+
+**Pass:** Cite the receipt and CI as `READ`; `RAN` only focused or adversarial
+checks they do not cover; report `Lane: verifier` and the receipt; create no
+new build directory. A full local rerun without a stated reason fails.
+
+## 5. Iterating worker
+
+A worker changes two units across several commits before freezing.
+
+**Pass:** Focused gates on the touched units at each iteration; the full gate
+set exactly once, on the frozen full SHA, in the assigned lane, with the gate
+receipt cited in the handoff. Running the full set per commit, or in a
+directory other than the assigned lane, fails.
+
+## 6. Draft-to-ready flip
+
+After the final current-head LGTM on `X`, the PR is flipped from draft to
+ready. No push happened.
+
+**Pass:** No gate runs; the verdict on `X` stands. Any rerun fails.
+
+## 7. Missing receipt and red CI
+
+The frozen SHA has no gate receipt and exact-head CI is red on one job.
+
+**Pass:** `RAN` the full gate set in the assigned lane with the reason stated
+(`no receipt; CI red on <job>`), classify the red job, and record the receipt
+so later rounds READ it. Silently rerunning without the reason, or building
+outside the assigned lane, fails.
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep -c "^## " skills/fleet-orchestrate/references/review-scope-pressure-tests.md
+```
+
+Expected: `7`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/fleet-orchestrate/references/review-scope-pressure-tests.md
+git commit -m "docs(fleet): add verify-once and build lane pressure tests" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: consistency check, dry-run pressure tests, PR
+
+**Files:**
+- Read only: all files above.
+- Create: nothing in the repository (dry-run outputs go into the PR body).
+
+**Interfaces:**
+- Consumes: fixtures 4–7 from Task 7; every carrier from Tasks 1–6.
+
+- [ ] **Step 1: A1 consistency grep across the six carriers**
+
+Run from the worktree root:
+
+```bash
+for f in .claude/CLAUDE.md AGENTS.md crates/edda-cli/src/skills/coord-orchestrate.md crates/edda-cli/src/skills/coord-review.md skills/fleet-orchestrate/SKILL.md skills/fleet-orchestrate/references/playbook.md; do
+  printf '%s: once=%s read=%s lane=%s flip=%s\n' "$f" \
+    "$(grep -c -i 'once per frozen' "$f")" \
+    "$(grep -c 'READ' "$f")" \
+    "$(grep -c -i 'lane' "$f")" \
+    "$(grep -c -i 'not a push' "$f")"
+done
+grep -l -i "cargo\|CARGO_" crates/edda-cli/src/skills/coord-orchestrate.md crates/edda-cli/src/skills/coord-review.md skills/fleet-orchestrate/SKILL.md skills/fleet-orchestrate/references/playbook.md skills/fleet-orchestrate/references/review-scope-pressure-tests.md
+```
+
+Expected: every carrier line shows all four counts ≥ 1; the final `grep -l` prints nothing (no Cargo words in shipped/methodology files). If any count is 0, fix that carrier in place and amend the relevant task commit before continuing.
+
+- [ ] **Step 2: Dry-run pressure tests with a fresh agent**
+
+For each fixture 4–7, start a **fresh** agent session whose working directory is the worktree (so it reads the new `AGENTS.md`, `.claude/CLAUDE.md`, and skills) — a fresh Codex session (`codex exec` from the worktree) is preferred because Codex is the population that over-verified; a fresh Claude subagent given only the repository files is acceptable. Use this prompt, substituting the fixture text:
+
+```text
+You are the reviewer/worker described below. Read AGENTS.md, .claude/CLAUDE.md,
+and the coord-review / coord-orchestrate skills in this repository first.
+DO NOT run any command. Output only the plan you would execute: the exact
+commands, each tagged RAN or READ, the build lane you would use, the reason for
+any full rerun, and what you would write under Evidence in the review handoff.
+
+Fixture:
+<paste fixture N from skills/fleet-orchestrate/references/review-scope-pressure-tests.md>
+```
+
+Record PASS/FAIL against the fixture's `**Pass:**` clause:
+
+| Fixture | Pass condition to check in the output |
+|---|---|
+| 4 | full workspace gates tagged READ (receipt + CI); RAN only focused/adversarial; `Lane: verifier`; no new target directory |
+| 5 | focused `-p` gates per iteration; full set exactly once at freeze; lane named; receipt cited |
+| 6 | zero gate commands |
+| 7 | full set tagged RAN with the stated reason; lane named; receipt recorded for later rounds |
+
+Expected: 4/4 PASS. If any fixture fails, the wording that the agent missed is the defect: strengthen that carrier (usually `AGENTS.md` or the skill the agent read), amend the task commit, and rerun that fixture.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin docs/verification-cost-discipline
+gh pr create --title "docs(coordination): verification cost discipline — ladder, lanes, receipts" --body-file - <<'EOF'
+## Summary
+
+Closes the cost gap left after GH-474: rules regulated evidence but not cost
+and reclamation. Adds the verification ladder (L0 iterate / L1 freeze once per
+frozen SHA / L2 READ receipt + exact-head CI before RAN / L3 nothing reruns on
+a status flip), bounded build lanes, gate receipts, and brake authority to
+every policy carrier. Docs-only.
+
+Spec: docs/superpowers/specs/2026-08-18-verification-cost-discipline-design.md
+Plan: docs/superpowers/plans/2026-08-18-verification-cost-discipline-pr1-edda-policy.md
+
+## Carriers
+
+- .claude/CLAUDE.md — Cargo L0–L3, build lanes, split checklist, cost subsection
+- AGENTS.md — Codex entry bullets
+- crates/edda-cli/src/skills/coord-orchestrate.md, coord-review.md — carrier-neutral
+- skills/fleet-orchestrate/SKILL.md, references/playbook.md, references/review-scope-pressure-tests.md (fixtures 4–7)
+
+## Evidence
+
+- RAN: A1 consistency grep (all four ideas in each of six carriers; no Cargo words in shipped/methodology files)
+- RAN: dry-run pressure tests 4–7 with a fresh agent — <n>/4 PASS (transcripts summarized below)
+- READ: exact-head CI on this PR (docs-only; no local Cargo gate, no target directory created)
+- Lane: n/a (docs-only)
+- Receipt: none (docs-only)
+
+## Follow-ups (not in this PR)
+
+- fleet-workstation PR-2: scripts/lane.ps1, doctor lanes check, adapter bullets, pin bump to this merge
+- fleet-playbook: fleet-review / fleet-pr-loop "re-run gates" wording (operator ruling)
+- pre-existing ubuntu flake codex_app_server::tests::dropping_concrete_client_makes_child_pid_disappear (main 7f5d155)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+```
+
+- [ ] **Step 4: Post the review handoff comment**
+
+Fill the SHAs from `git rev-parse HEAD` and `git rev-parse origin/main`, then:
+
+```bash
+gh pr comment <PR#> --body-file - <<'EOF'
+## Code Review Handoff: Round 1
+Full SHA: <full HEAD SHA>
+Base full SHA: <full origin/main SHA>
+IN SCOPE: policy wording in the six carriers + pressure fixtures 4–7; consistency (spec §6 A1); dry-run pressure tests (spec §6 A4)
+FOLLOW-UP ISSUE: none
+Blocking counts entering review: P0=0, P1=0
+Evidence:
+- RAN: A1 grep (see PR body); dry-run fixtures 4–7 <n>/4
+- READ: exact-head CI
+- Lane: n/a (docs-only)
+- Receipt: none (docs-only)
+Cost: elapsed=<available/unknown>, tokens=<available/unknown>, tools=<available/unknown>
+Request: audit the whole scoped surface; publish no self-verdict from the implementer
+EOF
+```
+
+- [ ] **Step 5: Record on the rail**
+
+```bash
+edda note "PR-1 verification cost discipline open: <PR URL> at <full SHA>; docs-only; A1 grep pass; dry-run fixtures <n>/4; awaiting Code Review: Round 1" --tag fleet-board
+```
+
+Expected: the PR shows the handoff comment; CI runs on the exact head; no local build output was created (`git status` clean, no new `target/` in the worktree).
+
+---
+
+## Post-merge (outside this plan, listed so nobody forgets)
+
+1. `scripts/skills/sync-fleet-orchestrate.ps1` to propagate `skills/fleet-orchestrate/*` to fleet-playbook / user skills (see `docs/guides/fleet-skill-distribution.md`).
+2. fleet-workstation PR-2 pins the merged edda revision and ships `lane.ps1`, doctor lanes check, and adapter bullets (separate plan in that repository).
+3. Optional operator line in `C:\ai_agent\EXECUTION-COORDINATION.md`.

--- a/docs/superpowers/specs/2026-08-18-verification-cost-discipline-design.md
+++ b/docs/superpowers/specs/2026-08-18-verification-cost-discipline-design.md
@@ -102,10 +102,21 @@ Non-goals:
 | L2 review | verifier, once per frozen full SHA | READ the L1 receipt and exact-head CI; RAN adversarial/focused checks and anything neither covers, including behavior on a platform the CI matrix only partially covers | full local rerun without a stated reason (missing receipt, red/absent CI, receipt suspected invalid, real CI coverage gap); a full run against deterministically red CI, which cannot change the verdict |
 | L3 pre-merge | controller / merge authority | READ exact-head CI + final current-head LGTM; RAN only a merge-conflict check against current base | any rerun triggered by a status/label/draft flip — that is not a push |
 
-Independence is preserved by construction: exact-head CI is an independent
-full run on three operating systems, and receipts are keyed to the immutable
-SHA. A verifier keeps the right to RAN anything, but must state why the READ
-evidence is insufficient.
+Independence is preserved **only as far as the project's CI actually reaches**,
+and receipts are keyed to the immutable SHA. This is a precondition of the
+ladder, not a given: before a reviewer may cite CI as independent evidence, the
+project must state what its CI covers and what it does not, and the uncovered
+surface is a standing reason to RAN. In this repository the gap is Windows
+tests outside the 7-crate subset (§1). A project whose CI covers less gets less
+independence from this ladder, and its L2 row must say so.
+
+Carrying this policy to another project (§4.5, §5 slice 2) therefore carries the
+obligation with it: the adapter bullet states the rule, and the project supplies
+its own coverage statement. A verifier who cannot find one treats CI as
+unproven coverage and RANs what the receipt alone would otherwise carry.
+
+A verifier keeps the right to RAN anything, but must state why the READ evidence
+is insufficient.
 
 Cargo instantiation for this repository (goes into `.claude/CLAUDE.md`):
 
@@ -149,7 +160,10 @@ Key = (`repo`, `sha`, `gate`, `crates`, `toolchain`, `lockfile`). Rules:
 ### 4.3 Build lanes (machine level)
 
 - One lane root per machine, configurable (`FLEET_LANE_ROOT`, default
-  `%LOCALAPPDATA%\fleet-workstation\lanes`); every lane is a subdirectory, so
+  the `LOCALAPPDATA` directory plus `\fleet-workstation\lanes`, written
+  shell-appropriately — `$env:LOCALAPPDATA` in PowerShell, `$LOCALAPPDATA` in
+  Git Bash; `%LOCALAPPDATA%` expands only in cmd.exe); every lane is a
+  subdirectory, so
   one scan measures the whole pool.
 - Fixed allowlist: `worker-1`, `worker-2`, `verifier`, `verifier-2`. Unknown
   names are refused. The controller's primary checkout keeps its normal

--- a/docs/superpowers/specs/2026-08-18-verification-cost-discipline-design.md
+++ b/docs/superpowers/specs/2026-08-18-verification-cost-discipline-design.md
@@ -1,0 +1,309 @@
+# Verification Cost Discipline — Design
+
+Date: 2026-08-18
+Status: draft for operator review
+Scope: edda coordination policy (this repo) + fleet-workstation machine tooling
+Basis: origin/main `7f5d1555b4c00e4fe6ac9a452a3c81c62289972c`
+
+## 1. Problem
+
+Fleet sessions in this repository over-verify, and every verification round
+runs as a new cold build in a new Cargo target directory. Nothing in the
+current rules bounds that cost or authorizes reclaiming it.
+
+Evidence collected on 2026-08-18 (read-only; nothing was modified or deleted):
+
+- 12 ad-hoc Cargo target directories exist next to the repository
+  (`C:\ai_agent\edda-target-*`), named per issue × round × SHA × timestamp:
+  `gh466-drill`, `gh466-drill-<ts>` ×3, `gh466-round3`, `gh466-round4`,
+  `gh466-tests`, `gh466-final`, `gh466-quoted-command-fix`,
+  `gh466-verifier-<sha>`, `gh465-verifier-<sha>`, `recovery-wave1`. One of them
+  (`recovery-wave1`) is 12.79 GB (deps 7.50 GB, incremental 5.11 GB). The
+  operator's audit counted 190 isolated-target Cargo invocations across 15
+  distinct target directories (the other three lived elsewhere or are already
+  gone), 63 workspace-level builds, 40 `--all-targets` runs, and zero cleanup
+  calls, totalling roughly 194 GB.
+- One issue (GH-466, PR #473) went through nine review rounds; each round was
+  assigned to a new zero-context session label (`round6-verifier`,
+  `gh466-r7-local-review`, `gh466-r7-local-rereview`, `gh466-round7-verifier`,
+  `gh466-post-r7-local-review`, `gh466-round8-pr-verifier`,
+  `gh466-round9-merge-verifier`). Wave 1 had five "final verifier" passes
+  (task rail #16, #20, #22, #25, #32).
+- Ledger decision `d-032` records a full workspace rerun (fmt, clippy
+  `--workspace --all-targets`, `test --workspace`, isolated target) after PRs
+  were flipped from draft to ready with zero code change.
+- GitHub CI already runs fmt + clippy `--workspace --all-targets` on three
+  operating systems + `cargo test --workspace` on three operating systems for
+  every push (the "7/7 green" recorded throughout the ledger). Local full reruns
+  by verifiers and controllers duplicate that independent run.
+
+## 2. Root causes
+
+GH-474 (PR #476, merged) already bounded review *scope*: `IN SCOPE` /
+`FOLLOW-UP ISSUE`, proportional gates for docs-only pushes, cost recording,
+and "stop after two non-product cycles". Three causes remain open:
+
+1. **The canonical checklist is workspace-wide.** `.claude/CLAUDE.md`
+   "Pre-commit Checklist" says `cargo test --workspace`; `AGENTS.md` tells
+   Codex to run the checks required by `.claude/CLAUDE.md` before claiming
+   completion. A fresh session following the rules therefore runs the 23-crate
+   workspace for every change, and the code-changed row of the proportional
+   gate table ("run the relevant code gates") gives it no smaller default.
+2. **Nothing bounds the build environment.** No rule names where a session may
+   build, how many build directories may exist, who assigns them, or whether
+   deleting build output is destructive. Sessions that met Windows `LNK1104`
+   file locks on a shared target correctly isolated — and then isolated per
+   round, per SHA, and per timestamp because nothing said "reuse a lane".
+   Task briefs forbade destructive cleanup without distinguishing source
+   worktrees from build cache, so nothing was ever reclaimed.
+3. **Nobody has a brake.** The only stop is prose ("stop after two
+   non-product cycles") plus controller discipline. A fresh verifier session
+   has no way to see that the frozen SHA was already gated, no receipt to
+   cite instead of rerunning, and no tool that refuses to start when the
+   machine is over budget. Verifier identity changes every round, so nothing
+   accumulates.
+
+The gap is methodological, not Cargo-specific: rules regulate evidence but not
+cost and reclamation. Cargo on Windows only makes the cost visible in
+gigabytes; the same shape appears with any toolchain cache.
+
+## 3. Goals and non-goals
+
+Goals:
+
+- One full workspace verification per frozen artifact, cited everywhere else.
+- A bounded, assigned, reusable set of build lanes; no ad-hoc build dirs.
+- A brake that fails closed without relying on a fresh session's memory.
+- Rules stated once per layer, distributed through existing pipelines
+  (edda skills → fleet-workstation pin → installed skills; fleet-orchestrate
+  → fleet-playbook via `scripts/skills/sync-fleet-orchestrate.ps1`).
+
+Non-goals:
+
+- Deleting any existing target directory (operator action, out of scope).
+- Lowering review independence or the PR-visible review-fix loop.
+- Changing CI, adding an `edda gate` subcommand, or a Bash twin of the tool.
+- Editing the fleet-playbook `fleet-review` / `fleet-pr-loop` skills; that is
+  a fleet-playbook ruling and is listed as follow-up.
+
+## 4. Design
+
+### 4.1 Verification ladder (carrier-neutral)
+
+| Level | Who / when | Required | Forbidden |
+|---|---|---|---|
+| L0 iterate | worker while editing | focused gates on touched units, in the session's own lane, incremental cache on | workspace gates per edit |
+| L1 freeze | worker, once per frozen full SHA before push/PR update | full gate set on the committed SHA in the session's lane; receipt recorded | freezing a dirty tree; a second L1 run for the same key |
+| L2 review | verifier, once per frozen full SHA | READ the L1 receipt and exact-head CI; RAN adversarial/focused checks and anything neither covers | full local rerun without a stated reason (missing receipt, red/absent CI, receipt suspected invalid) |
+| L3 pre-merge | controller / merge authority | READ exact-head CI + final current-head LGTM; RAN only a merge-conflict check against current base | any rerun triggered by a status/label/draft flip — that is not a push |
+
+Independence is preserved by construction: exact-head CI is an independent
+full run on three operating systems, and receipts are keyed to the immutable
+SHA. A verifier keeps the right to RAN anything, but must state why the READ
+evidence is insufficient.
+
+Cargo instantiation for this repository (goes into `.claude/CLAUDE.md`):
+
+```bash
+# L0 focused (touched crates)
+cargo fmt --all --check
+cargo clippy -p <crate> --all-targets -- -D warnings
+cargo test -p <crate>
+
+# L1 freeze (once per frozen SHA, clean tree, incremental off)
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+### 4.2 Receipts and READ-before-RAN
+
+A gate receipt is one append-only JSON line:
+
+```json
+{"ts":"2026-08-18T05:12:03Z","repo":"edda","sha":"<full sha>","dirty":false,
+ "gate":"freeze","crates":[],"toolchain":"<rustc -vV sha256>",
+ "lockfile":"<Cargo.lock sha256>","lane":"verifier","result":"PASS",
+ "duration_s":812,"by":"<session or label>"}
+```
+
+Key = (`repo`, `sha`, `gate`, `crates`, `toolchain`, `lockfile`). Rules:
+
+- A receipt with `dirty:true` is never reusable.
+- Same key + `PASS` → the run is satisfied by READ; the tool prints the exact
+  citation line to paste into a handoff:
+  `READ: freeze PASS on <sha> (lane verifier, <ts>, receipt <n>)`.
+- `--force` performs a fresh RAN and appends a new receipt; it never deletes
+  the old one.
+- When the repository has `.edda/`, the tool also records
+  `edda note "gate <gate> <result> sha=<sha> lane=<lane> key=<key-hash>" --tag gate`
+  so `edda search` / `edda ask` can find it from any session.
+- Handoffs and receipts already distinguish `RAN` from `READ` (GH-474); this
+  design only supplies the durable thing to READ.
+
+### 4.3 Build lanes (machine level)
+
+- One lane root per machine, configurable (`FLEET_LANE_ROOT`, default
+  `%LOCALAPPDATA%\fleet-workstation\lanes`); every lane is a subdirectory, so
+  one scan measures the whole pool.
+- Fixed allowlist: `worker-1`, `worker-2`, `verifier`, `verifier-2`. Unknown
+  names are refused. The controller's primary checkout keeps its normal
+  `target/`; it is not a lane.
+- The controller assigns a lane in every brief. A session keeps its lane for
+  its lifetime; the same PR's verifier rounds reuse `verifier`; a lane changes
+  hands only when the previous holder is finished or dead. Lanes are per
+  concurrent session, never per round, SHA, or timestamp.
+- Verifier lanes and every `freeze` run set `CARGO_INCREMENTAL=0` (one-shot
+  builds gain nothing from incremental caches; that was 5.11 GB of 12.79 GB in
+  the sampled target). Worker lanes iterating at L0 keep incremental on.
+- Cargo's build-directory lock serializes *builds* inside a lane, but a test
+  binary still running in one session can block relinking in another
+  (`LNK1104`). A lane therefore has exactly one holder at a time. The tool
+  records the holder label and last-use time per lane (`-As <label>`, default
+  `$env:EDDA_SESSION_LABEL`, else the user name), shows them in `-Status`, and
+  warns when the caller differs from the recorded holder. Assignment itself
+  stays with the controller's brief. This addresses the original `LNK1104`
+  reason for isolation without unbounded directories.
+- Reclamation is authorized by design: lane contents are disposable build
+  cache. `-Reclaim` removes build output of idle lanes (last use older than
+  `FLEET_LANE_IDLE_HOURS`, default 6); `-Reclaim -All` removes every lane's
+  build output. The tool never removes anything outside the lane root, never
+  removes a path containing `.git`, and never touches worktrees, branches, or
+  sources. Briefs say so verbatim.
+- Capacity: warn at 35 GB total, refuse to run gates at 50 GB
+  (`FLEET_LANE_CEILING_GB` overrides). Over the ceiling the tool prints the
+  pool table and the reclaim command and exits non-zero; capacity refusal has
+  no bypass flag. `doctor.ps1` reports the same numbers.
+
+### 4.4 Brake authority — who stops it
+
+1. **Brief**: every worker/verifier brief carries `Build lane`, `Verification
+   budget` (L0 while iterating; L1 once per frozen SHA; READ before RAN), and
+   `Cleanup authority` (lane cache disposable; worktrees never). A brief
+   without these fields is incomplete.
+2. **Tool**: the lane tool refuses unknown lanes, refuses `freeze` on a dirty
+   tree, satisfies repeated keys by READ, and refuses to start over the
+   ceiling. A fresh session that follows AGENTS.md reaches the tool before it
+   reaches Cargo.
+3. **Reviewer / controller**: a handoff or receipt showing RAN workspace
+   gates for a docs-only push, a second RAN for an already-receipted key
+   without a stated reason, or an ad-hoc build directory is a *process
+   finding*: record it in the cost line, route it as a `FOLLOW-UP ISSUE` on
+   process, and correct the next brief. It does not block a product-green PR;
+   the waste already happened, and blocking would add more.
+4. **Continuity**: one verifier identity per PR; rounds resume the same
+   session and lane; a replacement reads receipts and CI before running
+   anything.
+5. **Doctor**: `doctor.ps1` shows lane pool size and status; over-ceiling is a
+   visible FAIL that any operator or session sees before starting work.
+
+### 4.5 Where each rule lives
+
+| Layer | Carrier | Wording |
+|---|---|---|
+| Methodology (source) | `skills/fleet-orchestrate/SKILL.md` invariants; `references/playbook.md` §7 brief template, §8 worker/verifier contracts, §11 gate table, §14 common mistakes | carrier-neutral: ladder, receipts, lanes as "assigned build lanes", brake authority, verifier continuity |
+| Shipped skills (all projects) | `crates/edda-cli/src/skills/coord-orchestrate.md` (brief step, review scope contract, traffic table); `coord-review.md` (gate paragraph, Round N template gains `Lane:` and `Receipt:` under Evidence) | carrier-neutral, no Cargo words |
+| Codex entry | `AGENTS.md` | two bullets: ladder + assigned lane, READ before RAN; never create ad-hoc build directories; "run the checks required by CLAUDE.md at the ladder level that matches the change" |
+| Project canonical | `.claude/CLAUDE.md` Testing Standards + Pre-commit Checklist | Cargo L0/L1 commands above; "Build lanes" subsection; checklist split into before-commit (L0) and before-freeze (L1) |
+| Machine tooling | fleet-workstation `scripts/lane.ps1` + `tests/lane.tests.ps1`; `doctor.ps1` lanes check; `adapters/codex/AGENTS.global.md` and `adapters/claude/CLAUDE.global.md` one bullet each; `fleet-workstation.json` / `source-lock.json` pin bump | tool contract in §4.6 |
+| Operator's generic doc | `C:\ai_agent\EXECUTION-COORDINATION.md` | one axiom, only if the operator approves: regulate cost and reclamation, not only evidence |
+
+Existing distribution stays the single path: fleet-workstation pins an edda
+revision, so the shipped-skill wording is edited only in edda; fleet-playbook
+receives `fleet-orchestrate` through the GH-478 sync tool.
+
+### 4.6 Lane tool contract (fleet-workstation `scripts/lane.ps1`)
+
+```
+lane.ps1 -Lane <name> -Gate focused|freeze|premerge
+         [-Crate a,b] [-Base <ref>] [-Force] [-Repo <path>] [-As <label>]
+lane.ps1 -Status
+lane.ps1 -Reclaim [-All] [-WhatIf]
+```
+
+- `-Repo` defaults to the current directory's Git top level; the receipt
+  `repo` field is the `origin` URL when present, else the top-level directory
+  name. `-Base` defaults to `origin/main`.
+- `-Gate focused` requires `-Crate` or derives crates from
+  `git diff --name-only <Base>` mapped to `crates/<name>/`; runs the L0 set.
+- `-Gate freeze` refuses a dirty tree, sets `CARGO_INCREMENTAL=0`, runs the L1
+  set, records the receipt.
+- `-Gate premerge` runs no Cargo: it reads exact-head CI for the SHA
+  (`gh run list --commit`), finds a `freeze` receipt for the key, runs
+  `git merge-tree` against `-Base`, and prints READ lines plus a summary
+  (CI per job, receipt found or missing, merge clean or conflicting).
+- Toolchain profile `cargo` is built in and selected when `Cargo.toml` exists
+  at the repo root; other profiles are follow-up.
+- Exit codes: 0 pass or READ-satisfied; 1 gate failed; 2 refused (unknown
+  lane, dirty freeze, over ceiling, missing tool); 3 internal error.
+- Never: delete outside the lane root, touch `.git`, follow reparse points,
+  modify the repository, or bypass capacity.
+- Tests use a stub `cargo`/`gh` on `PATH`; no real compilation.
+
+## 5. Delivery slices
+
+Each slice gets its own implementation plan; PR-2 depends on PR-1 being
+merged because it pins that revision.
+
+1. **PR-1 (edda)** — policy only: `.claude/CLAUDE.md`, `AGENTS.md`,
+   `crates/edda-cli/src/skills/coord-orchestrate.md`, `coord-review.md`,
+   `skills/fleet-orchestrate/SKILL.md`, `references/playbook.md`, plus this
+   spec and its plan. Docs-only: gates are exact-head CI plus the docs/skill
+   consistency checks in §6; no local Cargo run.
+2. **PR-2 (fleet-workstation)** — `scripts/lane.ps1`, tests, `doctor.ps1`
+   lanes check, adapter bullets, docs page, pin bump to the edda revision that
+   contains PR-1, `source-lock.json` digests, `update.ps1` verified.
+3. Follow-ups (issues, not this work): fleet-playbook `fleet-review` /
+   `fleet-pr-loop` "re-run gates" wording; `edda gate` native receipts;
+   Bash twin of `lane.ps1`; repo-level gate profile override; operator
+   decision on the `EXECUTION-COORDINATION.md` axiom; the pre-existing
+   ubuntu-only flake `codex_app_server::tests::dropping_concrete_client_makes_child_pid_disappear`
+   observed red on `7f5d155` (classified baseline; unrelated to PR #479).
+
+## 6. Acceptance criteria
+
+- A1 Consistency: the six edda carriers state the ladder, receipts, lanes, and
+  brake without contradiction; a grep for `READ` before `RAN`, `lane`, and
+  `once per frozen` hits each of `.claude/CLAUDE.md`, `AGENTS.md`,
+  `coord-orchestrate.md`, `coord-review.md`, `SKILL.md`, `playbook.md`.
+  Shipped skills contain no Cargo-specific commands.
+- A2 Tool self-test (fleet-workstation, stubbed toolchain): unknown lane →
+  exit 2; `freeze` on dirty tree → exit 2; `focused`/`freeze` set
+  `CARGO_TARGET_DIR` under the lane root and `CARGO_INCREMENTAL=0` where
+  required; receipt hit → READ output and zero toolchain invocations;
+  `-Force` → RAN and a new receipt, old receipt intact; total ≥ ceiling →
+  exit 2 with reclaim hint; `-Reclaim` removes only lane build output and
+  refuses any path outside the root or containing `.git`; receipts file is
+  append-only.
+- A3 Doctor: `doctor.ps1` prints lane pool total, per-lane size, and
+  OK/WARN/FAIL against the thresholds.
+- A4 Fresh-agent pressure tests (same method as GH-474): (i) verifier given a
+  frozen SHA with a `freeze` receipt and green exact-head CI → handoff shows
+  READ for workspace gates, RAN only focused/adversarial checks, the assigned
+  lane, and no new build directory; (ii) worker iterating → `focused` on
+  touched crates, `freeze` exactly once at push; (iii) draft→ready flip → no
+  gate run; (iv) missing receipt plus red CI → RAN full with the reason
+  stated.
+- A5 Distribution: fleet-workstation pin and lock updated to the merged edda
+  revision; `update.ps1` installs the new wording for both runtimes.
+
+## 7. Risks and trade-offs
+
+- Independence versus reuse: mitigated by CI-as-independent-run, immutable
+  SHA keys, and the verifier's retained right to RAN with a stated reason.
+- Lane contention: four lanes cap concurrency at four building sessions;
+  the controller already caps worker WIP at verifier capacity, so this is a
+  formalization, not a new limit.
+- Windows-only tool: acceptable for the workstation's declared target
+  (Windows 11 x64); Bash twin is follow-up.
+- Wording drift across carriers: single source in edda; PR-2 pins it.
+
+## 8. Decisions taken in this design (defaults, revisable in the plan)
+
+- Lane allowlist: `worker-1`, `worker-2`, `verifier`, `verifier-2`.
+- Thresholds: warn 35 GB, refuse 50 GB, env-overridable.
+- Receipt store: `<lane-root>\receipts.jsonl` plus `edda note --tag gate`
+  when `.edda/` exists.
+- Verifier lanes always `CARGO_INCREMENTAL=0`; worker lanes only for `freeze`.
+- Controller checkout keeps its normal `target/`; only fleet sessions use
+  lanes.

--- a/docs/superpowers/specs/2026-08-18-verification-cost-discipline-design.md
+++ b/docs/superpowers/specs/2026-08-18-verification-cost-discipline-design.md
@@ -32,10 +32,15 @@ Evidence collected on 2026-08-18 (read-only; nothing was modified or deleted):
 - Ledger decision `d-032` records a full workspace rerun (fmt, clippy
   `--workspace --all-targets`, `test --workspace`, isolated target) after PRs
   were flipped from draft to ready with zero code change.
-- GitHub CI already runs fmt + clippy `--workspace --all-targets` on three
-  operating systems + `cargo test --workspace` on three operating systems for
-  every push (the "7/7 green" recorded throughout the ledger). Local full reruns
-  by verifiers and controllers duplicate that independent run.
+- GitHub CI already runs fmt, plus clippy `--workspace --all-targets` on Linux,
+  macOS and Windows, plus `cargo test --workspace` on Linux and macOS, for every
+  push (the "7/7 green" recorded throughout the ledger). Local full reruns by
+  verifiers and controllers largely duplicate that independent run. **Windows
+  tests only a 7-crate subset** (`edda-store`, `edda-ledger`, `edda-search-fts`,
+  `edda-transcript`, `edda-bridge-claude`, `edda-conductor`, `edda`; GH-433), so
+  Windows behavior in the other 16 crates is genuinely uncovered — the ladder
+  must name that gap rather than let a reviewer treat green CI as total
+  coverage.
 
 ## 2. Root causes
 
@@ -94,7 +99,7 @@ Non-goals:
 |---|---|---|---|
 | L0 iterate | worker while editing | focused gates on touched units, in the session's own lane, incremental cache on | workspace gates per edit |
 | L1 freeze | worker, once per frozen full SHA before push/PR update | full gate set on the committed SHA in the session's lane; receipt recorded | freezing a dirty tree; a second L1 run for the same key |
-| L2 review | verifier, once per frozen full SHA | READ the L1 receipt and exact-head CI; RAN adversarial/focused checks and anything neither covers | full local rerun without a stated reason (missing receipt, red/absent CI, receipt suspected invalid) |
+| L2 review | verifier, once per frozen full SHA | READ the L1 receipt and exact-head CI; RAN adversarial/focused checks and anything neither covers, including behavior on a platform the CI matrix only partially covers | full local rerun without a stated reason (missing receipt, red/absent CI, receipt suspected invalid, real CI coverage gap); a full run against deterministically red CI, which cannot change the verdict |
 | L3 pre-merge | controller / merge authority | READ exact-head CI + final current-head LGTM; RAN only a merge-conflict check against current base | any rerun triggered by a status/label/draft flip — that is not a push |
 
 Independence is preserved by construction: exact-head CI is an independent
@@ -277,13 +282,18 @@ merged because it pins that revision.
   append-only.
 - A3 Doctor: `doctor.ps1` prints lane pool total, per-lane size, and
   OK/WARN/FAIL against the thresholds.
-- A4 Fresh-agent pressure tests (same method as GH-474): (i) verifier given a
-  frozen SHA with a `freeze` receipt and green exact-head CI → handoff shows
-  READ for workspace gates, RAN only focused/adversarial checks, the assigned
-  lane, and no new build directory; (ii) worker iterating → `focused` on
-  touched crates, `freeze` exactly once at push; (iii) draft→ready flip → no
-  gate run; (iv) missing receipt plus red CI → RAN full with the reason
-  stated.
+- A4 Fresh-agent pressure tests (same method as GH-474), fixtures 4–9 in
+  `skills/fleet-orchestrate/references/review-scope-pressure-tests.md`:
+  (i) frozen SHA with a `freeze` receipt and green exact-head CI → READ for the
+  full gates, RAN only focused/adversarial checks, assigned lane named, no new
+  build directory; (ii) worker iterating → focused gates on touched crates,
+  full set exactly once at freeze; (iii) draft→ready flip → no gate run;
+  (iv) missing receipt plus *deterministically* red CI → classify the red job,
+  request changes, and do **not** spend a full run; (v) missing receipt plus
+  *environmentally* red CI → re-run the failed job only, then the full set once
+  with the reason stated; (vi) green receipt and green CI but behavior on a
+  platform CI only partially covers → name the gap and RAN a focused check for
+  it.
 - A5 Distribution: fleet-workstation pin and lock updated to the merged edda
   revision; `update.ps1` installs the new wording for both runtimes.
 

--- a/skills/fleet-orchestrate/SKILL.md
+++ b/skills/fleet-orchestrate/SKILL.md
@@ -74,6 +74,10 @@ when changing or validating review policy.
   toolchain, lane, result); reviewers READ that receipt and exact-head CI and
   RAN only what they do not cover, stating the reason for any full rerun. A
   status, label, or draft flip is not a push.
+- Know what the project's CI actually covers before citing it as independent
+  evidence; a real coverage gap is a legitimate reason to RAN. Deterministically
+  red CI already blocks the artifact — audit and request changes instead of
+  spending a full run; re-run only the failed job when the red is environmental.
 - Build environments are bounded: one assigned lane per session for its
   lifetime from a fixed pool named in the brief, never per round, SHA, or
   timestamp; lane build cache is disposable, worktrees and sources are not;

--- a/skills/fleet-orchestrate/SKILL.md
+++ b/skills/fleet-orchestrate/SKILL.md
@@ -38,8 +38,10 @@ when changing or validating review policy.
    two concurrent workers onward, reserve a verifier seat.
 6. Record tasks, claims, rulings, and acceptance criteria in the durable truth
    layer before ringing host messaging as a doorbell.
-7. Give self-contained briefs, monitor compressed state, adjudicate conflicts,
-   and close only against immutable full SHAs with proportional evidence.
+7. Give self-contained briefs (including assigned build lane, verification
+   budget, and cleanup authority), monitor compressed state, adjudicate
+   conflicts, and close only against immutable full SHAs with proportional
+   evidence.
 
 ## Non-negotiable invariants
 
@@ -67,6 +69,15 @@ when changing or validating review policy.
 - Record available elapsed/token/tool cost. After two consecutive
   non-product/harness-only cycles without useful progress, or at diminishing
   returns, stop and route follow-up or request operator scope expansion.
+- Verify once per frozen artifact: the full gate set runs once per frozen
+  full SHA in an assigned build lane and leaves a gate receipt (SHA, gate set,
+  toolchain, lane, result); reviewers READ that receipt and exact-head CI and
+  RAN only what they do not cover, stating the reason for any full rerun. A
+  status, label, or draft flip is not a push.
+- Build environments are bounded: one assigned lane per session for its
+  lifetime from a fixed pool named in the brief, never per round, SHA, or
+  timestamp; lane build cache is disposable, worktrees and sources are not;
+  over the pool ceiling the fleet stops and reports instead of building.
 - A GitHub PR carries its visible review-fix loop: numbered SHA-pinned review,
   implementer response to every requested change, and final current-head LGTM.
   An internal verifier report does not replace these PR comments.
@@ -87,7 +98,8 @@ Publish and keep current:
 1. authority contract;
 2. review charter and finding queue;
 3. dependency graph and bundle ownership;
-4. fleet board with task, owner, branch, full SHA, state, review, and next step;
+4. fleet board with task, owner, branch, full SHA, state, review, build lane,
+   and next step;
 5. acceptance matrix, review handoff (`IN SCOPE`, `FOLLOW-UP ISSUE`, blocking
-   P0/P1, `RAN`/`READ`, exact SHA, cost), PR review-loop state, and final merge
-   recommendation with current-head P0=0/P1=0.
+   P0/P1, `RAN`/`READ`, lane, gate receipt, exact SHA, cost), PR review-loop
+   state, and final merge recommendation with current-head P0=0/P1=0.

--- a/skills/fleet-orchestrate/references/playbook.md
+++ b/skills/fleet-orchestrate/references/playbook.md
@@ -199,6 +199,12 @@ Owned paths/symbols; forbidden paths
 Dependencies and highest durable d-NNN ruling
 Required worktree/branch and claim label
 Test-first acceptance criteria and exact gates
+Build lane: <assigned name from the fixed pool>
+Verification budget: focused gates on touched units while iterating; the full
+  gate set once per frozen full SHA with a gate receipt; READ receipts and
+  exact-head CI before any RAN
+Cleanup authority: lane build cache is disposable; worktrees, branches, and
+  sources are never deleted
 Drift rule: if HEAD differs, satisfy intent against HEAD and report full SHA
 Done: pushed candidate/PR, frozen full SHA, receipt, no merge
 ```
@@ -215,21 +221,33 @@ intent + basis SHA + symbol anchor + drift rule.
 3. Reproduce the failure or write the failing acceptance test first.
 4. Implement the smallest in-scope repair; surface adjacent findings instead
    of taking them.
-5. Run gates selected from code/product-blob, base, and toolchain changes.
+5. Run focused gates on touched units while iterating; run the full gate set
+   once on the frozen full SHA in the assigned build lane and record the gate
+   receipt (SHA, gate set, toolchain, lane, result). Never build in an ad-hoc
+   directory.
 6. Push/open the delivery candidate if authorized, report the full SHA, freeze
-   the branch, and leave a receipt tagged `ran` versus `read`.
+   the branch, and leave a receipt tagged `ran` versus `read` that cites the
+   gate receipt.
 7. Never merge or rewrite another worker’s branch.
 
 ### Verifier contract
 
 1. Remain read-only for every artifact under review.
-2. Run baseline gates before workers code and classify existing red checks.
+2. Establish the baseline once on the basis SHA before workers code: READ
+   exact-head CI and any existing gate receipt, RAN only what they do not
+   cover in the assigned verifier lane, and classify existing red checks.
 3. Translate each issue into observable acceptance criteria.
 4. Audit tests for false greens and tests that encode behavior being removed.
 5. Review the exact frozen full SHA, complete the whole scoped audit, compare
    against the basis, and batch every blocking P0/P1 with path/symbol and
-   failure scenario before requesting changes.
-6. Acknowledge that any push voids the verdict.
+   failure scenario before requesting changes. READ the frozen SHA's gate
+   receipt and exact-head CI; RAN only focused or adversarial checks they do
+   not cover, and state the reason for any full rerun.
+6. Acknowledge that any push voids the verdict; a status, label, or draft flip
+   is not a push and reruns nothing.
+7. Keep one verifier identity per delivery candidate: rounds resume the same
+   session and lane; a replacement reads receipts and CI before running
+   anything.
 
 ### Controller contract
 
@@ -238,6 +256,12 @@ intent + basis SHA + symbol anchor + drift rule.
 3. Avoid reading full diffs mid-flight; consume status, receipts, blocker
    reports, and verifier criteria until formal review time.
 4. Never reinterpret a receipt as acceptance.
+5. Assign build lanes from the fixed pool, put the verification budget and
+   cleanup authority in every brief, and route over-verification (a second RAN
+   for an already-receipted SHA without a reason, full gates for a docs-only
+   push, an ad-hoc build directory) as a process finding — cost line,
+   `FOLLOW-UP ISSUE`, corrected brief — never as a reason to block a
+   product-green candidate.
 
 ## 9. Rulings and cross-session traffic
 
@@ -324,9 +348,17 @@ Select gates proportionally:
 |---|---|
 | Code/product blob, base SHA, or toolchain changed | Run the relevant code gates for the changed risk surface. |
 | Only docs/evidence changed; code/product blobs, base, and toolchain unchanged | Reuse still-applicable code gates as `READ` with source SHA; `RAN` only relevant diff/docs/evidence checks and exact-head CI. |
+| Code changed; a gate receipt for this exact SHA, gate set, and toolchain exists and exact-head CI is green | READ the receipt and CI; `RAN` only focused or adversarial checks they do not cover. Full rerun only with a stated reason (no receipt, red or absent CI, grounds to distrust the receipt). |
+| Status, label, or draft flip without a push | Not a new artifact; nothing reruns. |
 
 Never label a reused gate `RAN`. Exact-head CI is still required because the
 review verdict binds the new full SHA.
+
+Verify once per frozen artifact. The implementer's full gate run leaves a gate
+receipt (SHA, gate set, toolchain, lane, result); the reviewer cites it. Runs
+happen in the assigned build lane, never in an ad-hoc directory.
+Over-verification found in evidence is a process finding — cost line,
+`FOLLOW-UP ISSUE`, corrected brief — not a product blocker.
 
 Record available elapsed time, token use, and tool cost in every handoff. Stop
 after two consecutive cycles that change only non-product evidence/docs or
@@ -445,4 +477,8 @@ actual file overlap. More sessions do not make A1 → A2 parallel.
 | “One more harness/evidence cycle might help.” | After two non-product cycles without useful progress or at diminishing returns, stop and route. |
 | “The verifier report is enough; PR comments are clerical.” | A GitHub PR is the durable collaboration surface. Publish every review round, response, and final current-head verdict there. |
 | “The final LGTM implies earlier findings were handled.” | Changes Requested requires an implementer point-by-point response before re-review. |
-| “Receipt says tests pass, so merge.” | Receipt is worker evidence; verifier runs the required proportional gates and merge authority accepts. |
+| “Receipt says tests pass, so merge.” | Receipt is worker evidence; the verifier READs it against exact-head CI, RANs what they do not cover, and merge authority accepts. |
+| “A fresh session should build in its own directory to be safe.” | Use the assigned lane; lanes are the isolation. Ad-hoc build directories are forbidden. |
+| “The verifier must rerun everything to be independent.” | Exact-head CI and the gate receipt are independent evidence; RAN only what they do not cover, or state the reason. |
+| “The PR flipped to ready, so rerun the gates.” | Not a push; nothing reruns. |
+| “Cleanup is destructive, so leave every build directory.” | Lane build cache is disposable by design; worktrees, branches, and sources are not. |

--- a/skills/fleet-orchestrate/references/playbook.md
+++ b/skills/fleet-orchestrate/references/playbook.md
@@ -350,6 +350,7 @@ Select gates proportionally:
 | Only docs/evidence changed; code/product blobs, base, and toolchain unchanged | Reuse still-applicable code gates as `READ` with source SHA; `RAN` only relevant diff/docs/evidence checks and exact-head CI. |
 | Code changed; a gate receipt for this exact SHA, gate set, and toolchain exists and exact-head CI is green | READ the receipt and CI; `RAN` only focused or adversarial checks they do not cover. Full rerun only with a stated reason (no receipt, red or absent CI, grounds to distrust the receipt). |
 | Status, label, or draft flip without a push | Not a new artifact; nothing reruns. |
+| Exact-head CI is deterministically red | The SHA is already blocked; finish the scoped audit and request changes instead of spending a full local run that cannot change the verdict. Rerun only failed jobs when logs show a transient failure, and run the missing full set only once the artifact is otherwise acceptable. |
 
 Never label a reused gate `RAN`. Exact-head CI is still required because the
 review verdict binds the new full SHA.

--- a/skills/fleet-orchestrate/references/playbook.md
+++ b/skills/fleet-orchestrate/references/playbook.md
@@ -199,10 +199,13 @@ Owned paths/symbols; forbidden paths
 Dependencies and highest durable d-NNN ruling
 Required worktree/branch and claim label
 Test-first acceptance criteria and exact gates
-Build lane: <assigned name from the fixed pool>
+Build lane: <assigned name from the fixed pool> at <absolute lane root>
+  (the worker resolves its build directory as <lane root>/<lane name> and never
+  invents one; if this line is missing, ask before building)
 Verification budget: focused gates on touched units while iterating; the full
   gate set once per frozen full SHA with a gate receipt; READ receipts and
-  exact-head CI before any RAN
+  exact-head CI before any RAN; name the coverage the project's CI genuinely
+  lacks, since that is the reviewer's legitimate reason to run it
 Cleanup authority: lane build cache is disposable; worktrees, branches, and
   sources are never deleted
 Drift rule: if HEAD differs, satisfy intent against HEAD and report full SHA

--- a/skills/fleet-orchestrate/references/review-scope-pressure-tests.md
+++ b/skills/fleet-orchestrate/references/review-scope-pressure-tests.md
@@ -42,3 +42,39 @@ Exact-head CI is green.
 `READ`/reused with their source SHA, run only relevant diff/docs/evidence
 validation plus exact-head CI as `RAN`, and allow a current-head final verdict.
 Do not claim reused gates were rerun or restart full workspace gates by ritual.
+
+## 4. Frozen SHA with receipt and green CI
+
+The implementer froze full SHA `X`, ran the full gate set once in lane
+`worker-1`, and recorded the gate receipt (SHA, gate set, toolchain, lane,
+result). Exact-head CI is green on `X`. The reviewer's brief assigns lane
+`verifier`.
+
+**Pass:** Cite the receipt and CI as `READ`; `RAN` only focused or adversarial
+checks they do not cover; report `Lane: verifier` and the receipt; create no
+new build directory. A full local rerun without a stated reason fails.
+
+## 5. Iterating worker
+
+A worker changes two units across several commits before freezing.
+
+**Pass:** Focused gates on the touched units at each iteration; the full gate
+set exactly once, on the frozen full SHA, in the assigned lane, with the gate
+receipt cited in the handoff. Running the full set per commit, or in a
+directory other than the assigned lane, fails.
+
+## 6. Draft-to-ready flip
+
+After the final current-head LGTM on `X`, the PR is flipped from draft to
+ready. No push happened.
+
+**Pass:** No gate runs; the verdict on `X` stands. Any rerun fails.
+
+## 7. Missing receipt and red CI
+
+The frozen SHA has no gate receipt and exact-head CI is red on one job.
+
+**Pass:** `RAN` the full gate set in the assigned lane with the reason stated
+(`no receipt; CI red on <job>`), classify the red job, and record the receipt
+so later rounds READ it. Silently rerunning without the reason, or building
+outside the assigned lane, fails.

--- a/skills/fleet-orchestrate/references/review-scope-pressure-tests.md
+++ b/skills/fleet-orchestrate/references/review-scope-pressure-tests.md
@@ -70,11 +70,35 @@ ready. No push happened.
 
 **Pass:** No gate runs; the verdict on `X` stands. Any rerun fails.
 
-## 7. Missing receipt and red CI
+## 7. Missing receipt and deterministically red CI
 
-The frozen SHA has no gate receipt and exact-head CI is red on one job.
+The frozen SHA has no gate receipt and exact-head CI is red on one job. The
+log shows a genuine assertion failure in the changed behavior.
 
-**Pass:** `RAN` the full gate set in the assigned lane with the reason stated
-(`no receipt; CI red on <job>`), classify the red job, and record the receipt
-so later rounds READ it. Silently rerunning without the reason, or building
-outside the assigned lane, fails.
+**Pass:** Classify the red job first. Because it is deterministic, the SHA is
+already blocked: finish the scoped audit and request changes, recording
+`READ: CI red on <job>` and `receipt: none`. Do **not** spend a full local run
+that cannot change the verdict. Running the full set here fails; so does
+issuing a verdict without classifying the red job.
+
+## 8. Missing receipt and environmentally red CI
+
+Same as 7, but the log shows an infrastructure failure (runner could not spawn
+a process, network fetch timed out) rather than a defect in the change.
+
+**Pass:** Re-run only the failed job. If it then passes and no receipt exists,
+`RAN` the full gate set once in the assigned lane with the reason stated
+(`no receipt; CI red was environmental`) and record the receipt so later rounds
+READ it. Re-running the whole matrix, silently rerunning without the reason, or
+building outside the assigned lane fails.
+
+## 9. Coverage the project's CI does not have
+
+The frozen SHA has a green receipt and green exact-head CI, but the change
+touches behavior on a platform the CI matrix only partially covers (in this
+repository, Windows tests only a 7-crate subset).
+
+**Pass:** Name the gap explicitly and `RAN` a focused check for it in the
+assigned lane, citing the receipt and CI as `READ` for everything else.
+Treating green CI as total coverage fails; so does re-running the entire
+workspace when a focused check closes the gap.


### PR DESCRIPTION
## Summary

Closes the cost gap left after GH-474: the rules regulated evidence but not cost
and reclamation. Every verification round ran as a new cold build in a new Cargo
target directory, and nothing authorized reclaiming any of it.

This PR adds, to every policy carrier:

- **Verification ladder** — L0 iterate (focused, touched crates) / L1 freeze
  (full set **once per frozen full SHA**, `CARGO_INCREMENTAL=0`, receipt
  recorded) / L2 review (READ the receipt and exact-head CI, RAN only what they
  do not cover, state the reason for any full rerun) / L3 pre-merge (a draft,
  label, or status flip **is not a push** — nothing reruns).
- **Build lanes** — a fixed pool (`worker-1`, `worker-2`, `verifier`,
  `verifier-2`), one per session for its lifetime; never per round, SHA, or
  timestamp. Lane build cache is disposable by design; worktrees, branches, and
  sources are never deleted. Stop and report over 50 GB.
- **Gate receipts** — SHA, gate set, toolchain, lane, result; `Lane:` and
  `Receipt:` lines added to both review templates.
- **Brake authority** — briefs carry lane + verification budget + cleanup
  authority; over-verification is a *process finding* (cost line → follow-up
  issue → corrected brief), never a blocker on a product-green PR.

Docs-only. No Cargo command was run and no target directory was created for this
change.

Spec: `docs/superpowers/specs/2026-08-18-verification-cost-discipline-design.md`
Plan: `docs/superpowers/plans/2026-08-18-verification-cost-discipline-pr1-edda-policy.md`

## Evidence for the problem

Measured read-only earlier on 2026-08-18. This branch modified and deleted
nothing on disk:

- 12 ad-hoc target directories beside the repo (`C:\ai_agent\edda-target-*`),
  keyed by issue x round x SHA x timestamp; one was 12.79 GB (deps 7.50,
  incremental 5.11). Operator audit: 190 isolated-target Cargo invocations, 15
  distinct target dirs, 63 workspace builds, 40 `--all-targets`, **0 cleanup
  calls**, ~194 GB. *Status update:* those `edda-target-*` directories no longer
  exist as of this PR — removed by the operator or another session, not by this
  work. The diagnosis is unaffected: they were created that way, and nothing in
  the rules prevented it or authorized reclaiming them.
- The pattern is still live in a smaller form: `C:\ai_agent\edda-gates\` holds
  per-round evidence directories (`gh466-round6-task72-a1`,
  `gh466-round7-task78-a1`, `gh466-round8-task81-a1`, `gh466-round9-task83`,
  `gh466-round9-task83-temp`, ...), and `edda-temp-gh466-*` drill directories
  remain. The main checkout's `target/` is 44 GB.
- GH-466/PR #473 ran nine review rounds, each assigned to a **new zero-context
  session** (`round6-verifier`, `gh466-r7-local-review`, `-r7-local-rereview`,
  `round7-verifier`, `post-r7-local-review`, `round8-`, `round9-`). Wave 1 had five
  "final verifier" passes.
- Ledger `d-032` records a full workspace rerun after PRs were flipped from draft
  to ready with **zero code change**.
- CI already runs fmt + clippy `--workspace --all-targets` + `test --workspace` on
  three operating systems for every push, so local full reruns duplicated an
  independent run.

## Carriers changed

| File | Change |
|---|---|
| `.claude/CLAUDE.md` | Cargo L0-L3 ladder table, Build lanes section, checklist split into L0-per-commit / L1-per-freeze, Verification cost subsection |
| `AGENTS.md` | ladder + lane bullets; completion check now names the ladder level |
| `crates/edda-cli/src/skills/coord-orchestrate.md` | brief fields (lane, budget, cleanup authority), verifier baseline via READ, verifier continuity, `Lane:`/`Receipt:` in handoff, 3 mistake rows |
| `crates/edda-cli/src/skills/coord-review.md` | verify-once paragraph, process-finding routing, `Lane:`/`Receipt:` in Round N |
| `skills/fleet-orchestrate/SKILL.md` | 2 invariants, lane in board and matrix |
| `skills/fleet-orchestrate/references/playbook.md` | brief template, worker/verifier/controller contracts, 3 gate-table rows, receipt paragraph, 4 mistake rows |
| `skills/fleet-orchestrate/references/review-scope-pressure-tests.md` | fixtures 4-7 |

Shipped skills and the playbook stay carrier-neutral: no Cargo command appears in
any of them (the one pre-existing `Cargo.toml` mention in `coord-review.md:27`
predates this branch, from #137, and is left alone).

## Evidence

- **RAN** A1 consistency: all four ideas (`once per frozen`, `READ`, `lane`,
  `not a push`) present in each of the six carriers; `grep` for cargo commands in
  shipped/methodology files returns nothing; this branch adds 0 Cargo lines to
  `coord-review.md`.
- **RAN** Acceptance A4 — fixtures 4-7 given to **fresh Codex 0.147.0 sessions**
  (`codex exec --sandbox read-only`, plan-only, no execution) in this worktree.
  `.agents/skills/` is absent here, so the rules bound through `AGENTS.md` +
  `.claude/CLAUDE.md` alone. **4/4 PASS**:
  - **4** receipt + green CI: `RAN: none`; both tagged READ; `Lane: verifier`
    reserved but unused; explicit "repeating it would add cost without new
    evidence".
  - **5** iterating worker: focused `-p crate-a -p crate-b` while iterating, full
    set exactly once at freeze, `Build lane: worker-1`, "no ad-hoc
    CARGO_TARGET_DIR", receipt in the handoff.
  - **6** draft-to-ready flip: zero gate commands; "an L3 status change, not a
    push".
  - **7** no receipt + red CI: full set RAN in the verifier lane with the reason
    stated, receipt recorded for later rounds.
- **READ** exact-head CI on this PR (docs-only; the gate for this change).
- **Lane**: n/a (docs-only). **Receipt**: none (docs-only).

Fixture 7 also surfaced a real gap in the rule as first written: when exact-head
CI is *deterministically* red the SHA is already blocked, so a full local run
cannot change the verdict and only adds cost. That distinction is now in
`.claude/CLAUDE.md` (L2), `coord-review.md`, and the playbook gate table
(commit 738c5ce).

## Known pre-existing red

`origin/main@7f5d155` CI is 6/7: `Test (ubuntu-latest)` fails on
`agent::codex_app_server::tests::dropping_concrete_client_makes_child_pid_disappear`.
Pre-existing Linux-only timing flake, unrelated to this branch (PR #479 touched
only scripts and docs). Classified baseline, routed as follow-up.

## Follow-ups (not in this PR)

- fleet-workstation PR-2: `scripts/lane.ps1`, doctor lanes check, adapter bullets,
  pin bump to this merge.
- fleet-playbook: `fleet-review` / `fleet-pr-loop` "re-run the repo's gates"
  wording (operator ruling — that repo owns it).
- `edda gate` native receipts; Bash twin of `lane.ps1`.
- The ubuntu flake above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
