### PR TITLE
docs(readme): reposition around one ledger, two layers — memory and fleet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 <h1 align="center">Edda</h1>
 
 <p align="center">
-  <strong>Your agent's decisions shouldn't reset every session.</strong><br/>
-  Edda gives coding agents a local, automatic memory of what was decided — and why.<br/>
+  <strong>Your agents' work shouldn't vanish when the session dies.</strong><br/>
+  Edda is a local, tamper-evident ledger for coding agents:<br/>
+  decisions that survive sessions, and coordination that survives agents.<br/>
   Works with Claude Code, Cursor, Codex, OpenClaw, and any MCP client.
 </p>
 
@@ -16,6 +17,8 @@
 
 <p align="center">
   <a href="#why-edda">Why Edda?</a> ·
+  <a href="#layer-1--memory-that-survives-sessions">Memory</a> ·
+  <a href="#layer-2--coordination-that-survives-agents">Fleet</a> ·
   <a href="#install">Install</a> ·
   <a href="#quick-start">Quick Start</a> ·
   <a href="#how-it-works">How It Works</a> ·
@@ -36,9 +39,24 @@
 
 ## Why Edda?
 
-Yesterday you and your agent argued through the tradeoffs and settled on SQLite. Today's session opens — and it proposes Postgres. Again. The reasoning died with the transcript, and compaction can't bring it back.
+Agent work disappears in two ways.
 
-Edda fixes exactly this: hooks watch your sessions, capture each decision with its rationale into a local ledger, and hand it to the next session before it starts. The agent stops forgetting.
+**The session dies, and the decisions die with it.** Yesterday you and your agent argued through the tradeoffs and settled on SQLite. Today's session opens — and it proposes Postgres. Again. The reasoning died with the transcript, and compaction can't bring it back.
+
+**The agent dies, and the work state dies with it.** You run two or three agents in parallel and one session crashes mid-task. What was it doing? What did it finish? Was anything half-done? If the answer lives in a process that no longer exists, you get to reconstruct it by hand — or worse, redo work that was already done.
+
+Edda fixes both with the same primitive: **an append-only, hash-chained ledger in `.edda/`, on your machine, that outlives any session, any agent, and any tool.** One ledger, two layers of application:
+
+| Layer | Question it answers | Primitives |
+|---|---|---|
+| **Memory** | *What was decided, and why?* | decisions, notes, session digests, automatic injection |
+| **Fleet** | *Who is doing what, and what actually happened?* | claims, tasks + receipts, plans, gates, verdicts |
+
+Use layer 1 alone from day one. Layer 2 is simply there — same ledger, same CLI — when you start running more than one agent.
+
+## Layer 1 — Memory that survives sessions
+
+Hooks watch your sessions, capture each decision with its rationale into the ledger, and hand it to the next session before it starts. The agent stops forgetting.
 
 ```
 Without edda                          With edda
@@ -60,7 +78,7 @@ You: "We settled this. YESTERDAY."       writer, JSONB not needed)…"
 
 **Data stays local** — the ledger lives in `.edda/` (SQLite + local files), with no cloud and no accounts. The core loop (record, retrieve, inject) is deterministic and never calls out. **Optional LLM assist** for session digests, decision extraction, and pattern correlation is opt-in via `EDDA_LLM_API_KEY` and budget-capped — leave the key unset and edda runs zero-egress.
 
-## One memory, every agent
+### One memory, every agent
 
 More and more developers alternate between agents — Claude Code for one task, Codex for a second opinion on the next. Both models are strong; what breaks is the memory. Each tool keeps its own silo, so every switch means re-explaining the project from zero.
 
@@ -91,6 +109,42 @@ Edda starts paying for itself when any of these is true:
 | Sessions run in containers | Each container is an island; the shared state you'd mount *is* `.edda/` |
 
 </details>
+
+## Layer 2 — Coordination that survives agents
+
+The moment you run a second agent, memory stops being the hard problem. The hard problems become: *who is working where, who decided what under which authority, and what actually happened while you weren't looking.* Edda answers all three from the same ledger.
+
+**Claims — who is working where.** Sessions declare their scope; every peer sees it injected into context, and a guard warns before an agent edits a path someone else claimed. Parallel sessions stop trampling each other.
+
+```bash
+edda claim "auth-refactor" --paths "src/auth/*"
+```
+
+**Tasks with receipts — what actually happened.** Work is handed off on a task rail, and a task is only done when it carries evidence. A `done` without a receipt does not exist.
+
+```bash
+edda task new "run integration tests" --assignee tester
+edda task done 13 --receipt "110/601 green, artifact in dist/"
+```
+
+**Plans with gates — multi-phase work that pauses for judgment.** `edda conduct` runs a YAML plan phase by phase: each phase dispatches an agent, verifies its output with checks, and can hold at a **verdict gate** before anything irreversible or expensive. The gate pins the exact git SHA it approves — a new push invalidates the old verdict by construction.
+
+```bash
+edda conduct run plan.yaml         # run a multi-phase plan
+edda conduct status                # where is every plan right now
+edda verdict approve my-plan/impl --sha <full-40-hex-sha>
+edda verdict reject  my-plan/impl --sha <sha> --comment "tests missing"
+```
+
+**Detached lanes — work that outlives its launcher.** `edda dispatch` runs one agent turn (Claude, Codex, or pi) as a self-contained unit you can launch detached. The lane does not depend on the session that spawned it: when a controller session died mid-flight — ours did, three times in one day — the dispatched work kept running, and its results were recovered from branches, PRs, and the ledger rather than from anyone's memory.
+
+```bash
+edda dispatch --agent codex --prompt-file task.md
+```
+
+**Two-tier authority — recorded is not binding.** Agents record decisions freely, but a recorded decision is *unratified* until the operator confers authority with `edda ratify`. Your fleet can propose all day; only you make it policy. Combined with the hash chain, this is the property the whole layer is built for: **agents run on your machine, and you can always check what they did — in order, tamper-evident, with the authority trail attached.**
+
+> **Maturity note:** layer 1 is stable daily-driver territory. Layer 2 ships today (claims, tasks, conduct, dispatch, verdict gates, ratify) and is where edda is growing fastest — in-flight work on liveness heartbeats, unified fleet status, and event-driven notifications is tracked in [#560](https://github.com/fagemx/edda/issues/560). It is developed by being used: edda's own multi-agent fleet builds edda with it.
 
 ## Install
 
@@ -141,7 +195,7 @@ This is the key to Edda's automation — the agent learns to call `edda decide` 
 Claude Code session
         │
    Bridge hooks (deterministic, always on)
-        │  ├── record decisions / notes / peer signals
+        │  ├── record decisions / notes / claims / peer signals
         │  ├── inject prior context on session start
         │  └── optional: doctrine pack from havamal
         ▼
@@ -157,7 +211,7 @@ Claude Code session
    Next session sees everything
 ```
 
-Edda stores every event as a hash-chained JSON record in a local SQLite database. Events include decisions, notes, session digests, and command outputs. The hash chain makes the history tamper-evident and the retrieval deterministic — same query, same answer, no LLM in the loop.
+Edda stores every event as a hash-chained JSON record in a local SQLite database. Events include decisions, notes, session digests, tasks, claims, verdicts, and command outputs. The hash chain makes the history tamper-evident and the retrieval deterministic — same query, same answer, no LLM in the loop.
 
 At the start of each session, edda assembles a context snapshot from the ledger and injects it — the agent sees recent decisions, active tasks, peer coordination, and (if configured) a doctrine pack from [havamal](https://github.com/fagemx/havamal), without reading through old transcripts.
 
@@ -175,6 +229,7 @@ At the start of each session, edda assembles a context snapshot from the ledger 
 | **Tracks "why"?** | Sometimes | No | Lossy | **Yes** (rationale + rejected alternatives) |
 | **Cross-session?** | Manual copy | Yes | Session-scoped | **Yes** (automatic) |
 | **Cross-agent?** | No — one tool's file | Per-app integration | No — vendor silo | **Yes** (Claude Code, Codex, OpenClaw, MCP) |
+| **Multi-agent coordination?** | No | No | No | **Yes** (claims, tasks + receipts, gates) |
 | **Cost per query** | Free | Embedding API call | LLM API call | **Free** (local SQLite); optional digests budget-capped |
 
 | **Examples** | Claude Code built-in, OpenClaw | mem0, Zep, Chroma | ChatGPT Memory, Copilot | — |
@@ -250,32 +305,45 @@ edda watch                 # real-time TUI: peers, events, decisions
 <details>
 <summary>All commands</summary>
 
+**Memory & retrieval**
+
 | Command | Description |
 |---------|-------------|
 | `edda init` | Initialize `.edda/` (auto-installs hooks if `.claude/` detected) |
 | `edda decide` | Record a decision (agent-authored; `edda ratify` to make binding) |
 | `edda note` | Record a note |
-| `edda ratify` | Confer operator authority on a decision (recorded ≠ ratified) |
-| `edda task` | Task rail: create, hand off, and track tasks (`new/start/done/fail/list/show`) |
 | `edda ask` | Query decisions, history, and conversations |
 | `edda search` | Full-text search across transcripts (Tantivy) |
 | `edda log` | Query events with filters (type, date, tag, branch) |
 | `edda context` | Output context snapshot (what the agent sees) |
 | `edda status` | Show workspace status |
-| `edda watch` | Real-time TUI: peers, events, decisions |
+| `edda run` | Run a command and record output |
 | `edda commit` | Create a commit event |
-| `edda branch` | Branch operations |
-| `edda switch` | Switch branch |
-| `edda merge` | Merge branches |
+
+**Fleet & orchestration**
+
+| Command | Description |
+|---------|-------------|
+| `edda claim` | Declare working scope so peers don't collide |
+| `edda task` | Task rail: create, hand off, and track tasks (`new/start/done/fail/list/show`) |
+| `edda ratify` | Confer operator authority on a decision (recorded ≠ ratified) |
+| `edda conduct` | Multi-phase plan orchestration with checks and gates |
+| `edda dispatch` | Single-turn agent dispatch (claude / codex / pi) |
+| `edda verdict` | Approve / reject a gated subject, pinned to a git SHA |
+| `edda watch` | Real-time TUI: peers, events, decisions |
 | `edda draft` | Propose / list / approve / reject drafts |
+
+**Workspace & plumbing**
+
+| Command | Description |
+|---------|-------------|
 | `edda bridge` | Install/uninstall tool hooks |
 | `edda doctor` | Health check |
 | `edda config` | Read/write workspace config |
 | `edda pattern` | Manage classification patterns |
 | `edda mcp` | Start MCP server (stdio JSON-RPC 2.0) |
-| `edda conduct` | Multi-phase plan orchestration |
 | `edda plan` | Plan scaffolding and templates |
-| `edda run` | Run a command and record output |
+| `edda branch` / `edda switch` / `edda merge` | Ledger branch operations |
 | `edda blob` | Manage blob metadata |
 | `edda gc` | Garbage collect expired content |
 
@@ -355,9 +423,13 @@ Shipped:
 - [x] Distribution — prebuilt binaries (macOS, Linux, Windows), one-line installer, Homebrew tap
 - [x] v0.2.0 — `edda watch` TUI, `edda ask`, peers/coordination commands, sub-agent visibility, model/token/cost capture in session hooks, user-level store (`~/.edda/`), post-mortem learned rules
 - [x] Decision deepening — `--paths`-scoped decisions, PreToolUse guard warnings, session-start decision pack, decision status lifecycle
+- [x] Fleet primitives — `edda conduct` multi-phase plans, `edda dispatch` single-turn lanes, verdict gates with SHA pinning, task rail with receipts, `edda ratify` two-tier authority
 
-Next:
+Next — folding the fleet intelligence layer into the product ([#560](https://github.com/fagemx/edda/issues/560)):
 
+- [ ] Surface-aware scheduling — phases declare the paths they own; claims carry them; overlapping dispatch is refused structurally
+- [ ] Event-driven delivery — phase terminal states and gate entries pushed through `edda-notify` instead of polled from stdout
+- [ ] Fleet observability — in-flight heartbeats and a single status plane covering both `conduct` plans and `dispatch` lanes
 - [ ] Cross-repo decision query surface — the user-level store already aggregates across projects; a first-class search/ask across repos is the remaining gap
 - [ ] Decision recall metrics — measure how often injected decisions actually change behavior
 
@@ -376,4 +448,4 @@ MIT OR Apache-2.0
 
 ---
 
-*Stop re-teaching your agent what you already decided.*
+*Stop re-teaching your agent what you already decided — and stop taking your fleet's word for what it did.*

--- a/README.md
+++ b/README.md
@@ -45,14 +45,16 @@ Agent work disappears in two ways.
 
 **The agent dies, and the work state dies with it.** You run two or three agents in parallel and one session crashes mid-task. What was it doing? What did it finish? Was anything half-done? If the answer lives in a process that no longer exists, you get to reconstruct it by hand — or worse, redo work that was already done.
 
-Edda fixes both with the same primitive: **an append-only, hash-chained ledger in `.edda/`, on your machine, that outlives any session, any agent, and any tool.** One ledger, two layers of application:
+Edda fixes both with the same primitive: **local, append-only state in `.edda/`, on your machine, that outlives any session, any agent, and any tool.** One workspace, two layers of application:
 
 | Layer | Question it answers | Primitives |
 |---|---|---|
 | **Memory** | *What was decided, and why?* | decisions, notes, session digests, automatic injection |
 | **Fleet** | *Who is doing what, and what actually happened?* | claims, tasks + receipts, plans, gates, verdicts |
 
-Use layer 1 alone from day one. Layer 2 is simply there — same ledger, same CLI — when you start running more than one agent.
+Use layer 1 alone from day one. Layer 2 is simply there — same workspace, same CLI — when you start running more than one agent.
+
+**Two persistence planes, deliberately.** Decisions, notes, session digests, tasks, and verdicts are events in the hash-chained SQLite ledger — tamper-evident and replayable. Live coordination state (claims, peer heartbeats) is a separate append-only log in the per-user store, and each `edda conduct` plan keeps its own state file and event log. All of it is local and inspectable; the hash chain covers the ledger.
 
 ## Layer 1 — Memory that survives sessions
 
@@ -114,16 +116,17 @@ Edda starts paying for itself when any of these is true:
 
 The moment you run a second agent, memory stops being the hard problem. The hard problems become: *who is working where, who decided what under which authority, and what actually happened while you weren't looking.* Edda answers all three from the same ledger.
 
-**Claims — who is working where.** Sessions declare their scope; every peer sees it injected into context, and a guard warns before an agent edits a path someone else claimed. Parallel sessions stop trampling each other.
+**Claims — who is working where.** Sessions declare their scope, and every peer sees it in the context injected at session start, so parallel agents know who owns what before they touch it. Claims are **advisory by default**: edda records and surfaces them, but nothing blocks a write until you opt in with `EDDA_ENFORCE_OFFLIMITS=1` (or `bridge.enforce_offlimits=true`), which makes the Claude Code hook refuse `Edit`/`Write` on a peer-claimed path.
 
 ```bash
 edda claim "auth-refactor" --paths "src/auth/*"
 ```
 
-**Tasks with receipts — what actually happened.** Work is handed off on a task rail, and a task is only done when it carries evidence. A `done` without a receipt does not exist.
+**Tasks with receipts — what actually happened.** Work is handed off on a task rail, and a task is only done when it carries evidence. A `done` without a receipt does not exist, and start/done pairs are what make the rail replayable.
 
 ```bash
 edda task new "run integration tests" --assignee tester
+edda task start 13
 edda task done 13 --receipt "110/601 green, artifact in dist/"
 ```
 
@@ -136,13 +139,13 @@ edda verdict approve my-plan/impl --sha <full-40-hex-sha>
 edda verdict reject  my-plan/impl --sha <sha> --comment "tests missing"
 ```
 
-**Detached lanes — work that outlives its launcher.** `edda dispatch` runs one agent turn (Claude, Codex, or pi) as a self-contained unit you can launch detached. The lane does not depend on the session that spawned it: when a controller session died mid-flight — ours did, three times in one day — the dispatched work kept running, and its results were recovered from branches, PRs, and the ledger rather than from anyone's memory.
+**Single-turn lanes — work a controller can detach.** `edda dispatch` runs exactly one agent turn (Claude, Codex, or pi) in the foreground and exits with a typed outcome — done, crash, timeout, budget exceeded — with `--json` for machine consumption. It carries no plan, DAG, or loop state; loop control stays with the caller. That statelessness is what makes it safe for a controller to launch as a detached OS process instead of a child of its own session — which is how work survives a dead controller. When our controller session died mid-flight, three times in one day, the detached lanes kept running and their results were recovered from branches, PRs, and the ledger rather than from anyone's memory.
 
 ```bash
 edda dispatch --agent codex --prompt-file task.md
 ```
 
-**Two-tier authority — recorded is not binding.** Agents record decisions freely, but a recorded decision is *unratified* until the operator confers authority with `edda ratify`. Your fleet can propose all day; only you make it policy. Combined with the hash chain, this is the property the whole layer is built for: **agents run on your machine, and you can always check what they did — in order, tamper-evident, with the authority trail attached.**
+**Two-tier authority — recorded is not binding.** Agents record decisions freely, but a recorded decision stays *unratified* until an operator confers authority with `edda ratify` — a separate append-only event, never a mutation of the decision, so the authority trail is auditable. The split lives in the data model and in what agents are taught (`decide` only, never `ratify`); today it is a workflow convention rather than an access-control boundary, since identity is not yet cryptographically enforced. Combined with the hash chain over the ledger, this is the property the whole layer is built for: **agents run on your machine, and you can always check what they did — in order, with the authority trail attached.**
 
 > **Maturity note:** layer 1 is stable daily-driver territory. Layer 2 ships today (claims, tasks, conduct, dispatch, verdict gates, ratify) and is where edda is growing fastest — in-flight work on liveness heartbeats, unified fleet status, and event-driven notifications is tracked in [#560](https://github.com/fagemx/edda/issues/560). It is developed by being used: edda's own multi-agent fleet builds edda with it.
 
@@ -195,14 +198,18 @@ This is the key to Edda's automation — the agent learns to call `edda decide` 
 Claude Code session
         │
    Bridge hooks (deterministic, always on)
-        │  ├── record decisions / notes / claims / peer signals
+        │  ├── record decisions / notes / tasks
+        │  ├── publish claims + peer heartbeats
         │  ├── inject prior context on session start
         │  └── optional: doctrine pack from havamal
         ▼
-   ┌─────────┐
-   │  .edda/  │  ← append-only SQLite ledger
-   │  ledger  │  ← hash-chained events
-   └─────────┘
+   ┌──────────────────────────────┐
+   │  .edda/ledger.db             │  ← decisions, notes, tasks,
+   │    append-only, hash-chained │     verdicts, digests
+   ├──────────────────────────────┤
+   │  coordination log (per-user) │  ← claims, peer heartbeats
+   │  conduct plan state + events │  ← one set per plan
+   └──────────────────────────────┘
         │
    Session end
         │  ├── deterministic digest (always)
@@ -211,7 +218,7 @@ Claude Code session
    Next session sees everything
 ```
 
-Edda stores every event as a hash-chained JSON record in a local SQLite database. Events include decisions, notes, session digests, tasks, claims, verdicts, and command outputs. The hash chain makes the history tamper-evident and the retrieval deterministic — same query, same answer, no LLM in the loop.
+Edda stores every ledger event as a hash-chained JSON record in a local SQLite database. Ledger events include decisions, notes, session digests, tasks, verdicts, and command outputs. The hash chain makes that history tamper-evident and the retrieval deterministic — same query, same answer, no LLM in the loop. Claims and peer heartbeats are deliberately kept out of the chain: they are live, expiring coordination state, appended to their own log and read on every session start.
 
 At the start of each session, edda assembles a context snapshot from the ledger and injects it — the agent sees recent decisions, active tasks, peer coordination, and (if configured) a doctrine pack from [havamal](https://github.com/fagemx/havamal), without reading through old transcripts.
 

--- a/docs/README_zh-TW.md
+++ b/docs/README_zh-TW.md
@@ -45,14 +45,16 @@ Agent 的工作有兩種消失法。
 
 **Agent 死了，工作狀態跟著死。** 你同時跑兩三個 agent，其中一個 session 半路掛掉。它剛剛在做什麼？做完了哪些？有沒有做到一半的？如果答案只存在一個已經不存在的程序裡，你就得手工重建現場——或更糟，重做已經做完的工。
 
-Edda 用同一個原語治這兩種病：**一本 append-only、hash-chained 的帳本，放在 `.edda/`、在你自己的機器上，比任何 session、任何 agent、任何工具都活得久。** 一本帳，兩層應用：
+Edda 用同一個原語治這兩種病：**append-only 的本地狀態，放在 `.edda/`、在你自己的機器上，比任何 session、任何 agent、任何工具都活得久。** 一個 workspace，兩層應用：
 
 | 層 | 回答的問題 | 原語 |
 |---|---|---|
 | **記憶** | *決定了什麼、為什麼？* | 決策、筆記、session 摘要、自動注入 |
 | **艦隊** | *誰在做什麼、實際發生了什麼？* | claims、任務＋receipt、計畫、gate、verdict |
 
-第一層從第一天就能單獨用。第二層不用另外裝——同一本帳、同一個 CLI——當你開始跑多個 agent，它就在那裡。
+第一層從第一天就能單獨用。第二層不用另外裝——同一個 workspace、同一個 CLI——當你開始跑多個 agent，它就在那裡。
+
+**兩個持久化平面，這是刻意的。** 決策、筆記、session 摘要、任務、verdict 是 hash-chained SQLite 帳本裡的事件——防篡改、可重播。即時協調狀態（claims、peer 心跳）是使用者層 store 裡另一份 append-only log，而每個 `edda conduct` 計畫各自保有自己的狀態檔與事件記錄。全部都在本地、都查得到；hash chain 覆蓋的是帳本那一份。
 
 ## 第一層——記憶跨 session 活著
 
@@ -113,16 +115,17 @@ Claude Code（早上）                  Codex（下午）
 
 跑第二個 agent 的那一刻起，記憶就不再是最難的問題。難的變成：*誰在動哪裡、誰用什麼權限決定了什麼、你沒在看的時候實際發生了什麼。* Edda 用同一本帳回答這三題。
 
-**Claims——誰在動哪裡。** 每個 session 宣告自己的工作範圍；所有 peer 都會在 context 裡看到，而且 guard 會在 agent 要動到別人 claim 的路徑之前警告。併行 session 不再互踩。
+**Claims——誰在動哪裡。** 每個 session 宣告自己的工作範圍，所有 peer 都會在 session 開始注入的 context 裡看到，併行的 agent 動手前就知道哪塊是誰的。Claims **預設是宣告性的**：edda 記錄並顯示它們，但在你用 `EDDA_ENFORCE_OFFLIMITS=1`（或 `bridge.enforce_offlimits=true`）開啟之前不會擋任何寫入；開啟後 Claude Code 的 hook 會拒絕對 peer 已 claim 路徑的 `Edit`／`Write`。
 
 ```bash
 edda claim "auth-refactor" --paths "src/auth/*"
 ```
 
-**任務帶 receipt——實際發生了什麼。** 工作在 task rail 上交接，任務要附證據才算完成。沒有 receipt 的 `done` 不存在。
+**任務帶 receipt——實際發生了什麼。** 工作在 task rail 上交接，任務要附證據才算完成。沒有 receipt 的 `done` 不存在，而 start／done 成對正是讓這條軌道可重播的原因。
 
 ```bash
 edda task new "run integration tests" --assignee tester
+edda task start 13
 edda task done 13 --receipt "110/601 green, artifact in dist/"
 ```
 
@@ -135,13 +138,13 @@ edda verdict approve my-plan/impl --sha <完整40位SHA>
 edda verdict reject  my-plan/impl --sha <sha> --comment "tests missing"
 ```
 
-**脫離的 lane——比啟動者活得久的工作。** `edda dispatch` 把單一 agent 回合（Claude、Codex 或 pi）跑成自足的工作單元，可以脫離啟動它的 session。lane 不依賴派它出去的那個 session：當 controller session 半路死掉——我們自己一天死了三次——派出去的工作照跑，事後從 branch、PR 和帳本把結果撿回來，而不是靠任何人的記憶。
+**單回合 lane——controller 可以讓它脫離。** `edda dispatch` 在前景跑完整整一個 agent 回合（Claude、Codex 或 pi），以型別化的結果收場——done、crash、timeout、超出預算——並可用 `--json` 供機器讀取。它不帶計畫、DAG 或迴圈狀態；迴圈控制留在呼叫端。正是這份無狀態，讓 controller 可以放心把它當**脫離的 OS 程序**啟動，而不是自己 session 的子程序——這才是工作能在 controller 死掉後活下來的原因。當我們的 controller session 半路死掉、一天死了三次，脫離的 lane 照跑，事後從 branch、PR 和帳本把結果撿回來，而不是靠任何人的記憶。
 
 ```bash
 edda dispatch --agent codex --prompt-file task.md
 ```
 
-**兩層權限——記錄不等於生效。** Agent 可以自由記錄決策，但記錄下來的決策在操作者用 `edda ratify` 追認之前都是 *unratified*。你的艦隊可以整天提案；只有你能把它變成政策。加上 hash chain，這就是整層存在的目的：**agent 跑在你的機器上，而你永遠查得到它做過什麼——按順序、防篡改、附權限軌跡。**
+**兩層權限——記錄不等於生效。** Agent 可以自由記錄決策，但記錄下來的決策在操作者用 `edda ratify` 追認之前都是 *unratified*——追認是另一筆 append-only 事件，從不改寫原決策，所以權限軌跡查得到。這個分層存在於資料模型，也存在於 agent 被教的內容（只教 `decide`，不教 `ratify`）；但它今天是流程慣例，還不是存取控制邊界——身分尚未做加密強制。加上帳本上的 hash chain，這就是整層存在的目的：**agent 跑在你的機器上，而你永遠查得到它做過什麼——按順序、附權限軌跡。**
 
 > **成熟度說明：** 第一層是穩定的日用等級。第二層今天就能用（claims、task、conduct、dispatch、verdict gate、ratify），也是 edda 成長最快的地方——進行中的 liveness 心跳、統一艦隊狀態面、事件推播都追蹤在 [#560](https://github.com/fagemx/edda/issues/560)。它是用出來的：edda 自己的多 agent 艦隊就用它蓋 edda。
 
@@ -194,14 +197,18 @@ CLAUDE.md 的段落會教 agent 何時以及如何記錄決策：
 Claude Code session
         │
    Bridge hooks（確定性，永遠開）
-        │  ├── 記錄決策 / 筆記 / claims / peer 訊號
+        │  ├── 記錄決策 / 筆記 / 任務
+        │  ├── 發布 claims 與 peer 心跳
         │  ├── session 開始注入前次 context
         │  └── 可選：注入 havamal doctrine pack
         ▼
-   ┌─────────┐
-   │  .edda/  │  ← append-only SQLite ledger
-   │  ledger  │  ← hash-chained 事件
-   └─────────┘
+   ┌──────────────────────────────┐
+   │  .edda/ledger.db             │  ← 決策、筆記、任務、
+   │    append-only、hash-chained │     verdict、摘要
+   ├──────────────────────────────┤
+   │  協調 log（使用者層）        │  ← claims、peer 心跳
+   │  conduct 計畫狀態 + 事件     │  ← 每個計畫各一份
+   └──────────────────────────────┘
         │
    Session 結束
         │  ├── 確定性摘要（永遠）
@@ -210,7 +217,7 @@ Claude Code session
    下次 session 看到全部
 ```
 
-Edda 將每個事件以 hash-chained JSON 記錄儲存在本地 SQLite 資料庫中。事件包括決策、筆記、session 摘要、任務、claims、verdicts 和指令輸出。Hash chain 讓歷史記錄防篡改、檢索確定性——同一個查詢永遠得同一個答案，迴圈裡沒有 LLM。
+Edda 將每個帳本事件以 hash-chained JSON 記錄儲存在本地 SQLite 資料庫中。帳本事件包括決策、筆記、session 摘要、任務、verdict 和指令輸出。Hash chain 讓這份歷史防篡改、檢索確定性——同一個查詢永遠得同一個答案，迴圈裡沒有 LLM。Claims 和 peer 心跳刻意不進這條鏈：它們是會過期的即時協調狀態，寫在自己的 log 裡，每次 session 開始時讀取。
 
 每次 session 開始時，edda 從 ledger 組裝 context snapshot 並注入——agent 看到最近的決策、進行中的任務、peer 協調狀態，以及（若有配置）來自 [havamal](https://github.com/fagemx/havamal) 的判斷層 pack，不需要閱讀舊 transcript。
 

--- a/docs/README_zh-TW.md
+++ b/docs/README_zh-TW.md
@@ -1,9 +1,10 @@
 <h1 align="center">Edda</h1>
 
 <p align="center">
-  <strong>你的 agent 的決策，不該每開新 session 就歸零。</strong><br/>
-  Edda 給 coding agent 一份本地、自動的記憶：記住決定了什麼——以及為什麼。<br/>
-  支援 Claude Code、Codex、OpenClaw 和任何 MCP 客戶端。
+  <strong>你的 agent 做的工作，不該跟著 session 一起消失。</strong><br/>
+  Edda 是給 coding agent 的本地、防篡改帳本：<br/>
+  決策跨 session 活著，協調跨 agent 活著。<br/>
+  支援 Claude Code、Cursor、Codex、OpenClaw 和任何 MCP 客戶端。
 </p>
 
 <p align="center">
@@ -16,6 +17,8 @@
 
 <p align="center">
   <a href="#為什麼需要-edda">為什麼需要 Edda？</a> ·
+  <a href="#第一層記憶跨-session-活著">記憶</a> ·
+  <a href="#第二層協調跨-agent-活著">艦隊</a> ·
   <a href="#安裝">安裝</a> ·
   <a href="#快速開始">快速開始</a> ·
   <a href="#運作原理">運作原理</a> ·
@@ -25,7 +28,7 @@
 </p>
 
 <p align="center">
-  <a href="./README.md">English</a> · 繁體中文
+  <a href="../README.md">English</a> · 繁體中文
 </p>
 
 <p align="center">
@@ -36,9 +39,24 @@
 
 ## 為什麼需要 Edda？
 
-昨天你和 agent 把利弊吵完，定案用 SQLite。今天開新 session——它又提議 Postgres。又來一次。推理跟著 transcript 一起消失了，context 壓縮救不回來。
+Agent 的工作有兩種消失法。
 
-Edda 治的就是這個：hooks 看著你的 session，把每個決策連同理由記進本地 ledger，在下一個 session 開始前交到它手上。agent 從此不再失憶。
+**Session 死了，決策跟著死。** 昨天你和 agent 把利弊吵完，定案用 SQLite。今天開新 session——它又提議 Postgres。又來一次。推理跟著 transcript 一起消失了，context 壓縮救不回來。
+
+**Agent 死了，工作狀態跟著死。** 你同時跑兩三個 agent，其中一個 session 半路掛掉。它剛剛在做什麼？做完了哪些？有沒有做到一半的？如果答案只存在一個已經不存在的程序裡，你就得手工重建現場——或更糟，重做已經做完的工。
+
+Edda 用同一個原語治這兩種病：**一本 append-only、hash-chained 的帳本，放在 `.edda/`、在你自己的機器上，比任何 session、任何 agent、任何工具都活得久。** 一本帳，兩層應用：
+
+| 層 | 回答的問題 | 原語 |
+|---|---|---|
+| **記憶** | *決定了什麼、為什麼？* | 決策、筆記、session 摘要、自動注入 |
+| **艦隊** | *誰在做什麼、實際發生了什麼？* | claims、任務＋receipt、計畫、gate、verdict |
+
+第一層從第一天就能單獨用。第二層不用另外裝——同一本帳、同一個 CLI——當你開始跑多個 agent，它就在那裡。
+
+## 第一層——記憶跨 session 活著
+
+Hooks 看著你的 session，把每個決策連同理由記進帳本，在下一個 session 開始前交到它手上。agent 從此不再失憶。
 
 ```
 沒有 edda                             有 edda
@@ -60,7 +78,7 @@ Session 2 開場：                      Session 2 開場：
 
 **資料都在本地** — ledger 存在 `.edda/`（SQLite + 本地檔案），沒有雲端、沒有帳號。核心迴圈（記錄、檢索、注入）是確定性的、永不外呼。**可選的 LLM 增強**（session 摘要、決策萃取、模式關聯）需設 `EDDA_LLM_API_KEY` 且有每日預算上限——不設 key，edda 就是完全零 egress。
 
-## 一份記憶，每個 agent 都看得到
+### 一份記憶，每個 agent 都看得到
 
 越來越多開發者在 agent 之間交替——這個任務用 Claude Code，下個任務找 Codex 要第二意見。兩邊的模型都強，壞掉的是記憶：每家工具的記憶都是自家孤島，每切換一次，就得從零重講一次專案。
 
@@ -90,6 +108,42 @@ Claude Code（早上）                  Codex（下午）
 | session 跑在 container 裡 | 每個 container 都是孤島；你要 mount 的那份共享狀態，就是 `.edda/` |
 
 </details>
+
+## 第二層——協調跨 agent 活著
+
+跑第二個 agent 的那一刻起，記憶就不再是最難的問題。難的變成：*誰在動哪裡、誰用什麼權限決定了什麼、你沒在看的時候實際發生了什麼。* Edda 用同一本帳回答這三題。
+
+**Claims——誰在動哪裡。** 每個 session 宣告自己的工作範圍；所有 peer 都會在 context 裡看到，而且 guard 會在 agent 要動到別人 claim 的路徑之前警告。併行 session 不再互踩。
+
+```bash
+edda claim "auth-refactor" --paths "src/auth/*"
+```
+
+**任務帶 receipt——實際發生了什麼。** 工作在 task rail 上交接，任務要附證據才算完成。沒有 receipt 的 `done` 不存在。
+
+```bash
+edda task new "run integration tests" --assignee tester
+edda task done 13 --receipt "110/601 green, artifact in dist/"
+```
+
+**計畫帶 gate——會停下來等判斷的多階段工作。** `edda conduct` 逐階段執行 YAML 計畫：每個 phase 派一個 agent、用 check 驗證產出，並且可以在任何不可逆或昂貴的動作前停在 **verdict gate**。gate 釘住它核准的那個 git SHA——新的 push 依構造就讓舊 verdict 失效。
+
+```bash
+edda conduct run plan.yaml         # 執行多階段計畫
+edda conduct status                # 每個計畫現在跑到哪
+edda verdict approve my-plan/impl --sha <完整40位SHA>
+edda verdict reject  my-plan/impl --sha <sha> --comment "tests missing"
+```
+
+**脫離的 lane——比啟動者活得久的工作。** `edda dispatch` 把單一 agent 回合（Claude、Codex 或 pi）跑成自足的工作單元，可以脫離啟動它的 session。lane 不依賴派它出去的那個 session：當 controller session 半路死掉——我們自己一天死了三次——派出去的工作照跑，事後從 branch、PR 和帳本把結果撿回來，而不是靠任何人的記憶。
+
+```bash
+edda dispatch --agent codex --prompt-file task.md
+```
+
+**兩層權限——記錄不等於生效。** Agent 可以自由記錄決策，但記錄下來的決策在操作者用 `edda ratify` 追認之前都是 *unratified*。你的艦隊可以整天提案；只有你能把它變成政策。加上 hash chain，這就是整層存在的目的：**agent 跑在你的機器上，而你永遠查得到它做過什麼——按順序、防篡改、附權限軌跡。**
+
+> **成熟度說明：** 第一層是穩定的日用等級。第二層今天就能用（claims、task、conduct、dispatch、verdict gate、ratify），也是 edda 成長最快的地方——進行中的 liveness 心跳、統一艦隊狀態面、事件推播都追蹤在 [#560](https://github.com/fagemx/edda/issues/560)。它是用出來的：edda 自己的多 agent 艦隊就用它蓋 edda。
 
 ## 安裝
 
@@ -140,7 +194,7 @@ CLAUDE.md 的段落會教 agent 何時以及如何記錄決策：
 Claude Code session
         │
    Bridge hooks（確定性，永遠開）
-        │  ├── 記錄決策 / 筆記 / peer 訊號
+        │  ├── 記錄決策 / 筆記 / claims / peer 訊號
         │  ├── session 開始注入前次 context
         │  └── 可選：注入 havamal doctrine pack
         ▼
@@ -156,7 +210,7 @@ Claude Code session
    下次 session 看到全部
 ```
 
-Edda 將每個事件以 hash-chained JSON 記錄儲存在本地 SQLite 資料庫中。事件包括決策、筆記、session 摘要和指令輸出。Hash chain 讓歷史記錄防篡改、檢索確定性——同一個查詢永遠得同一個答案，迴圈裡沒有 LLM。
+Edda 將每個事件以 hash-chained JSON 記錄儲存在本地 SQLite 資料庫中。事件包括決策、筆記、session 摘要、任務、claims、verdicts 和指令輸出。Hash chain 讓歷史記錄防篡改、檢索確定性——同一個查詢永遠得同一個答案，迴圈裡沒有 LLM。
 
 每次 session 開始時，edda 從 ledger 組裝 context snapshot 並注入——agent 看到最近的決策、進行中的任務、peer 協調狀態，以及（若有配置）來自 [havamal](https://github.com/fagemx/havamal) 的判斷層 pack，不需要閱讀舊 transcript。
 
@@ -174,6 +228,7 @@ Edda 將每個事件以 hash-chained JSON 記錄儲存在本地 SQLite 資料庫
 | **追蹤「為什麼」？** | 偶爾 | 否 | 有損 | **是**（理由 + 被拒絕的方案） |
 | **跨 Session？** | 手動複製 | 是 | Session 範圍內 | **是**（自動） |
 | **跨 Agent？** | 否——單一工具的檔案 | 每個 app 各自整合 | 否——vendor 孤島 | **是**（Claude Code、Codex、OpenClaw、MCP） |
+| **多 agent 協調？** | 否 | 否 | 否 | **是**（claims、任務＋receipt、gates） |
 | **每次查詢成本** | 免費 | Embedding API 呼叫 | LLM API 呼叫 | **免費**（本地 SQLite）；可選 LLM 摘要有預算上限 |
 | **範例** | Claude Code 內建、OpenClaw | mem0、Zep、Chroma | ChatGPT Memory、Copilot | — |
 
@@ -241,37 +296,52 @@ edda mcp serve    # stdio JSON-RPC 2.0
 edda ask "cache"           # 查詢過去的決策
 edda search query "auth"   # 全文搜尋 transcripts
 edda context               # 查看 agent 在 session 開始時看到什麼
-edda log --tag decision    # 篩選事件日誌
+edda log --type decision   # 篩選事件日誌
 edda watch                 # 即時 TUI：peers、事件、決策
 ```
 
 <details>
 <summary>所有指令</summary>
 
+**記憶與檢索**
+
 | 指令 | 說明 |
 |------|------|
 | `edda init` | 初始化 `.edda/`（偵測到 `.claude/` 時自動安裝 hooks） |
-| `edda decide` | 記錄一個 binding decision |
+| `edda decide` | 記錄決策（agent 記錄；`edda ratify` 後才生效） |
 | `edda note` | 記錄筆記 |
 | `edda ask` | 查詢決策、歷史和對話 |
 | `edda search` | 全文搜尋 transcripts（Tantivy） |
 | `edda log` | 用篩選條件查詢事件（類型、日期、標籤、分支） |
 | `edda context` | 輸出 context snapshot（agent 看到的內容） |
 | `edda status` | 顯示 workspace 狀態 |
-| `edda watch` | 即時 TUI：peers、事件、決策 |
+| `edda run` | 執行指令並記錄輸出 |
 | `edda commit` | 建立 commit 事件 |
-| `edda branch` | 分支操作 |
-| `edda switch` | 切換分支 |
-| `edda merge` | 合併分支 |
+
+**艦隊與編排**
+
+| 指令 | 說明 |
+|------|------|
+| `edda claim` | 宣告工作範圍，peers 不互踩 |
+| `edda task` | Task rail：建立、交接、追蹤任務（`new/start/done/fail/list/show`） |
+| `edda ratify` | 操作者追認決策（記錄 ≠ 生效） |
+| `edda conduct` | 多階段計畫編排，含 check 與 gate |
+| `edda dispatch` | 單回合 agent 派工（claude / codex / pi） |
+| `edda verdict` | 核准／駁回被 gate 的對象，釘住 git SHA |
+| `edda watch` | 即時 TUI：peers、事件、決策 |
 | `edda draft` | 提案 / 列表 / 批准 / 拒絕 drafts |
+
+**Workspace 與底層**
+
+| 指令 | 說明 |
+|------|------|
 | `edda bridge` | 安裝/移除工具 hooks |
 | `edda doctor` | 健康檢查 |
 | `edda config` | 讀寫 workspace 設定 |
 | `edda pattern` | 管理分類模式 |
 | `edda mcp` | 啟動 MCP server（stdio JSON-RPC 2.0） |
-| `edda conduct` | 多階段計畫編排 |
 | `edda plan` | 計畫鷹架和範本 |
-| `edda run` | 執行指令並記錄輸出 |
+| `edda branch` / `edda switch` / `edda merge` | Ledger 分支操作 |
 | `edda blob` | 管理 blob metadata |
 | `edda gc` | 垃圾回收過期內容 |
 
@@ -305,7 +375,7 @@ Cargo workspace，一個 crate 一個器官：
 | `edda-index` | Transcript 索引 |
 | `edda-postmortem` | L3 事後分析、learned rules（TTL 衰減） |
 | `edda-notify` | Workspace 事件推播 |
-| `edda-conductor` | 多階段計畫編排 |
+| `edda-conductor` | 多階段計畫編排——只管自域 phase pipeline；任務派發歸 [bryti](https://github.com/fagemx/bryti)，conductor 永不碰外部工作佇列 |
 
 <details>
 <summary>.edda/ 裡面有什麼</summary>
@@ -351,15 +421,19 @@ Cargo workspace，一個 crate 一個器官：
 - [x] 發行面——預編譯二進位檔（macOS、Linux、Windows）、一行安裝腳本、Homebrew tap
 - [x] v0.2.0——`edda watch` TUI、`edda ask`、peers／協調指令、sub-agent 可見性、session hooks 記錄 model／token／成本、使用者層 store（`~/.edda/`）、post-mortem learned rules
 - [x] Decision deepening——`--paths` 範圍決策、PreToolUse 守護警告、session 開始注入決策 pack、決策狀態生命週期
+- [x] 艦隊原語——`edda conduct` 多階段計畫、`edda dispatch` 單回合 lane、verdict gate 釘 SHA、task rail 帶 receipt、`edda ratify` 兩層權限
 
-接下來：
+接下來——把艦隊智慧層折進產品（[#560](https://github.com/fagemx/edda/issues/560)）：
 
+- [ ] Surface-aware 排程——phase 宣告自己擁有的路徑；claim 帶著路徑；重疊的派工被結構性拒絕
+- [ ] 事件驅動交付——phase 終態與 gate 進入透過 `edda-notify` 推播，不再輪詢 stdout
+- [ ] 艦隊可觀察性——進行中心跳，以及同時涵蓋 `conduct` 計畫與 `dispatch` lane 的單一狀態面
 - [ ] 跨 repo 決策查詢面——使用者層 store 已跨專案聚合；缺的是第一級的跨 repo search／ask 介面
 - [ ] 決策回憶指標——量測注入的決策實際改變行為的頻率
 
 ## 貢獻
 
-歡迎貢獻。請參閱 [CONTRIBUTING.md](CONTRIBUTING.md) 了解開發環境設定。
+歡迎貢獻。請參閱 [CONTRIBUTING.md](../CONTRIBUTING.md) 了解開發環境設定。
 
 ## 社群
 
@@ -372,4 +446,4 @@ MIT OR Apache-2.0
 
 ---
 
-*別再重教 agent 你已經決定過的事。*
+*別再重教 agent 你已經決定過的事——也別再只憑艦隊的一面之詞相信它做了什麼。*


### PR DESCRIPTION
## What

Repositions both READMEs (EN + zh-TW, kept in sync) from the single "agent memory" narrative to **one ledger, two layers**, per operator direction:

- **Hero**: protagonist is the local, tamper-evident ledger; tagline covers both failure modes (session dies → decisions die; agent dies → work state dies).
- **Layer 1 — Memory that survives sessions**: existing content condensed (SQLite/Postgres story, hooks table, zero-egress, cross-agent memory).
- **Layer 2 — Coordination that survives agents** (new): claims, task rail with receipts, `conduct` plans with SHA-pinned verdict gates, detached `dispatch` lanes, `ratify` two-tier authority. Closes on the audit framing: agents run on your machine and the ledger can answer what they did.
- **Honesty guardrails**: layer 2 carries an explicit maturity note pointing at #560 for in-flight work (heartbeats, unified status, event notifications — none claimed as shipped). Every command shown was verified against the clap arg structs (`DispatchArgs`, `VerdictCmd`, `ConductCmd`).
- Command table regrouped by layer; comparison table gains a multi-agent coordination row; roadmap updated to shipped fleet primitives + epic #560 direction.
- Fixes pre-existing zh-TW bugs: language-switcher and CONTRIBUTING links resolved inside `docs/`; command table called a recorded decision "binding" (recorded ≠ ratified); `edda log --tag decision` → `--type decision` to match EN and the actual flag.

## Scope / verification

Docs-only (no code/product blob, no `Cargo.lock`, no toolchain change): per the verification ladder, no local Cargo gate; `scripts/lint-markdown-content.sh` green locally; exact-head CI is the gate. Anchor slugs for the new headings (em-dash and CJK forms) were derived by GitHub slugger rules — reviewer should click the nav links in the rendered preview as the one check local lint cannot do.

Reference: #560 (epic; this PR only links it, nothing closes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
