### PR TITLE
feat(conductor): codex launcher adapter + --agent codex (#527)

### DIFF
--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -6,6 +6,7 @@ use edda_conductor::agent::launcher::{phase_session_id, AgentLauncher, ClaudeCod
 use edda_conductor::agent::pi_rpc::PiRpcLauncher;
 use edda_conductor::check::engine::CheckEngine;
 use edda_conductor::plan::parser::load_plan;
+use edda_conductor::plan::schema::Plan;
 use edda_conductor::runner::notify::StdoutNotifier;
 use edda_conductor::runner::sequential::{run_plan, RunContext};
 use edda_conductor::state::machine::{PhaseStatus, PlanState, PlanStatus};
@@ -194,6 +195,10 @@ pub fn run(
     } else {
         false
     };
+
+    if let Some(warning) = budget_warning(&plan, agent) {
+        eprintln!("{warning}");
+    }
 
     // Load or create state
     let mut state = match load_state(&cwd, &plan.name)? {
@@ -494,6 +499,42 @@ pub fn abort(repo_root: &Path, plan_name: Option<&str>) -> Result<()> {
 
 // --- helpers ---
 
+/// One-line startup warning when the selected backend cannot enforce budgets.
+///
+/// codex exposes no cost/usage data, so every phase reports `cost_usd: None`:
+/// the per-phase gate is inert and the sequential runner never feeds the
+/// plan-level `BudgetTracker`, leaving both phase and plan `budget_usd`
+/// unenforced and any printed cost figure a guess. Mirrors the --tmux
+/// warn-and-fall-back tone above.
+fn budget_warning(plan: &Plan, agent: AgentKind) -> Option<String> {
+    let any_budget =
+        plan.budget_usd.is_some() || plan.phases.iter().any(|p| p.budget_usd.is_some());
+    if agent == AgentKind::Codex && any_budget {
+        Some(format!(
+            "Warning: agent \"{}\" exposes no usage data, so budget_usd limits will not \
+             be enforced and reported cost is unavailable.",
+            agent.as_str()
+        ))
+    } else {
+        None
+    }
+}
+
+/// The status cost line.
+///
+/// `PlanState` does not record which agent backend ran, so a zero total
+/// cannot be attributed: usage-free backends like codex report no cost data
+/// at all, while a backend that reports usage overwrites the zero with a
+/// real figure once a phase completes. Printing "$0.00" for a codex run
+/// would assert a spend nobody measured, so a zero total renders as "n/a".
+fn cost_line(total_cost_usd: f64) -> String {
+    if total_cost_usd == 0.0 {
+        "n/a (no usage data reported)".to_owned()
+    } else {
+        format!("${total_cost_usd:.2}")
+    }
+}
+
 fn resolve_plan_name(repo_root: &Path, explicit: Option<&str>) -> Result<String> {
     if let Some(name) = explicit {
         return Ok(name.to_string());
@@ -532,7 +573,7 @@ fn print_status(state: &PlanState) {
     if !state.plan_file.is_empty() {
         println!("  File: {}", state.plan_file);
     }
-    println!("  Cost: ${:.2}", state.total_cost_usd);
+    println!("  Cost: {}", cost_line(state.total_cost_usd));
 
     println!();
     for ps in &state.phases {
@@ -581,6 +622,7 @@ fn ctrlc_cancel(cancel: CancellationToken) {
 mod tests {
     use super::*;
     use clap::Parser;
+    use edda_conductor::plan::parser::parse_plan;
 
     /// Minimal parser harness: `ConductCmd` is a `Subcommand`, so it needs a
     /// root command to be parsed standalone.
@@ -631,7 +673,62 @@ mod tests {
 
     #[test]
     fn run_rejects_unknown_agent() {
-        assert!(TestCli::try_parse_from(["edda", "run", "plan.yaml", "--agent", "gpt"]).is_err());
+        let error = match TestCli::try_parse_from(["edda", "run", "plan.yaml", "--agent", "gpt"]) {
+            Err(error) => error,
+            Ok(_) => panic!("unknown agent must be rejected"),
+        };
+        let text = error.to_string();
+        for expected in ["claude", "pi", "codex"] {
+            assert!(
+                text.contains(expected),
+                "error should list the valid agents, missing {expected:?}: {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn budget_warning_fires_for_codex_with_plan_budget() {
+        let plan = parse_plan("name: t\nphases:\n  - id: a\n    prompt: x\nbudget_usd: 5.0\n")
+            .expect("test plan parses");
+        let warning = budget_warning(&plan, AgentKind::Codex).expect("warning expected");
+        assert!(warning.contains("codex"), "{warning}");
+        assert!(warning.contains("budget_usd"), "{warning}");
+        assert!(warning.contains("not be enforced"), "{warning}");
+        assert!(warning.contains("cost is unavailable"), "{warning}");
+    }
+
+    #[test]
+    fn budget_warning_fires_for_codex_with_phase_budget() {
+        let plan = parse_plan("name: t\nphases:\n  - id: a\n    prompt: x\n    budget_usd: 1.0\n")
+            .expect("test plan parses");
+        assert!(budget_warning(&plan, AgentKind::Codex).is_some());
+    }
+
+    #[test]
+    fn budget_warning_stays_silent_without_a_budget() {
+        let plan =
+            parse_plan("name: t\nphases:\n  - id: a\n    prompt: x\n").expect("test plan parses");
+        assert!(budget_warning(&plan, AgentKind::Codex).is_none());
+    }
+
+    #[test]
+    fn budget_warning_stays_silent_for_other_agents() {
+        let plan = parse_plan("name: t\nphases:\n  - id: a\n    prompt: x\nbudget_usd: 5.0\n")
+            .expect("test plan parses");
+        assert!(budget_warning(&plan, AgentKind::Claude).is_none());
+        assert!(budget_warning(&plan, AgentKind::Pi).is_none());
+    }
+
+    #[test]
+    fn cost_line_reports_na_for_a_zero_total() {
+        // A zero total cannot be attributed to a backend (PlanState records
+        // no agent); codex runs would otherwise print a false "$0.00".
+        assert_eq!(cost_line(0.0), "n/a (no usage data reported)");
+    }
+
+    #[test]
+    fn cost_line_formats_a_reported_total() {
+        assert_eq!(cost_line(1.234), "$1.23");
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Context, Result};
 use clap::Subcommand;
 use edda_conductor::agent::budget::BudgetTracker;
+use edda_conductor::agent::codex_rpc::CodexLauncher;
 use edda_conductor::agent::launcher::{phase_session_id, AgentLauncher, ClaudeCodeLauncher};
 use edda_conductor::agent::pi_rpc::PiRpcLauncher;
 use edda_conductor::check::engine::CheckEngine;
@@ -22,6 +23,8 @@ pub enum AgentKind {
     Claude,
     /// pi coding agent via `pi --mode rpc`
     Pi,
+    /// codex CLI via `codex app-server`
+    Codex,
 }
 
 impl AgentKind {
@@ -29,6 +32,7 @@ impl AgentKind {
         match self {
             AgentKind::Claude => "claude",
             AgentKind::Pi => "pi",
+            AgentKind::Codex => "codex",
         }
     }
 
@@ -38,6 +42,7 @@ impl AgentKind {
         match self {
             AgentKind::Claude => true,
             AgentKind::Pi => false,
+            AgentKind::Codex => false,
         }
     }
 }
@@ -263,6 +268,11 @@ pub fn run(
         }
         AgentKind::Pi => {
             let launcher = PiRpcLauncher::new().with_verbose(verbose);
+            launcher.verify_available()?;
+            Box::new(launcher)
+        }
+        AgentKind::Codex => {
+            let launcher = CodexLauncher::new().with_verbose(verbose);
             launcher.verify_available()?;
             Box::new(launcher)
         }
@@ -613,6 +623,10 @@ mod tests {
             agent_of(parse(&["edda", "run", "plan.yaml", "--agent", "claude"])),
             AgentKind::Claude
         );
+        assert_eq!(
+            agent_of(parse(&["edda", "run", "plan.yaml", "--agent", "codex"])),
+            AgentKind::Codex
+        );
     }
 
     #[test]
@@ -626,7 +640,9 @@ mod tests {
         // otherwise get panes tailing files nobody writes.
         assert!(AgentKind::Claude.writes_transcripts());
         assert!(!AgentKind::Pi.writes_transcripts());
+        assert!(!AgentKind::Codex.writes_transcripts());
         assert_eq!(AgentKind::Claude.as_str(), "claude");
         assert_eq!(AgentKind::Pi.as_str(), "pi");
+        assert_eq!(AgentKind::Codex.as_str(), "codex");
     }
 }

--- a/crates/edda-conductor/src/agent/codex_app_server.rs
+++ b/crates/edda-conductor/src/agent/codex_app_server.rs
@@ -23,10 +23,10 @@ impl CodexAppServer {
     pub async fn spawn(bin: &Path) -> Result<Self> {
         let mut command = Command::new(bin);
         command.arg("app-server");
-        Self::spawn_command(command).await
+        Self::spawn_with_command(command).await
     }
 
-    pub(crate) async fn spawn_command(mut command: Command) -> Result<Self> {
+    async fn spawn_with_command(mut command: Command) -> Result<Self> {
         command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -64,6 +64,13 @@ impl CodexAppServer {
             .await?;
         server.notify("initialized").await?;
         Ok(server)
+    }
+
+    /// Test-only wrapper so sibling-module tests (codex_rpc) can drive fake
+    /// app-servers through the same spawn+initialize path as [`Self::spawn`].
+    #[cfg(test)]
+    pub(crate) async fn spawn_command(command: Command) -> Result<Self> {
+        Self::spawn_with_command(command).await
     }
 
     pub async fn open_thread(&mut self, cwd: &Path, resume: Option<&str>) -> Result<String> {

--- a/crates/edda-conductor/src/agent/codex_app_server.rs
+++ b/crates/edda-conductor/src/agent/codex_app_server.rs
@@ -26,7 +26,7 @@ impl CodexAppServer {
         Self::spawn_command(command).await
     }
 
-    async fn spawn_command(mut command: Command) -> Result<Self> {
+    pub(crate) async fn spawn_command(mut command: Command) -> Result<Self> {
         command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -393,46 +393,35 @@ impl<'a> TurnAccumulator<'a> {
     }
 }
 
+/// Scripted Codex App Server processes for tests, shared with the launcher
+/// tests in `codex_rpc.rs` so every protocol-level fake lives in one place.
 #[cfg(test)]
-fn response_for_id<'a>(lines: impl IntoIterator<Item = &'a str>, id: u64) -> Result<Value> {
-    for line in lines {
-        let message = parse_message(line)?;
-        if let Some(result) = matching_response(&message, id) {
-            return result;
-        }
-    }
-    bail!("unexpected EOF waiting for app-server response {id}")
-}
-
-#[cfg(test)]
-fn turn_outcome_from_lines<'a>(
-    lines: impl IntoIterator<Item = &'a str>,
-    thread_id: &str,
-    turn_id: &str,
-) -> Result<CodexTurnOutcome> {
-    let mut turn = TurnAccumulator::new(thread_id, turn_id);
-    for line in lines {
-        if let Some(outcome) = turn.observe(&parse_message(line)?)? {
-            return Ok(outcome);
-        }
-    }
-    bail!("unexpected EOF waiting for terminal Codex turn notification")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
+pub(crate) mod fake_support {
+    use anyhow::Result;
+    use tokio::process::Command;
 
     #[derive(Clone, Copy)]
-    enum FakeScenario {
+    pub(crate) enum FakeScenario {
         MissingThreadId,
         EmptyThreadId,
+        /// One thread/start (t-1) + one completed turn ("turn complete").
+        RunTurnCompletes,
         RunTurnInterleaving,
+        /// turn/start answers with a JSON-RPC error on request id 2, i.e. a
+        /// client that calls run_turn directly without opening a thread first.
         RunTurnError,
+        /// thread/start succeeds (t-1), then turn/start answers with a
+        /// JSON-RPC error. Scripted for a client that opened the thread first,
+        /// so the error lands on request id 3.
+        RunTurnStartError,
+        /// Two full turns: thread/start (t-1) + turn ("first answer"), then
+        /// thread/resume (t-2) + turn ("second answer"). Drives the session
+        /// continuity path end to end.
+        TwoTurnsWithResume,
         Idle,
     }
 
-    fn fake_app_server(scenario: FakeScenario) -> anyhow::Result<(tempfile::TempDir, Command)> {
+    pub(crate) fn fake_app_server(scenario: FakeScenario) -> Result<(tempfile::TempDir, Command)> {
         let dir = tempfile::tempdir()?;
 
         #[cfg(windows)]
@@ -485,14 +474,6 @@ mod tests {
         }
     }
 
-    async fn spawn_fake_app_server(
-        scenario: FakeScenario,
-    ) -> anyhow::Result<(tempfile::TempDir, CodexAppServer)> {
-        let (dir, command) = fake_app_server(scenario)?;
-        let server = CodexAppServer::spawn_command(command).await?;
-        Ok((dir, server))
-    }
-
     #[cfg(windows)]
     fn powershell_fake_script(scenario: FakeScenario) -> String {
         let body = match scenario {
@@ -502,11 +483,20 @@ mod tests {
             FakeScenario::EmptyThreadId => {
                 "Read-Line\nWrite-Line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"\"}}}'\nStart-Sleep -Seconds 60"
             }
+            FakeScenario::RunTurnCompletes => {
+                "Read-Line\nWrite-Line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"t-1\"}}}'\nRead-Line\nWrite-Line '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-1\"}}}'\nWrite-Line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-1\",\"turnId\":\"turn-1\",\"item\":{\"type\":\"agentMessage\",\"text\":\"turn complete\"}}}'\nWrite-Line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-1\",\"turn\":{\"id\":\"turn-1\",\"status\":\"completed\"}}}'\nStart-Sleep -Seconds 60"
+            }
             FakeScenario::RunTurnInterleaving => {
                 "Read-Line\nWrite-Line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"t-1\"}}}'\nRead-Line\nWrite-Line '{\"id\":99,\"result\":{\"ignored\":true}}'\nWrite-Line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"other-thread\",\"turnId\":\"turn-1\",\"item\":{\"type\":\"agentMessage\",\"text\":\"wrong thread\"}}}'\nWrite-Line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"other-thread\",\"turn\":{\"id\":\"turn-1\",\"status\":\"completed\"}}}'\nWrite-Line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-1\",\"turnId\":\"turn-1\",\"item\":{\"type\":\"agentMessage\",\"text\":\"target final\"}}}'\nWrite-Line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-1\",\"turn\":{\"id\":\"turn-1\",\"status\":\"completed\"}}}'\nWrite-Line '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-1\"}}}'\nStart-Sleep -Seconds 60"
             }
             FakeScenario::RunTurnError => {
                 "Read-Line\nWrite-Line '{\"id\":2,\"error\":{\"code\":-32602,\"message\":\"bad turn\"}}'\nStart-Sleep -Seconds 60"
+            }
+            FakeScenario::RunTurnStartError => {
+                "Read-Line\nWrite-Line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"t-1\"}}}'\nRead-Line\nWrite-Line '{\"id\":3,\"error\":{\"code\":-32602,\"message\":\"bad turn\"}}'\nStart-Sleep -Seconds 60"
+            }
+            FakeScenario::TwoTurnsWithResume => {
+                "Read-Line\nWrite-Line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"t-1\"}}}'\nRead-Line\nWrite-Line '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-1\"}}}'\nWrite-Line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-1\",\"turnId\":\"turn-1\",\"item\":{\"type\":\"agentMessage\",\"text\":\"first answer\"}}}'\nWrite-Line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-1\",\"turn\":{\"id\":\"turn-1\",\"status\":\"completed\"}}}'\nRead-Line\nWrite-Line '{\"id\":4,\"result\":{\"thread\":{\"id\":\"t-2\"}}}'\nRead-Line\nWrite-Line '{\"id\":5,\"result\":{\"turn\":{\"id\":\"turn-2\"}}}'\nWrite-Line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-2\",\"turnId\":\"turn-2\",\"item\":{\"type\":\"agentMessage\",\"text\":\"second answer\"}}}'\nWrite-Line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-2\",\"turn\":{\"id\":\"turn-2\",\"status\":\"completed\"}}}'\nStart-Sleep -Seconds 60"
             }
             FakeScenario::Idle => "Start-Sleep -Seconds 60",
         };
@@ -524,17 +514,66 @@ mod tests {
             FakeScenario::EmptyThreadId => {
                 "read_line\nwrite_line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"\"}}}'\nsleep 60"
             }
+            FakeScenario::RunTurnCompletes => {
+                "read_line\nwrite_line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"t-1\"}}}'\nread_line\nwrite_line '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-1\"}}}'\nwrite_line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-1\",\"turnId\":\"turn-1\",\"item\":{\"type\":\"agentMessage\",\"text\":\"turn complete\"}}}'\nwrite_line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-1\",\"turn\":{\"id\":\"turn-1\",\"status\":\"completed\"}}}'\nsleep 60"
+            }
             FakeScenario::RunTurnInterleaving => {
                 "read_line\nwrite_line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"t-1\"}}}'\nread_line\nwrite_line '{\"id\":99,\"result\":{\"ignored\":true}}'\nwrite_line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"other-thread\",\"turnId\":\"turn-1\",\"item\":{\"type\":\"agentMessage\",\"text\":\"wrong thread\"}}}'\nwrite_line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"other-thread\",\"turn\":{\"id\":\"turn-1\",\"status\":\"completed\"}}}'\nwrite_line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-1\",\"turnId\":\"turn-1\",\"item\":{\"type\":\"agentMessage\",\"text\":\"target final\"}}}'\nwrite_line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-1\",\"turn\":{\"id\":\"turn-1\",\"status\":\"completed\"}}}'\nwrite_line '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-1\"}}}'\nsleep 60"
             }
             FakeScenario::RunTurnError => {
                 "read_line\nwrite_line '{\"id\":2,\"error\":{\"code\":-32602,\"message\":\"bad turn\"}}'\nsleep 60"
             }
+            FakeScenario::RunTurnStartError => {
+                "read_line\nwrite_line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"t-1\"}}}'\nread_line\nwrite_line '{\"id\":3,\"error\":{\"code\":-32602,\"message\":\"bad turn\"}}'\nsleep 60"
+            }
+            FakeScenario::TwoTurnsWithResume => {
+                "read_line\nwrite_line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"t-1\"}}}'\nread_line\nwrite_line '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-1\"}}}'\nwrite_line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-1\",\"turnId\":\"turn-1\",\"item\":{\"type\":\"agentMessage\",\"text\":\"first answer\"}}}'\nwrite_line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-1\",\"turn\":{\"id\":\"turn-1\",\"status\":\"completed\"}}}'\nread_line\nwrite_line '{\"id\":4,\"result\":{\"thread\":{\"id\":\"t-2\"}}}'\nread_line\nwrite_line '{\"id\":5,\"result\":{\"turn\":{\"id\":\"turn-2\"}}}'\nwrite_line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-2\",\"turnId\":\"turn-2\",\"item\":{\"type\":\"agentMessage\",\"text\":\"second answer\"}}}'\nwrite_line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-2\",\"turn\":{\"id\":\"turn-2\",\"status\":\"completed\"}}}'\nsleep 60"
+            }
             FakeScenario::Idle => "sleep 60",
         };
         format!(
             "#!/bin/sh\nread_line() {{ IFS= read -r _ || exit 0; }}\nwrite_line() {{ printf '%s\\n' \"$1\"; }}\nread_line\nwrite_line '{{\"id\":1,\"result\":{{}}}}'\nread_line\n{body}\n"
         )
+    }
+}
+
+#[cfg(test)]
+fn response_for_id<'a>(lines: impl IntoIterator<Item = &'a str>, id: u64) -> Result<Value> {
+    for line in lines {
+        let message = parse_message(line)?;
+        if let Some(result) = matching_response(&message, id) {
+            return result;
+        }
+    }
+    bail!("unexpected EOF waiting for app-server response {id}")
+}
+
+#[cfg(test)]
+fn turn_outcome_from_lines<'a>(
+    lines: impl IntoIterator<Item = &'a str>,
+    thread_id: &str,
+    turn_id: &str,
+) -> Result<CodexTurnOutcome> {
+    let mut turn = TurnAccumulator::new(thread_id, turn_id);
+    for line in lines {
+        if let Some(outcome) = turn.observe(&parse_message(line)?)? {
+            return Ok(outcome);
+        }
+    }
+    bail!("unexpected EOF waiting for terminal Codex turn notification")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fake_support::{fake_app_server, FakeScenario};
+    use super::*;
+
+    async fn spawn_fake_app_server(
+        scenario: FakeScenario,
+    ) -> anyhow::Result<(tempfile::TempDir, CodexAppServer)> {
+        let (dir, command) = fake_app_server(scenario)?;
+        let server = CodexAppServer::spawn_command(command).await?;
+        Ok((dir, server))
     }
 
     async fn wait_for_process_stop(pid: u32) -> anyhow::Result<()> {

--- a/crates/edda-conductor/src/agent/codex_rpc.rs
+++ b/crates/edda-conductor/src/agent/codex_rpc.rs
@@ -43,9 +43,12 @@ fn default_codex_bin() -> PathBuf {
 /// [`CodexAppServer`] and is reused unchanged.
 ///
 /// Session continuity: the app-server process is spawned once and reused,
-/// and each conductor `session_id` maps to a codex thread id. A session
-/// seen before resumes its thread via `thread/resume`, so report →
-/// dispatch-next phases stay in one conversation. When the child dies
+/// and the `threads` map keys on the conductor session id, resuming a
+/// thread via `thread/resume` whenever a caller reuses a session id. That
+/// is a forward-looking path for a future dispatch primitive: the
+/// sequential runner derives a unique session id per plan+phase+attempt,
+/// so resume does not currently fire in production (see
+/// [`crate::agent::launcher::phase_session_id`]). When the child dies
 /// (crash, timeout, cancellation) the client is dropped and the next phase
 /// re-spawns it; the thread map survives because codex persists threads.
 pub struct CodexLauncher {
@@ -213,9 +216,13 @@ async fn drive_turn(
         _ = cancel.cancelled() => return (shutdown(), false),
     };
 
-    // The app-server protocol exposes no cost/usage data, so the per-phase
-    // budget gate cannot fire here (`over_budget(None, _)` is always false);
-    // the cost column stays empty for codex phases by design.
+    // The app-server protocol exposes no cost/usage data, so neither budget
+    // gate can fire. The per-phase check (`over_budget(None, _)`) is always
+    // false, and the sequential runner only calls BudgetTracker::record and
+    // accumulates state.total_cost_usd inside `if let Some(cost)`, so the
+    // plan-level tracker never sees a figure either: both phase and plan
+    // budget_usd are unenforced for codex. `edda conduct run` warns about
+    // this at startup; the cost column stays empty for codex phases by design.
     let cost_usd = None;
     if over_budget(cost_usd, phase.budget_usd) {
         return (PhaseResult::BudgetExceeded { cost_usd }, true);
@@ -454,9 +461,12 @@ mod tests {
 
     #[tokio::test]
     async fn same_session_id_resumes_the_same_conversation() -> Result<()> {
-        // The scripted fake answers thread/start with t-1 and thread/resume
-        // with t-2, so a second turn that produces output proves the launcher
-        // resumed the persisted thread instead of starting a new one.
+        // Exercises the forward-looking resume path: the scripted fake
+        // answers thread/start with t-1 and thread/resume with t-2, so a
+        // second turn that produces output proves the launcher resumed the
+        // persisted thread instead of starting a new one. The sequential
+        // runner assigns a unique session id per phase+attempt, so this
+        // reuse is not hit in production today.
         let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
         let (_dir, mut server) = spawn_fake_server(FakeScenario::TwoTurnsWithResume).await;
         let mut threads = HashMap::new();

--- a/crates/edda-conductor/src/agent/codex_rpc.rs
+++ b/crates/edda-conductor/src/agent/codex_rpc.rs
@@ -1,0 +1,598 @@
+use crate::agent::codex_app_server::{CodexAppServer, CodexTurnOutcome};
+use crate::agent::launcher::{AgentLauncher, PhaseResult};
+use crate::plan::schema::Phase;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+/// Resolve the codex executable from an explicit `EDDA_CODEX_BIN` value,
+/// falling back to the name npm installs on this platform.
+///
+/// Takes the override as an argument rather than reading the environment so
+/// the resolution is testable without mutating process-wide state.
+///
+/// Windows default is `codex.cmd` (GH-527 / GH-528): `where.exe codex` on a
+/// standard npm install finds the extensionless `codex` sh launcher and
+/// `codex.cmd`, and no `codex.exe`. `CreateProcess` — unlike a shell — does
+/// not apply `PATHEXT`, so neither the bare name nor the extensionless script
+/// ever resolves and every phase would fail at spawn.
+fn resolve_codex_bin(explicit: Option<OsString>) -> PathBuf {
+    match explicit {
+        // An empty `EDDA_CODEX_BIN=` is a set-but-unusable value; treat it as
+        // unset rather than spawning an empty path.
+        Some(value) if !value.is_empty() => PathBuf::from(value),
+        _ if cfg!(windows) => PathBuf::from("codex.cmd"),
+        _ => PathBuf::from("codex"),
+    }
+}
+
+fn default_codex_bin() -> PathBuf {
+    resolve_codex_bin(std::env::var_os("EDDA_CODEX_BIN"))
+}
+
+/// Launches the codex coding agent through `codex app-server`.
+///
+/// The app-server protocol is JSON-RPC over stdin/stdout: one request per
+/// line in, responses and notifications one per line out. One conductor
+/// phase maps to one codex turn (`turn/start` streamed until
+/// `turn/completed`). The protocol layer itself lives in
+/// [`CodexAppServer`] and is reused unchanged.
+///
+/// Session continuity: the app-server process is spawned once and reused,
+/// and each conductor `session_id` maps to a codex thread id. A session
+/// seen before resumes its thread via `thread/resume`, so report →
+/// dispatch-next phases stay in one conversation. When the child dies
+/// (crash, timeout, cancellation) the client is dropped and the next phase
+/// re-spawns it; the thread map survives because codex persists threads.
+pub struct CodexLauncher {
+    pub codex_bin: PathBuf,
+    pub verbose: bool,
+    state: Mutex<LauncherState>,
+}
+
+#[derive(Default)]
+struct LauncherState {
+    server: Option<CodexAppServer>,
+    /// conductor session_id → codex thread_id
+    threads: HashMap<String, String>,
+}
+
+impl Default for CodexLauncher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodexLauncher {
+    pub fn new() -> Self {
+        Self {
+            codex_bin: default_codex_bin(),
+            verbose: false,
+            state: Mutex::new(LauncherState::default()),
+        }
+    }
+
+    pub fn with_bin(codex_bin: PathBuf) -> Self {
+        Self {
+            codex_bin,
+            verbose: false,
+            state: Mutex::new(LauncherState::default()),
+        }
+    }
+
+    pub fn with_verbose(mut self, verbose: bool) -> Self {
+        self.verbose = verbose;
+        self
+    }
+
+    /// Check that the codex CLI binary is reachable.
+    pub fn verify_available(&self) -> Result<()> {
+        let status = std::process::Command::new(&self.codex_bin)
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        match status {
+            Ok(s) if s.success() => Ok(()),
+            _ => anyhow::bail!(
+                "codex CLI not found (looked for {:?}).\n\
+                 Install: npm install -g @openai/codex\n\
+                 Or set EDDA_CODEX_BIN if the executable lives elsewhere.",
+                self.codex_bin
+            ),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl AgentLauncher for CodexLauncher {
+    async fn run_phase(
+        &self,
+        phase: &Phase,
+        prompt: &str,
+        plan_context: &str,
+        session_id: &str,
+        cwd: &Path,
+        cancel: CancellationToken,
+    ) -> Result<PhaseResult> {
+        // The app-server has no system-prompt channel; carry plan context
+        // inline, same as the pi launcher.
+        let message = if plan_context.is_empty() {
+            prompt.to_owned()
+        } else {
+            format!("{plan_context}\n\n{prompt}")
+        };
+        let mut state = self.state.lock().await;
+        if state.server.is_none() {
+            match CodexAppServer::spawn(&self.codex_bin).await {
+                Ok(server) => state.server = Some(server),
+                Err(error) => {
+                    return Ok(PhaseResult::AgentCrash {
+                        error: format!(
+                            "failed to spawn codex app-server ({:?}): {error}",
+                            self.codex_bin
+                        ),
+                    });
+                }
+            }
+        }
+
+        let LauncherState { server, threads } = &mut *state;
+        let server = server.as_mut().expect("server spawned above");
+        let (result, keep_server) =
+            drive_turn(server, threads, phase, &message, session_id, cwd, &cancel).await;
+
+        if !keep_server {
+            // The turn ended in a crash, timeout, or shutdown, and the child
+            // was killed along the way (KillOnCancel or terminate). Drop the
+            // client so the next phase re-spawns a fresh app-server. The
+            // thread map survives: codex persists threads and `thread/resume`
+            // restores the conversation.
+            state.server = None;
+        }
+        Ok(result)
+    }
+}
+
+/// Open (or resume) the codex thread for `session_id`, run one turn, and map
+/// the outcome onto `PhaseResult`.
+///
+/// Returns whether the server is still usable: `false` after any crash,
+/// timeout, or cancellation, since every one of those paths kills the child.
+async fn drive_turn(
+    server: &mut CodexAppServer,
+    threads: &mut HashMap<String, String>,
+    phase: &Phase,
+    message: &str,
+    session_id: &str,
+    cwd: &Path,
+    cancel: &CancellationToken,
+) -> (PhaseResult, bool) {
+    let timeout = Duration::from_secs(phase.timeout_sec.unwrap_or(1800));
+    let deadline = tokio::time::sleep(timeout);
+    tokio::pin!(deadline);
+    let shutdown = || PhaseResult::AgentCrash {
+        error: "conductor shutdown".into(),
+    };
+
+    let resume = threads.get(session_id).cloned();
+    let thread_id = tokio::select! {
+        opened = server.open_thread(cwd, resume.as_deref()) => match opened {
+            Ok(thread_id) => thread_id,
+            Err(error) => {
+                return (
+                    PhaseResult::AgentCrash {
+                        error: error.to_string(),
+                    },
+                    false,
+                );
+            }
+        },
+        _ = &mut deadline => return (PhaseResult::Timeout, false),
+        _ = cancel.cancelled() => return (shutdown(), false),
+    };
+    threads.insert(session_id.to_owned(), thread_id.clone());
+
+    let outcome: CodexTurnOutcome = tokio::select! {
+        turned = server.run_turn(&thread_id, message) => match turned {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                return (
+                    PhaseResult::AgentCrash {
+                        error: error.to_string(),
+                    },
+                    false,
+                );
+            }
+        },
+        _ = &mut deadline => return (PhaseResult::Timeout, false),
+        _ = cancel.cancelled() => return (shutdown(), false),
+    };
+
+    // The app-server protocol exposes no cost/usage data, so the per-phase
+    // budget gate cannot fire here (`over_budget(None, _)` is always false);
+    // the cost column stays empty for codex phases by design.
+    let cost_usd = None;
+    if over_budget(cost_usd, phase.budget_usd) {
+        return (PhaseResult::BudgetExceeded { cost_usd }, true);
+    }
+    (
+        PhaseResult::AgentDone {
+            cost_usd,
+            result_text: outcome.final_text,
+        },
+        true,
+    )
+}
+
+fn over_budget(cost: Option<f64>, budget: Option<f64>) -> bool {
+    match (cost, budget) {
+        (Some(c), Some(b)) => c > b,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::CodexLauncher;
+    use crate::agent::codex_app_server::CodexAppServer;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use tokio::sync::Mutex;
+
+    /// A launcher pre-seeded with an already-spawned server, for tests that
+    /// drive `run_phase` against a fake app-server without spawning binaries.
+    pub(crate) fn launcher_with_server(server: CodexAppServer) -> CodexLauncher {
+        let mut launcher = CodexLauncher::with_bin(PathBuf::from("unused-fake-bin"));
+        launcher.state = Mutex::new(super::LauncherState {
+            server: Some(server),
+            threads: HashMap::new(),
+        });
+        launcher
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::launcher_with_server;
+    use super::*;
+    use crate::agent::codex_app_server::fake_support::{fake_app_server, FakeScenario};
+    use crate::agent::codex_app_server::CodexAppServer;
+    use crate::plan::parser::parse_plan;
+
+    fn phase_from_yaml(yaml: &str) -> Phase {
+        parse_plan(&format!("name: t\nphases:\n{yaml}"))
+            .expect("test plan parses")
+            .phases
+            .remove(0)
+    }
+
+    async fn spawn_fake_server(scenario: FakeScenario) -> (tempfile::TempDir, CodexAppServer) {
+        let (dir, command) = fake_app_server(scenario).expect("fake app-server script written");
+        let server = CodexAppServer::spawn_command(command)
+            .await
+            .expect("fake spawned");
+        (dir, server)
+    }
+    #[test]
+    fn codex_bin_falls_back_to_the_platform_install() {
+        // npm ships codex as an extensionless sh launcher plus codex.cmd on
+        // Windows, with no codex.exe, and CreateProcess does not apply
+        // PATHEXT — the bare name never resolves there.
+        let expected = if cfg!(windows) { "codex.cmd" } else { "codex" };
+        assert_eq!(resolve_codex_bin(None), PathBuf::from(expected));
+    }
+
+    #[test]
+    fn edda_codex_bin_overrides_the_platform_default() {
+        let custom = "/opt/codex/bin/codex-custom";
+        assert_eq!(
+            resolve_codex_bin(Some(OsString::from(custom))),
+            PathBuf::from(custom)
+        );
+    }
+
+    #[test]
+    fn empty_edda_codex_bin_is_treated_as_unset() {
+        let expected = if cfg!(windows) { "codex.cmd" } else { "codex" };
+        assert_eq!(
+            resolve_codex_bin(Some(OsString::new())),
+            PathBuf::from(expected),
+            "an empty override must not produce an unspawnable empty path"
+        );
+    }
+
+    #[test]
+    fn with_bin_overrides_the_default() {
+        let custom = PathBuf::from("/opt/codex/bin/codex");
+        assert_eq!(CodexLauncher::with_bin(custom.clone()).codex_bin, custom);
+    }
+
+    #[test]
+    fn over_budget_semantics() {
+        assert!(over_budget(Some(2.0), Some(1.0)));
+        assert!(!over_budget(Some(1.0), Some(1.0)));
+        assert!(!over_budget(None, Some(1.0)));
+        assert!(!over_budget(Some(5.0), None));
+        assert!(!over_budget(None, None));
+    }
+
+    #[tokio::test]
+    async fn completed_turn_maps_to_agent_done() -> Result<()> {
+        let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
+        let (_dir, mut server) = spawn_fake_server(FakeScenario::RunTurnCompletes).await;
+        let mut threads = HashMap::new();
+        let (result, keep_server) = drive_turn(
+            &mut server,
+            &mut threads,
+            &phase,
+            "do the task",
+            "sid",
+            Path::new("."),
+            &CancellationToken::new(),
+        )
+        .await;
+        assert!(keep_server);
+        match result {
+            PhaseResult::AgentDone {
+                cost_usd,
+                result_text,
+            } => {
+                assert_eq!(cost_usd, None, "codex app-server exposes no cost data");
+                assert_eq!(result_text.as_deref(), Some("turn complete"));
+            }
+            other => panic!("expected AgentDone, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn budget_cannot_fire_without_cost_data() -> Result<()> {
+        // The app-server protocol reports no usage, so a budgeted phase that
+        // completes normally still lands on AgentDone rather than
+        // BudgetExceeded — the budget gate is inert for codex by design.
+        let phase = phase_from_yaml("  - id: a\n    prompt: x\n    budget_usd: 0.01\n");
+        let (_dir, mut server) = spawn_fake_server(FakeScenario::RunTurnCompletes).await;
+        let mut threads = HashMap::new();
+        let (result, keep_server) = drive_turn(
+            &mut server,
+            &mut threads,
+            &phase,
+            "do the task",
+            "sid",
+            Path::new("."),
+            &CancellationToken::new(),
+        )
+        .await;
+        assert!(keep_server);
+        assert!(
+            matches!(result, PhaseResult::AgentDone { cost_usd: None, .. }),
+            "expected AgentDone without cost, got {result:?}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn turn_error_maps_to_agent_crash() -> Result<()> {
+        let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
+        let (_dir, mut server) = spawn_fake_server(FakeScenario::RunTurnStartError).await;
+        let mut threads = HashMap::new();
+        let (result, keep_server) = drive_turn(
+            &mut server,
+            &mut threads,
+            &phase,
+            "do the task",
+            "sid",
+            Path::new("."),
+            &CancellationToken::new(),
+        )
+        .await;
+        assert!(!keep_server, "a failed turn kills the app-server child");
+        match result {
+            PhaseResult::AgentCrash { error } => {
+                assert!(error.contains("bad turn"), "{error}");
+            }
+            other => panic!("expected AgentCrash, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn deadline_returns_timeout_result() -> Result<()> {
+        let phase = phase_from_yaml("  - id: a\n    prompt: x\n    timeout_sec: 2\n");
+        let (_dir, mut server) = spawn_fake_server(FakeScenario::Idle).await;
+        let mut threads = HashMap::new();
+        let started = tokio::time::Instant::now();
+        let (result, keep_server) = drive_turn(
+            &mut server,
+            &mut threads,
+            &phase,
+            "do the task",
+            "sid",
+            Path::new("."),
+            &CancellationToken::new(),
+        )
+        .await;
+        assert!(!keep_server);
+        assert!(matches!(result, PhaseResult::Timeout));
+        assert!(started.elapsed() < Duration::from_secs(15));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cancel_returns_conductor_shutdown() -> Result<()> {
+        let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
+        let (_dir, mut server) = spawn_fake_server(FakeScenario::Idle).await;
+        let mut threads = HashMap::new();
+        let cancel = CancellationToken::new();
+        let canceller = cancel.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            canceller.cancel();
+        });
+        let (result, keep_server) = drive_turn(
+            &mut server,
+            &mut threads,
+            &phase,
+            "do the task",
+            "sid",
+            Path::new("."),
+            &cancel,
+        )
+        .await;
+        assert!(!keep_server);
+        match result {
+            PhaseResult::AgentCrash { error } => assert_eq!(error, "conductor shutdown"),
+            other => panic!("expected AgentCrash, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn same_session_id_resumes_the_same_conversation() -> Result<()> {
+        // The scripted fake answers thread/start with t-1 and thread/resume
+        // with t-2, so a second turn that produces output proves the launcher
+        // resumed the persisted thread instead of starting a new one.
+        let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
+        let (_dir, mut server) = spawn_fake_server(FakeScenario::TwoTurnsWithResume).await;
+        let mut threads = HashMap::new();
+
+        let (first, keep) = drive_turn(
+            &mut server,
+            &mut threads,
+            &phase,
+            "turn one",
+            "sid",
+            Path::new("."),
+            &CancellationToken::new(),
+        )
+        .await;
+        assert!(keep);
+        match first {
+            PhaseResult::AgentDone { result_text, .. } => {
+                assert_eq!(result_text.as_deref(), Some("first answer"));
+            }
+            other => panic!("expected AgentDone, got {other:?}"),
+        }
+
+        let (second, keep) = drive_turn(
+            &mut server,
+            &mut threads,
+            &phase,
+            "turn two",
+            "sid",
+            Path::new("."),
+            &CancellationToken::new(),
+        )
+        .await;
+        assert!(keep);
+        match second {
+            PhaseResult::AgentDone { result_text, .. } => {
+                assert_eq!(result_text.as_deref(), Some("second answer"));
+            }
+            other => panic!("expected AgentDone, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_phase_maps_spawn_failure_to_agent_crash() {
+        let launcher =
+            CodexLauncher::with_bin(PathBuf::from("definitely-not-a-real-codex-binary-gh527"));
+        let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
+        let result = launcher
+            .run_phase(
+                &phase,
+                "do the task",
+                "",
+                "sid",
+                Path::new("."),
+                CancellationToken::new(),
+            )
+            .await
+            .expect("run_phase returns a result, not an IO error");
+        match result {
+            PhaseResult::AgentCrash { error } => {
+                assert!(
+                    error.contains("failed to spawn codex app-server"),
+                    "{error}"
+                );
+            }
+            other => panic!("expected AgentCrash, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_phase_survives_a_crashed_server_by_respawning() -> Result<()> {
+        // First phase crashes (turn error); the client is dropped, so the
+        // second phase reports the re-spawn failure instead of reusing a
+        // dead child — proving the reset happened.
+        let (_dir, server) = spawn_fake_server(FakeScenario::RunTurnStartError).await;
+        let launcher = launcher_with_server(server);
+        let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
+
+        let first = launcher
+            .run_phase(
+                &phase,
+                "do the task",
+                "",
+                "sid",
+                Path::new("."),
+                CancellationToken::new(),
+            )
+            .await?;
+        assert!(
+            matches!(&first, PhaseResult::AgentCrash { error } if error.contains("bad turn")),
+            "expected turn-error crash, got {first:?}"
+        );
+
+        let second = launcher
+            .run_phase(
+                &phase,
+                "do the task",
+                "",
+                "sid",
+                Path::new("."),
+                CancellationToken::new(),
+            )
+            .await?;
+        match second {
+            PhaseResult::AgentCrash { error } => {
+                assert!(
+                    error.contains("failed to spawn codex app-server"),
+                    "second phase should attempt a fresh spawn, got {error}"
+                );
+            }
+            other => panic!("expected spawn-failure crash, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_phase_completes_against_a_fake_server() -> Result<()> {
+        let (_dir, server) = spawn_fake_server(FakeScenario::RunTurnCompletes).await;
+        let launcher = launcher_with_server(server);
+        let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
+        let result = launcher
+            .run_phase(
+                &phase,
+                "do the task",
+                "plan context",
+                "sid",
+                Path::new("."),
+                CancellationToken::new(),
+            )
+            .await?;
+        match result {
+            PhaseResult::AgentDone { result_text, .. } => {
+                assert_eq!(result_text.as_deref(), Some("turn complete"));
+            }
+            other => panic!("expected AgentDone, got {other:?}"),
+        }
+        Ok(())
+    }
+}

--- a/crates/edda-conductor/src/agent/mod.rs
+++ b/crates/edda-conductor/src/agent/mod.rs
@@ -1,5 +1,6 @@
 pub mod budget;
 pub mod codex_app_server;
+pub mod codex_rpc;
 pub mod launcher;
 pub mod pi_rpc;
 pub mod stream;


### PR DESCRIPTION
Closes #527

## Problem

`edda conduct run --agent` accepts `claude|pi` only, while the tree already carries a full codex app-server protocol client (`codex_app_server.rs`) that was never adapted to `AgentLauncher` — so a conductor plan could not dispatch phases through codex at all. (The issue text assumed the launcher merely needed re-conformance; on `main` it never implemented the trait.)

## Change

New `crates/edda-conductor/src/agent/codex_rpc.rs` — `CodexLauncher` implementing `AgentLauncher` over the existing client (spawn / open_thread / run_turn / KillOnCancel; protocol layer reused, not rewritten):

- One conductor phase = one codex turn; the app-server child is spawned once and reused across phases; each conductor `session_id` maps to a codex thread resumed via `thread/resume` (create-or-continue parity with pi/claude).
- Outcome mapping: `CodexTurnOutcome` → `AgentDone { cost_usd: None, result_text }`; spawn/protocol failures and cancellation → `AgentCrash`; phase timeout → `Timeout`. Crashed/timed-out/cancelled turns drop the client so the next phase re-spawns fresh, while the thread map preserves conversation continuity.
- **The app-server protocol exposes no usage data, so `cost_usd` is `None` and the budget gate is inert for codex by design** (recorded as `codex-cost-usd=None`, `codex-budget-gate-inert=true`).
- Binary resolution mirrors #528: pure function, `EDDA_CODEX_BIN` override (empty = unset), Windows default `codex.cmd` — verified on this machine that npm ships `codex` (sh) + `codex.cmd` and **no `codex.exe`**.
- `codex_app_server.rs`: test fakes extracted into a shared `pub(crate) mod fake_support` reused by the launcher tests; `spawn_command` made `pub(crate)`. No protocol behavior changes.

`crates/edda-cli/src/cmd_conduct.rs`: `AgentKind::Codex` (value `codex`), `writes_transcripts() == false` so `--tmux` warns and falls back like pi, launcher arm with `verify_available()` probe whose not-found error names the install command and `EDDA_CODEX_BIN`.

## Provenance

Implemented by **pi (z-ai/glm-5.3-flash) dispatched programmatically** via `edda conduct run --agent pi` — a 3-phase conductor plan in an isolated worktree, no desktop automation. The dispatch machinery being extended here is the machinery that produced it.

## Gates (worker receipt, frozen SHA `42dfd0b7457d791350a1fc1196934f5dba0f7f4a`)

| Gate | Result |
|---|---|
| `cargo test -p edda-conductor` | 204 passed (was 182) |
| `cargo test -p edda` | 327 passed |
| `cargo clippy -p edda-conductor -p edda --all-targets -- -D warnings` | clean |
| `cargo fmt --all --check` | pass |

Lane: `worker-1`. Independent verifier round (read-only, verdict pinned to the SHA above) follows as a PR comment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
