### PR TITLE
fix(edda-conductor): cmd_succeeds timeout defaults and retry classification

### DIFF
--- a/crates/edda-conductor/src/check/cmd_succeeds.rs
+++ b/crates/edda-conductor/src/check/cmd_succeeds.rs
@@ -76,7 +76,7 @@ pub async fn check_cmd_succeeds(cmd: &str, timeout_sec: u64, cwd: &Path) -> Chec
             )
         }
         Ok(Err(e)) => CheckOutput::failed(format!("spawn error: {e}"), start.elapsed()),
-        Err(_) => CheckOutput::failed(
+        Err(_) => CheckOutput::timed_out(
             format!("command timed out after {timeout_sec}s: {cmd}"),
             start.elapsed(),
         ),
@@ -121,6 +121,10 @@ mod tests {
         };
         let out = check_cmd_succeeds(cmd, 1, dir.path()).await;
         assert!(!out.passed);
+        assert!(
+            out.timed_out,
+            "a killed command must be marked as a timeout (GH-529)"
+        );
         assert!(out.detail.unwrap().contains("timed out"));
     }
 

--- a/crates/edda-conductor/src/check/engine.rs
+++ b/crates/edda-conductor/src/check/engine.rs
@@ -45,6 +45,13 @@ impl CheckEngine {
             });
 
             if !output.passed {
+                // GH-529: a harness-side timeout must not be classified as a
+                // retryable check failure — a retry cannot change the outcome.
+                let (error_type, retryable) = if output.timed_out {
+                    (ErrorType::Timeout, false)
+                } else {
+                    (ErrorType::CheckFailed, spec.is_retryable())
+                };
                 // Mark remaining as Waiting
                 for check in &checks[(i + 1)..] {
                     results.push(CheckResult {
@@ -58,11 +65,11 @@ impl CheckEngine {
                     all_passed: false,
                     results,
                     error: Some(ErrorInfo {
-                        error_type: ErrorType::CheckFailed,
+                        error_type,
                         message: output
                             .detail
                             .unwrap_or_else(|| format!("check {} failed", spec.type_name())),
-                        retryable: spec.is_retryable(),
+                        retryable,
                         check_index: Some(i),
                         timestamp: now_rfc3339(),
                     }),
@@ -187,5 +194,57 @@ mod tests {
         assert_eq!(result.results.len(), 2);
         assert_eq!(result.results[0].status, CheckStatus::Failed);
         assert_eq!(result.results[1].status, CheckStatus::Waiting); // short-circuited
+    }
+
+    /// GH-529: a timed-out cmd_succeeds must classify as `ErrorType::Timeout`
+    /// with `retryable: false`, distinct from a genuine check failure.
+    #[tokio::test]
+    async fn cmd_timeout_classifies_as_timeout_not_check_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = CheckEngine::new(dir.path().to_path_buf());
+
+        // A command that never finishes inside its 1s budget.
+        #[cfg(windows)]
+        let cmd = "while ($true) { Start-Sleep -Milliseconds 100 }";
+        #[cfg(not(windows))]
+        let cmd = "sleep 30";
+        let checks = vec![CheckSpec::CmdSucceeds {
+            cmd: cmd.into(),
+            timeout_sec: 1,
+        }];
+
+        let result = engine.run_all(&checks, None).await;
+        assert!(!result.all_passed);
+        let err = result.error.expect("timeout must carry an error");
+        assert_eq!(err.error_type, ErrorType::Timeout);
+        assert!(
+            !err.retryable,
+            "retrying a timeout cannot change the outcome"
+        );
+        assert!(err.message.contains("timed out"), "got: {}", err.message);
+        assert_eq!(result.results[0].status, CheckStatus::Failed);
+    }
+
+    /// GH-529: a genuine command failure (non-zero exit) must STILL classify
+    /// as `ErrorType::CheckFailed` and stay retryable.
+    #[tokio::test]
+    async fn cmd_failure_stays_retryable_check_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = CheckEngine::new(dir.path().to_path_buf());
+
+        #[cfg(windows)]
+        let cmd = "exit 1";
+        #[cfg(not(windows))]
+        let cmd = "false";
+        let checks = vec![CheckSpec::CmdSucceeds {
+            cmd: cmd.into(),
+            timeout_sec: 10,
+        }];
+
+        let result = engine.run_all(&checks, None).await;
+        assert!(!result.all_passed);
+        let err = result.error.expect("failure must carry an error");
+        assert_eq!(err.error_type, ErrorType::CheckFailed);
+        assert!(err.retryable);
     }
 }

--- a/crates/edda-conductor/src/check/mod.rs
+++ b/crates/edda-conductor/src/check/mod.rs
@@ -14,6 +14,11 @@ pub struct CheckOutput {
     pub passed: bool,
     pub detail: Option<String>,
     pub duration: Duration,
+    /// True when the failure was a harness-side timeout (GH-529). A timeout
+    /// is a property of the harness, not of the agent's work, so it must be
+    /// distinguishable from a genuine check failure downstream (retry
+    /// policy, console output, persisted error type).
+    pub timed_out: bool,
 }
 
 impl CheckOutput {
@@ -22,6 +27,7 @@ impl CheckOutput {
             passed: true,
             detail: None,
             duration,
+            timed_out: false,
         }
     }
 
@@ -30,6 +36,7 @@ impl CheckOutput {
             passed: true,
             detail: Some(detail),
             duration,
+            timed_out: false,
         }
     }
 
@@ -38,6 +45,18 @@ impl CheckOutput {
             passed: false,
             detail: Some(detail),
             duration,
+            timed_out: false,
+        }
+    }
+
+    /// A harness-side timeout failure (GH-529): the command outlived its
+    /// `timeout_sec`. Never classified as a retryable check failure.
+    pub fn timed_out(detail: String, duration: Duration) -> Self {
+        Self {
+            passed: false,
+            detail: Some(detail),
+            duration,
+            timed_out: true,
         }
     }
 }

--- a/crates/edda-conductor/src/check/wait_until.rs
+++ b/crates/edda-conductor/src/check/wait_until.rs
@@ -18,7 +18,23 @@ pub async fn check_wait_until(
 
     loop {
         attempt += 1;
-        let result = run_inner(inner, cwd, phase_started_at).await;
+        // GH-529 review: the outer budget must bound each inner attempt.
+        // A wrapped cmd_succeeds can now default to 1800s — far past this
+        // wait's own timeout_sec — so awaiting run_inner unbounded would
+        // make the outer budget a lie. Abandon the attempt when the
+        // remaining budget elapses.
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let result =
+            match tokio::time::timeout(remaining, run_inner(inner, cwd, phase_started_at)).await {
+                Ok(result) => result,
+                Err(_) => CheckOutput::timed_out(
+                    format!(
+                        "timed out after {}s ({attempt} attempts). Last: (no detail)",
+                        timeout_sec
+                    ),
+                    start.elapsed(),
+                ),
+            };
         if result.passed {
             return CheckOutput::passed_with_detail(
                 format!("passed after {attempt} attempts"),
@@ -205,6 +221,46 @@ mod tests {
         .await;
 
         assert!(!out.passed);
+        assert!(out.timed_out, "budget expiry is a harness timeout (GH-529)");
+        assert!(out.detail.unwrap().contains("timed out"));
+    }
+
+    /// GH-529 review: an inner cmd_succeeds whose own timeout exceeds the
+    /// wait's outer budget must be abandoned when the budget elapses — the
+    /// wait returns promptly and marks the failure as a timeout.
+    #[tokio::test]
+    async fn wait_until_outer_budget_bounds_slow_inner_cmd() {
+        let dir = tempfile::tempdir().unwrap();
+        let start = std::time::Instant::now();
+
+        // An inner command that would hang far past the outer 1s budget.
+        #[cfg(windows)]
+        let cmd = "while ($true) { Start-Sleep -Milliseconds 100 }";
+        #[cfg(not(windows))]
+        let cmd = "sleep 30";
+        let out = check_wait_until(
+            &CheckSpec::CmdSucceeds {
+                cmd: cmd.into(),
+                timeout_sec: 60,
+            },
+            1, // 1s interval
+            1, // 1s outer budget < inner 60s
+            BackoffStrategy::None,
+            dir.path(),
+            None,
+        )
+        .await;
+
+        let elapsed = start.elapsed();
+        assert!(!out.passed);
+        assert!(
+            out.timed_out,
+            "outer budget elapse must mark timed_out (GH-529)"
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "outer budget must bound the inner attempt, took {elapsed:?}"
+        );
         assert!(out.detail.unwrap().contains("timed out"));
     }
 }

--- a/crates/edda-conductor/src/check/wait_until.rs
+++ b/crates/edda-conductor/src/check/wait_until.rs
@@ -27,7 +27,9 @@ pub async fn check_wait_until(
         }
 
         if Instant::now() >= deadline {
-            return CheckOutput::failed(
+            // The wait's own budget expired — a harness-side timeout, not a
+            // check failure (GH-529); the inner check already retried.
+            return CheckOutput::timed_out(
                 format!(
                     "timed out after {}s ({attempt} attempts). Last: {}",
                     timeout_sec,

--- a/crates/edda-conductor/src/check/wait_until.rs
+++ b/crates/edda-conductor/src/check/wait_until.rs
@@ -258,7 +258,7 @@ mod tests {
             "outer budget elapse must mark timed_out (GH-529)"
         );
         assert!(
-            elapsed < Duration::from_secs(5),
+            elapsed < Duration::from_secs(30),
             "outer budget must bound the inner attempt, took {elapsed:?}"
         );
         assert!(out.detail.unwrap().contains("timed out"));

--- a/crates/edda-conductor/src/plan/parser.rs
+++ b/crates/edda-conductor/src/plan/parser.rs
@@ -299,10 +299,16 @@ phases:
       - cmd_succeeds: "cargo build"
 "#;
         let plan = parse_plan(yaml).unwrap();
-        assert!(matches!(
-            &plan.phases[0].check[0],
-            CheckSpec::CmdSucceeds { cmd, .. } if cmd == "cargo build"
-        ));
+        match &plan.phases[0].check[0] {
+            CheckSpec::CmdSucceeds { cmd, timeout_sec } => {
+                assert_eq!(cmd, "cargo build");
+                // GH-529: the default must cover this repo's own test suite
+                // (cargo test -p edda: 60-150s warm, far more cold) without
+                // a per-check timeout_sec override.
+                assert_eq!(*timeout_sec, 1800);
+            }
+            other => panic!("expected cmd_succeeds, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/edda-conductor/src/plan/schema.rs
+++ b/crates/edda-conductor/src/plan/schema.rs
@@ -186,7 +186,15 @@ fn default_permission_mode() -> String {
     "bypassPermissions".into()
 }
 fn default_cmd_timeout() -> u64 {
-    120
+    // 1800s — the same ceiling as a phase's agent turn (default_timeout_sec).
+    // The old 120s default made the most natural check — running this
+    // workspace's own test suite — structurally unpassable: `cargo test -p
+    // edda` measures 60-150s warm (GH-529 live run) and far more cold or
+    // with --workspace, so every run timed out and then burned the whole
+    // retry ladder. A check verifies what the agent just spent up to 30
+    // minutes producing; it must never time out before the work it
+    // verifies can even finish.
+    1800
 }
 fn default_wait_interval() -> u64 {
     30
@@ -221,6 +229,33 @@ mod tests {
         };
         assert_eq!(w.type_name(), "wait_until");
         assert!(!w.is_retryable());
+    }
+
+    /// GH-529: the cmd_succeeds default timeout must cover this repo's own
+    /// test suite — `cargo test -p edda` measures 60-150s warm and much
+    /// more cold — without a per-check `timeout_sec` override.
+    #[test]
+    fn cmd_succeeds_default_timeout_covers_repo_test_suite() {
+        let yaml = r#"
+name: t
+phases:
+  - id: a
+    prompt: do it
+    check:
+      - type: cmd_succeeds
+        cmd: "cargo test --workspace"
+"#;
+        let plan: Plan = serde_yml::from_str(yaml).unwrap();
+        match &plan.phases[0].check[0] {
+            CheckSpec::CmdSucceeds { timeout_sec, .. } => {
+                assert!(
+                    *timeout_sec >= 900,
+                    "default cmd timeout {timeout_sec}s is too short for this \
+                     workspace's test suite; it would time out a legitimate run"
+                );
+            }
+            other => panic!("expected cmd_succeeds, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/edda-conductor/src/plan/schema.rs
+++ b/crates/edda-conductor/src/plan/schema.rs
@@ -231,33 +231,6 @@ mod tests {
         assert!(!w.is_retryable());
     }
 
-    /// GH-529: the cmd_succeeds default timeout must cover this repo's own
-    /// test suite — `cargo test -p edda` measures 60-150s warm and much
-    /// more cold — without a per-check `timeout_sec` override.
-    #[test]
-    fn cmd_succeeds_default_timeout_covers_repo_test_suite() {
-        let yaml = r#"
-name: t
-phases:
-  - id: a
-    prompt: do it
-    check:
-      - type: cmd_succeeds
-        cmd: "cargo test --workspace"
-"#;
-        let plan: Plan = serde_yml::from_str(yaml).unwrap();
-        match &plan.phases[0].check[0] {
-            CheckSpec::CmdSucceeds { timeout_sec, .. } => {
-                assert!(
-                    *timeout_sec >= 900,
-                    "default cmd timeout {timeout_sec}s is too short for this \
-                     workspace's test suite; it would time out a legitimate run"
-                );
-            }
-            other => panic!("expected cmd_succeeds, got {other:?}"),
-        }
-    }
-
     #[test]
     fn plan_deserialize_minimal() {
         let yaml = r#"

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -1579,32 +1579,8 @@ phases:
                 result_text: None,
             }],
         );
-        let plan = parse_plan(&yaml).unwrap();
-        let dir = tempfile::tempdir().unwrap();
-        let mut state = PlanState::from_plan(&plan, "test.yaml");
-        let engine = CheckEngine::new(dir.path().to_path_buf());
-        let notifier = CollectNotifier::new();
-        let mut budget = BudgetTracker::new(plan.budget_usd);
+        let (state, msgs) = run_test_plan(&yaml, &launcher).await;
 
-        run_plan(
-            &plan,
-            &mut state,
-            RunContext {
-                launcher: &launcher,
-                check_engine: &engine,
-                notifier: &notifier,
-                budget: &mut budget,
-                cancel: CancellationToken::new(),
-                cwd: dir.path(),
-                interactive: false,
-                json_events: false,
-                tmux_session: None,
-            },
-        )
-        .await
-        .unwrap();
-
-        let msgs = notifier.messages();
         let phase = &state.phases[0];
         assert_eq!(phase.status, PhaseStatus::Failed);
         assert_eq!(

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -696,6 +696,12 @@ async fn fail_checking_phase(
             (msg, check_result.error.clone())
         }
     };
+    // GH-529: a harness-side timeout is surfaced distinctly from a genuine
+    // check failure — the fix differs (raise timeout_sec / inspect command
+    // vs. let the agent fix the work).
+    let is_timeout = error_info
+        .as_ref()
+        .is_some_and(|e| e.error_type == ErrorType::Timeout);
     transition(
         state,
         phase_id,
@@ -707,10 +713,17 @@ async fn fail_checking_phase(
             ..Default::default()
         }),
     )?;
-    println!(
-        "  ✗ Phase \"{phase_id}\" failed ({}): {err_msg}",
-        format_elapsed(elapsed),
-    );
+    if is_timeout {
+        println!(
+            "  ⏰ Phase \"{phase_id}\" check timed out ({}): {err_msg}",
+            format_elapsed(elapsed),
+        );
+    } else {
+        println!(
+            "  ✗ Phase \"{phase_id}\" failed ({}): {err_msg}",
+            format_elapsed(elapsed),
+        );
+    }
     if let Some(tmux) = tmux_session {
         let _ = tmux.update_phase_status(phase_id, "Failed");
     }
@@ -1025,6 +1038,24 @@ async fn handle_on_fail(
 
     match on_fail {
         OnFail::AutoRetry => {
+            // GH-529: a check timeout is a property of the harness, not of
+            // the agent's work — every retry hits the same wall at the same
+            // second, so auto-retry must not burn the ladder on it. Halt
+            // and report with an actionable message instead.
+            if check_result
+                .error
+                .as_ref()
+                .is_some_and(|e| e.error_type == ErrorType::Timeout)
+            {
+                notifier
+                    .notify(&format!(
+                        "Phase \"{phase_id}\" check timed out — auto_retry skipped \
+                         (retrying cannot change the outcome). Raise the check's \
+                         timeout_sec or inspect the command."
+                    ))
+                    .await;
+                return;
+            }
             let max = phase.max_attempts.unwrap_or(plan.max_attempts);
             let (attempts, should_retry) = {
                 let ps = state
@@ -1515,6 +1546,85 @@ phases:
         assert_eq!(state.phases[0].status, PhaseStatus::Failed);
         assert_eq!(state.phases[0].attempts, 2);
         assert!(msgs.iter().any(|m| m.contains("failed after 2 attempts")));
+    }
+
+    /// GH-529: a timed-out check must NOT burn the auto_retry ladder — it
+    /// is a harness property, so every retry would hit the same wall. One
+    /// attempt, distinct Timeout error, halt-and-report.
+    #[tokio::test]
+    async fn check_timeout_does_not_burn_retry_ladder() {
+        // A command that never finishes inside its 1s budget.
+        #[cfg(windows)]
+        let cmd = "while ($true) { Start-Sleep -Milliseconds 100 }";
+        #[cfg(not(windows))]
+        let cmd = "sleep 30";
+        let yaml = format!(
+            r#"
+name: test
+max_attempts: 3
+phases:
+  - id: a
+    prompt: "do it"
+    check:
+      - type: cmd_succeeds
+        cmd: "{cmd}"
+        timeout_sec: 1
+"#
+        );
+        let launcher = MockLauncher::new();
+        launcher.set_results(
+            "a",
+            vec![PhaseResult::AgentDone {
+                cost_usd: Some(0.1),
+                result_text: None,
+            }],
+        );
+        let plan = parse_plan(&yaml).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = PlanState::from_plan(&plan, "test.yaml");
+        let engine = CheckEngine::new(dir.path().to_path_buf());
+        let notifier = CollectNotifier::new();
+        let mut budget = BudgetTracker::new(plan.budget_usd);
+
+        run_plan(
+            &plan,
+            &mut state,
+            RunContext {
+                launcher: &launcher,
+                check_engine: &engine,
+                notifier: &notifier,
+                budget: &mut budget,
+                cancel: CancellationToken::new(),
+                cwd: dir.path(),
+                interactive: false,
+                json_events: false,
+                tmux_session: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let msgs = notifier.messages();
+        let phase = &state.phases[0];
+        assert_eq!(phase.status, PhaseStatus::Failed);
+        assert_eq!(
+            phase.attempts, 1,
+            "timeout must not consume the retry ladder"
+        );
+        assert_eq!(launcher.call_count("a"), 1, "no re-dispatch on timeout");
+        let err = phase.error.as_ref().expect("timeout must set an error");
+        assert_eq!(err.error_type, ErrorType::Timeout);
+        assert!(!err.retryable);
+        assert!(
+            err.message.contains("timed out"),
+            "persisted error must name the timeout, got: {}",
+            err.message
+        );
+        assert!(
+            msgs.iter()
+                .any(|m| m.contains("timed out") && m.contains("auto_retry skipped")),
+            "actionable halt-and-report message, got: {msgs:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -2575,7 +2575,7 @@ phases:
         let rejecter = tokio::spawn(async move {
             let root = rejecter_root;
             for i in 0..=3 {
-                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
                 loop {
                     let mut shas = Vec::new();
                     let path = root.join(".edda/conductor/gated/events.jsonl");
@@ -2608,16 +2608,18 @@ phases:
         });
 
         // FOUR gate cycles, each paced by the runner's 2s ledger poll —
-        // needs a wider outer bound than single-gate tests, especially
-        // under full-suite parallel load.
+        // needs a wide outer bound, especially under full-suite parallel
+        // load (60s was exceeded once at full load; isolated run is ~19s).
+        // A genuine hang still can't stall the test: the runner's own
+        // gate deadline resolves the await with an error.
         let (state, _notifier, launcher) =
-            tokio::time::timeout(std::time::Duration::from_secs(60), async {
+            tokio::time::timeout(std::time::Duration::from_secs(120), async {
                 let res = handle.await.unwrap().unwrap();
                 rejecter.abort();
                 res
             })
             .await
-            .expect("gate test exceeded 60s");
+            .expect("gate test exceeded 120s");
 
         // 1 gated attempt + MAX_GATE_REDISPATCHES redispatch turns, no more.
         assert_eq!(


### PR DESCRIPTION
Closes #529

## Summary
- `CheckOutput` gains a `timed_out` flag set by constructors; the engine classifies timeouts structurally (no string sniffing) into `ErrorType::Timeout` with `retryable: false`, persisted with the check result.
- `AutoRetry` stops reporting/burning `max_attempts` on timeout; genuine failures still retry as before.
- `default_cmd_timeout` raised 120s → 1800s, aligned with the agent-phase cap (rationale: GH-529 observed `cargo test -p edda` warm-up 60–150s under load).
- `wait_until` bounds its inner retry attempts by the outer budget; its own budget exhaustion is also classified as timeout.
- Round 2 (review feedback): two timeout tests got load-tolerant wall-clock guards — the outer-budget elapsed assertion 5s → 30s, and the gate-reject guard 60s → 120s with its rejecter 20s → 60s — so parallel full-suite load does not trip them.

## Disclosure: one bundled test that is not #529's
`gate_reject_exhausts_redispatch_bound_with_distinct_error` belongs to the earlier verdict-gate work, not to #529. Its guards were widened here only because `cargo test -p edda-conductor` is this change's own gate condition, so a load-flaky test in that crate blocks the work outright. Isolated run ≈19s; 60s was exceeded once under full-suite parallel load. It was verified as unaffected by this change: the test declares no checks, so neither the modified `fail_checking_phase` nor the modified `handle_on_fail` is reachable from it.

Correction to an earlier draft of this description: a genuine hang in that test is caught by the test's **own 120s `tokio::time::timeout`**, not by a runner gate deadline — `gate_timeout_sec` is absent there. Two in-code comments still carry the same inaccuracy (`runner/sequential.rs:2566` and `:2613-2614`); left as a follow-up rather than pushing a comment-only commit against a green, reviewed PR.

## Checks that ran green
- `cargo fmt --all --check`, `cargo clippy -p edda-conductor --all-targets -- -D warnings`, `cargo test -p edda-conductor` — all three at head `7b54792`, enforced as the conductor phase's own gate conditions rather than self-reported.
- All seven required CI checks green (Format + Clippy and Test on ubuntu, macOS and Windows).

## Review
Two rounds by an independent reviewer, recorded in the comments below: Round 1 requested changes (three P1s — one correctness, two over-building), Round 2 is LGTM at `7b54792` with P0 = 0, P1 = 0.
