### PR TITLE
fix(edda-cli): say which claim a new one replaced

### DIFF
--- a/crates/edda-cli/src/cmd_bridge.rs
+++ b/crates/edda-cli/src/cmd_bridge.rs
@@ -656,6 +656,53 @@ pub fn peers(repo_root: &Path, json: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// The lines `claim` prints about what a new claim did to the session's old one.
+///
+/// Split out so the strings — and, more importantly, the *absence* of a
+/// `released:` line — can be asserted. Reporting a release that did not happen
+/// is the same false success this disclosure exists to remove.
+fn claim_disclosure(
+    previous: Option<&edda_bridge_claude::peers::ClaimEntry>,
+    label: &str,
+    paths: &[String],
+) -> Vec<String> {
+    let Some(previous) = previous else {
+        return vec![format!("Claimed scope: {label}")];
+    };
+
+    // Only paths the new claim no longer covers were actually let go. Naming
+    // `previous.paths` wholesale said "released" about paths this very command
+    // had just re-claimed — and an idempotent re-claim hits exactly that, since
+    // tier 4 mints a deterministic `cli-<label>` and board claims never expire,
+    // so a bare-shell restart re-runs the same command against its own
+    // surviving claim.
+    let released: Vec<&str> = previous
+        .paths
+        .iter()
+        .filter(|p| !paths.contains(p))
+        .map(String::as_str)
+        .collect();
+    let gained = paths.iter().any(|p| !previous.paths.contains(p));
+
+    let mut lines = Vec::new();
+    if previous.label != label {
+        lines.push(format!(
+            "Claimed scope: {label} (replaces this session's earlier claim on {})",
+            previous.label
+        ));
+    } else if released.is_empty() && !gained {
+        lines.push(format!("Re-claimed scope: {label} (unchanged)"));
+    } else {
+        lines.push(format!(
+            "Re-claimed scope: {label} (previous paths replaced)"
+        ));
+    }
+    if !released.is_empty() {
+        lines.push(format!("  released: {}", released.join(", ")));
+    }
+    lines
+}
+
 /// `edda bridge claude claim <label>` — claim a coordination scope
 ///
 /// The board folds claims into one per session, so a second claim replaces the
@@ -679,20 +726,8 @@ pub fn claim(
         .find(|c| c.session_id == session_id);
 
     edda_bridge_claude::peers::write_claim(&project_id, &session_id, label, paths);
-    if let Some(previous) = replaced {
-        if previous.label == label {
-            println!("Re-claimed scope: {label} (previous paths replaced)");
-        } else {
-            println!(
-                "Claimed scope: {label} (replaces this session's earlier claim on {})",
-                previous.label
-            );
-        }
-        if !previous.paths.is_empty() {
-            println!("  released: {}", previous.paths.join(", "));
-        }
-    } else {
-        println!("Claimed scope: {label}");
+    for line in claim_disclosure(replaced.as_ref(), label, paths) {
+        println!("{line}");
     }
     if !paths.is_empty() {
         println!("  paths: {}", paths.join(", "));
@@ -2301,6 +2336,93 @@ mod tests {
         assert!(body.contains("\"from_label\":\"auth\""), "{body}");
         assert!(body.contains("\"to_label\":\"billing\""), "{body}");
         assert!(body.contains("\"message\":\"need invoice type\""), "{body}");
+    }
+
+    fn prior_claim(label: &str, paths: &[&str]) -> edda_bridge_claude::peers::ClaimEntry {
+        edda_bridge_claude::peers::ClaimEntry {
+            session_id: "s1".into(),
+            label: label.into(),
+            paths: paths.iter().map(|p| (*p).to_string()).collect(),
+            ts: "2026-08-20T00:00:00Z".into(),
+        }
+    }
+
+    fn owned(paths: &[&str]) -> Vec<String> {
+        paths.iter().map(|p| (*p).to_string()).collect()
+    }
+
+    // The disclosure lines are asserted here rather than only through the board,
+    // because a test that reads `compute_board_state` passes whether or not
+    // anything was printed -- the fold it checks pre-dates this change.
+
+    #[test]
+    fn a_first_claim_reports_no_replacement() {
+        assert_eq!(
+            claim_disclosure(None, "auth", &owned(&["src/auth/*"])),
+            vec!["Claimed scope: auth"]
+        );
+    }
+
+    #[test]
+    fn a_new_label_names_the_claim_it_replaced() {
+        let previous = prior_claim("auth", &["src/auth/*"]);
+        assert_eq!(
+            claim_disclosure(Some(&previous), "api", &owned(&["src/api/*"])),
+            vec![
+                "Claimed scope: api (replaces this session's earlier claim on auth)",
+                "  released: src/auth/*",
+            ]
+        );
+    }
+
+    #[test]
+    fn an_identical_re_claim_releases_nothing() {
+        // The regression this verb exists to prevent, in its own image: the
+        // first version printed "released: src/api/*" for a command that had
+        // just re-claimed `src/api/*`. A bare-shell restart re-running its own
+        // command hits this, so it is the common case, not a corner.
+        let previous = prior_claim("api", &["src/api/*"]);
+        assert_eq!(
+            claim_disclosure(Some(&previous), "api", &owned(&["src/api/*"])),
+            vec!["Re-claimed scope: api (unchanged)"],
+            "an unchanged re-claim reports no release at all"
+        );
+    }
+
+    #[test]
+    fn narrowing_reports_only_the_path_it_gave_up() {
+        let previous = prior_claim("api", &["src/api/*", "src/api/v2/*"]);
+        assert_eq!(
+            claim_disclosure(Some(&previous), "api", &owned(&["src/api/v2/*"])),
+            vec![
+                "Re-claimed scope: api (previous paths replaced)",
+                "  released: src/api/*",
+            ],
+            "src/api/v2/* is still claimed, so it is not released"
+        );
+    }
+
+    #[test]
+    fn widening_reports_a_change_but_no_release() {
+        let previous = prior_claim("api", &["src/api/*"]);
+        assert_eq!(
+            claim_disclosure(
+                Some(&previous),
+                "api",
+                &owned(&["src/api/*", "src/api/v3/*"])
+            ),
+            vec!["Re-claimed scope: api (previous paths replaced)"]
+        );
+    }
+
+    #[test]
+    fn a_relabel_that_keeps_every_path_releases_nothing() {
+        let previous = prior_claim("auth", &["src/auth/*"]);
+        assert_eq!(
+            claim_disclosure(Some(&previous), "identity", &owned(&["src/auth/*"])),
+            vec!["Claimed scope: identity (replaces this session's earlier claim on auth)"],
+            "the label moved but the scope did not, so nothing was released"
+        );
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_bridge.rs
+++ b/crates/edda-cli/src/cmd_bridge.rs
@@ -657,6 +657,13 @@ pub fn peers(repo_root: &Path, json: bool) -> anyhow::Result<()> {
 }
 
 /// `edda bridge claude claim <label>` — claim a coordination scope
+///
+/// The board folds claims into one per session, so a second claim replaces the
+/// first rather than adding to it. That is the right shape — it is how a
+/// session narrows or moves its scope, and how a restart re-claims
+/// idempotently — but it used to happen in silence, so a worker could believe
+/// it held two scopes while peers saw one (GH-488). The replacement is now
+/// named.
 pub fn claim(
     repo_root: &Path,
     label: &str,
@@ -666,8 +673,27 @@ pub fn claim(
     let project_id = edda_store::project_id(repo_root);
     let (session_id, _) = resolve_session_id(cli_session, &project_id, label);
 
+    let replaced = edda_bridge_claude::peers::compute_board_state(&project_id)
+        .claims
+        .into_iter()
+        .find(|c| c.session_id == session_id);
+
     edda_bridge_claude::peers::write_claim(&project_id, &session_id, label, paths);
-    println!("Claimed scope: {label}");
+    if let Some(previous) = replaced {
+        if previous.label == label {
+            println!("Re-claimed scope: {label} (previous paths replaced)");
+        } else {
+            println!(
+                "Claimed scope: {label} (replaces this session's earlier claim on {})",
+                previous.label
+            );
+        }
+        if !previous.paths.is_empty() {
+            println!("  released: {}", previous.paths.join(", "));
+        }
+    } else {
+        println!("Claimed scope: {label}");
+    }
     if !paths.is_empty() {
         println!("  paths: {}", paths.join(", "));
     }
@@ -2275,6 +2301,75 @@ mod tests {
         assert!(body.contains("\"from_label\":\"auth\""), "{body}");
         assert!(body.contains("\"to_label\":\"billing\""), "{body}");
         assert!(body.contains("\"message\":\"need invoice type\""), "{body}");
+    }
+
+    #[test]
+    fn a_second_claim_replaces_the_first_and_says_so() {
+        let _store = crate::test_support::isolated_store();
+        let _env = env_guard();
+        std::env::remove_var("EDDA_SESSION_ID");
+        std::env::remove_var("EDDA_SESSION_LABEL");
+        let repo = tempfile::tempdir().expect("tempdir");
+        let pid = edda_store::project_id(repo.path());
+        let _ = edda_store::ensure_dirs(&pid);
+
+        claim(repo.path(), "auth", &["src/auth/*".into()], Some("s1")).expect("first claim");
+        claim(repo.path(), "api", &["src/api/*".into()], Some("s1")).expect("second claim");
+
+        // The board folds to one claim per session, so the first scope is gone.
+        // GH-488 item 2 was that this happened without saying so; the printed
+        // line is the fix, and the fold is the behaviour it discloses.
+        let claims = edda_bridge_claude::peers::compute_board_state(&pid).claims;
+        assert_eq!(claims.len(), 1, "one session holds one claim");
+        assert_eq!(claims[0].label, "api");
+        assert_eq!(claims[0].paths, vec!["src/api/*".to_string()]);
+    }
+
+    #[test]
+    fn re_claiming_the_same_label_keeps_one_claim() {
+        let _store = crate::test_support::isolated_store();
+        let _env = env_guard();
+        std::env::remove_var("EDDA_SESSION_ID");
+        std::env::remove_var("EDDA_SESSION_LABEL");
+        let repo = tempfile::tempdir().expect("tempdir");
+        let pid = edda_store::project_id(repo.path());
+        let _ = edda_store::ensure_dirs(&pid);
+
+        // Narrowing a scope, and re-claiming after a restart, both go through
+        // this path -- which is why replacement is right and rejecting a second
+        // claim would not be.
+        claim(
+            repo.path(),
+            "auth",
+            &["src/auth/*".into(), "src/token/*".into()],
+            Some("s1"),
+        )
+        .expect("first claim");
+        claim(repo.path(), "auth", &["src/auth/*".into()], Some("s1")).expect("narrowed claim");
+
+        let claims = edda_bridge_claude::peers::compute_board_state(&pid).claims;
+        assert_eq!(claims.len(), 1);
+        assert_eq!(claims[0].paths, vec!["src/auth/*".to_string()]);
+    }
+
+    #[test]
+    fn one_session_claiming_does_not_disturb_another() {
+        let _store = crate::test_support::isolated_store();
+        let _env = env_guard();
+        std::env::remove_var("EDDA_SESSION_ID");
+        std::env::remove_var("EDDA_SESSION_LABEL");
+        let repo = tempfile::tempdir().expect("tempdir");
+        let pid = edda_store::project_id(repo.path());
+        let _ = edda_store::ensure_dirs(&pid);
+
+        claim(repo.path(), "auth", &["src/auth/*".into()], Some("s1")).expect("s1 claim");
+        claim(repo.path(), "api", &["src/api/*".into()], Some("s2")).expect("s2 claim");
+
+        let mut claims = edda_bridge_claude::peers::compute_board_state(&pid).claims;
+        claims.sort_by(|a, b| a.session_id.cmp(&b.session_id));
+        assert_eq!(claims.len(), 2, "the fold is per session, not global");
+        assert_eq!(claims[0].label, "auth");
+        assert_eq!(claims[1].label, "api");
     }
 
     #[test]

--- a/crates/edda-cli/src/skills/coord-sync.md
+++ b/crates/edda-cli/src/skills/coord-sync.md
@@ -49,6 +49,27 @@ Guidelines:
 - Paths should use glob patterns (e.g., `crates/edda-store/*`)
 - If auto-claim already set a scope from your edits, show it and ask if manual override is needed
 
+A session holds **one** claim, so claiming again replaces the previous one
+rather than adding to it. That is how a scope is narrowed or moved, and how a
+restart re-claims — so the command says what it did to the old claim, and names
+only the paths it actually gave up:
+
+```bash edda-doctest
+$ edda claim "auth" --paths "src/auth/*" --session s1
+> Claimed scope: auth
+$ edda claim "api" --paths "src/api/*" --session s1
+> Claimed scope: api (replaces this session's earlier claim on auth)
+> released: src/auth/*
+$ edda claim "api" --paths "src/api/*" --session s1
+> Re-claimed scope: api (unchanged)
+$ edda claim "api" --paths "src/api/v2/*" --session s1
+> Re-claimed scope: api (previous paths replaced)
+> released: src/api/*
+```
+
+Re-running the same claim releases nothing — it is the same scope, not a new
+one. A peer's claim is untouched either way; the replacement is per session.
+
 ### Step 5: Acknowledge Requests
 
 For each pending request addressed to your label:


### PR DESCRIPTION
Delivers item 2 of **#488**. Items 3, 4 and 5 ship in #496; item 1 continues as #503.

No PR carries an auto-close link for #488 — an earlier version of this body said one did, which stopped being true when #496's body was corrected. #488 stays open and should be retired deliberately, with a pointer to #503, once this and #496 have both merged.

## The defect was silence, not the fold

`compute_board_state` keys claims by `session_id`, so one session holds one claim and a second replaces the first. That happened with no output, and a worker could believe it held two scopes while every peer saw one.

The issue offered three fixes. Only disclosure survives contact with normal use:

| Option | Why not |
|---|---|
| Reject the second claim | breaks narrowing a scope, and breaks re-claiming idempotently after a restart — both go through this path |
| Merge the paths | a scope could then never be narrowed, only grown |
| **Say what happened** | changes no behaviour; fixes the thing actually complained about |

## What it prints now

Captured from a real binary built at this content, in a throwaway repo under an isolated `EDDA_STORE_ROOT` — full output, including the two lines `claim` has always printed:

```
$ edda claim auth --paths "src/auth/*" --session s1
Claimed scope: auth
  paths: src/auth/*
  session: s1

$ edda claim api --paths "src/api/*" --session s1
Claimed scope: api (replaces this session's earlier claim on auth)
  released: src/auth/*
  paths: src/api/*
  session: s1

$ edda claim api --paths "src/api/*" --session s1
Re-claimed scope: api (unchanged)
  paths: src/api/*
  session: s1

$ edda claim api --paths "src/api/v2/*" --session s1
Re-claimed scope: api (previous paths replaced)
  released: src/api/*
  paths: src/api/v2/*
  session: s1

$ edda claim docs --paths "docs/*" --session s2
Claimed scope: docs
  paths: docs/*
  session: s2
```

The last one shows the fold is per session: `s2` is untouched by anything `s1` did.

## `released` names only what was actually given up

The third case above is the one Round 1 caught. `released` is the previous claim's paths **minus** the new ones, not the previous paths wholesale — so:

- an identical re-claim reports `(unchanged)` and releases nothing
- a relabel that keeps every path releases nothing
- narrowing names only the path it gave up, not the one still held

An idempotent re-claim is routine, not exotic: tier 4 mints a deterministic `cli-<label>` and board claims never expire, so a bare-shell restart re-running its own command hits it every time. Announcing a release there would be the same false success this disclosure exists to remove.

## What asserts it

The message construction is `claim_disclosure`, which returns the lines rather than printing them, so the **absence** of a `released:` line is assertable:

| Test | Establishes |
|---|---|
| `a_first_claim_reports_no_replacement` | one line, no replacement clause |
| `a_new_label_names_the_claim_it_replaced` | header names the old label; released line present |
| `an_identical_re_claim_releases_nothing` | `(unchanged)`, **exactly one line** |
| `narrowing_reports_only_the_path_it_gave_up` | the still-held path is not reported released |
| `widening_reports_a_change_but_no_release` | changed, nothing released |
| `a_relabel_that_keeps_every_path_releases_nothing` | label moved, scope did not |

Plus an `edda-doctest` block in `coord-sync.md` running all four cases against the built binary, so the wiring is covered end to end and not just the pure function. Mutating one expectation fails the harness with the real output.

The three board-level tests remain — a second claim under a different label leaves one claim, narrowing leaves one claim with the narrowed paths, two sessions keep two claims — but they are no longer the only coverage, since they would pass whether or not anything was printed.

## The automatic path gains no noise

`autoclaim` calls `peers::write_claim` directly and never reaches this verb, so a hooked session's output is unchanged. Only the explicit CLI verb discloses.

## What this does not do

The disclosure reaches the **caller**, not the victim. A session whose claim was replaced by a misattributed command sees its injected context render the new board with no notice that anything changed. That is the identity half, and it stays open as #503 — this PR makes the event leave a trace, it does not prevent it.

## Evidence

- RAN `cargo fmt --all --check` — PASS
- RAN `cargo clippy -p edda --all-targets -- -D warnings` — PASS
- RAN `cargo test -p edda` — **317 unit + 10 integration, 0 failed**
- RAN the transcript above end to end from a binary built at this content
- RAN a mutation of one doctest expectation, to establish the assertion is live
- Lane: worktree default `target/`; no ad-hoc `CARGO_TARGET_DIR`
- Receipt: L0 focused gates above. `edda` is inside the CI Windows test subset (GH-433), so exact-head CI covers this on all three platforms
