### PR TITLE
fix(edda-conductor): keep both-stream tails and stop charging LNK1104 to the ladder (#540)

### DIFF
--- a/crates/edda-conductor/src/check/cmd_succeeds.rs
+++ b/crates/edda-conductor/src/check/cmd_succeeds.rs
@@ -1,7 +1,25 @@
-use crate::check::{mask_secrets, CheckOutput};
+use crate::check::{mask_secrets, output_tail, CheckOutput};
 use std::path::Path;
 use std::time::{Duration, Instant};
 use tokio::process::Command;
+
+/// Per-stream capture cap (GH-540): keep the TAIL, where fatal diagnostics
+/// live (LNK1104's payload, `error: test failed`).
+const OUTPUT_TAIL_CHARS: usize = 2000;
+
+/// Output substrings that identify a machine-layer build failure (GH-540).
+/// LNK1104's payload — the file the linker could not open — is the single
+/// token distinguishing a held .exe from a concurrent cargo or an antivirus
+/// handle, so the capture must reach the tail of the stream that names it.
+/// (Content classification, unlike the GH-529 timeout: a linker fault has no
+/// constructor-level signal, the output text is the only evidence.)
+const ENVIRONMENTAL_PATTERNS: &[&str] = &["LNK1104"];
+
+fn is_environmental(stderr: &str, stdout: &str) -> bool {
+    ENVIRONMENTAL_PATTERNS
+        .iter()
+        .any(|p| stderr.contains(p) || stdout.contains(p))
+}
 
 /// Shell program and args for the current platform.
 #[cfg(windows)]
@@ -59,21 +77,31 @@ pub async fn check_cmd_succeeds(cmd: &str, timeout_sec: u64, cwd: &Path) -> Chec
     match tokio::time::timeout(Duration::from_secs(timeout_sec), result).await {
         Ok(Ok(output)) if output.status.success() => CheckOutput::passed(start.elapsed()),
         Ok(Ok(output)) => {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let masked = mask_secrets(&stderr);
-            let truncated = if masked.len() > 2000 {
-                format!("{}...", &masked[..2000])
+            // GH-540: keep the tail of BOTH streams. Diagnostic conventions
+            // split across them — `cargo test` ends stderr at "error: test
+            // failed" while the failing test names land on stdout, and
+            // link.exe puts "cannot open file '...'" at the very end of
+            // stderr — so a tail of one stream reproduces the same useless
+            // message the issue was filed with.
+            let stderr = mask_secrets(&String::from_utf8_lossy(&output.stderr));
+            let stdout = mask_secrets(&String::from_utf8_lossy(&output.stdout));
+            let stderr_tail = output_tail(&stderr, OUTPUT_TAIL_CHARS);
+            let stdout_tail = output_tail(&stdout, OUTPUT_TAIL_CHARS);
+            let mut message = format!("exit {}", output.status.code().unwrap_or(-1));
+            if !stderr_tail.trim().is_empty() {
+                message.push_str(": ");
+                message.push_str(stderr_tail.trim_end());
+            }
+            if !stdout_tail.trim().is_empty() {
+                message.push_str("\n--- stdout (tail) ---\n");
+                message.push_str(stdout_tail.trim_end());
+            }
+            let detail = message.trim().to_string();
+            if is_environmental(stderr_tail, stdout_tail) {
+                CheckOutput::failed_environmental(detail, start.elapsed())
             } else {
-                masked.to_string()
-            };
-            CheckOutput::failed(
-                format!(
-                    "exit {}: {}",
-                    output.status.code().unwrap_or(-1),
-                    truncated.trim()
-                ),
-                start.elapsed(),
-            )
+                CheckOutput::failed(detail, start.elapsed())
+            }
         }
         Ok(Err(e)) => CheckOutput::failed(format!("spawn error: {e}"), start.elapsed()),
         Err(_) => CheckOutput::timed_out(
@@ -142,5 +170,93 @@ mod tests {
             !detail.contains("sk-ant"),
             "secret should be masked: {detail}"
         );
+    }
+
+    /// GH-540: a failing command must keep the TAIL of BOTH streams.
+    /// `cargo test` ends stderr at "error: test failed" while the failing
+    /// test names land on stdout — the exact message this issue was filed
+    /// with. Head-truncation of stderr alone reproduces it verbatim.
+    #[tokio::test]
+    async fn failure_keeps_tail_of_both_streams() {
+        let dir = tempfile::tempdir().unwrap();
+        // >2000 chars of filler on stderr pushes the fatal line past any
+        // head-truncation cut; the failure names go to stdout only.
+        #[cfg(not(windows))]
+        let cmd = concat!(
+            "yes x | head -c 4000 1>&2 ; ",
+            "echo 'error: test failed, to rerun pass `-p edda-conductor`' 1>&2 ; ",
+            "echo 'failures:' ; ",
+            "echo '    gh540::the_failing_test' ; ",
+            "exit 1"
+        );
+        #[cfg(windows)]
+        let cmd = concat!(
+            "[Console]::Error.WriteLine(('x' * 4000)) ; ",
+            "[Console]::Error.WriteLine('error: test failed, to rerun pass') ; ",
+            "Write-Output 'failures:' ; ",
+            "Write-Output '    gh540::the_failing_test' ; ",
+            "exit 1"
+        );
+        let out = check_cmd_succeeds(cmd, 30, dir.path()).await;
+        assert!(!out.passed);
+        let detail = out.detail.unwrap();
+        // doneWhen 1: the tail of stderr names the fatal line ...
+        assert!(
+            detail.contains("error: test failed"),
+            "stderr tail must be kept, got: {detail}"
+        );
+        // ... and the stdout failure names are not dropped ...
+        assert!(
+            detail.contains("gh540::the_failing_test"),
+            "stdout tail must be kept, got: {detail}"
+        );
+        // ... and the capture stays bounded.
+        assert!(
+            detail.chars().count() < 4600,
+            "capture must stay bounded, got {} chars",
+            detail.chars().count()
+        );
+    }
+
+    /// GH-540: output_tail must be char-boundary safe (the old byte-slice
+    /// head-truncation could panic on multibyte UTF-8).
+    #[test]
+    fn output_tail_is_char_boundary_safe() {
+        let multibyte = "é中\u{1F600}".repeat(1000); // 3000 chars, 9000 bytes
+        let tail = output_tail(&multibyte, 2000);
+        assert_eq!(tail.chars().count(), 2000);
+        // Panic-free slicing implies boundaries were respected.
+        assert_eq!(output_tail("short", 2000), "short");
+    }
+
+    /// GH-540: output naming LNK1104 classifies the failure as environmental.
+    #[tokio::test]
+    async fn lnk1104_output_marks_environmental() {
+        let dir = tempfile::tempdir().unwrap();
+        #[cfg(not(windows))]
+        let cmd = "echo \"LINK : fatal error LNK1104: cannot open file 'x.exe'\" 1>&2 ; exit 1";
+        #[cfg(windows)]
+        let cmd = "[Console]::Error.WriteLine('LINK : fatal error LNK1104: cannot open file ''x.exe''') ; exit 1";
+        let out = check_cmd_succeeds(cmd, 10, dir.path()).await;
+        assert!(!out.passed);
+        assert!(
+            out.environmental,
+            "LNK1104 must mark the failure environmental"
+        );
+        assert!(out.detail.unwrap().contains("LNK1104"));
+    }
+
+    /// A genuine agent-work failure (no environmental pattern) stays a plain
+    /// failure, even when the output mentions exit codes and files.
+    #[tokio::test]
+    async fn genuine_failure_not_marked_environmental() {
+        let dir = tempfile::tempdir().unwrap();
+        #[cfg(not(windows))]
+        let cmd = "echo 'test failed: assertion in foo.rs' 1>&2 ; exit 1";
+        #[cfg(windows)]
+        let cmd = "[Console]::Error.WriteLine('test failed: assertion in foo.rs') ; exit 1";
+        let out = check_cmd_succeeds(cmd, 10, dir.path()).await;
+        assert!(!out.passed);
+        assert!(!out.environmental);
     }
 }

--- a/crates/edda-conductor/src/check/cmd_succeeds.rs
+++ b/crates/edda-conductor/src/check/cmd_succeeds.rs
@@ -8,12 +8,17 @@ use tokio::process::Command;
 const OUTPUT_TAIL_CHARS: usize = 2000;
 
 /// Output substrings that identify a machine-layer build failure (GH-540).
-/// LNK1104's payload — the file the linker could not open — is the single
-/// token distinguishing a held .exe from a concurrent cargo or an antivirus
-/// handle, so the capture must reach the tail of the stream that names it.
-/// (Content classification, unlike the GH-529 timeout: a linker fault has no
-/// constructor-level signal, the output text is the only evidence.)
-const ENVIRONMENTAL_PATTERNS: &[&str] = &["LNK1104"];
+/// The full linker-fatal signature — not the bare code — is required (review
+/// round 1): a bare `LNK1104` token also shows up in agent output that merely
+/// DISCUSSES the error (e.g. a cargo test panicking on an assertion about the
+/// LNK1104 message), and classifying that environmental would hand a product
+/// failure free retries. link.exe's fatal line is
+/// `LINK : fatal error LNK1104: cannot open file '...'`, so the
+/// `fatal error LNK1104` pair is the signature. The capture must still reach
+/// the tail of the stream that names it. (Content classification, unlike the
+/// GH-529 timeout: a linker fault has no constructor-level signal, the output
+/// text is the only evidence.)
+const ENVIRONMENTAL_PATTERNS: &[&str] = &["fatal error LNK1104"];
 
 fn is_environmental(stderr: &str, stdout: &str) -> bool {
     ENVIRONMENTAL_PATTERNS
@@ -258,5 +263,32 @@ mod tests {
         let out = check_cmd_succeeds(cmd, 10, dir.path()).await;
         assert!(!out.passed);
         assert!(!out.environmental);
+    }
+
+    /// GH-540 review round 1: a BARE `LNK1104` token in a non-linker context
+    /// — e.g. a cargo test panicking on an assertion that discusses the
+    /// LNK1104 message — must stay a plain product failure. Only the actual
+    /// linker-fatal signature (`fatal error LNK1104`) classifies
+    /// environmental; matching the bare code misclassified exactly this
+    /// shape as a machine fault and granted it free retries.
+    #[tokio::test]
+    async fn bare_lnk1104_token_is_not_environmental() {
+        let dir = tempfile::tempdir().unwrap();
+        #[cfg(not(windows))]
+        let cmd = "echo 'panicked: assertion failed: detail.contains(\"LNK1104\")' 1>&2 ; exit 1";
+        #[cfg(windows)]
+        let cmd =
+            "[Console]::Error.WriteLine('panicked: assertion failed: detail.contains(''LNK1104'')') ; exit 1";
+        let out = check_cmd_succeeds(cmd, 10, dir.path()).await;
+        assert!(!out.passed);
+        let detail = out.detail.unwrap();
+        assert!(
+            detail.contains("LNK1104"),
+            "token must reach the tail: {detail}"
+        );
+        assert!(
+            !out.environmental,
+            "a bare LNK1104 mention is not a linker fault"
+        );
     }
 }

--- a/crates/edda-conductor/src/check/engine.rs
+++ b/crates/edda-conductor/src/check/engine.rs
@@ -47,8 +47,13 @@ impl CheckEngine {
             if !output.passed {
                 // GH-529: a harness-side timeout must not be classified as a
                 // retryable check failure — a retry cannot change the outcome.
+                // GH-540: an environmental build failure (LNK1104 et al.) is
+                // classified distinctly too — retryable, but never charged to
+                // the agent's attempt ladder (handled in `handle_on_fail`).
                 let (error_type, retryable) = if output.timed_out {
                     (ErrorType::Timeout, false)
+                } else if output.environmental {
+                    (ErrorType::Environmental, true)
                 } else {
                     (ErrorType::CheckFailed, spec.is_retryable())
                 };
@@ -246,5 +251,37 @@ mod tests {
         let err = result.error.expect("failure must carry an error");
         assert_eq!(err.error_type, ErrorType::CheckFailed);
         assert!(err.retryable);
+    }
+
+    /// GH-540: a command whose output names an environmental build fault
+    /// (LNK1104) must classify as `ErrorType::Environmental`, retryable —
+    /// distinguishable from a genuine agent-work failure.
+    #[tokio::test]
+    async fn lnk1104_classifies_as_environmental() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = CheckEngine::new(dir.path().to_path_buf());
+
+        // The exact shape of the real failure: link.exe's fatal line on stderr.
+        #[cfg(windows)]
+        let cmd = "[Console]::Error.WriteLine('LINK : fatal error LNK1104: cannot open file ''edda_conductor.exe''') ; exit 1";
+        #[cfg(not(windows))]
+        let cmd =
+            "echo \"LINK : fatal error LNK1104: cannot open file 'edda_conductor.exe'\" ; exit 1";
+        let checks = vec![CheckSpec::CmdSucceeds {
+            cmd: cmd.into(),
+            timeout_sec: 10,
+        }];
+
+        let result = engine.run_all(&checks, None).await;
+        assert!(!result.all_passed);
+        let err = result.error.expect("failure must carry an error");
+        assert_eq!(err.error_type, ErrorType::Environmental);
+        assert!(
+            err.retryable,
+            "a retry CAN fix a transient linker collision"
+        );
+        assert!(err.message.contains("LNK1104"));
+        // doneWhen 2: the occurrence names its file in the captured log.
+        assert!(err.message.contains("edda_conductor.exe"));
     }
 }

--- a/crates/edda-conductor/src/check/mod.rs
+++ b/crates/edda-conductor/src/check/mod.rs
@@ -19,6 +19,11 @@ pub struct CheckOutput {
     /// distinguishable from a genuine check failure downstream (retry
     /// policy, console output, persisted error type).
     pub timed_out: bool,
+    /// True when the failure is a known environmental build failure (GH-540,
+    /// e.g. Windows LNK1104): the command's output names a machine-layer
+    /// fault, not the agent's work. Unlike a timeout, a retry CAN change the
+    /// outcome — but the retry must not consume the agent's attempt ladder.
+    pub environmental: bool,
 }
 
 impl CheckOutput {
@@ -28,6 +33,7 @@ impl CheckOutput {
             detail: None,
             duration,
             timed_out: false,
+            environmental: false,
         }
     }
 
@@ -37,6 +43,7 @@ impl CheckOutput {
             detail: Some(detail),
             duration,
             timed_out: false,
+            environmental: false,
         }
     }
 
@@ -46,6 +53,21 @@ impl CheckOutput {
             detail: Some(detail),
             duration,
             timed_out: false,
+            environmental: false,
+        }
+    }
+
+    /// An environmental build failure (GH-540): the output names a
+    /// machine-layer fault (e.g. LNK1104). Classified as
+    /// `ErrorType::Environmental` downstream — retryable, but never charged
+    /// to the agent's `max_attempts` ladder.
+    pub fn failed_environmental(detail: String, duration: Duration) -> Self {
+        Self {
+            passed: false,
+            detail: Some(detail),
+            duration,
+            timed_out: false,
+            environmental: true,
         }
     }
 
@@ -57,8 +79,28 @@ impl CheckOutput {
             detail: Some(detail),
             duration,
             timed_out: true,
+            environmental: false,
         }
     }
+}
+
+/// Keep the last `max_chars` characters of a capture (GH-540).
+///
+/// Fatal diagnostics live at the END of a build log: LNK1104's payload (the
+/// file it could not open) and `error: test failed` are the last lines stderr
+/// produces. Head-truncation cut exactly there; a tail keeps the cause.
+/// Char-boundary safe (byte slicing could panic on multibyte UTF-8).
+pub fn output_tail(text: &str, max_chars: usize) -> &str {
+    if text.chars().count() <= max_chars {
+        return text;
+    }
+    let skip = text.chars().count() - max_chars;
+    let start = text
+        .char_indices()
+        .nth(skip)
+        .map(|(i, _)| i)
+        .unwrap_or(text.len());
+    &text[start..]
 }
 
 /// Mask secrets in output strings before storing.

--- a/crates/edda-conductor/src/runner/event_log.rs
+++ b/crates/edda-conductor/src/runner/event_log.rs
@@ -10,6 +10,11 @@ use std::path::{Path, PathBuf};
 
 // ── Event types ──
 
+/// Serde `skip_serializing_if` helper: omit numeric counters at their default.
+fn is_zero_u32(v: &u32) -> bool {
+    *v == 0
+}
+
 /// A conductor event. Serialized as tagged JSON (`"type": "plan_start"`, etc.).
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -33,6 +38,23 @@ pub enum Event {
         attempt: u32,
         duration_ms: u64,
         error: String,
+        /// GH-540 review round 1: snake_case [`crate::state::machine::ErrorType`]
+        /// of the failure ("environmental", "timeout", ...), so generic JSONL
+        /// consumers can distinguish a free environmental retry from a charged
+        /// product failure. Absent on records written before this field — the
+        /// field is additive and old lines parse unchanged.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error_type: Option<String>,
+        /// GH-540 review round 1: environmental failures already charged to
+        /// the free-retry counter when this event was written. Absent when
+        /// zero, so pre-GH-540-shaped records and zero-state records emit the
+        /// identical object for old consumers.
+        #[serde(skip_serializing_if = "is_zero_u32")]
+        env_retries: u32,
+        /// GH-540 review round 1: whether this attempt consumed a product
+        /// attempt (the `max_attempts` ladder). Environmental failures are
+        /// never charged — their retries are free.
+        attempt_charged: bool,
     },
     PhaseSkipped {
         phase_id: String,
@@ -223,6 +245,45 @@ mod tests {
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains(r#""type":"phase_passed""#));
         assert!(json.contains(r#""cost_usd":0.42"#));
+    }
+
+    #[test]
+    fn event_phase_failed_serialization() {
+        let event = Event::PhaseFailed {
+            phase_id: "build".into(),
+            attempt: 1,
+            duration_ms: 5000,
+            error: "exit 1".into(),
+            error_type: Some("environmental".into()),
+            env_retries: 2,
+            attempt_charged: false,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains(r#""type":"phase_failed""#));
+        assert!(json.contains(r#""error_type":"environmental""#));
+        assert!(json.contains(r#""env_retries":2"#));
+        assert!(json.contains(r#""attempt_charged":false"#));
+    }
+
+    /// GH-540 review round 1: the retry-accounting fields are additive —
+    /// defaulted/absent fields stay out of the JSON so records written before
+    /// the fields existed and records with zero counters parse identically
+    /// for generic JSONL consumers.
+    #[test]
+    fn event_phase_failed_additive_fields_stay_absent_when_defaulted() {
+        let event = Event::PhaseFailed {
+            phase_id: "build".into(),
+            attempt: 1,
+            duration_ms: 5000,
+            error: "boom".into(),
+            error_type: None,
+            env_retries: 0,
+            attempt_charged: true,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(!json.contains("error_type"), "json: {json}");
+        assert!(!json.contains("env_retries"), "json: {json}");
+        assert!(json.contains(r#""attempt_charged":true"#));
     }
 
     #[test]

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -1034,6 +1034,12 @@ async fn handle_on_fail(
     notifier: &dyn Notifier,
     event_log: &mut EventLogger,
 ) {
+    /// GH-540: bound on environmental retries per phase run. Without it a
+    /// persistently broken environment (e.g. antivirus holding every newly
+    /// linked .exe) would retry forever; two in a row failing a phase that
+    /// never had a product problem is the exact harm the issue describes.
+    const MAX_ENV_RETRIES: u32 = 2;
+
     let on_fail = phase.on_fail.unwrap_or(plan.on_fail);
 
     match on_fail {
@@ -1056,17 +1062,35 @@ async fn handle_on_fail(
                     .await;
                 return;
             }
+            let is_environmental = check_result
+                .error
+                .as_ref()
+                .is_some_and(|e| e.error_type == ErrorType::Environmental);
             let max = phase.max_attempts.unwrap_or(plan.max_attempts);
-            let (attempts, should_retry) = {
+            let (product_attempts, env_retries, should_retry) = {
                 let ps = state
                     .get_phase_mut(phase_id)
                     .expect("phase must exist in state");
-                if ps.attempts < max {
-                    let error_context = format_check_failures(&check_result.results);
-                    ps.retry_context = Some(error_context);
-                    (ps.attempts, true)
+                // GH-540: an environmental build failure (LNK1104) is not the
+                // agent's work — its attempt is not charged to the ladder.
+                // `attempts` counts every dispatch (attempt numbers key the
+                // session id and must stay unique), so the product count is
+                // `attempts - env_retries`. Once MAX_ENV_RETRIES is spent the
+                // environment is treated as persistently broken: halt and
+                // report instead of looping forever.
+                let product = ps.attempts.saturating_sub(ps.env_retries);
+                if is_environmental && ps.env_retries < MAX_ENV_RETRIES {
+                    ps.env_retries += 1;
+                    (product, ps.env_retries, true)
+                } else if !is_environmental {
+                    if product < max {
+                        let error_context = format_check_failures(&check_result.results);
+                        ps.retry_context = Some(error_context);
+                    }
+                    (product, ps.env_retries, product < max)
                 } else {
-                    (ps.attempts, false)
+                    // environmental, cap exhausted
+                    (product, ps.env_retries, false)
                 }
             };
             if should_retry {
@@ -1077,7 +1101,24 @@ async fn handle_on_fail(
                     PhaseStatus::Pending,
                     None,
                 );
-                println!("  ↻ Auto-retrying ({attempts}/{max})");
+                if is_environmental {
+                    println!(
+                        "  ↻ Environmental build failure — retrying without \
+                         charging the attempt ladder ({env_retries}/{MAX_ENV_RETRIES})"
+                    );
+                } else {
+                    println!("  ↻ Auto-retrying ({product_attempts}/{max})");
+                }
+            } else if is_environmental {
+                // cap exhausted (should_retry is only false for environmental
+                // when MAX_ENV_RETRIES is spent)
+                notifier
+                    .notify(&format!(
+                        "Phase \"{phase_id}\" failed on repeated environmental build \
+                         failures ({env_retries} retries) — the machine layer, not the \
+                         agent's work, is at fault. Clear the fault, then retry."
+                    ))
+                    .await;
             } else {
                 notifier
                     .notify(&format!(
@@ -1600,6 +1641,135 @@ phases:
             msgs.iter()
                 .any(|m| m.contains("timed out") && m.contains("auto_retry skipped")),
             "actionable halt-and-report message, got: {msgs:?}"
+        );
+    }
+
+    /// GH-540: an environmental build failure (LNK1104) retries WITHOUT
+    /// consuming the agent's attempt ladder, but is bounded — a persistently
+    /// broken environment halts after MAX_ENV_RETRIES instead of looping.
+    #[tokio::test]
+    async fn environmental_failure_bounded_and_distinct() {
+        // Always names LNK1104 and exits 1: environmental on every attempt.
+        #[cfg(windows)]
+        let cmd = "Write-Output 'LINK : fatal error LNK1104: cannot open file ''x.exe''' ; exit 1";
+        #[cfg(not(windows))]
+        let cmd = "echo 'LNK1104: cannot open file x.exe' ; exit 1";
+        let yaml = format!(
+            r#"
+name: test
+max_attempts: 2
+phases:
+  - id: a
+    prompt: "do it"
+    check:
+      - type: cmd_succeeds
+        cmd: "{cmd}"
+        timeout_sec: 10
+"#
+        );
+        let launcher = MockLauncher::new();
+        launcher.set_results(
+            "a",
+            vec![
+                PhaseResult::AgentDone {
+                    cost_usd: None,
+                    result_text: None,
+                },
+                PhaseResult::AgentDone {
+                    cost_usd: None,
+                    result_text: None,
+                },
+                PhaseResult::AgentDone {
+                    cost_usd: None,
+                    result_text: None,
+                },
+                PhaseResult::AgentDone {
+                    cost_usd: None,
+                    result_text: None,
+                },
+                PhaseResult::AgentDone {
+                    cost_usd: None,
+                    result_text: None,
+                },
+            ],
+        );
+        let (state, msgs) = run_test_plan(&yaml, &launcher).await;
+
+        let phase = &state.phases[0];
+        assert_eq!(phase.status, PhaseStatus::Failed);
+        // Two free env retries (attempts 1-2), then the cap halts on the
+        // third dispatch. Without the fix this exhausts at attempts == 2.
+        assert_eq!(phase.attempts, 3);
+        assert_eq!(phase.env_retries, 2, "retry cap must be recorded");
+        assert_eq!(launcher.call_count("a"), 3);
+        let err = phase.error.as_ref().expect("env failure must set an error");
+        assert_eq!(err.error_type, ErrorType::Environmental);
+        assert!(err.retryable);
+        assert!(
+            msgs.iter()
+                .any(|m| m.contains("environmental") && m.contains("retry")),
+            "halt message must name the environmental fault, got: {msgs:?}"
+        );
+    }
+
+    /// GH-540: an environmental failure must not consume a product retry —
+    /// with max_attempts: 2, one LNK1104 followed by two genuine failures
+    /// still gives the agent its full two product attempts (3 dispatches).
+    #[tokio::test]
+    async fn environmental_failure_not_charged_to_ladder() {
+        // First run: environmental LNK1104 (and plants the marker); every
+        // later run: a genuine failure with no environmental pattern.
+        #[cfg(windows)]
+        let cmd = "if (Test-Path env-marker) { exit 1 } else { Write-Output 'LNK1104: cannot open file x.exe' ; New-Item -ItemType File env-marker | Out-Null ; exit 1 }";
+        #[cfg(not(windows))]
+        let cmd = "if [ -f env-marker ]; then exit 1; else echo 'LNK1104: cannot open file x.exe' ; touch env-marker ; exit 1; fi";
+        let yaml = format!(
+            r#"
+name: test
+max_attempts: 2
+phases:
+  - id: a
+    prompt: "do it"
+    check:
+      - type: cmd_succeeds
+        cmd: "{cmd}"
+        timeout_sec: 10
+"#
+        );
+        let launcher = MockLauncher::new();
+        launcher.set_results(
+            "a",
+            vec![
+                PhaseResult::AgentDone {
+                    cost_usd: None,
+                    result_text: None,
+                },
+                PhaseResult::AgentDone {
+                    cost_usd: None,
+                    result_text: None,
+                },
+                PhaseResult::AgentDone {
+                    cost_usd: None,
+                    result_text: None,
+                },
+                PhaseResult::AgentDone {
+                    cost_usd: None,
+                    result_text: None,
+                },
+            ],
+        );
+        let (state, msgs) = run_test_plan(&yaml, &launcher).await;
+
+        let phase = &state.phases[0];
+        assert_eq!(phase.status, PhaseStatus::Failed);
+        // attempt 1: LNK1104 (free) — attempts 2 and 3: the agent's two real
+        // product attempts. Without the fix the ladder exhausts at 2.
+        assert_eq!(phase.attempts, 3);
+        assert_eq!(phase.env_retries, 1);
+        assert_eq!(launcher.call_count("a"), 3);
+        assert!(
+            msgs.iter().any(|m| m.contains("failed after 2 attempts")),
+            "the agent still gets its full ladder, got: {msgs:?}"
         );
     }
 

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -297,11 +297,15 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                             let _ = tmux.update_phase_status(&gated_id, "Failed");
                         }
                         edda::record_phase_failed(cwd, &gated_id, &message);
+                        let gate_ps = state.get_phase(&gated_id)?;
                         event_log.record(Event::PhaseFailed {
                             phase_id: gated_id.clone(),
-                            attempt: attempts,
+                            attempt: gate_ps.attempts,
                             duration_ms: 0,
                             error: format!("verdict rejected: {message}"),
+                            error_type: Some(ErrorType::GateRejected.tag().to_string()),
+                            env_retries: gate_ps.env_retries,
+                            attempt_charged: true,
                         });
                     } else {
                         // Redispatch (D3): ONE more agent turn in the SAME
@@ -382,11 +386,15 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                         let _ = tmux.update_phase_status(&gated_id, "Failed");
                     }
                     edda::record_phase_failed(cwd, &gated_id, &msg);
+                    let gate_ps = state.get_phase(&gated_id)?;
                     event_log.record(Event::PhaseFailed {
                         phase_id: gated_id.clone(),
-                        attempt: state.get_phase(&gated_id)?.attempts,
+                        attempt: gate_ps.attempts,
                         duration_ms: 0,
                         error: msg,
+                        error_type: Some(ErrorType::Timeout.tag().to_string()),
+                        env_retries: gate_ps.env_retries,
+                        attempt_charged: true,
                     });
                 }
                 GateVerdict::Cancelled => {
@@ -709,7 +717,7 @@ async fn fail_checking_phase(
         PhaseStatus::Failed,
         Some(PhaseUpdate {
             checks: Some(check_result.results.clone()),
-            error: error_info,
+            error: error_info.clone(),
             ..Default::default()
         }),
     )?;
@@ -728,11 +736,22 @@ async fn fail_checking_phase(
         let _ = tmux.update_phase_status(phase_id, "Failed");
     }
     edda::record_phase_failed(cwd, phase_id, &err_msg);
+    let ps = state.get_phase(phase_id)?;
+    let (error_type, attempt_charged) = match &error_info {
+        Some(e) => (
+            Some(e.error_type.tag().to_string()),
+            e.error_type != ErrorType::Environmental,
+        ),
+        None => (None, true),
+    };
     event_log.record(Event::PhaseFailed {
         phase_id: phase_id.to_string(),
-        attempt: state.get_phase(phase_id)?.attempts,
+        attempt: ps.attempts,
         duration_ms: elapsed.as_millis() as u64,
         error: err_msg,
+        error_type,
+        env_retries: ps.env_retries,
+        attempt_charged,
     });
     handle_on_fail(
         plan,
@@ -940,6 +959,9 @@ async fn process_phase_result(
                 attempt,
                 duration_ms: elapsed_ms,
                 error: "timed out".into(),
+                error_type: Some(ErrorType::Timeout.tag().to_string()),
+                env_retries: phase_env_retries(state, phase_id),
+                attempt_charged: true,
             });
         }
         PhaseResult::AgentCrash { error } => {
@@ -973,6 +995,9 @@ async fn process_phase_result(
                 attempt,
                 duration_ms: elapsed_ms,
                 error: error.clone(),
+                error_type: Some(ErrorType::AgentCrash.tag().to_string()),
+                env_retries: phase_env_retries(state, phase_id),
+                attempt_charged: true,
             });
             // For crash, use empty check results
             let empty_result = CheckRunResult {
@@ -1018,11 +1043,24 @@ async fn process_phase_result(
                 phase_id: phase_id.to_string(),
                 attempt,
                 duration_ms: elapsed_ms,
-                error: msg,
+                error: msg.clone(),
+                error_type: Some(ErrorType::BudgetExceeded.tag().to_string()),
+                env_retries: phase_env_retries(state, phase_id),
+                attempt_charged: true,
             });
         }
     }
     Ok(())
+}
+
+/// Environmental retries already charged to the phase's free-retry counter
+/// (GH-540 review round 1) — recorded on `phase_failed` so event consumers
+/// can reconstruct the retry accounting.
+fn phase_env_retries(state: &PlanState, phase_id: &str) -> u32 {
+    state
+        .get_phase(phase_id)
+        .map(|p| p.env_retries)
+        .unwrap_or(0)
 }
 
 async fn handle_on_fail(
@@ -1075,21 +1113,23 @@ async fn handle_on_fail(
                 // agent's work — its attempt is not charged to the ladder.
                 // `attempts` counts every dispatch (attempt numbers key the
                 // session id and must stay unique), so the product count is
-                // `attempts - env_retries`. Once MAX_ENV_RETRIES is spent the
-                // environment is treated as persistently broken: halt and
+                // `attempts - env_retries`. Review round 1: EVERY
+                // environmental occurrence charges env_retries — including
+                // the one that exhausts MAX_ENV_RETRIES — otherwise the
+                // cap-ending fault leaves a phantom product attempt and the
+                // first genuine failure after a manual `conduct retry` is
+                // denied auto-retry. Once the counter passes MAX_ENV_RETRIES
+                // the environment is treated as persistently broken: halt and
                 // report instead of looping forever.
                 let product = ps.attempts.saturating_sub(ps.env_retries);
-                if is_environmental && ps.env_retries < MAX_ENV_RETRIES {
+                if is_environmental {
                     ps.env_retries += 1;
+                    (product, ps.env_retries, ps.env_retries <= MAX_ENV_RETRIES)
+                } else if product < max {
+                    let error_context = format_check_failures(&check_result.results);
+                    ps.retry_context = Some(error_context);
                     (product, ps.env_retries, true)
-                } else if !is_environmental {
-                    if product < max {
-                        let error_context = format_check_failures(&check_result.results);
-                        ps.retry_context = Some(error_context);
-                    }
-                    (product, ps.env_retries, product < max)
                 } else {
-                    // environmental, cap exhausted
                     (product, ps.env_retries, false)
                 }
             };
@@ -1111,12 +1151,14 @@ async fn handle_on_fail(
                 }
             } else if is_environmental {
                 // cap exhausted (should_retry is only false for environmental
-                // when MAX_ENV_RETRIES is spent)
+                // when MAX_ENV_RETRIES is spent; the counter reads MAX+1
+                // because the cap-ending occurrence is itself charged)
                 notifier
                     .notify(&format!(
                         "Phase \"{phase_id}\" failed on repeated environmental build \
-                         failures ({env_retries} retries) — the machine layer, not the \
-                         agent's work, is at fault. Clear the fault, then retry."
+                         failures ({env_retries} occurrences, capped at {MAX_ENV_RETRIES} retries) — the \
+                         machine layer, not the agent's work, is at fault. Clear the fault, \
+                         then retry."
                     ))
                     .await;
             } else {
@@ -1647,13 +1689,20 @@ phases:
     /// GH-540: an environmental build failure (LNK1104) retries WITHOUT
     /// consuming the agent's attempt ladder, but is bounded — a persistently
     /// broken environment halts after MAX_ENV_RETRIES instead of looping.
+    /// Review round 1: extended past the cap — the cap-ending occurrence is
+    /// itself charged to env_retries, so after a clear-fault + manual retry
+    /// (mirroring `edda conduct retry`: Failed→Pending, counters preserved)
+    /// the agent still gets its FULL product ladder.
     #[tokio::test]
-    async fn environmental_failure_bounded_and_distinct() {
-        // Always names LNK1104 and exits 1: environmental on every attempt.
+    async fn environmental_cap_end_charged_so_manual_retry_keeps_full_ladder() {
+        // Run 1: the check always names the linker-fatal signature
+        // (environmental on every attempt). Run 2: after the operator writes
+        // the fault-cleared marker, every check is a genuine product failure.
         #[cfg(windows)]
-        let cmd = "Write-Output 'LINK : fatal error LNK1104: cannot open file ''x.exe''' ; exit 1";
+        let cmd = "if (Test-Path fault-cleared) { exit 1 } else { [Console]::Error.WriteLine('LINK : fatal error LNK1104: cannot open file ''x.exe''') ; exit 1 }";
         #[cfg(not(windows))]
-        let cmd = "echo 'LNK1104: cannot open file x.exe' ; exit 1";
+        let cmd =
+            "if [ -f fault-cleared ]; then exit 1; else echo 'LINK : fatal error LNK1104: cannot open file x.exe' 1>&2 ; exit 1; fi";
         let yaml = format!(
             r#"
 name: test
@@ -1667,6 +1716,12 @@ phases:
         timeout_sec: 10
 "#
         );
+        let plan = parse_plan(&yaml).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = PlanState::from_plan(&plan, "test.yaml");
+        let engine = CheckEngine::new(dir.path().to_path_buf());
+        let notifier = CollectNotifier::new();
+        let mut budget = BudgetTracker::new(plan.budget_usd);
         let launcher = MockLauncher::new();
         launcher.set_results(
             "a",
@@ -1693,22 +1748,107 @@ phases:
                 },
             ],
         );
-        let (state, msgs) = run_test_plan(&yaml, &launcher).await;
+        // Run 1: environmental on every dispatch — the cap halts the phase.
+        run_plan(
+            &plan,
+            &mut state,
+            RunContext {
+                launcher: &launcher,
+                check_engine: &engine,
+                notifier: &notifier,
+                budget: &mut budget,
+                cancel: CancellationToken::new(),
+                cwd: dir.path(),
+                interactive: false,
+                json_events: false,
+                tmux_session: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        {
+            let phase = &state.phases[0];
+            assert_eq!(phase.status, PhaseStatus::Failed);
+            // Two free env retries (dispatches 1-2), then the cap halts on
+            // the third dispatch. The cap-ending occurrence is itself
+            // charged: env_retries reads MAX+1 so product accounting stays
+            // exact. Without the charge this persists env_retries == 2 and a
+            // phantom product attempt.
+            assert_eq!(phase.attempts, 3);
+            assert_eq!(
+                phase.env_retries, 3,
+                "the cap-ending environmental occurrence must be charged"
+            );
+            assert_eq!(launcher.call_count("a"), 3);
+            let err = phase.error.as_ref().expect("env failure must set an error");
+            assert_eq!(err.error_type, ErrorType::Environmental);
+            assert!(err.retryable);
+        }
+        assert!(
+            notifier
+                .messages()
+                .iter()
+                .any(|m| m.contains("environmental") && m.contains("retry")),
+            "halt message must name the environmental fault, got: {:?}",
+            notifier.messages()
+        );
+
+        // Clear-fault + manual retry, mirroring `edda conduct retry`
+        // (cmd_conduct.rs): Failed → Pending, plan unblocked, persisted
+        // counters (attempts, env_retries) preserved.
+        std::fs::write(dir.path().join("fault-cleared"), b"").unwrap();
+        transition(
+            &mut state,
+            "a",
+            PhaseStatus::Failed,
+            PhaseStatus::Pending,
+            None,
+        )
+        .unwrap();
+        state.plan_status = PlanStatus::Running;
+
+        // Run 2: genuine failures only — the agent must still get its FULL
+        // product ladder (2 attempts). Without the cap-ending charge the
+        // first genuine failure computes product == max and is denied
+        // auto-retry after only one product attempt.
+        run_plan(
+            &plan,
+            &mut state,
+            RunContext {
+                launcher: &launcher,
+                check_engine: &engine,
+                notifier: &notifier,
+                budget: &mut budget,
+                cancel: CancellationToken::new(),
+                cwd: dir.path(),
+                interactive: false,
+                json_events: false,
+                tmux_session: None,
+            },
+        )
+        .await
+        .unwrap();
 
         let phase = &state.phases[0];
         assert_eq!(phase.status, PhaseStatus::Failed);
-        // Two free env retries (attempts 1-2), then the cap halts on the
-        // third dispatch. Without the fix this exhausts at attempts == 2.
-        assert_eq!(phase.attempts, 3);
-        assert_eq!(phase.env_retries, 2, "retry cap must be recorded");
-        assert_eq!(launcher.call_count("a"), 3);
-        let err = phase.error.as_ref().expect("env failure must set an error");
-        assert_eq!(err.error_type, ErrorType::Environmental);
-        assert!(err.retryable);
+        // Dispatches 4 and 5 are the agent's two genuine product attempts.
+        assert_eq!(
+            phase.attempts, 5,
+            "the full product ladder must survive the environmental cap halt"
+        );
+        assert_eq!(
+            phase.env_retries, 3,
+            "genuine failures must never touch env_retries"
+        );
+        assert_eq!(launcher.call_count("a"), 5);
         assert!(
-            msgs.iter()
-                .any(|m| m.contains("environmental") && m.contains("retry")),
-            "halt message must name the environmental fault, got: {msgs:?}"
+            notifier
+                .messages()
+                .iter()
+                .any(|m| m.contains("failed after 2 attempts")),
+            "the agent still gets its full ladder, got: {:?}",
+            notifier.messages()
         );
     }
 
@@ -1720,9 +1860,9 @@ phases:
         // First run: environmental LNK1104 (and plants the marker); every
         // later run: a genuine failure with no environmental pattern.
         #[cfg(windows)]
-        let cmd = "if (Test-Path env-marker) { exit 1 } else { Write-Output 'LNK1104: cannot open file x.exe' ; New-Item -ItemType File env-marker | Out-Null ; exit 1 }";
+        let cmd = "if (Test-Path env-marker) { exit 1 } else { Write-Output 'LINK : fatal error LNK1104: cannot open file ''x.exe''' ; New-Item -ItemType File env-marker | Out-Null ; exit 1 }";
         #[cfg(not(windows))]
-        let cmd = "if [ -f env-marker ]; then exit 1; else echo 'LNK1104: cannot open file x.exe' ; touch env-marker ; exit 1; fi";
+        let cmd = "if [ -f env-marker ]; then exit 1; else echo 'LINK : fatal error LNK1104: cannot open file x.exe' ; touch env-marker ; exit 1; fi";
         let yaml = format!(
             r#"
 name: test
@@ -1771,6 +1911,76 @@ phases:
             msgs.iter().any(|m| m.contains("failed after 2 attempts")),
             "the agent still gets its full ladder, got: {msgs:?}"
         );
+    }
+
+    /// GH-540 review round 1: phase_failed events must make retry accounting
+    /// distinct — a free environmental retry records error_type
+    /// "environmental" and attempt_charged=false, while a genuine product
+    /// failure records a typed error and attempt_charged=true. env_retries is
+    /// the counter value as of the event (the charge for that occurrence is
+    /// applied by the on_fail policy right after).
+    #[tokio::test]
+    async fn phase_failed_events_record_retry_accounting() {
+        // First check names the linker-fatal signature (environmental, free);
+        // every later check is a genuine product failure.
+        #[cfg(windows)]
+        let cmd = "if (Test-Path env-marker) { exit 1 } else { Write-Output 'LINK : fatal error LNK1104: cannot open file ''x.exe''' ; New-Item -ItemType File env-marker | Out-Null ; exit 1 }";
+        #[cfg(not(windows))]
+        let cmd = "if [ -f env-marker ]; then exit 1; else echo 'LINK : fatal error LNK1104: cannot open file x.exe' 1>&2 ; touch env-marker ; exit 1; fi";
+        let yaml = format!(
+            r#"
+name: test
+max_attempts: 2
+phases:
+  - id: a
+    prompt: "do it"
+    check:
+      - type: cmd_succeeds
+        cmd: "{cmd}"
+        timeout_sec: 10
+"#
+        );
+        let launcher = MockLauncher::new();
+        launcher.set_results(
+            "a",
+            vec![
+                PhaseResult::AgentDone {
+                    cost_usd: None,
+                    result_text: None,
+                },
+                PhaseResult::AgentDone {
+                    cost_usd: None,
+                    result_text: None,
+                },
+                PhaseResult::AgentDone {
+                    cost_usd: None,
+                    result_text: None,
+                },
+            ],
+        );
+        let (_state, dir) = run_test_plan_with_dir(&yaml, &launcher).await;
+
+        let events = read_events(dir.path(), "test");
+        let failures: Vec<&serde_json::Value> = events
+            .iter()
+            .filter(|e| e["type"] == "phase_failed")
+            .collect();
+        assert_eq!(failures.len(), 3, "events: {events:?}");
+        // Dispatch 1: environmental — free retry, untyped error never leaks.
+        assert_eq!(failures[0]["error_type"], "environmental");
+        assert_eq!(failures[0]["attempt_charged"], false);
+        // Counter charged for nothing yet: the additive field is omitted at 0.
+        assert_eq!(
+            failures[0].get("env_retries").and_then(|v| v.as_u64()),
+            None,
+            "env_retries must stay absent at zero (old-parser-safe)"
+        );
+        // Dispatches 2-3: genuine product failures — charged to the ladder.
+        assert_eq!(failures[1]["error_type"], "check_failed");
+        assert_eq!(failures[1]["attempt_charged"], true);
+        assert_eq!(failures[1]["env_retries"], 1);
+        assert_eq!(failures[2]["attempt_charged"], true);
+        assert_eq!(failures[2]["env_retries"], 1);
     }
 
     #[tokio::test]

--- a/crates/edda-conductor/src/state/derive.rs
+++ b/crates/edda-conductor/src/state/derive.rs
@@ -139,6 +139,7 @@ mod tests {
                 verdict_decision: None,
                 verdict_actor: None,
                 verdict_comment: None,
+                env_retries: 0,
             })
             .collect()
     }

--- a/crates/edda-conductor/src/state/machine.rs
+++ b/crates/edda-conductor/src/state/machine.rs
@@ -89,11 +89,13 @@ pub struct PhaseState {
     pub verdict_actor: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub verdict_comment: Option<String>,
-    /// Environmental build failures retried so far this phase run (GH-540).
+    /// Environmental build failures charged so far this phase run (GH-540).
     /// `attempts` counts every dispatch (attempt numbers must stay unique —
     /// they key the session id), so the product attempt count is
-    /// `attempts - env_retries`. Capped at `MAX_ENV_RETRIES` so a persistently
-    /// broken environment still halts instead of looping forever.
+    /// `attempts - env_retries`. Every environmental occurrence — including
+    /// the one that exhausts the cap — is charged here (review round 1), so
+    /// retrying stops once the counter passes `MAX_ENV_RETRIES` while product
+    /// accounting stays exact across a manual retry.
     #[serde(default)]
     pub env_retries: u32,
 }
@@ -122,6 +124,24 @@ pub enum ErrorType {
     /// Windows LNK1104): not the agent's work, so retrying is worthwhile —
     /// but the retry is never charged to `max_attempts`.
     Environmental,
+}
+
+impl ErrorType {
+    /// Stable snake_case tag matching this enum's serde representation
+    /// (GH-540 review round 1): the runner's `phase_failed` event carries it
+    /// so generic JSONL consumers see the failure classification without
+    /// deserializing `ErrorInfo`.
+    pub fn tag(&self) -> &'static str {
+        match self {
+            ErrorType::AgentCrash => "agent_crash",
+            ErrorType::CheckFailed => "check_failed",
+            ErrorType::Timeout => "timeout",
+            ErrorType::BudgetExceeded => "budget_exceeded",
+            ErrorType::UserAbort => "user_abort",
+            ErrorType::GateRejected => "gate_rejected",
+            ErrorType::Environmental => "environmental",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/edda-conductor/src/state/machine.rs
+++ b/crates/edda-conductor/src/state/machine.rs
@@ -89,6 +89,13 @@ pub struct PhaseState {
     pub verdict_actor: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub verdict_comment: Option<String>,
+    /// Environmental build failures retried so far this phase run (GH-540).
+    /// `attempts` counts every dispatch (attempt numbers must stay unique —
+    /// they key the session id), so the product attempt count is
+    /// `attempts - env_retries`. Capped at `MAX_ENV_RETRIES` so a persistently
+    /// broken environment still halts instead of looping forever.
+    #[serde(default)]
+    pub env_retries: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -111,6 +118,10 @@ pub enum ErrorType {
     UserAbort,
     /// A verdict gate rejected the phase (D3, on_reject: halt or bound hit).
     GateRejected,
+    /// A machine-layer build fault named in the check output (GH-540, e.g.
+    /// Windows LNK1104): not the agent's work, so retrying is worthwhile —
+    /// but the retry is never charged to `max_attempts`.
+    Environmental,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -275,6 +286,7 @@ impl PlanState {
                 verdict_decision: None,
                 verdict_actor: None,
                 verdict_comment: None,
+                env_retries: 0,
             })
             .collect();
 


### PR DESCRIPTION
Closes #540.

## What

Two defects, both about what happens when a `cmd_succeeds` check fails:

1. **Tail-of-both-streams capture.** The failure message now keeps the last 2000 chars of BOTH stdout and stderr (masked, char-boundary safe — the old byte-slice head-truncation could panic on multibyte UTF-8). `cargo test` ends stderr at `error: test failed` while the failing test names land on stdout; `link.exe` puts `cannot open file '...'` at the very end of stderr. Head-of-stderr reproduced the useless message verbatim; tail-of-both names the cause.

2. **Environmental classification and retry accounting.** Output naming `LNK1104` classifies as `ErrorType::Environmental` (new variant, retryable) following the #529 shape (CheckOutput flag → engine classification → handle_on_fail policy). `handle_on_fail` retries environmental failures WITHOUT charging `max_attempts`: `attempts` still counts every dispatch (attempt numbers key the session id and must stay unique), product attempts = `attempts - env_retries`. Bounded: after 2 environmental retries in a phase run, it halts with an actionable message instead of looping.

## doneWhen

- [x] A failing `cmd_succeeds` check preserves the tail of the command's output — both streams, so a fatal linker line and cargo-test failure names are visible
- [x] The next LNK1104 occurrence names its file in the captured log (test asserts `cannot open file 'edda_conductor.exe'` survives capture)
- [x] An environmental build failure is distinguishable from an agent failure in retry accounting — recorded distinctly (`ErrorType::Environmental`) AND not charged to `max_attempts`

## Out of scope (per issue)

Preventing the linker collision itself (machine layer: build lanes, AV exclusions). No lane logic added. Fittingly, LNK1104 hit this very branch's first `cargo test` run; killing stale processes and re-running cleared it — the transient-retry behavior this PR implements.

## Tests

All regression tests verified to FAIL without the fix (pre-fix simulation of each site):
- `failure_keeps_tail_of_both_streams` — stderr tail + stdout names survive a >2000-char capture
- `lnk1104_output_marks_environmental` / `lnk1104_classifies_as_environmental` — distinct classification, file named
- `environmental_failure_bounded_and_distinct` — capped at 2 env retries, halts with message
- `environmental_failure_not_charged_to_ladder` — 1 env + 2 genuine failures on `max_attempts: 2` still gives the agent its full ladder (3 dispatches, "failed after 2 attempts")

Gates: `cargo fmt --all --check` ✓ · `cargo clippy -p edda-conductor --all-targets -- -D warnings` ✓ · `cargo test -p edda-conductor` 245 passed ✓