### PR TITLE
docs(readme): land the review findings #570 merged without

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Edda fixes both with the same primitive: **local, append-only state in `.edda/`,
 
 Use layer 1 alone from day one. Layer 2 is simply there — same workspace, same CLI — when you start running more than one agent.
 
-**Two persistence planes, deliberately.** Decisions, notes, session digests, tasks, and verdicts are events in the hash-chained SQLite ledger — tamper-evident and replayable. Live coordination state (claims, peer heartbeats) is a separate append-only log in the per-user store, and each `edda conduct` plan keeps its own state file and event log. All of it is local and inspectable; the hash chain covers the ledger.
+**Separate persistence planes, deliberately.** Decisions, notes, session digests, tasks, and verdicts are events in the hash-chained SQLite ledger — tamper-evident and replayable. Live coordination state sits outside that chain, in the per-user store: claims append to a coordination log, while each session's heartbeat is a small snapshot file, rewritten while the session runs and deleted when it ends. Each `edda conduct` plan keeps its own state file and event log again separately. All of it is local and inspectable; the hash chain covers the ledger.
 
 ## Layer 1 — Memory that survives sessions
 
@@ -114,7 +114,7 @@ Edda starts paying for itself when any of these is true:
 
 ## Layer 2 — Coordination that survives agents
 
-The moment you run a second agent, memory stops being the hard problem. The hard problems become: *who is working where, who decided what under which authority, and what actually happened while you weren't looking.* Edda answers all three from the same ledger.
+The moment you run a second agent, memory stops being the hard problem. The hard problems become: *who is working where, who decided what under which authority, and what actually happened while you weren't looking.* Edda answers all three from the same local workspace — the ledger holds the durable record, the coordination plane holds who is live right now.
 
 **Claims — who is working where.** Sessions declare their scope, and every peer sees it in the context injected at session start, so parallel agents know who owns what before they touch it. Claims are **advisory by default**: edda records and surfaces them, but nothing blocks a write until you opt in with `EDDA_ENFORCE_OFFLIMITS=1` (or `bridge.enforce_offlimits=true`), which makes the Claude Code hook refuse `Edit`/`Write` on a peer-claimed path.
 
@@ -139,7 +139,7 @@ edda verdict approve my-plan/impl --sha <full-40-hex-sha>
 edda verdict reject  my-plan/impl --sha <sha> --comment "tests missing"
 ```
 
-**Single-turn lanes — work a controller can detach.** `edda dispatch` runs exactly one agent turn (Claude, Codex, or pi) in the foreground and exits with a typed outcome — done, crash, timeout, budget exceeded — with `--json` for machine consumption. It carries no plan, DAG, or loop state; loop control stays with the caller. That statelessness is what makes it safe for a controller to launch as a detached OS process instead of a child of its own session — which is how work survives a dead controller. When our controller session died mid-flight, three times in one day, the detached lanes kept running and their results were recovered from branches, PRs, and the ledger rather than from anyone's memory.
+**Single-turn lanes — work a controller can detach.** `edda dispatch` runs exactly one agent turn (Claude, Codex, or pi) in the foreground and exits with a typed outcome — done, crash, timeout, max turns, or budget exceeded, each with its own exit code — and `--json` for machine consumption. It carries no plan, DAG, or loop state; loop control stays with the caller. That statelessness is what makes it safe for a controller to launch as a detached OS process instead of a child of its own session — which is how work survives a dead controller. When our controller session died mid-flight, three times in one day, the detached lanes kept running and their results were recovered from branches, PRs, and the ledger rather than from anyone's memory.
 
 ```bash
 edda dispatch --agent codex --prompt-file task.md
@@ -207,7 +207,8 @@ Claude Code session
    │  .edda/ledger.db             │  ← decisions, notes, tasks,
    │    append-only, hash-chained │     verdicts, digests
    ├──────────────────────────────┤
-   │  coordination log (per-user) │  ← claims, peer heartbeats
+   │  coordination log (per-user) │  ← claims (appended)
+   │  session heartbeat files     │  ← one per live session
    │  conduct plan state + events │  ← one set per plan
    └──────────────────────────────┘
         │
@@ -218,7 +219,7 @@ Claude Code session
    Next session sees everything
 ```
 
-Edda stores every ledger event as a hash-chained JSON record in a local SQLite database. Ledger events include decisions, notes, session digests, tasks, verdicts, and command outputs. The hash chain makes that history tamper-evident and the retrieval deterministic — same query, same answer, no LLM in the loop. Claims and peer heartbeats are deliberately kept out of the chain: they are live, expiring coordination state, appended to their own log and read on every session start.
+Edda stores every ledger event as a hash-chained JSON record in a local SQLite database. Ledger events include decisions, notes, session digests, tasks, verdicts, and command outputs. The hash chain makes that history tamper-evident and the retrieval deterministic — same query, same answer, no LLM in the loop. Coordination state is deliberately kept out of the chain, because it is live rather than historical: claims are appended to their own log, and a session's heartbeat is a snapshot file that exists only while that session does. Both are read on every session start.
 
 At the start of each session, edda assembles a context snapshot from the ledger and injects it — the agent sees recent decisions, active tasks, peer coordination, and (if configured) a doctrine pack from [havamal](https://github.com/fagemx/havamal), without reading through old transcripts.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Edda fixes both with the same primitive: **local, append-only state in `.edda/`,
 
 Use layer 1 alone from day one. Layer 2 is simply there — same workspace, same CLI — when you start running more than one agent.
 
-**Separate persistence planes, deliberately.** Decisions, notes, session digests, tasks, and verdicts are events in the hash-chained SQLite ledger — tamper-evident and replayable. Live coordination state sits outside that chain, in the per-user store: claims append to a coordination log, while each session's heartbeat is a small snapshot file, rewritten while the session runs and deleted when it ends. Each `edda conduct` plan keeps its own state file and event log again separately. All of it is local and inspectable; the hash chain covers the ledger.
+**Separate persistence planes, deliberately.** Decisions, notes, session digests, tasks, and verdicts are events in the hash-chained SQLite ledger — tamper-evident and replayable. Live coordination state sits outside that chain, in the per-user store: claims append to a coordination log, while each session's heartbeat is a small snapshot file, rewritten as the session works and removed when it exits cleanly — a session that dies without that exit leaves its snapshot behind, which `edda peers` reports as stale and `edda gc` can later reclaim. Each `edda conduct` plan keeps its own state file and event log again separately. All of it is local and inspectable; the hash chain covers the ledger.
 
 ## Layer 1 — Memory that survives sessions
 
@@ -208,7 +208,8 @@ Claude Code session
    │    append-only, hash-chained │     verdicts, digests
    ├──────────────────────────────┤
    │  coordination log (per-user) │  ← claims (appended)
-   │  session heartbeat files     │  ← one per live session
+   │  session heartbeat files     │  ← one per session, stale if
+   │                              │     it died without exiting
    │  conduct plan state + events │  ← one set per plan
    └──────────────────────────────┘
         │
@@ -219,7 +220,7 @@ Claude Code session
    Next session sees everything
 ```
 
-Edda stores every ledger event as a hash-chained JSON record in a local SQLite database. Ledger events include decisions, notes, session digests, tasks, verdicts, and command outputs. The hash chain makes that history tamper-evident and the retrieval deterministic — same query, same answer, no LLM in the loop. Coordination state is deliberately kept out of the chain, because it is live rather than historical: claims are appended to their own log, and a session's heartbeat is a snapshot file that exists only while that session does. Both are read on every session start.
+Edda stores every ledger event as a hash-chained JSON record in a local SQLite database. Ledger events include decisions, notes, session digests, tasks, verdicts, and command outputs. The hash chain makes that history tamper-evident and the retrieval deterministic — same query, same answer, no LLM in the loop. Coordination state is deliberately kept out of the chain, because it is live rather than historical: claims are appended to their own log, and a session's heartbeat is a snapshot file refreshed as it works and cleared on a clean exit, going stale rather than vanishing if the session dies. Both are read on every session start.
 
 At the start of each session, edda assembles a context snapshot from the ledger and injects it — the agent sees recent decisions, active tasks, peer coordination, and (if configured) a doctrine pack from [havamal](https://github.com/fagemx/havamal), without reading through old transcripts.
 

--- a/docs/README_zh-TW.md
+++ b/docs/README_zh-TW.md
@@ -54,7 +54,7 @@ Edda 用同一個原語治這兩種病：**append-only 的本地狀態，放在 
 
 第一層從第一天就能單獨用。第二層不用另外裝——同一個 workspace、同一個 CLI——當你開始跑多個 agent，它就在那裡。
 
-**兩個持久化平面，這是刻意的。** 決策、筆記、session 摘要、任務、verdict 是 hash-chained SQLite 帳本裡的事件——防篡改、可重播。即時協調狀態（claims、peer 心跳）是使用者層 store 裡另一份 append-only log，而每個 `edda conduct` 計畫各自保有自己的狀態檔與事件記錄。全部都在本地、都查得到；hash chain 覆蓋的是帳本那一份。
+**分開的持久化平面，這是刻意的。** 決策、筆記、session 摘要、任務、verdict 是 hash-chained SQLite 帳本裡的事件——防篡改、可重播。即時協調狀態在那條鏈之外，放在使用者層 store：claims 附加進一份協調 log，而每個 session 的心跳是一個小快照檔，session 跑著時持續覆寫、結束時刪除。每個 `edda conduct` 計畫又各自保有自己的狀態檔與事件記錄。全部都在本地、都查得到；hash chain 覆蓋的是帳本那一份。
 
 ## 第一層——記憶跨 session 活著
 
@@ -113,7 +113,7 @@ Claude Code（早上）                  Codex（下午）
 
 ## 第二層——協調跨 agent 活著
 
-跑第二個 agent 的那一刻起，記憶就不再是最難的問題。難的變成：*誰在動哪裡、誰用什麼權限決定了什麼、你沒在看的時候實際發生了什麼。* Edda 用同一本帳回答這三題。
+跑第二個 agent 的那一刻起，記憶就不再是最難的問題。難的變成：*誰在動哪裡、誰用什麼權限決定了什麼、你沒在看的時候實際發生了什麼。* Edda 用同一個本地 workspace 回答這三題——帳本存耐久的紀錄，協調平面存誰現在還活著。
 
 **Claims——誰在動哪裡。** 每個 session 宣告自己的工作範圍，所有 peer 都會在 session 開始注入的 context 裡看到，併行的 agent 動手前就知道哪塊是誰的。Claims **預設是宣告性的**：edda 記錄並顯示它們，但在你用 `EDDA_ENFORCE_OFFLIMITS=1`（或 `bridge.enforce_offlimits=true`）開啟之前不會擋任何寫入；開啟後 Claude Code 的 hook 會拒絕對 peer 已 claim 路徑的 `Edit`／`Write`。
 
@@ -138,7 +138,7 @@ edda verdict approve my-plan/impl --sha <完整40位SHA>
 edda verdict reject  my-plan/impl --sha <sha> --comment "tests missing"
 ```
 
-**單回合 lane——controller 可以讓它脫離。** `edda dispatch` 在前景跑完整整一個 agent 回合（Claude、Codex 或 pi），以型別化的結果收場——done、crash、timeout、超出預算——並可用 `--json` 供機器讀取。它不帶計畫、DAG 或迴圈狀態；迴圈控制留在呼叫端。正是這份無狀態，讓 controller 可以放心把它當**脫離的 OS 程序**啟動，而不是自己 session 的子程序——這才是工作能在 controller 死掉後活下來的原因。當我們的 controller session 半路死掉、一天死了三次，脫離的 lane 照跑，事後從 branch、PR 和帳本把結果撿回來，而不是靠任何人的記憶。
+**單回合 lane——controller 可以讓它脫離。** `edda dispatch` 在前景跑完整整一個 agent 回合（Claude、Codex 或 pi），以型別化的結果收場——done、crash、timeout、max turns、超出預算，各有自己的 exit code——並可用 `--json` 供機器讀取。它不帶計畫、DAG 或迴圈狀態；迴圈控制留在呼叫端。正是這份無狀態，讓 controller 可以放心把它當**脫離的 OS 程序**啟動，而不是自己 session 的子程序——這才是工作能在 controller 死掉後活下來的原因。當我們的 controller session 半路死掉、一天死了三次，脫離的 lane 照跑，事後從 branch、PR 和帳本把結果撿回來，而不是靠任何人的記憶。
 
 ```bash
 edda dispatch --agent codex --prompt-file task.md
@@ -206,7 +206,8 @@ Claude Code session
    │  .edda/ledger.db             │  ← 決策、筆記、任務、
    │    append-only、hash-chained │     verdict、摘要
    ├──────────────────────────────┤
-   │  協調 log（使用者層）        │  ← claims、peer 心跳
+   │  協調 log（使用者層）        │  ← claims（附加寫入）
+   │  session 心跳檔              │  ← 每個活著的 session 一份
    │  conduct 計畫狀態 + 事件     │  ← 每個計畫各一份
    └──────────────────────────────┘
         │
@@ -217,7 +218,7 @@ Claude Code session
    下次 session 看到全部
 ```
 
-Edda 將每個帳本事件以 hash-chained JSON 記錄儲存在本地 SQLite 資料庫中。帳本事件包括決策、筆記、session 摘要、任務、verdict 和指令輸出。Hash chain 讓這份歷史防篡改、檢索確定性——同一個查詢永遠得同一個答案，迴圈裡沒有 LLM。Claims 和 peer 心跳刻意不進這條鏈：它們是會過期的即時協調狀態，寫在自己的 log 裡，每次 session 開始時讀取。
+Edda 將每個帳本事件以 hash-chained JSON 記錄儲存在本地 SQLite 資料庫中。帳本事件包括決策、筆記、session 摘要、任務、verdict 和指令輸出。Hash chain 讓這份歷史防篡改、檢索確定性——同一個查詢永遠得同一個答案，迴圈裡沒有 LLM。協調狀態刻意不進這條鏈，因為它是即時的而非歷史的：claims 附加寫進自己的 log，而 session 的心跳是一個快照檔，只在那個 session 活著時存在。兩者都在每次 session 開始時讀取。
 
 每次 session 開始時，edda 從 ledger 組裝 context snapshot 並注入——agent 看到最近的決策、進行中的任務、peer 協調狀態，以及（若有配置）來自 [havamal](https://github.com/fagemx/havamal) 的判斷層 pack，不需要閱讀舊 transcript。
 

--- a/docs/README_zh-TW.md
+++ b/docs/README_zh-TW.md
@@ -54,7 +54,7 @@ Edda 用同一個原語治這兩種病：**append-only 的本地狀態，放在 
 
 第一層從第一天就能單獨用。第二層不用另外裝——同一個 workspace、同一個 CLI——當你開始跑多個 agent，它就在那裡。
 
-**分開的持久化平面，這是刻意的。** 決策、筆記、session 摘要、任務、verdict 是 hash-chained SQLite 帳本裡的事件——防篡改、可重播。即時協調狀態在那條鏈之外，放在使用者層 store：claims 附加進一份協調 log，而每個 session 的心跳是一個小快照檔，session 跑著時持續覆寫、結束時刪除。每個 `edda conduct` 計畫又各自保有自己的狀態檔與事件記錄。全部都在本地、都查得到；hash chain 覆蓋的是帳本那一份。
+**分開的持久化平面，這是刻意的。** 決策、筆記、session 摘要、任務、verdict 是 hash-chained SQLite 帳本裡的事件——防篡改、可重播。即時協調狀態在那條鏈之外，放在使用者層 store：claims 附加進一份協調 log，而每個 session 的心跳是一個小快照檔，工作時持續覆寫、正常結束時移除——沒走到正常結束就死掉的 session 會把快照留下，`edda peers` 會把它報成 stale，`edda gc` 之後可以回收。每個 `edda conduct` 計畫又各自保有自己的狀態檔與事件記錄。全部都在本地、都查得到；hash chain 覆蓋的是帳本那一份。
 
 ## 第一層——記憶跨 session 活著
 
@@ -207,7 +207,8 @@ Claude Code session
    │    append-only、hash-chained │     verdict、摘要
    ├──────────────────────────────┤
    │  協調 log（使用者層）        │  ← claims（附加寫入）
-   │  session 心跳檔              │  ← 每個活著的 session 一份
+   │  session 心跳檔              │  ← 每個 session 一份，非正常
+   │                              │     結束者留下並標為 stale
    │  conduct 計畫狀態 + 事件     │  ← 每個計畫各一份
    └──────────────────────────────┘
         │
@@ -218,7 +219,7 @@ Claude Code session
    下次 session 看到全部
 ```
 
-Edda 將每個帳本事件以 hash-chained JSON 記錄儲存在本地 SQLite 資料庫中。帳本事件包括決策、筆記、session 摘要、任務、verdict 和指令輸出。Hash chain 讓這份歷史防篡改、檢索確定性——同一個查詢永遠得同一個答案，迴圈裡沒有 LLM。協調狀態刻意不進這條鏈，因為它是即時的而非歷史的：claims 附加寫進自己的 log，而 session 的心跳是一個快照檔，只在那個 session 活著時存在。兩者都在每次 session 開始時讀取。
+Edda 將每個帳本事件以 hash-chained JSON 記錄儲存在本地 SQLite 資料庫中。帳本事件包括決策、筆記、session 摘要、任務、verdict 和指令輸出。Hash chain 讓這份歷史防篡改、檢索確定性——同一個查詢永遠得同一個答案，迴圈裡沒有 LLM。協調狀態刻意不進這條鏈，因為它是即時的而非歷史的：claims 附加寫進自己的 log，而 session 的心跳是一個快照檔，工作時更新、正常結束時清除，session 死掉時它不會消失而是變成 stale。兩者都在每次 session 開始時讀取。
 
 每次 session 開始時，edda 從 ledger 組裝 context snapshot 並注入——agent 看到最近的決策、進行中的任務、peer 協調狀態，以及（若有配置）來自 [havamal](https://github.com/fagemx/havamal) 的判斷層 pack，不需要閱讀舊 transcript。
 


### PR DESCRIPTION
## Why this exists

[#570](https://github.com/fagemx/edda/pull/570) was merged at head `1d7bb1a` while its review loop was still open — the standing verdict at that moment was `Changes Requested` (Round 2, posted three minutes before the merge). Two review findings had therefore not landed, and a third was found afterwards. `main` currently carries README text that overstates what the code does. This PR lands the remainder.

## What it fixes

**From Round 2 (verified, not disputed):**

- The layer-2 opener still said edda answers "who is working where" *from the same ledger*. Claims are not ledger events — they go through `peers::write_claim` into the per-user coordination log. Reworded to name the ledger and the coordination plane separately.
- The hero paragraph, the How It Works diagram, and the ledger paragraph lumped claims and peer heartbeats into one append-only log. Only claims append to `coordination.jsonl`; a heartbeat is `state/session.{id}.json`, written whole via `edda_store::write_atomic` (`peers/heartbeat.rs:139-166`). Now described as distinct planes in all three places.
- The `edda dispatch` outcome list omitted `max_turns`. `Outcome` has five variants mapped to exit codes 0–4 (`cmd_dispatch.rs:63-94`); all five are now listed.

**From Round 3 (fix-caused by the above, verified):**

- Saying heartbeat files are "deleted when the session ends" / "exist only while the session does" overstates cleanup. `remove_heartbeat` runs only on the `SessionEnd` path (`peers/heartbeat.rs:130-132`); a session that dies without it leaves the snapshot, which `edda peers` reports with `stale: true` (`cmd_bridge.rs:562-569`) and `edda gc` can reclaim later. All three locations now say cleared on clean exit, stale rather than gone on death.

Every change lands in both `README.md` and `docs/README_zh-TW.md`.

## Verification

Docs-only (no code, no `Cargo.lock`, no toolchain change): no Cargo gate per the verification ladder. `sh scripts/lint-markdown-content.sh` → exit 0. Exact-head CI is the gate.

Review requested against this PR's head before merge — the Round 3 verdict on the old branch does not carry over, since these commits sit on a new base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
