### PR TITLE
docs(cli): correct claim reference syntax and semantics

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -202,13 +202,18 @@ edda claim <LABEL> [OPTIONS]
 | Option | Description |
 |--------|-------------|
 | `LABEL` | Short label (e.g. `"auth"`, `"billing"`) |
-| `--paths PATTERN` | File path patterns (e.g. `"src/auth/*"`) |
+| `--paths PATTERN` | One file path pattern; repeat for multiple patterns |
 | `--session ID` | Session ID (auto-inferred) |
 
 ```bash
 edda claim "auth" --paths "src/auth/*"
-edda claim "billing" --paths "src/billing/*,src/invoice/*"
+edda claim "billing" --paths "src/billing/*" --paths "src/invoice/*"
 ```
+
+A session holds one active claim. Running `edda claim` again from the same
+session replaces its previous label and complete path list; it does not add a
+second claim. Pass each path pattern with its own `--paths` flag; comma-separated
+values are not split.
 
 ### `edda request`
 


### PR DESCRIPTION
## Summary
- correct the multi-path claim example to repeat `--paths`
- document the single active claim per session and replacement of the complete prior scope
- sweep the other list-valued examples and per-session coordination folds in this page; no other same-shape correction was needed

## Doctest harness disposition
Not expanded in this docs-only change. The current `skill_doctest` harness scans assertion transcripts under `crates/edda-cli/src/skills`; covering generic `docs/reference/` command listings needs a separate conversion and coverage design.

## Verification
- `git diff --check`
- read-only assertions: only `docs/reference/cli.md` changed; no comma-packed values remain for non-delimited repeatable flags; repeated `--paths` and replacement text are present
- Cargo: not run (docs-only; lane n/a)
- exact-head CI: 7/7 passed at `1cf24d66fd1607f51be00d683465218e4c58bb2a`

Closes #505