### PR TITLE
fix(edda-conductor): topo tie-break by declaration order

### DIFF
--- a/crates/edda-conductor/src/plan/topo.rs
+++ b/crates/edda-conductor/src/plan/topo.rs
@@ -29,8 +29,11 @@ pub fn topo_sort(plan: &Plan) -> Result<Vec<String>> {
         }
     }
 
-    // Kahn's algorithm; the queue is kept in declaration order so that
-    // equal-rank phases execute in the order they were declared (GH-532).
+    // Kahn's algorithm, one rank at a time: every phase currently in the
+    // queue is popped before any newly freed phase is enqueued, and the
+    // whole batch of newly freed phases is sorted by declaration position
+    // together. Ties are broken by declaration order in the plan file, not
+    // alphabetically (GH-532).
     let mut queue: VecDeque<&str> = plan
         .phases
         .iter()
@@ -40,23 +43,27 @@ pub fn topo_sort(plan: &Plan) -> Result<Vec<String>> {
 
     let mut order = Vec::with_capacity(plan.phases.len());
 
-    while let Some(id) = queue.pop_front() {
-        order.push(id.to_string());
-        if let Some(deps) = dependents.get(id) {
-            let mut next = Vec::new();
-            for &dep in deps {
-                let deg = in_degree
-                    .get_mut(dep)
-                    .context("dependent phase not found in in-degree map")?;
-                *deg -= 1;
-                if *deg == 0 {
-                    next.push(dep);
+    while !queue.is_empty() {
+        let rank: Vec<&str> = queue.drain(..).collect();
+        let mut next = Vec::new();
+        for id in &rank {
+            order.push(id.to_string());
+            if let Some(deps) = dependents.get(id) {
+                for &dep in deps {
+                    let deg = in_degree
+                        .get_mut(dep)
+                        .context("dependent phase not found in in-degree map")?;
+                    *deg -= 1;
+                    if *deg == 0 {
+                        next.push(dep);
+                    }
                 }
             }
-            // Re-sort by declaration position for deterministic output
-            next.sort_by_key(|id| position.get(id).copied().unwrap_or(usize::MAX));
-            queue.extend(next);
         }
+        // Sort the combined batch so children freed by different parents of
+        // the same rank also follow declaration order.
+        next.sort_by_key(|id| position.get(id).copied().unwrap_or(usize::MAX));
+        queue.extend(next);
     }
 
     if order.len() != plan.phases.len() {
@@ -184,6 +191,33 @@ phases:
         let plan = parse_plan(yaml).unwrap();
         let order = topo_sort(&plan).unwrap();
         assert_eq!(order, vec!["root", "zeta", "alpha"]);
+    }
+
+    #[test]
+    fn declaration_order_tie_break_across_parents() {
+        // GH-532 follow-up: children freed by DIFFERENT parents of the same
+        // rank must also follow declaration order. Here sb-child (declared
+        // 3rd, depends on root-b) and sa-child (declared 4th, depends on
+        // root-a) become ready at the same rank; declaration order is
+        // sb-child before sa-child. Alphabetical order is the opposite, so
+        // the test cannot pass by accident.
+        let yaml = r#"
+name: test
+phases:
+  - id: root-a
+    prompt: "x"
+  - id: root-b
+    prompt: "x"
+  - id: sb-child
+    prompt: "x"
+    depends_on: [root-b]
+  - id: sa-child
+    prompt: "x"
+    depends_on: [root-a]
+"#;
+        let plan = parse_plan(yaml).unwrap();
+        let order = topo_sort(&plan).unwrap();
+        assert_eq!(order, vec!["root-a", "root-b", "sb-child", "sa-child"]);
     }
 
     #[test]

--- a/crates/edda-conductor/src/plan/topo.rs
+++ b/crates/edda-conductor/src/plan/topo.rs
@@ -4,14 +4,21 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 /// Topological sort of phases by dependency order (Kahn's algorithm).
 /// Returns phase IDs in execution order.
+///
+/// Ties (phases whose dependencies are all satisfied at the same time) are
+/// broken by declaration order in the plan file, not alphabetically — the
+/// YAML sequence is what the author reads top-to-bottom (GH-532).
 pub fn topo_sort(plan: &Plan) -> Result<Vec<String>> {
     let mut in_degree: HashMap<&str, usize> = HashMap::new();
     let mut dependents: HashMap<&str, Vec<&str>> = HashMap::new();
+    // Declaration position of each phase id — the deterministic tie-break.
+    let mut position: HashMap<&str, usize> = HashMap::new();
 
     // Initialize
-    for phase in &plan.phases {
+    for (idx, phase) in plan.phases.iter().enumerate() {
         in_degree.entry(&phase.id).or_insert(0);
         dependents.entry(&phase.id).or_default();
+        position.entry(&phase.id).or_insert(idx);
     }
 
     // Build graph
@@ -22,17 +29,14 @@ pub fn topo_sort(plan: &Plan) -> Result<Vec<String>> {
         }
     }
 
-    // Kahn's algorithm
-    let mut queue: VecDeque<&str> = in_degree
+    // Kahn's algorithm; the queue is kept in declaration order so that
+    // equal-rank phases execute in the order they were declared (GH-532).
+    let mut queue: VecDeque<&str> = plan
+        .phases
         .iter()
-        .filter(|(_, &deg)| deg == 0)
-        .map(|(&id, _)| id)
+        .filter(|p| in_degree.get(p.id.as_str()) == Some(&0))
+        .map(|p| p.id.as_str())
         .collect();
-
-    // Sort the initial queue for deterministic output
-    let mut sorted_queue: Vec<&str> = queue.drain(..).collect();
-    sorted_queue.sort();
-    queue.extend(sorted_queue);
 
     let mut order = Vec::with_capacity(plan.phases.len());
 
@@ -49,8 +53,8 @@ pub fn topo_sort(plan: &Plan) -> Result<Vec<String>> {
                     next.push(dep);
                 }
             }
-            // Sort for deterministic output
-            next.sort();
+            // Re-sort by declaration position for deterministic output
+            next.sort_by_key(|id| position.get(id).copied().unwrap_or(usize::MAX));
             queue.extend(next);
         }
     }
@@ -118,7 +122,7 @@ phases:
         let order = topo_sort(&plan).unwrap();
         assert_eq!(order[0], "a");
         assert_eq!(order[3], "d");
-        // b and c can be in either order, but sorted deterministically
+        // b and c are tied after a; they run in declaration order (b first)
         assert_eq!(order[1], "b");
         assert_eq!(order[2], "c");
     }
@@ -137,8 +141,49 @@ phases:
 "#;
         let plan = parse_plan(yaml).unwrap();
         let order = topo_sort(&plan).unwrap();
-        // Alphabetically sorted since all have in_degree 0
-        assert_eq!(order, vec!["a", "b", "c"]);
+        // Declaration order preserved when all have in_degree 0
+        assert_eq!(order, vec!["c", "a", "b"]);
+    }
+
+    #[test]
+    fn declaration_order_tie_break_regression_gh532() {
+        // GH-532: a real plan declared phases in the order adapt, wire, freeze
+        // (no depends_on). Alphabetical tie-breaking executed freeze before
+        // wire — the commit/receipt phase sealed an unfinished tree.
+        let yaml = r#"
+name: gh532-regression
+phases:
+  - id: adapt
+    prompt: "x"
+  - id: wire
+    prompt: "x"
+  - id: freeze
+    prompt: "x"
+"#;
+        let plan = parse_plan(yaml).unwrap();
+        let order = topo_sort(&plan).unwrap();
+        assert_eq!(order, vec!["adapt", "wire", "freeze"]);
+    }
+
+    #[test]
+    fn declaration_order_tie_break_among_siblings() {
+        // Siblings freed at the same time run in declaration order, even when
+        // their ids sort the other way.
+        let yaml = r#"
+name: test
+phases:
+  - id: root
+    prompt: "x"
+  - id: zeta
+    prompt: "x"
+    depends_on: [root]
+  - id: alpha
+    prompt: "x"
+    depends_on: [root]
+"#;
+        let plan = parse_plan(yaml).unwrap();
+        let order = topo_sort(&plan).unwrap();
+        assert_eq!(order, vec!["root", "zeta", "alpha"]);
     }
 
     #[test]

--- a/demo/openclaw-skill/edda-conductor/SKILL.md
+++ b/demo/openclaw-skill/edda-conductor/SKILL.md
@@ -162,6 +162,7 @@ phases:
 
 - Each phase should produce verifiable output (files, content)
 - Use `depends_on` to express ordering between phases
+- Without `depends_on`, phases run in declaration order (top-to-bottom in the plan file), not alphabetically. Declare commit/receipt phases (e.g. `freeze`) last.
 - Keep prompts specific — the agent has no context from previous phases
 - Set `max_attempts: 2` so failed phases get one retry automatically
 - Add `timeout_sec` appropriate to phase complexity (300s for small, 600s for large)


### PR DESCRIPTION
Closes #532

## Summary

Kahn's algorithm broke in-degree ties alphabetically, so sequential plans without `depends_on` executed in phase-id order instead of the order authors declared in the YAML. A real run scheduled `freeze` (the commit/receipt phase) before `wire`, risking an unsealed receipt SHA if `wire` made edits.

This breaks ties by declaration position instead: the queue is seeded from the plan's phase sequence and freed siblings are re-sorted by declaration index. Equally deterministic, matches author intent, zero schema change.

- update `no_dependencies` test to pin declaration order
- add GH-532 regression test (adapt, wire, freeze) and a reverse-alphabetical sibling test
- document the ordering rule in the plan-authoring skill

## Checks

- `cargo test -p edda-conductor` at this SHA: **233 passed; 0 failed; 1 ignored** (82s)
- Reviewer-approved commit `d5689ff` pushed as-is