### PR TITLE
fix(conductor): resolve the pi binary on Windows (#525)

### DIFF
--- a/crates/edda-conductor/src/agent/pi_rpc.rs
+++ b/crates/edda-conductor/src/agent/pi_rpc.rs
@@ -2,6 +2,7 @@ use crate::agent::launcher::{AgentLauncher, PhaseResult};
 use crate::plan::schema::Phase;
 use anyhow::{anyhow, Context, Result};
 use serde_json::{json, Value};
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
@@ -14,6 +15,29 @@ use tokio_util::sync::CancellationToken;
 
 /// Upper bound on waiting for the stderr drain once stdout has hit EOF.
 const STDERR_DRAIN_GRACE: Duration = Duration::from_secs(2);
+
+/// Resolve the pi executable from an explicit `EDDA_PI_BIN` value, falling
+/// back to the name npm installs on this platform.
+///
+/// On Windows the npm package ships `pi` as a `.cmd` shim with no `.exe`;
+/// `CreateProcess` — unlike a shell — does not apply `PATHEXT`, so the bare
+/// name never resolves and every phase fails at `verify_available`.
+///
+/// Takes the override as an argument rather than reading the environment so
+/// the resolution is testable without mutating process-wide state.
+fn resolve_pi_bin(explicit: Option<OsString>) -> PathBuf {
+    match explicit {
+        // An empty `EDDA_PI_BIN=` is a set-but-unusable value; treat it as unset
+        // rather than spawning an empty path.
+        Some(value) if !value.is_empty() => PathBuf::from(value),
+        _ if cfg!(windows) => PathBuf::from("pi.cmd"),
+        _ => PathBuf::from("pi"),
+    }
+}
+
+fn default_pi_bin() -> PathBuf {
+    resolve_pi_bin(std::env::var_os("EDDA_PI_BIN"))
+}
 
 /// Launches the pi coding agent via `pi --mode rpc`.
 ///
@@ -43,7 +67,7 @@ impl Default for PiRpcLauncher {
 impl PiRpcLauncher {
     pub fn new() -> Self {
         Self {
-            pi_bin: PathBuf::from("pi"),
+            pi_bin: default_pi_bin(),
             verbose: false,
             model: None,
             session_dir: None,
@@ -85,7 +109,8 @@ impl PiRpcLauncher {
             Ok(s) if s.success() => Ok(()),
             _ => anyhow::bail!(
                 "pi CLI not found (looked for {:?}).\n\
-                 Install: npm install -g @earendil-works/pi-coding-agent",
+                 Install: npm install -g @earendil-works/pi-coding-agent\n\
+                 Or set EDDA_PI_BIN if the executable lives elsewhere.",
                 self.pi_bin
             ),
         }
@@ -933,6 +958,39 @@ mod tests {
         let tail = format_stderr_tail(raw);
         assert_eq!(tail, "second | third | fourth | fifth | sixth");
         assert!(!tail.contains("first"), "only the last 5 lines are kept");
+    }
+
+    #[test]
+    fn pi_bin_falls_back_to_the_platform_install() {
+        // npm ships pi as a .cmd shim on Windows with no .exe, and
+        // CreateProcess does not apply PATHEXT — the bare name never resolves.
+        let expected = if cfg!(windows) { "pi.cmd" } else { "pi" };
+        assert_eq!(resolve_pi_bin(None), PathBuf::from(expected));
+    }
+
+    #[test]
+    fn edda_pi_bin_overrides_the_platform_default() {
+        let custom = "/opt/pi/bin/pi-custom";
+        assert_eq!(
+            resolve_pi_bin(Some(OsString::from(custom))),
+            PathBuf::from(custom)
+        );
+    }
+
+    #[test]
+    fn empty_edda_pi_bin_is_treated_as_unset() {
+        let expected = if cfg!(windows) { "pi.cmd" } else { "pi" };
+        assert_eq!(
+            resolve_pi_bin(Some(OsString::new())),
+            PathBuf::from(expected),
+            "an empty override must not produce an unspawnable empty path"
+        );
+    }
+
+    #[test]
+    fn with_bin_overrides_the_default() {
+        let custom = PathBuf::from("/opt/pi/bin/pi");
+        assert_eq!(PiRpcLauncher::with_bin(custom.clone()).pi_bin, custom);
     }
 
     #[test]


### PR DESCRIPTION
Closes #525

## Problem

`edda conduct run --agent pi` failed at `verify_available` with "pi CLI not found" on Windows even on a working pi install — every phase dead on arrival, making the launcher from #523 unusable on the platform the fleet actually runs on.

Two facts compose:

1. **npm installs no `pi.exe` on Windows.** The global install ships `pi` (sh script), `pi.cmd`, and `pi.ps1`:

   ```text
   > where.exe pi
   C:\Users\synvoke\AppData\Roaming\npm\pi
   C:\Users\synvoke\AppData\Roaming\npm\pi.cmd
   ```

2. **`CreateProcess` does not apply `PATHEXT`.** A shell resolves `pi` → `pi.cmd`; Rust's `std::process::Command` only ever appends `.exe` to an extensionless name. `PiRpcLauncher::new()` hardcoded `PathBuf::from("pi")`, so resolution never succeeded.

Confirmed with a standalone `rustc` repro: `Command::new("pi")` → `program not found`; `Command::new("pi.cmd")` → `0.84.4`.

The existing launcher tests all inject fake processes, so none of them exercised binary resolution — the gap CI could not see.

## Change

`crates/edda-conductor/src/agent/pi_rpc.rs` only:

- `resolve_pi_bin(explicit: Option<OsString>)` — takes the override as an argument rather than reading the environment, so resolution is a pure function testable without mutating process-wide state.
- `default_pi_bin()` composes it with `std::env::var_os("EDDA_PI_BIN")`.
- Windows defaults to `pi.cmd`, everything else keeps `pi`. An empty `EDDA_PI_BIN=` is treated as unset rather than spawning an empty path.
- The not-found error now names `EDDA_PI_BIN` so the failure explains its own fix.

`edda-cli` needs no change — `cmd_conduct.rs` constructs `PiRpcLauncher::new()`, so it picks the fix up directly.

## Tests

Four unit tests, none touching process environment:

- `pi_bin_falls_back_to_the_platform_install` — `resolve_pi_bin(None)` is `pi.cmd` on Windows, `pi` elsewhere
- `edda_pi_bin_overrides_the_platform_default`
- `empty_edda_pi_bin_is_treated_as_unset`
- `with_bin_overrides_the_default`

## Gates

**L1 gate receipt** — frozen SHA `21783920651632ed865f25e04fac1a874ed4d93b`

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass (4m49s, zero warnings) |
| `cargo test --workspace --no-fail-fast` | 46 test binaries, 45 green; `edda` bin 325 passed / 2 failed |

- toolchain `rustc 1.93.1 (01f6ddf75 2026-02-11)`, `CARGO_INCREMENTAL=0`
- run in a dedicated worktree (`C:/ai_agent/edda-wt-gh525`) on its own target dir, clean tree
- `--no-fail-fast` matters here: a plain `cargo test --workspace` stops at the first failing
  binary and had covered only 1 of 46, leaving `edda-conductor` — the crate this PR changes —
  unrun. The 4 new tests are in that 46-binary run.

## Note on the two failing tests

Both belong to #524, both pre-existing:

- `simultaneous_reconciles_create_one_attempt_and_release_the_lock` — `workspace is locked by another process (...\.edda\LOCK)`
- `first_spawn_failure_does_not_prevent_later_plan_launch` — `assertion failed: launched_file.exists()` (`cmd_reconcile.rs:5298`)

**Control run, same machine / worktree / command, back to back:**

| ref | binaries | result | failures |
|---|---|---|---|
| `2178392` (this PR) | 46 | 325 passed / 2 failed | the two below |
| `c6246f1` (`main`, detached) | 46 | 325 passed / 2 failed | the same two |

Identical, so this change introduces no regression.

The second test is not yet named in #524, which recorded only the first; under
`--workspace --no-fail-fast` it fails on `main` too. Evidence posted to that issue.

This PR touches `pi_rpc.rs` only. `cmd_reconcile.rs` does reach into
`edda_conductor`, but only `codex_app_server::CodexAppServer` (lines 2321, 2412) —
no shared symbol with the pi launcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
