### PR TITLE
fix(edda-bridge-codex): emit hook event name

### DIFF
--- a/crates/edda-bridge-codex/src/dispatch.rs
+++ b/crates/edda-bridge-codex/src/dispatch.rs
@@ -4,7 +4,10 @@
 //! ```json
 //! {
 //!   "continue": true,
-//!   "hookSpecificOutput": { "additionalContext": "..." }
+//!   "hookSpecificOutput": {
+//!     "hookEventName": "SessionStart",
+//!     "additionalContext": "..."
+//!   }
 //! }
 //! ```
 //!
@@ -42,10 +45,13 @@ fn ok() -> HookResult {
     HookResult::output(r#"{"continue":true}"#.to_string())
 }
 
-fn with_context(context: &str) -> anyhow::Result<HookResult> {
+fn with_context(hook_event_name: &str, context: &str) -> anyhow::Result<HookResult> {
     let output = serde_json::json!({
         "continue": true,
-        "hookSpecificOutput": { "additionalContext": context }
+        "hookSpecificOutput": {
+            "hookEventName": hook_event_name,
+            "additionalContext": context
+        }
     });
     Ok(HookResult::output(serde_json::to_string(&output)?))
 }
@@ -148,7 +154,7 @@ fn dispatch_session_start(
     let budgeted_body = render::apply_budget(&body, body_budget);
     let content = format!("{budgeted_body}{tail}");
     let wrapped = render::wrap_boundary(&content);
-    with_context(&wrapped)
+    with_context(&envelope.hook_event_name, &wrapped)
 }
 
 // ── UserPromptSubmit: light workspace-only injection with dedup ──
@@ -176,7 +182,7 @@ fn dispatch_user_prompt_submit(
     if !session_id.is_empty() {
         state::write_inject_hash(project_id, session_id, &wrapped);
     }
-    with_context(&wrapped)
+    with_context(&envelope.hook_event_name, &wrapped)
 }
 
 // ── PreToolUse: L3 rule evaluation ──
@@ -216,7 +222,7 @@ fn dispatch_pre_tool_use(project_id: &str, envelope: &CodexEnvelope) -> anyhow::
         let _ = rules_store.save_project(project_id);
     }
     match edda_postmortem::hooks::format_warnings(&result) {
-        Some(warning) => with_context(&warning),
+        Some(warning) => with_context(&envelope.hook_event_name, &warning),
         None => Ok(ok()),
     }
 }
@@ -252,7 +258,7 @@ fn dispatch_post_tool_use(
     }
     state::mark_nudge_sent(project_id, session_id);
     state::increment_counter(project_id, session_id, "nudge_count");
-    with_context(&nudge_text)
+    with_context(&envelope.hook_event_name, &nudge_text)
 }
 
 // ── PreCompact / SessionEnd ──
@@ -327,6 +333,7 @@ mod tests {
         let stdin = stdin_event("SessionStart", tmp.path().to_str().unwrap(), "codex-ss-1");
         let r = hook_entrypoint_from_stdin(&stdin).unwrap();
         let v: serde_json::Value = serde_json::from_str(r.stdout.as_ref().unwrap()).unwrap();
+        assert_eq!(v["hookSpecificOutput"]["hookEventName"], "SessionStart");
         let ctx = v["hookSpecificOutput"]["additionalContext"]
             .as_str()
             .unwrap();


### PR DESCRIPTION
## Summary

- emit the required `hookSpecificOutput.hookEventName` from the shared Codex context-output helper
- pass the actual envelope event through SessionStart, UserPromptSubmit, PreToolUse, and PostToolUse
- add a SessionStart regression assertion and correct the documented output shape

Closes #509.

## Testing

- PASS `cargo fmt --all --check`
- PASS `cargo clippy --workspace --all-targets -- -D warnings`
- PASS `cargo test -p edda-bridge-codex` (16 passed)
- PASS actual `edda hook codex` CLI reproduction (`hookEventName=SessionStart`, context non-empty)
- `CARGO_INCREMENTAL=0 cargo test --workspace` reached an unrelated, load-sensitive existing timing assertion in `edda-core::secret_guard::tests::hot_path_under_ten_ms_for_realistic_length`: 538 ms / 515 ms versus a 500 ms threshold. The changed path is only `crates/edda-bridge-codex/src/dispatch.rs`.
- PASS isolated timing test (about 450 ms)
- PASS `cargo test -p edda-core --lib -- --test-threads=1` (189 passed)

Full SHA: `13284736233577dd5edb1725dd8cd9dc6a42c377`