### PR TITLE
feat(conductor): persist codex session-to-thread map across dispatch processes

### DIFF
--- a/crates/edda-cli/src/agent_kind.rs
+++ b/crates/edda-cli/src/agent_kind.rs
@@ -42,14 +42,21 @@ impl AgentKind {
 
 // ── Launcher factory ──
 
-/// Per-backend options for [`build_launcher`]: verbose streaming and, for
-/// the backend that tees transcripts, the directory to tee into.
+/// Per-backend options for [`build_launcher`]: verbose streaming, the
+/// transcript directory for the backend that tees transcripts, and whether
+/// codex thread persistence is enabled.
 pub(crate) struct LauncherOptions {
     /// Stream live agent activity while the phase runs.
     pub verbose: bool,
     /// If set, claude captures raw agent stdout to
     /// `{transcript_dir}/{phase_id}-{session_id_prefix}.jsonl`.
     pub transcript_dir: Option<PathBuf>,
+    /// Persist codex's session→thread map in the per-user edda store so a
+    /// repeated `--session-id` resumes across invocations. Dispatch-scoped
+    /// (GH-535 round 1): `edda dispatch` sets this, `edda conduct` must not
+    /// — conduct session ids are deterministic per plan/phase/attempt and
+    /// its behavior must stay byte-identical with the pre-persistence path.
+    pub persistent_codex_threads: bool,
 }
 
 /// Construct and probe (`verify_available`) the launcher for `agent`.
@@ -57,8 +64,9 @@ pub(crate) struct LauncherOptions {
 /// This is the single construct-and-probe table: the backend list exists in
 /// exactly one place, shared by `edda conduct run` (which threads
 /// `--verbose` and a transcript dir for claude) and `edda dispatch` (which
-/// uses defaults). pi has no transcript tee capability yet, so the
-/// transcript dir is claude-only — see [`AgentKind::writes_transcripts`].
+/// uses defaults plus codex thread persistence). pi has no transcript tee
+/// capability yet, so the transcript dir is claude-only — see
+/// [`AgentKind::writes_transcripts`].
 pub(crate) fn build_launcher(
     agent: AgentKind,
     options: LauncherOptions,
@@ -76,7 +84,10 @@ pub(crate) fn build_launcher(
             Box::new(launcher)
         }
         AgentKind::Codex => {
-            let launcher = CodexLauncher::new().with_verbose(options.verbose);
+            let mut launcher = CodexLauncher::new().with_verbose(options.verbose);
+            if options.persistent_codex_threads {
+                launcher = launcher.with_persistent_threads();
+            }
             launcher.verify_available()?;
             Box::new(launcher)
         }

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -233,6 +233,11 @@ pub fn run(
         LauncherOptions {
             verbose,
             transcript_dir: Some(transcript_dir.clone()),
+            // Conduct never persists codex threads (GH-535 round 1): its
+            // session ids are deterministic per plan/phase/attempt, so a
+            // persisted binding could leak a stale thread/resume into a
+            // later invocation and every turn would gain store I/O.
+            persistent_codex_threads: false,
         },
     )?;
     let engine = CheckEngine::new(cwd.clone());

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -31,12 +31,11 @@ pub struct DispatchArgs {
     #[arg(long)]
     pub prompt_file: String,
     /// Session id passed to the backend verbatim. Continuity semantics are
-    /// per-backend: claude and pi persist conversations externally, so the
-    /// same id resumes the prior conversation across invocations; codex
-    /// keeps its thread state in-process, so each `edda dispatch`
-    /// invocation starts a fresh conversation no matter what id you pass
-    /// (a warning is printed). Generated and printed when omitted so the
-    /// caller can reuse it on the next call.
+    /// per-backend, and all three persist conversations across invocations:
+    /// claude and pi delegate to their backends, and codex's session→thread
+    /// map is persisted in the per-user edda store (GH-535), so the same id
+    /// resumes the prior codex conversation. Generated and printed when
+    /// omitted so the caller can reuse it on the next call.
     #[arg(long)]
     pub session_id: Option<String>,
     /// Working directory for the agent (default: current directory)
@@ -233,31 +232,12 @@ pub fn generate_session_id() -> String {
     phase_session_id("dispatch", &unique).to_string()
 }
 
-/// One-line startup warning when an explicit `--session-id` cannot do what
-/// the caller probably expects.
-///
-/// claude and pi delegate continuity to their backends (external
-/// persistence), so a repeated id really does resume the prior
-/// conversation across dispatch invocations. CodexLauncher keeps
-/// continuity in its in-memory threads map, and `build_launcher`
-/// constructs a fresh launcher per process — so for codex the map is
-/// always empty, resume is `None`, and two calls with the same id are two
-/// unrelated conversations. Persistence for codex is routed as a follow-up
-/// issue; until then this warning is the honest surface. Mirrors
-/// [`budget_warning_for_agent`]'s tone.
-fn session_id_warning_for_agent(agent: AgentKind, explicit_id: bool) -> Option<String> {
-    if agent == AgentKind::Codex && explicit_id {
-        Some(
-            "Warning: codex thread state is per-process, so --session-id does not resume \
-             a prior conversation across dispatch invocations (claude/pi do persist); \
-             codex has no cross-invocation continuity today, and conduct shares the \
-             limitation for the same reason (persistence is tracked as GH-535)."
-                .to_owned(),
-        )
-    } else {
-        None
-    }
-}
+// The #534 round-2 startup warning for codex `--session-id` is gone
+// (GH-535): codex's session→thread map is persisted in the per-user edda
+// store, so an explicit id now resumes across dispatch invocations like
+// claude and pi. The warning survives only in the launcher, for the one
+// genuinely non-resumable case — a corrupt persisted map, which degrades
+// to `thread/start`.
 
 // ── Run ──
 
@@ -294,9 +274,6 @@ fn run_inner(args: DispatchArgs) -> Result<i32> {
     };
 
     if let Some(warning) = budget_warning_for_agent(args.agent, args.budget_usd.is_some()) {
-        eprintln!("{warning}");
-    }
-    if let Some(warning) = session_id_warning_for_agent(args.agent, args.session_id.is_some()) {
         eprintln!("{warning}");
     }
 
@@ -711,24 +688,6 @@ mod tests {
             "default",
         ]);
         assert_eq!(args.permission_mode, "default");
-    }
-
-    // ── codex --session-id warning ──
-
-    #[test]
-    fn session_id_warning_fires_only_for_codex_with_an_explicit_id() {
-        let warning =
-            session_id_warning_for_agent(AgentKind::Codex, true).expect("warning expected");
-        assert!(warning.contains("codex"), "{warning}");
-        assert!(warning.contains("per-process"), "{warning}");
-        assert!(warning.contains("does not resume"), "{warning}");
-        assert!(warning.contains("conduct"), "{warning}");
-
-        // A generated id (flag omitted) never warns, and neither do the
-        // backends whose persistence makes the id a real resume handle.
-        assert!(session_id_warning_for_agent(AgentKind::Codex, false).is_none());
-        assert!(session_id_warning_for_agent(AgentKind::Claude, true).is_none());
-        assert!(session_id_warning_for_agent(AgentKind::Pi, true).is_none());
     }
 
     // ── End-to-end-ish run through MockLauncher ──

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -282,6 +282,10 @@ fn run_inner(args: DispatchArgs) -> Result<i32> {
         LauncherOptions {
             verbose: false,
             transcript_dir: None,
+            // Dispatch is the persistence scope (GH-535): a caller-chosen
+            // --session-id must resume the conversation a previous dispatch
+            // recorded.
+            persistent_codex_threads: true,
         },
     )?;
     let phase = build_phase(

--- a/crates/edda-cli/tests/dispatch_codex_threads.rs
+++ b/crates/edda-cli/tests/dispatch_codex_threads.rs
@@ -1,0 +1,195 @@
+//! Cross-process codex thread resume (GH-535, round 1 review P1-3).
+//!
+//! The in-crate launcher tests build two launchers inside one test process,
+//! which cannot prove the separate-process doneWhen. This test spawns two
+//! real `edda dispatch` OS processes — the actual binary, through
+//! `run_inner`/`build_launcher` and the default `edda_store::store_root()`
+//! resolution (isolated to a temp store via `EDDA_STORE_ROOT`) — against a
+//! scripted fake app-server. The first process records
+//! sess→thread via `thread/start`; the second must send `thread/resume`
+//! (the fake answers "resumed answer" only on that path), proving two
+//! separate processes share one conversation.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Write a fake `codex` executable: a wrapper tolerating the launcher's
+/// `app-server` argument, feeding a scripted JSON-RPC app-server. First
+/// thread request decides the path: `thread/resume` answers t-2 with
+/// "resumed answer"; anything else (thread/start) answers t-1 with
+/// "turn complete". Request ids follow the client's protocol: initialize=1,
+/// open=2, turn/start=3.
+fn write_fake_codex_bin(dir: &Path) -> Result<PathBuf, std::io::Error> {
+    let body = if cfg!(windows) {
+        r#"# The client sends the `initialized` notification after the initialize
+# response; consume it so $req below is the first thread request.
+Read-Line
+$req = [Console]::In.ReadLine()
+if ($null -eq $req) { exit 0 }
+if ($req -match 'thread/resume') {
+  Write-Line '{"id":2,"result":{"thread":{"id":"t-2"}}}'
+  Read-Line
+  Write-Line '{"id":3,"result":{"turn":{"id":"turn-2"}}}'
+  Write-Line '{"method":"item/completed","params":{"threadId":"t-2","turnId":"turn-2","item":{"type":"agentMessage","text":"resumed answer"}}}'
+  Write-Line '{"method":"turn/completed","params":{"threadId":"t-2","turn":{"id":"turn-2","status":"completed"}}}'
+} else {
+  Write-Line '{"id":2,"result":{"thread":{"id":"t-1"}}}'
+  Read-Line
+  Write-Line '{"id":3,"result":{"turn":{"id":"turn-1"}}}'
+  Write-Line '{"method":"item/completed","params":{"threadId":"t-1","turnId":"turn-1","item":{"type":"agentMessage","text":"turn complete"}}}'
+  Write-Line '{"method":"turn/completed","params":{"threadId":"t-1","turn":{"id":"turn-1","status":"completed"}}}'
+}
+# A short tail sleep only: the responses are already buffered in the pipe
+# when the fake exits, and a long-lived grandchild would hold the inherited
+# stdout open and stall `Command::output()` past edda's own exit.
+Start-Sleep -Seconds 5"#
+    } else {
+        r#"# The client sends the `initialized` notification after the initialize
+# response; consume it so $req below is the first thread request.
+read_line
+IFS= read -r req || exit 0
+case "$req" in *'"thread/resume"'*)
+  write_line '{"id":2,"result":{"thread":{"id":"t-2"}}}'
+  read_line
+  write_line '{"id":3,"result":{"turn":{"id":"turn-2"}}}'
+  write_line '{"method":"item/completed","params":{"threadId":"t-2","turnId":"turn-2","item":{"type":"agentMessage","text":"resumed answer"}}}'
+  write_line '{"method":"turn/completed","params":{"threadId":"t-2","turn":{"id":"turn-2","status":"completed"}}}'
+  ;;
+*)
+  write_line '{"id":2,"result":{"thread":{"id":"t-1"}}}'
+  read_line
+  write_line '{"id":3,"result":{"turn":{"id":"turn-1"}}}'
+  write_line '{"method":"item/completed","params":{"threadId":"t-1","turnId":"turn-1","item":{"type":"agentMessage","text":"turn complete"}}}'
+  write_line '{"method":"turn/completed","params":{"threadId":"t-1","turn":{"id":"turn-1","status":"completed"}}}'
+  ;;
+esac
+# A short tail sleep only: the responses are already buffered in the pipe
+# when the fake exits, and a long-lived grandchild would hold the inherited
+# stdout open and stall `Command::output()` past edda's own exit.
+sleep 5"#
+    };
+
+    if cfg!(windows) {
+        let script = dir.join("fake-app-server.ps1");
+        std::fs::write(
+            &script,
+            format!(
+                "$ErrorActionPreference = 'Stop'\nfunction Read-Line {{ if ($null -eq [Console]::In.ReadLine()) {{ exit 0 }} }}\nfunction Write-Line([string]$line) {{ [Console]::Out.WriteLine($line); [Console]::Out.Flush() }}\nRead-Line\nWrite-Line '{{\"id\":1,\"result\":{{}}}}'\n{body}\n"
+            ),
+        )?;
+        let wrapper = dir.join("fake-codex.cmd");
+        std::fs::write(
+            &wrapper,
+            format!(
+                "@echo off\r\npowershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"{}\" %*\r\n",
+                script.display()
+            ),
+        )?;
+        Ok(wrapper)
+    } else {
+        #[cfg(unix)]
+        {
+            let script = dir.join("fake-app-server.sh");
+            std::fs::write(
+                &script,
+                format!(
+                    "#!/bin/sh\nread_line() {{ IFS= read -r _ || exit 0; }}\nwrite_line() {{ printf '%s\\n' \"$1\"; }}\nread_line\nwrite_line '{{\"id\":1,\"result\":{{}}}}'\n{body}\n"
+                ),
+            )?;
+            let wrapper = dir.join("fake-codex.sh");
+            std::fs::write(
+                &wrapper,
+                format!("#!/bin/sh\nexec /bin/sh '{}' \"$@\"\n", script.display()),
+            )?;
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o755))?;
+            Ok(wrapper)
+        }
+        #[cfg(not(unix))]
+        {
+            unreachable!("non-Windows, non-unix platform")
+        }
+    }
+}
+
+fn run_dispatch(
+    edda_bin: &Path,
+    codex_bin: &Path,
+    store_root: &Path,
+    cwd: &Path,
+    prompt_file: &Path,
+) -> Result<String, String> {
+    let output = Command::new(edda_bin)
+        .args([
+            "dispatch",
+            "--agent",
+            "codex",
+            "--session-id",
+            "sess-cross-proc",
+            "--prompt-file",
+        ])
+        .arg(prompt_file)
+        .arg("--cwd")
+        .arg(cwd)
+        .env("EDDA_STORE_ROOT", store_root)
+        .env("EDDA_CODEX_BIN", codex_bin)
+        // The fake codex must also survive `verify_available` (`codex
+        // --version`), whose child inherits this stdin; keep it detached so
+        // the fake's readline sees EOF instead of the test console.
+        .stdin(std::process::Stdio::null())
+        .output()
+        .map_err(|e| e.to_string())?;
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "edda dispatch failed ({}):\nstdout:\n{stdout}\nstderr:\n{stderr}",
+            output.status
+        ));
+    }
+    Ok(stdout)
+}
+
+#[test]
+fn two_dispatch_processes_share_one_codex_conversation() {
+    let root = tempfile::tempdir().expect("test root");
+    let store_root = root.path().join("store");
+    let cwd = root.path().join("repo");
+    std::fs::create_dir_all(&cwd).expect("cwd");
+    let prompt_file = root.path().join("prompt.txt");
+    std::fs::write(&prompt_file, "do the thing").expect("prompt");
+
+    let fake_dir = tempfile::tempdir().expect("fake dir");
+    let codex_bin = write_fake_codex_bin(fake_dir.path()).expect("fake codex written");
+
+    let edda_bin = PathBuf::from(env!("CARGO_BIN_EXE_edda"));
+
+    // Process 1: no persisted map, so this is a plain thread/start.
+    let first = run_dispatch(&edda_bin, &codex_bin, &store_root, &cwd, &prompt_file)
+        .expect("first dispatch process runs");
+    assert!(
+        first.contains("turn complete"),
+        "first dispatch should complete via thread/start, got:\n{first}"
+    );
+
+    // The first process recorded the binding in the shared per-user store.
+    let map = store_root
+        .join("projects")
+        .join(edda_store::project_id(&cwd))
+        .join("state")
+        .join("codex-threads.json");
+    let persisted = std::fs::read_to_string(&map).expect("map persisted by first process");
+    assert!(
+        persisted.contains(r#""sess-cross-proc":"t-1""#),
+        "map should record sess→t-1, got: {persisted}"
+    );
+
+    // Process 2: a genuinely separate OS process must load the map and
+    // resume — the fake only produces "resumed answer" on thread/resume.
+    let second = run_dispatch(&edda_bin, &codex_bin, &store_root, &cwd, &prompt_file)
+        .expect("second dispatch process runs");
+    assert!(
+        second.contains("resumed answer"),
+        "second dispatch process should resume the thread the first one recorded, got:\n{second}"
+    );
+}

--- a/crates/edda-conductor/src/agent/codex_app_server.rs
+++ b/crates/edda-conductor/src/agent/codex_app_server.rs
@@ -431,6 +431,11 @@ pub(crate) mod fake_support {
         /// JSON-RPC error, so a test fails loudly instead of silently
         /// passing through the start path.
         ResumeOnly,
+        /// Rejects `thread/resume` with a JSON-RPC error (simulating a
+        /// stale persisted binding the server no longer knows), but
+        /// answers `thread/start` with t-1 + one completed turn ("fresh
+        /// answer"). Drives the stale-binding degrade path.
+        ResumeErrorThenStart,
         Idle,
     }
 
@@ -555,6 +560,9 @@ pub(crate) mod fake_support {
             FakeScenario::ResumeOnly => {
                 "$req = [Console]::In.ReadLine()\nif ($null -eq $req) { exit 0 }\nif ($req -notmatch 'thread/resume') { Write-Line '{\"id\":2,\"error\":{\"code\":-1,\"message\":\"expected thread/resume\"}}'; exit 1 }\nWrite-Line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"t-2\"}}}'\nRead-Line\nWrite-Line '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-2\"}}}'\nWrite-Line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-2\",\"turnId\":\"turn-2\",\"item\":{\"type\":\"agentMessage\",\"text\":\"resumed answer\"}}}'\nWrite-Line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-2\",\"turn\":{\"id\":\"turn-2\",\"status\":\"completed\"}}}'\nStart-Sleep -Seconds 60"
             }
+            FakeScenario::ResumeErrorThenStart => {
+                "$req = [Console]::In.ReadLine()\nif ($null -eq $req) { exit 0 }\nif ($req -match 'thread/resume') { Write-Line '{\"id\":2,\"error\":{\"code\":-1,\"message\":\"unknown thread\"}}'; exit 1 }\nWrite-Line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"t-1\"}}}'\nRead-Line\nWrite-Line '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-1\"}}}'\nWrite-Line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-1\",\"turnId\":\"turn-1\",\"item\":{\"type\":\"agentMessage\",\"text\":\"fresh answer\"}}}'\nWrite-Line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-1\",\"turn\":{\"id\":\"turn-1\",\"status\":\"completed\"}}}'\nStart-Sleep -Seconds 60"
+            }
             FakeScenario::Idle => "Start-Sleep -Seconds 60",
         };
         format!(
@@ -588,6 +596,9 @@ pub(crate) mod fake_support {
             }
             FakeScenario::ResumeOnly => {
                 "IFS= read -r resume_request || exit 0\ncase \"$resume_request\" in *'\"thread/resume\"'*) ;; *) write_line '{\"id\":2,\"error\":{\"code\":-1,\"message\":\"expected thread/resume\"}}'; exit 1;; esac\nwrite_line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"t-2\"}}}'\nread_line\nwrite_line '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-2\"}}}'\nwrite_line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-2\",\"turnId\":\"turn-2\",\"item\":{\"type\":\"agentMessage\",\"text\":\"resumed answer\"}}}'\nwrite_line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-2\",\"turn\":{\"id\":\"turn-2\",\"status\":\"completed\"}}}'\nsleep 60"
+            }
+            FakeScenario::ResumeErrorThenStart => {
+                "IFS= read -r req || exit 0\ncase \"$req\" in *'\"thread/resume\"'*) write_line '{\"id\":2,\"error\":{\"code\":-1,\"message\":\"unknown thread\"}}'; exit 1;; esac\nwrite_line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"t-1\"}}}'\nread_line\nwrite_line '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-1\"}}}'\nwrite_line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-1\",\"turnId\":\"turn-1\",\"item\":{\"type\":\"agentMessage\",\"text\":\"fresh answer\"}}}'\nwrite_line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-1\",\"turn\":{\"id\":\"turn-1\",\"status\":\"completed\"}}}'\nsleep 60"
             }
             FakeScenario::Idle => "sleep 60",
         };

--- a/crates/edda-conductor/src/agent/codex_app_server.rs
+++ b/crates/edda-conductor/src/agent/codex_app_server.rs
@@ -436,6 +436,12 @@ pub(crate) mod fake_support {
         /// answers `thread/start` with t-1 + one completed turn ("fresh
         /// answer"). Drives the stale-binding degrade path.
         ResumeErrorThenStart,
+        /// Rejects the first thread request — `thread/resume` *or*
+        /// `thread/start` — with a JSON-RPC error. Drives the failed
+        /// fallback branch: after a rejected persisted resume, the fresh
+        /// `thread/start` retry fails too, so the phase cannot recover and
+        /// the erased stale binding must still not survive on disk.
+        ResumeErrorThenStartError,
         Idle,
     }
 
@@ -563,6 +569,9 @@ pub(crate) mod fake_support {
             FakeScenario::ResumeErrorThenStart => {
                 "$req = [Console]::In.ReadLine()\nif ($null -eq $req) { exit 0 }\nif ($req -match 'thread/resume') { Write-Line '{\"id\":2,\"error\":{\"code\":-1,\"message\":\"unknown thread\"}}'; exit 1 }\nWrite-Line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"t-1\"}}}'\nRead-Line\nWrite-Line '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-1\"}}}'\nWrite-Line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-1\",\"turnId\":\"turn-1\",\"item\":{\"type\":\"agentMessage\",\"text\":\"fresh answer\"}}}'\nWrite-Line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-1\",\"turn\":{\"id\":\"turn-1\",\"status\":\"completed\"}}}'\nStart-Sleep -Seconds 60"
             }
+            FakeScenario::ResumeErrorThenStartError => {
+                "Read-Line\nWrite-Line '{\"id\":2,\"error\":{\"code\":-1,\"message\":\"unknown thread\"}}'\nStart-Sleep -Seconds 60"
+            }
             FakeScenario::Idle => "Start-Sleep -Seconds 60",
         };
         format!(
@@ -599,6 +608,9 @@ pub(crate) mod fake_support {
             }
             FakeScenario::ResumeErrorThenStart => {
                 "IFS= read -r req || exit 0\ncase \"$req\" in *'\"thread/resume\"'*) write_line '{\"id\":2,\"error\":{\"code\":-1,\"message\":\"unknown thread\"}}'; exit 1;; esac\nwrite_line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"t-1\"}}}'\nread_line\nwrite_line '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-1\"}}}'\nwrite_line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-1\",\"turnId\":\"turn-1\",\"item\":{\"type\":\"agentMessage\",\"text\":\"fresh answer\"}}}'\nwrite_line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-1\",\"turn\":{\"id\":\"turn-1\",\"status\":\"completed\"}}}'\nsleep 60"
+            }
+            FakeScenario::ResumeErrorThenStartError => {
+                "read_line\nwrite_line '{\"id\":2,\"error\":{\"code\":-1,\"message\":\"unknown thread\"}}'\nsleep 60"
             }
             FakeScenario::Idle => "sleep 60",
         };

--- a/crates/edda-conductor/src/agent/codex_app_server.rs
+++ b/crates/edda-conductor/src/agent/codex_app_server.rs
@@ -425,6 +425,12 @@ pub(crate) mod fake_support {
         /// thread/resume (t-2) + turn ("second answer"). Drives the session
         /// continuity path end to end.
         TwoTurnsWithResume,
+        /// Expects the first thread request to be `thread/resume` and
+        /// answers it with t-2 + one completed turn ("resumed answer").
+        /// Any other method (e.g. a regression to thread/start) gets a
+        /// JSON-RPC error, so a test fails loudly instead of silently
+        /// passing through the start path.
+        ResumeOnly,
         Idle,
     }
 
@@ -481,6 +487,47 @@ pub(crate) mod fake_support {
         }
     }
 
+    /// The same fakes as [`fake_app_server`], packaged as a plain
+    /// executable path: tests that construct a
+    /// [`crate::agent::codex_rpc::CodexLauncher`] end to end need a
+    /// `codex_bin` the launcher can spawn as `{bin} app-server`, so a thin
+    /// wrapper script tolerates the extra argument and execs the scripted
+    /// fake.
+    pub(crate) fn fake_app_server_bin(
+        scenario: FakeScenario,
+    ) -> Result<(tempfile::TempDir, std::path::PathBuf)> {
+        let dir = tempfile::tempdir()?;
+
+        #[cfg(windows)]
+        {
+            let script = dir.path().join("fake-app-server.ps1");
+            std::fs::write(&script, powershell_fake_script(scenario))?;
+            let wrapper = dir.path().join("fake-app-server-codex.cmd");
+            std::fs::write(
+                &wrapper,
+                format!(
+                    "@echo off\r\npowershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"{}\" %*\r\n",
+                    script.display()
+                ),
+            )?;
+            Ok((dir, wrapper))
+        }
+
+        #[cfg(unix)]
+        {
+            let script = dir.path().join("fake-app-server.sh");
+            std::fs::write(&script, shell_fake_script(scenario))?;
+            let wrapper = dir.path().join("fake-app-server-codex.sh");
+            std::fs::write(
+                &wrapper,
+                format!("#!/bin/sh\nexec /bin/sh '{}' \"$@\"\n", script.display()),
+            )?;
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o755))?;
+            Ok((dir, wrapper))
+        }
+    }
+
     #[cfg(windows)]
     fn powershell_fake_script(scenario: FakeScenario) -> String {
         let body = match scenario {
@@ -504,6 +551,9 @@ pub(crate) mod fake_support {
             }
             FakeScenario::TwoTurnsWithResume => {
                 "Read-Line\nWrite-Line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"t-1\"}}}'\nRead-Line\nWrite-Line '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-1\"}}}'\nWrite-Line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-1\",\"turnId\":\"turn-1\",\"item\":{\"type\":\"agentMessage\",\"text\":\"first answer\"}}}'\nWrite-Line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-1\",\"turn\":{\"id\":\"turn-1\",\"status\":\"completed\"}}}'\nRead-Line\nWrite-Line '{\"id\":4,\"result\":{\"thread\":{\"id\":\"t-2\"}}}'\nRead-Line\nWrite-Line '{\"id\":5,\"result\":{\"turn\":{\"id\":\"turn-2\"}}}'\nWrite-Line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-2\",\"turnId\":\"turn-2\",\"item\":{\"type\":\"agentMessage\",\"text\":\"second answer\"}}}'\nWrite-Line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-2\",\"turn\":{\"id\":\"turn-2\",\"status\":\"completed\"}}}'\nStart-Sleep -Seconds 60"
+            }
+            FakeScenario::ResumeOnly => {
+                "$req = [Console]::In.ReadLine()\nif ($null -eq $req) { exit 0 }\nif ($req -notmatch 'thread/resume') { Write-Line '{\"id\":2,\"error\":{\"code\":-1,\"message\":\"expected thread/resume\"}}'; exit 1 }\nWrite-Line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"t-2\"}}}'\nRead-Line\nWrite-Line '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-2\"}}}'\nWrite-Line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-2\",\"turnId\":\"turn-2\",\"item\":{\"type\":\"agentMessage\",\"text\":\"resumed answer\"}}}'\nWrite-Line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-2\",\"turn\":{\"id\":\"turn-2\",\"status\":\"completed\"}}}'\nStart-Sleep -Seconds 60"
             }
             FakeScenario::Idle => "Start-Sleep -Seconds 60",
         };
@@ -535,6 +585,9 @@ pub(crate) mod fake_support {
             }
             FakeScenario::TwoTurnsWithResume => {
                 "read_line\nwrite_line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"t-1\"}}}'\nread_line\nwrite_line '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-1\"}}}'\nwrite_line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-1\",\"turnId\":\"turn-1\",\"item\":{\"type\":\"agentMessage\",\"text\":\"first answer\"}}}'\nwrite_line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-1\",\"turn\":{\"id\":\"turn-1\",\"status\":\"completed\"}}}'\nread_line\nwrite_line '{\"id\":4,\"result\":{\"thread\":{\"id\":\"t-2\"}}}'\nread_line\nwrite_line '{\"id\":5,\"result\":{\"turn\":{\"id\":\"turn-2\"}}}'\nwrite_line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-2\",\"turnId\":\"turn-2\",\"item\":{\"type\":\"agentMessage\",\"text\":\"second answer\"}}}'\nwrite_line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-2\",\"turn\":{\"id\":\"turn-2\",\"status\":\"completed\"}}}'\nsleep 60"
+            }
+            FakeScenario::ResumeOnly => {
+                "IFS= read -r resume_request || exit 0\ncase \"$resume_request\" in *'\"thread/resume\"'*) ;; *) write_line '{\"id\":2,\"error\":{\"code\":-1,\"message\":\"expected thread/resume\"}}'; exit 1;; esac\nwrite_line '{\"id\":2,\"result\":{\"thread\":{\"id\":\"t-2\"}}}'\nread_line\nwrite_line '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-2\"}}}'\nwrite_line '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"t-2\",\"turnId\":\"turn-2\",\"item\":{\"type\":\"agentMessage\",\"text\":\"resumed answer\"}}}'\nwrite_line '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"t-2\",\"turn\":{\"id\":\"turn-2\",\"status\":\"completed\"}}}'\nsleep 60"
             }
             FakeScenario::Idle => "sleep 60",
         };

--- a/crates/edda-conductor/src/agent/codex_rpc.rs
+++ b/crates/edda-conductor/src/agent/codex_rpc.rs
@@ -2,7 +2,7 @@ use crate::agent::codex_app_server::{CodexAppServer, CodexTurnOutcome};
 use crate::agent::launcher::{AgentLauncher, PhaseResult};
 use crate::plan::schema::Phase;
 use anyhow::Result;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -59,8 +59,16 @@ fn default_codex_bin() -> PathBuf {
 /// pre-persistence path (no store reads, no surprise resumes). A missing
 /// entry is simply a new conversation. A persisted binding that the server
 /// rejects — corrupt file or a stale/invalid thread id — degrades to
-/// `thread/start` within the same dispatch, and the bad binding is not
-/// written back: resume is a convenience and must never fail a dispatch.
+/// `thread/start` within the same dispatch, and the bad binding is erased
+/// from the persisted map: the removal is recorded as an explicit deletion
+/// that [`ThreadStore::persist`] honors, so even a failed fallback (the
+/// retry also erroring, timing out, or being cancelled) cannot write the
+/// rejected binding back and make the next dispatch resume it again.
+/// Resume is a convenience and must never fail a dispatch. This degrade
+/// path is persistence-scoped: a launcher without a thread store (conduct)
+/// keeps the pre-persistence behavior for an in-memory resume failure — the
+/// turn simply crashes — because conduct's verdict-gated redispatch turns
+/// reuse the same session id on purpose and must stay byte-identical.
 /// Within one process the in-memory map stays the hot path and behavior is
 /// unchanged. When the child dies (crash, timeout, cancellation) the
 /// client is dropped and the next phase re-spawns it; the thread map
@@ -120,9 +128,12 @@ impl ThreadStore {
 
     /// Merge `threads` into the persisted map under an exclusive file lock,
     /// so two concurrent dispatch processes cannot lose each other's
-    /// entries. In-memory entries win on key conflicts.
-    fn persist(&self, cwd: &Path, threads: &HashMap<String, String>) {
-        if threads.is_empty() {
+    /// entries. In-memory entries win on key conflicts, and every session
+    /// in `removals` is deleted from the merged map before the overlay: a
+    /// binding the server rejected must not survive a failed fallback just
+    /// because it is absent from the in-memory overlay.
+    fn persist(&self, cwd: &Path, threads: &HashMap<String, String>, removals: &HashSet<String>) {
+        if threads.is_empty() && removals.is_empty() {
             return;
         }
         let path = self.map_path(cwd);
@@ -130,6 +141,13 @@ impl ThreadStore {
             return;
         };
         let mut merged = self.load_quiet(cwd);
+        // Honor explicit deletions before overlaying in-memory entries, so
+        // a rejected binding is erased from disk even when no fresh binding
+        // replaces it. In-memory entries still win for anything present in
+        // both (a fresh binding supersedes its own tombstone).
+        for session in removals {
+            merged.remove(session);
+        }
         for (session, thread) in threads {
             merged.insert(session.clone(), thread.clone());
         }
@@ -155,6 +173,11 @@ struct LauncherState {
     server: Option<CodexAppServer>,
     /// conductor session_id → codex thread_id
     threads: HashMap<String, String>,
+    /// Sessions whose persisted binding the server rejected: explicit
+    /// deletions that [`ThreadStore::persist`] applies to the on-disk map.
+    /// A tombstone stays until a fresh binding for the session overrules
+    /// it in the merge, so it cannot be resurrected by a reload.
+    removals: HashSet<String>,
 }
 
 impl Default for CodexLauncher {
@@ -269,9 +292,31 @@ impl AgentLauncher for CodexLauncher {
             }
         }
 
-        let LauncherState { server, threads } = &mut *state;
+        let LauncherState {
+            server,
+            threads,
+            removals,
+        } = &mut *state;
         let server = server.as_mut().expect("server spawned above");
-        let outcome = drive_turn(server, threads, phase, &message, session_id, cwd, &cancel).await;
+        // Only a persistence-enabled launcher may degrade a rejected
+        // resume to thread/start. With `thread_store: None` (conduct), an
+        // in-memory resume failure must crash exactly as before the
+        // persistence feature: conduct deliberately redispatches the same
+        // session id, and silently starting a new thread would lose the
+        // same-session conversation.
+        let persist_enabled = self.thread_store.is_some();
+        let outcome = drive_turn(
+            server,
+            threads,
+            removals,
+            persist_enabled,
+            phase,
+            &message,
+            session_id,
+            cwd,
+            &cancel,
+        )
+        .await;
 
         if !outcome.keep_server {
             // The turn ended in a crash, timeout, or shutdown, and the child
@@ -299,10 +344,24 @@ impl AgentLauncher for CodexLauncher {
                     });
                 }
             }
-            let LauncherState { server, threads } = &mut *state;
+            let LauncherState {
+                server,
+                threads,
+                removals,
+            } = &mut *state;
             let server = server.as_mut().expect("server respawned above");
-            let retry =
-                drive_turn(server, threads, phase, &message, session_id, cwd, &cancel).await;
+            let retry = drive_turn(
+                server,
+                threads,
+                removals,
+                persist_enabled,
+                phase,
+                &message,
+                session_id,
+                cwd,
+                &cancel,
+            )
+            .await;
             if !retry.keep_server {
                 state.server = None;
             }
@@ -314,7 +373,7 @@ impl AgentLauncher for CodexLauncher {
         // the thread was created and codex persists it, so the next process
         // can resume it. Best-effort — failures are swallowed by design.
         if let Some(store) = &self.thread_store {
-            store.persist(cwd, &state.threads);
+            store.persist(cwd, &state.threads, &state.removals);
         }
         Ok(result)
     }
@@ -380,10 +439,15 @@ async fn open_thread_or_fail(
 }
 
 /// Open (or resume) the codex thread for `session_id`, run one turn, and map
-/// the outcome onto [`DriveOutcome`].
+/// the outcome onto [`DriveOutcome`]. The parameters are one flat turn
+/// description; a parameter struct would be churn, so the argument count is
+/// accepted here.
+#[allow(clippy::too_many_arguments)]
 async fn drive_turn(
     server: &mut CodexAppServer,
     threads: &mut HashMap<String, String>,
+    removals: &mut HashSet<String>,
+    persist_enabled: bool,
     phase: &Phase,
     message: &str,
     session_id: &str,
@@ -410,11 +474,15 @@ async fn drive_turn(
         Ok(thread_id) => thread_id,
         // A persisted binding the server rejects (stale or invalid thread
         // id) must degrade to `thread/start`, not fail the dispatch. Drop
-        // the binding so it is never written back, and tell run_phase to
-        // retry on a fresh app-server — the failed resume terminated the
-        // child.
-        Err(OpenFailure::Error(_)) if resume.is_some() => {
+        // the binding and record an explicit deletion so `persist` erases
+        // it from disk even if the fallback never records a fresh id, and
+        // tell run_phase to retry on a fresh app-server — the failed resume
+        // terminated the child. Gated on persistence: with no thread store
+        // (conduct) the error below falls through to the plain crash path,
+        // byte-identical with the pre-persistence behavior.
+        Err(OpenFailure::Error(_)) if resume.is_some() && persist_enabled => {
             threads.remove(session_id);
+            removals.insert(session_id.to_owned());
             return DriveOutcome {
                 result: PhaseResult::AgentCrash {
                     error: "persisted thread binding rejected; degrading to thread/start".into(),
@@ -474,7 +542,7 @@ fn over_budget(cost: Option<f64>, budget: Option<f64>) -> bool {
 pub(crate) mod test_support {
     use super::CodexLauncher;
     use crate::agent::codex_app_server::CodexAppServer;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::path::PathBuf;
     use tokio::sync::Mutex;
 
@@ -487,6 +555,7 @@ pub(crate) mod test_support {
         launcher.state = Mutex::new(super::LauncherState {
             server: Some(server),
             threads: HashMap::new(),
+            removals: HashSet::new(),
         });
         launcher
     }
@@ -596,6 +665,8 @@ mod tests {
         let outcome = drive_turn(
             &mut server,
             &mut threads,
+            &mut HashSet::new(),
+            false,
             &phase,
             "do the task",
             "sid",
@@ -628,6 +699,8 @@ mod tests {
         let outcome = drive_turn(
             &mut server,
             &mut threads,
+            &mut HashSet::new(),
+            false,
             &phase,
             "do the task",
             "sid",
@@ -655,6 +728,8 @@ mod tests {
         let outcome = drive_turn(
             &mut server,
             &mut threads,
+            &mut HashSet::new(),
+            false,
             &phase,
             "do the task",
             "sid",
@@ -684,6 +759,8 @@ mod tests {
         let outcome = drive_turn(
             &mut server,
             &mut threads,
+            &mut HashSet::new(),
+            false,
             &phase,
             "do the task",
             "sid",
@@ -711,6 +788,8 @@ mod tests {
         let outcome = drive_turn(
             &mut server,
             &mut threads,
+            &mut HashSet::new(),
+            false,
             &phase,
             "do the task",
             "sid",
@@ -741,6 +820,8 @@ mod tests {
         let first = drive_turn(
             &mut server,
             &mut threads,
+            &mut HashSet::new(),
+            false,
             &phase,
             "turn one",
             "sid",
@@ -759,6 +840,8 @@ mod tests {
         let second = drive_turn(
             &mut server,
             &mut threads,
+            &mut HashSet::new(),
+            false,
             &phase,
             "turn two",
             "sid",
@@ -893,7 +976,7 @@ mod tests {
         let mut threads = HashMap::new();
         threads.insert("sess-1".to_owned(), "t-1".to_owned());
 
-        store.persist(cwd.path(), &threads);
+        store.persist(cwd.path(), &threads, &HashSet::new());
 
         let loaded = store.load(cwd.path());
         assert_eq!(loaded.get("sess-1").map(String::as_str), Some("t-1"));
@@ -915,7 +998,7 @@ mod tests {
 
         let mut threads = HashMap::new();
         threads.insert("sess-mine".to_owned(), "t-fresh".to_owned());
-        store.persist(cwd.path(), &threads);
+        store.persist(cwd.path(), &threads, &HashSet::new());
 
         let loaded = store.load(cwd.path());
         assert_eq!(
@@ -923,6 +1006,40 @@ mod tests {
             Some("t-other")
         );
         assert_eq!(loaded.get("sess-mine").map(String::as_str), Some("t-fresh"));
+        Ok(())
+    }
+
+    #[test]
+    fn thread_store_persist_honors_removal_tombstones() -> Result<()> {
+        // A rejected binding is modeled as an explicit deletion, not mere
+        // absence from the in-memory overlay: persist must apply the
+        // removal to the on-disk map, so a failed fallback (no fresh
+        // binding recorded) cannot resurrect the rejected entry.
+        let root = tempfile::tempdir()?;
+        let cwd = tempfile::tempdir()?;
+        let store = ThreadStore {
+            root: root.path().to_path_buf(),
+        };
+        let map = map_path_for(root.path(), cwd.path());
+        std::fs::create_dir_all(map.parent().unwrap())?;
+        std::fs::write(&map, r#"{"sess-1":"stale","sess-other":"t-other"}"#)?;
+
+        let mut threads = HashMap::new();
+        threads.insert("sess-2".to_owned(), "t-2".to_owned());
+        let mut removals = HashSet::new();
+        removals.insert("sess-1".to_owned());
+        store.persist(cwd.path(), &threads, &removals);
+
+        let loaded = store.load(cwd.path());
+        assert_eq!(
+            loaded.get("sess-other").map(String::as_str),
+            Some("t-other")
+        );
+        assert_eq!(loaded.get("sess-2").map(String::as_str), Some("t-2"));
+        assert!(
+            !loaded.contains_key("sess-1"),
+            "the tombstoned binding must be deleted from disk, got {loaded:?}"
+        );
         Ok(())
     }
 
@@ -1076,6 +1193,100 @@ mod tests {
             std::fs::read_to_string(&map).expect("map rewritten"),
             r#"{"sess-1":"t-1"}"#,
             "the stale binding must not be written back"
+        );
+        Ok(())
+    }
+
+    /// Seed the in-memory session→thread map of a launcher built by
+    /// [`launcher_with_server`], without touching the real store.
+    async fn seed_threads(launcher: &CodexLauncher, session: &str, thread: &str) {
+        let mut state = launcher.state.lock().await;
+        state.threads.insert(session.to_owned(), thread.to_owned());
+    }
+
+    #[tokio::test]
+    async fn conduct_without_persistence_still_crashes_when_resume_is_rejected() -> Result<()> {
+        // GH-535 round 2, P1-B: the stale-binding fallback (drop + retry as
+        // thread/start) must be reachable only on the persistence-enabled
+        // dispatch path. Conduct reuses a deterministic session id for a
+        // verdict-gated redispatch; if that in-memory resume is rejected,
+        // conduct must fail with the server's error exactly as before the
+        // persistence feature — not silently start a new thread and lose
+        // the same-session conversation. The ResumeErrorThenStart fake
+        // would happily answer thread/start with "fresh answer", so a
+        // retry here would show up as AgentDone instead of the crash.
+        let (_dir, server) = spawn_fake_server(FakeScenario::ResumeErrorThenStart).await;
+        let launcher = launcher_with_server(server);
+        seed_threads(&launcher, "sid", "stale-thread").await;
+        let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
+        let result = launcher
+            .run_phase(
+                &phase,
+                "redispatch turn",
+                "",
+                "sid",
+                Path::new("."),
+                CancellationToken::new(),
+            )
+            .await
+            .expect("run_phase returns a result, not an IO error");
+        match result {
+            PhaseResult::AgentCrash { error } => {
+                assert!(
+                    error.contains("unknown thread"),
+                    "conduct resume failure must surface the server's own error, got {error}"
+                );
+            }
+            other => {
+                panic!("non-persistent conduct must not fall back to thread/start, got {other:?}")
+            }
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn failed_fallback_still_erases_the_stale_binding_from_disk() -> Result<()> {
+        // GH-535 round 2, P1-A: dropping the stale binding from the
+        // in-memory map is not enough — if the fallback thread/start fails
+        // (or times out, or is cancelled) before a fresh id is recorded,
+        // the merge-style persist reloads the on-disk map and would write
+        // the rejected binding straight back. The removal must survive as
+        // an explicit deletion that persist honors, so the next dispatch
+        // never resumes the same rejected thread id again.
+        let store_root = tempfile::tempdir()?;
+        let cwd = tempfile::tempdir()?;
+        let map = map_path_for(store_root.path(), cwd.path());
+        std::fs::create_dir_all(map.parent().unwrap())?;
+        std::fs::write(&map, br#"{"sess-1":"stale-thread"}"#)?;
+
+        let (_fake_dir, bin) =
+            fake_app_server_bin(FakeScenario::ResumeErrorThenStartError).expect("fake written");
+        let launcher =
+            CodexLauncher::with_bin(bin).with_thread_store(store_root.path().to_path_buf());
+        let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
+        let result = launcher
+            .run_phase(
+                &phase,
+                "turn one",
+                "",
+                "sess-1",
+                cwd.path(),
+                CancellationToken::new(),
+            )
+            .await
+            .expect("run_phase returns a result, not an IO error");
+        // The fallback thread/start fails too, so the phase ends in a
+        // crash — but the rejected binding must still be gone from disk.
+        assert!(
+            matches!(&result, PhaseResult::AgentCrash { error } if error.contains("unknown thread")),
+            "expected the failed fallback to surface as AgentCrash, got {result:?}"
+        );
+        let loaded: HashMap<String, String> =
+            serde_json::from_str(&std::fs::read_to_string(&map).expect("map still readable"))
+                .expect("map stays valid JSON");
+        assert!(
+            !loaded.contains_key("sess-1"),
+            "the rejected binding must not survive on disk after a failed fallback, got {loaded:?}"
         );
         Ok(())
     }

--- a/crates/edda-conductor/src/agent/codex_rpc.rs
+++ b/crates/edda-conductor/src/agent/codex_rpc.rs
@@ -44,17 +44,104 @@ fn default_codex_bin() -> PathBuf {
 ///
 /// Session continuity: the app-server process is spawned once and reused,
 /// and the `threads` map keys on the conductor session id, resuming a
-/// thread via `thread/resume` whenever a caller reuses a session id. That
-/// is a forward-looking path for a future dispatch primitive: the
-/// sequential runner derives a unique session id per plan+phase+attempt,
-/// so resume does not currently fire in production (see
-/// [`crate::agent::launcher::phase_session_id`]). When the child dies
-/// (crash, timeout, cancellation) the client is dropped and the next phase
-/// re-spawns it; the thread map survives because codex persists threads.
+/// thread via `thread/resume` whenever a caller reuses a session id.
+///
+/// Cross-process, the map is persisted in the per-user edda store at
+/// `<store_root>/projects/<project_id(cwd)>/state/codex-threads.json`,
+/// written through `edda_store::write_atomic` under an exclusive file lock
+/// (GH-535). A freshly constructed launcher — i.e. every `edda dispatch`
+/// process — merges the persisted map into `threads` on the first
+/// successful spawn, so a repeated `--session-id` resumes the conversation
+/// a previous process recorded. A missing entry is simply a new
+/// conversation; a corrupt file warns once and degrades to `thread/start`:
+/// resume is a convenience and must never fail a dispatch. Within one
+/// process (conduct) the in-memory map stays the hot path and behavior is
+/// unchanged. When the child dies (crash, timeout, cancellation) the
+/// client is dropped and the next phase re-spawns it; the thread map
+/// survives because codex persists threads and the store records their ids.
 pub struct CodexLauncher {
     pub codex_bin: PathBuf,
     pub verbose: bool,
+    thread_store: Option<ThreadStore>,
     state: Mutex<LauncherState>,
+}
+
+/// File-backed cold-start store for the session→thread map.
+///
+/// Purely a resume convenience: every fallible step (missing file, corrupt
+/// JSON, lock or write failure) degrades to "no persisted entries" rather
+/// than an error, so persistence problems can never fail a dispatch. Only
+/// corruption warns — a missing file is just a first conversation.
+struct ThreadStore {
+    /// Per-user edda store root (`edda_store::store_root()`).
+    root: PathBuf,
+}
+
+impl ThreadStore {
+    fn from_default_root() -> Self {
+        Self {
+            root: edda_store::store_root(),
+        }
+    }
+
+    /// One map per project, so two dispatch calls from the same repo (any
+    /// worktree — `project_id` resolves to the main root) share threads.
+    fn map_path(&self, cwd: &Path) -> PathBuf {
+        self.root
+            .join("projects")
+            .join(edda_store::project_id(cwd))
+            .join("state")
+            .join("codex-threads.json")
+    }
+
+    fn load(&self, cwd: &Path) -> HashMap<String, String> {
+        let path = self.map_path(cwd);
+        match std::fs::read_to_string(&path) {
+            Err(_) => HashMap::new(),
+            Ok(raw) => match serde_json::from_str(&raw) {
+                Ok(map) => map,
+                Err(_) => {
+                    eprintln!(
+                        "Warning: codex thread map {} is corrupt; ignoring it and \"
+                         starting fresh conversations (resume needs a new dispatch).",
+                        path.display()
+                    );
+                    HashMap::new()
+                }
+            },
+        }
+    }
+
+    /// Merge `threads` into the persisted map under an exclusive file lock,
+    /// so two concurrent dispatch processes cannot lose each other's
+    /// entries. In-memory entries win on key conflicts.
+    fn persist(&self, cwd: &Path, threads: &HashMap<String, String>) {
+        if threads.is_empty() {
+            return;
+        }
+        let path = self.map_path(cwd);
+        let Ok(_lock) = edda_store::lock_file(&path.with_extension("lock")) else {
+            return;
+        };
+        let mut merged = self.load_quiet(cwd);
+        for (session, thread) in threads {
+            merged.insert(session.clone(), thread.clone());
+        }
+        if let Ok(bytes) = serde_json::to_vec(&merged) {
+            let _ = edda_store::write_atomic(&path, &bytes);
+        }
+    }
+
+    /// [`Self::load`] without the corruption warning — used while already
+    /// holding the lock inside [`Self::persist`], where the warning would
+    /// fire twice for the same bad file.
+    fn load_quiet(&self, cwd: &Path) -> HashMap<String, String> {
+        let path = self.map_path(cwd);
+        std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|raw| serde_json::from_str(&raw).ok())
+            .unwrap_or_default()
+    }
 }
 
 #[derive(Default)]
@@ -75,6 +162,7 @@ impl CodexLauncher {
         Self {
             codex_bin: default_codex_bin(),
             verbose: false,
+            thread_store: Some(ThreadStore::from_default_root()),
             state: Mutex::new(LauncherState::default()),
         }
     }
@@ -83,8 +171,23 @@ impl CodexLauncher {
         Self {
             codex_bin,
             verbose: false,
+            thread_store: Some(ThreadStore::from_default_root()),
             state: Mutex::new(LauncherState::default()),
         }
+    }
+
+    /// Point the session→thread persistence at a custom store root (tests
+    /// use this to stay out of the real per-user store).
+    pub fn with_thread_store(mut self, root: PathBuf) -> Self {
+        self.thread_store = Some(ThreadStore { root });
+        self
+    }
+
+    /// Disable persistence entirely: in-memory thread continuity only.
+    #[cfg(test)]
+    fn without_thread_store(mut self) -> Self {
+        self.thread_store = None;
+        self
     }
 
     pub fn with_verbose(mut self, verbose: bool) -> Self {
@@ -132,7 +235,17 @@ impl AgentLauncher for CodexLauncher {
         let mut state = self.state.lock().await;
         if state.server.is_none() {
             match CodexAppServer::spawn(&self.codex_bin).await {
-                Ok(server) => state.server = Some(server),
+                // Cold start: merge the persisted session→thread map so a
+                // session id recorded by a previous process resumes instead
+                // of starting over. In-memory entries win (hot path).
+                Ok(server) => {
+                    if let Some(store) = &self.thread_store {
+                        for (session, thread) in store.load(cwd) {
+                            state.threads.entry(session).or_insert(thread);
+                        }
+                    }
+                    state.server = Some(server);
+                }
                 Err(error) => {
                     return Ok(PhaseResult::AgentCrash {
                         error: format!(
@@ -156,6 +269,12 @@ impl AgentLauncher for CodexLauncher {
             // thread map survives: codex persists threads and `thread/resume`
             // restores the conversation.
             state.server = None;
+        }
+        // Record the turn's session→thread binding even on a crash path:
+        // the thread was created and codex persists it, so the next process
+        // can resume it. Best-effort — failures are swallowed by design.
+        if let Some(store) = &self.thread_store {
+            store.persist(cwd, &state.threads);
         }
         Ok(result)
     }
@@ -253,8 +372,11 @@ pub(crate) mod test_support {
 
     /// A launcher pre-seeded with an already-spawned server, for tests that
     /// drive `run_phase` against a fake app-server without spawning binaries.
+    /// Persistence is off: these tests assert in-process behavior and must
+    /// never touch the real per-user store.
     pub(crate) fn launcher_with_server(server: CodexAppServer) -> CodexLauncher {
-        let mut launcher = CodexLauncher::with_bin(PathBuf::from("unused-fake-bin"));
+        let mut launcher =
+            CodexLauncher::with_bin(PathBuf::from("unused-fake-bin")).without_thread_store();
         launcher.state = Mutex::new(super::LauncherState {
             server: Some(server),
             threads: HashMap::new(),
@@ -267,7 +389,9 @@ pub(crate) mod test_support {
 mod tests {
     use super::test_support::launcher_with_server;
     use super::*;
-    use crate::agent::codex_app_server::fake_support::{fake_app_server, FakeScenario};
+    use crate::agent::codex_app_server::fake_support::{
+        fake_app_server, fake_app_server_bin, FakeScenario,
+    };
     use crate::agent::codex_app_server::CodexAppServer;
     use crate::plan::parser::parse_plan;
 
@@ -603,6 +727,194 @@ mod tests {
             }
             other => panic!("expected AgentDone, got {other:?}"),
         }
+        Ok(())
+    }
+
+    // ── Cross-process thread-map persistence (GH-535) ──
+
+    /// The map file a launcher with `root` writes for `cwd`.
+    fn map_path_for(root: &Path, cwd: &Path) -> PathBuf {
+        root.join("projects")
+            .join(edda_store::project_id(cwd))
+            .join("state")
+            .join("codex-threads.json")
+    }
+
+    #[test]
+    fn thread_store_round_trips_the_session_map() -> Result<()> {
+        let root = tempfile::tempdir()?;
+        let cwd = tempfile::tempdir()?;
+        let store = ThreadStore {
+            root: root.path().to_path_buf(),
+        };
+        let mut threads = HashMap::new();
+        threads.insert("sess-1".to_owned(), "t-1".to_owned());
+
+        store.persist(cwd.path(), &threads);
+
+        let loaded = store.load(cwd.path());
+        assert_eq!(loaded.get("sess-1").map(String::as_str), Some("t-1"));
+        Ok(())
+    }
+
+    #[test]
+    fn thread_store_persist_merges_with_entries_from_another_process() -> Result<()> {
+        // Simulate the other process having written its own binding to the
+        // shared map between our load and our write: the merge must keep it.
+        let root = tempfile::tempdir()?;
+        let cwd = tempfile::tempdir()?;
+        let store = ThreadStore {
+            root: root.path().to_path_buf(),
+        };
+        let foreign = r#"{"sess-other":"t-other","sess-mine":"t-stale"}"#;
+        std::fs::create_dir_all(map_path_for(root.path(), cwd.path()).parent().unwrap())?;
+        std::fs::write(map_path_for(root.path(), cwd.path()), foreign)?;
+
+        let mut threads = HashMap::new();
+        threads.insert("sess-mine".to_owned(), "t-fresh".to_owned());
+        store.persist(cwd.path(), &threads);
+
+        let loaded = store.load(cwd.path());
+        assert_eq!(
+            loaded.get("sess-other").map(String::as_str),
+            Some("t-other")
+        );
+        assert_eq!(loaded.get("sess-mine").map(String::as_str), Some("t-fresh"));
+        Ok(())
+    }
+
+    #[test]
+    fn thread_store_missing_or_corrupt_file_loads_empty() -> Result<()> {
+        let root = tempfile::tempdir()?;
+        let cwd = tempfile::tempdir()?;
+        let store = ThreadStore {
+            root: root.path().to_path_buf(),
+        };
+        assert!(store.load(cwd.path()).is_empty(), "missing file is empty");
+
+        let map = map_path_for(root.path(), cwd.path());
+        std::fs::create_dir_all(map.parent().unwrap())?;
+        std::fs::write(&map, b"{ not json")?;
+        assert!(store.load(cwd.path()).is_empty(), "corrupt file is empty");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fresh_launcher_resumes_the_thread_a_previous_process_recorded() -> Result<()> {
+        // Stand-in for two `edda dispatch --agent codex --session-id sess-1`
+        // processes: two independently constructed launchers sharing the
+        // store root. The first records sess-1 → t-1 via thread/start; the
+        // second must send thread/resume (the ResumeOnly fake answers an
+        // error for anything else) and produce the resumed turn's answer.
+        let store_root = tempfile::tempdir()?;
+        let cwd = tempfile::tempdir()?;
+        let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
+
+        let (_fake_dir, first_bin) =
+            fake_app_server_bin(FakeScenario::RunTurnCompletes).expect("first fake written");
+        let first =
+            CodexLauncher::with_bin(first_bin).with_thread_store(store_root.path().to_path_buf());
+        let first_result = first
+            .run_phase(
+                &phase,
+                "turn one",
+                "",
+                "sess-1",
+                cwd.path(),
+                CancellationToken::new(),
+            )
+            .await
+            .expect("first dispatch runs");
+        assert!(
+            matches!(&first_result, PhaseResult::AgentDone { result_text, .. } if result_text.as_deref() == Some("turn complete")),
+            "first dispatch should complete, got {first_result:?}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(map_path_for(store_root.path(), cwd.path()))
+                .expect("map persisted"),
+            r#"{"sess-1":"t-1"}"#
+        );
+
+        let (_fake_dir, second_bin) =
+            fake_app_server_bin(FakeScenario::ResumeOnly).expect("second fake written");
+        let second =
+            CodexLauncher::with_bin(second_bin).with_thread_store(store_root.path().to_path_buf());
+        let second_result = second
+            .run_phase(
+                &phase,
+                "turn two",
+                "",
+                "sess-1",
+                cwd.path(),
+                CancellationToken::new(),
+            )
+            .await
+            .expect("second dispatch runs");
+        match second_result {
+            PhaseResult::AgentDone { result_text, .. } => {
+                assert_eq!(result_text.as_deref(), Some("resumed answer"));
+            }
+            other => panic!("second dispatch should resume the recorded thread, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn corrupt_store_entry_degrades_to_thread_start() -> Result<()> {
+        // A corrupt map must never fail the dispatch: the fresh launcher
+        // warns and falls back to thread/start, which completes normally.
+        let store_root = tempfile::tempdir()?;
+        let cwd = tempfile::tempdir()?;
+        let map = map_path_for(store_root.path(), cwd.path());
+        std::fs::create_dir_all(map.parent().unwrap())?;
+        std::fs::write(&map, b"{ corrupted")?;
+
+        let (_fake_dir, bin) =
+            fake_app_server_bin(FakeScenario::RunTurnCompletes).expect("fake written");
+        let launcher =
+            CodexLauncher::with_bin(bin).with_thread_store(store_root.path().to_path_buf());
+        let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
+        let result = launcher
+            .run_phase(
+                &phase,
+                "do the task",
+                "",
+                "sess-1",
+                cwd.path(),
+                CancellationToken::new(),
+            )
+            .await
+            .expect("dispatch must not fail on a corrupt store entry");
+        assert!(
+            matches!(&result, PhaseResult::AgentDone { result_text, .. } if result_text.as_deref() == Some("turn complete")),
+            "degraded dispatch should complete via thread/start, got {result:?}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn missing_store_entry_starts_a_fresh_thread() -> Result<()> {
+        // No map file at all: the first dispatch with a session id is a
+        // plain thread/start, not a failure and not a warning.
+        let store_root = tempfile::tempdir()?;
+        let cwd = tempfile::tempdir()?;
+        let (_fake_dir, bin) =
+            fake_app_server_bin(FakeScenario::RunTurnCompletes).expect("fake written");
+        let launcher =
+            CodexLauncher::with_bin(bin).with_thread_store(store_root.path().to_path_buf());
+        let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
+        let result = launcher
+            .run_phase(
+                &phase,
+                "do the task",
+                "",
+                "sess-fresh",
+                cwd.path(),
+                CancellationToken::new(),
+            )
+            .await
+            .expect("first dispatch runs");
+        assert!(matches!(result, PhaseResult::AgentDone { .. }));
         Ok(())
     }
 }

--- a/crates/edda-conductor/src/agent/codex_rpc.rs
+++ b/crates/edda-conductor/src/agent/codex_rpc.rs
@@ -46,16 +46,22 @@ fn default_codex_bin() -> PathBuf {
 /// and the `threads` map keys on the conductor session id, resuming a
 /// thread via `thread/resume` whenever a caller reuses a session id.
 ///
-/// Cross-process, the map is persisted in the per-user edda store at
-/// `<store_root>/projects/<project_id(cwd)>/state/codex-threads.json`,
-/// written through `edda_store::write_atomic` under an exclusive file lock
-/// (GH-535). A freshly constructed launcher — i.e. every `edda dispatch`
-/// process — merges the persisted map into `threads` on the first
-/// successful spawn, so a repeated `--session-id` resumes the conversation
-/// a previous process recorded. A missing entry is simply a new
-/// conversation; a corrupt file warns once and degrades to `thread/start`:
-/// resume is a convenience and must never fail a dispatch. Within one
-/// process (conduct) the in-memory map stays the hot path and behavior is
+/// Cross-process, `edda dispatch` persists the map in the per-user edda
+/// store at `<store_root>/projects/<project_id(cwd)>/state/
+/// codex-threads.json`, written through `edda_store::write_atomic` under an
+/// exclusive file lock (GH-535). Persistence is dispatch-scoped: a launcher
+/// built with [`CodexLauncher::with_persistent_threads`] — which is exactly
+/// what `edda dispatch` builds — merges the persisted map into `threads` on
+/// the first successful spawn, so a repeated `--session-id` resumes the
+/// conversation a previous process recorded. Conduct deliberately keeps the
+/// default non-persistent launcher: its session ids are deterministic per
+/// plan/phase/attempt, and its behavior must stay byte-identical with the
+/// pre-persistence path (no store reads, no surprise resumes). A missing
+/// entry is simply a new conversation. A persisted binding that the server
+/// rejects — corrupt file or a stale/invalid thread id — degrades to
+/// `thread/start` within the same dispatch, and the bad binding is not
+/// written back: resume is a convenience and must never fail a dispatch.
+/// Within one process the in-memory map stays the hot path and behavior is
 /// unchanged. When the child dies (crash, timeout, cancellation) the
 /// client is dropped and the next phase re-spawns it; the thread map
 /// survives because codex persists threads and the store records their ids.
@@ -162,7 +168,7 @@ impl CodexLauncher {
         Self {
             codex_bin: default_codex_bin(),
             verbose: false,
-            thread_store: Some(ThreadStore::from_default_root()),
+            thread_store: None,
             state: Mutex::new(LauncherState::default()),
         }
     }
@@ -171,22 +177,28 @@ impl CodexLauncher {
         Self {
             codex_bin,
             verbose: false,
-            thread_store: Some(ThreadStore::from_default_root()),
+            thread_store: None,
             state: Mutex::new(LauncherState::default()),
         }
     }
 
-    /// Point the session→thread persistence at a custom store root (tests
-    /// use this to stay out of the real per-user store).
-    pub fn with_thread_store(mut self, root: PathBuf) -> Self {
-        self.thread_store = Some(ThreadStore { root });
+    /// Enable persistence in the per-user edda store
+    /// (`edda_store::store_root()`). Dispatch-scoped (GH-535): only `edda
+    /// dispatch` opts in, because its `--session-id` is caller-chosen across
+    /// invocations and resuming is the point. Conduct keeps the default
+    /// non-persistent launcher — deterministic conduct session ids must
+    /// never load an old binding, and conduct turns must not gain store
+    /// reads/writes.
+    pub fn with_persistent_threads(mut self) -> Self {
+        self.thread_store = Some(ThreadStore::from_default_root());
         self
     }
 
-    /// Disable persistence entirely: in-memory thread continuity only.
-    #[cfg(test)]
-    fn without_thread_store(mut self) -> Self {
-        self.thread_store = None;
+    /// Point the session→thread persistence at an explicit store root
+    /// (tests use this to stay out of the real per-user store; dispatch
+    /// uses [`CodexLauncher::with_persistent_threads`] instead).
+    pub fn with_thread_store(mut self, root: PathBuf) -> Self {
+        self.thread_store = Some(ThreadStore { root });
         self
     }
 
@@ -259,10 +271,9 @@ impl AgentLauncher for CodexLauncher {
 
         let LauncherState { server, threads } = &mut *state;
         let server = server.as_mut().expect("server spawned above");
-        let (result, keep_server) =
-            drive_turn(server, threads, phase, &message, session_id, cwd, &cancel).await;
+        let outcome = drive_turn(server, threads, phase, &message, session_id, cwd, &cancel).await;
 
-        if !keep_server {
+        if !outcome.keep_server {
             // The turn ended in a crash, timeout, or shutdown, and the child
             // was killed along the way (KillOnCancel or terminate). Drop the
             // client so the next phase re-spawns a fresh app-server. The
@@ -270,6 +281,35 @@ impl AgentLauncher for CodexLauncher {
             // restores the conversation.
             state.server = None;
         }
+        let result = if outcome.dropped_stale_binding {
+            // The persisted binding for this session was rejected by the
+            // server (stale or invalid thread id). Degrade to a plain
+            // `thread/start` within the same dispatch: the failed resume
+            // terminated the child, so spawn a fresh app-server first. The
+            // bad binding was already removed from `threads`, so it is not
+            // written back below.
+            match CodexAppServer::spawn(&self.codex_bin).await {
+                Ok(server) => state.server = Some(server),
+                Err(error) => {
+                    return Ok(PhaseResult::AgentCrash {
+                        error: format!(
+                            "failed to spawn codex app-server ({:?}): {error}",
+                            self.codex_bin
+                        ),
+                    });
+                }
+            }
+            let LauncherState { server, threads } = &mut *state;
+            let server = server.as_mut().expect("server respawned above");
+            let retry =
+                drive_turn(server, threads, phase, &message, session_id, cwd, &cancel).await;
+            if !retry.keep_server {
+                state.server = None;
+            }
+            retry.result
+        } else {
+            outcome.result
+        };
         // Record the turn's session→thread binding even on a crash path:
         // the thread was created and codex persists it, so the next process
         // can resume it. Best-effort — failures are swallowed by design.
@@ -280,11 +320,67 @@ impl AgentLauncher for CodexLauncher {
     }
 }
 
+/// One [`drive_turn`] attempt: the mapped phase result, whether the
+/// app-server child survived, and whether a stale persisted thread binding
+/// was dropped — asking [`AgentLauncher::run_phase`] to retry once as a
+/// plain `thread/start`.
+struct DriveOutcome {
+    result: PhaseResult,
+    keep_server: bool,
+    dropped_stale_binding: bool,
+}
+
+impl DriveOutcome {
+    fn now(result: PhaseResult, keep_server: bool) -> Self {
+        Self {
+            result,
+            keep_server,
+            dropped_stale_binding: false,
+        }
+    }
+}
+
+/// Why a thread open did not produce a thread id. `Error` leaves the
+/// child's fate to the protocol layer (a failed request terminates it);
+/// timeout and cancellation mean the dispatch itself is over.
+enum OpenFailure {
+    Error(anyhow::Error),
+    Timeout,
+    Cancelled,
+}
+
+impl OpenFailure {
+    fn into_result(self) -> PhaseResult {
+        match self {
+            OpenFailure::Error(error) => PhaseResult::AgentCrash {
+                error: error.to_string(),
+            },
+            OpenFailure::Timeout => PhaseResult::Timeout,
+            OpenFailure::Cancelled => PhaseResult::AgentCrash {
+                error: "conductor shutdown".into(),
+            },
+        }
+    }
+}
+
+/// [`CodexAppServer::open_thread`] raced against the turn deadline and the
+/// conductor cancel token.
+async fn open_thread_or_fail(
+    server: &mut CodexAppServer,
+    cwd: &Path,
+    resume: Option<&str>,
+    deadline: std::pin::Pin<&mut tokio::time::Sleep>,
+    cancel: &CancellationToken,
+) -> Result<String, OpenFailure> {
+    tokio::select! {
+        opened = server.open_thread(cwd, resume) => opened.map_err(OpenFailure::Error),
+        _ = deadline => Err(OpenFailure::Timeout),
+        _ = cancel.cancelled() => Err(OpenFailure::Cancelled),
+    }
+}
+
 /// Open (or resume) the codex thread for `session_id`, run one turn, and map
-/// the outcome onto `PhaseResult`.
-///
-/// Returns whether the server is still usable: `false` after any crash,
-/// timeout, or cancellation, since every one of those paths kills the child.
+/// the outcome onto [`DriveOutcome`].
 async fn drive_turn(
     server: &mut CodexAppServer,
     threads: &mut HashMap<String, String>,
@@ -293,7 +389,7 @@ async fn drive_turn(
     session_id: &str,
     cwd: &Path,
     cancel: &CancellationToken,
-) -> (PhaseResult, bool) {
+) -> DriveOutcome {
     let timeout = Duration::from_secs(phase.timeout_sec.unwrap_or(1800));
     let deadline = tokio::time::sleep(timeout);
     tokio::pin!(deadline);
@@ -302,20 +398,32 @@ async fn drive_turn(
     };
 
     let resume = threads.get(session_id).cloned();
-    let thread_id = tokio::select! {
-        opened = server.open_thread(cwd, resume.as_deref()) => match opened {
-            Ok(thread_id) => thread_id,
-            Err(error) => {
-                return (
-                    PhaseResult::AgentCrash {
-                        error: error.to_string(),
-                    },
-                    false,
-                );
-            }
-        },
-        _ = &mut deadline => return (PhaseResult::Timeout, false),
-        _ = cancel.cancelled() => return (shutdown(), false),
+    let thread_id = match open_thread_or_fail(
+        server,
+        cwd,
+        resume.as_deref(),
+        deadline.as_mut(),
+        cancel,
+    )
+    .await
+    {
+        Ok(thread_id) => thread_id,
+        // A persisted binding the server rejects (stale or invalid thread
+        // id) must degrade to `thread/start`, not fail the dispatch. Drop
+        // the binding so it is never written back, and tell run_phase to
+        // retry on a fresh app-server — the failed resume terminated the
+        // child.
+        Err(OpenFailure::Error(_)) if resume.is_some() => {
+            threads.remove(session_id);
+            return DriveOutcome {
+                result: PhaseResult::AgentCrash {
+                    error: "persisted thread binding rejected; degrading to thread/start".into(),
+                },
+                keep_server: false,
+                dropped_stale_binding: true,
+            };
+        }
+        Err(failure) => return DriveOutcome::now(failure.into_result(), false),
     };
     threads.insert(session_id.to_owned(), thread_id.clone());
 
@@ -323,7 +431,7 @@ async fn drive_turn(
         turned = server.run_turn(&thread_id, message) => match turned {
             Ok(outcome) => outcome,
             Err(error) => {
-                return (
+                return DriveOutcome::now(
                     PhaseResult::AgentCrash {
                         error: error.to_string(),
                     },
@@ -331,8 +439,8 @@ async fn drive_turn(
                 );
             }
         },
-        _ = &mut deadline => return (PhaseResult::Timeout, false),
-        _ = cancel.cancelled() => return (shutdown(), false),
+        _ = &mut deadline => return DriveOutcome::now(PhaseResult::Timeout, false),
+        _ = cancel.cancelled() => return DriveOutcome::now(shutdown(), false),
     };
 
     // The app-server protocol exposes no cost/usage data, so neither budget
@@ -344,9 +452,9 @@ async fn drive_turn(
     // this at startup; the cost column stays empty for codex phases by design.
     let cost_usd = None;
     if over_budget(cost_usd, phase.budget_usd) {
-        return (PhaseResult::BudgetExceeded { cost_usd }, true);
+        return DriveOutcome::now(PhaseResult::BudgetExceeded { cost_usd }, true);
     }
-    (
+    DriveOutcome::now(
         PhaseResult::AgentDone {
             cost_usd,
             result_text: outcome.final_text,
@@ -372,11 +480,10 @@ pub(crate) mod test_support {
 
     /// A launcher pre-seeded with an already-spawned server, for tests that
     /// drive `run_phase` against a fake app-server without spawning binaries.
-    /// Persistence is off: these tests assert in-process behavior and must
-    /// never touch the real per-user store.
+    /// Persistence is off (the default now): these tests assert in-process
+    /// behavior and must never touch the real per-user store.
     pub(crate) fn launcher_with_server(server: CodexAppServer) -> CodexLauncher {
-        let mut launcher =
-            CodexLauncher::with_bin(PathBuf::from("unused-fake-bin")).without_thread_store();
+        let mut launcher = CodexLauncher::with_bin(PathBuf::from("unused-fake-bin"));
         launcher.state = Mutex::new(super::LauncherState {
             server: Some(server),
             threads: HashMap::new(),
@@ -444,6 +551,35 @@ mod tests {
     }
 
     #[test]
+    fn persistence_is_opt_in() {
+        // GH-535 round 1: persistence must be dispatch-scoped. `new()` and
+        // `with_bin()` — the constructors conduct's launcher factory goes
+        // through — must not touch the per-user store at all; only an
+        // explicit opt-in enables it.
+        assert!(CodexLauncher::new().thread_store.is_none());
+        assert!(
+            CodexLauncher::with_bin(PathBuf::from("unused"))
+                .thread_store
+                .is_none(),
+            "with_bin must stay non-persistent by default"
+        );
+        assert!(
+            CodexLauncher::new()
+                .with_persistent_threads()
+                .thread_store
+                .is_some(),
+            "with_persistent_threads opts into the per-user store"
+        );
+        assert!(
+            CodexLauncher::new()
+                .with_thread_store(PathBuf::from("custom-root"))
+                .thread_store
+                .is_some(),
+            "with_thread_store opts into an explicit store root"
+        );
+    }
+
+    #[test]
     fn over_budget_semantics() {
         assert!(over_budget(Some(2.0), Some(1.0)));
         assert!(!over_budget(Some(1.0), Some(1.0)));
@@ -457,7 +593,7 @@ mod tests {
         let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
         let (_dir, mut server) = spawn_fake_server(FakeScenario::RunTurnCompletes).await;
         let mut threads = HashMap::new();
-        let (result, keep_server) = drive_turn(
+        let outcome = drive_turn(
             &mut server,
             &mut threads,
             &phase,
@@ -467,8 +603,8 @@ mod tests {
             &CancellationToken::new(),
         )
         .await;
-        assert!(keep_server);
-        match result {
+        assert!(outcome.keep_server);
+        match outcome.result {
             PhaseResult::AgentDone {
                 cost_usd,
                 result_text,
@@ -489,7 +625,7 @@ mod tests {
         let phase = phase_from_yaml("  - id: a\n    prompt: x\n    budget_usd: 0.01\n");
         let (_dir, mut server) = spawn_fake_server(FakeScenario::RunTurnCompletes).await;
         let mut threads = HashMap::new();
-        let (result, keep_server) = drive_turn(
+        let outcome = drive_turn(
             &mut server,
             &mut threads,
             &phase,
@@ -499,10 +635,14 @@ mod tests {
             &CancellationToken::new(),
         )
         .await;
-        assert!(keep_server);
+        assert!(outcome.keep_server);
         assert!(
-            matches!(result, PhaseResult::AgentDone { cost_usd: None, .. }),
-            "expected AgentDone without cost, got {result:?}"
+            matches!(
+                outcome.result,
+                PhaseResult::AgentDone { cost_usd: None, .. }
+            ),
+            "expected AgentDone without cost, got {:?}",
+            outcome.result
         );
         Ok(())
     }
@@ -512,7 +652,7 @@ mod tests {
         let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
         let (_dir, mut server) = spawn_fake_server(FakeScenario::RunTurnStartError).await;
         let mut threads = HashMap::new();
-        let (result, keep_server) = drive_turn(
+        let outcome = drive_turn(
             &mut server,
             &mut threads,
             &phase,
@@ -522,8 +662,11 @@ mod tests {
             &CancellationToken::new(),
         )
         .await;
-        assert!(!keep_server, "a failed turn kills the app-server child");
-        match result {
+        assert!(
+            !outcome.keep_server,
+            "a failed turn kills the app-server child"
+        );
+        match outcome.result {
             PhaseResult::AgentCrash { error } => {
                 assert!(error.contains("bad turn"), "{error}");
             }
@@ -538,7 +681,7 @@ mod tests {
         let (_dir, mut server) = spawn_fake_server(FakeScenario::Idle).await;
         let mut threads = HashMap::new();
         let started = tokio::time::Instant::now();
-        let (result, keep_server) = drive_turn(
+        let outcome = drive_turn(
             &mut server,
             &mut threads,
             &phase,
@@ -548,8 +691,8 @@ mod tests {
             &CancellationToken::new(),
         )
         .await;
-        assert!(!keep_server);
-        assert!(matches!(result, PhaseResult::Timeout));
+        assert!(!outcome.keep_server);
+        assert!(matches!(outcome.result, PhaseResult::Timeout));
         assert!(started.elapsed() < Duration::from_secs(15));
         Ok(())
     }
@@ -565,7 +708,7 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(300)).await;
             canceller.cancel();
         });
-        let (result, keep_server) = drive_turn(
+        let outcome = drive_turn(
             &mut server,
             &mut threads,
             &phase,
@@ -575,8 +718,8 @@ mod tests {
             &cancel,
         )
         .await;
-        assert!(!keep_server);
-        match result {
+        assert!(!outcome.keep_server);
+        match outcome.result {
             PhaseResult::AgentCrash { error } => assert_eq!(error, "conductor shutdown"),
             other => panic!("expected AgentCrash, got {other:?}"),
         }
@@ -595,7 +738,7 @@ mod tests {
         let (_dir, mut server) = spawn_fake_server(FakeScenario::TwoTurnsWithResume).await;
         let mut threads = HashMap::new();
 
-        let (first, keep) = drive_turn(
+        let first = drive_turn(
             &mut server,
             &mut threads,
             &phase,
@@ -605,15 +748,15 @@ mod tests {
             &CancellationToken::new(),
         )
         .await;
-        assert!(keep);
-        match first {
+        assert!(first.keep_server);
+        match first.result {
             PhaseResult::AgentDone { result_text, .. } => {
                 assert_eq!(result_text.as_deref(), Some("first answer"));
             }
             other => panic!("expected AgentDone, got {other:?}"),
         }
 
-        let (second, keep) = drive_turn(
+        let second = drive_turn(
             &mut server,
             &mut threads,
             &phase,
@@ -623,8 +766,8 @@ mod tests {
             &CancellationToken::new(),
         )
         .await;
-        assert!(keep);
-        match second {
+        assert!(second.keep_server);
+        match second.result {
             PhaseResult::AgentDone { result_text, .. } => {
                 assert_eq!(result_text.as_deref(), Some("second answer"));
             }
@@ -888,6 +1031,51 @@ mod tests {
         assert!(
             matches!(&result, PhaseResult::AgentDone { result_text, .. } if result_text.as_deref() == Some("turn complete")),
             "degraded dispatch should complete via thread/start, got {result:?}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_persisted_binding_degrades_to_thread_start_and_is_not_rewritten() -> Result<()> {
+        // A syntactically valid but stale entry (the server no longer knows
+        // the thread) loads fine, so the first open is a thread/resume that
+        // the fake rejects. The dispatch must recover via thread/start
+        // within the same run — not crash — and must not write the stale
+        // binding back: the map ends up holding only the fresh binding.
+        let store_root = tempfile::tempdir()?;
+        let cwd = tempfile::tempdir()?;
+        let map = map_path_for(store_root.path(), cwd.path());
+        std::fs::create_dir_all(map.parent().unwrap())?;
+        std::fs::write(&map, br#"{"sess-1":"stale-thread"}"#)?;
+
+        let (_fake_dir, bin) =
+            fake_app_server_bin(FakeScenario::ResumeErrorThenStart).expect("fake written");
+        let launcher =
+            CodexLauncher::with_bin(bin).with_thread_store(store_root.path().to_path_buf());
+        let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
+        let result = launcher
+            .run_phase(
+                &phase,
+                "turn one",
+                "",
+                "sess-1",
+                cwd.path(),
+                CancellationToken::new(),
+            )
+            .await
+            .expect("a stale binding must degrade, not fail the dispatch");
+        match result {
+            PhaseResult::AgentDone { result_text, .. } => {
+                assert_eq!(result_text.as_deref(), Some("fresh answer"));
+            }
+            other => panic!(
+                "stale binding should degrade to thread/start in the same dispatch, got {other:?}"
+            ),
+        }
+        assert_eq!(
+            std::fs::read_to_string(&map).expect("map rewritten"),
+            r#"{"sess-1":"t-1"}"#,
+            "the stale binding must not be written back"
         );
         Ok(())
     }


### PR DESCRIPTION
Closes #535

## Summary

CodexLauncher persists the conductor session id → codex thread id map in the per-user edda store (`projects/<project_id>/state/codex-threads.json`, atomic write under an exclusive file lock) and merges it into the in-memory map on cold start. A repeated `edda dispatch --agent codex --session-id S` in a new process now resumes the recorded codex thread via `thread/resume` instead of starting an unrelated conversation.

- Corrupt or missing store entries degrade to `thread/start`; only corruption warns, and persistence failures never fail a dispatch.
- Conduct-path behavior is unchanged (in-memory map stays the hot path within one process).
- The #534 round-2 cross-process `--session-id` warning for codex is removed from dispatch; the launcher keeps a warning only for the corrupt-map degrade case.

## Gates (all green at head e9f3e7d)

- `cargo fmt --all --check`
- `cargo clippy -p edda-conductor --all-targets -- -D warnings`
- `cargo test -p edda-conductor` — 244 passed, 0 failed

Regression coverage: a two-launcher fake-server test proves `thread/resume` fires on the second process (verified to fail without the fix), plus merge-under-lock, corrupt/missing-degrade, and fresh-start tests. Cost/usage symbols (`total_cost_usd`, `cost_line`, `NO_USAGE_COST_TEXT`) are untouched — that boundary belongs to #533.