### PR TITLE
fix(reconcile): replace fixed-count wait budgets with time-based deadlines (#524)

### DIFF
--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -2031,16 +2031,26 @@ fn persist_reconciliation(
     Ok(PersistOutcome { plans, errors })
 }
 
+// A reconciler legitimately holds the workspace lock for its whole critical
+// section (git batch prep incl. `git worktree add`, SQLite appends,
+// `rebuild_branch`), which measured 3-5 s on Windows under full-suite load.
+// A concurrent reconciler must wait out that section rather than bail early;
+// a fixed small retry budget here was the root cause of the GH-524 flake.
+const WORKSPACE_LOCK_WAIT_BUDGET: std::time::Duration = std::time::Duration::from_secs(30);
+
 fn acquire_workspace_lock(paths: &edda_ledger::EddaPaths) -> anyhow::Result<WorkspaceLock> {
-    let mut last = None;
-    for _ in 0..120 {
+    let deadline = std::time::Instant::now() + WORKSPACE_LOCK_WAIT_BUDGET;
+    loop {
         match WorkspaceLock::acquire(paths) {
             Ok(lock) => return Ok(lock),
-            Err(error) => last = Some(error),
+            Err(error) => {
+                if std::time::Instant::now() >= deadline {
+                    return Err(error);
+                }
+            }
         }
         std::thread::sleep(std::time::Duration::from_millis(25));
     }
-    Err(last.expect("lock retry records an error"))
 }
 
 fn task_view(views: &[TaskView], task_id: u64) -> anyhow::Result<&TaskView> {
@@ -5289,10 +5299,15 @@ mod tests {
 
         assert_eq!(launched.len(), 1);
         assert_eq!(errors.len(), 1);
-        for _ in 0..40 {
-            if launched_file.exists() {
-                break;
-            }
+        // Spawning a .cmd child via cmd.exe routinely exceeds 1 s under full-suite
+        // load; wait for the side effect with a realistic deadline instead of a
+        // fixed 40 x 25 ms budget (same shape as the GH-524 lock-wait flake).
+        let spawn_deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while !launched_file.exists() {
+            anyhow::ensure!(
+                std::time::Instant::now() < spawn_deadline,
+                "later-launch.cmd side effect did not appear before the spawn deadline"
+            );
             std::thread::sleep(std::time::Duration::from_millis(25));
         }
         assert!(launched_file.exists());


### PR DESCRIPTION
Closes #524

## Problem

Two `cmd_reconcile` tests fail intermittently under the parallel suite, in two different-looking ways that share one mechanism: **a wait budget expressed as an iteration count, sized smaller than the work it waits for.**

1. `simultaneous_reconciles_create_one_attempt_and_release_the_lock` — the test races two reconciles at a `Barrier` on purpose; the loser called `acquire_workspace_lock`, which retried `120 x 25 ms = 3 s` and gave up, while the winner legitimately holds the lock for **3–5 s** under suite load (`git worktree add` alone measured 1.8–4.2 s on Windows, plus SQLite appends and `rebuild_branch`, all deliberately inside the critical section).
2. `first_spawn_failure_does_not_prevent_later_plan_launch` — `for _ in 0..40 { if launched_file.exists() { break } }`, a 1 s poll waiting on a spawned `.cmd` child that routinely takes longer under load, falling through to a bare `assert!` with no context.

The issue's original hypothesis (cross-test `.edda/LOCK` contention) was wrong: every `cmd_reconcile` test builds its workspace in a unique tempdir, and the lock paths captured in the failures are each test's own repo. #524 has been corrected accordingly.

## Change

`crates/edda-cli/src/cmd_reconcile.rs` only, +23/-8:

- `acquire_workspace_lock` — the 120-iteration loop becomes a **30 s `Instant`-based deadline**, with the measured critical-section numbers recorded in a comment so the constant is justifiable rather than arbitrary.
- The spawn-wait poll becomes a 30 s deadline with an explicit `anyhow::ensure!` message naming what did not appear.

## This is a production behavior change, not only a test fix

`acquire_workspace_lock` is product code (three callers: `persist_reconciliation`, `record_session_if_current`, `finish_runner`). A concurrent reconciler now waits out a busy workspace for up to 30 s instead of failing after 3 s.

That is the correct behavior for this command's role: `edda reconcile` is the **L3 fallback sweep run by the OS scheduler** (Windows Task Scheduler / cron — `docs/plan/task-rail/TASK_RAIL_V1.md`), not an interactive fast path and not wired into any hook. A scheduled sweep that bails after 3 s silently skips a dispatch cycle; one that waits gets the work done. No interactive path acquires this lock, so no user-visible command gains a 30 s stall.

## What the fix deliberately does not do

No `#[ignore]`, no weakened assertion, no serialization of the racing pair. The two reconciles still hit the `Barrier` simultaneously and still race one lock; the loser now waits out the winner's full critical section and plans zero dispatches — the production-shaped outcome the test asserts.

## Verification note

`--no-fail-fast` is required to verify this. A plain `cargo test --workspace` stops at the first failing binary (1 of 46 covered in the run that filed the issue), which is why the second test stayed invisible; under `--no-fail-fast` all 46 run, load is higher, and both surface.

Authored by pi (`z-ai/glm-5.3-flash`) via `edda conduct run --agent pi`, reviewed and verified in a separate Claude session.
