### PR TITLE
fix(coord): bind session identity to process

### DIFF
--- a/crates/edda-bridge-claude/src/dispatch/session.rs
+++ b/crates/edda-bridge-claude/src/dispatch/session.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::Write;
 use std::path::Path;
 
 use crate::signals::{extract_session_signals, save_session_signals, TaskSnapshot};
@@ -698,6 +699,8 @@ pub(super) fn dispatch_session_start(
     cwd: &str,
     digest_warning: Option<&str>,
 ) -> anyhow::Result<HookResult> {
+    persist_session_identity(session_id)?;
+
     // Conductor mode: skip sections that overlap with conductor's --append-system-prompt.
     // See CONDUCTOR-SPEC.md §10.2.
     let conductor_mode = std::env::var("EDDA_CONDUCTOR_MODE").is_ok();
@@ -916,4 +919,21 @@ pub(super) fn dispatch_session_start(
     } else {
         Ok(HookResult::empty())
     }
+}
+
+fn persist_session_identity(session_id: &str) -> anyhow::Result<()> {
+    let Some(env_file) = std::env::var_os("CLAUDE_ENV_FILE") else {
+        return Ok(());
+    };
+    if session_id.is_empty() || env_file.is_empty() {
+        return Ok(());
+    }
+
+    let quoted = session_id.replace('\'', "'\\''");
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(env_file)?;
+    writeln!(file, "export EDDA_SESSION_ID='{quoted}'")?;
+    Ok(())
 }

--- a/crates/edda-bridge-claude/src/dispatch/tests.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tests.rs
@@ -62,6 +62,31 @@ fn hook_entrypoint_session_start() {
 }
 
 #[test]
+fn session_start_exports_shell_quoted_process_identity() {
+    let env_file = tempfile::NamedTempFile::new().expect("env file");
+    fs::write(env_file.path(), "export EXISTING=kept\n").expect("seed env file");
+    let env_path = env_file.path().to_string_lossy().into_owned();
+    crate::with_env_guard(
+        &[
+            ("EDDA_BRIDGE_AUTO_DIGEST", Some("0")),
+            ("EDDA_PLANS_DIR", Some("/nonexistent/plans/dir")),
+            ("CLAUDE_ENV_FILE", Some(&env_path)),
+        ],
+        || {
+            let stdin = r#"{"session_id":"claude-'worker","hook_event_name":"SessionStart","cwd":".","transcript_path":"","permission_mode":"default"}"#;
+            hook_entrypoint_from_stdin(stdin).expect("session start");
+            let resumed = r#"{"session_id":"claude-resumed","hook_event_name":"SessionStart","source":"resume","cwd":".","transcript_path":"","permission_mode":"default"}"#;
+            hook_entrypoint_from_stdin(resumed).expect("resumed session start");
+        },
+    );
+
+    assert_eq!(
+        fs::read_to_string(env_file.path()).expect("read env file"),
+        "export EXISTING=kept\nexport EDDA_SESSION_ID='claude-'\\''worker'\nexport EDDA_SESSION_ID='claude-resumed'\n"
+    );
+}
+
+#[test]
 fn hook_entrypoint_camel_case_input() {
     crate::with_env_guard(&[("EDDA_CLAUDE_AUTO_APPROVE", Some("1"))], || {
         // Claude Code sends camelCase JSON

--- a/crates/edda-bridge-claude/src/peers/discovery.rs
+++ b/crates/edda-bridge-claude/src/peers/discovery.rs
@@ -164,11 +164,13 @@ pub fn discover_all_sessions(project_id: &str) -> Vec<PeerSummary> {
 /// If exactly one non-stale session exists for the project, returns
 /// `Some((session_id, label))`. Otherwise returns `None` (ambiguous or no context).
 ///
-/// Used by CLI commands (`edda decide`, etc.) to resolve session identity
-/// when `EDDA_SESSION_ID` env var is not set.
-///
-/// This cannot tell the caller apart from a lone peer: a process has no way to
-/// prove a heartbeat is its own (GH-488).
+/// This observes heartbeat cardinality; it does not establish caller identity.
+/// A process has no way to prove a heartbeat is its own, so mutating CLI verbs
+/// must use explicit `--session` or process-carried `EDDA_SESSION_ID` instead.
+/// The environment value is attribution and a user override, not
+/// authentication or authorization. This helper remains available only for
+/// callers that need the observational "exactly one live heartbeat" fact
+/// (GH-503).
 pub fn infer_session_id(project_id: &str) -> Option<(String, String)> {
     let state_dir = edda_store::project_dir(project_id).join("state");
     let stale_threshold = stale_secs();

--- a/crates/edda-bridge-codex/src/dispatch.rs
+++ b/crates/edda-bridge-codex/src/dispatch.rs
@@ -11,10 +11,9 @@
 //! }
 //! ```
 //!
-//! For PreToolUse we can also return `{ "continue": false, "stopReason": "..." }`
-//! to block, but this skeleton emits advisory context only — L3 rule enforcement
-//! is wired to the same `edda_postmortem::hooks::evaluate_rules` used by the
-//! Claude bridge, but delivered as `additionalContext` warnings for now.
+//! For Bash `PreToolUse`, `permissionDecision: "allow"` plus `updatedInput`
+//! carries the hook session id into that command. L3 rule enforcement is wired
+//! to the same evaluator as the Claude bridge and remains advisory context.
 
 use edda_bridge_claude::{render, state};
 
@@ -54,6 +53,60 @@ fn with_context(hook_event_name: &str, context: &str) -> anyhow::Result<HookResu
         }
     });
     Ok(HookResult::output(serde_json::to_string(&output)?))
+}
+
+fn pre_tool_context(context: &str) -> anyhow::Result<HookResult> {
+    let output = serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "additionalContext": context,
+        }
+    });
+    Ok(HookResult::output(serde_json::to_string(&output)?))
+}
+
+fn pre_tool_result(envelope: &CodexEnvelope, warning: Option<&str>) -> anyhow::Result<HookResult> {
+    let rewritten = if envelope.tool_name == "Bash" && !envelope.session_id.is_empty() {
+        envelope
+            .tool_input
+            .get("command")
+            .and_then(|value| value.as_str())
+            .map(|command| command_with_session_identity(command, &envelope.session_id))
+    } else {
+        None
+    };
+
+    let Some(command) = rewritten else {
+        return match warning {
+            Some(warning) => pre_tool_context(warning),
+            None => Ok(HookResult::output("{}".to_string())),
+        };
+    };
+
+    let mut hook_output = serde_json::json!({
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "allow",
+        "updatedInput": { "command": command },
+    });
+    if let Some(warning) = warning {
+        hook_output["additionalContext"] = serde_json::Value::String(warning.to_string());
+    }
+    let output = serde_json::json!({ "hookSpecificOutput": hook_output });
+    Ok(HookResult::output(serde_json::to_string(&output)?))
+}
+
+fn command_with_session_identity(command: &str, session_id: &str) -> String {
+    if cfg!(windows) {
+        format!(
+            "$env:EDDA_SESSION_ID = '{}';\n{command}",
+            session_id.replace('\'', "''")
+        )
+    } else {
+        format!(
+            "export EDDA_SESSION_ID='{}';\n{command}",
+            session_id.replace('\'', "'\\''")
+        )
+    }
 }
 
 // ── Entry ──
@@ -189,11 +242,11 @@ fn dispatch_user_prompt_submit(
 
 fn dispatch_pre_tool_use(project_id: &str, envelope: &CodexEnvelope) -> anyhow::Result<HookResult> {
     if std::env::var("EDDA_POSTMORTEM").unwrap_or_else(|_| "1".into()) == "0" {
-        return Ok(ok());
+        return pre_tool_result(envelope, None);
     }
     let mut rules_store = edda_postmortem::RulesStore::load_project(project_id);
     if rules_store.active_rules().is_empty() {
-        return Ok(ok());
+        return pre_tool_result(envelope, None);
     }
 
     let files_touched: Vec<String> = envelope
@@ -221,10 +274,8 @@ fn dispatch_pre_tool_use(project_id: &str, envelope: &CodexEnvelope) -> anyhow::
         edda_postmortem::hooks::record_matched_hits(&mut rules_store, &result.matched_rule_ids);
         let _ = rules_store.save_project(project_id);
     }
-    match edda_postmortem::hooks::format_warnings(&result) {
-        Some(warning) => with_context(&envelope.hook_event_name, &warning),
-        None => Ok(ok()),
-    }
+    let warning = edda_postmortem::hooks::format_warnings(&result);
+    pre_tool_result(envelope, warning.as_deref())
 }
 
 // ── PostToolUse: nudge on decision signals ──
@@ -363,19 +414,49 @@ mod tests {
     }
 
     #[test]
-    fn pre_tool_use_no_rules_returns_ok() {
+    fn pre_tool_use_carries_process_identity_without_changing_command_bytes() {
         std::env::set_var("EDDA_POSTMORTEM", "1");
+        let command = "printf 'untouched';\nwhoami";
         let stdin = serde_json::json!({
             "hook_event_name": "PreToolUse",
-            "session_id": "codex-ptu-1",
+            "session_id": "codex-'ptu-1",
             "cwd": "/tmp/codex-ptu",
             "tool_name": "Bash",
-            "tool_input": { "command": "ls" }
+            "tool_input": { "command": command }
         })
         .to_string();
         let r = hook_entrypoint_from_stdin(&stdin).unwrap();
         let v: serde_json::Value = serde_json::from_str(r.stdout.as_ref().unwrap()).unwrap();
-        assert_eq!(v["continue"], true);
+        assert_eq!(v["hookSpecificOutput"]["permissionDecision"], "allow");
+        assert!(
+            v.get("continue").is_none(),
+            "PreToolUse rejects the SessionStart-only continue field"
+        );
+        let rewritten = v["hookSpecificOutput"]["updatedInput"]["command"]
+            .as_str()
+            .expect("rewritten Bash command");
+        let prefix = if cfg!(windows) {
+            "$env:EDDA_SESSION_ID = 'codex-''ptu-1';\n"
+        } else {
+            "export EDDA_SESSION_ID='codex-'\\''ptu-1';\n"
+        };
+        assert_eq!(rewritten, format!("{prefix}{command}"));
+    }
+
+    #[test]
+    fn pre_tool_use_leaves_non_shell_tools_unchanged() {
+        let stdin = serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "session_id": "codex-read-1",
+            "cwd": "/tmp/codex-read",
+            "tool_name": "Read",
+            "tool_input": { "file_path": "README.md" }
+        })
+        .to_string();
+        let r = hook_entrypoint_from_stdin(&stdin).unwrap();
+        let v: serde_json::Value = serde_json::from_str(r.stdout.as_ref().unwrap()).unwrap();
+        assert!(v["hookSpecificOutput"]["updatedInput"].is_null());
+        assert!(v.get("continue").is_none());
     }
 
     #[test]

--- a/crates/edda-bridge-cursor/src/dispatch.rs
+++ b/crates/edda-bridge-cursor/src/dispatch.rs
@@ -266,6 +266,7 @@ fn dispatch_session_start(
     let output = serde_json::json!({
         "env": {
             "EDDA_HOT_PACK_PATH": sidefile.to_string_lossy(),
+            "EDDA_SESSION_ID": session_id,
         },
         "additional_context": wrapped,
     });
@@ -332,6 +333,7 @@ mod tests {
         assert!(context.contains("edda decide"));
         let sidefile = output["env"]["EDDA_HOT_PACK_PATH"].as_str().unwrap();
         assert!(std::path::Path::new(sidefile).is_file());
+        assert_eq!(output["env"]["EDDA_SESSION_ID"], "cursor-session-start-1");
     }
 
     #[test]

--- a/crates/edda-bridge-hermes/src/dispatch.rs
+++ b/crates/edda-bridge-hermes/src/dispatch.rs
@@ -7,12 +7,12 @@
 //! | `pre_llm_call`    | `{"context": "..."}`                              | Injects into next LLM turn   |
 //! | `pre_tool_call`   | `{"decision":"block","reason":"..."}` (Claude)    | Blocks tool call             |
 //! | `pre_tool_call`   | `{"action":"block","message":"..."}` (Hermes)     | Blocks tool call             |
+//! | `pre_tool_call`   | `{"action":"modify","args":{...}}`                 | Rewrites tool arguments      |
 //! | `pre_verify`      | `{"action":"continue","message":"..."}`           | Keep going with instruction  |
 //! | others            | `{}` or empty                                     | No-op (observation only)     |
 //!
-//! Emit Claude-Code style for `pre_tool_call` since Hermes translates
-//! internally — this lets us reuse `edda_postmortem::hooks::format_warnings`
-//! logic without a Hermes-specific translation layer.
+//! Block responses retain the Claude-compatible shape Hermes translates;
+//! command-local identity uses Hermes' canonical modify response.
 
 use edda_bridge_claude::{render, state};
 
@@ -55,6 +55,44 @@ fn block_tool_call(reason: &str) -> anyhow::Result<HookResult> {
     // (verified via shell_hooks.py::_parse_response line 601-602).
     let out = serde_json::json!({ "decision": "block", "reason": reason });
     Ok(HookResult::output(serde_json::to_string(&out)?))
+}
+
+fn process_identity_modification(envelope: &HermesEnvelope) -> anyhow::Result<Option<HookResult>> {
+    if !matches!(
+        envelope.tool_name.as_str(),
+        "terminal" | "shell" | "bash" | "Bash"
+    ) || envelope.session_id.is_empty()
+    {
+        return Ok(None);
+    }
+    let Some(command) = envelope
+        .tool_input
+        .get("command")
+        .and_then(|value| value.as_str())
+    else {
+        return Ok(None);
+    };
+    let out = serde_json::json!({
+        "action": "modify",
+        "args": {
+            "command": command_with_session_identity(command, &envelope.session_id),
+        }
+    });
+    Ok(Some(HookResult::output(serde_json::to_string(&out)?)))
+}
+
+fn command_with_session_identity(command: &str, session_id: &str) -> String {
+    if cfg!(windows) {
+        format!(
+            "$env:EDDA_SESSION_ID = '{}';\n{command}",
+            session_id.replace('\'', "''")
+        )
+    } else {
+        format!(
+            "export EDDA_SESSION_ID='{}';\n{command}",
+            session_id.replace('\'', "'\\''")
+        )
+    }
 }
 
 // ── Entry ──
@@ -208,12 +246,13 @@ fn dispatch_pre_tool_call(
     project_id: &str,
     envelope: &HermesEnvelope,
 ) -> anyhow::Result<HookResult> {
+    let identity = process_identity_modification(envelope)?;
     if std::env::var("EDDA_POSTMORTEM").unwrap_or_else(|_| "1".into()) == "0" {
-        return Ok(ok());
+        return Ok(identity.unwrap_or_else(ok));
     }
     let mut rules_store = edda_postmortem::RulesStore::load_project(project_id);
     if rules_store.active_rules().is_empty() {
-        return Ok(ok());
+        return Ok(identity.unwrap_or_else(ok));
     }
 
     let files_touched: Vec<String> = envelope
@@ -258,7 +297,7 @@ fn dispatch_pre_tool_call(
         // blocks on Hermes.
         // TODO: honor category=Block once the postmortem module distinguishes.
     }
-    Ok(ok())
+    Ok(identity.unwrap_or_else(ok))
 }
 
 fn normalize_tool_name(name: &str) -> &str {
@@ -442,14 +481,39 @@ mod tests {
     }
 
     #[test]
-    fn pre_tool_call_no_rules_returns_ok() {
+    fn pre_tool_call_carries_process_identity_without_changing_command_bytes() {
         std::env::set_var("EDDA_POSTMORTEM", "1");
+        let command = "printf 'untouched';\nwhoami";
         let stdin = serde_json::json!({
             "hook_event_name": "pre_tool_call",
-            "session_id": "hermes-pt-1",
+            "session_id": "hermes-'pt-1",
             "cwd": "/tmp/hermes-pt",
             "tool_name": "terminal",
-            "tool_input": { "command": "ls" }
+            "tool_input": { "command": command }
+        })
+        .to_string();
+        let r = hook_entrypoint_from_stdin(&stdin).unwrap();
+        let v: serde_json::Value = serde_json::from_str(r.stdout.as_ref().unwrap()).unwrap();
+        assert_eq!(v["action"], "modify");
+        let rewritten = v["args"]["command"]
+            .as_str()
+            .expect("rewritten terminal command");
+        let prefix = if cfg!(windows) {
+            "$env:EDDA_SESSION_ID = 'hermes-''pt-1';\n"
+        } else {
+            "export EDDA_SESSION_ID='hermes-'\\''pt-1';\n"
+        };
+        assert_eq!(rewritten, format!("{prefix}{command}"));
+    }
+
+    #[test]
+    fn pre_tool_call_leaves_non_shell_tools_unchanged() {
+        let stdin = serde_json::json!({
+            "hook_event_name": "pre_tool_call",
+            "session_id": "hermes-read-1",
+            "cwd": "/tmp/hermes-read",
+            "tool_name": "read_file",
+            "tool_input": { "path": "README.md" }
         })
         .to_string();
         let r = hook_entrypoint_from_stdin(&stdin).unwrap();

--- a/crates/edda-bridge-openclaw/src/admin.rs
+++ b/crates/edda-bridge-openclaw/src/admin.rs
@@ -14,10 +14,21 @@ const PLUGIN_PACKAGE_JSON: &str = r#"{
 
 const PLUGIN_INDEX_JS: &str = r#"const { execSync } = require("child_process");
 
+const sessionIdentityByKey = new Map();
+
+function heartbeatSessionId(ctx) {
+  const sessionKey = ctx.sessionKey || "";
+  const sessionId = ctx.sessionId || sessionKey;
+  if (sessionKey && sessionId) {
+    sessionIdentityByKey.set(sessionKey, sessionId);
+  }
+  return sessionId;
+}
+
 function callEdda(hookName, eventData, ctx, logger, timeout) {
   const payload = JSON.stringify({
     hook_event_name: hookName,
-    session_id: ctx.sessionId || "",
+    session_id: heartbeatSessionId(ctx),
     session_key: ctx.sessionKey || "",
     agent_id: ctx.agentId || "main",
     workspace_dir: ctx.workspaceDir || "",
@@ -46,6 +57,12 @@ const plugin = {
 
     api.on("session_start", async (event, ctx) => {
       callEdda("session_start", {}, ctx, logger, 15000);
+    });
+
+    api.on("resolve_exec_env", async (event, ctx) => {
+      const sessionKey = event.sessionKey || ctx.sessionKey || "";
+      const sessionId = sessionIdentityByKey.get(sessionKey);
+      return sessionId ? { EDDA_SESSION_ID: sessionId } : {};
     });
 
     api.on("before_agent_start", async (event, ctx) => {
@@ -115,6 +132,9 @@ const plugin = {
         logger,
         15000,
       );
+      if (ctx.sessionKey) {
+        sessionIdentityByKey.delete(ctx.sessionKey);
+      }
     });
   },
 };
@@ -250,6 +270,10 @@ mod tests {
         assert!(js.contains("before_compaction"));
         assert!(js.contains("message_sent"));
         assert!(js.contains("additionalContext"));
+        assert!(js.contains("resolve_exec_env"));
+        assert!(js.contains("session_id: heartbeatSessionId(ctx)"));
+        assert!(js.contains("sessionIdentityByKey.get(sessionKey)"));
+        assert!(js.contains("{ EDDA_SESSION_ID: sessionId }"));
     }
 
     #[test]

--- a/crates/edda-bridge-openclaw/src/admin.rs
+++ b/crates/edda-bridge-openclaw/src/admin.rs
@@ -18,7 +18,8 @@ const sessionIdentityByKey = new Map();
 
 function heartbeatSessionId(ctx) {
   const sessionKey = ctx.sessionKey || "";
-  const sessionId = ctx.sessionId || sessionKey;
+  const sessionId =
+    ctx.sessionId || sessionIdentityByKey.get(sessionKey) || sessionKey;
   if (sessionKey && sessionId) {
     sessionIdentityByKey.set(sessionKey, sessionId);
   }
@@ -272,7 +273,7 @@ mod tests {
         assert!(js.contains("additionalContext"));
         assert!(js.contains("resolve_exec_env"));
         assert!(js.contains("session_id: heartbeatSessionId(ctx)"));
-        assert!(js.contains("sessionIdentityByKey.get(sessionKey)"));
+        assert!(js.contains("ctx.sessionId || sessionIdentityByKey.get(sessionKey) || sessionKey"));
         assert!(js.contains("{ EDDA_SESSION_ID: sessionId }"));
     }
 

--- a/crates/edda-cli/src/cmd_bridge.rs
+++ b/crates/edda-cli/src/cmd_bridge.rs
@@ -114,13 +114,13 @@ pub enum BridgeClaudeCmd {
         /// File path patterns this scope covers (e.g. "src/auth/*")
         #[arg(long)]
         paths: Vec<String>,
-        /// Session ID (auto-inferred from active heartbeats if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
     },
     /// Release this session's coordination scope
     Unclaim {
-        /// Session ID (inferred from a sole live session; required otherwise)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
         /// Exit 0 when there is nothing to release, for unconditional teardown
@@ -137,7 +137,7 @@ pub enum BridgeClaudeCmd {
         /// Decision keys this decision depends on (repeatable)
         #[arg(long = "refs")]
         refs: Vec<String>,
-        /// Session ID (auto-inferred from active heartbeats if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
         /// File glob patterns this decision governs (repeatable)
@@ -153,7 +153,7 @@ pub enum BridgeClaudeCmd {
         to: String,
         /// Request message
         message: String,
-        /// Session ID (auto-inferred from active heartbeats if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
         /// Send even when no active session answers to the target label
@@ -170,7 +170,7 @@ pub enum BridgeClaudeCmd {
     },
     /// Render L2 coordination protocol
     RenderCoordination {
-        /// Session ID (auto-inferred if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
     },
@@ -189,19 +189,19 @@ pub enum BridgeClaudeCmd {
         /// Session label (e.g. "auth", "billing")
         #[arg(long)]
         label: String,
-        /// Session ID (auto-inferred if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
     },
     /// Touch heartbeat timestamp (liveness ping)
     HeartbeatTouch {
-        /// Session ID (auto-inferred if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
     },
     /// Remove session heartbeat
     HeartbeatRemove {
-        /// Session ID (auto-inferred if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
     },
@@ -726,7 +726,7 @@ pub fn claim(
     cli_session: Option<&str>,
 ) -> anyhow::Result<()> {
     let project_id = edda_store::project_id(repo_root);
-    let (session_id, _) = resolve_session_id(cli_session, &project_id, label);
+    let (session_id, _) = resolve_session_id(cli_session, &project_id, label)?;
 
     let replaced = edda_bridge_claude::peers::compute_board_state(&project_id)
         .claims
@@ -808,11 +808,10 @@ pub fn unclaim(
 
 /// Name the session whose claim `unclaim` should release.
 ///
-/// Explicit `--session` wins, then `EDDA_SESSION_ID`, then a sole live
-/// heartbeat. There is deliberately no further tier: a caller with none of
-/// those has no identity, and picking a claim off the board for it would
-/// release a scope its real owner is still relying on. Refuse and show the
-/// board instead, so the id for `--session` is in the error.
+/// Explicit `--session` wins, then process-carried `EDDA_SESSION_ID`.
+/// Heartbeats are evidence that identity is ambiguous, never evidence that a
+/// session belongs to this process. Refuse and show the board instead, so the
+/// id for `--session` is in the error.
 fn resolve_unclaim_target(
     cli_session: Option<&str>,
     project_id: &str,
@@ -826,8 +825,11 @@ fn resolve_unclaim_target(
             return Ok(sid);
         }
     }
-    if let Some((sid, _label)) = edda_bridge_claude::peers::infer_session_id(project_id) {
-        return Ok(sid);
+    if has_live_sessions(project_id) {
+        anyhow::bail!(
+            "cannot prove which live session belongs to this process, so --session is required.\n{}",
+            describe_claims(claims)
+        );
     }
 
     // No identity of our own, so there is nothing to infer from. Do NOT fall
@@ -911,7 +913,7 @@ pub fn decide(
     }
 
     let project_id = edda_store::project_id(repo_root);
-    let (session_id, label) = resolve_session_id(cli_session, &project_id, "cli");
+    let (session_id, label) = resolve_session_id(cli_session, &project_id, "cli")?;
 
     // L2 conflict check (coordination.jsonl) — before writing
     if let Some(conflict) =
@@ -1086,7 +1088,7 @@ pub fn ratify(
 ) -> anyhow::Result<()> {
     let key = key.trim();
     let project_id = edda_store::project_id(repo_root);
-    let (_session_id, label) = resolve_session_id(cli_session, &project_id, "cli");
+    let (_session_id, label) = resolve_session_id(cli_session, &project_id, "cli")?;
     let ratified_by = by.unwrap_or(&label);
 
     let ledger = edda_ledger::Ledger::open(repo_root).context("cmd_bridge: opening ledger")?;
@@ -1130,7 +1132,7 @@ pub fn request(
     force: bool,
 ) -> anyhow::Result<()> {
     let project_id = edda_store::project_id(repo_root);
-    let (session_id, from_label) = resolve_session_id(cli_session, &project_id, "cli");
+    let (session_id, from_label) = resolve_session_id(cli_session, &project_id, "cli")?;
 
     let targets = edda_bridge_claude::peers::resolve_request_targets(&project_id, to);
     if targets.is_empty() && !force {
@@ -1201,29 +1203,32 @@ pub fn request_ack(
     cli_session: Option<&str>,
 ) -> anyhow::Result<()> {
     let project_id = edda_store::project_id(repo_root);
-    let (session_id, _label) = resolve_session_id(cli_session, &project_id, "cli");
+    let (session_id, _label) = resolve_session_id(cli_session, &project_id, "cli")?;
 
     edda_bridge_claude::peers::write_request_ack(&project_id, &session_id, from_label);
     println!("Acknowledged request from [{from_label}]");
     Ok(())
 }
 
-/// Resolve session identity via 4-tier fallback:
+/// Resolve attribution identity for a session-taking CLI verb.
 ///
 /// 1. `--session` CLI flag (explicit override)
-/// 2. `EDDA_SESSION_ID` env var (conductor path, user override)
-/// 3. Heartbeat inference (auto-detect sole active session)
-/// 4. `"cli-{fallback_label}"` (genuine CLI usage)
+/// 2. Process-carried `EDDA_SESSION_ID` (bridge/conductor path, user override)
+/// 3. `"cli-{fallback_label}"` only when no live session makes that ambiguous
 ///
-/// Tier 3 cannot tell the caller apart from a lone peer, and GH-488 item 1 is
-/// still open on that. A branch does not fix it: a branch belongs to a
-/// worktree, not to a process, so every process in that worktree matches one
-/// equally well.
+/// `EDDA_SESSION_ID` proves only that the invoking process received an id; it
+/// is attribution and an explicit user override, not authentication or
+/// authorization. Heartbeats, branches, and working directories cannot prove
+/// which process owns a session, so any live heartbeat makes an uncarried
+/// identity an error. With no live sessions, the deterministic `cli-*`
+/// fallback preserves genuine standalone CLI use. A carrier can preserve only
+/// the identity its host exposes; Codex tool hooks, for example, attribute
+/// subagent commands to the parent session (GH-503).
 fn resolve_session_id(
     cli_session: Option<&str>,
     project_id: &str,
     fallback_label: &str,
-) -> (String, String) {
+) -> anyhow::Result<(String, String)> {
     let env_label = std::env::var("EDDA_SESSION_LABEL")
         .ok()
         .filter(|v| !v.is_empty());
@@ -1231,25 +1236,33 @@ fn resolve_session_id(
     // Tier 1: explicit --session flag
     if let Some(sid) = cli_session.filter(|s| !s.is_empty()) {
         let label = env_label.unwrap_or_else(|| fallback_label.to_string());
-        return (sid.to_string(), label);
+        return Ok((sid.to_string(), label));
     }
 
     // Tier 2: EDDA_SESSION_ID env var
     if let Ok(sid) = std::env::var("EDDA_SESSION_ID") {
         if !sid.is_empty() {
             let label = env_label.unwrap_or_else(|| fallback_label.to_string());
-            return (sid, label);
+            return Ok((sid, label));
         }
     }
 
-    // Tier 3: heartbeat inference (sole active session)
-    if let Some((sid, label)) = edda_bridge_claude::peers::infer_session_id(project_id) {
-        return (sid, label);
+    if has_live_sessions(project_id) {
+        anyhow::bail!(
+            "cannot prove which live session belongs to this process, so --session is required \
+             (or set EDDA_SESSION_ID in the invoking process)"
+        );
     }
 
-    // Tier 4: fallback
     let label = env_label.unwrap_or_else(|| fallback_label.to_string());
-    (format!("cli-{fallback_label}"), label)
+    Ok((format!("cli-{fallback_label}"), label))
+}
+
+fn has_live_sessions(project_id: &str) -> bool {
+    let stale = edda_bridge_claude::peers::stale_secs();
+    edda_bridge_claude::peers::discover_all_sessions(project_id)
+        .into_iter()
+        .any(|session| session.age_secs <= stale)
 }
 
 /// `edda bridge claude digest --session <id>` or `--all`
@@ -1382,7 +1395,7 @@ pub fn render_workspace(repo_root: &Path, budget: usize) -> anyhow::Result<()> {
 /// `edda bridge claude render-coordination`
 pub fn render_coordination(repo_root: &Path, cli_session: Option<&str>) -> anyhow::Result<()> {
     let project_id = edda_store::project_id(repo_root);
-    let (session_id, _) = resolve_session_id(cli_session, &project_id, "cli");
+    let (session_id, _) = resolve_session_id(cli_session, &project_id, "cli")?;
     match edda_bridge_claude::render::coordination(&project_id, &session_id) {
         Some(s) => println!("{s}"),
         None => println!("(no coordination context)"),
@@ -1432,7 +1445,7 @@ pub fn heartbeat_write(
     cli_session: Option<&str>,
 ) -> anyhow::Result<()> {
     let project_id = edda_store::project_id(repo_root);
-    let (session_id, _) = resolve_session_id(cli_session, &project_id, label);
+    let (session_id, _) = resolve_session_id(cli_session, &project_id, label)?;
     let _ = edda_store::ensure_dirs(&project_id);
     edda_bridge_claude::peers::write_heartbeat_minimal(
         &project_id,
@@ -1447,7 +1460,7 @@ pub fn heartbeat_write(
 /// `edda bridge claude heartbeat-touch`
 pub fn heartbeat_touch(repo_root: &Path, cli_session: Option<&str>) -> anyhow::Result<()> {
     let project_id = edda_store::project_id(repo_root);
-    let (session_id, _) = resolve_session_id(cli_session, &project_id, "cli");
+    let (session_id, _) = resolve_session_id(cli_session, &project_id, "cli")?;
     edda_bridge_claude::peers::touch_heartbeat(&project_id, &session_id);
     println!("Heartbeat touched: {session_id}");
     Ok(())
@@ -1456,7 +1469,7 @@ pub fn heartbeat_touch(repo_root: &Path, cli_session: Option<&str>) -> anyhow::R
 /// `edda bridge claude heartbeat-remove`
 pub fn heartbeat_remove(repo_root: &Path, cli_session: Option<&str>) -> anyhow::Result<()> {
     let project_id = edda_store::project_id(repo_root);
-    let (session_id, _) = resolve_session_id(cli_session, &project_id, "cli");
+    let (session_id, _) = resolve_session_id(cli_session, &project_id, "cli")?;
     edda_bridge_claude::peers::remove_heartbeat(&project_id, &session_id);
     println!("Heartbeat removed: {session_id}");
     Ok(())
@@ -2062,7 +2075,47 @@ mod tests {
         let _ = std::fs::remove_dir_all(edda_store::project_dir(&pid));
     }
 
-    // ── Integration: resolve_session_id 4-tier fallback (Issue #148 Gap 4) ──
+    #[test]
+    fn bare_decide_beside_two_live_sessions_refuses_without_writing() {
+        let _store = crate::test_support::isolated_store();
+        let _env = env_guard();
+        std::env::remove_var("EDDA_SESSION_ID");
+        std::env::remove_var("EDDA_SESSION_LABEL");
+        let (repo, ledger) = setup_workspace();
+        let pid = edda_store::project_id(&repo);
+        edda_store::ensure_dirs(&pid).expect("store dirs");
+        edda_bridge_claude::peers::write_heartbeat_minimal(&pid, "worker-a", "worker-a", "/tmp/a");
+        edda_bridge_claude::peers::write_heartbeat_minimal(&pid, "worker-b", "worker-b", "/tmp/b");
+        let before = ledger.iter_events().expect("events before").len();
+
+        let err = decide(
+            &repo,
+            "unsafe.adoption=blocked",
+            Some("identity must come from the process"),
+            &[],
+            None,
+            None,
+            &[],
+            &[],
+        )
+        .expect_err("a bare shell beside live sessions must refuse");
+        assert!(err.to_string().contains("--session"), "{err}");
+        assert_eq!(
+            ledger.iter_events().expect("events after").len(),
+            before,
+            "a refused decide must not append to the ledger"
+        );
+        assert!(
+            edda_bridge_claude::peers::compute_board_state(&pid)
+                .bindings
+                .is_empty(),
+            "a refused decide must not broadcast a binding"
+        );
+        let _ = std::fs::remove_dir_all(&repo);
+        let _ = std::fs::remove_dir_all(edda_store::project_dir(&pid));
+    }
+
+    // ── Integration: process-bound session identity (GH-503) ──
 
     #[test]
     fn resolve_session_id_tiers() {
@@ -2076,17 +2129,17 @@ mod tests {
         std::env::remove_var("EDDA_SESSION_LABEL");
 
         // Tier 1: explicit cli_session
-        let (sid, label) = resolve_session_id(Some("explicit-sid"), pid, "cli");
+        let (sid, label) = resolve_session_id(Some("explicit-sid"), pid, "cli").unwrap();
         assert_eq!(sid, "explicit-sid");
         assert_eq!(label, "cli");
 
         // Tier 2: EDDA_SESSION_ID env
         std::env::set_var("EDDA_SESSION_ID", "env-sid");
-        let (sid, _) = resolve_session_id(None, pid, "cli");
+        let (sid, _) = resolve_session_id(None, pid, "cli").unwrap();
         assert_eq!(sid, "env-sid");
         std::env::remove_var("EDDA_SESSION_ID");
 
-        // Tier 3: heartbeat inference (single active session)
+        // A process-carried id remains authoritative beside a live session.
         // Clean state dir first to avoid interference from concurrent sessions
         let state_dir = edda_store::project_dir(pid).join("state");
         if state_dir.exists() {
@@ -2122,19 +2175,24 @@ mod tests {
             serde_json::to_string_pretty(&hb).unwrap(),
         )
         .unwrap();
-        let (sid, label) = resolve_session_id(None, pid, "cli");
-        assert_eq!(sid, "inferred-sess", "should infer from sole heartbeat");
-        assert_eq!(label, "worker", "should use heartbeat label");
+        std::env::set_var("EDDA_SESSION_ID", "env-live-sid");
+        let (sid, _) = resolve_session_id(None, pid, "cli").unwrap();
+        assert_eq!(sid, "env-live-sid");
+        std::env::set_var("EDDA_SESSION_ID", "");
+        let err = resolve_session_id(None, pid, "cli")
+            .expect_err("an empty env value must not adopt the sole heartbeat");
+        assert!(err.to_string().contains("--session"), "{err}");
+        std::env::remove_var("EDDA_SESSION_ID");
         let _ = std::fs::remove_file(state_dir.join("session.inferred-sess.json"));
 
-        // Tier 4: fallback (no heartbeats, no env)
-        let (sid, label) = resolve_session_id(None, pid, "cli");
+        // Standalone fallback (no heartbeats, no env)
+        let (sid, label) = resolve_session_id(None, pid, "cli").unwrap();
         assert_eq!(sid, "cli-cli");
         assert_eq!(label, "cli");
 
         // Tier 1 wins over Tier 2
         std::env::set_var("EDDA_SESSION_ID", "env-sid");
-        let (sid, _) = resolve_session_id(Some("explicit-wins"), pid, "cli");
+        let (sid, _) = resolve_session_id(Some("explicit-wins"), pid, "cli").unwrap();
         assert_eq!(sid, "explicit-wins", "tier 1 should beat tier 2");
         std::env::remove_var("EDDA_SESSION_ID");
 
@@ -2350,6 +2408,9 @@ mod tests {
     #[test]
     fn request_emits_request_pending_notification() {
         let _store = crate::test_support::isolated_store();
+        let _env = env_guard();
+        std::env::set_var("EDDA_SESSION_ID", "s-auth");
+        std::env::set_var("EDDA_SESSION_LABEL", "auth");
         let repo = tempfile::tempdir().expect("tempdir");
         let pid = edda_store::project_id(repo.path());
         let _ = edda_store::ensure_dirs(&pid);
@@ -2371,6 +2432,8 @@ mod tests {
         assert!(body.contains("\"from_label\":\"auth\""), "{body}");
         assert!(body.contains("\"to_label\":\"billing\""), "{body}");
         assert!(body.contains("\"message\":\"need invoice type\""), "{body}");
+        std::env::remove_var("EDDA_SESSION_ID");
+        std::env::remove_var("EDDA_SESSION_LABEL");
     }
 
     fn prior_claim(label: &str, paths: &[&str]) -> edda_bridge_claude::peers::ClaimEntry {
@@ -2482,6 +2545,39 @@ mod tests {
     }
 
     #[test]
+    fn bare_claim_beside_one_live_session_refuses_and_preserves_scope() {
+        let _store = crate::test_support::isolated_store();
+        let _env = env_guard();
+        std::env::remove_var("EDDA_SESSION_ID");
+        std::env::remove_var("EDDA_SESSION_LABEL");
+        let repo = tempfile::tempdir().expect("tempdir");
+        let pid = edda_store::project_id(repo.path());
+        edda_store::ensure_dirs(&pid).expect("store dirs");
+        edda_bridge_claude::peers::write_heartbeat_minimal(
+            &pid,
+            "live-worker",
+            "worker",
+            "/tmp/worker",
+        );
+        edda_bridge_claude::peers::write_claim(
+            &pid,
+            "live-worker",
+            "worker",
+            &["src/worker.rs".into()],
+        );
+
+        let err = claim(repo.path(), "intruder", &["docs/*".into()], None)
+            .expect_err("an adjacent shell must not adopt the live worker");
+        assert!(err.to_string().contains("--session"), "{err}");
+
+        let claims = edda_bridge_claude::peers::compute_board_state(&pid).claims;
+        assert_eq!(claims.len(), 1);
+        assert_eq!(claims[0].session_id, "live-worker");
+        assert_eq!(claims[0].label, "worker");
+        assert_eq!(claims[0].paths, vec!["src/worker.rs".to_string()]);
+    }
+
+    #[test]
     fn re_claiming_the_same_label_keeps_one_claim() {
         let _store = crate::test_support::isolated_store();
         let _env = env_guard();
@@ -2577,10 +2673,9 @@ mod tests {
         let pid = edda_store::project_id(repo.path());
         let _ = edda_store::ensure_dirs(&pid);
 
-        // Two live peers, so infer_session_id yields nothing, and only one of
-        // them holds a claim. A shell with no identity of its own must not
-        // decide that claim is its to release: check_offlimits enforces
-        // exactly this claim for its live owner.
+        // Only one of two live peers holds a claim. A shell with no identity
+        // of its own must not decide that claim is its to release:
+        // check_offlimits enforces exactly this claim for its live owner.
         edda_bridge_claude::peers::write_heartbeat_minimal(&pid, "sess-a", "worker-a", "/tmp/a");
         edda_bridge_claude::peers::write_heartbeat_minimal(&pid, "sess-b", "worker-b", "/tmp/b");
         edda_bridge_claude::peers::write_claim(&pid, "sess-a", "worker-a", &["src/a.rs".into()]);
@@ -2595,6 +2690,40 @@ mod tests {
                 .len(),
             1,
             "the live peer's claim must survive"
+        );
+    }
+
+    #[test]
+    fn unclaim_without_identity_never_releases_the_sole_live_peers_claim() {
+        let _store = crate::test_support::isolated_store();
+        let _env = env_guard();
+        std::env::remove_var("EDDA_SESSION_ID");
+        std::env::remove_var("EDDA_SESSION_LABEL");
+        let repo = tempfile::tempdir().expect("tempdir");
+        let pid = edda_store::project_id(repo.path());
+        edda_store::ensure_dirs(&pid).expect("store dirs");
+        edda_bridge_claude::peers::write_heartbeat_minimal(
+            &pid,
+            "sole-live-worker",
+            "worker",
+            "/tmp/worker",
+        );
+        edda_bridge_claude::peers::write_claim(
+            &pid,
+            "sole-live-worker",
+            "worker",
+            &["src/worker.rs".into()],
+        );
+
+        let err = unclaim(repo.path(), None, false)
+            .expect_err("an adjacent shell must not release the sole live worker");
+        assert!(err.to_string().contains("--session"), "{err}");
+        assert_eq!(
+            edda_bridge_claude::peers::compute_board_state(&pid)
+                .claims
+                .len(),
+            1,
+            "the live worker's claim must survive"
         );
     }
 

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -104,7 +104,7 @@ enum Command {
         /// Decision keys this decision depends on (repeatable)
         #[arg(long = "refs")]
         refs: Vec<String>,
-        /// Session ID (auto-inferred from active heartbeats if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
         /// Decision scope: local (default), shared, or global
@@ -129,7 +129,7 @@ enum Command {
         /// resolved session label.
         #[arg(long)]
         by: Option<String>,
-        /// Session ID (auto-inferred from active heartbeats if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
     },
@@ -164,13 +164,13 @@ enum Command {
         /// File path patterns this scope covers (e.g. "src/auth/*")
         #[arg(long)]
         paths: Vec<String>,
-        /// Session ID (auto-inferred from active heartbeats if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
     },
     /// Release this session's coordination scope
     Unclaim {
-        /// Session ID (inferred from a sole live session; required otherwise)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
         /// Exit 0 when there is nothing to release, for unconditional teardown
@@ -183,7 +183,7 @@ enum Command {
         to: String,
         /// Request message
         message: String,
-        /// Session ID (auto-inferred from active heartbeats if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
         /// Send even when no active session answers to the target label
@@ -195,7 +195,7 @@ enum Command {
     RequestAck {
         /// Label of the session whose request to acknowledge
         from: String,
-        /// Session ID (auto-inferred from active heartbeats if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
     },
@@ -207,7 +207,7 @@ enum Command {
     },
     /// Show coordination state (shortcut for `bridge claude render-coordination`)
     Coord {
-        /// Session ID (auto-inferred from active heartbeats if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
     },
@@ -716,7 +716,7 @@ enum BridgeClaudeCmd {
         /// File path patterns this scope covers (e.g. "src/auth/*")
         #[arg(long)]
         paths: Vec<String>,
-        /// Session ID (auto-inferred from active heartbeats if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
     },
@@ -730,7 +730,7 @@ enum BridgeClaudeCmd {
         /// Decision keys this decision depends on (repeatable)
         #[arg(long = "refs")]
         refs: Vec<String>,
-        /// Session ID (auto-inferred from active heartbeats if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
         /// File glob patterns this decision governs (repeatable)
@@ -746,7 +746,7 @@ enum BridgeClaudeCmd {
         to: String,
         /// Request message
         message: String,
-        /// Session ID (auto-inferred from active heartbeats if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
         /// Send even when no active session answers to the target label
@@ -763,7 +763,7 @@ enum BridgeClaudeCmd {
     },
     /// Render L2 coordination protocol
     RenderCoordination {
-        /// Session ID (auto-inferred if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
     },
@@ -776,19 +776,19 @@ enum BridgeClaudeCmd {
         /// Session label (e.g. "auth", "billing")
         #[arg(long)]
         label: String,
-        /// Session ID (auto-inferred if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
     },
     /// Touch heartbeat timestamp (liveness ping)
     HeartbeatTouch {
-        /// Session ID (auto-inferred if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
     },
     /// Remove session heartbeat
     HeartbeatRemove {
-        /// Session ID (auto-inferred if omitted)
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
     },

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -153,7 +153,7 @@ edda decide <DECISION> [OPTIONS]
 |--------|-------------|
 | `DECISION` | Key=value format (e.g. `"db.engine=postgres"`) |
 | `--reason TEXT` | Reason for the decision |
-| `--session ID` | Session ID (auto-inferred from active heartbeats) |
+| `--session ID` | Explicit session attribution; otherwise uses process-carried `EDDA_SESSION_ID` |
 
 ```bash
 edda decide "db.engine=sqlite" --reason "embedded, zero-config"
@@ -191,6 +191,13 @@ edda run -- npm run build
 
 ## Coordination (multi-agent)
 
+Hook integrations carry their session ID into shell commands as
+`EDDA_SESSION_ID`; an explicit `--session` overrides it. Without either, the
+CLI uses a deterministic `cli-<label>` identity only when no live session is
+present. Beside one or more live sessions it refuses before mutating state and
+asks for `--session`, because a heartbeat cannot prove which process owns it.
+These IDs provide attribution, not authentication or authorization.
+
 ### `edda claim`
 
 Claim a scope for coordination. Other agents see claimed paths as off-limits.
@@ -203,7 +210,7 @@ edda claim <LABEL> [OPTIONS]
 |--------|-------------|
 | `LABEL` | Short label (e.g. `"auth"`, `"billing"`) |
 | `--paths PATTERN` | One file path pattern; repeat for multiple patterns |
-| `--session ID` | Session ID (auto-inferred) |
+| `--session ID` | Explicit session attribution; otherwise uses process-carried `EDDA_SESSION_ID` |
 
 ```bash
 edda claim "auth" --paths "src/auth/*"
@@ -227,7 +234,7 @@ edda request <TO> <MESSAGE> [OPTIONS]
 |--------|-------------|
 | `TO` | Target session label |
 | `MESSAGE` | Request message |
-| `--session ID` | Session ID (auto-inferred) |
+| `--session ID` | Explicit session attribution; otherwise uses process-carried `EDDA_SESSION_ID` |
 | `--force` | Send even when no active session answers to `TO` |
 
 ```bash

--- a/integrations/openclaw/index.js
+++ b/integrations/openclaw/index.js
@@ -1,9 +1,20 @@
 const { execSync } = require("child_process");
 
+const sessionIdentityByKey = new Map();
+
+function heartbeatSessionId(ctx) {
+  const sessionKey = ctx.sessionKey || "";
+  const sessionId = ctx.sessionId || sessionKey;
+  if (sessionKey && sessionId) {
+    sessionIdentityByKey.set(sessionKey, sessionId);
+  }
+  return sessionId;
+}
+
 function callEdda(hookName, eventData, ctx, logger, timeout) {
   const payload = JSON.stringify({
     hook_event_name: hookName,
-    session_id: ctx.sessionId || "",
+    session_id: heartbeatSessionId(ctx),
     session_key: ctx.sessionKey || "",
     agent_id: ctx.agentId || "main",
     workspace_dir: ctx.workspaceDir || "",
@@ -32,6 +43,12 @@ const plugin = {
 
     api.on("session_start", async (event, ctx) => {
       callEdda("session_start", {}, ctx, logger, 15000);
+    });
+
+    api.on("resolve_exec_env", async (event, ctx) => {
+      const sessionKey = event.sessionKey || ctx.sessionKey || "";
+      const sessionId = sessionIdentityByKey.get(sessionKey);
+      return sessionId ? { EDDA_SESSION_ID: sessionId } : {};
     });
 
     api.on("before_agent_start", async (event, ctx) => {
@@ -101,6 +118,9 @@ const plugin = {
         logger,
         15000,
       );
+      if (ctx.sessionKey) {
+        sessionIdentityByKey.delete(ctx.sessionKey);
+      }
     });
   },
 };

--- a/integrations/openclaw/index.js
+++ b/integrations/openclaw/index.js
@@ -4,7 +4,8 @@ const sessionIdentityByKey = new Map();
 
 function heartbeatSessionId(ctx) {
   const sessionKey = ctx.sessionKey || "";
-  const sessionId = ctx.sessionId || sessionKey;
+  const sessionId =
+    ctx.sessionId || sessionIdentityByKey.get(sessionKey) || sessionKey;
   if (sessionKey && sessionId) {
     sessionIdentityByKey.set(sessionKey, sessionId);
   }


### PR DESCRIPTION
## Summary

- require mutating CLI identity to come from explicit --session or process-carried EDDA_SESSION_ID whenever any live session exists
- preserve deterministic cli-label fallback only for genuine standalone CLI use with zero live sessions
- carry host session identity through Claude CLAUDE_ENV_FILE, Cursor sessionStart env, OpenClaw resolve_exec_env, and command-local Codex/Hermes rewrites
- update duplicated help, reference docs, and rustdoc with attribution and authentication limits

## Acceptance evidence

- TDD red reproduced peer adoption: bare claim replaced the sole live scope, bare decide appended state beside two live sessions, and bare unclaim released the sole live claim
- Green tests prove one- and two-live-session refusal names --session and preserves state
- explicit --session and non-empty EDDA_SESSION_ID retain precedence; empty EDDA_SESSION_ID cannot adopt a heartbeat; zero-live fallback remains
- shell rewrites preserve original command bytes, quote opaque IDs for PowerShell/POSIX, and leave non-shell tools unchanged
- OpenClaw runtime probe proved two sessionKey mappings resolve to their exact heartbeat IDs and session_end clears the mapping

## Verification receipt

Frozen SHA: 631931074ac137098bc51794a81ed47ea8ac1848
Host: x86_64-pc-windows-msvc
Toolchain: rustc 1.93.1, cargo 1.93.1
Lane: C:\Users\synvoke\AppData\Local\fleet-workstation\lanes\worker-2
Freeze setting: CARGO_INCREMENTAL=0

L0 PASS:
- cargo fmt --all --check
- cargo clippy and cargo test for edda, edda-bridge-claude, edda-bridge-codex, edda-bridge-cursor, edda-bridge-hermes, and edda-bridge-openclaw
- counts: edda 323 unit + 11 integration; Claude 574; Codex 17; Cursor 22; Hermes 22; OpenClaw 32; zero failures

L1 PASS at the frozen SHA:
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

The first workspace-test link attempt hit transient Windows LNK1104 on the conductor test executable after format and workspace clippy had passed. The artifact was absent and no Cargo, rustc, or conductor process remained; per the ladder, only cargo test --workspace was retried at the same SHA, and it passed across all crates and doc-tests.

Additional PASS:
- executable Node probe for OpenClaw resolve_exec_env mapping and cleanup
- generated OpenClaw plugin copy byte-matches integrations/openclaw/index.js after line-ending normalization
- clean worktree at frozen SHA

Out of scope by design: branch-refresh and subagent-stale follow-ups from #503.

Closes #503