### PR TITLE
test(edda-cli): let shipped skills prove their own CLI claims

### DIFF
--- a/crates/edda-cli/src/skills/coord-handoff.md
+++ b/crates/edda-cli/src/skills/coord-handoff.md
@@ -68,24 +68,53 @@ Where host bridge hooks are wired, unclaim happens automatically on session
 end — nothing to do.
 
 Where they are not (claims made from a bare CLI, CI, or a host without bridge
-hooks), release the scope by naming it:
+hooks), release the scope by naming it. The id is the `session:` line
+`edda claim` printed:
 
-```bash
-edda unclaim --session <id>
+```bash edda-doctest
+$ edda claim "auth" --paths "src/auth/*"
+> session: cli-auth
+$ edda unclaim --session cli-auth
+> Unclaimed scope for session: cli-auth
 ```
 
-The id is the `session:` line `edda claim` printed. Run it without `--session`
-and the refusal lists every claim with its session id, so the value you need is
-in the error. `edda peers --json` carries it too, under `claims[].session_id`;
-plain `edda peers` does not, because it lists live heartbeats and a bare-CLI
-claim has none.
+Omit `--session` and it refuses rather than guessing, listing every claim with
+its id — so the value you need is in the error:
 
-`unclaim` deliberately does not pick a claim for you when you have no session
-of your own: it cannot tell whose claim it is, and releasing the wrong one
-would drop the off-limits protection a live peer is relying on.
+```bash edda-doctest
+$ edda claim "auth" --paths "src/auth/*"
+> session: cli-auth
+$ edda unclaim
+! cannot tell which claim is yours
+! cli-auth
+```
 
-`unclaim` never reports success for a session that holds nothing — if it prints
-a released scope, that scope is gone.
+That refusal is deliberate. A caller with no session of its own cannot tell
+whose claim it is, and releasing the wrong one would drop the off-limits
+protection a live peer is relying on.
+
+`unclaim` also never reports success for a session that holds nothing — if it
+prints a released scope, that scope is gone:
+
+```bash edda-doctest
+$ edda claim "auth" --paths "src/auth/*"
+> session: cli-auth
+$ edda unclaim --session cli-nobody
+! holds no claim
+```
+
+`edda peers --json` carries the id too, under `claims[].session_id`. Plain
+`edda peers` does not, because it lists live heartbeats and a bare-CLI claim
+has none:
+
+```bash edda-doctest
+$ edda claim "auth" --paths "src/auth/*"
+> session: cli-auth
+$ edda peers --json
+> "session_id": "cli-auth"
+$ edda peers
+> No active sessions
+```
 
 Enforcement stays safe either way: every consumer joins claims against live
 heartbeats, so a claim left behind by a dead session does not block a peer.

--- a/crates/edda-cli/tests/skill_doctest.rs
+++ b/crates/edda-cli/tests/skill_doctest.rs
@@ -1,0 +1,248 @@
+//! Executable examples for the coordination skills shipped by `edda init`.
+//!
+//! `crates/edda-cli/src/skills/*.md` are compiled into the binary with
+//! `include_str!` and written into every project. Nothing used to check that
+//! the commands they teach are real: over one review loop this file set shipped
+//! four separate false CLI claims — a verb declared not to exist while it did,
+//! an invocation whose bare form silently released nothing, and twice a command
+//! named as the way to read a value it does not print. Every one passed fmt,
+//! clippy and the whole test suite.
+//!
+//! A skill can now carry its own proof. Mark a fenced block `bash edda-doctest`
+//! and this harness runs it against the built binary in a throwaway project:
+//!
+//! ```text
+//! ```bash edda-doctest
+//! $ edda claim "auth" --paths "src/auth/*"
+//! > session: cli-auth
+//! $ edda unclaim
+//! ! cannot tell which claim is yours
+//! ```
+//! ```
+//!
+//! `$` runs a command, `>` asserts it succeeded and printed the text, and `!`
+//! asserts it failed with the text. Unmarked blocks are prose and are ignored,
+//! so existing examples do not have to be converted at once.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const EDDA: &str = env!("CARGO_BIN_EXE_edda");
+
+/// One `$`/`>`/`!` line from a doctest block.
+#[derive(Debug)]
+enum Step {
+    Run(Vec<String>),
+    ExpectOk(String),
+    ExpectErr(String),
+}
+
+fn skills_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src/skills")
+}
+
+/// Split a command line on spaces, keeping double-quoted runs together.
+///
+/// Enough for the shapes skills actually use (`--paths "src/a/*"`); anything
+/// needing more is a sign the example belongs in a test rather than a doc.
+fn split_args(line: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    let mut quoted = false;
+    for ch in line.chars() {
+        match ch {
+            '"' => quoted = !quoted,
+            c if c.is_whitespace() && !quoted => {
+                if !cur.is_empty() {
+                    out.push(std::mem::take(&mut cur));
+                }
+            }
+            c => cur.push(c),
+        }
+    }
+    if !cur.is_empty() {
+        out.push(cur);
+    }
+    out
+}
+
+/// Pull every `bash edda-doctest` block out of one skill.
+fn parse_blocks(markdown: &str) -> Vec<Vec<Step>> {
+    let mut blocks = Vec::new();
+    let mut current: Option<Vec<Step>> = None;
+
+    for line in markdown.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            if let Some(block) = current.take() {
+                blocks.push(block);
+            } else if trimmed == "```bash edda-doctest" {
+                current = Some(Vec::new());
+            }
+            continue;
+        }
+        let Some(block) = current.as_mut() else {
+            continue;
+        };
+        if let Some(rest) = trimmed.strip_prefix("$ ") {
+            let args = split_args(rest);
+            assert_eq!(
+                args.first().map(String::as_str),
+                Some("edda"),
+                "a doctest step must invoke edda: {trimmed}"
+            );
+            block.push(Step::Run(args[1..].to_vec()));
+        } else if let Some(rest) = trimmed.strip_prefix("> ") {
+            block.push(Step::ExpectOk(rest.to_string()));
+        } else if let Some(rest) = trimmed.strip_prefix("! ") {
+            block.push(Step::ExpectErr(rest.to_string()));
+        } else if !trimmed.is_empty() {
+            panic!("unrecognized doctest line (want `$ `, `> ` or `! `): {trimmed}");
+        }
+    }
+    blocks
+}
+
+struct Outcome {
+    ok: bool,
+    text: String,
+}
+
+fn run(args: &[String], repo: &Path, store: &Path) -> Outcome {
+    let out = Command::new(EDDA)
+        .args(args)
+        .current_dir(repo)
+        .env("EDDA_STORE_ROOT", store)
+        .env_remove("EDDA_SESSION_ID")
+        .env_remove("EDDA_SESSION_LABEL")
+        .output()
+        .unwrap_or_else(|e| panic!("could not run edda {args:?}: {e}"));
+    let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
+    text.push_str(&String::from_utf8_lossy(&out.stderr));
+    Outcome {
+        ok: out.status.success(),
+        text,
+    }
+}
+
+/// A fresh project for one block, so blocks cannot leak state into each other.
+fn fixture() -> (tempfile::TempDir, PathBuf, PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path().join("repo");
+    let store = dir.path().join("store");
+    std::fs::create_dir_all(&repo).expect("repo dir");
+    std::fs::create_dir_all(&store).expect("store dir");
+
+    let git = Command::new("git")
+        .args(["init", "-q", "."])
+        .current_dir(&repo)
+        .output()
+        .expect("git init");
+    assert!(git.status.success(), "git init failed");
+
+    let init = run(
+        &["init".to_string(), "--no-hooks".to_string()],
+        &repo,
+        &store,
+    );
+    assert!(init.ok, "edda init failed in the fixture:\n{}", init.text);
+
+    (dir, repo, store)
+}
+
+#[test]
+fn shipped_skill_examples_still_do_what_they_say() {
+    let dir = skills_dir();
+    let mut checked = 0usize;
+    let mut files_with_blocks = Vec::new();
+
+    let entries =
+        std::fs::read_dir(&dir).unwrap_or_else(|e| panic!("cannot read {}: {e}", dir.display()));
+    for entry in entries {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("md") {
+            continue;
+        }
+        let name = path.file_name().unwrap().to_string_lossy().into_owned();
+        let markdown = std::fs::read_to_string(&path).expect("read skill");
+        let blocks = parse_blocks(&markdown);
+        if blocks.is_empty() {
+            continue;
+        }
+        files_with_blocks.push(name.clone());
+
+        for (b, block) in blocks.iter().enumerate() {
+            let (_guard, repo, store) = fixture();
+            let mut last: Option<Outcome> = None;
+
+            for step in block {
+                match step {
+                    Step::Run(args) => last = Some(run(args, &repo, &store)),
+                    Step::ExpectOk(want) => {
+                        let got = last
+                            .as_ref()
+                            .unwrap_or_else(|| panic!("{name} block {b}: `> ` before any command"));
+                        assert!(
+                            got.ok,
+                            "{name} block {b}: expected success containing {want:?}, but the \
+                             command failed:\n{}",
+                            got.text
+                        );
+                        assert!(
+                            got.text.contains(want),
+                            "{name} block {b}: output did not contain {want:?}:\n{}",
+                            got.text
+                        );
+                        checked += 1;
+                    }
+                    Step::ExpectErr(want) => {
+                        let got = last
+                            .as_ref()
+                            .unwrap_or_else(|| panic!("{name} block {b}: `! ` before any command"));
+                        assert!(
+                            !got.ok,
+                            "{name} block {b}: expected failure containing {want:?}, but the \
+                             command succeeded:\n{}",
+                            got.text
+                        );
+                        // A misspelled or removed verb also exits non-zero, and
+                        // would otherwise satisfy any `!` expectation. That is
+                        // exactly the class this harness exists to catch.
+                        assert!(
+                            !got.text.contains("unrecognized subcommand"),
+                            "{name} block {b}: the command does not exist:\n{}",
+                            got.text
+                        );
+                        assert!(
+                            got.text.contains(want),
+                            "{name} block {b}: error did not contain {want:?}:\n{}",
+                            got.text
+                        );
+                        checked += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        checked > 0,
+        "no skill doctest assertions ran; the harness is not reaching {}",
+        dir.display()
+    );
+    println!("skill doctests: {checked} assertions across {files_with_blocks:?}");
+}
+
+#[test]
+fn a_doctest_block_is_parsed_into_its_steps() {
+    let blocks = parse_blocks(
+        "prose\n\n```bash edda-doctest\n$ edda claim \"auth\" --paths \"src/a/*\"\n> session: \
+         cli-auth\n! nope\n```\n\n```bash\n$ edda not-a-doctest\n```\n",
+    );
+    assert_eq!(blocks.len(), 1, "only the marked block is a doctest");
+    assert_eq!(blocks[0].len(), 3);
+    match &blocks[0][0] {
+        Step::Run(args) => assert_eq!(args, &["claim", "auth", "--paths", "src/a/*"]),
+        other => panic!("expected a command, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Closes the gap that produced four blocking findings across #481, #485 and #487.

## The gap

`crates/edda-cli/src/skills/*.md` are compiled into the binary with `include_str!` and written into every project by `edda init`. Before this PR the only assertion about them anywhere in the workspace was:

```rust
assert!(path.exists(), "{name}/SKILL.md should be scaffolded");
```

File exists. Nothing about whether the commands they teach are real.

Over one review loop, this one file set shipped **four false CLI claims**, each passing fmt, clippy and the full suite:

| Claim | Reality |
|---|---|
| "there is currently no `edda unclaim` verb (GH-455)" | it existed, implemented and tested — shipped to every project for months |
| `edda unclaim [--session <id>]` | the bare form resolved a different session, exited 0, released nothing |
| "`edda peers` shows it too" | `peers` lists live heartbeats; a bare-CLI claim has none |
| rustdoc: "then the board itself…" | described a tier deleted in the commit before |

All four were caught by an independent reviewer reading the code, never by CI.

## The mechanism

A skill can now carry its own proof. Mark a fenced block `bash edda-doctest` and it runs against the built binary in a throwaway project with an isolated store:

````markdown
```bash edda-doctest
$ edda claim "auth" --paths "src/auth/*"
> session: cli-auth
$ edda unclaim
! cannot tell which claim is yours
! cli-auth
```
````

`$` runs, `>` asserts success containing the text, `!` asserts failure containing the text. Unmarked blocks stay prose, so nothing has to be converted at once.

`!` expectations additionally assert the output is **not** `unrecognized subcommand`. A removed or misspelled verb exits non-zero too and would otherwise satisfy any failure expectation — that is the hole that let a doc declaring a working verb nonexistent survive.

## Mutation-tested, not merely green

A passing new test proves little on its own, so I reinjected each of the four historical false claims in turn and ran the harness:

```
CAUGHT  #1  a verb declared not to exist (main, before #485)
CAUGHT  #2  bare unclaim documented as working (#485 first fix)
CAUGHT  #3  `edda peers` said to show the id (#485 second fix)
CAUGHT  #4  unclaim of a claimless session called a success (base behavior)
```

4/4 rejected; the file was restored afterwards and the working tree verified clean of mutations. The mutation script is not committed — it is evidence about the harness, not a fixture.

## Scope, and what this does not cover

`coord-handoff` Step 5 is converted first, being where all four claims landed. Its four blocks execute the claim/unclaim round trip, the refusal that lists claim ids, the refusal for a session holding nothing, and the `peers` / `peers --json` distinction.

The other skills mention 12 distinct verbs between them and remain unconverted — deliberately, so this PR is reviewable. Converting them is follow-up work, and the harness reports which files carry blocks so coverage is visible.

**It does not cover rustdoc.** Finding #4 above lived in a doc comment, outside any skill, and this mechanism would not have caught it. Nothing here replaces independent review; it removes one recurring class from the reviewer's plate.

## First integration test in the workspace

`.claude/CLAUDE.md` records that tests were inline until now. This one has to be an integration test: `CARGO_BIN_EXE_edda` is only defined for `tests/`.

## Evidence

- RAN `cargo fmt --all --check` — PASS
- RAN `cargo clippy -p edda --all-targets -- -D warnings` — PASS
- RAN `cargo test -p edda` — 308 unit + 2 integration, 0 failed
- RAN the mutation check above — 4/4 caught
- Lane: worktree default `target/`; no ad-hoc `CARGO_TARGET_DIR`
- Receipt: L0 focused gates above; `-p edda` is in the CI Windows test subset, so exact-head CI covers this crate on all three platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
