### PR TITLE
coord(cli): widening a scope reports 'previous paths replaced' when nothing was replaced

### DIFF
--- a/crates/edda-cli/src/cmd_bridge.rs
+++ b/crates/edda-cli/src/cmd_bridge.rs
@@ -698,6 +698,8 @@ fn claim_disclosure(
         ));
     } else if released.is_empty() && !gained {
         lines.push(format!("Re-claimed scope: {label} (unchanged)"));
+    } else if released.is_empty() {
+        lines.push(format!("Re-claimed scope: {label} (paths added)"));
     } else {
         lines.push(format!(
             "Re-claimed scope: {label} (previous paths replaced)"
@@ -2436,7 +2438,7 @@ mod tests {
     }
 
     #[test]
-    fn widening_reports_a_change_but_no_release() {
+    fn widening_reports_paths_added_but_no_release() {
         let previous = prior_claim("api", &["src/api/*"]);
         assert_eq!(
             claim_disclosure(
@@ -2444,7 +2446,7 @@ mod tests {
                 "api",
                 &owned(&["src/api/*", "src/api/v3/*"])
             ),
-            vec!["Re-claimed scope: api (previous paths replaced)"]
+            vec!["Re-claimed scope: api (paths added)"]
         );
     }
 
@@ -2459,7 +2461,7 @@ mod tests {
     }
 
     #[test]
-    fn a_second_claim_replaces_the_first_and_says_so() {
+    fn a_second_claim_leaves_one_claim_on_the_board() {
         let _store = crate::test_support::isolated_store();
         let _env = env_guard();
         std::env::remove_var("EDDA_SESSION_ID");
@@ -2472,8 +2474,7 @@ mod tests {
         claim(repo.path(), "api", &["src/api/*".into()], Some("s1")).expect("second claim");
 
         // The board folds to one claim per session, so the first scope is gone.
-        // GH-488 item 2 was that this happened without saying so; the printed
-        // line is the fix, and the fold is the behaviour it discloses.
+        // The disclosure tests above separately pin what the command prints.
         let claims = edda_bridge_claude::peers::compute_board_state(&pid).claims;
         assert_eq!(claims.len(), 1, "one session holds one claim");
         assert_eq!(claims[0].label, "api");

--- a/crates/edda-cli/src/skills/coord-sync.md
+++ b/crates/edda-cli/src/skills/coord-sync.md
@@ -62,6 +62,8 @@ $ edda claim "api" --paths "src/api/*" --session s1
 > released: src/auth/*
 $ edda claim "api" --paths "src/api/*" --session s1
 > Re-claimed scope: api (unchanged)
+$ edda claim "api" --paths "src/api/*" --paths "src/api/v2/*" --session s1
+> Re-claimed scope: api (paths added)
 $ edda claim "api" --paths "src/api/v2/*" --session s1
 > Re-claimed scope: api (previous paths replaced)
 > released: src/api/*


### PR DESCRIPTION
Closes #508

Summary:
- report (paths added) when a same-label claim widens without releasing paths
- pin the header in both the unit test and shipped coord-sync executable doctest
- rename the board-level test to the one-claim state it establishes
- audited claim_disclosure and unclaim outcome messages; no other mismatch found

TDD evidence:
- RED unit: expected (paths added), received (previous paths replaced)
- RED shipped doctest: coord-sync.md output did not contain (paths added)
- GREEN: both focused regressions passed after the branch change

Verification receipt:
- SHA: ef614241ed589b7d672f61cb386c72783a3ed83c
- base: origin/main 8a54a2f081599b912ba0c18fb68246b04f73dfa5
- lane: C:\Users\synvoke\AppData\Local\fleet-workstation\lanes\worker-2
- toolchain: rustc 1.93.1 / cargo 1.93.1
- L0 PASS: cargo fmt --all --check; cargo clippy -p edda --all-targets -- -D warnings; cargo test -p edda (320 unit + 11 skill-doctest tests)
- L1 PASS, CARGO_INCREMENTAL=0, 344.1s: cargo fmt --all --check; cargo clippy --workspace --all-targets -- -D warnings; cargo test --workspace
- clean tree before and after L1

Scope guard: only cmd_bridge.rs and coord-sync.md changed; the #503 identity chain was not touched.