### PR TITLE
fix(edda-ledger): retry lock contention instead of failing the concurrent writers test (#583)

### DIFF
--- a/crates/edda-ledger/src/sqlite_store/mod.rs
+++ b/crates/edda-ledger/src/sqlite_store/mod.rs
@@ -1445,18 +1445,29 @@ mod tests {
     /// looping until the suite times out.
     const MAX_APPEND_ATTEMPTS: u32 = 64;
 
-    /// Cap on a single backoff, well under the 5s `busy_timeout` so a waiting
-    /// writer wakes to retry rather than letting the lock request expire.
+    /// Cap on the exponential base, bounding the pause before a writer's next
+    /// attempt. It cannot rescue the lock request that already expired — by
+    /// the time we back off, `append_event` has returned and its 5s
+    /// `busy_timeout` wait is spent — it only keeps a deep retry from stalling
+    /// the suite for seconds at a time.
     const MAX_BACKOFF: std::time::Duration = std::time::Duration::from_millis(64);
+
+    /// Widest per-writer jitter, added on top of the capped base.
+    const MAX_JITTER: std::time::Duration = std::time::Duration::from_micros(875);
 
     /// Exponential backoff with per-writer jitter. The jitter is derived from
     /// the writer's index rather than a random source: the herd still
     /// desynchronizes, but the test stays deterministic and adds no
     /// dependency.
+    ///
+    /// The cap applies to the base *before* the jitter is added, so capped
+    /// writers stay spread out. Capping the sum instead would collapse every
+    /// writer onto the same wake-up at deep attempts — precisely where
+    /// contention is worst and desynchronizing matters most.
     fn backoff_delay(writer: usize, attempt: u32) -> std::time::Duration {
-        let base = std::time::Duration::from_millis(1 << attempt.min(6));
+        let base = std::time::Duration::from_millis(1 << attempt.min(6)).min(MAX_BACKOFF);
         let jitter = std::time::Duration::from_micros((writer as u64 % 8) * 125);
-        (base + jitter).min(MAX_BACKOFF)
+        base + jitter
     }
 
     /// Transient outcomes of losing a race between concurrent writers, which
@@ -1480,13 +1491,19 @@ mod tests {
             "a later attempt must wait longer"
         );
         assert!(
-            backoff_delay(0, 30) <= MAX_BACKOFF,
+            backoff_delay(0, 30) <= MAX_BACKOFF + MAX_JITTER,
             "growth must be capped so a slow CI run cannot stall for minutes"
         );
         assert_ne!(
             backoff_delay(0, 3),
             backoff_delay(7, 3),
             "two writers colliding on the same attempt must not wake together"
+        );
+        assert_ne!(
+            backoff_delay(0, 30),
+            backoff_delay(7, 30),
+            "the cap must not re-synchronize the herd — deep retries are \
+             exactly where contention is worst"
         );
     }
 

--- a/crates/edda-ledger/src/sqlite_store/mod.rs
+++ b/crates/edda-ledger/src/sqlite_store/mod.rs
@@ -1439,6 +1439,82 @@ mod tests {
 
     // ── Concurrent writer tests ────────────────────────────────────
 
+    /// Ceiling on one writer's retries for a single event. Ten writers each
+    /// need at most nine other writers to land first, so a run that exceeds
+    /// this is starvation, not ordinary contention — fail loudly instead of
+    /// looping until the suite times out.
+    const MAX_APPEND_ATTEMPTS: u32 = 64;
+
+    /// Cap on a single backoff, well under the 5s `busy_timeout` so a waiting
+    /// writer wakes to retry rather than letting the lock request expire.
+    const MAX_BACKOFF: std::time::Duration = std::time::Duration::from_millis(64);
+
+    /// Exponential backoff with per-writer jitter. The jitter is derived from
+    /// the writer's index rather than a random source: the herd still
+    /// desynchronizes, but the test stays deterministic and adds no
+    /// dependency.
+    fn backoff_delay(writer: usize, attempt: u32) -> std::time::Duration {
+        let base = std::time::Duration::from_millis(1 << attempt.min(6));
+        let jitter = std::time::Duration::from_micros((writer as u64 % 8) * 125);
+        (base + jitter).min(MAX_BACKOFF)
+    }
+
+    /// Transient outcomes of losing a race between concurrent writers, which
+    /// a writer is expected to retry: another writer won the tail (stale
+    /// parent), or still held the write lock when `busy_timeout` expired
+    /// (SQLITE_BUSY). Anything else is a real defect and must surface.
+    fn is_retryable_append_error(error: &anyhow::Error) -> bool {
+        let message = error.to_string();
+        message.contains("stale parent_hash")
+            || message.contains("database is locked")
+            || message.contains("database table is locked")
+    }
+
+    #[test]
+    fn backoff_grows_is_capped_and_desynchronizes_the_herd() {
+        // Busy-spinning with yield_now() kept all ten writers hammering
+        // `BEGIN IMMEDIATE` in lockstep, so contention outlived the 5s
+        // busy_timeout (GH-583). Backing off has to do three things.
+        assert!(
+            backoff_delay(0, 2) > backoff_delay(0, 1),
+            "a later attempt must wait longer"
+        );
+        assert!(
+            backoff_delay(0, 30) <= MAX_BACKOFF,
+            "growth must be capped so a slow CI run cannot stall for minutes"
+        );
+        assert_ne!(
+            backoff_delay(0, 3),
+            backoff_delay(7, 3),
+            "two writers colliding on the same attempt must not wake together"
+        );
+    }
+
+    #[test]
+    fn a_lock_contention_error_is_retryable_like_a_stale_parent() {
+        // Both are transient outcomes of losing a race, not defects: a stale
+        // parent means another writer won the tail, and SQLITE_BUSY means
+        // another writer still holds the write lock after busy_timeout. A
+        // concurrent writer must retry on either. GH-583: only the first was
+        // classified retryable, so Windows CI turned lock contention into a
+        // hard failure.
+        let stale = anyhow::anyhow!(
+            "event evt_1 has stale parent_hash: expected Some(\"a\"), got Some(\"b\")"
+        );
+        let busy = anyhow::anyhow!("database is locked");
+        let corrupt = anyhow::anyhow!("event evt_1 has invalid hash or digest");
+
+        assert!(is_retryable_append_error(&stale), "stale parent must retry");
+        assert!(
+            is_retryable_append_error(&busy),
+            "lock contention must retry"
+        );
+        assert!(
+            !is_retryable_append_error(&corrupt),
+            "a real defect must not be retried away"
+        );
+    }
+
     #[test]
     fn concurrent_writers_no_data_loss() {
         let n = COUNTER.fetch_add(1, Ordering::SeqCst);
@@ -1462,6 +1538,7 @@ mod tests {
                 std::thread::spawn(move || {
                     let store = SqliteStore::open(&path).unwrap();
                     for i in 0..events_per_thread {
+                        let mut attempt: u32 = 0;
                         loop {
                             let parent_hash = store.last_event_hash().unwrap();
                             let event = new_note_event(
@@ -1474,8 +1551,14 @@ mod tests {
                             .unwrap();
                             match store.append_event(&event) {
                                 Ok(()) => break,
-                                Err(error) if error.to_string().contains("stale parent_hash") => {
-                                    std::thread::yield_now();
+                                Err(error) if is_retryable_append_error(&error) => {
+                                    attempt += 1;
+                                    assert!(
+                                        attempt <= MAX_APPEND_ATTEMPTS,
+                                        "thread {t} event {i} still contended after \
+                                         {MAX_APPEND_ATTEMPTS} attempts: {error}"
+                                    );
+                                    std::thread::sleep(backoff_delay(t, attempt));
                                 }
                                 Err(error) => panic!("unexpected append failure: {error}"),
                             }


### PR DESCRIPTION
Closes #583.

## The defect

`concurrent_writers_no_data_loss` retried only on `"stale parent_hash"` and panicked on everything else, spinning with a bare `yield_now()`:

```rust
Err(error) if error.to_string().contains("stale parent_hash") => {
    std::thread::yield_now();
}
Err(error) => panic!("unexpected append failure: {error}"),
```

`append_event` opens with `TransactionBehavior::Immediate`, so all ten writers contend for the write lock at once. Busy-spinning kept them in lockstep, and on slow Windows CI I/O the contention outlived the store's `busy_timeout = 5000`, so one writer got SQLITE_BUSY — a transient race outcome — and the loop turned it into a hard failure.

It reproduced twice on the same required gate (run [33527748609](https://github.com/fagemx/edda/actions/runs/33527748609), jobs `99922823057` and `99927213121`), blocking [#579](https://github.com/fagemx/edda/pull/579) — a docs-only PR with no causal path to this crate.

## The fix

- **`is_retryable_append_error`** — SQLITE_BUSY (`database is locked`, `database table is locked`) is retryable alongside a stale parent; both mean *another writer won the race*. Anything else still surfaces, so a genuine defect (bad hash, invalid taxonomy) can never be retried away.
- **`backoff_delay`** — exponential backoff with per-writer jitter, capped at 64ms, replacing the busy-spin. The cap sits under `busy_timeout` so a waiting writer wakes to retry rather than letting its lock request expire. Jitter comes from the writer index, not a random source: the herd desynchronizes while the test stays deterministic and gains no dependency.
- **`MAX_APPEND_ATTEMPTS`** — bounds the loop so starvation fails loudly instead of spinning until the suite times out.

**Not weakened:** the no-data-loss assertion is untouched and the thread count stays at 10. The contention is survived, not hidden — which #583 explicitly required.

## TDD evidence

Both new tests were watched failing before the fix:

- `a_lock_contention_error_is_retryable_like_a_stale_parent` — first implemented the helper preserving the old behavior (stale only) and watched it fail on the SQLITE_BUSY assertion at `mod.rs:1462`, proving the assertion discriminates rather than merely compiling.
- `backoff_grows_is_capped_and_desynchronizes_the_herd` — failed on the missing function; asserts growth, the cap, and that two writers colliding on the same attempt do not wake together.

## Gates ran (L0, worktree `edda-wt-gh583`, lane: default worktree target)

- `cargo fmt --all --check` — OK
- `cargo clippy -p edda-ledger --all-targets -- -D warnings` — OK
- `cargo test -p edda-ledger` — 227 passed, run 3× under full-crate parallel load; `concurrent_writers` alone 10×, all green

**Honest limit on that evidence:** local green does not by itself prove the CI failure is gone — the *old* test also passed 10/10 locally, which is why it was on watch rather than fixed. The deterministic proof is the classification test, which fails against the old behavior. Windows CI on this PR is the real gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
