### PR TITLE
feat(conductor): verdict-gated phases (AWAITING_VERDICT) + edda verdict ledger object (#519)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,6 +890,8 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "edda-core",
+ "edda-ledger",
  "edda-store",
  "regex",
  "serde",

--- a/crates/edda-cli/src/cmd_bridge.rs
+++ b/crates/edda-cli/src/cmd_bridge.rs
@@ -1224,7 +1224,7 @@ pub fn request_ack(
 /// fallback preserves genuine standalone CLI use. A carrier can preserve only
 /// the identity its host exposes; Codex tool hooks, for example, attribute
 /// subagent commands to the parent session (GH-503).
-fn resolve_session_id(
+pub(crate) fn resolve_session_id(
     cli_session: Option<&str>,
     project_id: &str,
     fallback_label: &str,

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -546,6 +546,7 @@ fn print_status(state: &PlanState) {
             PhaseStatus::Running | PhaseStatus::Checking => "\u{25B6}", // ▶
             PhaseStatus::Skipped => "\u{2298}",                         // ⊘
             PhaseStatus::Stale => "\u{23F0}",                           // ⏰
+            PhaseStatus::AwaitingVerdict => "\u{23F8}",                 // ⏸
             PhaseStatus::Pending => "\u{25CB}",                         // ○
         };
         let detail = match ps.status {

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -215,6 +215,9 @@ pub fn build_phase(
         budget_usd,
         allowed_tools: None,
         permission_mode: permission_mode.to_owned(),
+        gate: None,
+        gate_timeout_sec: None,
+        on_reject: Default::default(),
     }
 }
 

--- a/crates/edda-cli/src/cmd_verdict.rs
+++ b/crates/edda-cli/src/cmd_verdict.rs
@@ -1,0 +1,390 @@
+//! `edda verdict` — issue a verdict on a gated subject (GH-519 D1).
+//!
+//! An external actor approves or rejects a subject bound to (subject, full
+//! SHA); each verdict is a first-class `verdict.recorded` ledger event. The
+//! conductor consumes verdicts, it does not own them. A verdict for a
+//! mismatched SHA is findable but never satisfies a gate waiting on another
+//! SHA. `<subject>` is a free-form string; for conductor gates it is
+//! `<plan-name>/<phase-id>`.
+
+use clap::Subcommand;
+use edda_core::event::new_verdict_event;
+use edda_core::secret_guard::redact;
+use edda_core::{VerdictDecision, VerdictPayload};
+use edda_ledger::lock::WorkspaceLock;
+use edda_ledger::Ledger;
+use std::path::Path;
+
+#[derive(Debug, Subcommand)]
+pub enum VerdictCmd {
+    /// Approve a gated subject — the waiting gate may resume
+    Approve {
+        /// Free-form subject; for conductor gates `<plan-name>/<phase-id>`
+        subject: String,
+        /// Full 40-hex git SHA the verdict applies to
+        #[arg(long)]
+        sha: String,
+        /// Optional context recorded with the approval
+        #[arg(long)]
+        comment: Option<String>,
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
+        #[arg(long)]
+        session: Option<String>,
+    },
+    /// Reject a gated subject — the comment feeds back into the gated agent session
+    Reject {
+        /// Free-form subject; for conductor gates `<plan-name>/<phase-id>`
+        subject: String,
+        /// Full 40-hex git SHA the verdict applies to
+        #[arg(long)]
+        sha: String,
+        /// Required: why the gate was rejected (fed back to the agent as the next turn)
+        #[arg(long)]
+        comment: String,
+        /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
+        #[arg(long)]
+        session: Option<String>,
+    },
+}
+
+/// Arguments for recording a verdict (mirrors the `verdict.recorded` payload).
+pub struct RecordVerdictArgs<'a> {
+    pub subject: &'a str,
+    pub decision: VerdictDecision,
+    pub sha: &'a str,
+    pub comment: Option<&'a str>,
+    pub cli_session: Option<&'a str>,
+}
+
+#[derive(Debug)]
+pub struct RecordOutcome {
+    pub event_id: String,
+    pub decision: VerdictDecision,
+}
+
+/// A verdict binds to a full 40-hex git SHA. A short or malformed SHA would
+/// silently never match a gate's `gate_sha`, so it is refused at the door.
+pub(crate) fn validate_sha(sha: &str) -> anyhow::Result<()> {
+    if sha.len() == 40 && sha.bytes().all(|b| b.is_ascii_hexdigit()) {
+        Ok(())
+    } else {
+        anyhow::bail!("--sha must be a full 40-hex git SHA (got \"{sha}\")")
+    }
+}
+
+pub fn run(cmd: VerdictCmd, repo_root: &Path) -> anyhow::Result<()> {
+    let (subject, sha, decision, comment, cli_session) = match cmd {
+        VerdictCmd::Approve {
+            subject,
+            sha,
+            comment,
+            session,
+        } => (subject, sha, VerdictDecision::Approved, comment, session),
+        VerdictCmd::Reject {
+            subject,
+            sha,
+            comment,
+            session,
+        } => (
+            subject,
+            sha,
+            VerdictDecision::Rejected,
+            Some(comment),
+            session,
+        ),
+    };
+    let outcome = do_record(
+        repo_root,
+        &RecordVerdictArgs {
+            subject: &subject,
+            decision,
+            sha: &sha,
+            comment: comment.as_deref(),
+            cli_session: cli_session.as_deref(),
+        },
+    )?;
+    println!("Verdict recorded: {} {subject} @ {sha}", outcome.decision);
+    println!("  event: {}", outcome.event_id);
+    if let Some(c) = comment.as_deref().filter(|c| !c.trim().is_empty()) {
+        println!("  comment: {c}");
+    }
+    Ok(())
+}
+
+pub(crate) fn do_record(
+    repo_root: &Path,
+    args: &RecordVerdictArgs<'_>,
+) -> anyhow::Result<RecordOutcome> {
+    validate_sha(args.sha)?;
+    if args.subject.trim().is_empty() {
+        anyhow::bail!("subject must not be empty");
+    }
+    // Comment is REQUIRED on reject: it is what feeds back into the gated
+    // agent session as its next turn. Enforced here, not just at the CLI
+    // layer, so every writer of the ledger object honors the invariant.
+    if args.decision == VerdictDecision::Rejected
+        && args.comment.is_none_or(|c| c.trim().is_empty())
+    {
+        anyhow::bail!(
+            "a rejection without a comment does not exist — the comment is what feeds \
+             back into the gated agent session"
+        );
+    }
+
+    // EDDA-SECRET-GUARD1 q331: scrub the comment before any persistence,
+    // same deterministic zero-LLM pass decide/note run.
+    let comment = match args.comment {
+        Some(c) => {
+            let (safe, hits) = redact(c);
+            if !hits.is_empty() {
+                eprintln!(
+                    "⚠ secret-guard: redacted {} secret pattern(s) before writing verdict",
+                    hits.len()
+                );
+            }
+            Some(safe)
+        }
+        None => None,
+    };
+
+    // Same identity source as other edda writes (decide/claim/request).
+    let project_id = edda_store::project_id(repo_root);
+    let (_session_id, label) =
+        crate::cmd_bridge::resolve_session_id(args.cli_session, &project_id, "cli")?;
+
+    let ledger = Ledger::open(repo_root)?;
+    let _lock = WorkspaceLock::acquire(&ledger.paths)?;
+    let branch = ledger.head_branch()?;
+    let parent_hash = ledger.last_event_hash()?;
+
+    let payload = VerdictPayload {
+        subject: args.subject.to_string(),
+        decision: args.decision,
+        sha: args.sha.to_string(),
+        comment: comment.filter(|c| !c.trim().is_empty()),
+        actor: label,
+    };
+    let event = new_verdict_event(&branch, parent_hash.as_deref(), &payload)?;
+    ledger.append_event(&event)?;
+    let _ = edda_derive::rebuild_branch(&ledger, &branch);
+
+    Ok(RecordOutcome {
+        event_id: event.event_id,
+        decision: args.decision,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(clap::Parser)]
+    struct TestCli {
+        #[command(subcommand)]
+        cmd: VerdictCmd,
+    }
+
+    fn parse(args: &[&str]) -> Result<VerdictCmd, clap::Error> {
+        use clap::Parser;
+        let cli = TestCli::try_parse_from(std::iter::once("edda").chain(args.iter().copied()))?;
+        Ok(cli.cmd)
+    }
+
+    fn sha(ch: char) -> String {
+        std::iter::repeat_n(ch, 40).collect()
+    }
+
+    fn temp_ws(name: &str) -> std::path::PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("edda_cmdverdict_{name}_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        Ledger::ensure_initialized(&dir).unwrap();
+        dir
+    }
+
+    // ── CLI parse ──
+
+    #[test]
+    fn parses_approve_with_optional_comment() {
+        let cmd = parse(&["approve", "plan-x/phase-1", "--sha", &sha('a')]).unwrap();
+        match cmd {
+            VerdictCmd::Approve {
+                subject,
+                sha: s,
+                comment,
+                ..
+            } => {
+                assert_eq!(subject, "plan-x/phase-1");
+                assert_eq!(s, sha('a'));
+                assert_eq!(comment, None);
+            }
+            other => panic!("expected approve, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_reject_with_comment() {
+        let cmd = parse(&[
+            "reject",
+            "plan-x/phase-1",
+            "--sha",
+            &sha('b'),
+            "--comment",
+            "tests fail",
+        ])
+        .unwrap();
+        match cmd {
+            VerdictCmd::Reject {
+                subject, comment, ..
+            } => {
+                assert_eq!(subject, "plan-x/phase-1");
+                assert_eq!(comment, "tests fail");
+            }
+            other => panic!("expected reject, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reject_requires_comment_at_parse_time() {
+        let err = parse(&["reject", "plan-x/phase-1", "--sha", &sha('b')])
+            .expect_err("missing --comment must be a parse error");
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn short_sha_is_refused() {
+        let ws = temp_ws("shortsha");
+        let err = do_record(
+            &ws,
+            &RecordVerdictArgs {
+                subject: "plan-x/phase-1",
+                decision: VerdictDecision::Approved,
+                sha: "abc123",
+                comment: None,
+                cli_session: Some("test-session-id"),
+            },
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("40-hex"), "unexpected error: {err}");
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    // ── Write/read roundtrip ──
+
+    #[test]
+    fn approve_roundtrip_is_queryable() {
+        let ws = temp_ws("roundtrip");
+        let s = sha('a');
+        let outcome = do_record(
+            &ws,
+            &RecordVerdictArgs {
+                subject: "plan-x/phase-1",
+                decision: VerdictDecision::Approved,
+                sha: &s,
+                comment: Some("looks good"),
+                cli_session: Some("test-session-id"),
+            },
+        )
+        .unwrap();
+        assert_eq!(outcome.decision, VerdictDecision::Approved);
+        assert!(outcome.event_id.starts_with("evt_"));
+
+        let ledger = Ledger::open(&ws).unwrap();
+        let verdict = ledger
+            .latest_verdict("plan-x/phase-1", &s)
+            .unwrap()
+            .expect("verdict should be found");
+        assert_eq!(verdict.payload.decision, VerdictDecision::Approved);
+        assert!(!verdict.payload.actor.is_empty());
+        assert_eq!(verdict.payload.comment.as_deref(), Some("looks good"));
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn sha_mismatch_does_not_satisfy_query() {
+        let ws = temp_ws("mismatch");
+        let s = sha('a');
+        do_record(
+            &ws,
+            &RecordVerdictArgs {
+                subject: "plan-x/phase-1",
+                decision: VerdictDecision::Approved,
+                sha: &s,
+                comment: None,
+                cli_session: Some("test-session-id"),
+            },
+        )
+        .unwrap();
+
+        let ledger = Ledger::open(&ws).unwrap();
+        // The verdict is findable in the listing...
+        assert_eq!(ledger.iter_verdicts().unwrap().len(), 1);
+        // ...but never satisfies a gate waiting on a different SHA.
+        let other = sha('b');
+        assert!(ledger
+            .latest_verdict("plan-x/phase-1", &other)
+            .unwrap()
+            .is_none());
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn reject_without_comment_is_refused() {
+        let ws = temp_ws("rejectnocomment");
+        let s = sha('c');
+        let err = do_record(
+            &ws,
+            &RecordVerdictArgs {
+                subject: "plan-x/phase-1",
+                decision: VerdictDecision::Rejected,
+                sha: &s,
+                comment: Some("   "),
+                cli_session: Some("test-session-id"),
+            },
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("comment"), "unexpected error: {err}");
+        let ledger = Ledger::open(&ws).unwrap();
+        assert_eq!(ledger.iter_verdicts().unwrap().len(), 0);
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn later_verdict_supersedes_for_same_subject_and_sha() {
+        let ws = temp_ws("supersede");
+        let s = sha('d');
+        do_record(
+            &ws,
+            &RecordVerdictArgs {
+                subject: "plan-x/phase-1",
+                decision: VerdictDecision::Rejected,
+                sha: &s,
+                comment: Some("no"),
+                cli_session: Some("test-session-id"),
+            },
+        )
+        .unwrap();
+        do_record(
+            &ws,
+            &RecordVerdictArgs {
+                subject: "plan-x/phase-1",
+                decision: VerdictDecision::Approved,
+                sha: &s,
+                comment: None,
+                cli_session: Some("test-session-id"),
+            },
+        )
+        .unwrap();
+
+        let ledger = Ledger::open(&ws).unwrap();
+        let latest = ledger
+            .latest_verdict("plan-x/phase-1", &s)
+            .unwrap()
+            .unwrap();
+        assert_eq!(latest.payload.decision, VerdictDecision::Approved);
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+}

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -46,6 +46,7 @@ mod cmd_sync;
 mod cmd_task;
 mod cmd_tool_tier;
 mod cmd_user;
+mod cmd_verdict;
 mod cmd_watch;
 mod fleet;
 mod pipeline_templates;
@@ -153,6 +154,11 @@ enum Command {
     Task {
         #[command(subcommand)]
         cmd: cmd_task::TaskCmd,
+    },
+    /// Issue a verdict on a gated subject (approve/reject) — GH-519
+    Verdict {
+        #[command(subcommand)]
+        cmd: cmd_verdict::VerdictCmd,
     },
     /// Recover and dispatch unfinished task attempts
     Reconcile {
@@ -1079,6 +1085,7 @@ fn main() -> anyhow::Result<()> {
         Command::Group { cmd } => cmd_group::execute(cmd, &repo_root),
         Command::Sync { from, dry_run } => cmd_sync::execute(&repo_root, from.as_deref(), dry_run),
         Command::Task { cmd } => cmd_task::execute(cmd, &repo_root),
+        Command::Verdict { cmd } => cmd_verdict::run(cmd, &repo_root),
         Command::Reconcile { args } => cmd_reconcile::run(&repo_root, args),
         Command::Claim {
             label,

--- a/crates/edda-conductor/Cargo.toml
+++ b/crates/edda-conductor/Cargo.toml
@@ -11,6 +11,8 @@ keywords.workspace = true
 
 [dependencies]
 edda-store = { path = "../edda-store", version = "0.3.0" }
+edda-core = { path = "../edda-core", version = "0.3.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.3.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/edda-conductor/src/agent/launcher.rs
+++ b/crates/edda-conductor/src/agent/launcher.rs
@@ -201,10 +201,20 @@ impl AgentLauncher for ClaudeCodeLauncher {
     }
 }
 
+/// One recorded launcher call (for tests asserting session continuity etc.).
+#[derive(Debug, Clone)]
+pub struct LauncherCall {
+    pub phase_id: String,
+    pub session_id: String,
+    pub prompt: String,
+}
+
 /// Mock launcher for testing. Pops results on each call per phase ID.
 /// If no results configured (or exhausted), returns AgentDone.
+/// Records every call so tests can assert session ids and prompts.
 pub struct MockLauncher {
     results: std::sync::Mutex<std::collections::HashMap<String, Vec<PhaseResult>>>,
+    calls: std::sync::Mutex<Vec<LauncherCall>>,
 }
 
 impl Default for MockLauncher {
@@ -217,6 +227,7 @@ impl MockLauncher {
     pub fn new() -> Self {
         Self {
             results: std::sync::Mutex::new(std::collections::HashMap::new()),
+            calls: std::sync::Mutex::new(Vec::new()),
         }
     }
 
@@ -226,6 +237,24 @@ impl MockLauncher {
             .unwrap()
             .insert(phase_id.to_string(), results);
     }
+
+    /// Every recorded call, in launch order.
+    pub fn calls(&self) -> Vec<LauncherCall> {
+        self.calls.lock().unwrap().clone()
+    }
+
+    /// Recorded calls for one phase, in launch order.
+    pub fn calls_for(&self, phase_id: &str) -> Vec<LauncherCall> {
+        self.calls()
+            .into_iter()
+            .filter(|c| c.phase_id == phase_id)
+            .collect()
+    }
+
+    /// How many times this phase launched an agent turn.
+    pub fn call_count(&self, phase_id: &str) -> u32 {
+        self.calls_for(phase_id).len() as u32
+    }
 }
 
 #[async_trait::async_trait]
@@ -233,9 +262,9 @@ impl AgentLauncher for MockLauncher {
     async fn run_phase(
         &self,
         phase: &Phase,
-        _prompt: &str,
+        prompt: &str,
         _plan_context: &str,
-        _session_id: &str,
+        session_id: &str,
         _cwd: &Path,
         cancel: CancellationToken,
     ) -> Result<PhaseResult> {
@@ -244,6 +273,12 @@ impl AgentLauncher for MockLauncher {
                 error: "cancelled".into(),
             });
         }
+
+        self.calls.lock().unwrap().push(LauncherCall {
+            phase_id: phase.id.clone(),
+            session_id: session_id.to_string(),
+            prompt: prompt.to_string(),
+        });
 
         let mut map = self.results.lock().unwrap();
         if let Some(vec) = map.get_mut(&phase.id) {

--- a/crates/edda-conductor/src/plan/schema.rs
+++ b/crates/edda-conductor/src/plan/schema.rs
@@ -56,6 +56,36 @@ pub struct Phase {
     pub allowed_tools: Option<Vec<String>>,
     #[serde(default = "default_permission_mode")]
     pub permission_mode: String,
+    /// Verdict gate: after checks pass, the phase pauses in AWAITING_VERDICT
+    /// until an external `edda verdict` arrives (D2).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gate: Option<GateKind>,
+    /// Gate wait timeout in seconds; None = wait until cancelled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gate_timeout_sec: Option<u64>,
+    /// Policy when the gate verdict rejects. Default: redispatch.
+    #[serde(default)]
+    pub on_reject: OnReject,
+}
+
+/// Kind of approval gate a phase can declare (D2).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GateKind {
+    /// External verdict via `edda verdict approve|reject`.
+    Verdict,
+}
+
+/// What happens when a verdict gate is rejected (D2/D3).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OnReject {
+    /// Run ONE more agent turn in the SAME session with the rejection
+    /// comment as prompt, then re-check and re-gate.
+    #[default]
+    Redispatch,
+    /// Fail the phase with the rejection comment as the error.
+    Halt,
 }
 
 /// Failure policy for a phase.
@@ -254,5 +284,74 @@ phases:
         assert_eq!(phase.on_fail, Some(OnFail::Abort));
         assert_eq!(phase.check.len(), 2);
         assert_eq!(phase.env.get("FOO").unwrap(), "bar");
+    }
+
+    // ── Gate fields (D2) ─────────────────────────────────────────────
+
+    #[test]
+    fn phase_defaults_have_no_gate() {
+        let yaml = r#"
+name: test
+phases:
+  - id: a
+    prompt: "x"
+"#;
+        let plan: Plan = serde_yml::from_str(yaml).unwrap();
+        let phase = &plan.phases[0];
+        assert!(phase.gate.is_none());
+        assert!(phase.gate_timeout_sec.is_none());
+        assert_eq!(phase.on_reject, OnReject::Redispatch);
+    }
+
+    #[test]
+    fn phase_deserialize_gate_verdict() {
+        let yaml = r#"
+name: test
+phases:
+  - id: a
+    prompt: "x"
+    gate: verdict
+    gate_timeout_sec: 3600
+    on_reject: halt
+"#;
+        let plan: Plan = serde_yml::from_str(yaml).unwrap();
+        let phase = &plan.phases[0];
+        assert_eq!(phase.gate, Some(GateKind::Verdict));
+        assert_eq!(phase.gate_timeout_sec, Some(3600));
+        assert_eq!(phase.on_reject, OnReject::Halt);
+    }
+
+    #[test]
+    fn phase_unknown_gate_value_fails_loudly() {
+        let yaml = r#"
+name: test
+phases:
+  - id: a
+    prompt: "x"
+    gate: magic_gate
+"#;
+        let err = serde_yml::from_str::<Plan>(yaml).unwrap_err();
+        assert!(err.to_string().to_lowercase().contains("magic_gate"));
+    }
+
+    #[test]
+    fn phase_unknown_on_reject_value_fails_loudly() {
+        let yaml = r#"
+name: test
+phases:
+  - id: a
+    prompt: "x"
+    gate: verdict
+    on_reject: explode
+"#;
+        assert!(serde_yml::from_str::<Plan>(yaml).is_err());
+    }
+
+    #[test]
+    fn gate_kind_serializes_snake_case() {
+        let json = serde_json::to_string(&GateKind::Verdict).unwrap();
+        assert_eq!(json, r#""verdict""#);
+        let back: GateKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, GateKind::Verdict);
     }
 }

--- a/crates/edda-conductor/src/runner/event_log.rs
+++ b/crates/edda-conductor/src/runner/event_log.rs
@@ -38,6 +38,22 @@ pub enum Event {
         phase_id: String,
         reason: String,
     },
+    /// A gated phase passed its checks and entered AWAITING_VERDICT (D4).
+    GateEntered {
+        phase_id: String,
+        /// `<plan-name>/<phase-id>` — the subject an `edda verdict` targets.
+        subject: String,
+        gate_sha: String,
+    },
+    /// A verdict for a waiting gate was observed in the ledger (D4).
+    VerdictReceived {
+        phase_id: String,
+        /// "approved" | "rejected"
+        decision: String,
+        gate_sha: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        comment: Option<String>,
+    },
     PlanCompleted {
         phases_passed: usize,
         total_cost_usd: f64,
@@ -124,6 +140,9 @@ pub struct RunnerStatus {
     pub current_phase: Option<String>,
     pub completed: Vec<String>,
     pub failed: Vec<String>,
+    /// Phases holding AWAITING_VERDICT (D4) — external actors poll this
+    /// to learn the subject + gate_sha they must issue a verdict against.
+    pub awaiting_verdict: Vec<String>,
     pub updated_at: String,
 }
 
@@ -149,6 +168,12 @@ pub fn write_runner_status(
             .phases
             .iter()
             .filter(|p| p.status == PhaseStatus::Failed || p.status == PhaseStatus::Stale)
+            .map(|p| p.id.clone())
+            .collect(),
+        awaiting_verdict: state
+            .phases
+            .iter()
+            .filter(|p| p.status == PhaseStatus::AwaitingVerdict)
             .map(|p| p.id.clone())
             .collect(),
         updated_at: now_rfc3339(),
@@ -268,11 +293,39 @@ mod tests {
             current_phase: Some("build".into()),
             completed: vec!["lint".into()],
             failed: vec![],
+            awaiting_verdict: vec!["build".into()],
             updated_at: "2026-02-18T10:00:00Z".into(),
         };
         let json = serde_json::to_string_pretty(&status).unwrap();
         assert!(json.contains(r#""plan": "my-plan""#));
         assert!(json.contains(r#""current_phase": "build""#));
         assert!(json.contains(r#""completed""#));
+    }
+
+    #[test]
+    fn event_gate_entered_serialization() {
+        let event = Event::GateEntered {
+            phase_id: "build".into(),
+            subject: "my-plan/build".into(),
+            gate_sha: "a".repeat(40),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains(r#""type":"gate_entered""#));
+        assert!(json.contains(r#""subject":"my-plan/build""#));
+        assert!(json.contains(r#""gate_sha":"aaaa"#));
+    }
+
+    #[test]
+    fn event_verdict_received_serialization() {
+        let event = Event::VerdictReceived {
+            phase_id: "build".into(),
+            decision: "rejected".into(),
+            gate_sha: "b".repeat(40),
+            comment: Some("fix tests".into()),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains(r#""type":"verdict_received""#));
+        assert!(json.contains(r#""decision":"rejected""#));
+        assert!(json.contains(r#""comment":"fix tests""#));
     }
 }

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -1,7 +1,7 @@
 use crate::agent::budget::BudgetTracker;
 use crate::agent::launcher::{phase_session_id_attempt, AgentLauncher, PhaseResult};
 use crate::check::engine::{CheckEngine, CheckRunResult};
-use crate::plan::schema::{CheckSpec, OnFail, Plan};
+use crate::plan::schema::{CheckSpec, OnFail, OnReject, Plan};
 use crate::plan::topo::topo_sort;
 use crate::runner::edda;
 use crate::runner::event_log::{self, Event, EventLogger};
@@ -18,8 +18,10 @@ use crate::state::persist::save_state;
 use crate::tmux::TmuxSession;
 use anyhow::Context;
 use anyhow::Result;
+use edda_core::VerdictPayload;
+use edda_ledger::VerdictRecord;
 use std::path::Path;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
 /// Runtime context for [`run_plan`], grouping execution environment parameters.
@@ -159,6 +161,247 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
             break;
         }
 
+        // ── Verdict gate wait (GH-519 D3) ────────────────────────────
+        // A phase holding AWAITING_VERDICT pauses the plan until a verdict
+        // arrives. On restart this re-enters the wait WITHOUT re-running the
+        // phase agent turn or checks; gate_sha comes from persisted state.
+        if let Some(gated_id) = state
+            .phases
+            .iter()
+            .find(|p| p.status == PhaseStatus::AwaitingVerdict)
+            .map(|p| p.id.clone())
+        {
+            let phase = plan
+                .phases
+                .iter()
+                .find(|p| p.id == gated_id)
+                .with_context(|| format!("gated phase \"{gated_id}\" not found in plan"))?;
+            let phase_cwd = phase
+                .cwd
+                .as_deref()
+                .or(plan.cwd.as_deref())
+                .map(|p| cwd.join(p))
+                .unwrap_or_else(|| cwd.to_path_buf());
+            let subject = gate_subject(&plan.name, &gated_id);
+            let (gate_sha, entered_at) = {
+                let ps = state.get_phase(&gated_id)?;
+                let sha = ps.gate_sha.clone().with_context(|| {
+                    format!("AWAITING_VERDICT state for \"{gated_id}\" is missing gate_sha")
+                })?;
+                let at = ps.gate_entered_at.clone().unwrap_or_else(now_rfc3339);
+                (sha, at)
+            };
+            let phase_num = order.iter().position(|id| id == &gated_id).unwrap_or(0) + 1;
+
+            // D4: unmistakable surface naming subject + gate_sha + the exact
+            // approve/reject commands to run.
+            println!("\n⏸ [{phase_num}/{total_phases}] Phase \"{gated_id}\" AWAITING_VERDICT — waiting for an external verdict");
+            println!("  subject:  {subject}");
+            println!("  gate_sha: {gate_sha}");
+            println!("  approve:  edda verdict approve {subject} --sha {gate_sha}");
+            println!(
+                "  reject:   edda verdict reject {subject} --sha {gate_sha} --comment \"<why>\""
+            );
+            event_log::write_runner_status(cwd, state, Some(&gated_id));
+            write_brief(cwd, state, None);
+
+            match wait_for_verdict(
+                cwd,
+                &subject,
+                &gate_sha,
+                phase.gate_timeout_sec,
+                Some(&entered_at),
+                &cancel,
+            )
+            .await
+            {
+                GateVerdict::Approved(record) => {
+                    event_log.record(Event::VerdictReceived {
+                        phase_id: gated_id.clone(),
+                        decision: "approved".into(),
+                        gate_sha: gate_sha.clone(),
+                        comment: record.payload.comment.clone(),
+                    });
+                    transition(
+                        state,
+                        &gated_id,
+                        PhaseStatus::AwaitingVerdict,
+                        PhaseStatus::Passed,
+                        Some(PhaseUpdate {
+                            completed_at: Some(now_rfc3339()),
+                            ..Default::default()
+                        }),
+                    )?;
+                    record_verdict_metadata(state, &gated_id, &record.payload);
+                    println!("  ✓ Verdict approved — phase \"{gated_id}\" passed");
+                    if let Some(tmux) = tmux_session {
+                        let _ = tmux.update_phase_status(&gated_id, "Passed");
+                    }
+                    edda::record_note(
+                        cwd,
+                        &format!("Gate \"{subject}\" approved (sha {gate_sha})"),
+                        &["conductor", "verdict"],
+                    );
+                }
+                GateVerdict::Rejected(record) => {
+                    let comment = record.payload.comment.clone().unwrap_or_default();
+                    event_log.record(Event::VerdictReceived {
+                        phase_id: gated_id.clone(),
+                        decision: "rejected".into(),
+                        gate_sha: gate_sha.clone(),
+                        comment: Some(comment.clone()),
+                    });
+                    println!("  ✗ Verdict rejected for \"{gated_id}\"");
+                    edda::record_note(
+                        cwd,
+                        &format!("Gate \"{subject}\" rejected (sha {gate_sha})"),
+                        &["conductor", "verdict"],
+                    );
+
+                    let (attempts, redispatches) = {
+                        let ps = state.get_phase(&gated_id)?;
+                        (ps.attempts, ps.gate_redispatches)
+                    };
+                    let max = phase.max_attempts.unwrap_or(plan.max_attempts);
+                    let bound_exhausted = redispatches >= MAX_GATE_REDISPATCHES;
+                    if phase.on_reject == OnReject::Halt || attempts >= max || bound_exhausted {
+                        // Halt (or a bound exhausted): the comment is the
+                        // error (D3). The redispatch bound gets a distinct
+                        // message naming the bound (D6).
+                        let message = if bound_exhausted {
+                            format!(
+                                "verdict gate redispatch bound exhausted ({redispatches} redispatch cycles, max {MAX_GATE_REDISPATCHES}) for \"{subject}\"; last rejection: {comment}"
+                            )
+                        } else {
+                            comment.clone()
+                        };
+                        transition(
+                            state,
+                            &gated_id,
+                            PhaseStatus::AwaitingVerdict,
+                            PhaseStatus::Failed,
+                            Some(PhaseUpdate {
+                                error: Some(ErrorInfo {
+                                    error_type: ErrorType::GateRejected,
+                                    message: message.clone(),
+                                    retryable: false,
+                                    check_index: None,
+                                    timestamp: now_rfc3339(),
+                                }),
+                                ..Default::default()
+                            }),
+                        )?;
+                        record_verdict_metadata(state, &gated_id, &record.payload);
+                        println!("  ✗ Phase \"{gated_id}\" failed: {message}");
+                        if let Some(tmux) = tmux_session {
+                            let _ = tmux.update_phase_status(&gated_id, "Failed");
+                        }
+                        edda::record_phase_failed(cwd, &gated_id, &message);
+                        event_log.record(Event::PhaseFailed {
+                            phase_id: gated_id.clone(),
+                            attempt: attempts,
+                            duration_ms: 0,
+                            error: format!("verdict rejected: {message}"),
+                        });
+                    } else {
+                        // Redispatch (D3): ONE more agent turn in the SAME
+                        // session — do NOT increment attempt; the rejection
+                        // comment becomes the prompt, prefixed with context.
+                        // D6: count the cycle on its own persisted counter.
+                        state.get_phase_mut(&gated_id)?.gate_redispatches += 1;
+                        let session_id =
+                            phase_session_id_attempt(&plan.name, &gated_id, attempts).to_string();
+                        let prompt = build_redispatch_prompt(phase, &gated_id, &comment);
+                        let plan_context =
+                            build_plan_context_with_edda(plan, state, &gated_id, cwd);
+                        transition(
+                            state,
+                            &gated_id,
+                            PhaseStatus::AwaitingVerdict,
+                            PhaseStatus::Running,
+                            None,
+                        )?;
+                        save_state(cwd, state)?;
+                        println!(
+                            "  ↻ Redispatching one more turn in the same session ({session_id})"
+                        );
+                        let result = launcher
+                            .run_phase(
+                                phase,
+                                &prompt,
+                                &plan_context,
+                                &session_id,
+                                &phase_cwd,
+                                cancel.child_token(),
+                            )
+                            .await?;
+                        process_phase_result(
+                            plan,
+                            phase,
+                            state,
+                            &gated_id,
+                            attempts,
+                            result,
+                            cwd,
+                            &phase_cwd,
+                            Instant::now(),
+                            budget,
+                            check_engine,
+                            notifier,
+                            &mut event_log,
+                            tmux_session,
+                        )
+                        .await?;
+                    }
+                }
+                GateVerdict::TimedOut => {
+                    // D3: distinct "gate timed out" failure — NOT silent,
+                    // NOT auto-approve.
+                    let msg = format!(
+                        "gate timed out: no verdict for \"{subject}\" (sha {gate_sha}) within {}s",
+                        phase.gate_timeout_sec.unwrap_or(0)
+                    );
+                    transition(
+                        state,
+                        &gated_id,
+                        PhaseStatus::AwaitingVerdict,
+                        PhaseStatus::Failed,
+                        Some(PhaseUpdate {
+                            error: Some(ErrorInfo {
+                                error_type: ErrorType::Timeout,
+                                message: msg.clone(),
+                                retryable: false,
+                                check_index: None,
+                                timestamp: now_rfc3339(),
+                            }),
+                            ..Default::default()
+                        }),
+                    )?;
+                    println!("  ⏰ Phase \"{gated_id}\" {msg}");
+                    if let Some(tmux) = tmux_session {
+                        let _ = tmux.update_phase_status(&gated_id, "Failed");
+                    }
+                    edda::record_phase_failed(cwd, &gated_id, &msg);
+                    event_log.record(Event::PhaseFailed {
+                        phase_id: gated_id.clone(),
+                        attempt: state.get_phase(&gated_id)?.attempts,
+                        duration_ms: 0,
+                        error: msg,
+                    });
+                }
+                GateVerdict::Cancelled => {
+                    // The loop top sees the cancelled token and shuts down;
+                    // the phase stays AWAITING_VERDICT so a later
+                    // `edda conduct run` resumes the wait (D3 restart).
+                }
+            }
+
+            save_state(cwd, state)?;
+            event_log::write_runner_status(cwd, state, Some(&gated_id));
+            write_brief(cwd, state, None);
+            continue;
+        }
+
         // 2. Find next runnable phase
         let Some(phase_id) = find_next_phase(plan, state, &order) else {
             break; // all done or no runnable phase
@@ -229,221 +472,25 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
             )
             .await?;
 
-        // 5. Process result
-        match result {
-            PhaseResult::AgentDone {
-                cost_usd,
-                result_text,
-            } => {
-                if let Some(cost) = cost_usd {
-                    budget.record(cost);
-                    state.total_cost_usd += cost;
-                }
-
-                // running → checking
-                transition(
-                    state,
-                    &phase_id,
-                    PhaseStatus::Running,
-                    PhaseStatus::Checking,
-                    None,
-                )?;
-                save_state(cwd, state)?;
-
-                // Run checks
-                let check_result = check_engine
-                    .run_all(
-                        &phase.check,
-                        state.get_phase(&phase_id)?.started_at.as_deref(),
-                    )
-                    .await;
-
-                if check_result.all_passed {
-                    transition(
-                        state,
-                        &phase_id,
-                        PhaseStatus::Checking,
-                        PhaseStatus::Passed,
-                        Some(PhaseUpdate {
-                            completed_at: Some(now_rfc3339()),
-                            checks: Some(check_result.results),
-                            ..Default::default()
-                        }),
-                    )?;
-                    let elapsed_ms = phase_start.elapsed().as_millis() as u64;
-                    println!(
-                        "  ✓ Phase \"{phase_id}\" passed ({})",
-                        format_elapsed(phase_start.elapsed())
-                    );
-                    if let Some(tmux) = tmux_session {
-                        let _ = tmux.update_phase_status(&phase_id, "Passed");
-                    }
-
-                    // Record to edda ledger
-                    edda::record_phase_done(cwd, &phase_id, result_text.as_deref(), cost_usd);
-                    event_log.record(Event::PhasePassed {
-                        phase_id: phase_id.clone(),
-                        attempt,
-                        duration_ms: elapsed_ms,
-                        cost_usd,
-                    });
-                } else {
-                    transition(
-                        state,
-                        &phase_id,
-                        PhaseStatus::Checking,
-                        PhaseStatus::Failed,
-                        Some(PhaseUpdate {
-                            checks: Some(check_result.results.clone()),
-                            error: check_result.error.clone(),
-                            ..Default::default()
-                        }),
-                    )?;
-                    let elapsed_ms = phase_start.elapsed().as_millis() as u64;
-                    let err_msg = check_result
-                        .error
-                        .as_ref()
-                        .map(|e| e.message.as_str())
-                        .unwrap_or("check failed");
-                    println!(
-                        "  ✗ Phase \"{phase_id}\" failed ({}): {err_msg}",
-                        format_elapsed(phase_start.elapsed()),
-                    );
-                    if let Some(tmux) = tmux_session {
-                        let _ = tmux.update_phase_status(&phase_id, "Failed");
-                    }
-                    edda::record_phase_failed(cwd, &phase_id, err_msg);
-                    event_log.record(Event::PhaseFailed {
-                        phase_id: phase_id.clone(),
-                        attempt,
-                        duration_ms: elapsed_ms,
-                        error: err_msg.to_string(),
-                    });
-                    handle_on_fail(
-                        plan,
-                        phase,
-                        state,
-                        &phase_id,
-                        &check_result,
-                        notifier,
-                        &mut event_log,
-                    )
-                    .await;
-                }
-            }
-            PhaseResult::Timeout => {
-                transition(
-                    state,
-                    &phase_id,
-                    PhaseStatus::Running,
-                    PhaseStatus::Stale,
-                    Some(PhaseUpdate {
-                        error: Some(ErrorInfo {
-                            error_type: ErrorType::Timeout,
-                            message: format!("phase \"{phase_id}\" timed out"),
-                            retryable: true,
-                            check_index: None,
-                            timestamp: now_rfc3339(),
-                        }),
-                        ..Default::default()
-                    }),
-                )?;
-                let elapsed_ms = phase_start.elapsed().as_millis() as u64;
-                println!(
-                    "  ⏰ Phase \"{phase_id}\" timed out ({})",
-                    format_elapsed(phase_start.elapsed())
-                );
-                if let Some(tmux) = tmux_session {
-                    let _ = tmux.update_phase_status(&phase_id, "Stale");
-                }
-                edda::record_phase_failed(cwd, &phase_id, "timed out");
-                event_log.record(Event::PhaseFailed {
-                    phase_id: phase_id.clone(),
-                    attempt,
-                    duration_ms: elapsed_ms,
-                    error: "timed out".into(),
-                });
-            }
-            PhaseResult::AgentCrash { error } => {
-                transition(
-                    state,
-                    &phase_id,
-                    PhaseStatus::Running,
-                    PhaseStatus::Failed,
-                    Some(PhaseUpdate {
-                        error: Some(ErrorInfo {
-                            error_type: ErrorType::AgentCrash,
-                            message: error.clone(),
-                            retryable: true,
-                            check_index: None,
-                            timestamp: now_rfc3339(),
-                        }),
-                        ..Default::default()
-                    }),
-                )?;
-                let elapsed_ms = phase_start.elapsed().as_millis() as u64;
-                println!(
-                    "  ✗ Phase \"{phase_id}\" crashed ({}): {error}",
-                    format_elapsed(phase_start.elapsed())
-                );
-                if let Some(tmux) = tmux_session {
-                    let _ = tmux.update_phase_status(&phase_id, "Failed");
-                }
-                edda::record_phase_failed(cwd, &phase_id, &error);
-                event_log.record(Event::PhaseFailed {
-                    phase_id: phase_id.clone(),
-                    attempt,
-                    duration_ms: elapsed_ms,
-                    error: error.clone(),
-                });
-                // For crash, use empty check results
-                let empty_result = CheckRunResult {
-                    all_passed: false,
-                    results: vec![],
-                    error: None,
-                };
-                handle_on_fail(
-                    plan,
-                    phase,
-                    state,
-                    &phase_id,
-                    &empty_result,
-                    notifier,
-                    &mut event_log,
-                )
-                .await;
-            }
-            PhaseResult::MaxTurns { cost_usd } | PhaseResult::BudgetExceeded { cost_usd } => {
-                if let Some(cost) = cost_usd {
-                    budget.record(cost);
-                    state.total_cost_usd += cost;
-                }
-                let elapsed_ms = phase_start.elapsed().as_millis() as u64;
-                let msg = format!("{result:?}");
-                transition(
-                    state,
-                    &phase_id,
-                    PhaseStatus::Running,
-                    PhaseStatus::Failed,
-                    Some(PhaseUpdate {
-                        error: Some(ErrorInfo {
-                            error_type: ErrorType::BudgetExceeded,
-                            message: msg.clone(),
-                            retryable: false,
-                            check_index: None,
-                            timestamp: now_rfc3339(),
-                        }),
-                        ..Default::default()
-                    }),
-                )?;
-                event_log.record(Event::PhaseFailed {
-                    phase_id: phase_id.clone(),
-                    attempt,
-                    duration_ms: elapsed_ms,
-                    error: msg,
-                });
-            }
-        }
+        // 5. Process result (shared with the post-rejection redispatch turn;
+        // gated phases enter AWAITING_VERDICT here instead of Passed — D3)
+        process_phase_result(
+            plan,
+            phase,
+            state,
+            &phase_id,
+            attempt,
+            result,
+            cwd,
+            &phase_cwd,
+            phase_start,
+            budget,
+            check_engine,
+            notifier,
+            &mut event_log,
+            tmux_session,
+        )
+        .await?;
 
         save_state(cwd, state)?;
     }
@@ -474,6 +521,494 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
 
     event_log::write_runner_status(cwd, state, None);
     write_brief(cwd, state, None);
+    Ok(())
+}
+
+/// Verdict gate helpers (GH-519 D3/D4/D5) ────────────────────────────────
+/// Ledger poll interval while a gate waits for a verdict.
+const GATE_POLL_SEC: u64 = 2;
+
+/// D6: bound gate redispatch cycles with their own persisted counter, NOT
+/// `attempt` (which D3 forbids incrementing on redispatch). A redispatch
+/// turn is not guaranteed to produce a commit, so a re-entered gate can
+/// wait on the same `(subject, gate_sha)` forever while `max_attempts`
+/// never trips — this counter is the real loop bound. Exhausting it fails
+/// the phase like `on_reject: halt`, with a distinct error naming the bound.
+const MAX_GATE_REDISPATCHES: u32 = 3;
+
+/// `<plan-name>/<phase-id>` — the subject an `edda verdict` targets (D1/D3).
+fn gate_subject(plan_name: &str, phase_id: &str) -> String {
+    format!("{plan_name}/{phase_id}")
+}
+
+/// Current git HEAD of `cwd` — the SHA a verdict must match (D3).
+fn capture_git_head(cwd: &Path) -> Result<String> {
+    let out = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(cwd)
+        .output()
+        .context("spawning git rev-parse HEAD to capture the gate sha")?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "git rev-parse HEAD failed in {}: {}",
+            cwd.display(),
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    let sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if sha.len() != 40 || !sha.bytes().all(|b| b.is_ascii_hexdigit()) {
+        anyhow::bail!("git rev-parse HEAD returned a non-40-hex sha: \"{sha}\"");
+    }
+    Ok(sha)
+}
+
+/// Outcome of waiting on a verdict gate.
+#[derive(Debug)]
+enum GateVerdict {
+    Approved(VerdictRecord),
+    Rejected(VerdictRecord),
+    /// `gate_timeout_sec` elapsed with no matching verdict — NOT silent,
+    /// NOT auto-approve (D3).
+    TimedOut,
+    /// The CancellationToken fired while waiting. The phase stays
+    /// AWAITING_VERDICT so a later resume re-enters the wait (D3 restart).
+    Cancelled,
+}
+
+/// Poll the ledger for a verdict matching `(subject, gate_sha)` that was
+/// recorded AFTER this gate's `gate_entered_at` (D3 + D6 freshness).
+///
+/// A verdict bound to a different SHA is findable in the ledger but never
+/// satisfies this wait (D1). A stale verdict — one predating this gate's
+/// entry, e.g. the rejection still sitting in the ledger when a redispatch
+/// turn produced no new commit — also never satisfies it (D6); without that
+/// bound the re-entered gate would re-read the same rejection forever.
+/// The timeout deadline is computed from the persisted `gate_entered_at`,
+/// so it survives restarts.
+async fn wait_for_verdict(
+    cwd: &Path,
+    subject: &str,
+    gate_sha: &str,
+    timeout_sec: Option<u64>,
+    entered_at: Option<&str>,
+    cancel: &CancellationToken,
+) -> GateVerdict {
+    let deadline = timeout_sec.map(|t| {
+        let base = entered_at
+            .and_then(|s| {
+                time::OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339).ok()
+            })
+            .unwrap_or_else(time::OffsetDateTime::now_utc);
+        base + time::Duration::seconds(t as i64)
+    });
+
+    loop {
+        // Poll BEFORE the deadline check: a verdict recorded during this
+        // wait (e.g. right after the gate_entered event) must be observed
+        // at the last poll, not skipped by a deadline that fires first.
+        // Poll the ledger. Best-effort: an unreadable or locked ledger simply
+        // means "no verdict observed yet" this round.
+        if let Ok(ledger) = edda_ledger::Ledger::open(cwd) {
+            if let Ok(Some(record)) = ledger.latest_verdict_fresh(subject, gate_sha, entered_at) {
+                return match record.payload.decision {
+                    edda_core::VerdictDecision::Approved => GateVerdict::Approved(record),
+                    edda_core::VerdictDecision::Rejected => GateVerdict::Rejected(record),
+                };
+            }
+        }
+        if let Some(deadline) = deadline {
+            if time::OffsetDateTime::now_utc() >= deadline {
+                return GateVerdict::TimedOut;
+            }
+        }
+        tokio::select! {
+            _ = tokio::time::sleep(Duration::from_secs(GATE_POLL_SEC)) => {}
+            _ = cancel.cancelled() => return GateVerdict::Cancelled,
+        }
+    }
+}
+
+/// Record verdict metadata on the phase state (D3).
+fn record_verdict_metadata(state: &mut PlanState, phase_id: &str, payload: &VerdictPayload) {
+    if let Ok(ps) = state.get_phase_mut(phase_id) {
+        ps.verdict_decision = Some(payload.decision.to_string());
+        ps.verdict_actor = Some(payload.actor.clone());
+        ps.verdict_comment = payload.comment.clone();
+    }
+}
+
+/// Prompt for the redispatch turn after a rejected verdict (D3): the
+/// rejection comment becomes the prompt, prefixed with brief context.
+fn build_redispatch_prompt(
+    phase: &crate::plan::schema::Phase,
+    phase_id: &str,
+    comment: &str,
+) -> String {
+    let mut prompt = String::new();
+    if let Some(ctx) = &phase.context {
+        prompt.push_str(ctx);
+        prompt.push_str("\n\n");
+    }
+    prompt.push_str(&format!(
+        "## Verdict: REJECTED\n\n\
+         The external reviewer rejected the gated result for phase \"{phase_id}\".\n\n\
+         Reviewer feedback:\n{comment}\n\n\
+         Address the feedback above (your previous changes are still on disk), \
+         then make sure the phase checks pass again."
+    ));
+    prompt
+}
+
+/// Shared tail of a failed check run: transition Checking → Failed, print,
+/// record to edda + event log, then apply the phase's on_fail policy.
+#[allow(clippy::too_many_arguments)]
+async fn fail_checking_phase(
+    plan: &Plan,
+    phase: &crate::plan::schema::Phase,
+    state: &mut PlanState,
+    phase_id: &str,
+    cwd: &Path,
+    check_result: &CheckRunResult,
+    err_override: Option<&str>,
+    elapsed: Duration,
+    notifier: &dyn Notifier,
+    event_log: &mut EventLogger,
+    tmux_session: Option<&TmuxSession>,
+) -> Result<()> {
+    let (err_msg, error_info) = match err_override {
+        Some(msg) => (
+            msg.to_string(),
+            Some(ErrorInfo {
+                error_type: ErrorType::CheckFailed,
+                message: msg.to_string(),
+                retryable: true,
+                check_index: None,
+                timestamp: now_rfc3339(),
+            }),
+        ),
+        None => {
+            let msg = check_result
+                .error
+                .as_ref()
+                .map(|e| e.message.as_str())
+                .unwrap_or("check failed")
+                .to_string();
+            (msg, check_result.error.clone())
+        }
+    };
+    transition(
+        state,
+        phase_id,
+        PhaseStatus::Checking,
+        PhaseStatus::Failed,
+        Some(PhaseUpdate {
+            checks: Some(check_result.results.clone()),
+            error: error_info,
+            ..Default::default()
+        }),
+    )?;
+    println!(
+        "  ✗ Phase \"{phase_id}\" failed ({}): {err_msg}",
+        format_elapsed(elapsed),
+    );
+    if let Some(tmux) = tmux_session {
+        let _ = tmux.update_phase_status(phase_id, "Failed");
+    }
+    edda::record_phase_failed(cwd, phase_id, &err_msg);
+    event_log.record(Event::PhaseFailed {
+        phase_id: phase_id.to_string(),
+        attempt: state.get_phase(phase_id)?.attempts,
+        duration_ms: elapsed.as_millis() as u64,
+        error: err_msg,
+    });
+    handle_on_fail(
+        plan,
+        phase,
+        state,
+        phase_id,
+        check_result,
+        notifier,
+        event_log,
+    )
+    .await;
+    Ok(())
+}
+
+/// Process the result of one agent turn: classify it, run checks, resolve the
+/// phase (Passed / AWAITING_VERDICT gate entry / Failed / Stale) and apply the
+/// on_fail policy. Shared by the main loop and the post-rejection redispatch
+/// turn (D3).
+#[allow(clippy::too_many_arguments)]
+async fn process_phase_result(
+    plan: &Plan,
+    phase: &crate::plan::schema::Phase,
+    state: &mut PlanState,
+    phase_id: &str,
+    attempt: u32,
+    result: PhaseResult,
+    cwd: &Path,
+    phase_cwd: &Path,
+    phase_start: Instant,
+    budget: &mut BudgetTracker,
+    check_engine: &CheckEngine,
+    notifier: &dyn Notifier,
+    event_log: &mut EventLogger,
+    tmux_session: Option<&TmuxSession>,
+) -> Result<()> {
+    match result {
+        PhaseResult::AgentDone {
+            cost_usd,
+            result_text,
+        } => {
+            if let Some(cost) = cost_usd {
+                budget.record(cost);
+                state.total_cost_usd += cost;
+            }
+
+            // running → checking
+            transition(
+                state,
+                phase_id,
+                PhaseStatus::Running,
+                PhaseStatus::Checking,
+                None,
+            )?;
+            save_state(cwd, state)?;
+
+            // Run checks
+            let check_result = check_engine
+                .run_all(
+                    &phase.check,
+                    state.get_phase(phase_id)?.started_at.as_deref(),
+                )
+                .await;
+
+            if check_result.all_passed {
+                if phase.gate.is_some() {
+                    // D3: capture gate_sha = current git HEAD of the phase
+                    // cwd, persist AWAITING_VERDICT, emit GateEntered + a
+                    // notifier message, then wait (the loop's gate-wait branch).
+                    match capture_git_head(phase_cwd) {
+                        Ok(gate_sha) => {
+                            let subject = gate_subject(&plan.name, phase_id);
+                            transition(
+                                state,
+                                phase_id,
+                                PhaseStatus::Checking,
+                                PhaseStatus::AwaitingVerdict,
+                                Some(PhaseUpdate {
+                                    checks: Some(check_result.results),
+                                    gate_sha: Some(gate_sha.clone()),
+                                    gate_entered_at: Some(now_rfc3339()),
+                                    ..Default::default()
+                                }),
+                            )?;
+                            println!("\n  ⏸ Phase \"{phase_id}\" AWAITING_VERDICT — waiting for an external verdict");
+                            println!("    subject:  {subject}");
+                            println!("    gate_sha: {gate_sha}");
+                            println!(
+                                "    approve:  edda verdict approve {subject} --sha {gate_sha}"
+                            );
+                            println!("    reject:   edda verdict reject {subject} --sha {gate_sha} --comment \"<why>\"");
+                            if let Some(tmux) = tmux_session {
+                                let _ = tmux.update_phase_status(phase_id, "AwaitingVerdict");
+                            }
+                            event_log.record(Event::GateEntered {
+                                phase_id: phase_id.to_string(),
+                                subject: subject.clone(),
+                                gate_sha: gate_sha.clone(),
+                            });
+                            notifier
+                                .notify(&format!(
+                                    "Phase \"{phase_id}\" is AWAITING_VERDICT. Approve: edda verdict approve {subject} --sha {gate_sha} | Reject: edda verdict reject {subject} --sha {gate_sha} --comment \"<why>\""
+                                ))
+                                .await;
+                            edda::record_note(
+                                cwd,
+                                &format!(
+                                    "Phase \"{phase_id}\" entered AWAITING_VERDICT (gate sha {gate_sha})"
+                                ),
+                                &["conductor", "gate"],
+                            );
+                        }
+                        Err(e) => {
+                            let msg = format!("failed to capture gate sha: {e}");
+                            fail_checking_phase(
+                                plan,
+                                phase,
+                                state,
+                                phase_id,
+                                cwd,
+                                &check_result,
+                                Some(&msg),
+                                phase_start.elapsed(),
+                                notifier,
+                                event_log,
+                                tmux_session,
+                            )
+                            .await?;
+                        }
+                    }
+                } else {
+                    transition(
+                        state,
+                        phase_id,
+                        PhaseStatus::Checking,
+                        PhaseStatus::Passed,
+                        Some(PhaseUpdate {
+                            completed_at: Some(now_rfc3339()),
+                            checks: Some(check_result.results),
+                            ..Default::default()
+                        }),
+                    )?;
+                    let elapsed_ms = phase_start.elapsed().as_millis() as u64;
+                    println!(
+                        "  ✓ Phase \"{phase_id}\" passed ({})",
+                        format_elapsed(phase_start.elapsed())
+                    );
+                    if let Some(tmux) = tmux_session {
+                        let _ = tmux.update_phase_status(phase_id, "Passed");
+                    }
+
+                    // Record to edda ledger
+                    edda::record_phase_done(cwd, phase_id, result_text.as_deref(), cost_usd);
+                    event_log.record(Event::PhasePassed {
+                        phase_id: phase_id.to_string(),
+                        attempt,
+                        duration_ms: elapsed_ms,
+                        cost_usd,
+                    });
+                }
+            } else {
+                fail_checking_phase(
+                    plan,
+                    phase,
+                    state,
+                    phase_id,
+                    cwd,
+                    &check_result,
+                    None,
+                    phase_start.elapsed(),
+                    notifier,
+                    event_log,
+                    tmux_session,
+                )
+                .await?;
+            }
+        }
+        PhaseResult::Timeout => {
+            transition(
+                state,
+                phase_id,
+                PhaseStatus::Running,
+                PhaseStatus::Stale,
+                Some(PhaseUpdate {
+                    error: Some(ErrorInfo {
+                        error_type: ErrorType::Timeout,
+                        message: format!("phase \"{phase_id}\" timed out"),
+                        retryable: true,
+                        check_index: None,
+                        timestamp: now_rfc3339(),
+                    }),
+                    ..Default::default()
+                }),
+            )?;
+            let elapsed_ms = phase_start.elapsed().as_millis() as u64;
+            println!(
+                "  ⏰ Phase \"{phase_id}\" timed out ({})",
+                format_elapsed(phase_start.elapsed())
+            );
+            if let Some(tmux) = tmux_session {
+                let _ = tmux.update_phase_status(phase_id, "Stale");
+            }
+            edda::record_phase_failed(cwd, phase_id, "timed out");
+            event_log.record(Event::PhaseFailed {
+                phase_id: phase_id.to_string(),
+                attempt,
+                duration_ms: elapsed_ms,
+                error: "timed out".into(),
+            });
+        }
+        PhaseResult::AgentCrash { error } => {
+            transition(
+                state,
+                phase_id,
+                PhaseStatus::Running,
+                PhaseStatus::Failed,
+                Some(PhaseUpdate {
+                    error: Some(ErrorInfo {
+                        error_type: ErrorType::AgentCrash,
+                        message: error.clone(),
+                        retryable: true,
+                        check_index: None,
+                        timestamp: now_rfc3339(),
+                    }),
+                    ..Default::default()
+                }),
+            )?;
+            let elapsed_ms = phase_start.elapsed().as_millis() as u64;
+            println!(
+                "  ✗ Phase \"{phase_id}\" crashed ({}): {error}",
+                format_elapsed(phase_start.elapsed())
+            );
+            if let Some(tmux) = tmux_session {
+                let _ = tmux.update_phase_status(phase_id, "Failed");
+            }
+            edda::record_phase_failed(cwd, phase_id, &error);
+            event_log.record(Event::PhaseFailed {
+                phase_id: phase_id.to_string(),
+                attempt,
+                duration_ms: elapsed_ms,
+                error: error.clone(),
+            });
+            // For crash, use empty check results
+            let empty_result = CheckRunResult {
+                all_passed: false,
+                results: vec![],
+                error: None,
+            };
+            handle_on_fail(
+                plan,
+                phase,
+                state,
+                phase_id,
+                &empty_result,
+                notifier,
+                event_log,
+            )
+            .await;
+        }
+        PhaseResult::MaxTurns { cost_usd } | PhaseResult::BudgetExceeded { cost_usd } => {
+            if let Some(cost) = cost_usd {
+                budget.record(cost);
+                state.total_cost_usd += cost;
+            }
+            let elapsed_ms = phase_start.elapsed().as_millis() as u64;
+            let msg = format!("{result:?}");
+            transition(
+                state,
+                phase_id,
+                PhaseStatus::Running,
+                PhaseStatus::Failed,
+                Some(PhaseUpdate {
+                    error: Some(ErrorInfo {
+                        error_type: ErrorType::BudgetExceeded,
+                        message: msg.clone(),
+                        retryable: false,
+                        check_index: None,
+                        timestamp: now_rfc3339(),
+                    }),
+                    ..Default::default()
+                }),
+            )?;
+            event_log.record(Event::PhaseFailed {
+                phase_id: phase_id.to_string(),
+                attempt,
+                duration_ms: elapsed_ms,
+                error: msg,
+            });
+        }
+    }
     Ok(())
 }
 
@@ -660,6 +1195,7 @@ fn build_plan_context(plan: &Plan, state: &PlanState, current_phase: &str) -> St
             PhaseStatus::Passed => "✓",
             PhaseStatus::Failed => "✗",
             PhaseStatus::Running | PhaseStatus::Checking => "▶",
+            PhaseStatus::AwaitingVerdict => "⏸",
             PhaseStatus::Skipped => "⊘",
             PhaseStatus::Stale => "⏰",
             PhaseStatus::Pending => {
@@ -1293,5 +1829,727 @@ phases:
             .as_array()
             .unwrap()
             .contains(&serde_json::json!("a")));
+    }
+
+    // ── Verdict gate (GH-519 D3/D4) ─────────────────────────────────────
+
+    use edda_core::event::new_verdict_event;
+    use edda_core::{VerdictDecision, VerdictPayload};
+    use edda_ledger::lock::WorkspaceLock;
+    use edda_ledger::Ledger;
+
+    /// Init a git repo in `dir` and return its HEAD (the gate_sha source).
+    fn init_git_repo(dir: &Path) -> String {
+        let run = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(dir)
+                .output()
+                .expect("git must be available");
+            assert!(
+                out.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+            out
+        };
+        run(&["init"]);
+        run(&["config", "user.email", "test@example.com"]);
+        run(&["config", "user.name", "test"]);
+        run(&["commit", "--allow-empty", "-m", "init"]);
+        String::from_utf8_lossy(&run(&["rev-parse", "HEAD"]).stdout)
+            .trim()
+            .to_string()
+    }
+
+    /// Record a verdict directly into the ledger at `root` (what
+    /// `edda verdict approve|reject` writes). Retries to ride out SQLite
+    /// busy windows while the runner polls concurrently.
+    fn record_verdict(
+        root: &Path,
+        subject: &str,
+        sha: &str,
+        decision: VerdictDecision,
+        comment: Option<&str>,
+    ) {
+        for _ in 0..50 {
+            let opened = Ledger::open(root).and_then(|ledger| {
+                let _lock = WorkspaceLock::acquire(&ledger.paths)?;
+                let branch = ledger.head_branch()?;
+                let parent = ledger.last_event_hash()?;
+                let payload = VerdictPayload {
+                    subject: subject.to_string(),
+                    decision,
+                    sha: sha.to_string(),
+                    comment: comment.map(Into::into),
+                    actor: "tester".into(),
+                };
+                let event = new_verdict_event(&branch, parent.as_deref(), &payload)?;
+                ledger.append_event(&event)
+            });
+            if opened.is_ok() {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        panic!("failed to record verdict into the ledger");
+    }
+
+    /// Poll the runner's events.jsonl until `n` gate_entered events have been
+    /// observed; returns their gate shas in order.
+    async fn wait_for_gate_events(root: &Path, plan_name: &str, n: usize) -> Vec<String> {
+        let path = root
+            .join(".edda")
+            .join("conductor")
+            .join(plan_name)
+            .join("events.jsonl");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            let mut shas = Vec::new();
+            if let Ok(content) = std::fs::read_to_string(&path) {
+                for line in content.lines().filter(|l| !l.trim().is_empty()) {
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+                        if v["type"] == "gate_entered" {
+                            shas.push(v["gate_sha"].as_str().unwrap().to_string());
+                        }
+                    }
+                }
+            }
+            if shas.len() >= n {
+                return shas;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "only {} gate_entered events observed, wanted {n}",
+                shas.len()
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
+    /// Spawn `run_plan` on a background task; returns state, notifier and
+    /// launcher through the handle so the test can inspect them afterwards.
+    fn spawn_runner(
+        yaml: &'static str,
+        root: std::path::PathBuf,
+        launcher: MockLauncher,
+        state: PlanState,
+    ) -> tokio::task::JoinHandle<anyhow::Result<(PlanState, CollectNotifier, MockLauncher)>> {
+        tokio::spawn(async move {
+            let plan = parse_plan(yaml).unwrap();
+            let mut state = state;
+            let engine = CheckEngine::new(root.clone());
+            let notifier = CollectNotifier::new();
+            let mut budget = BudgetTracker::new(plan.budget_usd);
+            let cancel = CancellationToken::new();
+            let result = run_plan(
+                &plan,
+                &mut state,
+                RunContext {
+                    launcher: &launcher,
+                    check_engine: &engine,
+                    notifier: &notifier,
+                    budget: &mut budget,
+                    cancel,
+                    cwd: &root,
+                    interactive: false,
+                    json_events: false,
+                    tmux_session: None,
+                },
+            )
+            .await;
+            result.map(|_| (state, notifier, launcher))
+        })
+    }
+
+    fn fresh_root(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("edda_gate_{tag}_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        // The gate wait polls the ledger; tests that record verdicts need it.
+        Ledger::ensure_initialized(&dir).unwrap();
+        dir
+    }
+
+    /// Outer deadline for gate tests: a regression that makes a gate wait
+    /// forever must fail loudly here, not hang CI.
+    const GATE_TEST_DEADLINE: Duration = Duration::from_secs(30);
+
+    const GATED_YAML: &str = r#"
+name: gated
+phases:
+  - id: a
+    prompt: "do it"
+    gate: verdict
+  - id: b
+    prompt: "after"
+    depends_on: [a]
+"#;
+
+    #[tokio::test]
+    async fn gate_pauses_then_approve_resumes() {
+        let root = fresh_root("approve");
+        let head = init_git_repo(&root);
+        let launcher = MockLauncher::new();
+        let plan = parse_plan(GATED_YAML).unwrap();
+        let state = PlanState::from_plan(&plan, "test.yaml");
+        let handle = spawn_runner(GATED_YAML, root.clone(), launcher, state);
+
+        // The gate engages after checks pass; approve the captured sha.
+        let shas = wait_for_gate_events(&root, "gated", 1).await;
+        assert_eq!(shas[0], head, "gate_sha must be the phase cwd's git HEAD");
+        record_verdict(&root, "gated/a", &shas[0], VerdictDecision::Approved, None);
+
+        let (state, _notifier, launcher) = tokio::time::timeout(GATE_TEST_DEADLINE, handle)
+            .await
+            .expect("gate test exceeded 30s")
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.plan_status, PlanStatus::Completed);
+        assert_eq!(state.phases[0].status, PhaseStatus::Passed);
+        assert_eq!(state.phases[1].status, PhaseStatus::Passed);
+        assert_eq!(
+            state.phases[0].verdict_decision.as_deref(),
+            Some("approved")
+        );
+        assert_eq!(launcher.call_count("a"), 1);
+        assert_eq!(launcher.call_count("b"), 1);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn gate_reject_redispatches_same_session_then_regates() {
+        let root = fresh_root("redispatch");
+        init_git_repo(&root);
+        let launcher = MockLauncher::new();
+        let plan = parse_plan(GATED_YAML).unwrap();
+        let state = PlanState::from_plan(&plan, "test.yaml");
+        let handle = spawn_runner(GATED_YAML, root.clone(), launcher, state);
+
+        // First gate: reject with a comment.
+        let shas = wait_for_gate_events(&root, "gated", 1).await;
+        record_verdict(
+            &root,
+            "gated/a",
+            &shas[0],
+            VerdictDecision::Rejected,
+            Some("fix the flaky test"),
+        );
+
+        // Redispatch re-enters the gate with a fresh gate_sha; approve it.
+        let shas = wait_for_gate_events(&root, "gated", 2).await;
+        record_verdict(
+            &root,
+            "gated/a",
+            &shas[1],
+            VerdictDecision::Approved,
+            Some("looks good now"),
+        );
+
+        let (state, _notifier, launcher) = tokio::time::timeout(GATE_TEST_DEADLINE, handle)
+            .await
+            .expect("gate test exceeded 30s")
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.plan_status, PlanStatus::Completed);
+        assert_eq!(state.phases[0].status, PhaseStatus::Passed);
+        let calls = launcher.calls_for("a");
+        assert_eq!(calls.len(), 2, "exactly ONE redispatch turn");
+        assert_eq!(
+            calls[0].session_id, calls[1].session_id,
+            "redispatch must reuse the SAME session id"
+        );
+        assert!(
+            calls[1].prompt.contains("fix the flaky test"),
+            "rejection comment becomes the prompt"
+        );
+        assert!(calls[1].prompt.contains("REJECTED"));
+        assert_eq!(
+            state.phases[0].attempts, 1,
+            "redispatch must NOT increment attempt"
+        );
+        assert_eq!(
+            state.phases[0].verdict_decision.as_deref(),
+            Some("approved")
+        );
+        // D3: state records the FINAL verdict's metadata — the approval
+        // supersedes the earlier rejection.
+        assert_eq!(
+            state.phases[0].verdict_comment.as_deref(),
+            Some("looks good now")
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn gate_reject_halt_fails_with_comment_as_error() {
+        let root = fresh_root("halt");
+        init_git_repo(&root);
+        let launcher = MockLauncher::new();
+        let yaml = r#"
+name: gated
+phases:
+  - id: a
+    prompt: "do it"
+    gate: verdict
+    on_reject: halt
+"#;
+        let plan = parse_plan(yaml).unwrap();
+        let state = PlanState::from_plan(&plan, "test.yaml");
+        let handle = spawn_runner(yaml, root.clone(), launcher, state);
+
+        // D6: the reject must postdate gate_entered_at, so record it after
+        // observing the gate_entered event (a pre-recorded verdict is stale
+        // and would never satisfy the gate).
+        let shas = wait_for_gate_events(&root, "gated", 1).await;
+        record_verdict(
+            &root,
+            "gated/a",
+            &shas[0],
+            VerdictDecision::Rejected,
+            Some("wrong approach"),
+        );
+
+        let (state, _notifier, launcher) = tokio::time::timeout(GATE_TEST_DEADLINE, handle)
+            .await
+            .expect("gate test exceeded 30s")
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(state.phases[0].status, PhaseStatus::Failed);
+        assert_eq!(
+            state.phases[0].error.as_ref().unwrap().message,
+            "wrong approach"
+        );
+        assert_eq!(
+            state.phases[0].error.as_ref().unwrap().error_type,
+            ErrorType::GateRejected
+        );
+        assert_eq!(state.plan_status, PlanStatus::Blocked);
+        assert_eq!(launcher.call_count("a"), 1, "no redispatch turn on halt");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn gate_reject_respects_max_attempts_bound() {
+        let root = fresh_root("bound");
+        init_git_repo(&root);
+        let launcher = MockLauncher::new();
+        let yaml = r#"
+name: gated
+max_attempts: 1
+phases:
+  - id: a
+    prompt: "do it"
+    gate: verdict
+"#;
+        let plan = parse_plan(yaml).unwrap();
+        let state = PlanState::from_plan(&plan, "test.yaml");
+        let handle = spawn_runner(yaml, root.clone(), launcher, state);
+
+        // D6: record the reject after the gate enters so it is fresh.
+        // on_reject defaults to redispatch, but max_attempts: 1 is already
+        // exhausted after the gated attempt — reject must halt instead.
+        let shas = wait_for_gate_events(&root, "gated", 1).await;
+        record_verdict(
+            &root,
+            "gated/a",
+            &shas[0],
+            VerdictDecision::Rejected,
+            Some("still wrong"),
+        );
+
+        let (state, _notifier, launcher) = tokio::time::timeout(GATE_TEST_DEADLINE, handle)
+            .await
+            .expect("gate test exceeded 30s")
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(state.phases[0].status, PhaseStatus::Failed);
+        assert_eq!(
+            state.phases[0].error.as_ref().unwrap().message,
+            "still wrong"
+        );
+        assert_eq!(
+            launcher.call_count("a"),
+            1,
+            "no redispatch beyond max_attempts"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn restart_reenters_gate_wait_without_rerunning() {
+        let root = fresh_root("restart");
+        let sha = "e".repeat(40);
+        // Simulate persisted state from a previous run: phase a is mid-gate.
+        let plan = parse_plan(GATED_YAML).unwrap();
+        let mut state = PlanState::from_plan(&plan, "test.yaml");
+        state.started_at = Some(now_rfc3339());
+        transition(
+            &mut state,
+            "a",
+            PhaseStatus::Pending,
+            PhaseStatus::Running,
+            None,
+        )
+        .unwrap();
+        transition(
+            &mut state,
+            "a",
+            PhaseStatus::Running,
+            PhaseStatus::Checking,
+            None,
+        )
+        .unwrap();
+        transition(
+            &mut state,
+            "a",
+            PhaseStatus::Checking,
+            PhaseStatus::AwaitingVerdict,
+            Some(PhaseUpdate {
+                attempts: Some(1),
+                gate_sha: Some(sha.clone()),
+                gate_entered_at: Some(now_rfc3339()),
+                ..Default::default()
+            }),
+        )
+        .unwrap();
+        crate::state::persist::save_state(&root, &state).unwrap();
+
+        // Approve BEFORE resuming — the resumed wait observes it on its
+        // first poll; no gate_entered is re-emitted and no turn re-runs.
+        // (gate_entered_at was set above, so this verdict postdates it and
+        // satisfies the D6 freshness rule.)
+        record_verdict(&root, "gated/a", &sha, VerdictDecision::Approved, None);
+
+        let launcher = MockLauncher::new();
+        let (state, _notifier, launcher) = tokio::time::timeout(
+            GATE_TEST_DEADLINE,
+            spawn_runner(GATED_YAML, root.clone(), launcher, state),
+        )
+        .await
+        .expect("gate test exceeded 30s")
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(state.plan_status, PlanStatus::Completed);
+        assert_eq!(state.phases[0].status, PhaseStatus::Passed);
+        assert_eq!(
+            launcher.call_count("a"),
+            0,
+            "restart must NOT re-run the phase agent turn"
+        );
+        assert_eq!(state.phases[0].attempts, 1);
+        assert_eq!(state.phases[1].status, PhaseStatus::Passed);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn gate_timeout_fails_distinctly() {
+        let root = fresh_root("timeout");
+        init_git_repo(&root);
+        // No verdict will ever arrive.
+        let launcher = MockLauncher::new();
+        let yaml = r#"
+name: gated
+timeout_sec: 600
+phases:
+  - id: a
+    prompt: "do it"
+    gate: verdict
+    gate_timeout_sec: 1
+"#;
+        let plan = parse_plan(yaml).unwrap();
+        let state = PlanState::from_plan(&plan, "test.yaml");
+        let (state, _notifier, _launcher) = tokio::time::timeout(
+            GATE_TEST_DEADLINE,
+            spawn_runner(yaml, root.clone(), launcher, state),
+        )
+        .await
+        .expect("gate test exceeded 30s")
+        .unwrap()
+        .unwrap();
+
+        let phase = &state.phases[0];
+        assert_eq!(phase.status, PhaseStatus::Failed);
+        let err = phase
+            .error
+            .as_ref()
+            .expect("gate timeout must set an error");
+        assert_eq!(err.error_type, ErrorType::Timeout);
+        assert!(
+            err.message.contains("gate timed out"),
+            "distinct gate timeout error, got: {}",
+            err.message
+        );
+        assert_eq!(state.plan_status, PlanStatus::Blocked);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn non_gated_plan_completes_without_gate_events() {
+        let root = fresh_root("nongated");
+        // No git repo, no ledger — a non-gated plan must not touch any of it.
+        let (state, _msgs) = {
+            let plan = parse_plan(
+                "name: plain\nphases:\n  - id: a\n    prompt: \"x\"\n  - id: b\n    prompt: \"y\"\n    depends_on: [a]\n",
+            )
+            .unwrap();
+            let mut state = PlanState::from_plan(&plan, "test.yaml");
+            let engine = CheckEngine::new(root.clone());
+            let notifier = CollectNotifier::new();
+            let mut budget = BudgetTracker::new(plan.budget_usd);
+            run_plan(
+                &plan,
+                &mut state,
+                RunContext {
+                    launcher: &MockLauncher::new(),
+                    check_engine: &engine,
+                    notifier: &notifier,
+                    budget: &mut budget,
+                    cancel: CancellationToken::new(),
+                    cwd: &root,
+                    interactive: false,
+                    json_events: false,
+                    tmux_session: None,
+                },
+            )
+            .await
+            .unwrap();
+            (state, notifier.messages())
+        };
+        assert_eq!(state.plan_status, PlanStatus::Completed);
+        assert!(state.phases.iter().all(|p| p.status == PhaseStatus::Passed));
+        assert!(state.phases.iter().all(|p| p.gate_sha.is_none()));
+        // No gate events in the event log.
+        let events = read_events(&root, "plain");
+        assert!(!events
+            .iter()
+            .any(|e| e["type"] == "gate_entered" || e["type"] == "verdict_received"));
+    }
+
+    #[test]
+    fn gate_subject_format() {
+        assert_eq!(gate_subject("my-plan", "build"), "my-plan/build");
+    }
+
+    #[tokio::test]
+    async fn wait_for_verdict_ignores_sha_mismatch_and_times_out() {
+        let root = fresh_root("mismatchwait");
+        let sha_a = "a".repeat(40);
+        let sha_b = "b".repeat(40);
+        // A verdict for a DIFFERENT sha is recorded... the wait on sha_b must
+        // never satisfy on it and must hit its timeout instead.
+        record_verdict(&root, "plan/phase", &sha_a, VerdictDecision::Approved, None);
+        let cancel = CancellationToken::new();
+        let verdict = wait_for_verdict(
+            &root,
+            "plan/phase",
+            &sha_b,
+            Some(1),
+            Some(&now_rfc3339()),
+            &cancel,
+        )
+        .await;
+        assert!(matches!(verdict, GateVerdict::TimedOut));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn wait_for_verdict_returns_matching_verdict() {
+        let root = fresh_root("matchwait");
+        let sha = "c".repeat(40);
+        // D6 freshness: the gate's entered_at must predate the verdict.
+        let entered_at = now_rfc3339();
+        record_verdict(
+            &root,
+            "plan/phase",
+            &sha,
+            VerdictDecision::Rejected,
+            Some("no"),
+        );
+        let cancel = CancellationToken::new();
+        let verdict = wait_for_verdict(
+            &root,
+            "plan/phase",
+            &sha,
+            Some(30),
+            Some(&entered_at),
+            &cancel,
+        )
+        .await;
+        match verdict {
+            GateVerdict::Rejected(record) => {
+                assert_eq!(record.payload.comment.as_deref(), Some("no"));
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// D6 regression: the exact 176-loop scenario. The redispatch turn
+    /// produces no new commit, so the re-entered gate waits on the SAME
+    /// `(subject, gate_sha)`; the rejected verdict recorded for the first
+    /// gate is now STALE (it predates the second gate_entered_at) and must
+    /// not re-satisfy the gate. Assert exactly ONE redispatch, then the
+    /// gate times out instead of looping forever.
+    #[tokio::test]
+    async fn stale_reject_does_not_resatisfy_regated_same_sha() {
+        let root = fresh_root("stale");
+        init_git_repo(&root); // HEAD never changes → same gate_sha on re-entry
+        let launcher = MockLauncher::new();
+        let yaml = r#"
+name: gated
+phases:
+  - id: a
+    prompt: "do it"
+    gate: verdict
+    gate_timeout_sec: 5
+"#;
+        // Generous timeout: the first wait must observe the reject recorded
+        // right after the gate_entered event, even under parallel-test load.
+        let plan = parse_plan(yaml).unwrap();
+        let state = PlanState::from_plan(&plan, "test.yaml");
+        let handle = spawn_runner(yaml, root.clone(), launcher, state);
+
+        // First gate: reject → one redispatch turn → re-enter the gate.
+        let shas = wait_for_gate_events(&root, "gated", 1).await;
+        record_verdict(
+            &root,
+            "gated/a",
+            &shas[0],
+            VerdictDecision::Rejected,
+            Some("fix it"),
+        );
+        let shas = wait_for_gate_events(&root, "gated", 2).await;
+        assert_eq!(
+            shas[0], shas[1],
+            "no commit between gates: same gate_sha — the stale-verdict scenario"
+        );
+
+        // No fresh verdict ever arrives. Without the freshness bound the
+        // runner would re-read the stale rejection and redispatch forever.
+        let (state, _notifier, launcher) = tokio::time::timeout(GATE_TEST_DEADLINE, handle)
+            .await
+            .expect("gate test exceeded 30s")
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            launcher.call_count("a"),
+            2,
+            "exactly ONE redispatch — the stale rejection must not re-satisfy the re-entered gate"
+        );
+        assert_eq!(state.phases[0].status, PhaseStatus::Failed);
+        let err = state.phases[0]
+            .error
+            .as_ref()
+            .expect("gate timeout must set an error");
+        assert_eq!(err.error_type, ErrorType::Timeout);
+        assert!(
+            err.message.contains("gate timed out"),
+            "distinct gate timeout error, got: {}",
+            err.message
+        );
+        assert_eq!(
+            state.phases[0].gate_redispatches, 1,
+            "the persisted redispatch counter counts exactly the one cycle"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// D6: exhausting the persisted redispatch bound fails the phase with a
+    /// distinct error naming the bound (like on_reject: halt).
+    #[tokio::test]
+    async fn gate_reject_exhausts_redispatch_bound_with_distinct_error() {
+        let root = fresh_root("rdbound");
+        init_git_repo(&root);
+        let launcher = MockLauncher::new();
+        let yaml = r#"
+name: gated
+max_attempts: 99
+phases:
+  - id: a
+    prompt: "do it"
+    gate: verdict
+"#;
+        // No gate_timeout_sec: the wait polls until each verdict lands
+        // (record_verdict retries through SQLite busy windows under parallel
+        // load); the outer 30s deadline catches a genuine hang.
+        let plan = parse_plan(yaml).unwrap();
+        let state = PlanState::from_plan(&plan, "test.yaml");
+        let handle = spawn_runner(yaml, root.clone(), launcher, state);
+
+        // Reject every gate entry. Each redispatch re-enters the gate with
+        // the same sha; each fresh reject costs one more redispatch cycle.
+        // Rejections are recorded as the gates appear, by a helper task.
+        let rejecter_root = root.clone();
+        let rejecter = tokio::spawn(async move {
+            let root = rejecter_root;
+            for i in 0..=3 {
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+                loop {
+                    let mut shas = Vec::new();
+                    let path = root.join(".edda/conductor/gated/events.jsonl");
+                    if let Ok(content) = std::fs::read_to_string(&path) {
+                        for line in content.lines().filter(|l| !l.trim().is_empty()) {
+                            if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+                                if v["type"] == "gate_entered" {
+                                    shas.push(v["gate_sha"].as_str().unwrap().to_string());
+                                }
+                            }
+                        }
+                    }
+                    if shas.len() > i {
+                        record_verdict(
+                            &root,
+                            "gated/a",
+                            &shas[i],
+                            VerdictDecision::Rejected,
+                            Some("no good"),
+                        );
+                        break;
+                    }
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "rejecter: gate {i} never appeared"
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+            }
+        });
+
+        // FOUR gate cycles, each paced by the runner's 2s ledger poll —
+        // needs a wider outer bound than single-gate tests, especially
+        // under full-suite parallel load.
+        let (state, _notifier, launcher) =
+            tokio::time::timeout(std::time::Duration::from_secs(60), async {
+                let res = handle.await.unwrap().unwrap();
+                rejecter.abort();
+                res
+            })
+            .await
+            .expect("gate test exceeded 60s");
+
+        // 1 gated attempt + MAX_GATE_REDISPATCHES redispatch turns, no more.
+        assert_eq!(
+            launcher.call_count("a"),
+            1 + MAX_GATE_REDISPATCHES,
+            "redispatch bound must cap agent turns"
+        );
+        assert_eq!(state.phases[0].status, PhaseStatus::Failed);
+        let err = state.phases[0]
+            .error
+            .as_ref()
+            .expect("bound must set an error");
+        assert_eq!(err.error_type, ErrorType::GateRejected);
+        assert!(
+            err.message.contains("redispatch bound exhausted"),
+            "distinct error naming the bound, got: {}",
+            err.message
+        );
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/edda-conductor/src/state/derive.rs
+++ b/crates/edda-conductor/src/state/derive.rs
@@ -3,10 +3,11 @@ use crate::state::machine::{ErrorInfo, ErrorType, PhaseStatus, PlanState, PlanSt
 
 /// Derive plan-level status from phase states.
 pub fn derive_plan_status(phases: &[crate::state::machine::PhaseState]) -> PlanStatus {
-    if phases
-        .iter()
-        .any(|p| p.status == PhaseStatus::Running || p.status == PhaseStatus::Checking)
-    {
+    if phases.iter().any(|p| {
+        p.status == PhaseStatus::Running
+            || p.status == PhaseStatus::Checking
+            || p.status == PhaseStatus::AwaitingVerdict
+    }) {
         return PlanStatus::Running;
     }
     if phases
@@ -132,6 +133,12 @@ mod tests {
                 error: None,
                 skip_reason: None,
                 retry_context: None,
+                gate_sha: None,
+                gate_entered_at: None,
+                gate_redispatches: 0,
+                verdict_decision: None,
+                verdict_actor: None,
+                verdict_comment: None,
             })
             .collect()
     }

--- a/crates/edda-conductor/src/state/machine.rs
+++ b/crates/edda-conductor/src/state/machine.rs
@@ -15,6 +15,8 @@ pub enum PhaseStatus {
     Failed,
     Skipped,
     Stale,
+    /// Checks passed but an external verdict gate is holding the phase (D3).
+    AwaitingVerdict,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -66,6 +68,27 @@ pub struct PhaseState {
     /// Error context from previous attempt, injected into retry prompt.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retry_context: Option<String>,
+    /// Git HEAD captured when the phase entered AWAITING_VERDICT (D3).
+    /// On restart the wait resumes against this SHA without re-running the phase.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gate_sha: Option<String>,
+    /// RFC3339 timestamp of when the phase entered AWAITING_VERDICT (D3).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gate_entered_at: Option<String>,
+    /// Completed redispatch cycles at the verdict gate (D6). Persisted and
+    /// counted separately from `attempts` — D3 forbids incrementing attempt
+    /// on redispatch, and a redispatch turn is not guaranteed to produce a
+    /// new commit, so `max_attempts` can never bound the (subject, gate_sha)
+    /// loop. This counter is the real bound.
+    #[serde(default)]
+    pub gate_redispatches: u32,
+    /// Verdict metadata recorded when the gate resolved (D3).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verdict_decision: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verdict_actor: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verdict_comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -86,6 +109,8 @@ pub enum ErrorType {
     Timeout,
     BudgetExceeded,
     UserAbort,
+    /// A verdict gate rejected the phase (D3, on_reject: halt or bound hit).
+    GateRejected,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -123,7 +148,21 @@ const VALID_TRANSITIONS: &[(PhaseStatus, &[PhaseStatus])] = &[
     ),
     (
         PhaseStatus::Checking,
-        &[PhaseStatus::Passed, PhaseStatus::Failed],
+        &[
+            PhaseStatus::Passed,
+            PhaseStatus::Failed,
+            PhaseStatus::AwaitingVerdict,
+        ],
+    ),
+    (
+        PhaseStatus::AwaitingVerdict,
+        &[
+            PhaseStatus::Passed,
+            PhaseStatus::Failed,
+            // Rejected verdict with on_reject: redispatch runs one more agent
+            // turn in the SAME session (D3), so the phase goes back to Running.
+            PhaseStatus::Running,
+        ],
     ),
     (PhaseStatus::Failed, &[PhaseStatus::Pending]), // retry
     (PhaseStatus::Stale, &[PhaseStatus::Pending]),  // retry
@@ -148,6 +187,10 @@ pub struct PhaseUpdate {
     pub error: Option<ErrorInfo>,
     pub skip_reason: Option<String>,
     pub retry_context: Option<Option<String>>,
+    /// Gate SHA captured when entering AWAITING_VERDICT.
+    pub gate_sha: Option<String>,
+    /// RFC3339 timestamp of gate entry.
+    pub gate_entered_at: Option<String>,
 }
 
 impl PhaseUpdate {
@@ -172,6 +215,12 @@ impl PhaseUpdate {
         }
         if let Some(v) = self.retry_context {
             phase.retry_context = v;
+        }
+        if let Some(v) = self.gate_sha {
+            phase.gate_sha = Some(v);
+        }
+        if let Some(v) = self.gate_entered_at {
+            phase.gate_entered_at = Some(v);
         }
     }
 }
@@ -220,6 +269,12 @@ impl PlanState {
                 error: None,
                 skip_reason: None,
                 retry_context: None,
+                gate_sha: None,
+                gate_entered_at: None,
+                gate_redispatches: 0,
+                verdict_decision: None,
+                verdict_actor: None,
+                verdict_comment: None,
             })
             .collect();
 
@@ -453,5 +508,145 @@ phases:
         let restored: PlanState = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.plan_name, "test");
         assert_eq!(restored.phases.len(), 2);
+    }
+
+    // ── AwaitingVerdict gate state (D2/D3) ──────────────────────────
+
+    #[test]
+    fn awaiting_verdict_serializes_snake_case() {
+        let json = serde_json::to_string(&PhaseStatus::AwaitingVerdict).unwrap();
+        assert_eq!(json, r#""awaiting_verdict""#);
+        let back: PhaseStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, PhaseStatus::AwaitingVerdict);
+    }
+
+    fn run_to_checking(state: &mut PlanState, id: &str) {
+        transition(state, id, PhaseStatus::Pending, PhaseStatus::Running, None).unwrap();
+        transition(state, id, PhaseStatus::Running, PhaseStatus::Checking, None).unwrap();
+    }
+
+    #[test]
+    fn checking_to_awaiting_verdict_is_valid() {
+        let plan = test_plan();
+        let mut state = PlanState::from_plan(&plan, "plan.yaml");
+        run_to_checking(&mut state, "a");
+        transition(
+            &mut state,
+            "a",
+            PhaseStatus::Checking,
+            PhaseStatus::AwaitingVerdict,
+            Some(PhaseUpdate {
+                gate_sha: Some("abc123".into()),
+                gate_entered_at: Some("2026-01-01T00:00:00Z".into()),
+                ..Default::default()
+            }),
+        )
+        .unwrap();
+        let phase = state.get_phase("a").unwrap();
+        assert_eq!(phase.status, PhaseStatus::AwaitingVerdict);
+        assert_eq!(phase.gate_sha.as_deref(), Some("abc123"));
+        assert_eq!(
+            phase.gate_entered_at.as_deref(),
+            Some("2026-01-01T00:00:00Z")
+        );
+    }
+
+    #[test]
+    fn awaiting_verdict_resolves_to_passed_or_failed() {
+        let plan = test_plan();
+
+        // approve → Passed
+        let mut state = PlanState::from_plan(&plan, "plan.yaml");
+        run_to_checking(&mut state, "a");
+        transition(
+            &mut state,
+            "a",
+            PhaseStatus::Checking,
+            PhaseStatus::AwaitingVerdict,
+            None,
+        )
+        .unwrap();
+        transition(
+            &mut state,
+            "a",
+            PhaseStatus::AwaitingVerdict,
+            PhaseStatus::Passed,
+            None,
+        )
+        .unwrap();
+        assert_eq!(state.get_phase("a").unwrap().status, PhaseStatus::Passed);
+
+        // reject (halt) / timeout → Failed
+        let mut state = PlanState::from_plan(&plan, "plan.yaml");
+        run_to_checking(&mut state, "a");
+        transition(
+            &mut state,
+            "a",
+            PhaseStatus::Checking,
+            PhaseStatus::AwaitingVerdict,
+            None,
+        )
+        .unwrap();
+        transition(
+            &mut state,
+            "a",
+            PhaseStatus::AwaitingVerdict,
+            PhaseStatus::Failed,
+            None,
+        )
+        .unwrap();
+        assert_eq!(state.get_phase("a").unwrap().status, PhaseStatus::Failed);
+    }
+
+    #[test]
+    fn awaiting_verdict_to_pending_is_invalid() {
+        let plan = test_plan();
+        let mut state = PlanState::from_plan(&plan, "plan.yaml");
+        run_to_checking(&mut state, "a");
+        transition(
+            &mut state,
+            "a",
+            PhaseStatus::Checking,
+            PhaseStatus::AwaitingVerdict,
+            None,
+        )
+        .unwrap();
+        let err = transition(
+            &mut state,
+            "a",
+            PhaseStatus::AwaitingVerdict,
+            PhaseStatus::Pending,
+            None,
+        );
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn awaiting_verdict_state_persists_gate_sha_and_restore() {
+        let plan = test_plan();
+        let mut state = PlanState::from_plan(&plan, "plan.yaml");
+        run_to_checking(&mut state, "a");
+        transition(
+            &mut state,
+            "a",
+            PhaseStatus::Checking,
+            PhaseStatus::AwaitingVerdict,
+            Some(PhaseUpdate {
+                gate_sha: Some("deadbeef".into()),
+                gate_entered_at: Some("2026-01-01T00:00:00Z".into()),
+                ..Default::default()
+            }),
+        )
+        .unwrap();
+
+        let json = serde_json::to_string(&state).unwrap();
+        let restored: PlanState = serde_json::from_str(&json).unwrap();
+        let phase = restored.get_phase("a").unwrap();
+        assert_eq!(phase.status, PhaseStatus::AwaitingVerdict);
+        assert_eq!(phase.gate_sha.as_deref(), Some("deadbeef"));
+        assert_eq!(
+            phase.gate_entered_at.as_deref(),
+            Some("2026-01-01T00:00:00Z")
+        );
     }
 }

--- a/crates/edda-conductor/src/state/persist.rs
+++ b/crates/edda-conductor/src/state/persist.rs
@@ -82,6 +82,53 @@ mod tests {
         assert_eq!(loaded.version, 42);
     }
 
+    #[test]
+    fn awaiting_verdict_state_survives_disk_roundtrip() {
+        use crate::state::machine::{transition, PhaseStatus, PhaseUpdate};
+
+        let dir = tempfile::tempdir().unwrap();
+        let plan = parse_plan("name: gated\nphases:\n  - id: a\n    prompt: x\n").unwrap();
+        let mut state = PlanState::from_plan(&plan, "plan.yaml");
+        transition(
+            &mut state,
+            "a",
+            crate::state::machine::PhaseStatus::Pending,
+            crate::state::machine::PhaseStatus::Running,
+            None,
+        )
+        .unwrap();
+        transition(
+            &mut state,
+            "a",
+            PhaseStatus::Running,
+            PhaseStatus::Checking,
+            None,
+        )
+        .unwrap();
+        transition(
+            &mut state,
+            "a",
+            PhaseStatus::Checking,
+            PhaseStatus::AwaitingVerdict,
+            Some(PhaseUpdate {
+                gate_sha: Some("0123456789abcdef".into()),
+                gate_entered_at: Some("2026-01-01T00:00:00Z".into()),
+                ..Default::default()
+            }),
+        )
+        .unwrap();
+
+        save_state(dir.path(), &state).unwrap();
+        let loaded = load_state(dir.path(), "gated").unwrap().unwrap();
+        let phase = loaded.get_phase("a").unwrap();
+        assert_eq!(phase.status, PhaseStatus::AwaitingVerdict);
+        assert_eq!(phase.gate_sha.as_deref(), Some("0123456789abcdef"));
+        assert_eq!(
+            phase.gate_entered_at.as_deref(),
+            Some("2026-01-01T00:00:00Z")
+        );
+    }
+
     // ── Corrupted state recovery tests ─────────────────────────────
 
     /// Helper: create the state.json directory structure and write content.

--- a/crates/edda-core/src/event.rs
+++ b/crates/edda-core/src/event.rs
@@ -1,7 +1,8 @@
 use crate::canon::canonical_json_bytes;
 use crate::hash::sha256_hex;
 use crate::types::{
-    classify_event_type, DecisionPayload, Digest, Event, Refs, CANON_EDDA_V1, SCHEMA_VERSION,
+    classify_event_type, DecisionPayload, Digest, Event, Refs, VerdictPayload, CANON_EDDA_V1,
+    SCHEMA_VERSION,
 };
 
 /// Compute the hash for an event: serialize without the `hash` field,
@@ -281,6 +282,33 @@ pub fn new_decision_ratify_event(
         event_level: None,
     };
 
+    finalize(&mut event)?;
+    Ok(event)
+}
+
+/// Create a new `verdict.recorded` event — an external actor's approval or
+/// rejection of a gated subject (GH-519). The conductor consumes verdicts;
+/// it does not own them. A verdict is bound to (subject, full SHA) and is
+/// queryable via `edda log --type verdict.recorded`.
+pub fn new_verdict_event(
+    branch: &str,
+    parent_hash: Option<&str>,
+    verdict: &VerdictPayload,
+) -> anyhow::Result<Event> {
+    let mut event = Event {
+        event_id: new_event_id(),
+        ts: now_rfc3339(),
+        event_type: "verdict.recorded".to_string(),
+        branch: branch.to_string(),
+        parent_hash: parent_hash.map(|s| s.to_string()),
+        hash: String::new(),
+        payload: serde_json::to_value(verdict)?,
+        refs: Refs::default(),
+        schema_version: SCHEMA_VERSION,
+        digests: Vec::new(),
+        event_family: None,
+        event_level: None,
+    };
     finalize(&mut event)?;
     Ok(event)
 }
@@ -1167,6 +1195,7 @@ pub fn new_task_requeued_event(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::{VerdictDecision, VerdictPayload};
 
     #[test]
     fn note_event_has_valid_id_and_hash() {
@@ -2074,6 +2103,44 @@ mod tests {
         assert_eq!(event.payload["acp_session_id"], "sess-acp-42");
         assert_eq!(event.event_family.as_deref(), Some("signal"));
         assert_eq!(event.event_level.as_deref(), Some("trace"));
+    }
+
+    #[test]
+    fn verdict_event_fields_roundtrip() {
+        let payload = VerdictPayload {
+            subject: "plan-x/phase-1".to_string(),
+            decision: VerdictDecision::Rejected,
+            sha: "a".repeat(40),
+            comment: Some("check 2 failed".to_string()),
+            actor: "tim".to_string(),
+        };
+        let event = new_verdict_event("main", Some("abc"), &payload).unwrap();
+        assert_eq!(event.event_type, "verdict.recorded");
+        assert_eq!(event.payload["subject"], "plan-x/phase-1");
+        assert_eq!(event.payload["decision"], "rejected");
+        assert_eq!(event.payload["sha"], "a".repeat(40));
+        assert_eq!(event.payload["actor"], "tim");
+        assert_eq!(event.event_family.as_deref(), Some("governance"));
+        assert_eq!(event.event_level.as_deref(), Some("governance"));
+        assert_eq!(event.digests[0].value, event.hash);
+        // The payload deserializes back into the typed struct.
+        let parsed: VerdictPayload = serde_json::from_value(event.payload).unwrap();
+        assert_eq!(parsed, payload);
+    }
+
+    #[test]
+    fn verdict_event_approved_without_comment_omits_comment_key() {
+        let payload = VerdictPayload {
+            subject: "plan-x/phase-1".to_string(),
+            decision: VerdictDecision::Approved,
+            sha: "b".repeat(40),
+            comment: None,
+            actor: "tim".to_string(),
+        };
+        let event = new_verdict_event("main", None, &payload).unwrap();
+        assert!(event.payload.get("comment").is_none());
+        let parsed: VerdictPayload = serde_json::from_value(event.payload).unwrap();
+        assert_eq!(parsed.comment, None);
     }
 
     #[test]

--- a/crates/edda-core/src/types.rs
+++ b/crates/edda-core/src/types.rs
@@ -130,6 +130,10 @@ pub fn classify_event_type(event_type: &str) -> (Option<&'static str>, Option<&'
         "task.session" => (Some(event_family::SIGNAL), Some(event_level::TRACE)),
         "task.done" => (Some(event_family::MILESTONE), Some(event_level::MILESTONE)),
         "task.requeued" => (Some(event_family::ADMIN), Some(event_level::INFO)),
+        "verdict.recorded" => (
+            Some(event_family::GOVERNANCE),
+            Some(event_level::GOVERNANCE),
+        ),
         _ => (None, None),
     }
 }
@@ -201,6 +205,42 @@ pub struct DecisionPayload {
     /// Village scope identifier. Default: None (not village-scoped).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub village_id: Option<String>,
+}
+
+/// An issued verdict on a gated subject (GH-519).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VerdictDecision {
+    Approved,
+    Rejected,
+}
+
+impl std::fmt::Display for VerdictDecision {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Approved => write!(f, "approved"),
+            Self::Rejected => write!(f, "rejected"),
+        }
+    }
+}
+
+/// Structured payload of a `verdict.recorded` ledger event (GH-519).
+///
+/// A verdict is a first-class ledger object bound to (subject, full SHA):
+/// the conductor consumes verdicts, it does not own them. A verdict recorded
+/// for one SHA is findable but never satisfies a gate waiting on another SHA.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct VerdictPayload {
+    /// Free-form subject; for conductor gates it is `<plan-name>/<phase-id>`.
+    pub subject: String,
+    pub decision: VerdictDecision,
+    /// Full 40-hex git SHA the verdict applies to.
+    pub sha: String,
+    /// Required on reject (fed back to the agent); optional context on approve.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+    /// Who issued the verdict — same identity source as other edda writes.
+    pub actor: String,
 }
 
 /// Status of a task brief.
@@ -421,6 +461,11 @@ mod tests {
             ("task.done", event_family::MILESTONE, event_level::MILESTONE),
             ("task.failed", event_family::SIGNAL, event_level::INFO),
             ("task.requeued", event_family::ADMIN, event_level::INFO),
+            (
+                "verdict.recorded",
+                event_family::GOVERNANCE,
+                event_level::GOVERNANCE,
+            ),
         ];
 
         for (event_type, expected_family, expected_level) in &table {

--- a/crates/edda-ledger/src/ledger.rs
+++ b/crates/edda-ledger/src/ledger.rs
@@ -1,5 +1,6 @@
 use crate::paths::EddaPaths;
 use crate::sqlite_store::{BundleRow, SqliteStore};
+use crate::verdict::{self, VerdictRecord};
 use crate::view::{self, DecisionView};
 use anyhow::Context;
 use edda_core::Event;
@@ -76,6 +77,51 @@ impl Ledger {
         self.sqlite
             .set_head_branch(name)
             .context("Ledger::set_head_branch")
+    }
+
+    // ── Verdicts (GH-519) ───────────────────────────────────────
+
+    /// Read every `verdict.recorded` event in insertion order. Malformed
+    /// payloads are skipped: the ledger stays append-only, and a broken row
+    /// must not take down the whole verdict history.
+    pub fn iter_verdicts(&self) -> anyhow::Result<Vec<VerdictRecord>> {
+        let events = self
+            .iter_events_by_type("verdict.recorded")
+            .context("Ledger::iter_verdicts")?;
+        Ok(events
+            .iter()
+            .filter_map(verdict::parse_verdict_event)
+            .collect())
+    }
+
+    /// Latest verdict for `(subject, sha)`, by ledger insertion order.
+    /// A verdict recorded against a different SHA never matches this query:
+    /// it stays findable via [`Ledger::iter_verdicts`] but cannot satisfy a
+    /// gate waiting on another SHA (GH-519 D1).
+    pub fn latest_verdict(
+        &self,
+        subject: &str,
+        sha: &str,
+    ) -> anyhow::Result<Option<VerdictRecord>> {
+        let verdicts = self.iter_verdicts()?;
+        Ok(verdict::latest_verdict(&verdicts, subject, sha).cloned())
+    }
+
+    /// Latest verdict for `(subject, sha)` recorded strictly AFTER
+    /// `not_before` (RFC3339, e.g. a gate's `gate_entered_at`) — GH-519 D6
+    /// verdict freshness. A re-entered gate can wait on the same
+    /// `(subject, gate_sha)` as its previous incarnation (a redispatch turn
+    /// is not guaranteed to produce a commit), so only verdicts that
+    /// postdate this gate's entry may satisfy it. See
+    /// [`verdict::latest_verdict_fresh`] for the exact semantics.
+    pub fn latest_verdict_fresh(
+        &self,
+        subject: &str,
+        sha: &str,
+        not_before: Option<&str>,
+    ) -> anyhow::Result<Option<VerdictRecord>> {
+        let verdicts = self.iter_verdicts()?;
+        Ok(verdict::latest_verdict_fresh(&verdicts, subject, sha, not_before).cloned())
     }
 
     // ── Events ──────────────────────────────────────────────────────

--- a/crates/edda-ledger/src/lib.rs
+++ b/crates/edda-ledger/src/lib.rs
@@ -9,6 +9,7 @@ pub(crate) mod sqlite_store;
 pub mod sync;
 pub mod tasks;
 pub mod tombstone;
+pub mod verdict;
 pub mod view;
 
 pub use blob_meta::{BlobClass, BlobMetaEntry, BlobMetaMap, ClassChange};
@@ -28,6 +29,7 @@ pub use lock::WorkspaceLock;
 pub use paths::{validate_branch_name, EddaPaths};
 pub use tasks::{TaskStatus, TaskView};
 pub use tombstone::{append_tombstone, list_tombstones, make_tombstone, DeleteReason, Tombstone};
+pub use verdict::{latest_verdict, parse_verdict_event, VerdictRecord};
 pub use view::DecisionView;
 
 /// Maximum number of decision snapshots returned by one query.

--- a/crates/edda-ledger/src/verdict.rs
+++ b/crates/edda-ledger/src/verdict.rs
@@ -1,0 +1,282 @@
+//! Verdict ledger object (GH-519 D1) — read-side helpers for
+//! `verdict.recorded` events.
+//!
+//! A verdict is written by `edda verdict approve|reject` (see edda-cli
+//! `cmd_verdict`) and consumed by external readers such as the conductor's
+//! AWAITING_VERDICT wait. The conductor consumes verdicts; it does not own
+//! them. Every verdict is bound to `(subject, sha)`: a verdict recorded for
+//! one SHA remains findable but never matches a query for another SHA.
+
+use edda_core::{Event, VerdictPayload};
+
+/// One parsed `verdict.recorded` event.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VerdictRecord {
+    pub event_id: String,
+    pub ts: String,
+    pub payload: VerdictPayload,
+}
+
+/// Parse a `verdict.recorded` event into a [`VerdictRecord`].
+/// Returns `None` for any other event type or a malformed payload.
+pub fn parse_verdict_event(event: &Event) -> Option<VerdictRecord> {
+    if event.event_type != "verdict.recorded" {
+        return None;
+    }
+    let payload: VerdictPayload = serde_json::from_value(event.payload.clone()).ok()?;
+    Some(VerdictRecord {
+        event_id: event.event_id.clone(),
+        ts: event.ts.clone(),
+        payload,
+    })
+}
+
+/// The latest verdict (by ledger insertion order) for `(subject, sha)`.
+///
+/// Events are expected in insertion (rowid) order, which is the ledger's
+/// reliable chronology — RFC3339 strings with mixed precision do not sort
+/// chronologically. Later verdicts for the same `(subject, sha)` supersede
+/// earlier ones.
+pub fn latest_verdict<'a>(
+    verdicts: &'a [VerdictRecord],
+    subject: &str,
+    sha: &str,
+) -> Option<&'a VerdictRecord> {
+    verdicts
+        .iter()
+        .rev()
+        .find(|v| v.payload.subject == subject && v.payload.sha == sha)
+}
+
+/// Parse an RFC3339 timestamp; `None` on failure.
+fn parse_rfc3339(s: &str) -> Option<time::OffsetDateTime> {
+    time::OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339).ok()
+}
+
+/// The latest verdict for `(subject, sha)` that was **recorded after**
+/// `not_before` (an RFC3339 timestamp, e.g. a gate's `gate_entered_at`) —
+/// GH-519 D6 verdict freshness.
+///
+/// A redispatch turn is not guaranteed to produce a commit, so a re-entered
+/// gate can wait on the *same* `(subject, gate_sha)` as the previous one;
+/// without the freshness bound the stale rejected verdict still sitting in
+/// the ledger would re-satisfy the gate forever. Comparison is done on
+/// parsed instants, not string order (mixed-precision RFC3339 does not sort
+/// chronologically).
+///
+/// An unparsable `not_before` imposes no bound (the caller always writes it
+/// via the same well-formed formatter). A verdict whose own `ts` cannot be
+/// parsed never satisfies a bounded query — it must not resurrect itself
+/// through a formatting defect.
+pub fn latest_verdict_fresh<'a>(
+    verdicts: &'a [VerdictRecord],
+    subject: &str,
+    sha: &str,
+    not_before: Option<&str>,
+) -> Option<&'a VerdictRecord> {
+    let bound = not_before.and_then(parse_rfc3339);
+    verdicts.iter().rev().find(|v| {
+        if v.payload.subject != subject || v.payload.sha != sha {
+            return false;
+        }
+        match bound {
+            None => true,
+            Some(bound) => parse_rfc3339(&v.ts).is_some_and(|ts| ts > bound),
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use edda_core::event::new_verdict_event;
+    use edda_core::{VerdictDecision, VerdictPayload};
+
+    fn verdict_payload(subject: &str, sha: &str, decision: VerdictDecision) -> VerdictPayload {
+        VerdictPayload {
+            subject: subject.to_string(),
+            decision,
+            sha: sha.to_string(),
+            comment: None,
+            actor: "tester".to_string(),
+        }
+    }
+
+    fn append(ledger: &crate::Ledger, subject: &str, sha: &str, decision: VerdictDecision) {
+        let branch = ledger.head_branch().unwrap();
+        let parent_hash = ledger.last_event_hash().unwrap();
+        let event = new_verdict_event(
+            &branch,
+            parent_hash.as_deref(),
+            &verdict_payload(subject, sha, decision),
+        )
+        .unwrap();
+        ledger.append_event(&event).unwrap();
+    }
+
+    fn temp_ledger(name: &str) -> (std::path::PathBuf, crate::Ledger) {
+        let dir = std::env::temp_dir().join(format!("edda_verdict_{name}_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let ledger = crate::Ledger::open_or_init(&dir).unwrap();
+        (dir, ledger)
+    }
+
+    #[test]
+    fn parse_ignores_other_event_types() {
+        let dir = std::env::temp_dir().join(format!("edda_verdict_parse_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let ledger = crate::Ledger::open_or_init(&dir).unwrap();
+        let event = edda_core::event::new_note_event(
+            &ledger.head_branch().unwrap(),
+            None,
+            "user",
+            "hi",
+            &[],
+        )
+        .unwrap();
+        ledger.append_event(&event).unwrap();
+        let events = ledger.iter_events().unwrap();
+        assert!(!events.is_empty());
+        assert!(parse_verdict_event(&events[0]).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn roundtrip_write_then_read_by_subject_and_sha() {
+        let (_dir, ledger) = temp_ledger("roundtrip");
+        let sha = "a".repeat(40);
+        append(&ledger, "plan-x/phase-1", &sha, VerdictDecision::Approved);
+
+        let verdicts = ledger.iter_verdicts().unwrap();
+        assert_eq!(verdicts.len(), 1);
+        assert_eq!(verdicts[0].payload.subject, "plan-x/phase-1");
+        assert_eq!(verdicts[0].payload.sha, sha);
+        assert_eq!(verdicts[0].payload.decision, VerdictDecision::Approved);
+
+        let latest = ledger.latest_verdict("plan-x/phase-1", &sha).unwrap();
+        assert!(latest.is_some());
+        assert_eq!(latest.unwrap().payload.decision, VerdictDecision::Approved);
+    }
+
+    #[test]
+    fn sha_mismatch_never_matches() {
+        let (_dir, ledger) = temp_ledger("shamismatch");
+        let sha_a = "a".repeat(40);
+        let sha_b = "b".repeat(40);
+        append(&ledger, "plan-x/phase-1", &sha_a, VerdictDecision::Approved);
+
+        // Findable as a general listing, but never satisfies another SHA.
+        assert_eq!(ledger.iter_verdicts().unwrap().len(), 1);
+        assert!(ledger
+            .latest_verdict("plan-x/phase-1", &sha_b)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn latest_insertion_order_wins_not_timestamp_string() {
+        let (_dir, ledger) = temp_ledger("latestwins");
+        let sha = "c".repeat(40);
+        append(&ledger, "plan-x/phase-1", &sha, VerdictDecision::Rejected);
+        append(&ledger, "plan-x/phase-1", &sha, VerdictDecision::Approved);
+
+        let latest = ledger
+            .latest_verdict("plan-x/phase-1", &sha)
+            .unwrap()
+            .expect("a verdict exists");
+        assert_eq!(latest.payload.decision, VerdictDecision::Approved);
+    }
+
+    #[test]
+    fn different_subject_does_not_match() {
+        let (_dir, ledger) = temp_ledger("subject");
+        let sha = "d".repeat(40);
+        append(&ledger, "plan-x/phase-1", &sha, VerdictDecision::Approved);
+        assert!(ledger
+            .latest_verdict("plan-x/phase-2", &sha)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn stale_verdict_does_not_satisfy_fresh_query() {
+        // D6: a verdict recorded BEFORE the bound must not satisfy a query
+        // for the same (subject, sha) — the re-entered-gate scenario.
+        let (_dir, ledger) = temp_ledger("stale");
+        let sha = "e".repeat(40);
+        append(&ledger, "plan-x/phase-1", &sha, VerdictDecision::Rejected);
+
+        let verdicts = ledger.iter_verdicts().unwrap();
+        let after = time::OffsetDateTime::now_utc()
+            .checked_add(time::Duration::minutes(1))
+            .unwrap();
+        let not_before = after
+            .format(&time::format_description::well_known::Rfc3339)
+            .unwrap();
+        assert!(
+            latest_verdict_fresh(&verdicts, "plan-x/phase-1", &sha, Some(&not_before)).is_none()
+        );
+        // Unbounded query still finds it (findable ≠ satisfying).
+        assert!(latest_verdict(&verdicts, "plan-x/phase-1", &sha).is_some());
+    }
+
+    #[test]
+    fn fresh_verdict_satisfies_fresh_query() {
+        let (_dir, ledger) = temp_ledger("fresh");
+        let sha = "f".repeat(40);
+        append(&ledger, "plan-x/phase-1", &sha, VerdictDecision::Approved);
+
+        let verdicts = ledger.iter_verdicts().unwrap();
+        let before = time::OffsetDateTime::now_utc()
+            .checked_sub(time::Duration::minutes(1))
+            .unwrap();
+        let not_before = before
+            .format(&time::format_description::well_known::Rfc3339)
+            .unwrap();
+        let fresh = latest_verdict_fresh(&verdicts, "plan-x/phase-1", &sha, Some(&not_before))
+            .expect("verdict recorded after the bound must satisfy");
+        assert_eq!(fresh.payload.decision, VerdictDecision::Approved);
+    }
+
+    #[test]
+    fn fresh_query_compares_instants_not_strings() {
+        // "…9Z" (0 fractional digits) sorts after "…0.1Z" as a string but is
+        // an EARLIER instant; the fresh query must use parsed instants.
+        let sha = "1".repeat(40);
+        let mk = |ts: &str| VerdictRecord {
+            event_id: "ev".into(),
+            ts: ts.into(),
+            payload: VerdictPayload {
+                subject: "s".into(),
+                decision: VerdictDecision::Rejected,
+                sha: sha.clone(),
+                comment: None,
+                actor: "tester".into(),
+            },
+        };
+        // 12:00:00.100Z (verdict) vs bound 12:00:00Z → later instant.
+        let verdicts = vec![mk("2026-01-01T12:00:00.1Z")];
+        assert!(latest_verdict_fresh(&verdicts, "s", &sha, Some("2026-01-01T12:00:00Z")).is_some());
+        // Bound 12:00:01Z (string-smaller) is a LATER instant → stale.
+        assert!(latest_verdict_fresh(&verdicts, "s", &sha, Some("2026-01-01T12:00:01Z")).is_none());
+    }
+
+    #[test]
+    fn fresh_query_unparsable_not_before_imposes_no_bound() {
+        let sha = "2".repeat(40);
+        let verdicts = vec![VerdictRecord {
+            event_id: "ev".into(),
+            ts: "2026-01-01T12:00:00Z".into(),
+            payload: VerdictPayload {
+                subject: "s".into(),
+                decision: VerdictDecision::Approved,
+                sha: sha.clone(),
+                comment: None,
+                actor: "tester".into(),
+            },
+        }];
+        assert!(latest_verdict_fresh(&verdicts, "s", &sha, Some("not-a-timestamp")).is_some());
+    }
+}


### PR DESCRIPTION
Closes #519

## What this adds

A conductor phase can declare `gate: verdict`. After its checks pass the phase enters **AWAITING_VERDICT** instead of Passed: the runner persists that state, emits a gate event (+ notifier), prints the exact approve/reject commands, and waits. An external actor — any platform, any session — issues the verdict through a new CLI, and the plan resumes.

This is the missing piece for unattended orchestrator → executor → verifier → orchestrator loops: the loop that produced this PR (and the four before it) was driven by hand.

## Design

Per the architecture recorded as `orchestration.cross-platform=ledger-data-plane-adapter-control-plane`, **verdicts are ledger objects, not conductor-internal state** — the conductor *consumes* them:

    edda verdict approve <subject> --sha <full-40-hex> [--comment "..."]
    edda verdict reject  <subject> --sha <full-40-hex> --comment "..."   # comment required

- `<subject>` is free-form; conductor gates use `<plan>/<phase>`. Fields: subject, decision, full SHA, comment, actor, timestamp. A verdict bound to a different SHA stays findable but never satisfies a gate waiting on another — push-voids-verdict falls out structurally.
- Schema: `gate: verdict`, `gate_timeout_sec`, `on_reject: redispatch|halt`; unknown gate values fail parse loudly.
- Runner: capture `gate_sha` (phase cwd HEAD) → persist AWAITING_VERDICT with `gate_entered_at` → poll the ledger → approve resumes; **reject redispatches ONE turn in the SAME session id** (rejection comment becomes the prompt) without incrementing `attempt`; `halt` fails with the comment as the error. Restart re-enters the wait without re-running the agent turn or checks; the timeout deadline is computed from the persisted `gate_entered_at`, so it survives restarts. A phase without `gate:` is unchanged.
- `edda-conductor` now depends on `edda-core` + `edda-ledger` — a new dependency edge, required to consume verdicts.

## D6 — a design defect found and corrected mid-delivery (please review this closely)

The controller's original frozen design said a redispatch re-enters the gate "with a fresh `gate_sha`". **That assumption is false**: `gate_sha` is the phase cwd's git HEAD, and a redispatch turn is not guaranteed to commit anything. With HEAD unchanged the re-entered gate has *exactly the same* `(subject, gate_sha)`, so the wait immediately re-read the **same rejected verdict still in the ledger** and redispatched again — forever. Because the design also forbids incrementing `attempt` on redispatch, `max_attempts` never tripped.

Measured before the fix: `gate_reject_redispatches_same_session_then_regates` produced **176** `gate_entered`/`verdict_received` events with exactly **one distinct `gate_sha`**; the loop stopped only because the test injected an approval. Unattended, that burns agent turns and money until a human intervenes.

Correction (recorded as `gate.verdict-freshness=verdict-must-postdate-gate-entered-at` and `gate.redispatch-counter=persisted-gate_redispatches-u32-max-3`):
1. A verdict satisfies a gate only if recorded **after that gate's `gate_entered_at`** — already persisted, so the rule survives restarts.
2. Redispatch cycles are bounded by a **separate persisted counter** (`gate_redispatches`), not `attempt`; exhausting it fails the phase like `halt`.
3. Regression test `stale_reject_does_not_resatisfy_regated_same_sha` reproduces the exact 176-loop scenario and asserts exactly one redispatch, then a distinct gate timeout.

**Attribution:** the defect was in the controller's frozen design, not the implementer's work — the implementation faithfully followed the spec it was given. It was caught by the controller running the suite, not by review.

## Provenance

Implemented by pi (glm-5.3-flash) via `edda conduct run --agent pi` in an isolated worktree. The first dispatch was killed mid-p3 by an external session teardown (Windows `STATUS_CONTROL_C_EXIT`) with all work uncommitted but intact; a resume dispatch implemented D6 and sealed. Two phases in this delivery lost an attempt to environmental `LNK1104` linker file locks (third occurrence on this workstation) and passed on retry — no product failure involved.

## Gates (frozen SHA `752ce4d58d7bc1c40409163f24f0a206dcdb0c2d`, receipt SHA shell-derived)

| Gate | Result |
|---|---|
| `cargo test -p edda-conductor` | 231 passed |
| `cargo test -p edda` | 373 passed |
| `cargo test -p edda-ledger` | 225 passed |
| `cargo clippy -p edda-conductor -p edda -p edda-ledger -p edda-core --all-targets -- -D warnings` | clean |
| `cargo fmt --all --check` | pass |

Lane worker-1. Independent verifier round (read-only, verdict pinned to the SHA above) follows as a PR comment before merge.

Follow-ups deliberately **not** in this PR: `edda phase approve/reject` sugar, parallel-runner gate support, notify channel config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
