### PR TITLE
fix(edda-conductor): model plan-level cost measured-ness (#533)

### DIFF
--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -508,15 +508,14 @@ fn gate_preview(phase: &Phase) -> String {
 /// `edda dispatch`'s no-usage rendering so the string has one source.
 pub(crate) const NO_USAGE_COST_TEXT: &str = "n/a (no usage data reported)";
 
-/// The status cost line.
+/// The status cost line, derived from the cost model (GH-533).
 ///
-/// `PlanState` does not record which agent backend ran, so a zero total
-/// cannot be attributed: usage-free backends like codex report no cost data
-/// at all, while a backend that reports usage overwrites the zero with a
-/// real figure once a phase completes. Printing "$0.00" for a codex run
-/// would assert a spend nobody measured, so a zero total renders as "n/a".
-pub(crate) fn cost_line(total_cost_usd: f64) -> String {
-    if total_cost_usd == 0.0 {
+/// `PlanState` records `cost_measured` alongside `total_cost_usd`, so a
+/// total nobody measured (usage-free backends like codex) renders as "n/a"
+/// while a genuine measured figure — including a real $0.00 — is asserted
+/// as-is. Under-claiming beats asserting an unmeasured figure.
+pub(crate) fn cost_line(total_cost_usd: f64, cost_measured: bool) -> String {
+    if !cost_measured {
         NO_USAGE_COST_TEXT.to_owned()
     } else {
         format!("${total_cost_usd:.2}")
@@ -561,7 +560,10 @@ fn print_status(state: &PlanState) {
     if !state.plan_file.is_empty() {
         println!("  File: {}", state.plan_file);
     }
-    println!("  Cost: {}", cost_line(state.total_cost_usd));
+    println!(
+        "  Cost: {}",
+        cost_line(state.total_cost_usd, state.cost_measured)
+    );
 
     println!();
     for ps in &state.phases {
@@ -749,14 +751,20 @@ mod tests {
     }
 
     #[test]
-    fn cost_line_reports_na_for_a_zero_total() {
-        // A zero total cannot be attributed to a backend (PlanState records
-        // no agent); codex runs would otherwise print a false "$0.00".
-        assert_eq!(cost_line(0.0), "n/a (no usage data reported)");
+    fn cost_line_reports_na_when_unmeasured() {
+        // GH-533: measured-ness comes from the model, not the zero sentinel.
+        assert_eq!(cost_line(0.0, false), "n/a (no usage data reported)");
     }
 
     #[test]
-    fn cost_line_formats_a_reported_total() {
-        assert_eq!(cost_line(1.234), "$1.23");
+    fn cost_line_formats_a_measured_total() {
+        assert_eq!(cost_line(1.234, true), "$1.23");
+    }
+
+    #[test]
+    fn cost_line_asserts_a_genuinely_measured_zero() {
+        // A backend that reported usage summing to zero measured a real $0.00;
+        // the model now distinguishes it from "nobody measured anything".
+        assert_eq!(cost_line(0.0, true), "$0.00");
     }
 }

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -155,10 +155,12 @@ impl DispatchOutput {
     }
 
     /// The `Cost:` line, reusing conduct's honest rendering: a total nobody
-    /// measured renders as "n/a", never as a fabricated "$0.00".
+    /// measured renders as "n/a", never as a fabricated "$0.00". Here
+    /// measured-ness is the `Option` itself — `Some(c)` means the backend
+    /// reported that figure, including a genuine $0.00 (GH-533).
     fn cost_text(&self) -> String {
         self.cost_usd
-            .map(cost_line)
+            .map(|cost| cost_line(cost, true))
             .unwrap_or_else(|| NO_USAGE_COST_TEXT.to_owned())
     }
 

--- a/crates/edda-conductor/src/runner/event_log.rs
+++ b/crates/edda-conductor/src/runner/event_log.rs
@@ -56,7 +56,10 @@ pub enum Event {
     },
     PlanCompleted {
         phases_passed: usize,
-        total_cost_usd: f64,
+        /// GH-533: `None` until any phase recorded a measured cost — same
+        /// pattern as `PhasePassed::cost_usd`. A usage-free backend (codex)
+        /// emits `null`, never the unmeasured `0.0` sentinel.
+        total_cost_usd: Option<f64>,
     },
     PlanAborted {
         phases_passed: usize,
@@ -210,6 +213,29 @@ mod tests {
         assert!(json.contains(r#""type":"plan_start""#));
         assert!(json.contains(r#""plan_name":"test""#));
         assert!(json.contains(r#""phase_count":3"#));
+    }
+
+    #[test]
+    fn event_plan_completed_unmeasured_cost_is_not_asserted() {
+        // GH-533: a usage-free backend (codex) must not emit the sentinel
+        // `total_cost_usd: 0.0` as if it were a measured figure.
+        let event = Event::PlanCompleted {
+            phases_passed: 2,
+            total_cost_usd: None,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(!json.contains(r#""total_cost_usd":0.0"#));
+        assert!(json.contains(r#""total_cost_usd":null"#));
+    }
+
+    #[test]
+    fn event_plan_completed_measured_cost_round_trips_exactly() {
+        let event = Event::PlanCompleted {
+            phases_passed: 1,
+            total_cost_usd: Some(1.234),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains(r#""total_cost_usd":1.234"#));
     }
 
     #[test]

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -509,7 +509,8 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
         println!("\n✓ Plan \"{}\" completed ({passed} passed)", plan.name);
         event_log.record(Event::PlanCompleted {
             phases_passed: passed,
-            total_cost_usd: state.total_cost_usd,
+            // GH-533: None (null in JSONL) until some phase measured a cost.
+            total_cost_usd: state.cost_measured.then_some(state.total_cost_usd),
         });
         notifier
             .notify(&format!(
@@ -775,7 +776,7 @@ async fn process_phase_result(
         } => {
             if let Some(cost) = cost_usd {
                 budget.record(cost);
-                state.total_cost_usd += cost;
+                state.record_cost(cost);
             }
 
             // running → checking
@@ -994,7 +995,7 @@ async fn process_phase_result(
         PhaseResult::MaxTurns { cost_usd } | PhaseResult::BudgetExceeded { cost_usd } => {
             if let Some(cost) = cost_usd {
                 budget.record(cost);
-                state.total_cost_usd += cost;
+                state.record_cost(cost);
             }
             let elapsed_ms = phase_start.elapsed().as_millis() as u64;
             let msg = format!("{result:?}");
@@ -1848,6 +1849,65 @@ phases:
         // Seq increments
         assert_eq!(events[0]["seq"], 0);
         assert_eq!(events[3]["seq"], 3);
+    }
+
+    #[tokio::test]
+    async fn plan_completed_usage_free_run_does_not_assert_zero_cost() {
+        // GH-533: a codex-style run (no usage data) must not emit the
+        // unmeasured sentinel `total_cost_usd: 0.0` in the event stream.
+        let yaml = r#"
+name: test
+phases:
+  - id: a
+    prompt: "usage-free"
+"#;
+        let launcher = MockLauncher::new();
+        launcher.set_results(
+            "a",
+            vec![PhaseResult::AgentDone {
+                cost_usd: None,
+                result_text: None,
+            }],
+        );
+        let (state, dir) = run_test_plan_with_dir(yaml, &launcher).await;
+
+        assert!(!state.cost_measured, "usage-free run must not be measured");
+        let events = read_events(dir.path(), "test");
+        let completed = events
+            .iter()
+            .find(|e| e["type"] == "plan_completed")
+            .expect("plan_completed event");
+        assert_ne!(completed["total_cost_usd"], serde_json::json!(0.0));
+        assert!(completed["total_cost_usd"].is_null());
+    }
+
+    #[tokio::test]
+    async fn plan_completed_measured_cost_round_trips_exactly() {
+        // GH-533: a run whose backend reported usage keeps the exact total.
+        let yaml = r#"
+name: test
+phases:
+  - id: a
+    prompt: "measured"
+"#;
+        let launcher = MockLauncher::new();
+        launcher.set_results(
+            "a",
+            vec![PhaseResult::AgentDone {
+                cost_usd: Some(0.42),
+                result_text: None,
+            }],
+        );
+        let (state, dir) = run_test_plan_with_dir(yaml, &launcher).await;
+
+        assert!(state.cost_measured);
+        assert!((state.total_cost_usd - 0.42).abs() < 1e-9);
+        let events = read_events(dir.path(), "test");
+        let completed = events
+            .iter()
+            .find(|e| e["type"] == "plan_completed")
+            .expect("plan_completed event");
+        assert_eq!(completed["total_cost_usd"], serde_json::json!(0.42));
     }
 
     #[tokio::test]

--- a/crates/edda-conductor/src/state/machine.rs
+++ b/crates/edda-conductor/src/state/machine.rs
@@ -44,6 +44,13 @@ pub struct PlanState {
     pub aborted_at: Option<String>,
     #[serde(default)]
     pub total_cost_usd: f64,
+    /// GH-533: whether any phase recorded a measured cost. `total_cost_usd`
+    /// alone cannot distinguish "usage-free backend (codex)" from a genuine
+    /// $0.00 run, so renderers must consult this flag instead of inferring
+    /// from the zero sentinel. Legacy state files (field absent) restore as
+    /// unmeasured — under-claiming beats asserting an unmeasured figure.
+    #[serde(default)]
+    pub cost_measured: bool,
     pub phases: Vec<PhaseState>,
     #[serde(default)]
     pub version: u32,
@@ -286,6 +293,7 @@ impl PlanState {
             completed_at: None,
             aborted_at: None,
             total_cost_usd: 0.0,
+            cost_measured: false,
             phases,
             version: 0,
         }
@@ -296,6 +304,12 @@ impl PlanState {
             .iter()
             .find(|p| p.id == id)
             .ok_or_else(|| anyhow::anyhow!("phase not found: \"{id}\""))
+    }
+
+    /// Record a measured cost reported by an agent backend (GH-533).
+    pub fn record_cost(&mut self, cost: f64) {
+        self.total_cost_usd += cost;
+        self.cost_measured = true;
     }
 
     pub fn get_phase_mut(&mut self, id: &str) -> Result<&mut PhaseState> {
@@ -511,6 +525,34 @@ phases:
     }
 
     // ── AwaitingVerdict gate state (D2/D3) ──────────────────────────
+
+    #[test]
+    fn legacy_state_without_cost_measured_deserializes_unmeasured() {
+        // Pre-GH-533 state files carry `total_cost_usd` but no `cost_measured`
+        // flag; they must restore as unmeasured (under-claim), never as a
+        // measured figure.
+        let json = r#"{
+            "plan_name": "test",
+            "plan_file": "plan.yaml",
+            "plan_status": "pending",
+            "total_cost_usd": 0.0,
+            "phases": [],
+            "version": 0
+        }"#;
+        let restored: PlanState = serde_json::from_str(json).unwrap();
+        assert!(!restored.cost_measured);
+    }
+
+    #[test]
+    fn record_cost_marks_measured_and_accumulates() {
+        let plan = test_plan();
+        let mut state = PlanState::from_plan(&plan, "plan.yaml");
+        assert!(!state.cost_measured);
+        state.record_cost(0.42);
+        state.record_cost(0.11);
+        assert!(state.cost_measured);
+        assert!((state.total_cost_usd - 0.53).abs() < 1e-9);
+    }
 
     #[test]
     fn awaiting_verdict_serializes_snake_case() {

--- a/demo/runtime-edda.js
+++ b/demo/runtime-edda.js
@@ -173,6 +173,13 @@ function translateEvent(event, taskId) {
       };
 
     case "plan_completed":
+      // GH-533: total_cost_usd is f64|null — null means the backend never
+      // reported usage (unmeasured), not a genuine $0.00. The brief schema
+      // documents cost.total_usd as a number, so an unmeasured total emits
+      // no cost claim at all rather than asserting null or a coerced 0.
+      // Mirrors the Rust cost_line model: unmeasured renders "n/a", a
+      // measured zero round-trips as 0.
+      if (event.total_cost_usd == null) return null;
       return {
         cost: { total_usd: event.total_cost_usd },
       };
@@ -195,7 +202,14 @@ function translateEvent(event, taskId) {
 function extractReplyText(events) {
   const completed = events.find((e) => e.type === "plan_completed");
   if (completed) {
-    return `Plan completed: ${completed.phases_passed} phases, $${completed.total_cost_usd.toFixed(2)}`;
+    // GH-533: null total_cost_usd is unmeasured (no usage data), not $0.00.
+    // Render it as not-available, matching the Rust cost_line wording; a
+    // genuine measured zero still renders $0.00.
+    const costText =
+      completed.total_cost_usd != null
+        ? `$${completed.total_cost_usd.toFixed(2)}`
+        : "n/a (no usage data reported)";
+    return `Plan completed: ${completed.phases_passed} phases, ${costText}`;
   }
   const aborted = events.find((e) => e.type === "plan_aborted");
   if (aborted) {

--- a/demo/tests/test_runtime_edda.js
+++ b/demo/tests/test_runtime_edda.js
@@ -123,6 +123,25 @@ function testTranslatePlanCompleted() {
   console.log("  PASS: translateEvent plan_completed");
 }
 
+function testTranslatePlanCompletedUnmeasured() {
+  // GH-533: a usage-free run emits total_cost_usd:null — unmeasured, not zero.
+  // The brief schema documents cost.total_usd as a number, so an unmeasured
+  // total must not produce a cost claim at all (no null, no coerced 0).
+  const event = { type: "plan_completed", phases_passed: 3, total_cost_usd: null, seq: 5, ts: "2026-01-01T00:01:00Z" };
+  const patch = translateEvent(event, "T5");
+  assert.strictEqual(patch, null, "unmeasured total must not emit a numeric cost patch");
+  console.log("  PASS: translateEvent plan_completed unmeasured");
+}
+
+function testTranslatePlanCompletedMeasuredZero() {
+  // GH-533: a backend that reported usage summing to zero measured a real $0.00;
+  // it must round-trip as 0, distinct from an unmeasured null.
+  const event = { type: "plan_completed", phases_passed: 3, total_cost_usd: 0, seq: 5, ts: "2026-01-01T00:01:00Z" };
+  const patch = translateEvent(event, "T5");
+  assert.strictEqual(patch.cost.total_usd, 0, "a measured zero must survive as 0, not be dropped");
+  console.log("  PASS: translateEvent plan_completed measured zero");
+}
+
 function testTranslatePlanAborted() {
   const event = { type: "plan_aborted", phases_passed: 1, phases_pending: 2, seq: 5, ts: "2026-01-01T00:01:00Z" };
   const patch = translateEvent(event, "T5");
@@ -149,6 +168,29 @@ function testExtractReplyTextCompleted() {
   assert(text.includes("2 phases"), "should mention phases");
   assert(text.includes("$1.50"), "should mention cost");
   console.log("  PASS: extractReplyText completed");
+}
+
+function testExtractReplyTextUnmeasured() {
+  // GH-533: null total_cost_usd must render as not-available, mirroring the
+  // Rust cost_line model — and must not throw on toFixed of null.
+  const events = [
+    { type: "plan_start", plan_name: "test", phase_count: 2 },
+    { type: "plan_completed", phases_passed: 2, total_cost_usd: null },
+  ];
+  const text = extractReplyText(events);
+  assert(text.includes("n/a"), "unmeasured total must render as n/a");
+  console.log("  PASS: extractReplyText completed unmeasured");
+}
+
+function testExtractReplyTextMeasuredZero() {
+  // GH-533: a genuine measured zero renders $0.00, not n/a and not a lie.
+  const events = [
+    { type: "plan_start", plan_name: "test", phase_count: 2 },
+    { type: "plan_completed", phases_passed: 2, total_cost_usd: 0 },
+  ];
+  const text = extractReplyText(events);
+  assert(text.includes("$0.00"), "a measured zero must render $0.00");
+  console.log("  PASS: extractReplyText completed measured zero");
 }
 
 function testExtractReplyTextAborted() {
@@ -206,11 +248,15 @@ testTranslatePhasePassed();
 testTranslatePhaseFailed();
 testTranslatePhaseSkipped();
 testTranslatePlanCompleted();
+testTranslatePlanCompletedUnmeasured();
+testTranslatePlanCompletedMeasuredZero();
 testTranslatePlanAborted();
 testTranslateUnknownEvent();
 
 console.log("\nextractReplyText:");
 testExtractReplyTextCompleted();
+testExtractReplyTextUnmeasured();
+testExtractReplyTextMeasuredZero();
 testExtractReplyTextAborted();
 
 console.log("\nextractSessionId:");


### PR DESCRIPTION
## What changed

`PlanCompleted { total_cost_usd: f64 }` was filled from `PlanState`, so a usage-free backend (codex) asserted the unmeasured sentinel `0.0` into the JSONL / `--json` event stream — the same unmeasured-zero shape #531 removed from `print_status`. Measured-ness is now modeled once, at the source, following `PhasePassed`'s existing `Option<f64>` pattern:

- **`PlanState`** (`crates/edda-conductor/src/state/machine.rs`): new `cost_measured: bool` (`#[serde(default)]` — legacy state files restore as unmeasured, the accepted under-claim failure mode) + `record_cost()` helper that accumulates and marks measured-ness. Both accumulation sites in `sequential.rs` now go through it.
- **`PlanCompleted`** (`crates/edda-conductor/src/runner/event_log.rs`): `total_cost_usd: Option<f64>` — `null` in JSONL until a phase records a measured cost; a measured total round-trips exactly.
- **`cost_line(total, measured)`** (`crates/edda-cli/src/cmd_conduct.rs`): derives from the model instead of the zero sentinel — a genuine measured `Some(0.0)` now honestly prints `$0.00`, an unmeasured total prints `n/a (no usage data reported)`.
- **`cmd_dispatch.rs`**: minimal one-line adaptation required by the signature change (at that phase-level surface measured-ness *is* the `Option`; `Some(c)` passes `measured = true`).

### JSONL / `--json` schema audit (deliberate change)

`Event` is `Serialize`-only; nothing in the repo *deserializes* the conductor `events.jsonl` — the `total_cost_usd` hits in `edda-aggregate` / `edda-serve` / `edda-ledger` belong to the unrelated `cycle_telemetry` pipeline. The field stays present (emitting `null` when unmeasured, same as `PhasePassed::cost_usd`), so external consumers see `f64` → `f64|null` type-widening, not a removed key.

**Correction (Round 1 review):** the original audit also claimed no in-repo consumer reads conductor events — that was false. `demo/runtime-edda.js` consumes the conductor `--json` stream and translated `plan_completed` into a brief PATCH `{cost:{total_usd:null}}` (contradicting the documented numeric brief schema), and its exported `extractReplyText` threw `TypeError` on `null.toFixed(2)`. Fixed in 69aa05ab4a18f5502120eac7cbf1cf3e189c2786: an unmeasured total emits no cost claim (mirrors `cost_line`'s `n/a` semantics) while a genuine measured `0` still round-trips as `0`; `extractReplyText` renders `n/a (no usage data reported)` for unmeasured totals. Both shapes are pinned in `demo/tests/test_runtime_edda.js`.

## doneWhen → evidence

- [x] **A codex (usage-free) run's `PlanCompleted` does not assert `total_cost_usd: 0.0`** — `plan_completed_usage_free_run_does_not_assert_zero_cost` (end-to-end via `MockLauncher` with `cost_usd: None`) asserts the event is not `0.0` and is `null`; `event_plan_completed_unmeasured_cost_is_not_asserted` pins the serialization.
- [x] **A genuine measured total round-trips exactly** — `plan_completed_measured_cost_round_trips_exactly` (`Some(0.42)` → `"total_cost_usd":0.42`) and `event_plan_completed_measured_cost_round_trips_exactly` (`Some(1.234)`).
- [x] **`cost_line` derives from the model** — `cost_line_reports_na_when_unmeasured`, `cost_line_formats_a_measured_total`, `cost_line_asserts_a_genuinely_measured_zero`.
- [x] **JSONL schema change is deliberate** — audit above, including the Round-1 correction for the `demo/runtime-edda.js` consumer (fixed and tested); compat preserved (field kept, `null` when unmeasured).
- Bonus coverage: `legacy_state_without_cost_measured_deserializes_unmeasured` and `record_cost_marks_measured_and_accumulates` pin the `PlanState` model.

## Gate receipt (L1, frozen SHA `d3aaa1d4dc014ecea777020df87410c4d2f7c349`)

- Gate set: `cargo fmt --all --check` (OK); `cargo clippy --workspace --all-targets -- -D warnings` (OK); `cargo test --workspace` (OK with two re-runs of load-flaky tests, see below).
- Toolchain: rustc 1.93.1 (01f6ddf75 2026-02-11), `x86_64-pc-windows-msvc`; lane `worker-1`, `CARGO_INCREMENTAL=0`, clean tree.
- Notes: one full-suite flake per run — `edda-bridge-claude peers::tests::render_coordination_protocol_with_matches_original` (crate untouched by this diff) failed under parallel load and passes on isolated re-run; earlier L0 runs of `-p edda-conductor` showed the same pattern for 3 timing-sensitive tests, all green standalone.

L0 during iteration: `fmt --check`, `clippy -p edda-conductor` and `-p edda` (all-targets, `-D warnings`), `cargo test -p edda-conductor` (241 passed) and `cargo test -p edda` (366 + 11 passed) — all green.

Fixes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)
