### PR TITLE
docs(edda-conductor): say what the liveness probe guarantees, and rename a test

### DIFF
--- a/crates/edda-conductor/src/agent/codex_app_server.rs
+++ b/crates/edda-conductor/src/agent/codex_app_server.rs
@@ -439,7 +439,16 @@ mod tests {
         {
             let script = dir.path().join("fake-app-server.ps1");
             std::fs::write(&script, powershell_fake_script(scenario))?;
-            let mut command = Command::new("powershell.exe");
+            // Absolute where the platform offers a reliable one, so a doctored
+            // PATH cannot choose the shell this harness runs. `%SystemRoot%` is
+            // set on every Windows install; falling back to PATH keeps the
+            // helper working if it is somehow absent (GH-482).
+            let mut command = match std::env::var("SystemRoot") {
+                Ok(root) => Command::new(format!(
+                    "{root}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+                )),
+                Err(_) => Command::new("powershell.exe"),
+            };
             command.args([
                 "-NoLogo",
                 "-NoProfile",
@@ -463,11 +472,13 @@ mod tests {
             // the script read-only, so that window cannot bite.
             let script = dir.path().join("fake-app-server.sh");
             std::fs::write(&script, shell_fake_script(scenario))?;
-            // Absolute, where the Windows branch above lets PATH resolve
-            // powershell.exe. The asymmetry is deliberate: `/bin/sh` is
-            // guaranteed by POSIX at that path, so resolving it through PATH
-            // would only add a way for a doctored PATH to choose the shell
-            // this harness runs (GH-482).
+            // Absolute for the same reason as the Windows branch above. Note
+            // POSIX does *not* fix this path -- the `sh` page's Application
+            // Usage says so outright and points applications at `getconf PATH`,
+            // and Solaris put the conformant shell under /usr/xpg4/bin. What
+            // makes it safe here is narrower: every platform this harness runs
+            // on has /bin/sh, so pinning it costs portability we do not need
+            // and removes a lookup we do not control (GH-482).
             let mut command = Command::new("/bin/sh");
             command.arg(script);
             Ok((dir, command))
@@ -566,12 +577,23 @@ mod tests {
     /// arguments -- BusyBox does not accept `-o state= -p`, and the two cases
     /// are indistinguishable from the exit status alone. On such a system a
     /// caller waiting for exit would pass without the process having gone
-    /// anywhere. The pre-existing `kill -0` probe had the same blind spot; it
-    /// is recorded rather than fixed because `ci.yml` runs only the three
+    /// anywhere.
+    ///
+    /// The `kill -0` probe this replaced shared the *class* of flaw and was in
+    /// one way worse -- it swallowed spawn failure too. But on BusyBox, the
+    /// trigger named above, the two do not match: BusyBox `kill` parses numeric
+    /// signals, so `kill -0` worked there, while its `ps` rejects these
+    /// arguments twice over (the state column is `stat`, and an unknown `-o`
+    /// column is fatal; `-p` is not in its base option set). So the switch to
+    /// `ps` made this case reachable on exactly the platform class the
+    /// deferral cites, rather than inheriting it.
+    ///
+    /// It is recorded rather than fixed because `ci.yml` runs only the three
     /// GitHub-hosted images, none of them musl or Alpine and none in a
-    /// container. Distinguishing them (treating a non-zero exit that also
-    /// wrote to stderr as a probe failure) is worth doing the day such a job
-    /// is added (GH-482).
+    /// container -- so no job can reach it today. Distinguishing the two
+    /// (treating a non-zero exit that also wrote to stderr as a probe failure)
+    /// is worth doing the day such a job is added, and this note is what should
+    /// make that obvious then (GH-482).
     fn process_is_alive(pid: u32) -> anyhow::Result<bool> {
         #[cfg(windows)]
         {

--- a/crates/edda-conductor/src/agent/codex_app_server.rs
+++ b/crates/edda-conductor/src/agent/codex_app_server.rs
@@ -463,6 +463,11 @@ mod tests {
             // the script read-only, so that window cannot bite.
             let script = dir.path().join("fake-app-server.sh");
             std::fs::write(&script, shell_fake_script(scenario))?;
+            // Absolute, where the Windows branch above lets PATH resolve
+            // powershell.exe. The asymmetry is deliberate: `/bin/sh` is
+            // guaranteed by POSIX at that path, so resolving it through PATH
+            // would only add a way for a doctored PATH to choose the shell
+            // this harness runs (GH-482).
             let mut command = Command::new("/bin/sh");
             command.arg(script);
             Ok((dir, command))
@@ -555,6 +560,18 @@ mod tests {
     /// absent" is not something drop can guarantee -- "the process no longer
     /// runs" is. A zombie has already terminated, so it does not count as
     /// alive; a child that drop failed to kill still does.
+    ///
+    /// The unix probe reads a non-zero `ps` exit as "gone". That is right when
+    /// `ps` ran and found nothing, and wrong when `ps` itself rejected the
+    /// arguments -- BusyBox does not accept `-o state= -p`, and the two cases
+    /// are indistinguishable from the exit status alone. On such a system a
+    /// caller waiting for exit would pass without the process having gone
+    /// anywhere. The pre-existing `kill -0` probe had the same blind spot; it
+    /// is recorded rather than fixed because `ci.yml` runs only the three
+    /// GitHub-hosted images, none of them musl or Alpine and none in a
+    /// container. Distinguishing them (treating a non-zero exit that also
+    /// wrote to stderr as a probe failure) is worth doing the day such a job
+    /// is added (GH-482).
     fn process_is_alive(pid: u32) -> anyhow::Result<bool> {
         #[cfg(windows)]
         {
@@ -764,7 +781,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn dropping_concrete_client_makes_child_pid_disappear() -> anyhow::Result<()> {
+    async fn dropping_concrete_client_stops_the_child_process() -> anyhow::Result<()> {
         let (_fake, server) = spawn_fake_app_server(FakeScenario::Idle).await?;
         let pid = server.child.id().context("fake app-server has no PID")?;
 

--- a/docs/superpowers/specs/2026-08-18-verification-cost-discipline-design.md
+++ b/docs/superpowers/specs/2026-08-18-verification-cost-discipline-design.md
@@ -310,8 +310,11 @@ the tool enforces a limit against an artificially inflated number.
    `fleet-pr-loop` "re-run gates" wording; `edda gate` native receipts;
    Bash twin of `lane.ps1`; repo-level gate profile override; operator
    decision on the `EXECUTION-COORDINATION.md` axiom; the pre-existing
-   ubuntu-only flake `codex_app_server::tests::dropping_concrete_client_makes_child_pid_disappear`
-   observed red on `7f5d155` (classified baseline; unrelated to PR #479).
+   ubuntu-only flake in `codex_app_server` observed red on `7f5d155`
+   (classified baseline; unrelated to PR #479). The test was
+   `dropping_concrete_client_makes_child_pid_disappear`, renamed to
+   `..._stops_the_child_process` in GH-482 because a zombie has already
+   terminated, so the assertion was never about the PID disappearing.
 
 ## 6. Acceptance criteria
 


### PR DESCRIPTION
Closes #482, filed from the independent review of #480.

## 1. The doc overclaimed what the probe guarantees

The overclaim was that the probe errors rather than reporting "gone" when it cannot run. **Correction to this PR's original description and to #482's:** that sentence was never in a comment — it is from commit `813f416`'s *message*, and a grep of the base for it returns nothing. #482 inherited the misattribution from the review that filed it, and this body repeated it for two rounds. The doc did overclaim, but not in those words.

The claim itself holds only when `ps` is **absent**, where ENOENT propagates. A `ps` that exists but rejects `-o state= -p` — BusyBox — exits non-zero, and the code cannot tell that apart from *the PID is genuinely gone*. On such a system `wait_for_pid_exit` passes vacuously: the caller believes the process stopped when nothing was ever observed.

**The behaviour is not the wrong part.** Distinguishing the two cases only earns its cost the day a musl/Alpine or container job exists — `ci.yml` runs the three GitHub-hosted images, no `container:`, and nothing else. So the doc states the limit and the condition under which fixing it is worth doing, which is what the issue recommended.

The comparison to the probe this replaced is **narrower than Round 1 first claimed**. The old `kill -0` probe shared the class of flaw and was worse in one way — it swallowed spawn failure too. But on BusyBox, the trigger the doc names, the two diverge: BusyBox `kill` parses numeric signals, so `kill -0` worked there, while its `ps` rejects these arguments on two independent grounds (the state column is `stat`, and an unknown `-o` column is fatal; `-p` is not in its base option set). The switch to `ps` therefore made this case *reachable* on exactly the platform class the deferral cites, rather than inheriting it. The doc says so, because that strengthens the case for recording the limit.

## 2. The shell-path asymmetry — resolved by consistency, not justification

`fake_app_server` used an absolute `/bin/sh` while the Windows branch let PATH resolve `powershell.exe`. The issue asked for **either justification or consistency**.

The justification originally written here was false: `/bin/sh` is *not* guaranteed by POSIX. POSIX does not standardise utility locations, and the `sh` page's Application Usage says so directly, pointing applications at `getconf PATH`; Solaris ≤10 put the conformant shell at `/usr/xpg4/bin/sh`. And the comment named PATH resolution as the hazard while leaving the Windows branch doing precisely that, unchanged and unmentioned.

So this takes consistency:

- **Windows** resolves `powershell.exe` under `%SystemRoot%`, falling back to PATH only if the variable is missing.
- **POSIX** keeps the absolute `/bin/sh`, on the true and narrower premise: every platform this harness runs on has it, so pinning it costs portability we do not need and removes a lookup we do not control. The comment states that POSIX does not fix the path, so the next reader cannot re-derive the old error.

This is the one place the PR changes code rather than comments.

## 3. The test name outlived its assertion

`dropping_concrete_client_makes_child_pid_disappear` → `..._stops_the_child_process`. The assertion was already correct — a zombie has terminated, so it passes — and only the name still described a PID disappearing.

The spec's mention of that flake carries the rename inline, so a reader searching the old name finds where it went. The **plan** keeps the old name untouched: it is a frozen execution record of what was true at `738c5ce`, and carries an explicit banner saying so.

Two sibling names with the same defect (`cancelling_concrete_method_makes_child_pid_disappear`, and the `wait_for_pid_exit` helper) are **#506**, along with the Windows arm of `process_is_alive` not checking `output.status`.

## Evidence

- RAN `cargo fmt --all --check` — PASS
- RAN `cargo clippy -p edda-conductor --all-targets -- -D warnings` — PASS
- RAN `cargo test -p edda-conductor` — **166 passed, 0 failed, 1 ignored**, including the renamed test and going through the new `%SystemRoot%` path
- RAN a check that `%SystemRoot%` is set and the absolute powershell path exists on this workstation
- RAN `grep` for the old test name across `crates/` and `docs/` — handled as described above
- Lane: worktree default `target/`; no ad-hoc `CARGO_TARGET_DIR`
- Receipt: L0 focused gates above; `edda-conductor` is in the CI Windows test subset, so exact-head CI covers all three platforms

## Review history

- `Code Review: Round 1` on `9762e11` — P1=2, Changes Requested
- `Review Response: Round 1` — both fixed; four findings routed to #506
- Round 2 requested on `6df688cceaeaa44d5ef9a65d2f6b15ee1b49f8a6`
