### PR TITLE
feat(conductor): decouple the lane heartbeat from the Claude bridge; runner writes it (GH-566 + GH-569)

### DIFF
--- a/crates/edda-bridge-claude/src/agent_phase.rs
+++ b/crates/edda-bridge-claude/src/agent_phase.rs
@@ -323,9 +323,11 @@ fn detect_pr_from_tasks(tasks: &[String]) -> Option<u64> {
 }
 
 fn heartbeat_age_secs(project_id: &str, session_id: &str, now_epoch: u64) -> u64 {
-    let path = edda_store::project_dir(project_id)
-        .join("state")
-        .join(format!("session.{session_id}.json"));
+    // Resolve through the one funnel: `heartbeat_path` sanitizes the id,
+    // so this reader sees the exact file every writer produced. Raw
+    // interpolation of the raw id reads a name the writer never wrote for
+    // any id that needs encoding (e.g. `x/reader`).
+    let path = edda_store::heartbeat_path(project_id, session_id);
     let content = match std::fs::read_to_string(&path) {
         Ok(c) => c,
         Err(_) => return u64::MAX, // No heartbeat -> stale
@@ -397,6 +399,45 @@ mod tests {
     fn detect_pr_from_tasks_found() {
         let tasks = vec!["Review PR #53".to_string()];
         assert_eq!(detect_pr_from_tasks(&tasks), Some(53));
+    }
+
+    /// P1 regression (review round 2): the age reader must resolve through
+    /// `heartbeat_path`, not raw interpolation. A fresh heartbeat written
+    /// for an id that needs encoding (`x/reader`) used to be read at the
+    /// raw name, not found, and reported stale (u64::MAX) while the session
+    /// was alive. The safe-id control guards against the test passing for
+    /// the wrong reason (e.g. env not isolated).
+    #[test]
+    fn heartbeat_age_secs_reads_through_the_sanitized_funnel() {
+        // No EDDA_STORE_ROOT redirect: a redirect here races every concurrent
+        // store-writing test in this process that doesn't hold ENV_LOCK (the
+        // exact cross-store hazard this round is closing). Peers tests use
+        // unique pids against the default store instead.
+        let pid = "test_agent_phase_age";
+        let _ = std::fs::remove_dir_all(edda_store::project_dir(pid));
+        let now = now_rfc3339();
+        for sid in ["x/reader", "reader-control"] {
+            let mut hb = edda_store::SessionHeartbeat::blank(sid);
+            hb.started_at = now.clone();
+            hb.last_heartbeat = now.clone();
+            hb.label = "reader".into();
+            edda_store::write_heartbeat(pid, &hb).expect("write fresh heartbeat");
+        }
+        let now_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let age = heartbeat_age_secs(pid, "x/reader", now_epoch);
+        assert!(
+            age < 60,
+            "fresh encoded-id heartbeat must read as active, got age {age} (stale sentinel is u64::MAX)"
+        );
+        let control = heartbeat_age_secs(pid, "reader-control", now_epoch);
+        assert!(
+            control < 60,
+            "safe-id control must stay active, got {control}"
+        );
+        let _ = std::fs::remove_dir_all(edda_store::project_dir(pid));
     }
 
     #[test]

--- a/crates/edda-bridge-claude/src/dispatch/tests.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tests.rs
@@ -1992,6 +1992,11 @@ fn write_test_heartbeat(pid: &str, sid: &str, branch: Option<&str>) {
         branch: branch.map(|s| s.to_string()),
         current_phase: None,
         parent_session_id: None,
+        plan: None,
+        phase: None,
+        attempt: None,
+        stage: None,
+        pid: None,
     };
     let path = edda_store::project_dir(pid)
         .join("state")

--- a/crates/edda-bridge-claude/src/peers/discovery.rs
+++ b/crates/edda-bridge-claude/src/peers/discovery.rs
@@ -48,8 +48,12 @@ pub fn discover_active_peers(project_id: &str, current_session_id: &str) -> Vec<
         let hb_epoch = parse_rfc3339_to_epoch(&hb.last_heartbeat).unwrap_or(0);
         let age = now.saturating_sub(hb_epoch);
 
-        // Sub-agents can't touch_heartbeat (no hook events fire during execution),
-        // so use a much longer stale threshold (15x = ~30min at default 120s).
+        // Sub-agent heartbeats (Claude Code Task tool) still have no in-flight
+        // writer: no hook events fire during their execution, so a fresh
+        // heartbeat written once at spawn would otherwise age out mid-run.
+        // GH-569 narrowed this exception: conductor/dispatch lanes now write
+        // real periodic heartbeats (runner/heartbeat.rs) and use the standard
+        // threshold — only parented sub-agents keep the 15x multiplier.
         let effective_threshold = if hb.parent_session_id.is_some() {
             stale_threshold * 15
         } else {

--- a/crates/edda-bridge-claude/src/peers/heartbeat.rs
+++ b/crates/edda-bridge-claude/src/peers/heartbeat.rs
@@ -150,6 +150,10 @@ pub fn write_heartbeat_minimal(project_id: &str, session_id: &str, label: &str, 
 
 /// Write a heartbeat for a sub-agent spawned via Claude Code's Task tool.
 /// Uses agent_id as session identifier and records parent session for cleanup.
+///
+/// Rides the shared sidecar lock via `update_heartbeat` like every other
+/// producer: a raw whole-record write here would clobber anything another
+/// producer had already written for this id instead of refreshing it.
 pub(crate) fn write_subagent_heartbeat(
     project_id: &str,
     agent_id: &str,
@@ -158,31 +162,19 @@ pub(crate) fn write_subagent_heartbeat(
     cwd: &str,
 ) {
     let now = now_rfc3339();
-    let path = heartbeat_path(project_id, agent_id);
-    let heartbeat = SessionHeartbeat {
-        session_id: agent_id.to_string(),
-        started_at: now.clone(),
-        last_heartbeat: now,
-        label: label.to_string(),
-        focus_files: Vec::new(),
-        active_tasks: Vec::new(),
-        files_modified_count: 0,
-        total_edits: 0,
-        recent_commits: Vec::new(),
-        branch: detect_git_branch_in(cwd),
-        current_phase: None,
-        parent_session_id: Some(parent_session_id.to_string()),
-        plan: None,
-        phase: None,
-        attempt: None,
-        stage: None,
-        pid: None,
-    };
-    let data = match serde_json::to_string_pretty(&heartbeat) {
-        Ok(d) => d,
-        Err(_) => return,
-    };
-    let _ = edda_store::write_atomic(&path, data.as_bytes());
+    let branch = detect_git_branch_in(cwd);
+    let _ = edda_store::update_heartbeat(project_id, agent_id, |hb| {
+        if hb.started_at.is_empty() {
+            hb.started_at = now.clone();
+        }
+        hb.last_heartbeat = now;
+        hb.label = label.to_string();
+        hb.parent_session_id = Some(parent_session_id.to_string());
+        if branch.is_some() {
+            hb.branch = branch;
+        }
+        // Signal fields and lane fields belong to other producers — preserved.
+    });
 }
 
 /// Remove all sub-agent heartbeats belonging to a parent session.
@@ -489,15 +481,22 @@ pub(crate) fn resolve_teammate_session(project_id: &str, teammate_name: &str) ->
 
 /// Update a teammate's heartbeat phase to the given value.
 /// Used to set phase to "idle" when a TeammateIdle event is received.
+///
+/// Rides the shared sidecar lock via `update_heartbeat`: an unlocked
+/// read-modify-write here raced the runner's locked refresh (read a
+/// pre-lane record, then atomically restored it after the runner wrote
+/// lane fields, erasing them).
 pub(crate) fn update_teammate_phase(project_id: &str, session_id: &str, phase: &str) {
-    let path = heartbeat_path(project_id, session_id);
-    if let Some(mut hb) = read_heartbeat(project_id, session_id) {
+    let _ = edda_store::update_heartbeat(project_id, session_id, |hb| {
+        // `update_heartbeat` seeds a blank record when no file exists; a
+        // TeammateIdle event must not create a heartbeat for a session that
+        // never had one, so leave the still-blank record unwritten.
+        if hb.started_at.is_empty() {
+            return;
+        }
         hb.current_phase = Some(phase.to_string());
         hb.last_heartbeat = now_rfc3339();
-        if let Ok(data) = serde_json::to_string_pretty(&hb) {
-            let _ = edda_store::write_atomic(&path, data.as_bytes());
-        }
-    }
+    });
 }
 
 /// Write a teammate idle event to coordination.jsonl.

--- a/crates/edda-bridge-claude/src/peers/heartbeat.rs
+++ b/crates/edda-bridge-claude/src/peers/heartbeat.rs
@@ -7,7 +7,7 @@ use crate::signals::SessionSignals;
 use super::board::{compute_board_state, partition_requests_for_session};
 use super::helpers::{auto_label, parse_rfc3339_to_epoch, session_label_from_board};
 use super::{
-    coordination_path, detect_git_branch_in, env_label, heartbeat_path, stale_secs,
+    coordination_path, detect_git_branch_in, env_label, heartbeat_path, read_heartbeat, stale_secs,
     BindingConflict, CoordEvent, CoordEventType, SessionHeartbeat,
 };
 
@@ -73,6 +73,11 @@ pub(crate) fn write_heartbeat(
         current_phase: crate::agent_phase::read_phase_state(project_id, session_id)
             .map(|ps| ps.phase.to_string()),
         parent_session_id: None,
+        plan: None,
+        phase: None,
+        attempt: None,
+        stage: None,
+        pid: None,
     };
 
     let data = match serde_json::to_string_pretty(&heartbeat) {
@@ -157,6 +162,11 @@ pub fn write_heartbeat_minimal(project_id: &str, session_id: &str, label: &str, 
         branch: detect_git_branch_in(cwd),
         current_phase: None,
         parent_session_id: None,
+        plan: None,
+        phase: None,
+        attempt: None,
+        stage: None,
+        pid: None,
     };
 
     let data = match serde_json::to_string_pretty(&heartbeat) {
@@ -190,6 +200,11 @@ pub(crate) fn write_subagent_heartbeat(
         branch: detect_git_branch_in(cwd),
         current_phase: None,
         parent_session_id: Some(parent_session_id.to_string()),
+        plan: None,
+        phase: None,
+        attempt: None,
+        stage: None,
+        pid: None,
     };
     let data = match serde_json::to_string_pretty(&heartbeat) {
         Ok(d) => d,
@@ -221,12 +236,7 @@ pub(crate) fn cleanup_subagent_heartbeats(project_id: &str, parent_session_id: &
     }
 }
 
-/// Read a single session's heartbeat file.
-pub(crate) fn read_heartbeat(project_id: &str, session_id: &str) -> Option<SessionHeartbeat> {
-    let path = heartbeat_path(project_id, session_id);
-    let content = fs::read_to_string(path).ok()?;
-    serde_json::from_str(&content).ok()
-}
+// read_heartbeat lives in edda_store (re-exported by super).
 
 // ── Coordination Events (append-only log) ──
 
@@ -377,8 +387,9 @@ pub fn resolve_request_targets(project_id: &str, to_label: &str) -> Vec<String> 
             None => continue,
         };
 
-        // Sub-agents can't touch their heartbeat while running; match the
-        // extended threshold peer discovery already uses for them.
+        // Parented sub-agent heartbeats match the extended threshold peer
+        // discovery uses for them (they have no in-flight writer); conductor
+        // lanes write real periodic heartbeats and use the standard one.
         let effective_threshold = if hb.parent_session_id.is_some() {
             stale_threshold * 15
         } else {

--- a/crates/edda-bridge-claude/src/peers/heartbeat.rs
+++ b/crates/edda-bridge-claude/src/peers/heartbeat.rs
@@ -14,6 +14,10 @@ use super::{
 // ── Heartbeat Write/Read ──
 
 /// Write a full heartbeat (called from ingest_and_build_pack after signal extraction).
+/// Read-modify-write via `edda_store::update_heartbeat`: the hook producer
+/// owns the signal fields; lane fields (plan/phase/attempt/stage/pid) and
+/// the parent link written by other producers on the same shared surface are
+/// preserved, and concurrent writers are serialized by the sidecar lock.
 pub(crate) fn write_heartbeat(
     project_id: &str,
     session_id: &str,
@@ -22,12 +26,6 @@ pub(crate) fn write_heartbeat(
     cwd: &str,
 ) {
     let now = now_rfc3339();
-    let path = heartbeat_path(project_id, session_id);
-
-    // Preserve started_at from existing heartbeat, or use now
-    let started_at = read_heartbeat(project_id, session_id)
-        .map(|h| h.started_at)
-        .unwrap_or_else(|| now.clone());
 
     let branch = detect_git_branch_in(cwd);
 
@@ -48,67 +46,59 @@ pub(crate) fn write_heartbeat(
             }
         });
 
-    let heartbeat = SessionHeartbeat {
-        session_id: session_id.to_string(),
-        started_at,
-        last_heartbeat: now,
-        label: derived_label,
-        focus_files: signals
+    let _ = edda_store::update_heartbeat(project_id, session_id, |hb| {
+        if hb.started_at.is_empty() {
+            hb.started_at = now.clone();
+        }
+        hb.last_heartbeat = now.clone();
+        hb.label = derived_label.clone();
+        hb.focus_files = signals
             .files_modified
             .iter()
             .take(5)
             .map(|f| f.path.clone())
-            .collect(),
-        active_tasks: signals.tasks.clone(),
-        files_modified_count: signals.files_modified.len(),
-        total_edits: signals.files_modified.iter().map(|f| f.count).sum(),
-        recent_commits: signals
+            .collect();
+        hb.active_tasks = signals.tasks.clone();
+        hb.files_modified_count = signals.files_modified.len();
+        hb.total_edits = signals.files_modified.iter().map(|f| f.count).sum();
+        hb.recent_commits = signals
             .commits
             .iter()
             .rev()
             .take(3)
             .map(|c| format!("{} {}", &c.hash[..7.min(c.hash.len())], c.message))
-            .collect(),
-        branch,
-        current_phase: crate::agent_phase::read_phase_state(project_id, session_id)
-            .map(|ps| ps.phase.to_string()),
-        parent_session_id: None,
-        plan: None,
-        phase: None,
-        attempt: None,
-        stage: None,
-        pid: None,
-    };
-
-    let data = match serde_json::to_string_pretty(&heartbeat) {
-        Ok(d) => d,
-        Err(_) => return,
-    };
-    let _ = edda_store::write_atomic(&path, data.as_bytes());
+            .collect();
+        hb.branch = branch.clone();
+        hb.current_phase = crate::agent_phase::read_phase_state(project_id, session_id)
+            .map(|ps| ps.phase.to_string());
+        // parent_session_id and the conductor lane fields (plan, phase,
+        // attempt, stage, pid) belong to other producers — preserved.
+    });
 }
 
 /// Lightweight heartbeat touch: only update last_heartbeat timestamp.
+/// Rides the shared locked update; a still-virgin record is not persisted.
 pub fn touch_heartbeat(project_id: &str, session_id: &str) {
-    let path = heartbeat_path(project_id, session_id);
-    if let Some(mut hb) = read_heartbeat(project_id, session_id) {
-        hb.last_heartbeat = now_rfc3339();
-        if let Ok(data) = serde_json::to_string_pretty(&hb) {
-            let _ = edda_store::write_atomic(&path, data.as_bytes());
+    let now = now_rfc3339();
+    let _ = edda_store::update_heartbeat(project_id, session_id, |hb| {
+        if hb.started_at.is_empty() && hb.last_heartbeat.is_empty() {
+            // No existing heartbeat: skip touch (write_heartbeat creates it).
+            return;
         }
-    }
-    // If no existing heartbeat, skip touch (write_heartbeat will create it)
+        hb.last_heartbeat = now.clone();
+    });
 }
 
 /// Update the branch field in an existing heartbeat.
 /// Called when the agent intentionally switches branch (git checkout / git switch).
 pub(crate) fn update_heartbeat_branch(project_id: &str, session_id: &str, branch: &str) {
-    let path = heartbeat_path(project_id, session_id);
-    if let Some(mut hb) = read_heartbeat(project_id, session_id) {
-        hb.branch = Some(branch.to_string());
-        if let Ok(data) = serde_json::to_string_pretty(&hb) {
-            let _ = edda_store::write_atomic(&path, data.as_bytes());
+    let _ = edda_store::update_heartbeat(project_id, session_id, |hb| {
+        if hb.started_at.is_empty() && hb.last_heartbeat.is_empty() {
+            // No existing heartbeat: nothing to update.
+            return;
         }
-    }
+        hb.branch = Some(branch.to_string());
+    });
 }
 
 /// Ensure a heartbeat file exists for this session.
@@ -143,37 +133,19 @@ pub fn remove_heartbeat(project_id: &str, session_id: &str) {
 /// for peer discovery. Use `write_heartbeat` for full signal-enriched heartbeats.
 pub fn write_heartbeat_minimal(project_id: &str, session_id: &str, label: &str, cwd: &str) {
     let now = now_rfc3339();
-    let path = heartbeat_path(project_id, session_id);
-
-    let started_at = read_heartbeat(project_id, session_id)
-        .map(|h| h.started_at)
-        .unwrap_or_else(|| now.clone());
-
-    let heartbeat = SessionHeartbeat {
-        session_id: session_id.to_string(),
-        started_at,
-        last_heartbeat: now,
-        label: label.to_string(),
-        focus_files: Vec::new(),
-        active_tasks: Vec::new(),
-        files_modified_count: 0,
-        total_edits: 0,
-        recent_commits: Vec::new(),
-        branch: detect_git_branch_in(cwd),
-        current_phase: None,
-        parent_session_id: None,
-        plan: None,
-        phase: None,
-        attempt: None,
-        stage: None,
-        pid: None,
-    };
-
-    let data = match serde_json::to_string_pretty(&heartbeat) {
-        Ok(d) => d,
-        Err(_) => return,
-    };
-    let _ = edda_store::write_atomic(&path, data.as_bytes());
+    let branch = detect_git_branch_in(cwd);
+    let _ = edda_store::update_heartbeat(project_id, session_id, |hb| {
+        if hb.started_at.is_empty() {
+            hb.started_at = now.clone();
+        }
+        hb.last_heartbeat = now.clone();
+        hb.label = label.to_string();
+        if branch.is_some() {
+            hb.branch = branch.clone();
+        }
+        // Signal fields and the conductor lane fields belong to other
+        // producers on the shared surface — preserved.
+    });
 }
 
 /// Write a heartbeat for a sub-agent spawned via Claude Code's Task tool.

--- a/crates/edda-bridge-claude/src/peers/helpers.rs
+++ b/crates/edda-bridge-claude/src/peers/helpers.rs
@@ -1,5 +1,5 @@
 use super::board::{compute_board_state, partition_requests_for_session};
-use super::heartbeat::read_heartbeat;
+use super::read_heartbeat;
 use super::{BoardState, RequestEntry};
 use crate::signals::SessionSignals;
 

--- a/crates/edda-bridge-claude/src/peers/mod.rs
+++ b/crates/edda-bridge-claude/src/peers/mod.rs
@@ -2,7 +2,10 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
-use crate::signals::TaskSnapshot;
+// GH-569: the heartbeat type and its path/IO live in edda-store so any crate
+// (conductor runner included) can write heartbeats without depending on this
+// bridge. This module re-exports to preserve the public API surface.
+pub use edda_store::{heartbeat_path, read_heartbeat, SessionHeartbeat};
 
 // ── Configuration ──
 
@@ -60,28 +63,10 @@ pub(crate) fn detect_git_branch_in(cwd: &str) -> Option<String> {
 
 // ── Data Structures ──
 
-/// Per-session heartbeat file.
-/// Location: ~/.edda/projects/{pid}/state/session.{sid}.json
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SessionHeartbeat {
-    pub session_id: String,
-    pub started_at: String,
-    pub last_heartbeat: String,
-    pub label: String,
-    pub focus_files: Vec<String>,
-    pub active_tasks: Vec<TaskSnapshot>,
-    pub files_modified_count: usize,
-    pub total_edits: usize,
-    pub recent_commits: Vec<String>,
-    #[serde(default)]
-    pub branch: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub current_phase: Option<String>,
-    /// Set for sub-agent heartbeats to link back to the parent session.
-    /// Used for orphan cleanup and extended stale threshold.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub parent_session_id: Option<String>,
-}
+// Per-session heartbeat file.
+// Location: ~/.edda/projects/{pid}/state/session.{sid}.json
+// GH-569: the struct itself lives in `edda_store::SessionHeartbeat` and is
+// re-exported above.
 
 /// Append-only coordination event.
 /// Location: ~/.edda/projects/{pid}/state/coordination.jsonl
@@ -221,11 +206,7 @@ fn autoclaim_state_path(project_id: &str, session_id: &str) -> PathBuf {
         .join(format!("autoclaim.{session_id}.json"))
 }
 
-fn heartbeat_path(project_id: &str, session_id: &str) -> PathBuf {
-    edda_store::project_dir(project_id)
-        .join("state")
-        .join(format!("session.{session_id}.json"))
-}
+// heartbeat_path now comes from edda_store (re-exported above).
 
 pub(crate) fn coordination_path(project_id: &str) -> PathBuf {
     let dir = edda_store::project_dir(project_id).join("state");
@@ -256,7 +237,7 @@ pub use board::{
 };
 pub use discovery::{discover_active_peers, discover_all_sessions, infer_session_id};
 pub(crate) use heartbeat::{
-    cleanup_subagent_heartbeats, ensure_heartbeat_exists, read_heartbeat, resolve_teammate_session,
+    cleanup_subagent_heartbeats, ensure_heartbeat_exists, resolve_teammate_session,
     update_heartbeat_branch, update_teammate_phase, write_heartbeat, write_subagent_completed,
     write_subagent_heartbeat, write_task_completed, write_teammate_idle, SubagentReport,
 };

--- a/crates/edda-bridge-claude/src/peers/render_coord.rs
+++ b/crates/edda-bridge-claude/src/peers/render_coord.rs
@@ -3,10 +3,10 @@ use crate::signals::FileEditCount;
 use super::autoclaim::derive_scope_from_files;
 use super::board::{compute_board_state, partition_requests_for_session};
 use super::discovery::discover_active_peers;
-use super::heartbeat::read_heartbeat;
 use super::helpers::{
     self, format_age, format_peer_suffix, session_label_from_board, truncate_to_budget,
 };
+use super::read_heartbeat;
 use super::{
     protocol_budget, BoardState, PeerSummary, RequestEntry, SessionHeartbeat, PEER_UPDATES_BUDGET,
 };

--- a/crates/edda-bridge-claude/src/peers/tests.rs
+++ b/crates/edda-bridge-claude/src/peers/tests.rs
@@ -2281,6 +2281,90 @@ fn write_subagent_heartbeat_sets_parent() {
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }
 
+/// P1 regression (review round 2): `update_teammate_phase` must ride the
+/// sidecar lock like every other producer. The reviewed interleaving was:
+/// TeammateIdle reads a pre-lane record, the runner writes lane fields
+/// under the sidecar lock, TeammateIdle atomically restores its stale copy
+/// and erases those fields. Here the runner's window is held open
+/// deterministically: while the sidecar lock is held, the teammate write
+/// must NOT land (the old unlocked writer wrote straight through it), and
+/// after the runner's refresh lands first, the unblocked teammate write
+/// must preserve the lane fields it re-reads.
+#[test]
+fn teammate_idle_update_waits_for_the_sidecar_lock_and_preserves_lane_fields() {
+    // No EDDA_STORE_ROOT redirect: a redirect here races every concurrent
+    // store-writing test in this process that doesn't hold ENV_LOCK (the
+    // exact cross-store hazard this round is closing). Peers tests use
+    // unique pids against the default store instead.
+    let pid = "test_teammate_phase_lock";
+    let sid = "lane-1";
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    edda_store::ensure_dirs(pid).unwrap();
+
+    // Pre-lane record: hook telemetry only, no lane fields.
+    let _ = edda_store::update_heartbeat(pid, sid, |hb| {
+        hb.started_at = crate::parse::now_rfc3339();
+        hb.last_heartbeat = crate::parse::now_rfc3339();
+        hb.label = "worker".into();
+        hb.branch = Some("main".into());
+    });
+
+    // Hold the sidecar lock — the runner's read-to-write window.
+    let mut lock_path = edda_store::heartbeat_path(pid, sid).into_os_string();
+    lock_path.push(".lock");
+    let guard =
+        edda_store::lock_file(std::path::Path::new(&lock_path)).expect("acquire sidecar lock");
+
+    let writer = {
+        let pid = pid.to_string();
+        let sid = sid.to_string();
+        std::thread::spawn(move || update_teammate_phase(&pid, &sid, "idle"))
+    };
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    // While the lock is held, no teammate write may have landed on disk.
+    let on_disk = std::fs::read_to_string(edda_store::heartbeat_path(pid, sid)).unwrap();
+    let on_disk: serde_json::Value = serde_json::from_str(&on_disk).unwrap();
+    assert_eq!(
+        on_disk["current_phase"],
+        serde_json::Value::Null,
+        "TeammateIdle must not write while the sidecar lock is held"
+    );
+
+    // The runner's locked refresh lands in that window.
+    let hb_now = edda_store::read_heartbeat(pid, sid).expect("record exists");
+    let mut refreshed = hb_now;
+    refreshed.plan = Some("fleet-pr-loop".into());
+    refreshed.phase = Some("fix".into());
+    refreshed.attempt = Some(1);
+    refreshed.stage = Some("running".into());
+    refreshed.pid = Some(4242);
+    edda_store::write_heartbeat(pid, &refreshed).expect("runner refresh");
+    drop(guard);
+    writer.join().unwrap();
+
+    let hb = read_heartbeat(pid, sid).expect("heartbeat exists");
+    assert_eq!(
+        hb.current_phase.as_deref(),
+        Some("idle"),
+        "TeammateIdle phase must land after the lock frees"
+    );
+    assert_eq!(
+        hb.plan.as_deref(),
+        Some("fleet-pr-loop"),
+        "lane fields must survive the teammate write"
+    );
+    assert_eq!(hb.stage.as_deref(), Some("running"));
+    assert_eq!(hb.pid, Some(4242));
+    assert_eq!(
+        hb.branch.as_deref(),
+        Some("main"),
+        "hook fields survive too"
+    );
+
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
 #[test]
 fn cleanup_subagent_heartbeats_selective() {
     let pid = "test_cleanup_subagent";

--- a/crates/edda-bridge-claude/src/peers/tests.rs
+++ b/crates/edda-bridge-claude/src/peers/tests.rs
@@ -1699,6 +1699,11 @@ fn suggest_claim_command_from_focus_files() {
         branch: Some("feat/issue-131".into()),
         current_phase: None,
         parent_session_id: None,
+        plan: None,
+        phase: None,
+        attempt: None,
+        stage: None,
+        pid: None,
     };
     let result = suggest_claim_command("worker", &Some(hb));
     assert!(result.contains("edda claim"), "should contain edda claim");
@@ -1723,6 +1728,11 @@ fn suggest_claim_command_from_branch() {
         branch: Some("feat/auth-refactor".into()),
         current_phase: None,
         parent_session_id: None,
+        plan: None,
+        phase: None,
+        attempt: None,
+        stage: None,
+        pid: None,
     };
     let result = suggest_claim_command("", &Some(hb));
     assert!(
@@ -1842,6 +1852,11 @@ fn protocol_nudge_uses_branch_context() {
         branch: Some("feat/billing-v2".into()),
         current_phase: None,
         parent_session_id: None,
+        plan: None,
+        phase: None,
+        attempt: None,
+        stage: None,
+        pid: None,
     };
     let hb_path = heartbeat_path(pid, "s2");
     let _ = fs::create_dir_all(hb_path.parent().unwrap());
@@ -2349,6 +2364,11 @@ fn subagent_stale_threshold_extended() {
         branch: None,
         current_phase: None,
         parent_session_id: Some("parent-session".to_string()),
+        plan: None,
+        phase: None,
+        attempt: None,
+        stage: None,
+        pid: None,
     };
     let path = heartbeat_path(pid, "sub-stale");
     let _ = fs::create_dir_all(path.parent().unwrap());
@@ -3201,5 +3221,66 @@ fn legacy_ack_comparison_keeps_subsecond_order() {
         "an earlier same-second ack must not retire a later request"
     );
 
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+/// GH-569/GH-566: a lane that fires no bridge hooks (e.g. `edda dispatch
+/// --agent pi`) must still become a discoverable peer. The conductor runner
+/// writes the shared session heartbeat through the store-level writer
+/// (`edda-store`), NOT through any bridge API — that decoupling is the fix.
+/// Before it, the only production writer sat inside the Claude hook path, so
+/// such a lane never appeared in `edda peers` at all.
+#[test]
+fn lane_heartbeat_written_without_bridge_is_discovered_then_goes_stale() {
+    let pid = "test_lane_hb_discovery";
+    let sid = "lane-sess-001";
+    let _ = edda_store::ensure_dirs(pid);
+
+    let fmt = |t: time::OffsetDateTime| {
+        t.format(&time::format_description::well_known::Rfc3339)
+            .unwrap()
+    };
+    let now = time::OffsetDateTime::now_utc();
+    let make = |last: String| edda_store::SessionHeartbeat {
+        session_id: sid.into(),
+        started_at: fmt(now),
+        last_heartbeat: last,
+        label: "a".into(),
+        focus_files: vec![],
+        active_tasks: vec![],
+        files_modified_count: 0,
+        total_edits: 0,
+        recent_commits: vec![],
+        branch: None,
+        current_phase: Some("running".into()),
+        parent_session_id: None,
+        plan: Some("hbplan".into()),
+        phase: Some("a".into()),
+        attempt: Some(1),
+        stage: Some("running".into()),
+        pid: Some(4242),
+    };
+
+    edda_store::write_heartbeat(pid, &make(fmt(now))).expect("lane heartbeat write");
+
+    let peers = discover_active_peers(pid, "observer");
+    assert_eq!(
+        peers.len(),
+        1,
+        "a no-hook lane with a fresh heartbeat must be a peer"
+    );
+    assert_eq!(peers[0].label, "a");
+    assert_eq!(peers[0].current_phase.as_deref(), Some("running"));
+
+    // The lane stops: backdate beyond the stale threshold; discovery must
+    // drop it without any explicit removal call.
+    let stale = fmt(now - time::Duration::new(3600, 0));
+    edda_store::write_heartbeat(pid, &make(stale)).expect("stale heartbeat write");
+    assert!(
+        discover_active_peers(pid, "observer").is_empty(),
+        "a stopped lane goes stale naturally"
+    );
+
+    remove_heartbeat(pid, sid);
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }

--- a/crates/edda-bridge-claude/src/signals.rs
+++ b/crates/edda-bridge-claude/src/signals.rs
@@ -6,12 +6,10 @@ use crate::parse::now_rfc3339;
 
 // ── Session Signals (extracted from transcript) ──
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TaskSnapshot {
-    pub id: String,
-    pub subject: String,
-    pub status: String,
-}
+// GH-569: the heartbeat surface (and its TaskSnapshot) moved to edda-store so
+// non-bridge producers (the conductor runner) can write heartbeats. Re-export
+// to keep `crate::signals::TaskSnapshot` paths stable.
+pub use edda_store::TaskSnapshot;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct FileEditCount {

--- a/crates/edda-cli/src/cmd_bridge.rs
+++ b/crates/edda-cli/src/cmd_bridge.rs
@@ -571,9 +571,30 @@ fn peers_json(project_id: &str) -> serde_json::Value {
             })
             .collect();
     let board = edda_bridge_claude::peers::compute_board_state(project_id);
+    // GH-569: claims are part of the JSON surface programs consume, so each
+    // carries its age and a stale flag — otherwise a 55-day-old zombie claim
+    // and a 37-second-old live claim are indistinguishable to a program.
+    let now_epoch = time::OffsetDateTime::now_utc().unix_timestamp();
+    let claims: Vec<serde_json::Value> = board
+        .claims
+        .iter()
+        .map(|claim| {
+            let mut value = serde_json::to_value(claim).unwrap_or_default();
+            let ts_epoch = time::OffsetDateTime::parse(
+                &claim.ts,
+                &time::format_description::well_known::Rfc3339,
+            )
+            .map(|t| t.unix_timestamp())
+            .unwrap_or(0);
+            let age_secs = (now_epoch - ts_epoch).max(0) as u64;
+            value["age_secs"] = serde_json::json!(age_secs);
+            value["stale"] = serde_json::json!(age_secs > stale_threshold);
+            value
+        })
+        .collect();
     serde_json::json!({
         "sessions": sessions,
-        "claims": board.claims,
+        "claims": claims,
         "requests": board.requests,
         "acks": board.request_acks,
     })
@@ -2853,6 +2874,26 @@ mod tests {
             2,
             "and it must still release nothing"
         );
+    }
+
+    #[test]
+    fn peers_json_claims_carry_staleness() {
+        // GH-569: programs reading `edda peers --json` must be able to make
+        // the same live-vs-stale judgement the human view makes. Claims are
+        // entries of that surface, so each carries its age and a stale flag.
+        let _store = crate::test_support::isolated_store();
+        let repo = tempfile::tempdir().expect("tempdir");
+        let pid = edda_store::project_id(repo.path());
+        let _ = edda_store::ensure_dirs(&pid);
+        edda_bridge_claude::peers::write_claim(&pid, "s1", "auth", &["src/auth.rs".into()]);
+
+        let json = peers_json(&pid);
+        let claim = &json["claims"][0];
+        assert!(
+            claim["age_secs"].is_u64(),
+            "claim carries age_secs: {claim}"
+        );
+        assert_eq!(claim["stale"], false, "fresh claim is not stale");
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_bridge.rs
+++ b/crates/edda-cli/src/cmd_bridge.rs
@@ -2760,6 +2760,23 @@ mod tests {
         edda_bridge_claude::peers::write_claim(&pid, "cli-auth", "auth", &["src/auth.rs".into()]);
         edda_bridge_claude::peers::write_claim(&pid, "cli-api", "api", &["src/api.rs".into()]);
 
+        // Windows-CI regression (PR #588): a sibling test that relocated
+        // EDDA_STORE_ROOT outside the shared isolated_store() lock made the
+        // claims land in one store while unclaim() read another, and the test
+        // failed with the misleading "no claims on the board". Assert the
+        // write is visible *under this test's own root* before the verb runs,
+        // so a future lock escape fails here naming the real cause instead of
+        // masquerading as a board-state defect.
+        assert_eq!(
+            edda_bridge_claude::peers::compute_board_state(&pid)
+                .claims
+                .len(),
+            2,
+            "claims must be readable under this test's own isolated store root \
+             before unclaim runs; if this fails, EDDA_STORE_ROOT was relocated \
+             mid-test by a test that bypassed the shared isolation lock"
+        );
+
         let err = unclaim(repo.path(), None, false).expect_err("ambiguous target must not guess");
         let msg = err.to_string();
         assert!(msg.contains("cli-auth") && msg.contains("cli-api"), "{msg}");

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -671,6 +671,62 @@ mod tests {
         assert_eq!(recorded[1], "fixed-id");
     }
 
+    /// P0 regression (review round 1): the user-controlled `--session-id`
+    /// reaches the heartbeat writer; a traversal id (`x\..\..\..\escaped`
+    /// was the reviewed repro that wrote `store/projects/escaped.json`)
+    /// must be contained by the store's path funnel, not escape the state
+    /// directory.
+    #[tokio::test]
+    // The mutex guard protects the process-global EDDA_STORE_ROOT against
+    // other test threads for the whole test, including the await below —
+    // that is the point, not an accidental hold.
+    #[allow(clippy::await_holding_lock)]
+    async fn hostile_session_id_cannot_escape_the_state_directory() {
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let previous = std::env::var_os("EDDA_STORE_ROOT");
+        std::env::set_var("EDDA_STORE_ROOT", tmp.path());
+
+        let launcher = RecordingLauncher {
+            session_ids: Mutex::new(Vec::new()),
+        };
+        let phase = build_phase("prompt", None, None, "bypassPermissions");
+        let sid = "x\\..\\..\\..\\escaped";
+        run_with_launcher(
+            &launcher,
+            &phase,
+            sid,
+            Path::new("."),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        let project_id = edda_store::project_id(Path::new("."));
+        let project = edda_store::project_dir(&project_id);
+        let state = project.join("state");
+        assert!(
+            edda_store::read_heartbeat(&project_id, sid).is_some(),
+            "heartbeat written under the sanitized in-state-dir path"
+        );
+        // Nothing escaped to the project dir, the projects/ level or the
+        // store root.
+        assert!(!project.join("escaped.json").exists());
+        assert!(!state.join("escaped.json").exists());
+        if let Some(projects) = project.parent() {
+            assert!(!projects.join("escaped.json").exists());
+            if let Some(root) = projects.parent() {
+                assert!(!root.join("escaped.json").exists());
+            }
+        }
+        match previous {
+            Some(v) => std::env::set_var("EDDA_STORE_ROOT", v),
+            None => std::env::remove_var("EDDA_STORE_ROOT"),
+        }
+        let _ = std::fs::remove_dir_all(tmp.path());
+    }
+
     // ── Synthetic phase parity with conduct ──
 
     #[test]

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -324,6 +324,13 @@ fn run_inner(args: DispatchArgs) -> Result<i32> {
 
 /// One turn through the launcher with an empty plan context. Split out from
 /// [`run`] so tests can drive it with MockLauncher or a recording stub.
+///
+/// GH-566/GH-569: the turn runs through the conductor runner's
+/// `run_phase_with_heartbeat`, so a dispatched lane (any backend, no Claude
+/// hooks) periodically refreshes the session heartbeat and is visible to
+/// `edda peers` while it works. The write lives in the conductor runner;
+/// dispatch stays stateless — the heartbeat is an observation surface, not a
+/// control surface, and ages out through the normal staleness threshold.
 pub async fn run_with_launcher(
     launcher: &dyn AgentLauncher,
     phase: &PhaseSchema,
@@ -331,9 +338,25 @@ pub async fn run_with_launcher(
     cwd: &std::path::Path,
     cancel: CancellationToken,
 ) -> Result<DispatchOutput> {
-    let result = launcher
-        .run_phase(phase, &phase.prompt, "", session_id, cwd, cancel)
-        .await?;
+    let result = {
+        let hb = edda_conductor::runner::heartbeat::LaneHeartbeat {
+            cwd: cwd.to_path_buf(),
+            session_id: session_id.to_string(),
+            plan: "dispatch".to_string(),
+            phase: phase.id.clone(),
+            attempt: 1,
+        };
+        edda_conductor::runner::heartbeat::run_phase_with_heartbeat(
+            launcher,
+            phase,
+            &phase.prompt,
+            "",
+            cwd,
+            &cancel,
+            &hb,
+        )
+        .await?
+    };
     Ok(DispatchOutput::from_result(result, session_id.to_owned()))
 }
 

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -677,16 +677,15 @@ mod tests {
     /// must be contained by the store's path funnel, not escape the state
     /// directory.
     #[tokio::test]
-    // The mutex guard protects the process-global EDDA_STORE_ROOT against
-    // other test threads for the whole test, including the await below —
-    // that is the point, not an accidental hold.
+    // isolated_store() takes the shared test-support lock, so the process-global
+    // EDDA_STORE_ROOT stays ours for the whole test, including the await below —
+    // that is the point, not an accidental hold. A private lock here is what
+    // broke Windows CI (PR #588, round 2): this test relocated the root under a
+    // lock no other test knew about, so a concurrent cmd_bridge test that held
+    // the shared lock had its writes land in one store and its reads in another.
     #[allow(clippy::await_holding_lock)]
     async fn hostile_session_id_cannot_escape_the_state_directory() {
-        static ENV_LOCK: Mutex<()> = Mutex::new(());
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let tmp = tempfile::tempdir().unwrap();
-        let previous = std::env::var_os("EDDA_STORE_ROOT");
-        std::env::set_var("EDDA_STORE_ROOT", tmp.path());
+        let _store = crate::test_support::isolated_store();
 
         let launcher = RecordingLauncher {
             session_ids: Mutex::new(Vec::new()),
@@ -720,11 +719,7 @@ mod tests {
                 assert!(!root.join("escaped.json").exists());
             }
         }
-        match previous {
-            Some(v) => std::env::set_var("EDDA_STORE_ROOT", v),
-            None => std::env::remove_var("EDDA_STORE_ROOT"),
-        }
-        let _ = std::fs::remove_dir_all(tmp.path());
+        // _store (the IsolatedStore guard) restores EDDA_STORE_ROOT on drop.
     }
 
     // ── Synthetic phase parity with conduct ──

--- a/crates/edda-conductor/src/runner/edda.rs
+++ b/crates/edda-conductor/src/runner/edda.rs
@@ -127,19 +127,62 @@ mod tests {
     /// `set_var` is process-wide, so a concurrent test that reads
     /// `EDDA_STORE_ROOT` mid-write would see a torn value. Everything here wants
     /// the same store, so serialising the spawns costs nothing worth having.
+    ///
+    /// The lock is the *shared* `CLAIM_ENV_LOCK`, not a private one (review
+    /// round 2): a second private mutex here could relocate the root while a
+    /// heartbeat test held `ClaimEnvGuard`, recreating the ordering-dependent
+    /// cross-store write/read split the Windows-CI fix closed. Reentrancy
+    /// caveat: a caller already holding `ClaimEnvGuard` must not reach this
+    /// (`std::sync::Mutex` is not reentrant). The only production-path caller
+    /// is `ensure_init`, and its test callers that run under `ClaimEnvGuard`
+    /// pre-mark the cwd with `.edda` (see `sequential::tests::make_repo`), so
+    /// `ensure_init` early-returns before the lock is taken.
     pub(super) fn isolate_store_for_this_process() -> std::sync::MutexGuard<'static, ()> {
-        use std::sync::{Mutex, Once, OnceLock};
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        use std::sync::Once;
         static SET: Once = Once::new();
 
+        let lock = crate::runner::sequential::tests::CLAIM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         SET.call_once(|| {
             let store = tempfile::tempdir().expect("temp store for edda-conductor tests");
             std::env::set_var("EDDA_STORE_ROOT", store.path());
             std::mem::forget(store);
         });
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+        lock
+    }
+
+    /// P1 regression (review round 2): the store-isolation redirect must
+    /// serialize on the *shared* `CLAIM_ENV_LOCK`, not a private mutex. With
+    /// the old private lock, this helper could relocate `EDDA_STORE_ROOT`
+    /// while a heartbeat test held `ClaimEnvGuard`, splitting writes and
+    /// reads across two stores. Here `ClaimEnvGuard` is held while the
+    /// helper runs on another thread: it must stay blocked (no relocation,
+    /// not finished) until the guard drops.
+    #[test]
+    fn store_isolation_uses_the_shared_claim_env_lock() {
+        use crate::runner::sequential::tests::ClaimEnvGuard;
+
+        let guard = ClaimEnvGuard::new();
+        let before = std::env::var_os("EDDA_STORE_ROOT")
+            .expect("ClaimEnvGuard must have redirected the root");
+        let handle = std::thread::spawn(|| {
+            drop(super::tests::isolate_store_for_this_process());
+        });
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        // With the old private lock this thread either relocated the root
+        // under us (Once unfired) or returned immediately (Once fired).
+        assert_eq!(
+            std::env::var_os("EDDA_STORE_ROOT").as_deref(),
+            Some(before.as_os_str()),
+            "store isolation must not relocate EDDA_STORE_ROOT while ClaimEnvGuard holds the shared lock"
+        );
+        assert!(
+            !handle.is_finished(),
+            "store isolation must block on CLAIM_ENV_LOCK while ClaimEnvGuard is held"
+        );
+        drop(guard);
+        handle.join().expect("isolation helper must not panic");
     }
 
     /// GH-417: the runner shells out to the installed `edda`, and `edda init`

--- a/crates/edda-conductor/src/runner/heartbeat.rs
+++ b/crates/edda-conductor/src/runner/heartbeat.rs
@@ -44,39 +44,40 @@ pub struct LaneHeartbeat {
 }
 
 impl LaneHeartbeat {
-    /// Refresh the heartbeat once with the given stage. Best-effort: any
-    /// failure is a warning on stderr, never an error — the observation plane
-    /// must not be able to kill the work plane.
-    pub fn write(&self, stage: &str) {
+    /// Refresh the heartbeat once with the given stage. Updates only the
+    /// fields the lane owns (stage/plan/phase/attempt/pid/label/timestamps)
+    /// and preserves hook-produced telemetry — see `edda_store::
+    /// update_heartbeat`. Best-effort: callers own error policy.
+    pub fn try_write(&self, stage: &str) -> anyhow::Result<()> {
         let project_id = edda_store::project_id(&self.cwd);
         let now = now_rfc3339();
-        // Preserve started_at across refreshes so age-of-session stays true.
-        let started_at = edda_store::read_heartbeat(&project_id, &self.session_id)
-            .map(|h| h.started_at)
-            .unwrap_or_else(|| now.clone());
-        let hb = edda_store::SessionHeartbeat {
-            session_id: self.session_id.clone(),
-            started_at,
-            last_heartbeat: now,
+        edda_store::update_heartbeat(&project_id, &self.session_id, |hb| {
+            // Preserve started_at across refreshes so age-of-session stays
+            // true; a fresh record starts its clock here.
+            if hb.started_at.is_empty() {
+                hb.started_at = now.clone();
+            }
+            hb.last_heartbeat = now;
             // The claim for a conduct phase uses the phase id as its label
             // (`write_phase_claim`); matching it keeps `edda request`
             // routing and the peers view coherent.
-            label: self.phase.clone(),
-            focus_files: Vec::new(),
-            active_tasks: Vec::new(),
-            files_modified_count: 0,
-            total_edits: 0,
-            recent_commits: Vec::new(),
-            branch: None,
-            current_phase: Some(stage.to_string()),
-            parent_session_id: None,
-            plan: Some(self.plan.clone()),
-            phase: Some(self.phase.clone()),
-            attempt: Some(self.attempt),
-            stage: Some(stage.to_string()),
-            pid: Some(std::process::id()),
-        };
-        if let Err(e) = edda_store::write_heartbeat(&project_id, &hb) {
+            hb.label = self.phase.clone();
+            hb.current_phase = Some(stage.to_string());
+            hb.plan = Some(self.plan.clone());
+            hb.phase = Some(self.phase.clone());
+            hb.attempt = Some(self.attempt);
+            hb.stage = Some(stage.to_string());
+            hb.pid = Some(std::process::id());
+            // focus_files, active_tasks, edit counts, recent commits, branch
+            // and the parent link belong to the hook producer — untouched.
+        })
+    }
+
+    /// Refresh the heartbeat once, degrading any failure to a warning on
+    /// stderr — the observation plane must not be able to kill the work
+    /// plane.
+    pub fn write(&self, stage: &str) {
+        if let Err(e) = self.try_write(stage) {
             eprintln!(
                 "warning: lane heartbeat write failed for {} (continuing): {e}",
                 self.session_id
@@ -84,20 +85,23 @@ impl LaneHeartbeat {
         }
     }
 
-    /// Spawn a background task that refreshes the heartbeat every interval
-    /// until the token is cancelled or the task is aborted at turn end.
+    /// Start refreshing the heartbeat every interval until the token is
+    /// cancelled (or the handle is aborted at turn end). The FIRST write
+    /// happens here, synchronously on the caller's task — never inside the
+    /// spawned task, which a fast caller could finish before the scheduler
+    /// ever polls.
     pub fn spawn(
         &self,
         stage: &'static str,
         cancel: CancellationToken,
     ) -> tokio::task::JoinHandle<()> {
+        self.write(stage);
         let hb = self.clone();
         tokio::spawn(async move {
-            let interval = lane_heartbeat_interval_secs();
-            hb.write(stage);
+            let interval = Duration::from_secs(lane_heartbeat_interval_secs());
             loop {
                 tokio::select! {
-                    _ = tokio::time::sleep(Duration::from_secs(interval)) => hb.write(stage),
+                    _ = tokio::time::sleep(interval) => hb.write(stage),
                     _ = cancel.cancelled() => break,
                 }
             }
@@ -111,10 +115,14 @@ fn now_rfc3339() -> String {
         .unwrap_or_default()
 }
 
-/// Run one agent turn with a live lane heartbeat: a background task refreshes
-/// the heartbeat every interval while the turn runs, and is stopped when the
-/// turn returns (the heartbeat then ages out through the normal staleness
-/// threshold — no delete step, a stopped lane is simply stale).
+/// Run one agent turn with a live lane heartbeat: the first write happens
+/// synchronously before the turn can complete, then a background task
+/// refreshes the heartbeat every interval while the turn runs, and is
+/// stopped when the turn returns. The phase's checks are covered separately
+/// by `process_phase_result` (stage "checking"), so the heartbeat spans the
+/// whole phase lifetime (GH-566). Afterwards the heartbeat ages out through
+/// the normal staleness threshold — no delete step, a stopped lane is
+/// simply stale.
 ///
 /// This is the single write site serving `edda conduct` (both the main phase
 /// loop and post-rejection redispatch turns) and `edda dispatch`.
@@ -148,6 +156,7 @@ pub async fn run_phase_with_heartbeat(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runner::sequential::tests::{make_repo, ClaimEnvGuard};
 
     #[test]
     fn interval_defaults_to_30s_and_reads_env() {
@@ -160,6 +169,81 @@ mod tests {
             Ok(v) => std::env::set_var("EDDA_LANE_HEARTBEAT_SECS", v),
             Err(_) => std::env::remove_var("EDDA_LANE_HEARTBEAT_SECS"),
         }
+    }
+
+    /// P1-2 regression (review round 1): the runner refresh must update only
+    /// the fields the lane owns and preserve hook-produced telemetry
+    /// (branch, focus_files, active_tasks, edit counts, recent commits) —
+    /// a Claude conduct lane has both producers racing on one file.
+    #[test]
+    fn lane_refresh_preserves_hook_telemetry_it_does_not_own() {
+        // ClaimEnvGuard serializes EDDA_STORE_ROOT mutation with the other
+        // heartbeat tests via CLAIM_ENV_LOCK.
+        let guard = ClaimEnvGuard::new();
+        let cwd = make_repo(guard._store_root.path());
+        let project_id = edda_store::project_id(&cwd);
+
+        // Hook telemetry pre-seeded by the Claude hook producer.
+        let seeded = edda_store::SessionHeartbeat {
+            session_id: "s".into(),
+            started_at: "2026-09-01T00:00:00Z".into(),
+            last_heartbeat: "2026-09-01T00:00:10Z".into(),
+            label: "hook-label".into(),
+            focus_files: vec!["src/lib.rs".into(), "src/main.rs".into()],
+            active_tasks: vec![edda_store::TaskSnapshot {
+                id: "t1".into(),
+                subject: "ship it".into(),
+                status: "in_progress".into(),
+            }],
+            files_modified_count: 3,
+            total_edits: 7,
+            recent_commits: vec!["abc1234 fix things".into()],
+            branch: Some("feat/x".into()),
+            current_phase: None,
+            parent_session_id: None,
+            plan: None,
+            phase: None,
+            attempt: None,
+            stage: None,
+            pid: None,
+        };
+        edda_store::write_heartbeat(&project_id, &seeded).unwrap();
+
+        let hb = LaneHeartbeat {
+            cwd: cwd.clone(),
+            session_id: "s".into(),
+            plan: "p".into(),
+            phase: "a".into(),
+            attempt: 1,
+        };
+        hb.write("running");
+
+        let after = edda_store::read_heartbeat(&project_id, "s").expect("heartbeat exists");
+        assert_eq!(
+            after.focus_files, seeded.focus_files,
+            "focus_files preserved"
+        );
+        assert_eq!(after.active_tasks.len(), 1, "active_tasks preserved");
+        assert_eq!(
+            after.files_modified_count, 3,
+            "files_modified_count preserved"
+        );
+        assert_eq!(after.total_edits, 7, "total_edits preserved");
+        assert_eq!(
+            after.recent_commits, seeded.recent_commits,
+            "commits preserved"
+        );
+        assert_eq!(after.branch.as_deref(), Some("feat/x"), "branch preserved");
+        assert_eq!(
+            after.started_at, "2026-09-01T00:00:00Z",
+            "started_at preserved"
+        );
+        // The lane still stamps the fields it owns.
+        assert_eq!(after.plan.as_deref(), Some("p"));
+        assert_eq!(after.phase.as_deref(), Some("a"));
+        assert_eq!(after.attempt, Some(1));
+        assert_eq!(after.stage.as_deref(), Some("running"));
+        assert!(after.pid.is_some());
     }
 
     #[test]
@@ -183,7 +267,15 @@ mod tests {
             phase: "a".into(),
             attempt: 1,
         };
-        hb.write("running");
+        // The write IS attempted and its failure is surfaced: a store whose
+        // project dir is a regular file must make `try_write` return Err
+        // (the `write` wrapper turns that into the promised warning), not
+        // silently skip the attempt.
+        let result = hb.try_write("running");
+        assert!(
+            result.is_err(),
+            "expected the heartbeat write to fail against a file-as-project-dir store, got Ok"
+        );
         match previous {
             Some(v) => std::env::set_var("EDDA_STORE_ROOT", v),
             None => std::env::remove_var("EDDA_STORE_ROOT"),

--- a/crates/edda-conductor/src/runner/heartbeat.rs
+++ b/crates/edda-conductor/src/runner/heartbeat.rs
@@ -1,0 +1,192 @@
+//! Lane heartbeat (GH-566/GH-569).
+//!
+//! While a conductor phase runs — whether dispatched by `edda conduct` or
+//! `edda dispatch` — the runner periodically refreshes the session's existing
+//! heartbeat file so `edda peers` (and any future status plane) can see the
+//! lane is alive and what it is doing. This is the SAME surface the Claude
+//! hook path writes (the type and IO live in `edda-store`); there is exactly
+//! one liveness surface, no parallel format.
+//!
+//! The heartbeat is an observation plane, never a control plane (decision
+//! `fleet.lane-dispatch`): a write failure degrades to a warning and can
+//! never fail the phase. Writes are atomic (temp + rename) over a bounded
+//! single file, and the lane goes stale naturally once it stops — there is
+//! deliberately no delete step.
+
+use crate::agent::launcher::{AgentLauncher, PhaseResult};
+use crate::plan::schema::Phase;
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+/// Heartbeat refresh interval: env-configurable, default ~30s. Must stay well
+/// under the peer staleness threshold (`EDDA_PEER_STALE_SECS`, default 120s).
+pub fn lane_heartbeat_interval_secs() -> u64 {
+    std::env::var("EDDA_LANE_HEARTBEAT_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(30)
+}
+
+/// Identity of one running lane, enough to answer "what is it doing".
+#[derive(Debug, Clone)]
+pub struct LaneHeartbeat {
+    /// The cwd the heartbeat is rooted at — resolved through
+    /// `edda_store::project_id`, the same root resolution every reader uses,
+    /// so worktree-launched plans land where readers look.
+    pub cwd: PathBuf,
+    pub session_id: String,
+    pub plan: String,
+    pub phase: String,
+    pub attempt: u32,
+}
+
+impl LaneHeartbeat {
+    /// Refresh the heartbeat once with the given stage. Best-effort: any
+    /// failure is a warning on stderr, never an error — the observation plane
+    /// must not be able to kill the work plane.
+    pub fn write(&self, stage: &str) {
+        let project_id = edda_store::project_id(&self.cwd);
+        let now = now_rfc3339();
+        // Preserve started_at across refreshes so age-of-session stays true.
+        let started_at = edda_store::read_heartbeat(&project_id, &self.session_id)
+            .map(|h| h.started_at)
+            .unwrap_or_else(|| now.clone());
+        let hb = edda_store::SessionHeartbeat {
+            session_id: self.session_id.clone(),
+            started_at,
+            last_heartbeat: now,
+            // The claim for a conduct phase uses the phase id as its label
+            // (`write_phase_claim`); matching it keeps `edda request`
+            // routing and the peers view coherent.
+            label: self.phase.clone(),
+            focus_files: Vec::new(),
+            active_tasks: Vec::new(),
+            files_modified_count: 0,
+            total_edits: 0,
+            recent_commits: Vec::new(),
+            branch: None,
+            current_phase: Some(stage.to_string()),
+            parent_session_id: None,
+            plan: Some(self.plan.clone()),
+            phase: Some(self.phase.clone()),
+            attempt: Some(self.attempt),
+            stage: Some(stage.to_string()),
+            pid: Some(std::process::id()),
+        };
+        if let Err(e) = edda_store::write_heartbeat(&project_id, &hb) {
+            eprintln!(
+                "warning: lane heartbeat write failed for {} (continuing): {e}",
+                self.session_id
+            );
+        }
+    }
+
+    /// Spawn a background task that refreshes the heartbeat every interval
+    /// until the token is cancelled or the task is aborted at turn end.
+    pub fn spawn(
+        &self,
+        stage: &'static str,
+        cancel: CancellationToken,
+    ) -> tokio::task::JoinHandle<()> {
+        let hb = self.clone();
+        tokio::spawn(async move {
+            let interval = lane_heartbeat_interval_secs();
+            hb.write(stage);
+            loop {
+                tokio::select! {
+                    _ = tokio::time::sleep(Duration::from_secs(interval)) => hb.write(stage),
+                    _ = cancel.cancelled() => break,
+                }
+            }
+        })
+    }
+}
+
+fn now_rfc3339() -> String {
+    time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_default()
+}
+
+/// Run one agent turn with a live lane heartbeat: a background task refreshes
+/// the heartbeat every interval while the turn runs, and is stopped when the
+/// turn returns (the heartbeat then ages out through the normal staleness
+/// threshold — no delete step, a stopped lane is simply stale).
+///
+/// This is the single write site serving `edda conduct` (both the main phase
+/// loop and post-rejection redispatch turns) and `edda dispatch`.
+///
+/// `hb` carries the heartbeat identity (rooted at the plan cwd, matching
+/// `write_phase_claim`); `turn_cwd` is where the agent itself runs.
+pub async fn run_phase_with_heartbeat(
+    launcher: &dyn AgentLauncher,
+    phase: &Phase,
+    prompt: &str,
+    plan_context: &str,
+    turn_cwd: &Path,
+    cancel: &CancellationToken,
+    hb: &LaneHeartbeat,
+) -> Result<PhaseResult> {
+    let writer = hb.spawn("running", cancel.child_token());
+    let result = launcher
+        .run_phase(
+            phase,
+            prompt,
+            plan_context,
+            &hb.session_id,
+            turn_cwd,
+            cancel.child_token(),
+        )
+        .await;
+    writer.abort();
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interval_defaults_to_30s_and_reads_env() {
+        let previous = std::env::var("EDDA_LANE_HEARTBEAT_SECS");
+        std::env::remove_var("EDDA_LANE_HEARTBEAT_SECS");
+        assert_eq!(lane_heartbeat_interval_secs(), 30);
+        std::env::set_var("EDDA_LANE_HEARTBEAT_SECS", "5");
+        assert_eq!(lane_heartbeat_interval_secs(), 5);
+        match previous {
+            Ok(v) => std::env::set_var("EDDA_LANE_HEARTBEAT_SECS", v),
+            Err(_) => std::env::remove_var("EDDA_LANE_HEARTBEAT_SECS"),
+        }
+    }
+
+    #[test]
+    fn write_failure_is_swallowed_not_fatal() {
+        // Serialize env mutation with the other heartbeat test.
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let previous = std::env::var_os("EDDA_STORE_ROOT");
+        std::env::set_var("EDDA_STORE_ROOT", tmp.path());
+        let cwd = tmp.path().join("repo");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let project_dir = edda_store::project_dir(&edda_store::project_id(&cwd));
+        let _ = std::fs::remove_dir_all(&project_dir);
+        std::fs::create_dir_all(project_dir.parent().unwrap()).unwrap();
+        std::fs::write(&project_dir, b"file").unwrap();
+        let hb = LaneHeartbeat {
+            cwd,
+            session_id: "s".into(),
+            plan: "p".into(),
+            phase: "a".into(),
+            attempt: 1,
+        };
+        hb.write("running");
+        match previous {
+            Some(v) => std::env::set_var("EDDA_STORE_ROOT", v),
+            None => std::env::remove_var("EDDA_STORE_ROOT"),
+        }
+    }
+}

--- a/crates/edda-conductor/src/runner/heartbeat.rs
+++ b/crates/edda-conductor/src/runner/heartbeat.rs
@@ -248,13 +248,18 @@ mod tests {
 
     #[test]
     fn write_failure_is_swallowed_not_fatal() {
-        // Serialize env mutation with the other heartbeat test.
-        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let tmp = tempfile::tempdir().unwrap();
-        let previous = std::env::var_os("EDDA_STORE_ROOT");
-        std::env::set_var("EDDA_STORE_ROOT", tmp.path());
-        let cwd = tmp.path().join("repo");
+        // Serialize env mutation with the other heartbeat tests via
+        // ClaimEnvGuard's shared CLAIM_ENV_LOCK. A private lock here (as an
+        // earlier draft had) is what flaked `lane_refresh_preserves_hook_
+        // telemetry_it_does_not_own`: this test relocated EDDA_STORE_ROOT
+        // under a lock that test never saw, so its seeded write landed in
+        // one store and its read-modify-write polled another — persist
+        // os error 2/5 when the stolen root's tempdir was deleted, and
+        // "focus_files preserved: left []" when the RMW read a blank
+        // record. Same defect as PR #588's Windows CI failure in edda-cli.
+        let guard = ClaimEnvGuard::new();
+        let root = guard._store_root.path();
+        let cwd = root.join("file-as-project-dir-repo");
         std::fs::create_dir_all(&cwd).unwrap();
         let project_dir = edda_store::project_dir(&edda_store::project_id(&cwd));
         let _ = std::fs::remove_dir_all(&project_dir);
@@ -276,9 +281,6 @@ mod tests {
             result.is_err(),
             "expected the heartbeat write to fail against a file-as-project-dir store, got Ok"
         );
-        match previous {
-            Some(v) => std::env::set_var("EDDA_STORE_ROOT", v),
-            None => std::env::remove_var("EDDA_STORE_ROOT"),
-        }
+        // The guard restores EDDA_STORE_ROOT on drop.
     }
 }

--- a/crates/edda-conductor/src/runner/mod.rs
+++ b/crates/edda-conductor/src/runner/mod.rs
@@ -1,4 +1,5 @@
 pub mod edda;
 pub mod event_log;
+pub mod heartbeat;
 pub mod notify;
 pub mod sequential;

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -5,6 +5,9 @@ use crate::plan::schema::{CheckSpec, OnFail, OnReject, Plan};
 use crate::plan::topo::topo_sort;
 use crate::runner::edda;
 use crate::runner::event_log::{self, Event, EventLogger};
+use crate::runner::heartbeat::{
+    lane_heartbeat_interval_secs, run_phase_with_heartbeat, LaneHeartbeat,
+};
 use crate::runner::notify::Notifier;
 use crate::state::brief::write_brief;
 use crate::state::derive::{
@@ -205,6 +208,20 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
             event_log::write_runner_status(cwd, state, Some(&gated_id));
             write_brief(cwd, state, None);
 
+            // The lane stays alive while gated — keep its heartbeat honest
+            // with an "awaiting_verdict" stage (GH-566).
+            let lane_hb = {
+                let ps = state.get_phase(&gated_id)?;
+                LaneHeartbeat {
+                    cwd: cwd.to_path_buf(),
+                    session_id: phase_session_id_attempt(&plan.name, &gated_id, ps.attempts)
+                        .to_string(),
+                    plan: plan.name.clone(),
+                    phase: gated_id.clone(),
+                    attempt: ps.attempts,
+                }
+            };
+
             match wait_for_verdict(
                 cwd,
                 &subject,
@@ -212,6 +229,7 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                 phase.gate_timeout_sec,
                 Some(&entered_at),
                 &cancel,
+                Some(&lane_hb),
             )
             .await
             {
@@ -329,16 +347,23 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                         println!(
                             "  ↻ Redispatching one more turn in the same session ({session_id})"
                         );
-                        let result = launcher
-                            .run_phase(
-                                phase,
-                                &prompt,
-                                &plan_context,
-                                &session_id,
-                                &phase_cwd,
-                                cancel.child_token(),
-                            )
-                            .await?;
+                        let lane_hb = LaneHeartbeat {
+                            cwd: cwd.to_path_buf(),
+                            session_id: session_id.clone(),
+                            plan: plan.name.clone(),
+                            phase: gated_id.clone(),
+                            attempt: attempts,
+                        };
+                        let result = run_phase_with_heartbeat(
+                            launcher,
+                            phase,
+                            &prompt,
+                            &plan_context,
+                            &phase_cwd,
+                            &cancel,
+                            &lane_hb,
+                        )
+                        .await?;
                         process_phase_result(
                             plan,
                             phase,
@@ -469,16 +494,26 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
         // Auto-claim scope for this phase (so peers can see it and send requests)
         write_phase_claim(cwd, &session_id, &phase_id, &phase.owns);
 
-        let result = launcher
-            .run_phase(
-                phase,
-                &prompt,
-                &plan_context,
-                &session_id,
-                &phase_cwd,
-                cancel.child_token(),
-            )
-            .await?;
+        // GH-566/GH-569: the runner refreshes the lane heartbeat during the
+        // agent turn so any backend (no Claude hooks required) is visible to
+        // `edda peers` while it works. One write site serves conduct + dispatch.
+        let lane_hb = LaneHeartbeat {
+            cwd: cwd.to_path_buf(),
+            session_id: session_id.clone(),
+            plan: plan.name.clone(),
+            phase: phase_id.clone(),
+            attempt,
+        };
+        let result = run_phase_with_heartbeat(
+            launcher,
+            phase,
+            &prompt,
+            &plan_context,
+            &phase_cwd,
+            &cancel,
+            &lane_hb,
+        )
+        .await?;
 
         // 5. Process result (shared with the post-rejection redispatch turn;
         // gated phases enter AWAITING_VERDICT here instead of Passed — D3)
@@ -601,6 +636,7 @@ async fn wait_for_verdict(
     timeout_sec: Option<u64>,
     entered_at: Option<&str>,
     cancel: &CancellationToken,
+    heartbeat: Option<&LaneHeartbeat>,
 ) -> GateVerdict {
     let deadline = timeout_sec.map(|t| {
         let base = entered_at
@@ -610,6 +646,13 @@ async fn wait_for_verdict(
             .unwrap_or_else(time::OffsetDateTime::now_utc);
         base + time::Duration::seconds(t as i64)
     });
+
+    // A gated lane is still alive — refresh its heartbeat while waiting so
+    // it does not read as stale to peer discovery (GH-566).
+    if let Some(hb) = heartbeat {
+        hb.write("awaiting_verdict");
+    }
+    let mut last_heartbeat = Instant::now();
 
     loop {
         // Poll BEFORE the deadline check: a verdict recorded during this
@@ -631,7 +674,14 @@ async fn wait_for_verdict(
             }
         }
         tokio::select! {
-            _ = tokio::time::sleep(Duration::from_secs(GATE_POLL_SEC)) => {}
+            _ = tokio::time::sleep(Duration::from_secs(GATE_POLL_SEC)) => {
+                if let Some(hb) = heartbeat {
+                    if last_heartbeat.elapsed() >= Duration::from_secs(lane_heartbeat_interval_secs()) {
+                        hb.write("awaiting_verdict");
+                        last_heartbeat = Instant::now();
+                    }
+                }
+            }
             _ = cancel.cancelled() => return GateVerdict::Cancelled,
         }
     }
@@ -2879,6 +2929,7 @@ phases:
             Some(1),
             Some(&now_rfc3339()),
             &cancel,
+            None,
         )
         .await;
         assert!(matches!(verdict, GateVerdict::TimedOut));
@@ -2906,6 +2957,7 @@ phases:
             Some(30),
             Some(&entered_at),
             &cancel,
+            None,
         )
         .await;
         match verdict {
@@ -3175,6 +3227,151 @@ phases:
             "payload": { "label": "no-owns", "paths": [] }
         });
         assert_eq!(events[0], legacy);
+    }
+
+    // ── Lane heartbeat (GH-566/GH-569) ──────────────────────────────
+
+    /// A launcher that stalls briefly, so the test can observe the lane
+    /// heartbeat while the agent turn is genuinely mid-flight.
+    struct SlowLauncher;
+
+    #[async_trait::async_trait]
+    impl AgentLauncher for SlowLauncher {
+        async fn run_phase(
+            &self,
+            _phase: &crate::plan::schema::Phase,
+            _prompt: &str,
+            _plan_context: &str,
+            _session_id: &str,
+            _cwd: &Path,
+            _cancel: CancellationToken,
+        ) -> Result<PhaseResult> {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            Ok(PhaseResult::AgentDone {
+                cost_usd: None,
+                result_text: None,
+            })
+        }
+    }
+
+    fn hb_path(cwd: &Path, session_id: &str) -> std::path::PathBuf {
+        let project_id = edda_store::project_id(cwd);
+        edda_store::project_dir(&project_id)
+            .join("state")
+            .join(format!("session.{session_id}.json"))
+    }
+
+    /// A lane launched with no bridge hooks (`edda dispatch --agent pi`) must
+    /// still leave a session heartbeat that `edda peers` can find: the runner
+    /// writes it during the agent turn, carrying plan/phase/attempt/stage/pid.
+    #[tokio::test]
+    async fn phase_heartbeat_written_during_agent_turn() {
+        let guard = ClaimEnvGuard::new();
+        let cwd = make_repo(guard._store_root.path());
+
+        let yaml = "name: hbplan\nphases:\n  - id: a\n    prompt: \"work\"\n";
+        let plan = parse_plan(yaml).unwrap();
+        let mut state = PlanState::from_plan(&plan, "test.yaml");
+        let engine = CheckEngine::new(cwd.clone());
+        let notifier = CollectNotifier::new();
+        let mut budget = BudgetTracker::new(plan.budget_usd);
+        let cancel = CancellationToken::new();
+
+        let run_cwd = cwd.clone();
+        let handle = tokio::spawn(async move {
+            run_plan(
+                &plan,
+                &mut state,
+                RunContext {
+                    launcher: &SlowLauncher,
+                    check_engine: &engine,
+                    notifier: &notifier,
+                    budget: &mut budget,
+                    cancel,
+                    cwd: &run_cwd,
+                    interactive: false,
+                    json_events: false,
+                    tmux_session: None,
+                },
+            )
+            .await
+            .map(|_| state)
+        });
+
+        let session_id = phase_session_id_attempt("hbplan", "a", 1).to_string();
+        let path = hb_path(&cwd, &session_id);
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            if path.exists() {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "lane heartbeat never appeared during the agent turn"
+            );
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        let hb: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(hb["session_id"], session_id.as_str());
+        assert_eq!(hb["label"], "a", "heartbeat label matches the claim label");
+        assert_eq!(hb["plan"], "hbplan");
+        assert_eq!(hb["phase"], "a");
+        assert_eq!(hb["attempt"], 1);
+        assert_eq!(hb["stage"], "running");
+        assert!(hb["pid"].as_u64().is_some(), "heartbeat carries the pid");
+        assert!(hb["last_heartbeat"].as_str().is_some());
+
+        let (state, _dir) = {
+            let state = handle.await.unwrap().unwrap();
+            (state, ())
+        };
+        assert_eq!(state.plan_status, PlanStatus::Completed);
+    }
+
+    /// The observation plane must never kill the work plane: if the store is
+    /// unwritable (here: the project directory is a regular file), the phase
+    /// still runs to completion — at most a warning is printed.
+    #[tokio::test]
+    async fn heartbeat_write_failure_does_not_fail_phase() {
+        let guard = ClaimEnvGuard::new();
+        let store_root = guard._store_root.path();
+        let cwd = make_repo(store_root);
+
+        let project_id = edda_store::project_id(&cwd);
+        let project_dir = edda_store::project_dir(&project_id);
+        let _ = std::fs::remove_dir_all(&project_dir);
+        std::fs::write(&project_dir, b"not a directory").unwrap();
+
+        let yaml = "name: hbplan2\nphases:\n  - id: a\n    prompt: \"work\"\n";
+        let launcher = SlowLauncher;
+        let (state, _msgs) = {
+            let plan = parse_plan(yaml).unwrap();
+            let mut state = PlanState::from_plan(&plan, "test.yaml");
+            let engine = CheckEngine::new(cwd.clone());
+            let notifier = CollectNotifier::new();
+            let mut budget = BudgetTracker::new(plan.budget_usd);
+            run_plan(
+                &plan,
+                &mut state,
+                RunContext {
+                    launcher: &launcher,
+                    check_engine: &engine,
+                    notifier: &notifier,
+                    budget: &mut budget,
+                    cancel: CancellationToken::new(),
+                    cwd: &cwd,
+                    interactive: false,
+                    json_events: false,
+                    tmux_session: None,
+                },
+            )
+            .await
+            .unwrap();
+            (state, notifier.messages())
+        };
+        assert_eq!(state.plan_status, PlanStatus::Completed);
+        assert_eq!(state.phases[0].status, PhaseStatus::Passed);
     }
 
     #[test]

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -3198,6 +3198,14 @@ phases:
     pub(crate) fn make_repo(store_root: &Path) -> std::path::PathBuf {
         let cwd = store_root.join("repo");
         std::fs::create_dir_all(&cwd).unwrap();
+        // Pre-mark the repo as initialized so `run_plan`'s `ensure_init`
+        // early-returns. Without this, the first run_plan-driven test in a
+        // process fires edda.rs's store-isolation Once, which re-points
+        // EDDA_STORE_ROOT at a leaked throwaway store mid-test — every
+        // write (claims, lane heartbeats) then lands in that store while
+        // the test polls its own guard's store, and the assertion can never
+        // observe them.
+        std::fs::create_dir_all(cwd.join(".edda")).unwrap();
         // Production writes claims into an existing project state dir
         // (created by ensure_dirs); mirror that layout here.
         let project_id = edda_store::project_id(&cwd);

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -379,6 +379,8 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                             notifier,
                             &mut event_log,
                             tmux_session,
+                            &cancel,
+                            Some(&lane_hb),
                         )
                         .await?;
                     }
@@ -532,6 +534,8 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
             notifier,
             &mut event_log,
             tmux_session,
+            &cancel,
+            Some(&lane_hb),
         )
         .await?;
 
@@ -837,6 +841,8 @@ async fn process_phase_result(
     notifier: &dyn Notifier,
     event_log: &mut EventLogger,
     tmux_session: Option<&TmuxSession>,
+    cancel: &CancellationToken,
+    lane_hb: Option<&LaneHeartbeat>,
 ) -> Result<()> {
     match result {
         PhaseResult::AgentDone {
@@ -858,6 +864,10 @@ async fn process_phase_result(
             )?;
             save_state(cwd, state)?;
 
+            // GH-566: the lane heartbeat must cover the whole phase
+            // lifetime — keep it beating (stage "checking") while the
+            // checks run, not just during the agent turn.
+            let checking_writer = lane_hb.map(|hb| hb.spawn("checking", cancel.child_token()));
             // Run checks
             let check_result = check_engine
                 .run_all(
@@ -865,6 +875,9 @@ async fn process_phase_result(
                     state.get_phase(phase_id)?.started_at.as_deref(),
                 )
                 .await;
+            if let Some(writer) = checking_writer {
+                writer.abort();
+            }
 
             if check_result.all_passed {
                 if phase.gate.is_some() {
@@ -1447,7 +1460,7 @@ fn write_phase_claim(cwd: &Path, session_id: &str, phase_id: &str, owns: &[Strin
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::agent::launcher::{MockLauncher, PhaseResult};
     use crate::plan::parser::parse_plan;
@@ -3138,12 +3151,12 @@ phases:
     // ── Phase claims carry owned write surfaces (GH-561) ────────────
 
     /// Serialize tests that redirect `EDDA_STORE_ROOT`.
-    static CLAIM_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    pub(crate) static CLAIM_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-    struct ClaimEnvGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
+    pub(crate) struct ClaimEnvGuard {
+        pub(crate) _lock: std::sync::MutexGuard<'static, ()>,
         previous_store_root: Option<std::ffi::OsString>,
-        _store_root: tempfile::TempDir,
+        pub(crate) _store_root: tempfile::TempDir,
     }
 
     impl Drop for ClaimEnvGuard {
@@ -3156,7 +3169,7 @@ phases:
     }
 
     impl ClaimEnvGuard {
-        fn new() -> Self {
+        pub(crate) fn new() -> Self {
             let lock = CLAIM_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
             let previous_store_root = std::env::var_os("EDDA_STORE_ROOT");
             let store_root = tempfile::tempdir().unwrap();
@@ -3182,7 +3195,7 @@ phases:
             .collect()
     }
 
-    fn make_repo(store_root: &Path) -> std::path::PathBuf {
+    pub(crate) fn make_repo(store_root: &Path) -> std::path::PathBuf {
         let cwd = store_root.join("repo");
         std::fs::create_dir_all(&cwd).unwrap();
         // Production writes claims into an existing project state dir
@@ -3254,7 +3267,7 @@ phases:
         }
     }
 
-    fn hb_path(cwd: &Path, session_id: &str) -> std::path::PathBuf {
+    pub(crate) fn hb_path(cwd: &Path, session_id: &str) -> std::path::PathBuf {
         let project_id = edda_store::project_id(cwd);
         edda_store::project_dir(&project_id)
             .join("state")
@@ -3327,6 +3340,118 @@ phases:
             (state, ())
         };
         assert_eq!(state.plan_status, PlanStatus::Completed);
+    }
+
+    /// P1-1 regression (review round 1): the lane heartbeat must cover the
+    /// whole phase lifetime — checks included — with the stage reflecting
+    /// what is actually happening. A fast agent turn followed by a slow
+    /// check used to abort the writer while the check still ran, letting the
+    /// lane go stale mid-work.
+    #[tokio::test]
+    async fn heartbeat_keeps_beating_through_the_running_check_stage() {
+        let guard = ClaimEnvGuard::new();
+        let previous_interval = std::env::var("EDDA_LANE_HEARTBEAT_SECS");
+        std::env::set_var("EDDA_LANE_HEARTBEAT_SECS", "1");
+        let cwd = make_repo(guard._store_root.path());
+
+        // A check slow enough to span several heartbeat intervals.
+        #[cfg(windows)]
+        let cmd = "Start-Sleep -Seconds 3";
+        #[cfg(not(windows))]
+        let cmd = "sleep 3";
+        let yaml = format!(
+            r#"
+name: hbdur
+phases:
+  - id: a
+    prompt: "work"
+    check:
+      - type: cmd_succeeds
+        cmd: "{cmd}"
+        timeout_sec: 15
+"#
+        );
+        let plan = parse_plan(&yaml).unwrap();
+        let mut state = PlanState::from_plan(&plan, "test.yaml");
+        let engine = CheckEngine::new(cwd.clone());
+        let notifier = CollectNotifier::new();
+        let mut budget = BudgetTracker::new(plan.budget_usd);
+        let cancel = CancellationToken::new();
+
+        // Fast agent turn, then the slow check above runs in
+        // `process_phase_result`.
+        let launcher = MockLauncher::new();
+        launcher.set_results(
+            "a",
+            vec![PhaseResult::AgentDone {
+                cost_usd: None,
+                result_text: None,
+            }],
+        );
+
+        let run_cwd = cwd.clone();
+        let handle = tokio::spawn(async move {
+            run_plan(
+                &plan,
+                &mut state,
+                RunContext {
+                    launcher: &launcher,
+                    check_engine: &engine,
+                    notifier: &notifier,
+                    budget: &mut budget,
+                    cancel,
+                    cwd: &run_cwd,
+                    interactive: false,
+                    json_events: false,
+                    tmux_session: None,
+                },
+            )
+            .await
+            .map(|_| state)
+        });
+
+        let session_id = phase_session_id_attempt("hbdur", "a", 1).to_string();
+        let path = hb_path(&cwd, &session_id);
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+
+        // The heartbeat must reach the checking stage ...
+        let first_checking = loop {
+            if let Ok(text) = std::fs::read_to_string(&path) {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
+                    if v["stage"] == "checking" {
+                        break v["last_heartbeat"].clone();
+                    }
+                }
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "heartbeat never reached the checking stage while checks ran"
+            );
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        };
+        // ... and keep refreshing (1s interval vs 3s check) while the check
+        // is still running.
+        loop {
+            if let Ok(text) = std::fs::read_to_string(&path) {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
+                    if v["stage"] == "checking" && v["last_heartbeat"] != first_checking {
+                        break;
+                    }
+                }
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "heartbeat stopped refreshing during the running check"
+            );
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+
+        let state = handle.await.unwrap().unwrap();
+        assert_eq!(state.plan_status, PlanStatus::Completed);
+        match previous_interval {
+            Ok(v) => std::env::set_var("EDDA_LANE_HEARTBEAT_SECS", v),
+            Err(_) => std::env::remove_var("EDDA_LANE_HEARTBEAT_SECS"),
+        }
     }
 
     /// The observation plane must never kill the work plane: if the store is

--- a/crates/edda-store/src/heartbeat.rs
+++ b/crates/edda-store/src/heartbeat.rs
@@ -1,0 +1,134 @@
+//! Shared session heartbeat surface (GH-569).
+//!
+//! The heartbeat file (`~/.edda/projects/<pid>/state/session.<sid>.json`) is
+//! THE one liveness surface consumed by peer discovery. It used to live in
+//! `edda-bridge-claude`, which made the Claude hook path the only production
+//! writer: lanes launched by `edda dispatch --agent pi|codex` fire no hooks,
+//! wrote no heartbeat, and could never appear in `edda peers` (GH-569).
+//!
+//! The type and its writers now live here so any crate that can depend on
+//! `edda-store` — the conductor runner, any bridge — can produce heartbeats.
+//! `edda-bridge-claude` remains *a* producer (the hook path enriches the
+//! heartbeat with transcript signals); it is no longer the only one.
+//!
+//! One surface, one format: do not add a parallel liveness file.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// A snapshot of one task the session is working on.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskSnapshot {
+    pub id: String,
+    pub subject: String,
+    pub status: String,
+}
+
+/// Per-session heartbeat file.
+/// Location: `~/.edda/projects/{pid}/state/session.{sid}.json`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionHeartbeat {
+    pub session_id: String,
+    pub started_at: String,
+    pub last_heartbeat: String,
+    pub label: String,
+    pub focus_files: Vec<String>,
+    pub active_tasks: Vec<TaskSnapshot>,
+    pub files_modified_count: usize,
+    pub total_edits: usize,
+    pub recent_commits: Vec<String>,
+    #[serde(default)]
+    pub branch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_phase: Option<String>,
+    /// Set for sub-agent heartbeats to link back to the parent session.
+    /// Used for orphan cleanup and extended stale threshold.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_session_id: Option<String>,
+    // ── Conductor lane fields (GH-566) — additive, old readers ignore them ──
+    /// Plan name the lane is running (`edda conduct` / `edda dispatch`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan: Option<String>,
+    /// Phase id within the plan.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+    /// Attempt number of the running phase.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attempt: Option<u32>,
+    /// What the lane is doing right now (running / awaiting_verdict / ...).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stage: Option<String>,
+    /// OS pid of the process writing the heartbeat.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pid: Option<u32>,
+}
+
+/// Path of one session's heartbeat file under the project state dir.
+pub fn heartbeat_path(project_id: &str, session_id: &str) -> PathBuf {
+    crate::project_dir(project_id)
+        .join("state")
+        .join(format!("session.{session_id}.json"))
+}
+
+/// Read one session's heartbeat file, if present and well-formed.
+pub fn read_heartbeat(project_id: &str, session_id: &str) -> Option<SessionHeartbeat> {
+    let content = std::fs::read_to_string(heartbeat_path(project_id, session_id)).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// Atomically write a session heartbeat (temp + rename, bounded single file —
+/// never an append log). Callers own error policy: the observation plane must
+/// not be able to fail the work plane, so treat `Err` as a warning upstream.
+pub fn write_heartbeat(project_id: &str, hb: &SessionHeartbeat) -> anyhow::Result<()> {
+    let data = serde_json::to_string_pretty(hb)?;
+    crate::write_atomic(&heartbeat_path(project_id, &hb.session_id), data.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(sid: &str) -> SessionHeartbeat {
+        SessionHeartbeat {
+            session_id: sid.into(),
+            started_at: "2026-09-01T00:00:00Z".into(),
+            last_heartbeat: "2026-09-01T00:00:30Z".into(),
+            label: "a".into(),
+            focus_files: vec![],
+            active_tasks: vec![],
+            files_modified_count: 0,
+            total_edits: 0,
+            recent_commits: vec![],
+            branch: None,
+            current_phase: Some("running".into()),
+            parent_session_id: None,
+            plan: Some("p".into()),
+            phase: Some("a".into()),
+            attempt: Some(1),
+            stage: Some("running".into()),
+            pid: Some(42),
+        }
+    }
+
+    #[test]
+    fn heartbeat_roundtrips_through_the_shared_writer() {
+        let _lock = crate::ENV_STORE_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let previous = std::env::var_os("EDDA_STORE_ROOT");
+        std::env::set_var("EDDA_STORE_ROOT", tmp.path());
+        let pid = "test_store_hb_roundtrip";
+        write_heartbeat(pid, &sample("s1")).expect("write");
+        let hb = read_heartbeat(pid, "s1").expect("read");
+        assert_eq!(hb.plan.as_deref(), Some("p"));
+        assert_eq!(hb.attempt, Some(1));
+        assert_eq!(hb.pid, Some(42));
+        assert!(heartbeat_path(pid, "s1").exists());
+        match previous {
+            Some(v) => std::env::set_var("EDDA_STORE_ROOT", v),
+            None => std::env::remove_var("EDDA_STORE_ROOT"),
+        }
+        let _ = std::fs::remove_dir_all(tmp.path());
+    }
+}

--- a/crates/edda-store/src/heartbeat.rs
+++ b/crates/edda-store/src/heartbeat.rs
@@ -306,30 +306,3 @@ mod tests {
     }
 }
 
-#[cfg(test)]
-mod scratch_tests {
-    use super::*;
-
-    #[test]
-    fn scratch_update_heartbeat_creates_file() {
-        let tmp = tempfile::tempdir().unwrap();
-        let previous = std::env::var_os("EDDA_STORE_ROOT");
-        std::env::set_var("EDDA_STORE_ROOT", tmp.path());
-        let r = update_heartbeat("proj", "s1", |hb| {
-            eprintln!("DEBUG mutate: started_at={:?} last={:?}", hb.started_at, hb.last_heartbeat);
-            if hb.started_at.is_empty() {
-                hb.started_at = "T0".into();
-            }
-            hb.last_heartbeat = "T1".into();
-            hb.plan = Some("p".into());
-        });
-        eprintln!("DEBUG update result: {r:?}");
-        let p = heartbeat_path("proj", "s1");
-        eprintln!("DEBUG path {} exists={}", p.display(), p.exists());
-        match previous {
-            Some(v) => std::env::set_var("EDDA_STORE_ROOT", v),
-            None => std::env::remove_var("EDDA_STORE_ROOT"),
-        }
-        assert!(p.exists());
-    }
-}

--- a/crates/edda-store/src/heartbeat.rs
+++ b/crates/edda-store/src/heartbeat.rs
@@ -63,11 +63,104 @@ pub struct SessionHeartbeat {
     pub pid: Option<u32>,
 }
 
+/// Sanitize a session id for safe interpolation into a filesystem path.
+///
+/// Every heartbeat reader/writer funnels through `heartbeat_path`, so
+/// encoding here (rather than rejecting at individual CLI entry points)
+/// cannot be bypassed by a second caller, keeps the IO surface infallible,
+/// and defuses separators, `..`, absolute/drive-letter prefixes, control
+/// bytes and reserved Windows device names in one move: the result is
+/// always the single filename `session.<encoded>.json`, and a reserved
+/// device name only matches as a whole filename (`session.con.json` is
+/// not reserved). Chosen over rejecting: a hostile id then cannot fail a
+/// phase at an observation-plane trust boundary, and read/write stay
+/// consistent because both sides sanitize identically.
+fn sanitize_session_id(session_id: &str) -> String {
+    let mut out = String::with_capacity(session_id.len());
+    for b in session_id.bytes() {
+        match b {
+            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'.' | b'_' | b'-' => out.push(b as char),
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
 /// Path of one session's heartbeat file under the project state dir.
+/// The session id is sanitized, so the result always stays inside the
+/// project state directory regardless of what the caller passes.
 pub fn heartbeat_path(project_id: &str, session_id: &str) -> PathBuf {
     crate::project_dir(project_id)
         .join("state")
-        .join(format!("session.{session_id}.json"))
+        .join(format!("session.{}.json", sanitize_session_id(session_id)))
+}
+
+/// Sidecar lock guarding read-modify-write updates of one session's
+/// heartbeat file. Derived from the (sanitized) heartbeat path, so it stays
+/// inside the state dir too; the `.json.lock` suffix keeps discovery's
+/// `session.*.json` enumeration from ever seeing it.
+fn heartbeat_lock_path(project_id: &str, session_id: &str) -> PathBuf {
+    let mut p = heartbeat_path(project_id, session_id).into_os_string();
+    p.push(".lock");
+    PathBuf::from(p)
+}
+
+impl SessionHeartbeat {
+    /// A blank record for `update_heartbeat` to seed when no file exists yet.
+    /// `started_at`/`last_heartbeat` stay empty until the producing writer
+    /// (which owns the clock) stamps them; `update_heartbeat` never persists
+    /// a still-blank record, so a "touch" on a nonexistent session creates
+    /// no file.
+    pub fn blank(session_id: &str) -> Self {
+        Self {
+            session_id: session_id.to_string(),
+            started_at: String::new(),
+            last_heartbeat: String::new(),
+            label: String::new(),
+            focus_files: Vec::new(),
+            active_tasks: Vec::new(),
+            files_modified_count: 0,
+            total_edits: 0,
+            recent_commits: Vec::new(),
+            branch: None,
+            current_phase: None,
+            parent_session_id: None,
+            plan: None,
+            phase: None,
+            attempt: None,
+            stage: None,
+            pid: None,
+        }
+    }
+
+    fn is_blank(&self) -> bool {
+        self.started_at.is_empty() && self.last_heartbeat.is_empty()
+    }
+}
+
+/// Read-modify-write one session's heartbeat under an exclusive lock.
+///
+/// Multiple producers share one file/format (the Claude hook path, the
+/// conductor runner, external bridges). A refresh must update only the
+/// fields its producer owns and preserve everything else — reconstructing
+/// the whole record races and destroys the other producer's data. This
+/// serializes read-modify-write cycles between cooperating writers via a
+/// sidecar lock file; `mutate` receives the existing record, or a blank one
+/// (see [`SessionHeartbeat::blank`]) when no file exists yet. A still-blank
+/// record is not written, so no-op touches create nothing.
+pub fn update_heartbeat<F>(project_id: &str, session_id: &str, mutate: F) -> anyhow::Result<()>
+where
+    F: FnOnce(&mut SessionHeartbeat),
+{
+    let _guard = crate::lock_file(&heartbeat_lock_path(project_id, session_id))?;
+    let mut hb = read_heartbeat(project_id, session_id)
+        .unwrap_or_else(|| SessionHeartbeat::blank(session_id));
+    mutate(&mut hb);
+    hb.session_id = session_id.to_string();
+    if hb.is_blank() {
+        return Ok(());
+    }
+    write_heartbeat(project_id, &hb)
 }
 
 /// Read one session's heartbeat file, if present and well-formed.
@@ -108,6 +201,86 @@ mod tests {
             stage: Some("running".into()),
             pid: Some(42),
         }
+    }
+
+    /// P0 regression (review round 1): a user-controlled `--session-id` must
+    /// never escape the project state directory through `heartbeat_path` —
+    /// this is the single funnel every heartbeat reader/writer passes through.
+    /// Covers the exact reviewed reproduction plus absolute-path and
+    /// drive-letter forms, on both separator styles.
+    #[test]
+    fn heartbeat_path_confines_a_hostile_session_id_to_the_state_dir() {
+        // Serialize with the other heartbeat tests: they mutate
+        // EDDA_STORE_ROOT, and this test compares paths against it.
+        let _lock = crate::ENV_STORE_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let state_dir = heartbeat_path("proj", "innocent")
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        let hostile = [
+            "x\\..\\..\\..\\escaped", // the reviewed reproduction
+            "x/../../../escaped",     // same shape, forward slashes
+            "..",                     // bare dot-dot
+            "..\\..\\evil",           // pure dot-dot escape
+            "C:\\evil\\x",            // drive-letter absolute
+            "C:/evil",                // drive letter, forward slashes
+            "/abs/evil",              // Unix-style absolute
+            "a:b",                    // NTFS alternate-data-stream separator
+            "con",                    // reserved Windows device name
+        ];
+        for sid in hostile {
+            let p = heartbeat_path("proj", sid);
+            assert_eq!(
+                p.parent(),
+                Some(state_dir.as_path()),
+                "session id {sid:?} escaped the state dir: {}",
+                p.display()
+            );
+        }
+    }
+
+    /// P0 regression: the shared writer/reader must both contain a hostile
+    /// session id — the file lands (encoded) inside the state dir, nothing
+    /// named `escaped.json` appears outside it, and the record round-trips.
+    #[test]
+    fn hostile_session_id_round_trips_without_leaving_the_state_dir() {
+        let _lock = crate::ENV_STORE_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let previous = std::env::var_os("EDDA_STORE_ROOT");
+        std::env::set_var("EDDA_STORE_ROOT", tmp.path());
+        let sid = "x\\..\\..\\..\\escaped";
+        write_heartbeat("proj", &sample(sid)).expect("write");
+        let project = crate::project_dir("proj");
+        let state = project.join("state");
+        let session_files = std::fs::read_dir(&state)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().starts_with("session."))
+            .count();
+        assert_eq!(session_files, 1, "exactly one bounded session file");
+        // Nothing escaped to the project dir, the projects/ level or the
+        // store root (the reviewed repro wrote `store/projects/escaped.json`).
+        assert!(!project.join("escaped.json").exists());
+        assert!(!state.join("escaped.json").exists());
+        if let Some(projects) = project.parent() {
+            assert!(!projects.join("escaped.json").exists());
+            if let Some(root) = projects.parent() {
+                assert!(!root.join("escaped.json").exists());
+            }
+        }
+        assert!(
+            read_heartbeat("proj", sid).is_some(),
+            "heartbeat round-trips through the sanitized path"
+        );
+        match previous {
+            Some(v) => std::env::set_var("EDDA_STORE_ROOT", v),
+            None => std::env::remove_var("EDDA_STORE_ROOT"),
+        }
+        let _ = std::fs::remove_dir_all(tmp.path());
     }
 
     #[test]

--- a/crates/edda-store/src/heartbeat.rs
+++ b/crates/edda-store/src/heartbeat.rs
@@ -305,3 +305,31 @@ mod tests {
         let _ = std::fs::remove_dir_all(tmp.path());
     }
 }
+
+#[cfg(test)]
+mod scratch_tests {
+    use super::*;
+
+    #[test]
+    fn scratch_update_heartbeat_creates_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let previous = std::env::var_os("EDDA_STORE_ROOT");
+        std::env::set_var("EDDA_STORE_ROOT", tmp.path());
+        let r = update_heartbeat("proj", "s1", |hb| {
+            eprintln!("DEBUG mutate: started_at={:?} last={:?}", hb.started_at, hb.last_heartbeat);
+            if hb.started_at.is_empty() {
+                hb.started_at = "T0".into();
+            }
+            hb.last_heartbeat = "T1".into();
+            hb.plan = Some("p".into());
+        });
+        eprintln!("DEBUG update result: {r:?}");
+        let p = heartbeat_path("proj", "s1");
+        eprintln!("DEBUG path {} exists={}", p.display(), p.exists());
+        match previous {
+            Some(v) => std::env::set_var("EDDA_STORE_ROOT", v),
+            None => std::env::remove_var("EDDA_STORE_ROOT"),
+        }
+        assert!(p.exists());
+    }
+}

--- a/crates/edda-store/src/heartbeat.rs
+++ b/crates/edda-store/src/heartbeat.rs
@@ -305,4 +305,3 @@ mod tests {
         let _ = std::fs::remove_dir_all(tmp.path());
     }
 }
-

--- a/crates/edda-store/src/heartbeat.rs
+++ b/crates/edda-store/src/heartbeat.rs
@@ -75,12 +75,24 @@ pub struct SessionHeartbeat {
 /// not reserved). Chosen over rejecting: a hostile id then cannot fail a
 /// phase at an observation-plane trust boundary, and read/write stay
 /// consistent because both sides sanitize identically.
+///
+/// The encoding must also be injective **on the target filesystem**, not
+/// just on bytes: two distinct session ids must never produce the same
+/// filename. Case-insensitive filesystems (NTFS, macOS APFS, most Windows
+/// tooling) identify names differing only in letter case, and NTFS
+/// additionally folds some non-ASCII code points onto ASCII ones (e.g.
+/// U+212A KELVIN SIGN with `K`). Both collision vectors are closed by
+/// construction: the emitted alphabet is `a-z 0-9 . _ - %` — no uppercase
+/// letters, and every non-ASCII byte is percent-encoded — so two outputs
+/// that a case-insensitive filesystem considers equal must be
+/// byte-identical, and because a literal `%` is itself encoded (`%25`) the
+/// id→output mapping is a standard injective percent-encoding.
 fn sanitize_session_id(session_id: &str) -> String {
     let mut out = String::with_capacity(session_id.len());
     for b in session_id.bytes() {
         match b {
-            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'.' | b'_' | b'-' => out.push(b as char),
-            _ => out.push_str(&format!("%{b:02X}")),
+            b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b'-' => out.push(b as char),
+            _ => out.push_str(&format!("%{b:02x}")),
         }
     }
     out
@@ -237,6 +249,118 @@ mod tests {
                 Some(state_dir.as_path()),
                 "session id {sid:?} escaped the state dir: {}",
                 p.display()
+            );
+        }
+    }
+
+    /// P0 regression (review round 2): ids differing only by ASCII case must
+    /// get distinct files. The pre-fix encoder emitted `A-Z` unchanged, so on
+    /// case-insensitive NTFS `Lane` and `lane` shared one file and the first
+    /// lane's heartbeat was destroyed.
+    #[test]
+    fn session_ids_differing_only_by_case_get_distinct_files() {
+        let _lock = crate::ENV_STORE_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let previous = std::env::var_os("EDDA_STORE_ROOT");
+        std::env::set_var("EDDA_STORE_ROOT", tmp.path());
+        write_heartbeat("proj", &sample("Lane")).expect("write Lane");
+        write_heartbeat("proj", &sample("lane")).expect("write lane");
+        let state = crate::project_dir("proj").join("state");
+        let session_files: Vec<std::path::PathBuf> = std::fs::read_dir(&state)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| {
+                let n = e.file_name().to_string_lossy().to_string();
+                n.starts_with("session.") && n.ends_with(".json")
+            })
+            .map(|e| e.path())
+            .collect();
+        assert_eq!(
+            session_files.len(),
+            2,
+            "two distinct case-variant ids must be two distinct files, got {session_files:?}"
+        );
+        let lane_upper = read_heartbeat("proj", "Lane").expect("Lane heartbeat survives");
+        let lane_lower = read_heartbeat("proj", "lane").expect("lane heartbeat survives");
+        assert_eq!(lane_upper.session_id, "Lane");
+        assert_eq!(lane_lower.session_id, "lane");
+        match previous {
+            Some(v) => std::env::set_var("EDDA_STORE_ROOT", v),
+            None => std::env::remove_var("EDDA_STORE_ROOT"),
+        }
+        let _ = std::fs::remove_dir_all(tmp.path());
+    }
+
+    /// P0 regression (review round 2): a Unicode pair NTFS folds onto the
+    /// same name must still get two distinct files. U+212A (KELVIN SIGN)
+    /// case-folds onto ASCII `K`; the encoder emits no non-ASCII bytes, so
+    /// no folding can ever identify two of its outputs.
+    #[test]
+    fn unicode_folded_session_ids_get_distinct_files() {
+        let _lock = crate::ENV_STORE_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let previous = std::env::var_os("EDDA_STORE_ROOT");
+        std::env::set_var("EDDA_STORE_ROOT", tmp.path());
+        let kelvin = "\u{212A}"; // KELVIN SIGN — NTFS folds onto ASCII K
+        write_heartbeat("proj", &sample(kelvin)).expect("write Kelvin sign");
+        write_heartbeat("proj", &sample("K")).expect("write K");
+        let state = crate::project_dir("proj").join("state");
+        let session_files: Vec<std::path::PathBuf> = std::fs::read_dir(&state)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| {
+                let n = e.file_name().to_string_lossy().to_string();
+                n.starts_with("session.") && n.ends_with(".json")
+            })
+            .map(|e| e.path())
+            .collect();
+        assert_eq!(
+            session_files.len(),
+            2,
+            "two NTFS-folded ids must be two distinct files, got {session_files:?}"
+        );
+        let a = read_heartbeat("proj", kelvin).expect("Kelvin-sign heartbeat survives");
+        let b = read_heartbeat("proj", "K").expect("K heartbeat survives");
+        assert_eq!(a.session_id, kelvin);
+        assert_eq!(b.session_id, "K");
+        match previous {
+            Some(v) => std::env::set_var("EDDA_STORE_ROOT", v),
+            None => std::env::remove_var("EDDA_STORE_ROOT"),
+        }
+        let _ = std::fs::remove_dir_all(tmp.path());
+    }
+
+    /// P0 regression (review round 2), the injectivity argument as a pinned
+    /// property: the encoded filename's alphabet contains no uppercase
+    /// letters and no non-ASCII bytes, so a case-insensitive or
+    /// Unicode-folding filesystem has nothing left to identify.
+    #[test]
+    fn encoded_filenames_contain_no_case_or_folding_surface() {
+        for sid in [
+            "Lane",
+            "lane",
+            "MiXeD-Case_1.Json",
+            "\u{212A}",
+            "\u{00DF}",
+            "\u{0131}",
+            "\u{FF41}\u{FF22}",
+        ] {
+            let name = heartbeat_path("proj", sid)
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .to_string();
+            assert!(
+                name.chars().all(|c| {
+                    c.is_ascii_lowercase()
+                        || c.is_ascii_digit()
+                        || matches!(c, '.' | '_' | '-' | '%')
+                }),
+                "encoded name for {sid:?} must expose no case/Unicode folding surface, got {name:?}"
             );
         }
     }

--- a/crates/edda-store/src/lib.rs
+++ b/crates/edda-store/src/lib.rs
@@ -1,7 +1,12 @@
 pub mod fleet;
+pub mod heartbeat;
 pub mod registry;
 pub mod skill_registry;
 pub mod user_config;
+
+pub use heartbeat::{
+    heartbeat_path, read_heartbeat, write_heartbeat, SessionHeartbeat, TaskSnapshot,
+};
 
 use fs2::FileExt;
 use std::fs;

--- a/crates/edda-store/src/lib.rs
+++ b/crates/edda-store/src/lib.rs
@@ -5,7 +5,8 @@ pub mod skill_registry;
 pub mod user_config;
 
 pub use heartbeat::{
-    heartbeat_path, read_heartbeat, write_heartbeat, SessionHeartbeat, TaskSnapshot,
+    heartbeat_path, read_heartbeat, update_heartbeat, write_heartbeat, SessionHeartbeat,
+    TaskSnapshot,
 };
 
 use fs2::FileExt;


### PR DESCRIPTION
## What changed

Three moving parts, one liveness surface:

1. **Decoupling seam (GH-569).** `SessionHeartbeat`, `TaskSnapshot`, the heartbeat path helper and its read/write IO moved verbatim from `edda-bridge-claude` into a new `edda_store::heartbeat` module (re-exported from the store root). `edda-bridge-claude` re-exports them (`peers::SessionHeartbeat`, `signals::TaskSnapshot`) so all existing **import paths** keep working — the refactor inside `peers/**` is mechanical: the bridge deletes its private copies and delegates. Note: import-path compatibility is not source compatibility — see **Compatibility: breaking source change** below.
2. **Runner writes it (GH-566).** New `edda-conductor/src/runner/heartbeat.rs`: `LaneHeartbeat` + `run_phase_with_heartbeat`. While an agent turn runs, a background task atomically refreshes the session heartbeat every `EDDA_LANE_HEARTBEAT_SECS` (default 30s, well under the 120s peer staleness threshold) with stage `running`, carrying plan, phase, attempt, stage, timestamp, pid. While a verdict gate waits, the poll loop refreshes with stage `awaiting_verdict` (interval-throttled). The heartbeat is rooted at the plan cwd via `edda_store::project_id` — the same root resolution every reader and `write_phase_claim` uses, so worktree-launched plans write where readers look (no GH-543 repeat).
3. **JSON honesty (GH-569).** `edda peers --json` claims now carry `age_secs` and a `stale` flag (sessions already carried both). Hook-injected peer context already lists only non-stale peers and states each peer's age — verified, unchanged.

### Chosen seam, and why

`edda-store` rather than a new crate or an existing shared one: the heartbeat file already lives under the store root (`~/.edda/projects/<pid>/state/session.<sid>.json`), `edda_store::write_atomic` is the canonical atomic-write primitive, and both `edda-conductor` and every bridge already depend on `edda-store`. Zero new dependencies, zero new crates; `edda-conductor` gains **no** dependency on `edda-bridge-claude`.

### The 15x sub-agent threshold (discovery.rs)

**Narrowed, not removed.** The multiplier now applies *only* to parented (Claude Code Task-tool) sub-agent heartbeats, which still have no in-flight writer — no hook events fire during their execution, so removing it would make real sub-agents vanish from `edda peers` mid-run. Conductor/dispatch lanes now write real periodic heartbeats and use the standard threshold; the exception no longer papers over a missing writer for lanes, and comments in `discovery.rs`/`heartbeat.rs` (bridge) say exactly that. Fully removing it should ride the sub-agent-writer fix (follow-up).

### Honest defaults

- Heartbeat write failure degrades to a stderr warning; it can never fail a phase (regression-tested).
- Atomic temp+rename, bounded single file per session, not an append log.
- No delete step: when a lane stops, the heartbeat ages out through the normal staleness threshold.

## Compatibility: breaking source change (corrected)

An earlier revision of this body claimed the bridge API was "unchanged". That was **wrong as written**, and was called out in review round 1 (P1-4): the import path `edda_bridge_claude::peers::SessionHeartbeat` is preserved, but five public fields were **added** to the struct (`plan`, `phase`, `attempt`, `stage`, `pid`). A downstream consumer constructing the old complete struct literal no longer compiles without supplying the five new fields — this PR itself had to patch every workspace literal.

- **What still works unchanged:** all import paths, all reads, and JSON parsing of old heartbeat files (new fields are `#[serde(default)]`; old readers ignore them).
- **What breaks:** exact struct-literal construction of `SessionHeartbeat` outside `edda-store`.
- **Migration:** either supply the five new fields, or construct via `SessionHeartbeat::blank(session_id)` (new in round 2) and override only the fields you own — `..SessionHeartbeat::blank("")`-style. Round-2 code migrates the runner and bridge writers to read-modify-write through `edda_store::update_heartbeat`, which constructs via `blank`.

## doneWhen → evidence

**GH-566**
| doneWhen | Evidence |
|---|---|
| heartbeat refreshes at least every N sec during phase execution; N configurable | `runner/heartbeat.rs::spawn` loop; `EDDA_LANE_HEARTBEAT_SECS` (default 30); test `interval_defaults_to_30s_and_reads_env` |
| atomic overwrite, bounded single file | `edda_store::write_heartbeat` → `write_atomic` (temp+rename) |
| dispatch single-turn and conduct phases share one write site | `run_phase_with_heartbeat` called from `runner/sequential.rs` (main loop + redispatch turn) and `cmd_dispatch.rs::run_with_launcher`; test `phase_heartbeat_written_during_agent_turn` |
| write failure never fails the phase | test `heartbeat_write_failure_does_not_fail_phase`; test `write_failure_is_swallowed_not_fatal` |

**GH-569**
| doneWhen | Evidence |
|---|---|
| dispatch/conduct lanes (any backend) written periodically during execution, stale naturally after | `run_phase_with_heartbeat` (no Claude hooks involved); tests `phase_heartbeat_written_during_agent_turn` (conductor) and `lane_heartbeat_written_without_bridge_is_discovered_then_goes_stale` (bridge — a heartbeat written purely through the store seam is discovered, then drops out once backdated past the threshold) |
| heartbeat writer lives outside any bridge crate | `edda_store::heartbeat`; conductor's `Cargo.toml` unchanged (already depended on edda-store) |
| one heartbeat surface, no second format | same `SessionHeartbeat` type, same file path; additive optional fields (`plan`, `phase`, `attempt`, `stage`, `pid`) with serde defaults — old heartbeats parse unchanged (existing bridge tests untouched) |
| `edda peers --json` staleness per entry | test `peers_json_claims_carry_staleness`; sessions already carried `age_secs`+`stale` |
| hook-injected peer context non-stale only / states age | unchanged `discover_active_peers` filtering + `format_age` rendering (verified) |
| 15x threshold re-evaluated | narrowed to parented sub-agents only, rationale above and in-code |
| regression tests verified FAIL first | `phase_heartbeat_written_during_agent_turn` failed with "lane heartbeat never appeared"; `peers_json_claims_carry_staleness` failed (no `age_secs` on claims); the bridge test did not compile (no store-level writer existed) — all red before the fix, all green after |

## Gate receipt

- Round 1 receipt at `4e2ca6c48a81707ed201eb90a8e31006225d1a21` (preserved for the record); the round-2 receipt lives in `## Review Response: Round 1` below.
- Frozen full SHA: `4e2ca6c48a81707ed201eb90a8e31006225d1a21` (clean tree)
- Toolchain: rustc/cargo 1.93.1 (01f6ddf75 2026-02-11)
- Lane: `worker-1` (`CARGO_TARGET_DIR=...\lanes\worker-1`), `CARGO_INCREMENTAL=0` set in the environment
- `cargo fmt --all --check`: **PASS**
- `cargo clippy --workspace --all-targets -- -D warnings`: **PASS**
- `cargo test --workspace`: **PASS** — all suites green on the frozen SHA. Honesty note: two earlier full-workspace runs flaked on `runner::sequential` gate timing tests (`gate_reject_exhausts_redispatch_bound_with_distinct_error`, `stale_reject_does_not_resatisfy_regated_same_sha` — the known 752ce4d/3efd58a flakiness, outside this delta) and once on `check::cmd_succeeds::tests::secrets_masked_in_output`; each passed in isolation, and the final frozen-SHA run passed clean without reducing parallelism.

## Test plan

- New tests: `edda-store` heartbeat roundtrip; conductor `phase_heartbeat_written_during_agent_turn`, `heartbeat_write_failure_does_not_fail_phase`, `interval_defaults_to_30s_and_reads_env`, `write_failure_is_swallowed_not_fatal`; bridge `lane_heartbeat_written_without_bridge_is_discovered_then_goes_stale`; cli `peers_json_claims_carry_staleness`.
- Forbidden paths untouched: `codex_rpc.rs`, `agent_kind.rs`, `cmd_claim.rs`; `record_cost`/`cost_measured`/`PlanCompleted`/`cost_line`/`write_phase_claim` bodies untouched.

Fixes #566
Fixes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)

