### PR TITLE
feat(edda-conductor): plan phases declare owned write surfaces; phase claims carry them

### DIFF
--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -218,6 +218,8 @@ pub fn build_phase(
         gate: None,
         gate_timeout_sec: None,
         on_reject: Default::default(),
+        // A dispatched single turn declares no owned write surface.
+        owns: Vec::new(),
     }
 }
 

--- a/crates/edda-conductor/src/plan/schema.rs
+++ b/crates/edda-conductor/src/plan/schema.rs
@@ -66,6 +66,10 @@ pub struct Phase {
     /// Policy when the gate verdict rejects. Default: redispatch.
     #[serde(default)]
     pub on_reject: OnReject,
+    /// Path globs this phase owns as its write surface. Published in the
+    /// phase's auto-claim event so peer lanes can see the scope (GH-561).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub owns: Vec<String>,
 }
 
 /// Kind of approval gate a phase can declare (D2).
@@ -353,6 +357,48 @@ phases:
     on_reject: explode
 "#;
         assert!(serde_yml::from_str::<Plan>(yaml).is_err());
+    }
+
+    // ── Owned write surfaces (GH-561) ─────────────────────────────
+
+    #[test]
+    fn phase_owns_parses_and_defaults_empty() {
+        let yaml = r#"
+name: owns-plan
+phases:
+  - id: touch-agent
+    prompt: "Edit the agent surface"
+    owns:
+      - "crates/edda-conductor/src/agent/*"
+      - "crates/edda-conductor/src/plan/**"
+  - id: no-owns
+    prompt: "No declared surface"
+"#;
+        let plan: Plan = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(
+            plan.phases[0].owns,
+            vec![
+                "crates/edda-conductor/src/agent/*".to_string(),
+                "crates/edda-conductor/src/plan/**".to_string(),
+            ]
+        );
+        assert!(plan.phases[1].owns.is_empty());
+    }
+
+    #[test]
+    fn phase_without_owns_omits_field_when_serialized() {
+        let yaml = r#"
+name: minimal
+phases:
+  - id: a
+    prompt: "x"
+"#;
+        let plan: Plan = serde_yml::from_str(yaml).unwrap();
+        let json = serde_json::to_string(&plan.phases[0]).unwrap();
+        assert!(
+            !json.contains("owns"),
+            "empty owns must not serialize: {json}"
+        );
     }
 
     #[test]

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -467,7 +467,7 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
         let session_id = phase_session_id_attempt(&plan.name, &phase_id, attempt).to_string();
 
         // Auto-claim scope for this phase (so peers can see it and send requests)
-        write_phase_claim(cwd, &session_id, &phase_id);
+        write_phase_claim(cwd, &session_id, &phase_id, &phase.owns);
 
         let result = launcher
             .run_phase(
@@ -1371,7 +1371,9 @@ fn now_rfc3339() -> String {
 
 /// Write a claim event to coordination.jsonl for a conductor phase.
 /// Written directly (no edda-bridge-claude dependency) since the format is simple.
-fn write_phase_claim(cwd: &Path, session_id: &str, phase_id: &str) {
+/// `owns` carries the phase's declared write-surface path globs (GH-561); an
+/// empty slice produces the same event as before the field existed.
+fn write_phase_claim(cwd: &Path, session_id: &str, phase_id: &str, owns: &[String]) {
     let project_id = edda_store::project_id(cwd);
     let state_dir = edda_store::project_dir(&project_id).join("state");
     let coord_path = state_dir.join("coordination.jsonl");
@@ -1379,7 +1381,7 @@ fn write_phase_claim(cwd: &Path, session_id: &str, phase_id: &str) {
         "ts": now_rfc3339(),
         "session_id": session_id,
         "event_type": "claim",
-        "payload": { "label": phase_id, "paths": serde_json::Value::Array(vec![]) }
+        "payload": { "label": phase_id, "paths": owns }
     });
     if let Ok(line) = serde_json::to_string(&event) {
         use std::io::Write;
@@ -3019,5 +3021,118 @@ phases:
             err.message
         );
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    // ── Phase claims carry owned write surfaces (GH-561) ────────────
+
+    /// Serialize tests that redirect `EDDA_STORE_ROOT`.
+    static CLAIM_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct ClaimEnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        previous_store_root: Option<std::ffi::OsString>,
+        _store_root: tempfile::TempDir,
+    }
+
+    impl Drop for ClaimEnvGuard {
+        fn drop(&mut self) {
+            match self.previous_store_root.take() {
+                Some(root) => std::env::set_var("EDDA_STORE_ROOT", root),
+                None => std::env::remove_var("EDDA_STORE_ROOT"),
+            }
+        }
+    }
+
+    impl ClaimEnvGuard {
+        fn new() -> Self {
+            let lock = CLAIM_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let previous_store_root = std::env::var_os("EDDA_STORE_ROOT");
+            let store_root = tempfile::tempdir().unwrap();
+            std::env::set_var("EDDA_STORE_ROOT", store_root.path());
+            Self {
+                _lock: lock,
+                previous_store_root,
+                _store_root: store_root,
+            }
+        }
+    }
+
+    fn coord_lines(cwd: &Path) -> Vec<serde_json::Value> {
+        let project_id = edda_store::project_id(cwd);
+        let coord_path = edda_store::project_dir(&project_id)
+            .join("state")
+            .join("coordination.jsonl");
+        let content = std::fs::read_to_string(&coord_path).expect("coordination.jsonl exists");
+        content
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).expect("each line parses as JSON"))
+            .collect()
+    }
+
+    fn make_repo(store_root: &Path) -> std::path::PathBuf {
+        let cwd = store_root.join("repo");
+        std::fs::create_dir_all(&cwd).unwrap();
+        // Production writes claims into an existing project state dir
+        // (created by ensure_dirs); mirror that layout here.
+        let project_id = edda_store::project_id(&cwd);
+        std::fs::create_dir_all(edda_store::project_dir(&project_id).join("state")).unwrap();
+        cwd
+    }
+
+    #[test]
+    fn phase_claim_with_owns_carries_the_paths() {
+        let guard = ClaimEnvGuard::new();
+        let cwd = make_repo(guard._store_root.path());
+        let owns = vec!["crates/edda-conductor/src/agent/*".to_string()];
+
+        write_phase_claim(&cwd, "sess-1", "touch-agent", &owns);
+
+        let events = coord_lines(&cwd);
+        assert_eq!(events.len(), 1);
+        let payload = &events[0]["payload"];
+        assert_eq!(payload["label"], "touch-agent");
+        assert_eq!(
+            payload["paths"],
+            serde_json::json!(["crates/edda-conductor/src/agent/*"])
+        );
+    }
+
+    #[test]
+    fn phase_claim_without_owns_is_byte_identical_to_legacy() {
+        let guard = ClaimEnvGuard::new();
+        let cwd = make_repo(guard._store_root.path());
+
+        write_phase_claim(&cwd, "sess-2", "no-owns", &[]);
+
+        let events = coord_lines(&cwd);
+        assert_eq!(events.len(), 1);
+        // Identical to the pre-GH-561 event in every field except ts.
+        let legacy = serde_json::json!({
+            "ts": events[0]["ts"],
+            "session_id": "sess-2",
+            "event_type": "claim",
+            "payload": { "label": "no-owns", "paths": [] }
+        });
+        assert_eq!(events[0], legacy);
+    }
+
+    #[test]
+    fn old_claim_event_without_paths_field_still_parses() {
+        // Legacy peer-written claims never had a paths field; the consumer
+        // reads `payload["paths"]` tolerantly (as_array → default). Prove an
+        // old record parses and yields no paths under that exact pattern.
+        let old = r#"{"event_type":"claim","payload":{"label":"legacy"},"session_id":"s"}"#;
+        let parsed: serde_json::Value = serde_json::from_str(old).unwrap();
+        let paths = parsed["payload"]
+            .get("paths")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect::<Vec<String>>()
+            })
+            .unwrap_or_default();
+        assert!(paths.is_empty());
     }
 }


### PR DESCRIPTION
## What changed

Implements #561: plan phases can declare an owned write surface, and the runner's auto-claim publishes it to peer lanes.

- `crates/edda-conductor/src/plan/schema.rs` — `Phase` gains an optional `owns: Vec<String>` of path globs (`#[serde(default, skip_serializing_if = "Vec::is_empty")]`). Additive; no `deny_unknown_fields` anywhere on the parse path, so existing plans parse unchanged.
- `crates/edda-conductor/src/runner/sequential.rs` — `write_phase_claim` (and its single call site at the phase-start auto-claim) now takes `owns: &[String]` and writes it into the claim event's `payload.paths`. The consumer in `edda-bridge-claude/src/peers/board.rs` already reads `payload["paths"]` tolerantly (`as_array` → default empty), so claims now surface paths in `edda peers` / bridge injection with zero consumer changes.
- `crates/edda-cli/src/cmd_dispatch.rs` — one-line mechanical fix: `build_phase` initializes `Phase` exhaustively, so it gains `owns: Vec::new()` (a dispatched single turn declares no owned surface). No other CLI behavior touched.

## doneWhen → evidence

| doneWhen | Evidence |
|---|---|
| Phase with `owns:` produces a claim event carrying those paths | `runner::sequential::tests::phase_claim_with_owns_carries_the_paths` — writes a claim for a phase with `owns: ["crates/edda-conductor/src/agent/*"]`, reads back `coordination.jsonl`, asserts `payload.paths` equals the globs. **Verified FAILING before the fix** (E0609 no field `owns` / E0061 arity, pre-implementation run). |
| Phase without `owns` behaves byte-identically to today | `phase_claim_without_owns_is_byte_identical_to_legacy` — reconstructs the pre-GH-561 event JSON and asserts full equality (all fields except the timestamp). Empty `owns` serializes as `"paths": []`, same as before; `serde_json` map ordering is deterministic (BTreeMap, no `preserve_order`). Also `phase_without_owns_omits_field_when_serialized` proves `owns` never appears in serialized phases without it. |
| Old claim events (no paths field) still parse | `old_claim_event_without_paths_field_still_parses` — a legacy claim line without `paths` parses and yields no paths under the exact consumer access pattern (`payload.get("paths").and_then(as_array)` → default). The consumer tolerance itself lives in `edda-bridge-claude/src/peers/board.rs`, unchanged and untouched (peers/** is off-limits for this lane; #566/#569 own it). |

## Gate receipt

- **Full SHA:** `f4039fc532ff89b1fd12e502fee927360da3f0e6` (base `f3eb50f` after rebase onto main, clean tree)
- **Gate set:** L1 — `cargo fmt --all --check` PASS; `cargo clippy --workspace --all-targets -- -D warnings` PASS; `cargo test --workspace` PASS (all crates, 0 failures)
- **Toolchain:** Rust stable, x86_64-pc-windows-msvc
- **Lane:** worker-1 (`CARGO_TARGET_DIR=%LOCALAPPDATA%\fleet-workstation\lanes\worker-1`, `CARGO_INCREMENTAL=0`)
- **Result:** GREEN

Fixes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)
