### PR TITLE
feat(edda-cli): scaffold coord skills for Codex, and fix the unclaim doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 .edda/
 .claude/
+.agents/
 CLAUDE.md
 docs/archive/
 /tmp/

--- a/crates/edda-cli/src/cmd_init.rs
+++ b/crates/edda-cli/src/cmd_init.rs
@@ -122,9 +122,12 @@ actors: {}
         auto_install_bridges(repo_root);
     }
 
-    // Scaffold coordination skills into .claude/skills/
+    // Scaffold coordination skills for detected agent hosts.
     if repo_root.join(".claude").is_dir() {
-        scaffold_skills(repo_root, force_skills);
+        scaffold_skills(&repo_root.join(".claude").join("skills"), force_skills);
+    }
+    if repo_root.join("AGENTS.md").is_file() || repo_root.join(".agents").is_dir() {
+        scaffold_skills(&repo_root.join(".agents").join("skills"), force_skills);
     }
 
     // Scan and register skills in the user-level skill registry
@@ -154,10 +157,9 @@ fn auto_install_bridges(repo_root: &Path) {
     }
 }
 
-/// Write embedded coord skill templates to `.claude/skills/coord-*/SKILL.md`.
+/// Write embedded coord skill templates to `<host>/skills/coord-*/SKILL.md`.
 /// Skips files that already exist unless `force` is true.
-fn scaffold_skills(repo_root: &Path, force: bool) {
-    let skills_dir = repo_root.join(".claude").join("skills");
+fn scaffold_skills(skills_dir: &Path, force: bool) {
     for &(name, content) in SKILLS {
         let dir = skills_dir.join(name);
         let path = dir.join("SKILL.md");
@@ -310,6 +312,29 @@ mod tests {
             assert!(
                 content.contains(&format!("name: {name}")),
                 "{name} should have correct frontmatter"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn init_scaffolds_codex_coord_skills() {
+        let _store = crate::test_support::isolated_store();
+        let tmp = temp_dir();
+        std::fs::write(tmp.join("AGENTS.md"), "# Project instructions\n").unwrap();
+
+        execute(&tmp, true, false).unwrap();
+
+        for &(name, _) in SKILLS {
+            let path = tmp
+                .join(".agents")
+                .join("skills")
+                .join(name)
+                .join("SKILL.md");
+            assert!(
+                path.exists(),
+                "{name}/SKILL.md should be scaffolded for Codex"
             );
         }
 

--- a/crates/edda-cli/src/skills/coord-handoff.md
+++ b/crates/edda-cli/src/skills/coord-handoff.md
@@ -74,10 +74,12 @@ hooks), release the scope explicitly — and **pass the session id**:
 edda unclaim --session <id>
 ```
 
-The id is the `session:` line `edda claim` printed, and `edda peers` shows it
-too. Without hooks there is no heartbeat to infer from, and bare `edda unclaim`
-falls back to the session `cli-cli` rather than the `cli-<label>` your claim
-created: it exits 0, prints a reassuring line, and releases nothing (GH-455).
+The id is the `session:` line `edda claim` printed; `edda peers --json` also
+carries it. Plain `edda peers` will not: it lists live heartbeats, which a
+bare-CLI claim does not have, and it abbreviates ids. Without hooks there is no
+heartbeat to infer from either, so bare `edda unclaim` falls back to the
+session `cli-cli` rather than the `cli-<label>` your claim created: it exits 0,
+prints a reassuring line, and releases nothing (GH-455).
 
 Enforcement stays safe either way: every consumer joins claims against live
 heartbeats, so a claim left behind by a dead session does not block a peer.

--- a/crates/edda-cli/src/skills/coord-handoff.md
+++ b/crates/edda-cli/src/skills/coord-handoff.md
@@ -68,11 +68,19 @@ Where host bridge hooks are wired, unclaim happens automatically on session
 end — nothing to do.
 
 Where they are not (claims made from a bare CLI, CI, or a host without bridge
-hooks), release the scope explicitly:
+hooks), release the scope explicitly — and **pass the session id**:
 
 ```bash
-edda unclaim [--session <id>]
+edda unclaim --session <id>
 ```
+
+The id is the `session:` line `edda claim` printed, and `edda peers` shows it
+too. Without hooks there is no heartbeat to infer from, and bare `edda unclaim`
+falls back to the session `cli-cli` rather than the `cli-<label>` your claim
+created: it exits 0, prints a reassuring line, and releases nothing (GH-455).
+
+Enforcement stays safe either way: every consumer joins claims against live
+heartbeats, so a claim left behind by a dead session does not block a peer.
 
 ## Output Format
 

--- a/crates/edda-cli/src/skills/coord-handoff.md
+++ b/crates/edda-cli/src/skills/coord-handoff.md
@@ -64,15 +64,15 @@ Include:
 
 ### Step 5: Scope Release
 
-Where the Claude Code hooks are wired, unclaim happens automatically on
-session end via the SessionEnd hook — nothing to do.
+Where host bridge hooks are wired, unclaim happens automatically on session
+end — nothing to do.
 
-Where they are not (claims made from a bare CLI, CI, or a host without the
-bridge hooks), the claim outlives the session: there is currently no
-`edda unclaim` verb to release it by hand (GH-455). In that case, say so in
-your handoff summary — peers reading the board should know the claim is dead
-even though it still folds. Enforcement stays safe either way: every consumer
-joins claims against live heartbeats.
+Where they are not (claims made from a bare CLI, CI, or a host without bridge
+hooks), release the scope explicitly:
+
+```bash
+edda unclaim [--session <id>]
+```
 
 ## Output Format
 


### PR DESCRIPTION
Rescues two changes from an abandoned session and drops the rest.

## Where this came from

The shared checkout `C:\ai_agent\edda` sits on `codex/fleet-orchestrate-skill` (76 behind main) with six uncommitted files from a session that is no longer live. Four of those files were superseded by main — their content is the ancestor of what landed via #476, #480, and #481. Two are real work main does not have, and they are what this PR carries forward, applied to current main on a fresh branch.

**The original working tree was left untouched**, so nothing is destroyed and that session can still resume if it comes back. A conflict analysis was queued to its label via `edda request`.

## 1. `edda init` scaffolds coord skills for Codex

Before: skills were written only to `.claude/skills/`, and only when `.claude/` existed. A Codex-only repository got no coord skills at all — which is why several have had to install them by hand.

After: the destination follows the hosts a repository actually uses.

| Detected | Destination |
|---|---|
| `.claude/` exists | `.claude/skills/` |
| `AGENTS.md` or `.agents/` exists | `.agents/skills/` |

`scaffold_skills` now takes the destination directory rather than deriving it, so both call sites share one implementation. New test `init_scaffolds_codex_coord_skills` creates a repo with only `AGENTS.md` and asserts every skill lands under `.agents/skills/`.

## 2. `coord-handoff.md` claimed a working command does not exist

The shipped skill said:

> there is currently no `edda unclaim` verb to release it by hand (GH-455)

That is false on main. `unclaim` is implemented at `crates/edda-cli/src/cmd_bridge.rs:679`, wired at `crates/edda-cli/src/main.rs:1063`, and tested at `cmd_bridge.rs:2197`. Because this skill ships to every project through `edda init`, main has been telling every reader to work around a command that works. Step 5 now documents it.

I hit this myself: `edda unclaim --help` fails on my machine, which looks like confirmation of the doc — but that is only because the installed binary is 0.2.1, older than main. Checking the source rather than the binary is what settled it.

## Evidence

- RAN `cargo fmt --all --check` — PASS
- RAN `cargo clippy -p edda --all-targets -- -D warnings` — PASS (1m38s)
- RAN `cargo test -p edda` — **303 passed, 0 failed**, including `init_scaffolds_codex_coord_skills`
- READ: the two files were unchanged on main since the abandoned branch's base `0dbae23`, so the patch applied cleanly with no conflict resolution
- Lane: worktree default `target/` (solo work, per the Build lanes rule)
- Receipt: L0 focused gates above; L1 to follow if this SHA is frozen for review

Touched crate only — `edda` is in the CI Windows test subset, so Windows behavior here is covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)