### PR TITLE
test(edda-cli): make a demoted doctest fence loud instead of silent

### DIFF
--- a/crates/edda-cli/tests/skill_doctest.rs
+++ b/crates/edda-cli/tests/skill_doctest.rs
@@ -23,6 +23,12 @@
 //! `$` runs a command, `>` asserts it succeeded and printed the text, and `!`
 //! asserts it failed with the text. Unmarked blocks are prose and are ignored,
 //! so existing examples do not have to be converted at once.
+//!
+//! Ignoring unmarked blocks is also how coverage could disappear: demoting a
+//! fence back to ```` ```bash ```` is a one-token edit that reads as cosmetic
+//! and silently stops that block from running. The steps it leaves behind are
+//! what give it away, so a `$ ` line inside an unmarked block is an error
+//! rather than prose.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -103,6 +109,36 @@ fn parse_blocks(markdown: &str) -> Vec<Vec<Step>> {
     blocks
 }
 
+/// Find doctest steps stranded in a block that is no longer marked as one.
+///
+/// `parse_blocks` ignores unmarked fences by design, so a demoted fence would
+/// otherwise drop its assertions with the suite still green. Nothing else in a
+/// skill starts a line with `$ `, so its presence outside a doctest fence means
+/// the marker was lost rather than that the block is prose.
+fn find_demoted_steps(markdown: &str) -> Vec<String> {
+    let mut stranded = Vec::new();
+    let mut in_fence = false;
+    let mut is_doctest = false;
+
+    for line in markdown.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            if in_fence {
+                in_fence = false;
+                is_doctest = false;
+            } else {
+                in_fence = true;
+                is_doctest = trimmed == "```bash edda-doctest";
+            }
+            continue;
+        }
+        if in_fence && !is_doctest && trimmed.starts_with("$ ") {
+            stranded.push(trimmed.to_string());
+        }
+    }
+    stranded
+}
+
 struct Outcome {
     ok: bool,
     text: String,
@@ -165,6 +201,17 @@ fn shipped_skill_examples_still_do_what_they_say() {
         }
         let name = path.file_name().unwrap().to_string_lossy().into_owned();
         let markdown = std::fs::read_to_string(&path).expect("read skill");
+
+        // Checked before the emptiness test: a file whose only doctest fence
+        // was demoted parses to zero blocks, which is precisely the silent
+        // loss this guard exists to make loud.
+        let stranded = find_demoted_steps(&markdown);
+        assert!(
+            stranded.is_empty(),
+            "{name}: doctest steps sit in a block that is not marked \
+             ```bash edda-doctest, so they never run: {stranded:?}"
+        );
+
         let blocks = parse_blocks(&markdown);
         if blocks.is_empty() {
             continue;
@@ -231,6 +278,32 @@ fn shipped_skill_examples_still_do_what_they_say() {
         dir.display()
     );
     println!("skill doctests: {checked} assertions across {files_with_blocks:?}");
+}
+
+#[test]
+fn a_demoted_fence_is_an_error_rather_than_silence() {
+    let demoted = "```bash\n$ edda claim \"auth\"\n> session: cli-auth\n```\n";
+    assert_eq!(
+        find_demoted_steps(demoted).len(),
+        1,
+        "a doctest block whose marker was removed must be reported"
+    );
+    assert!(
+        parse_blocks(demoted).is_empty(),
+        "and it must indeed have stopped running, which is why reporting matters"
+    );
+
+    let marked = "```bash edda-doctest\n$ edda claim \"auth\"\n> session: cli-auth\n```\n";
+    assert!(
+        find_demoted_steps(marked).is_empty(),
+        "a properly marked block is not stranded"
+    );
+
+    let prose = "```bash\nedda claim \"auth\" --paths \"src/a/*\"\n```\n";
+    assert!(
+        find_demoted_steps(prose).is_empty(),
+        "an ordinary example without doctest steps stays prose"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #490, filed from the #489 review.

## The gap

`skill_doctest.rs` guarded coverage with one global assertion:

```rust
assert!(checked > 0, "no skill doctest assertions ran; ...");
```

That catches total loss. It does not catch partial loss. Changing one block's fence from ` ```bash edda-doctest ` to ` ```bash ` is a one-token edit that reads as cosmetic, and the block silently stops running — the #489 reviewer reproduced it dropping 10 assertions to 8, exit 0.

Harmless while one skill is converted. Not harmless the moment a second is, which #489 states as the next step: the other skills mention 12 distinct verbs between them.

## The fix

Derive the expectation from the file instead of from a list to keep in sync.

Nothing in a skill starts a line with `$ ` except a doctest step. So a `$ ` line inside an **unmarked** fence means the marker was lost — not that the block is prose:

```rust
if in_fence && !is_doctest && trimmed.starts_with("$ ") {
    stranded.push(trimmed.to_string());
}
```

Two details that matter:

- The check runs **before** the empty-blocks early return. A file whose only fence was demoted parses to zero doctest blocks, so the old flow skipped it entirely — exactly the case the guard exists for.
- Ordinary ` ```bash ` examples are untouched. Verified across the shipped skills: the only `$ `-prefixed lines anywhere are the four converted blocks, and the eight plain bash blocks use bare `edda …` lines.

## Mutation-tested, not merely green

A passing test proves nothing here, so I reproduced the reviewer's scenario in three positions:

```
CAUGHT  demote the first fence
CAUGHT  demote the last fence
CAUGHT  demote every fence
```

3/3 rejected; file restored and verified back at four fences. The mutation script is not committed — it is evidence about the guard, not a fixture.

A unit test pins the behavior directly: a demoted block is reported **and** confirmed to have stopped running (so the report is not decorative), a marked block is not reported, and an ordinary example without doctest steps stays prose.

## Residual gap, stated rather than papered over

Deleting a whole block removes the `$ ` lines with it and is **not** caught. That is a visible content removal in a diff, unlike a fence tag change, so it stays reviewer territory. A checked-in per-file baseline would catch it too, at the cost of a list to maintain; I judged that not worth it for a failure mode that is already loud in review, but it is a defensible call to disagree with.

## Evidence

- RAN `cargo fmt --all --check` — PASS
- RAN `cargo clippy -p edda --all-targets -- -D warnings` — PASS
- RAN `cargo test -p edda` — 308 unit + 3 integration, 0 failed
- RAN the three-position mutation check above — 3/3 caught
- RAN `grep -rn '^\s*\$ ' crates/edda-cli/src/skills/*.md` — only the four converted blocks, so no existing example false-positives
- Lane: worktree default `target/`; no ad-hoc `CARGO_TARGET_DIR`
- Receipt: L0 focused gates above; `-p edda` is in the CI Windows test subset

Note for the reviewer: #489's exact-head CI showed a 26-minute `Test (ubuntu-latest)`, independently traced to runner degradation rather than the harness (the doctest binary itself ran 1.96s on Windows, while the untouched 304-test unit binary went 4.2s to 667s in the same run). Worth a glance at this PR's timings to confirm that reading held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
