### PR TITLE
feat(edda-cli): phase approve/reject sugar resolving gate_sha and session from conductor state

### DIFF
--- a/crates/edda-cli/src/cmd_phase.rs
+++ b/crates/edda-cli/src/cmd_phase.rs
@@ -1,6 +1,193 @@
+use clap::Subcommand;
 use edda_bridge_claude::agent_phase;
+use edda_conductor::agent::launcher::phase_session_id_attempt;
+use edda_conductor::state::machine::PhaseStatus;
 use edda_core::agent_phase::{phase_suggestion, AgentPhaseMap};
+use edda_core::VerdictDecision;
 use std::path::Path;
+
+// ── GH-547: `phase approve|reject` sugar over `edda verdict` ─────────────
+//
+// Relaying a verdict for a gated phase by hand means typing a 40-hex SHA
+// and a session UUID, and a wrong-but-valid value is accepted while the
+// gate silently waits forever. The persisted conductor state already knows
+// both, so this sugar resolves them and then delegates to the exact same
+// `verdict.recorded` write path (validation and secret redaction included).
+
+#[derive(Debug, Subcommand)]
+pub enum PhaseCmd {
+    /// Approve the live verdict gate on <plan>/<phase>
+    ///
+    /// gate_sha and session are resolved from the persisted conductor state;
+    /// --sha and --session remain available as explicit overrides.
+    Approve {
+        /// Gated subject as <plan-name>/<phase-id>
+        subject: String,
+        /// Override: full 40-hex git SHA (default: the SHA captured at gate entry)
+        #[arg(long)]
+        sha: Option<String>,
+        /// Optional context recorded with the approval
+        #[arg(long)]
+        comment: Option<String>,
+        /// Override: session ID (default: the conductor session running the phase)
+        #[arg(long)]
+        session: Option<String>,
+    },
+    /// Reject the live verdict gate on <plan>/<phase>
+    ///
+    /// The comment is mandatory: it is fed back to the gated agent session
+    /// as its next redispatch turn.
+    Reject {
+        /// Gated subject as <plan-name>/<phase-id>
+        subject: String,
+        /// Required: why the gate was rejected (becomes the redispatch prompt)
+        #[arg(long)]
+        comment: String,
+        /// Override: full 40-hex git SHA (default: the SHA captured at gate entry)
+        #[arg(long)]
+        sha: Option<String>,
+        /// Override: session ID (default: the conductor session running the phase)
+        #[arg(long)]
+        session: Option<String>,
+    },
+}
+
+/// A gate resolved from the persisted conductor state (GH-547).
+#[derive(Debug)]
+pub(crate) struct ResolvedGate {
+    pub phase_id: String,
+    pub gate_sha: String,
+    pub session_id: String,
+}
+
+/// Resolve subject/gate_sha/session for a gated phase from conductor state.
+///
+/// Refuses LOUDLY and immediately when the plan does not exist, the phase
+/// does not exist, or the phase is not actually in AWAITING_VERDICT — the
+/// whole point is to turn today's silent-eternal-wait failures into instant
+/// errors. Resolution reads the same state.json the conductor itself uses;
+/// no new notion of "where" is introduced (that is #543's problem, not ours).
+pub(crate) fn resolve_gate(repo_root: &Path, subject: &str) -> anyhow::Result<ResolvedGate> {
+    let (plan_name, phase_id) = subject.split_once('/').ok_or_else(|| {
+        anyhow::anyhow!(
+            "subject must be <plan-name>/<phase-id> (got \"{subject}\") — \
+                 e.g. edda phase approve my-plan/impl"
+        )
+    })?;
+
+    let state =
+        edda_conductor::state::persist::load_state(repo_root, plan_name)?.ok_or_else(|| {
+            anyhow::anyhow!(
+                "no conductor state for plan \"{plan_name}\" — expected {}\n  \
+                 run `edda conduct status` to list plans that have state",
+                edda_conductor::state::persist::state_path(repo_root, plan_name).display()
+            )
+        })?;
+
+    let phase = state.get_phase(phase_id).map_err(|_| {
+        anyhow::anyhow!(
+            "plan \"{plan_name}\" has no phase \"{phase_id}\" — phases: {}",
+            state
+                .phases
+                .iter()
+                .map(|p| p.id.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    })?;
+
+    if phase.status != PhaseStatus::AwaitingVerdict {
+        anyhow::bail!(
+            "phase \"{plan_name}/{phase_id}\" is not awaiting a verdict (status: {:?});\n  \
+             refusing instead of recording a verdict the gate would silently wait on forever",
+            phase.status
+        );
+    }
+
+    let gate_sha = phase.gate_sha.clone().ok_or_else(|| {
+        anyhow::anyhow!(
+            "phase \"{plan_name}/{phase_id}\" is awaiting_verdict but has no gate_sha \
+             recorded; pass --sha explicitly"
+        )
+    })?;
+
+    // Same deterministic session the runner used for this attempt
+    // (edda-conductor/src/runner/sequential.rs); phase.attempts >= 1 by the
+    // time a phase can be in AWAITING_VERDICT.
+    let session_id = phase_session_id_attempt(plan_name, phase_id, phase.attempts).to_string();
+
+    Ok(ResolvedGate {
+        phase_id: phase_id.to_string(),
+        gate_sha,
+        session_id,
+    })
+}
+
+/// Execute `edda phase approve|reject` — resolve the gate from conductor
+/// state, then record through the unchanged `edda verdict` path.
+pub fn run_gate_sugar(cmd: PhaseCmd, repo_root: &Path) -> anyhow::Result<()> {
+    let (subject, decision, comment, sha_override, session_override) = match cmd {
+        PhaseCmd::Approve {
+            subject,
+            sha,
+            comment,
+            session,
+        } => (subject, VerdictDecision::Approved, comment, sha, session),
+        PhaseCmd::Reject {
+            subject,
+            comment,
+            sha,
+            session,
+        } => (
+            subject,
+            VerdictDecision::Rejected,
+            Some(comment),
+            sha,
+            session,
+        ),
+    };
+
+    let gate = resolve_gate(repo_root, &subject)?;
+    let sha = sha_override.unwrap_or_else(|| gate.gate_sha.clone());
+    let session = session_override.unwrap_or_else(|| gate.session_id.clone());
+    println!(
+        "Resolved gate for \"{subject}\" from conductor state (phase: {}, status: awaiting_verdict):",
+        gate.phase_id
+    );
+    if sha == gate.gate_sha {
+        println!("  gate_sha: {}", gate.gate_sha);
+    } else {
+        println!(
+            "  gate_sha: {sha} (--sha override; state had {})",
+            gate.gate_sha
+        );
+    }
+    if session == gate.session_id {
+        println!("  session:  {session}");
+    } else {
+        println!(
+            "  session:  {session} (--session override; state had {})",
+            gate.session_id
+        );
+    }
+
+    let outcome = crate::cmd_verdict::do_record(
+        repo_root,
+        &crate::cmd_verdict::RecordVerdictArgs {
+            subject: &subject,
+            decision,
+            sha: &sha,
+            comment: comment.as_deref(),
+            cli_session: Some(&session),
+        },
+    )?;
+    println!("Verdict recorded: {} {subject} @ {sha}", outcome.decision);
+    println!("  event: {}", outcome.event_id);
+    if let Some(c) = comment.as_deref().filter(|c| !c.trim().is_empty()) {
+        println!("  comment: {c}");
+    }
+    Ok(())
+}
 
 /// Execute `edda phase` — show current agent phase map.
 pub fn execute(repo_root: &Path, json: bool) -> anyhow::Result<()> {
@@ -115,5 +302,212 @@ mod tests {
         let map = AgentPhaseMap::from_agents(vec![state], vec![]);
         // Should not panic
         print_phase_map(&map, Some("sess-1"));
+    }
+
+    // ── GH-547: phase approve/reject sugar over `edda verdict` ──────
+
+    use edda_conductor::plan::parser::parse_plan;
+    use edda_conductor::state::machine::{transition, PhaseUpdate, PlanState};
+    use edda_ledger::Ledger;
+
+    fn sha(ch: char) -> String {
+        std::iter::repeat_n(ch, 40).collect()
+    }
+
+    /// Workspace with ledger + a conductor state where phase "impl" is
+    /// AWAITING_VERDICT on gate_sha("a"*40), attempt 1.
+    fn awaiting_ws(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("edda_cmdphase_{name}_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        Ledger::ensure_initialized(&dir).unwrap();
+
+        let plan = parse_plan("name: gated\nphases:\n  - id: impl\n    prompt: x\n").unwrap();
+        let mut state = PlanState::from_plan(&plan, "plan.yaml");
+        transition(
+            &mut state,
+            "impl",
+            PhaseStatus::Pending,
+            PhaseStatus::Running,
+            Some(PhaseUpdate {
+                attempts: Some(1),
+                ..Default::default()
+            }),
+        )
+        .unwrap();
+        transition(
+            &mut state,
+            "impl",
+            PhaseStatus::Running,
+            PhaseStatus::Checking,
+            None,
+        )
+        .unwrap();
+        transition(
+            &mut state,
+            "impl",
+            PhaseStatus::Checking,
+            PhaseStatus::AwaitingVerdict,
+            Some(PhaseUpdate {
+                gate_sha: Some(sha('a')),
+                gate_entered_at: Some("2026-01-01T00:00:00Z".into()),
+                ..Default::default()
+            }),
+        )
+        .unwrap();
+        edda_conductor::state::persist::save_state(&dir, &state).unwrap();
+        dir
+    }
+
+    #[test]
+    fn sugar_requires_plan_slash_phase_subject() {
+        let ws = awaiting_ws("subject");
+        let err = resolve_gate(&ws, "gated-impl").unwrap_err().to_string();
+        assert!(err.contains("<plan-name>/<phase-id>"), "unexpected: {err}");
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn sugar_missing_plan_is_loud() {
+        let ws = awaiting_ws("noplan");
+        let err = resolve_gate(&ws, "no-such-plan/impl")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("no conductor state"), "unexpected: {err}");
+        assert!(err.contains("state.json"), "unexpected: {err}");
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn sugar_missing_phase_lists_candidates() {
+        let ws = awaiting_ws("nophase");
+        let err = resolve_gate(&ws, "gated/wrong-id").unwrap_err().to_string();
+        assert!(err.contains("no phase \"wrong-id\""), "unexpected: {err}");
+        assert!(err.contains("impl"), "unexpected: {err}");
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn sugar_refuses_phase_not_awaiting_verdict() {
+        let ws = awaiting_ws("notawaiting");
+        // Reset the phase to Pending so the gate is not live.
+        let mut state = edda_conductor::state::persist::load_state(&ws, "gated")
+            .unwrap()
+            .unwrap();
+        state.phases[0].status = PhaseStatus::Pending;
+        edda_conductor::state::persist::save_state(&ws, &state).unwrap();
+
+        let err = resolve_gate(&ws, "gated/impl").unwrap_err().to_string();
+        assert!(err.contains("not awaiting a verdict"), "unexpected: {err}");
+        assert!(err.to_lowercase().contains("pending"), "unexpected: {err}");
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn sugar_resolves_sha_and_session_from_conductor_state() {
+        let ws = awaiting_ws("resolve");
+        let gate = resolve_gate(&ws, "gated/impl").unwrap();
+        assert_eq!(gate.gate_sha, sha('a'));
+        assert_eq!(
+            gate.session_id,
+            phase_session_id_attempt("gated", "impl", 1).to_string()
+        );
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn sugar_approve_records_verdict_through_the_verdict_path() {
+        let ws = awaiting_ws("approve");
+        run_gate_sugar(
+            PhaseCmd::Approve {
+                subject: "gated/impl".into(),
+                sha: None,
+                comment: Some("looks good".into()),
+                session: None,
+            },
+            &ws,
+        )
+        .unwrap();
+        let ledger = Ledger::open(&ws).unwrap();
+        let verdict = ledger
+            .latest_verdict("gated/impl", &sha('a'))
+            .unwrap()
+            .expect("verdict should be recorded at the resolved gate_sha");
+        assert_eq!(verdict.payload.decision, VerdictDecision::Approved);
+        assert_eq!(verdict.payload.comment.as_deref(), Some("looks good"));
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn sugar_reject_records_verdict_and_keeps_comment() {
+        let ws = awaiting_ws("reject");
+        run_gate_sugar(
+            PhaseCmd::Reject {
+                subject: "gated/impl".into(),
+                comment: "tests fail".into(),
+                sha: None,
+                session: None,
+            },
+            &ws,
+        )
+        .unwrap();
+        let ledger = Ledger::open(&ws).unwrap();
+        let verdict = ledger
+            .latest_verdict("gated/impl", &sha('a'))
+            .unwrap()
+            .expect("verdict should be recorded");
+        assert_eq!(verdict.payload.decision, VerdictDecision::Rejected);
+        assert_eq!(verdict.payload.comment.as_deref(), Some("tests fail"));
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn sugar_sha_override_wins_and_short_sha_still_refused() {
+        let ws = awaiting_ws("override");
+        // Explicit --sha override is honored...
+        let good = sha('f');
+        run_gate_sugar(
+            PhaseCmd::Approve {
+                subject: "gated/impl".into(),
+                sha: Some(good.clone()),
+                comment: None,
+                session: None,
+            },
+            &ws,
+        )
+        .unwrap();
+        let ledger = Ledger::open(&ws).unwrap();
+        assert!(ledger
+            .latest_verdict("gated/impl", &good)
+            .unwrap()
+            .is_some());
+
+        // ...but the verdict path's 40-hex validation still applies.
+        let err = run_gate_sugar(
+            PhaseCmd::Approve {
+                subject: "gated/impl".into(),
+                sha: Some("abc123".into()),
+                comment: None,
+                session: None,
+            },
+            &ws,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("40-hex"), "unexpected: {err}");
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn sugar_reject_requires_comment_at_parse_time() {
+        use clap::Parser;
+        #[derive(Debug, Parser)]
+        struct Cli {
+            #[command(subcommand)]
+            cmd: PhaseCmd,
+        }
+        let err = Cli::try_parse_from(["edda", "reject", "gated/impl"])
+            .expect_err("missing --comment must be a parse error");
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
     }
 }

--- a/crates/edda-cli/src/cmd_phase.rs
+++ b/crates/edda-cli/src/cmd_phase.rs
@@ -62,12 +62,19 @@ pub(crate) struct ResolvedGate {
 
 /// Resolve subject/gate_sha/session for a gated phase from conductor state.
 ///
-/// Refuses LOUDLY and immediately when the plan does not exist, the phase
-/// does not exist, or the phase is not actually in AWAITING_VERDICT — the
+/// `sha_override` is an explicit audit override (`--sha`): when the persisted
+/// state has no `gate_sha`, the override is used instead of failing — an
+/// explicit `--sha` must always be able to record a verdict. Without an
+/// override, a missing `gate_sha` still refuses LOUDLY, as does a missing
+/// plan/phase or a phase not actually in AWAITING_VERDICT — the
 /// whole point is to turn today's silent-eternal-wait failures into instant
 /// errors. Resolution reads the same state.json the conductor itself uses;
 /// no new notion of "where" is introduced (that is #543's problem, not ours).
-pub(crate) fn resolve_gate(repo_root: &Path, subject: &str) -> anyhow::Result<ResolvedGate> {
+pub(crate) fn resolve_gate(
+    repo_root: &Path,
+    subject: &str,
+    sha_override: Option<&str>,
+) -> anyhow::Result<ResolvedGate> {
     let (plan_name, phase_id) = subject.split_once('/').ok_or_else(|| {
         anyhow::anyhow!(
             "subject must be <plan-name>/<phase-id> (got \"{subject}\") — \
@@ -104,12 +111,16 @@ pub(crate) fn resolve_gate(repo_root: &Path, subject: &str) -> anyhow::Result<Re
         );
     }
 
-    let gate_sha = phase.gate_sha.clone().ok_or_else(|| {
-        anyhow::anyhow!(
+    let gate_sha = match phase.gate_sha.clone() {
+        Some(gate_sha) => gate_sha,
+        // An explicit --sha is an audit override: it must work even when the
+        // persisted state never recorded a gate_sha (GH-547 review, round 1).
+        None if sha_override.is_some() => sha_override.expect("checked above").to_string(),
+        None => anyhow::bail!(
             "phase \"{plan_name}/{phase_id}\" is awaiting_verdict but has no gate_sha \
              recorded; pass --sha explicitly"
-        )
-    })?;
+        ),
+    };
 
     // Same deterministic session the runner used for this attempt
     // (edda-conductor/src/runner/sequential.rs); phase.attempts >= 1 by the
@@ -147,7 +158,7 @@ pub fn run_gate_sugar(cmd: PhaseCmd, repo_root: &Path) -> anyhow::Result<()> {
         ),
     };
 
-    let gate = resolve_gate(repo_root, &subject)?;
+    let gate = resolve_gate(repo_root, &subject, sha_override.as_deref())?;
     let sha = sha_override.unwrap_or_else(|| gate.gate_sha.clone());
     let session = session_override.unwrap_or_else(|| gate.session_id.clone());
     println!(
@@ -362,7 +373,9 @@ mod tests {
     #[test]
     fn sugar_requires_plan_slash_phase_subject() {
         let ws = awaiting_ws("subject");
-        let err = resolve_gate(&ws, "gated-impl").unwrap_err().to_string();
+        let err = resolve_gate(&ws, "gated-impl", None)
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("<plan-name>/<phase-id>"), "unexpected: {err}");
         let _ = std::fs::remove_dir_all(&ws);
     }
@@ -370,7 +383,7 @@ mod tests {
     #[test]
     fn sugar_missing_plan_is_loud() {
         let ws = awaiting_ws("noplan");
-        let err = resolve_gate(&ws, "no-such-plan/impl")
+        let err = resolve_gate(&ws, "no-such-plan/impl", None)
             .unwrap_err()
             .to_string();
         assert!(err.contains("no conductor state"), "unexpected: {err}");
@@ -381,7 +394,9 @@ mod tests {
     #[test]
     fn sugar_missing_phase_lists_candidates() {
         let ws = awaiting_ws("nophase");
-        let err = resolve_gate(&ws, "gated/wrong-id").unwrap_err().to_string();
+        let err = resolve_gate(&ws, "gated/wrong-id", None)
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("no phase \"wrong-id\""), "unexpected: {err}");
         assert!(err.contains("impl"), "unexpected: {err}");
         let _ = std::fs::remove_dir_all(&ws);
@@ -397,7 +412,9 @@ mod tests {
         state.phases[0].status = PhaseStatus::Pending;
         edda_conductor::state::persist::save_state(&ws, &state).unwrap();
 
-        let err = resolve_gate(&ws, "gated/impl").unwrap_err().to_string();
+        let err = resolve_gate(&ws, "gated/impl", None)
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("not awaiting a verdict"), "unexpected: {err}");
         assert!(err.to_lowercase().contains("pending"), "unexpected: {err}");
         let _ = std::fs::remove_dir_all(&ws);
@@ -406,7 +423,7 @@ mod tests {
     #[test]
     fn sugar_resolves_sha_and_session_from_conductor_state() {
         let ws = awaiting_ws("resolve");
-        let gate = resolve_gate(&ws, "gated/impl").unwrap();
+        let gate = resolve_gate(&ws, "gated/impl", None).unwrap();
         assert_eq!(gate.gate_sha, sha('a'));
         assert_eq!(
             gate.session_id,
@@ -458,6 +475,46 @@ mod tests {
             .expect("verdict should be recorded");
         assert_eq!(verdict.payload.decision, VerdictDecision::Rejected);
         assert_eq!(verdict.payload.comment.as_deref(), Some("tests fail"));
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn sugar_sha_override_applies_even_when_state_has_no_gate_sha() {
+        let ws = awaiting_ws("override-no-state-sha");
+        // State in AWAITING_VERDICT but with gate_sha absent — a shape
+        // PhaseState permits.
+        let mut state = edda_conductor::state::persist::load_state(&ws, "gated")
+            .unwrap()
+            .unwrap();
+        state.phases[0].gate_sha = None;
+        edda_conductor::state::persist::save_state(&ws, &state).unwrap();
+
+        // Without an override, resolution still refuses loudly...
+        let err = resolve_gate(&ws, "gated/impl", None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("no gate_sha"), "unexpected: {err}");
+        assert!(err.contains("pass --sha explicitly"), "unexpected: {err}");
+
+        // ...but an explicit --sha must override the missing gate_sha.
+        let good = sha('f');
+        run_gate_sugar(
+            PhaseCmd::Approve {
+                subject: "gated/impl".into(),
+                sha: Some(good.clone()),
+                comment: Some("audited manually".into()),
+                session: None,
+            },
+            &ws,
+        )
+        .unwrap();
+        let ledger = Ledger::open(&ws).unwrap();
+        let verdict = ledger
+            .latest_verdict("gated/impl", &good)
+            .unwrap()
+            .expect("verdict should be recorded at the explicit --sha");
+        assert_eq!(verdict.payload.decision, VerdictDecision::Approved);
+        assert_eq!(verdict.payload.comment.as_deref(), Some("audited manually"));
         let _ = std::fs::remove_dir_all(&ws);
     }
 

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -475,11 +475,13 @@ enum Command {
         #[command(subcommand)]
         cmd: IntakeCmd,
     },
-    /// Show agent phase detection status
+    /// Agent phase map, plus approve/reject sugar over `edda verdict` (GH-547)
     Phase {
-        /// Output as JSON
+        /// Output as JSON (status view only)
         #[arg(long)]
         json: bool,
+        #[command(subcommand)]
+        cmd: Option<cmd_phase::PhaseCmd>,
     },
     /// Scan and record PR events from GitHub
     Prs {
@@ -1243,7 +1245,10 @@ fn main() -> anyhow::Result<()> {
         Command::Intake { cmd } => match cmd {
             IntakeCmd::Github { issue_id } => cmd_intake::execute_github(&repo_root, issue_id),
         },
-        Command::Phase { json } => cmd_phase::execute(&repo_root, json),
+        Command::Phase { json, cmd } => match cmd {
+            Some(phase_cmd) => cmd_phase::run_gate_sugar(phase_cmd, &repo_root),
+            None => cmd_phase::execute(&repo_root, json),
+        },
         Command::Prs { cmd } => cmd_prs::run_prs(cmd, &repo_root),
         Command::Pipeline { cmd } => match cmd {
             PipelineCmd::Run { issue_id, dry_run } => {


### PR DESCRIPTION
Closes #547

## Summary

`edda phase approve <plan>/<phase>` and `edda phase reject <plan>/<phase> --comment ...` now resolve all three error-prone inputs from the persisted conductor state instead of requiring hand-copied identifiers (the third input — the plan's session — comes from the issue comment):

- **subject** → parsed from `<plan>/<phase>`, validated against the state file
- **gate_sha** → `PhaseState.gate_sha` captured at gate entry (`--sha` remains as an explicit override)
- **session** → the deterministic per-attempt conductor session (`phase_session_id_attempt(plan, phase, attempts)`), the same id the runner used for the gated turn (`--session` remains as an explicit override)

Refusal is loud and immediate — the whole point of the issue:

- plan has no conductor state → error naming the exact `state.json` path expected
- phase does not exist → error listing the plan's actual phase ids
- phase is not in `AWAITING_VERDICT` → error showing the actual status, before any verdict is written

This is sugar over `edda verdict`, not a replacement: recording goes through the unchanged `cmd_verdict::do_record` path, so 40-hex SHA validation, mandatory reject `--comment`, actor attribution, and secret redaction are all inherited — none of it duplicated. `edda verdict approve|reject` itself is untouched; bare `edda phase` (the agent phase map) still works exactly as before.

Resolution reads the same `.edda/conductor/<plan>/state.json` the conductor itself uses via the existing public `state::persist::load_state` — no new notion of "where" was needed, and no fourth authority was introduced (#543 remains the fix for that). Writes stay inside `crates/edda-cli`; conductor state/machine.rs, runner/, and agent/ are untouched (read-only use of their existing public functions).

## Verified fail-without-fix

Stashed the change on 749570c: pre-fix binary refuses the surface outright — `edda phase approve x/y` → `error: unexpected argument 'approve' found` — so every regression test necessarily fails without the fix; restored and re-ran.

## Gates run green

- `cargo fmt --all --check` ✅
- `cargo clippy -p edda --all-targets -- -D warnings` ✅
- `cargo test -p edda` ✅ (374 passed incl. 9 new `sugar_*` tests; 0 failed)