### PR TITLE
ci: lint markdown tool output outside fences

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal --component rustfmt
       - run: cargo fmt --check
-      - run: sh -n install.sh
+      - run: sh -n install.sh scripts/lint-markdown-content.sh
+      - name: Lint Markdown content
+        run: sh scripts/lint-markdown-content.sh
       - name: Verify installer latest-version stdout
         shell: bash
         run: |

--- a/scripts/lint-markdown-content.sh
+++ b/scripts/lint-markdown-content.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+set -eu
+
+cd "$(git rev-parse --show-toplevel)"
+files=$(mktemp)
+trap 'rm -f "$files"' 0 HUP INT TERM
+git ls-files -z --format='./%(path)' -- '*.md' >"$files"
+
+if xargs -0 awk '
+function marker(s,    i, c) {
+    for (i = 0; i < 3 && substr(s, 1, 1) == " "; i++)
+        s = substr(s, 2)
+    c = substr(s, 1, 1)
+    if (c != "`" && c != "~")
+        return 0
+    mark_width = 0
+    while (substr(s, mark_width + 1, 1) == c)
+        mark_width++
+    if (mark_width < 3)
+        return 0
+    mark_char = c
+    mark_rest = substr(s, mark_width + 1)
+    return 1
+}
+
+FNR == 1 {
+    in_fence = 0
+    fence_char = ""
+    fence_width = 0
+}
+
+{
+    line = $0
+    sub(/\r$/, "", line)
+
+    if (in_fence) {
+        if (marker(line) && mark_char == fence_char &&
+            mark_width >= fence_width && mark_rest ~ /^[ \t]*$/)
+            in_fence = 0
+        next
+    }
+
+    if (marker(line) && !(mark_char == "`" && mark_rest ~ /`/)) {
+        in_fence = 1
+        fence_char = mark_char
+        fence_width = mark_width
+        next
+    }
+
+    if (line ~ /^running [0-9]+ tests?$/ ||
+        line ~ /^test result: (ok|FAILED)\./ ||
+        line ~ /^test [A-Za-z0-9_:]+ \.\.\. (ok|FAILED|ignored)$/ ||
+        line ~ /^ *(Compiling|Finished|Running|Checking) /) {
+        printf "%s:%d: tool output outside a fenced block: %s\n", \
+            substr(FILENAME, 3), FNR, line
+        failed = 1
+    }
+}
+
+END { exit failed }
+' <"$files"; then
+    exit 0
+fi
+
+printf '%s\n' \
+    'Markdown content lint failed. Put command transcripts inside fenced code blocks.' \
+    'Blocked outside fences:' \
+    '  ^running [0-9]+ tests?$' \
+    '  ^test result: (ok|FAILED)\.' \
+    '  ^test [A-Za-z0-9_:]+ \.\.\. (ok|FAILED|ignored)$' \
+    '  ^ *(Compiling|Finished|Running|Checking) ' >&2
+exit 1

--- a/scripts/lint-markdown-content.sh
+++ b/scripts/lint-markdown-content.sh
@@ -23,24 +23,42 @@ function marker(s,    i, c) {
     return 1
 }
 
+function container_line(s, track,    indent, base, rest) {
+    for (indent = 0; substr(s, indent + 1, 1) == " "; indent++);
+    if (!track)
+        return indent >= container_indent ? substr(s, container_indent + 1) : s
+    if (s !~ /^[ \t]*$/ && indent < container_indent)
+        container_indent = 0
+    base = container_indent
+    rest = substr(s, base + 1)
+    if (match(rest, /^ {0,3}([-+*]|[0-9]{1,9}[.)])[ \t]{1,4}/) &&
+        substr(rest, RLENGTH + 1, 1) !~ /[ \t]/) {
+        container_indent = base + RLENGTH
+        return substr(rest, RLENGTH + 1)
+    }
+    return rest
+}
+
 FNR == 1 {
     in_fence = 0
     fence_char = ""
     fence_width = 0
+    container_indent = 0
 }
 
 {
     line = $0
     sub(/\r$/, "", line)
+    fence_line = container_line(line, !in_fence)
 
     if (in_fence) {
-        if (marker(line) && mark_char == fence_char &&
+        if (marker(fence_line) && mark_char == fence_char &&
             mark_width >= fence_width && mark_rest ~ /^[ \t]*$/)
             in_fence = 0
         next
     }
 
-    if (marker(line) && !(mark_char == "`" && mark_rest ~ /`/)) {
+    if (marker(fence_line) && !(mark_char == "`" && mark_rest ~ /`/)) {
         in_fence = 1
         fence_char = mark_char
         fence_width = mark_width

--- a/scripts/test-lint-markdown-content.sh
+++ b/scripts/test-lint-markdown-content.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' 0 HUP INT TERM
+case_number=0
+
+check() {
+    expected=$1
+    name=$2
+    file=$3
+    content=$4
+    case_number=$((case_number + 1))
+    case_dir="$tmp/$case_number"
+    mkdir -p "$case_dir/scripts"
+    cp "$root/scripts/lint-markdown-content.sh" "$case_dir/scripts/"
+    printf '%s\n' "$content" >"$case_dir/$file"
+    git -C "$case_dir" init -q
+    git -C "$case_dir" config core.autocrlf false
+    git -C "$case_dir" add -- "$file"
+
+    if output=$(cd "$case_dir" && sh scripts/lint-markdown-content.sh 2>&1); then
+        actual=pass
+    else
+        actual=fail
+    fi
+    if [ "$actual" != "$expected" ]; then
+        printf '%s: expected %s, got %s\n%s\n' "$name" "$expected" "$actual" "$output" >&2
+        exit 1
+    fi
+}
+
+check pass 'fenced transcripts and spaced filename' 'spaced name.md' '
+````text
+running 1 test
+test result: ok. 1 passed
+test crate::case ... ok
+ Compiling demo v0.1.0
+````
+
+~~~~
+Running tests
+~~~~
+'
+
+check pass 'list-nested fenced transcript' 'nested.md' '
+- build transcript
+
+    ```text
+    Compiling demo v0.1.0
+    ```
+'
+
+check fail 'running signature outside a fence' 'running.md' 'running 1 test'
+check fail 'result signature outside a fence' 'result.md' 'test result: FAILED. 0 passed'
+check fail 'test signature outside a fence' 'test.md' 'test crate::case ... ignored'
+check fail 'cargo signature outside a fence' 'cargo.md' 'Checking demo v0.1.0'
+check fail 'backtick in info string is not a fence' 'info.md' '
+```bad`info
+Compiling demo v0.1.0
+```
+'
+check fail 'list-like fence content does not hide later output' 'fence-list.md' '
+- transcript
+
+    ```text
+    - literal output
+    ```
+
+Checking demo v0.1.0
+'
+
+printf 'lint-markdown-content fixtures passed\n'


### PR DESCRIPTION
Closes #507

Summary:
- scan every tracked Markdown file for the four issue-defined tool-output signatures
- ignore matching content only while inside a matching-width backtick or tilde fence
- run the content lint in the existing Format job

Verification at dca37818328438d8866e47cf1b608b5ce8d949df:
- sh -n install.sh scripts/lint-markdown-content.sh
- synthetic outside-fence fixture rejected with all four file:line diagnostics
- identical fenced fixtures accepted, including shorter non-closing fence runs and a spaced filename
- whole tracked Markdown tree passed: 105 files, no exclusions
- git diff --check origin/main...HEAD
- Cargo/lane: n/a (CI shell script and workflow only)