### PR TITLE
docs(coordination): scope build lanes to local heavy builds

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -130,8 +130,9 @@ cargo test --workspace
 ### Verification ladder
 
 Verify once per frozen SHA; cite that result everywhere else. Full workspace
-gates are expensive (23 crates; 8–13 GB of build output per target directory),
-and CI already re-runs most of them independently on every push.
+gates are expensive (23 crates; a long-lived target directory for this
+workspace measured 40.9 GB — see Build lanes), and CI already re-runs most of
+them independently on every push.
 
 **Know exactly what CI does and does not cover** (`.github/workflows/ci.yml`):
 
@@ -161,27 +162,58 @@ run no Cargo gate locally; exact-head CI is the gate.
 
 ### Build lanes
 
+**When this section applies:** only to sessions that compile this workspace on
+this machine. It is a rule about local Cargo build cache, not about edda or the
+fleet in general. For scale: *using* edda costs about 26 MB for the binary plus
+0.4–9 MB of ledger per project, while *compiling* this 23-crate workspace costs
+tens of GB per target directory. Everything below is about the second number.
+A fleet session that runs no local build has no lane and needs none.
+
 - Never create ad-hoc `CARGO_TARGET_DIR`s per round, per SHA, or per
   timestamp. Build output is disposable cache, but unbounded copies are not: an
-  audit of one workstation counted 15 such directories and ~194 GB, with a
-  single directory at 12.79 GB.
+  audit of one workstation counted 15 such directories and ~194 GB.
 - Solo work uses the worktree's default `target/`.
 - **Lane root** is the `LOCALAPPDATA` directory plus `\fleet-workstation\lanes`
   — `$env:LOCALAPPDATA\fleet-workstation\lanes` in PowerShell,
   `$LOCALAPPDATA/fleet-workstation/lanes` in Git Bash — unless `FLEET_LANE_ROOT`
   is set or the brief names a different absolute path. A lane is always
   `<lane-root>\<lane-name>`; resolve it from that rule, never invent a path.
-- Fleet sessions build only in the lane named in their brief — one of
-  `worker-1`, `worker-2`, `verifier`, `verifier-2` — for their whole lifetime.
-  The workstation lane tool (`lane.ps1 -Lane <assigned> -Gate focused|freeze`)
-  is not shipped yet; until it is, set `CARGO_TARGET_DIR` to
+- Fleet sessions that build locally use only the lane named in their brief —
+  one of `worker-1`, `worker-2`, `verifier`, `verifier-2` — for their whole
+  lifetime. The workstation lane tool (`lane.ps1 -Lane <assigned> -Gate
+  focused|freeze`) is not shipped yet; until it is, set `CARGO_TARGET_DIR` to
   `<lane-root>\<assigned-lane>` yourself and reuse it every round. If your brief
   names no lane and you are running gates for a fleet, ask the controller for
   one rather than creating a directory.
 - Verifier lanes and every L1 run set `CARGO_INCREMENTAL=0`.
 - Deleting lane build output is authorized and non-destructive; deleting
-  worktrees, branches, or sources is not. Stop and report instead of building
-  when the lane pool exceeds 50 GB.
+  worktrees, branches, or sources is not.
+
+#### Footprint and thresholds — measured, and larger than they should be
+
+A long-lived `target/debug` for this workspace was measured at **40.9 GB**
+across 88,789 files:
+
+| Part | Size | What it is |
+|---|---:|---|
+| `incremental` | 21.6 GB | per-session codegen caches (`.o` + `.bin`) |
+| `.rlib` + `.rmeta` | 10.3 GB | compiled libraries and metadata |
+| `.pdb` | 8.1 GB | Windows debug symbols — `edda.pdb` alone is 310 MB against a 51 MB `edda.exe` |
+| `.exe` | 0.9 GB | the 84 test and binary executables that actually run |
+
+Two thirds of that is avoidable rather than intrinsic. Every one of the 509
+incremental session directories was older than 24 hours — orphans left by
+interrupted or killed builds, which nothing in Cargo ever reclaims. The
+workspace tunes `[profile.release]` only, so debug builds carry full symbols
+into every statically linked test binary.
+
+**Any lane pool ceiling stated before that footprint is fixed is provisional.**
+A single warm lane can reach 40 GB, so a four-lane pool at today's settings
+would need well over 100 GB — a ceiling calibrated against the 194 GB pathology
+would refuse during normal operation. Do not treat a fixed number here as
+authority yet: reclaim stale `incremental` sessions by age, and measure again
+before setting a limit. Stop and report if the pool is clearly growing without
+bound.
 
 ## Pre-commit Checklist
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -375,11 +375,15 @@ Rules regulate cost and reclamation, not only evidence:
 - Verify once per frozen SHA on the ladder above. READ recorded gate results
   and exact-head CI before any RAN, and state the reason whenever you rerun a
   recorded gate.
-- Every worker/verifier brief names a build lane, a verification budget (L0
-  while iterating; L1 once per frozen SHA), and cleanup authority (lane build
-  cache is disposable; worktrees, branches, and sources are never deleted).
-- One verifier identity per PR: rounds resume the same session and lane; a
-  replacement reads receipts and CI before running anything.
+- Every worker/verifier brief names a verification budget (L0 while iterating;
+  L1 once per frozen SHA) and cleanup authority (build cache is disposable and
+  stale cache should be reclaimed by age; worktrees, branches, and sources are
+  never deleted). It names a build lane **only when the session compiles
+  locally** — see Build lanes; a session that builds nothing has no lane and
+  reports `n/a`.
+- One verifier identity per PR: rounds resume the same session, and the same
+  lane where one applies; a replacement reads receipts and CI before running
+  anything.
 - Over-verification — a second RAN for an already-recorded SHA without a
   reason, workspace gates for a docs-only push, an ad-hoc target directory —
   is a process finding: record it in the handoff cost line, route it as a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,11 +39,15 @@ and multi-agent coordination.
   Deterministically red CI already blocks the SHA: audit and request changes
   instead of spending a full run; re-run only the failed job when the red is
   environmental.
-- Build only in the lane your brief assigns (`worker-1`, `worker-2`,
-  `verifier`, `verifier-2`). Never create ad-hoc `CARGO_TARGET_DIR`s per round,
-  SHA, or timestamp; solo work uses the worktree's default `target/`. Lane
-  build cache is disposable; worktrees, branches, and sources are not. Stop and
-  report when the lane pool exceeds 50 GB.
+- When you compile this workspace locally, build only in the lane your brief
+  assigns (`worker-1`, `worker-2`, `verifier`, `verifier-2`). Never create
+  ad-hoc `CARGO_TARGET_DIR`s per round, SHA, or timestamp; solo work uses the
+  worktree's default `target/`. Lane build cache is disposable; worktrees,
+  branches, and sources are not. This is about local Cargo build output only —
+  a session that runs no local build has no lane and needs none. Reclaim stale
+  `incremental` sessions by age, and report if the pool grows without bound;
+  see Build lanes in `.claude/CLAUDE.md` for the measured footprint and why any
+  fixed ceiling is provisional.
 - This is policy for sessions invoking `coord-review`, `coord-orchestrate`, or
   `fleet-orchestrate`; it is not an Edda runtime rule imposed on every project.
 - Review immutable full SHAs; any push invalidates the prior verdict.

--- a/crates/edda-cli/src/skills/coord-orchestrate.md
+++ b/crates/edda-cli/src/skills/coord-orchestrate.md
@@ -61,8 +61,9 @@ reuses still-applicable code results as `READ` with source SHA, then runs only
 relevant diff/docs/evidence checks and exact-head CI as `RAN`.
 
 Verify once per frozen artifact. The implementer runs the full gate set once
-per frozen full SHA in the assigned build lane and records a gate receipt (SHA,
-gate set, toolchain, lane, result). The reviewer READs that receipt and
+per frozen full SHA — in the assigned build lane where the session builds
+locally — and records a gate receipt (SHA, gate set, toolchain, lane or n/a,
+result). The reviewer READs that receipt and
 exact-head CI, RANs only focused or adversarial checks they do not cover, and
 states the reason for any full rerun (no receipt, red or absent CI, grounds to
 distrust the receipt, or coverage the project's CI genuinely lacks — know that
@@ -94,7 +95,7 @@ Blocking counts entering review: P0=<n>, P1=<n>
 Evidence:
 - RAN: <commands/checks run on this SHA>
 - READ: <reused results and source SHAs>
-- Lane: <assigned build lane>
+- Lane: <assigned build lane, or n/a when nothing was built locally>
 - Receipt: <gate receipt for this SHA (SHA, gate set, toolchain, lane, result), or none>
 Cost: elapsed=<available/unknown>, tokens=<available/unknown>, tools=<available/unknown>
 Request: audit the whole scoped surface; publish no self-verdict from the implementer
@@ -108,17 +109,18 @@ Request: audit the whole scoped surface; publish no self-verdict from the implem
    bundle. Specs live in issues, never only in messages.
 3. **Brief workers** — self-contained (they have zero context): issues to
    read, worktree + branch command, `edda claim` label and paths, files
-   owned/forbidden, quality gates verbatim, assigned build lane from the fixed
-   pool **with its absolute lane root** (a worker who cannot resolve
-   `<lane root>/<lane name>` will invent a directory — the exact failure the
-   lane rule exists to prevent), verification budget (focused gates on touched
-   units while iterating; the full gate set once per frozen SHA with a receipt;
-   READ receipts before any RAN), cleanup authority (lane build cache is
-   disposable; worktrees, branches, and sources are never deleted), done =
-   GitHub PR when available,
-   otherwise a frozen local branch plus durable review carrier (never invent a
-   PR); never merge + `edda task done --receipt`. Include the receiver tie-break
-   verbatim (see Traffic rules).
+   owned/forbidden, quality gates verbatim, verification budget (focused gates
+   on touched units while iterating; the full gate set once per frozen SHA with
+   a receipt; READ receipts before any RAN), cleanup authority (build cache is
+   disposable and stale cache should be reclaimed by age; worktrees, branches,
+   and sources are never deleted), and — only when the session compiles locally
+   — an assigned build lane from the fixed pool **with its absolute lane root**
+   (a worker who cannot resolve `<lane root>/<lane name>` will invent a
+   directory, the exact failure the lane rule exists to prevent; a session that
+   builds nothing needs no lane), done = GitHub PR when available, otherwise a
+   frozen local branch plus durable review carrier (never invent a PR); never
+   merge + `edda task done --receipt`. Include the receiver tie-break verbatim
+   (see Traffic rules).
 4. **Brief the verifier — read-only, starts BEFORE code:** baseline on the
    basis SHA by READing exact-head CI and any existing gate receipt, RANning
    only what they do not cover in the assigned verifier lane, and classifying

--- a/crates/edda-cli/src/skills/coord-review.md
+++ b/crates/edda-cli/src/skills/coord-review.md
@@ -113,10 +113,11 @@ independent evidence, because a partial matrix is a real gap, not a formality.
 When exact-head CI is deterministically red the artifact is already blocked —
 finish the scoped audit and request changes rather than spending a full run
 that cannot change the verdict; when the red is environmental, re-run only the
-failed job. Run in the build lane your brief assigns, resolving it as
-`<lane root>/<lane name>`; never create an ad-hoc build directory. Outside a
-fleet, with no lane assigned, use the repository's own default build directory.
-A status, label, or draft flip is not a push and reruns nothing.
+failed job. When you build locally, run in the build lane your brief assigns,
+resolving it as `<lane root>/<lane name>`; never create an ad-hoc build
+directory. A review that compiles nothing needs no lane and reports `n/a`.
+Outside a fleet, with no lane assigned, use the repository's own default build
+directory. A status, label, or draft flip is not a push and reruns nothing.
 
 Record available elapsed, token, and tool cost. Stop after two consecutive
 cycles that change only non-product evidence/docs or harness material without
@@ -184,7 +185,7 @@ FOLLOW-UP ISSUE:
 Evidence:
 - RAN: <exact command/check and result on reviewed SHA>
 - READ: <reused result and its source SHA, or none>
-- Lane: <build lane used, or n/a for docs-only>
+- Lane: <build lane used, or n/a when nothing was built locally>
 - Receipt: <implementer gate receipt cited (SHA, gate set, toolchain, lane, result), or none>
 Cost: elapsed=<available/unknown>, tokens=<available/unknown>, tools=<available/unknown>
 Verdict: Changes Requested | LGTM

--- a/docs/superpowers/plans/2026-08-18-verification-cost-discipline-pr1-edda-policy.md
+++ b/docs/superpowers/plans/2026-08-18-verification-cost-discipline-pr1-edda-policy.md
@@ -8,6 +8,14 @@
 
 **Tech Stack:** Markdown, git, `rg`/`grep` for consistency checks, one fresh agent session per dry-run pressure test. No Cargo invocation anywhere in this plan.
 
+> **This plan is a historical execution record, frozen at `738c5ce`. Do not
+> take any figure or constraint below as current.** Three review rounds and a
+> follow-up PR changed several of them — notably the `8–13 GB` per-target
+> figure (measured 40.9 GB) and the `warn 35 GB / refuse 50 GB` thresholds
+> (withdrawn; no default ceiling ships until a measured steady state exists).
+> See “Round 1 review amendments” at the end of this file, and the spec for the
+> living contract.
+
 ## Global Constraints
 
 - Branch `docs/verification-cost-discipline` in worktree `C:\ai_agent\edda\.claude\worktrees\verification-cost-discipline`, based on `origin/main 7f5d1555b4c00e4fe6ac9a452a3c81c62289972c`. Do not touch the `codex/fleet-orchestrate-skill` checkout at `C:\ai_agent\edda` (stale, has another session's uncommitted diff).

--- a/docs/superpowers/specs/2026-08-18-verification-cost-discipline-design.md
+++ b/docs/superpowers/specs/2026-08-18-verification-cost-discipline-design.md
@@ -187,8 +187,9 @@ measure second, set a number third.
 - Fixed allowlist: `worker-1`, `worker-2`, `verifier`, `verifier-2`. Unknown
   names are refused. The controller's primary checkout keeps its normal
   `target/`; it is not a lane.
-- The controller assigns a lane in every brief. A session keeps its lane for
-  its lifetime; the same PR's verifier rounds reuse `verifier`; a lane changes
+- The controller assigns a lane in every brief **for a session that builds or
+  caches locally**; a session that compiles nothing gets no lane and reports
+  `n/a`. A session that has one keeps it for its lifetime; the same PR's verifier rounds reuse `verifier`; a lane changes
   hands only when the previous holder is finished or dead. Lanes are per
   concurrent session, never per round, SHA, or timestamp.
 - Verifier lanes and every `freeze` run set `CARGO_INCREMENTAL=0` (one-shot
@@ -208,10 +209,12 @@ measure second, set a number third.
   build output. The tool never removes anything outside the lane root, never
   removes a path containing `.git`, and never touches worktrees, branches, or
   sources. Briefs say so verbatim.
-- Capacity: warn at 35 GB total, refuse to run gates at 50 GB
-  (`FLEET_LANE_CEILING_GB` overrides). Over the ceiling the tool prints the
-  pool table and the reclaim command and exits non-zero; capacity refusal has
-  no bypass flag. `doctor.ps1` reports the same numbers.
+- Capacity: **the tool ships with no default ceiling** (see the footprint note
+  above — a limit sized against the 194 GB pathology would refuse during normal
+  operation). `-Status` and `doctor.ps1` report the pool size; `FLEET_LANE_WARN_GB`
+  and `FLEET_LANE_CEILING_GB` are unset until an operator sets them from a
+  measured steady state. Once a ceiling exists, exceeding it prints the pool
+  table and the reclaim command and exits non-zero, with no bypass flag.
 
 ### 4.4 Brake authority — who stops it
 
@@ -356,7 +359,10 @@ the tool enforces a limit against an artificially inflated number.
 ## 8. Decisions taken in this design (defaults, revisable in the plan)
 
 - Lane allowlist: `worker-1`, `worker-2`, `verifier`, `verifier-2`.
-- Thresholds: warn 35 GB, refuse 50 GB, env-overridable.
+- Thresholds: **none by default.** `FLEET_LANE_WARN_GB` and
+  `FLEET_LANE_CEILING_GB` are operator-set from a measured steady state; the
+  earlier 35/50 GB pair was drawn from the pathology, not from a healthy
+  lane, and is superseded (§4.3).
 - Receipt store: `<lane-root>\receipts.jsonl` plus `edda note --tag gate`
   when `.edda/` exists.
 - Verifier lanes always `CARGO_INCREMENTAL=0`; worker lanes only for `freeze`.

--- a/docs/superpowers/specs/2026-08-18-verification-cost-discipline-design.md
+++ b/docs/superpowers/specs/2026-08-18-verification-cost-discipline-design.md
@@ -159,6 +159,25 @@ Key = (`repo`, `sha`, `gate`, `crates`, `toolchain`, `lockfile`). Rules:
 
 ### 4.3 Build lanes (machine level)
 
+**Scope of this section — narrower than the rest of the design.** Lanes govern
+*local compilation cache for a large Cargo workspace on one Windows
+workstation*. They are not fleet-wide infrastructure and not a cost of adopting
+edda: the installed binary is ~26 MB and a project ledger is 0.4–9 MB, while a
+long-lived `target/debug` for this 23-crate workspace measured 40.9 GB. Only
+the second number motivates anything here. A project that is not compiled on
+this machine needs no lane, and `lane.ps1` must be presented as a tool for
+local heavy builds rather than as a standard every fleet session adopts.
+
+**Footprint before ceilings.** That 40.9 GB is mostly reclaimable, not
+intrinsic: 21.6 GB sat in 509 `incremental` session directories, every one older
+than 24 hours — orphans from interrupted or killed builds that Cargo never
+collects — and 8.1 GB was Windows debug symbols (`edda.pdb` 310 MB against a
+51 MB `edda.exe`) because the workspace tunes `[profile.release]` only. Any
+fixed pool ceiling is therefore provisional until that footprint work lands;
+sizing a limit against the 194 GB pathology would refuse during normal
+operation, since one warm lane alone approaches 40 GB. Reclaim by age first,
+measure second, set a number third.
+
 - One lane root per machine, configurable (`FLEET_LANE_ROOT`, default
   the `LOCALAPPDATA` directory plus `\fleet-workstation\lanes`, written
   shell-appropriately — `$env:LOCALAPPDATA` in PowerShell, `$LOCALAPPDATA` in
@@ -224,7 +243,7 @@ Key = (`repo`, `sha`, `gate`, `crates`, `toolchain`, `lockfile`). Rules:
 | Shipped skills (all projects) | `crates/edda-cli/src/skills/coord-orchestrate.md` (brief step, review scope contract, traffic table); `coord-review.md` (gate paragraph, Round N template gains `Lane:` and `Receipt:` under Evidence) | carrier-neutral, no Cargo words |
 | Codex entry | `AGENTS.md` | two bullets: ladder + assigned lane, READ before RAN; never create ad-hoc build directories; "run the checks required by CLAUDE.md at the ladder level that matches the change" |
 | Project canonical | `.claude/CLAUDE.md` Testing Standards + Pre-commit Checklist | Cargo L0/L1 commands above; "Build lanes" subsection; checklist split into before-commit (L0) and before-freeze (L1) |
-| Machine tooling | fleet-workstation `scripts/lane.ps1` + `tests/lane.tests.ps1`; `doctor.ps1` lanes check; `adapters/codex/AGENTS.global.md` and `adapters/claude/CLAUDE.global.md` one bullet each; `fleet-workstation.json` / `source-lock.json` pin bump | tool contract in §4.6 |
+| Machine tooling (local heavy builds only) | fleet-workstation `scripts/lane.ps1` + tests; `doctor.ps1` lanes check; `adapters/codex/AGENTS.global.md` and `adapters/claude/CLAUDE.global.md` one bullet each, worded so a session that runs no local build knows the rule does not apply to it; `fleet-workstation.json` / `source-lock.json` pin bump | tool contract in §4.6 |
 | Operator's generic doc | `C:\ai_agent\EXECUTION-COORDINATION.md` | one axiom, only if the operator approves: regulate cost and reclamation, not only evidence |
 
 Existing distribution stays the single path: fleet-workstation pins an edda
@@ -261,17 +280,29 @@ lane.ps1 -Reclaim [-All] [-WhatIf]
 
 ## 5. Delivery slices
 
-Each slice gets its own implementation plan; PR-2 depends on PR-1 being
-merged because it pins that revision.
+Each slice gets its own implementation plan. **Order matters and changed after
+measurement:** shrink the footprint before building a tool that polices it, or
+the tool enforces a limit against an artificially inflated number.
 
 1. **PR-1 (edda)** — policy only: `.claude/CLAUDE.md`, `AGENTS.md`,
    `crates/edda-cli/src/skills/coord-orchestrate.md`, `coord-review.md`,
    `skills/fleet-orchestrate/SKILL.md`, `references/playbook.md`, plus this
    spec and its plan. Docs-only: gates are exact-head CI plus the docs/skill
-   consistency checks in §6; no local Cargo run.
-2. **PR-2 (fleet-workstation)** — `scripts/lane.ps1`, tests, `doctor.ps1`
+   consistency checks in §6; no local Cargo run. *(Merged as `91534f9`;
+   scope-correction follow-up in progress.)*
+2. **PR-1b (edda) — footprint, new and now ahead of the tool.** Reclaim stale
+   `incremental` sessions by age, and evaluate a debug-profile setting
+   (`debug = "line-tables-only"` or `debug = 1`) against a measured before/after
+   in an isolated directory. Both are the difference between a ~40 GB and a
+   ~10 GB steady state, and neither needs a tool. Only after this does a pool
+   ceiling mean anything.
+3. **PR-2 (fleet-workstation)** — `scripts/lane.ps1`, tests, `doctor.ps1`
    lanes check, adapter bullets, docs page, pin bump to the edda revision that
-   contains PR-1, `source-lock.json` digests, `update.ps1` verified.
+   contains PR-1, `source-lock.json` digests, `update.ps1` verified. Positioned
+   as a tool for machines that compile a large workspace locally, not as
+   default workstation infrastructure: `bootstrap.ps1` installs it without
+   implying every session uses it, and its docs page opens with the scope
+   statement from §4.3. Thresholds come from PR-1b's measurement.
 3. Follow-ups (issues, not this work): fleet-playbook `fleet-review` /
    `fleet-pr-loop` "re-run gates" wording; `edda gate` native receipts;
    Bash twin of `lane.ps1`; repo-level gate profile override; operator

--- a/skills/fleet-orchestrate/SKILL.md
+++ b/skills/fleet-orchestrate/SKILL.md
@@ -38,10 +38,10 @@ when changing or validating review policy.
    two concurrent workers onward, reserve a verifier seat.
 6. Record tasks, claims, rulings, and acceptance criteria in the durable truth
    layer before ringing host messaging as a doorbell.
-7. Give self-contained briefs (including assigned build lane, verification
-   budget, and cleanup authority), monitor compressed state, adjudicate
-   conflicts, and close only against immutable full SHAs with proportional
-   evidence.
+7. Give self-contained briefs (verification budget and cleanup authority
+   always; an assigned build lane whenever the session builds locally),
+   monitor compressed state, adjudicate conflicts, and close only against
+   immutable full SHAs with proportional evidence.
 
 ## Non-negotiable invariants
 
@@ -70,18 +70,22 @@ when changing or validating review policy.
   non-product/harness-only cycles without useful progress, or at diminishing
   returns, stop and route follow-up or request operator scope expansion.
 - Verify once per frozen artifact: the full gate set runs once per frozen
-  full SHA in an assigned build lane and leaves a gate receipt (SHA, gate set,
-  toolchain, lane, result); reviewers READ that receipt and exact-head CI and
-  RAN only what they do not cover, stating the reason for any full rerun. A
-  status, label, or draft flip is not a push.
+  full SHA — in the assigned build lane where one applies — and leaves a gate
+  receipt (SHA, gate set, toolchain, lane or n/a, result); reviewers READ that
+  receipt and exact-head CI and RAN only what they do not cover, stating the
+  reason for any full rerun. A status, label, or draft flip is not a push.
 - Know what the project's CI actually covers before citing it as independent
   evidence; a real coverage gap is a legitimate reason to RAN. Deterministically
   red CI already blocks the artifact — audit and request changes instead of
   spending a full run; re-run only the failed job when the red is environmental.
-- Build environments are bounded: one assigned lane per session for its
-  lifetime from a fixed pool named in the brief, never per round, SHA, or
-  timestamp; lane build cache is disposable, worktrees and sources are not;
-  over the pool ceiling the fleet stops and reports instead of building.
+- Where sessions build or cache locally, that environment is bounded: one
+  assigned lane per session for its lifetime from a fixed pool named in the
+  brief, never per round, SHA, or timestamp; lane build cache is disposable,
+  worktrees and sources are not; the fleet stops and reports rather than let
+  the pool grow without bound. This invariant is inert for work that produces
+  no local build cache — it costs nothing to carry and binds nothing to invent.
+  Size any ceiling from a measurement of the project’s own footprint, never
+  from a number carried over from another project.
 - A GitHub PR carries its visible review-fix loop: numbered SHA-pinned review,
   implementer response to every requested change, and final current-head LGTM.
   An internal verifier report does not replace these PR comments.

--- a/skills/fleet-orchestrate/references/playbook.md
+++ b/skills/fleet-orchestrate/references/playbook.md
@@ -199,15 +199,16 @@ Owned paths/symbols; forbidden paths
 Dependencies and highest durable d-NNN ruling
 Required worktree/branch and claim label
 Test-first acceptance criteria and exact gates
-Build lane: <assigned name from the fixed pool> at <absolute lane root>
+Build lane (only when the session builds or caches locally; write "n/a"
+  otherwise): <assigned name from the fixed pool> at <absolute lane root>
   (the worker resolves its build directory as <lane root>/<lane name> and never
-  invents one; if this line is missing, ask before building)
+  invents one; if this line is missing and you are about to build, ask first)
 Verification budget: focused gates on touched units while iterating; the full
   gate set once per frozen full SHA with a gate receipt; READ receipts and
   exact-head CI before any RAN; name the coverage the project's CI genuinely
   lacks, since that is the reviewer's legitimate reason to run it
-Cleanup authority: lane build cache is disposable; worktrees, branches, and
-  sources are never deleted
+Cleanup authority: build cache is disposable and stale cache should be
+  reclaimed by age; worktrees, branches, and sources are never deleted
 Drift rule: if HEAD differs, satisfy intent against HEAD and report full SHA
 Done: pushed candidate/PR, frozen full SHA, receipt, no merge
 ```

--- a/skills/fleet-orchestrate/references/playbook.md
+++ b/skills/fleet-orchestrate/references/playbook.md
@@ -260,8 +260,10 @@ intent + basis SHA + symbol anchor + drift rule.
 3. Avoid reading full diffs mid-flight; consume status, receipts, blocker
    reports, and verifier criteria until formal review time.
 4. Never reinterpret a receipt as acceptance.
-5. Assign build lanes from the fixed pool, put the verification budget and
-   cleanup authority in every brief, and route over-verification (a second RAN
+5. Put the verification budget and cleanup authority in every brief, and
+   assign a build lane from the fixed pool to every session that builds or
+   caches locally (a session that builds nothing needs none). Route
+   over-verification (a second RAN
    for an already-receipted SHA without a reason, full gates for a docs-only
    push, an ad-hoc build directory) as a process finding — cost line,
    `FOLLOW-UP ISSUE`, corrected brief — never as a reason to block a


### PR DESCRIPTION
Follow-up to #481. Measurement changed what that policy should claim.

## What was wrong

**Mis-scoped.** The lane rules read as fleet-wide infrastructure. They only ever governed local Cargo build cache. Measured:

| | Size |
|---|---:|
| `edda.exe` (installed once, all projects) | 26.2 MB |
| `.edda/` per project | 0.36 – 8.96 MB |
| `target/debug` for this workspace | **40.9 GB** |

Only the last row motivates lanes. A fleet session that runs no local build was left carrying a rule it cannot apply.

**Two figures were wrong, not merely broad.**

- The ladder claimed `8–13 GB of build output per target directory`. A long-lived target measured **40.9 GB** across 88,789 files.
- `Stop and report when the lane pool exceeds 50 GB` would refuse during normal operation: one warm lane approaches 40 GB, so a four-lane pool needs well over 100 GB. The ceiling was calibrated against the 194 GB pathology and lands inside the healthy range of the design's own pool.

## What this changes

- `Build lanes` opens with when it applies, and the using-vs-compiling numbers.
- The 50 GB ceiling was made **provisional** in `146136d`, and after Round 1 the spec's own unqualified copies of `warn 35 GB / refuse 50 GB` were withdrawn too, so no default ceiling ships. The footprint that explains why: 21.6 GB of the 40.9 sat in 509 `incremental` session directories, every one older than 24 hours — orphans from interrupted or killed builds that Cargo never collects; 8.1 GB was Windows debug symbols (`edda.pdb` 310 MB against a 51 MB `edda.exe`) because the workspace tunes `[profile.release]` only.
- Lane references in the ladder, `AGENTS.md`, `fleet-orchestrate`, the playbook brief template, and both shipped coord skills become conditional on the session actually compiling locally (`n/a` otherwise).
- Cleanup authority now says reclaim stale cache by age, not just wait for a ceiling — the rule as merged would never have touched that 21.6 GB, which lived in a lane in daily use.
- Spec delivery order gains **PR-1b (footprint)** ahead of the lane tool: reclaim and profile work are the difference between a ~40 GB and a ~10 GB steady state, and neither needs a tool. Sizing a ceiling first enforces an inflated number.

## Evidence

- RAN: measured `target/debug` — 40.88 GB / 88,789 files; `.o` 10.72, `.bin` 10.66, `.rlib` 8.56, `.pdb` 8.05, `.rmeta` 1.76, `.exe` 0.88 GB; 509 incremental session dirs, all older than 24h, 21.62 GB; `edda.exe` 51.1 MB vs `edda.pdb` 310.1 MB.
- RAN: measured installed binary and every project ledger (table above).
- RAN: consistency greps — the two blocking phrases are gone from every live carrier; methodology files and shipped skills still contain no Cargo commands. **Corrected after Round 1:** this line originally claimed no `8–13 GB` or unconditional `50 GB` claim survived anywhere. That was false — my grep covered the carriers but not the spec or the plan. Repo-wide `git grep` at head shows those figures only in the PR-1 plan, which is a frozen execution record and now opens with a staleness banner, and in the spec's own supersession note.
- READ: `.github/workflows/ci.yml`, `Cargo.toml` (`[profile.release]` only).
- Lane: n/a (docs-only). Receipt: none (docs-only).

## Coordination note

`crates/edda-cli/*` was claimed by a peer when this started, so the first commit deliberately excluded it and routed the change by `edda request`. That session then went stale (`edda peers` shows only this one), and leaving two shipped skills disagreeing with four corrected carriers is the defect class that blocked #481 twice — so the second commit completes them here.

Companion: fleet-workstation `feat/lane-tool` commit `46775c3` removes the hard-coded thresholds from the tool plan and adds the stale-incremental sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
