### PR TITLE
fix(edda-bridge-claude): remove redundant test imports

### DIFF
--- a/crates/edda-bridge-claude/src/digest/tests.rs
+++ b/crates/edda-bridge-claude/src/digest/tests.rs
@@ -4,8 +4,6 @@ use std::path::Path;
 use super::extract::*;
 use super::helpers::*;
 use super::orchestrate::*;
-use super::prev::*;
-use super::render::*;
 use super::*;
 
 use std::io::Write;

--- a/crates/edda-bridge-claude/src/peers/tests.rs
+++ b/crates/edda-bridge-claude/src/peers/tests.rs
@@ -1,8 +1,6 @@
 use std::fs;
 
 use super::autoclaim::*;
-use super::board::*;
-use super::discovery::*;
 use super::heartbeat::*;
 use super::helpers::*;
 use super::render_coord::*;

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -626,7 +626,9 @@ impl SchedulerOutput {
                 "scheduler Query XML contains odd-length UTF-16"
             );
             let units = encoded
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|bytes| {
                     if little_endian {
                         u16::from_le_bytes([bytes[0], bytes[1]])


### PR DESCRIPTION
## Summary

Current Rust stable 1.98, with CI's `RUSTFLAGS=-Dwarnings`, exposed two layers of inherited lint failures:

- four redundant wildcard imports in two `edda-bridge-claude` test modules
- fixed-size `chunks_exact(2)` iteration in the Windows scheduler UTF-16 decoder

This removes the redundant imports and uses `as_chunks::<2>()` behind the existing even-length guard. No product behavior changes.

This is the separate current-base repair required by [PR #510 Round 1](https://github.com/fagemx/edda/pull/510#issuecomment-5381769518). PR #510 remains unchanged until this repair lands.

## Evidence

RED:

- [PR #510 CI run 32586901630](https://github.com/fagemx/edda/actions/runs/32586901630): all Clippy/Test platforms failed on redundant imports.
- [PR #511 CI run 32622013959](https://github.com/fagemx/edda/actions/runs/32622013959): tests passed after import removal; all Clippy platforms then exposed `clippy::chunks-exact-to-as-chunks`.

GREEN locally at full SHA `16d6549faa61a2c6031aa7755ccf8b9e2b4db848`:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p edda-bridge-claude` — 573 passed
- `cargo test -p edda scheduler_query_decodes_raw_utf16_xml_with_non_ascii_paths` — passed

Exact-head GitHub CI on Rust 1.98 is the acceptance gate.