### PR TITLE
fix(edda-bridge-claude): stop writing empty session digests with absurd durations (GH-578)

### DIFF
--- a/crates/edda-bridge-claude/src/digest/extract.rs
+++ b/crates/edda-bridge-claude/src/digest/extract.rs
@@ -3,7 +3,7 @@ use std::io::BufRead;
 use std::path::Path;
 
 use super::helpers::{
-    compute_duration_minutes, extract_bash_command, extract_envelope_cwd, extract_exit_code,
+    accumulate_active_secs, extract_bash_command, extract_envelope_cwd, extract_exit_code,
     extract_file_path, extract_git_commit_msg,
 };
 use super::{ActivityType, DigestTaskSnapshot, FailedCommand, SessionOutcome, SessionStats};
@@ -16,6 +16,12 @@ pub fn extract_stats(session_ledger_path: &Path) -> anyhow::Result<SessionStats>
     // Track session outcome: last event type + trailing failure count
     let mut last_event_name = String::new();
     let mut trailing_failures: u32 = 0;
+
+    // Track timestamps for duration. Duration is the session's real activity
+    // span: consecutive-event gaps are summed with idle gaps capped
+    // (GH-578) — not "first timestamp until now".
+    let mut active_secs: i64 = 0;
+    let mut last_seen: Option<time::OffsetDateTime> = None;
 
     if !session_ledger_path.exists() {
         return Ok(stats);
@@ -34,13 +40,13 @@ pub fn extract_stats(session_ledger_path: &Path) -> anyhow::Result<SessionStats>
             Err(_) => continue, // skip malformed lines
         };
 
-        // Track timestamps for duration
         let ts = envelope.get("ts").and_then(|v| v.as_str()).unwrap_or("");
         if !ts.is_empty() {
             if stats.first_ts.is_none() {
                 stats.first_ts = Some(ts.to_string());
             }
             stats.last_ts = Some(ts.to_string());
+            accumulate_active_secs(&mut active_secs, &mut last_seen, ts);
         }
 
         let event_name = envelope
@@ -135,7 +141,7 @@ pub fn extract_stats(session_ledger_path: &Path) -> anyhow::Result<SessionStats>
 
     stats.files_modified = files_set.into_iter().collect();
     stats.file_edit_counts = file_edit_map.into_iter().collect();
-    stats.duration_minutes = compute_duration_minutes(&stats.first_ts, &stats.last_ts);
+    stats.duration_minutes = active_secs.unsigned_abs() / 60;
 
     // Determine session outcome
     stats.outcome = if trailing_failures >= 3 {

--- a/crates/edda-bridge-claude/src/digest/extract.rs
+++ b/crates/edda-bridge-claude/src/digest/extract.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::io::BufRead;
+use std::io::{BufRead, Read, Seek, SeekFrom};
 use std::path::Path;
 
 use super::helpers::{
@@ -9,6 +9,113 @@ use super::helpers::{
 use super::{ActivityType, DigestTaskSnapshot, FailedCommand, SessionOutcome, SessionStats};
 
 pub fn extract_stats(session_ledger_path: &Path) -> anyhow::Result<SessionStats> {
+    Ok(extract_stats_from(session_ledger_path, 0)?.0)
+}
+
+/// Tool-call event names across the bridges that persist session ledgers
+/// (round-1 P1-1): Claude Code `PostToolUse`, OpenClaw `after_tool_call`
+/// (tool data nested under `event_data`), Cursor `postToolUse`, Hermes
+/// `post_tool_call`. Without these, sessions from three of the five bridges
+/// did real work but were classified zero-call and silently dropped.
+fn is_tool_call_event(name: &str) -> bool {
+    matches!(
+        name,
+        "PostToolUse" | "after_tool_call" | "postToolUse" | "post_tool_call"
+    )
+}
+
+/// User-prompt event names across bridges: Claude Code `UserPromptSubmit`,
+/// Cursor `beforeSubmitPrompt`, OpenClaw `before_agent_start`.
+fn is_user_prompt_event(name: &str) -> bool {
+    matches!(
+        name,
+        "UserPromptSubmit" | "beforeSubmitPrompt" | "before_agent_start"
+    )
+}
+
+/// OpenClaw has no separate failure event: a failed tool call is an
+/// `after_tool_call` with a non-empty `event_data.error` string or
+/// `event_data.success: false`.
+fn openclaw_tool_failed(envelope: &serde_json::Value) -> bool {
+    let data = envelope.get("event_data");
+    if data
+        .and_then(|d| d.get("success"))
+        .and_then(|v| v.as_bool())
+        == Some(false)
+    {
+        return true;
+    }
+    data.and_then(|d| d.get("error"))
+        .and_then(|v| v.as_str())
+        .is_some_and(|s| !s.is_empty())
+}
+
+/// Normalize lower-case bridge tool names (OpenClaw/Hermes) to the Claude
+/// equivalents the digest breakdown and per-tool extraction expect.
+fn normalize_tool_name(name: &str) -> &str {
+    match name {
+        "bash" | "terminal" | "shell" => "Bash",
+        "edit_file" | "file_edit" => "Edit",
+        "write_file" | "file_write" => "Write",
+        other => other,
+    }
+}
+
+/// Extract the tool name from an envelope in any bridge's shape:
+/// top-level `tool_name`, `raw.toolName`/`raw.tool_name`, or OpenClaw's
+/// `event_data.tool_name`.
+fn tool_name_of(envelope: &serde_json::Value) -> String {
+    let raw = envelope
+        .get("tool_name")
+        .or_else(|| {
+            envelope
+                .get("raw")
+                .and_then(|r| r.get("toolName").or_else(|| r.get("tool_name")))
+        })
+        .or_else(|| envelope.get("event_data").and_then(|d| d.get("tool_name")))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    normalize_tool_name(raw).to_string()
+}
+
+/// Byte offset just past the last complete (newline-terminated) line.
+///
+/// A ledger that ends mid-line (truncated or concurrently-written final
+/// line, round-1 P0-2) is only ever consumed up to its last complete line.
+fn complete_prefix_len(file: &mut std::fs::File) -> std::io::Result<u64> {
+    let len = file.metadata()?.len();
+    if len == 0 {
+        return Ok(0);
+    }
+    const CHUNK: u64 = 8192;
+    let mut pos = len;
+    loop {
+        let start = pos.saturating_sub(CHUNK);
+        let size = (pos - start) as usize;
+        file.seek(SeekFrom::Start(start))?;
+        let mut buf = vec![0u8; size];
+        file.read_exact(&mut buf)?;
+        if let Some(i) = buf.iter().rposition(|&b| b == b'\n') {
+            return Ok(start + i as u64 + 1);
+        }
+        if start == 0 {
+            return Ok(0);
+        }
+        pos = start;
+    }
+}
+
+/// Extract statistics from the delta of a session ledger starting at
+/// `start_offset` (the digest watermark) up to the end of the last complete
+/// line. Returns the stats and the consumed byte offset.
+///
+/// A trailing unterminated line is NOT consumed: the producer may still be
+/// writing it. Only complete, newline-terminated lines count as consumed,
+/// so a line is digested exactly once, once its write completes.
+pub fn extract_stats_from(
+    session_ledger_path: &Path,
+    start_offset: u64,
+) -> anyhow::Result<(SessionStats, u64)> {
     let mut stats = SessionStats::default();
     let mut files_set: BTreeSet<String> = BTreeSet::new();
     let mut file_edit_map: BTreeMap<String, u64> = BTreeMap::new();
@@ -24,20 +131,46 @@ pub fn extract_stats(session_ledger_path: &Path) -> anyhow::Result<SessionStats>
     let mut last_seen: Option<time::OffsetDateTime> = None;
 
     if !session_ledger_path.exists() {
-        return Ok(stats);
+        return Ok((stats, start_offset));
     }
 
-    let file = std::fs::File::open(session_ledger_path)?;
-    let reader = std::io::BufReader::new(file);
+    let mut file = std::fs::File::open(session_ledger_path)?;
+    let end = complete_prefix_len(&mut file)?;
+    if start_offset >= end {
+        // Nothing new (complete) since the watermark.
+        return Ok((stats, start_offset));
+    }
 
-    for line in reader.lines() {
-        let line = line?;
-        if line.trim().is_empty() {
+    file.seek(SeekFrom::Start(start_offset))?;
+    let mut reader = std::io::BufReader::new(file);
+    let mut consumed = start_offset;
+    let mut line_buf: Vec<u8> = Vec::new();
+    let mut malformed: u64 = 0;
+
+    loop {
+        line_buf.clear();
+        let n = reader.read_until(b'\n', &mut line_buf)?;
+        if n == 0 {
+            break;
+        }
+        if line_buf.last() != Some(&b'\n') {
+            // Unterminated tail: the producer is (or was) mid-write.
+            // Not consumed — it will be picked up once complete.
+            break;
+        }
+        consumed += n as u64;
+
+        let line = String::from_utf8_lossy(&line_buf);
+        let line = line.trim();
+        if line.is_empty() {
             continue;
         }
-        let envelope: serde_json::Value = match serde_json::from_str(&line) {
+        let envelope: serde_json::Value = match serde_json::from_str(line) {
             Ok(v) => v,
-            Err(_) => continue, // skip malformed lines
+            Err(_) => {
+                malformed += 1;
+                continue; // skip malformed lines
+            }
         };
 
         let ts = envelope.get("ts").and_then(|v| v.as_str()).unwrap_or("");
@@ -54,89 +187,82 @@ pub fn extract_stats(session_ledger_path: &Path) -> anyhow::Result<SessionStats>
             .and_then(|v| v.as_str())
             .unwrap_or("");
 
+        // Failure classification: Claude Code has a dedicated failure event;
+        // OpenClaw reports failures inline on after_tool_call.
+        let is_failure = event_name == "PostToolUseFailure"
+            || (event_name == "after_tool_call" && openclaw_tool_failed(&envelope));
+        let is_call = !is_failure && is_tool_call_event(event_name);
+
         // Track trailing failures for outcome detection
-        if event_name == "PostToolUseFailure" {
+        if is_failure {
             trailing_failures += 1;
-        } else if event_name == "PostToolUse" {
+        } else if is_call {
             trailing_failures = 0;
         }
         if !event_name.is_empty() {
             last_event_name = event_name.to_string();
         }
 
-        match event_name {
-            "PostToolUse" => {
-                stats.tool_calls += 1;
-                // Extract tool_name and accumulate per-tool breakdown
-                let tool_name = envelope
-                    .get("tool_name")
-                    .or_else(|| {
-                        envelope
-                            .get("raw")
-                            .and_then(|r| r.get("toolName").or_else(|| r.get("tool_name")))
-                    })
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                if !tool_name.is_empty() {
-                    *stats
-                        .tool_call_breakdown
-                        .entry(tool_name.to_string())
-                        .or_insert(0) += 1;
+        if is_failure {
+            stats.tool_failures += 1;
+            // Extract failed Bash commands
+            let tool_name = tool_name_of(&envelope);
+            if tool_name == "Bash" {
+                if let Some(cmd) = extract_bash_command(&envelope) {
+                    let cwd_val = extract_envelope_cwd(&envelope);
+                    let exit_code = extract_exit_code(&envelope);
+                    stats.failed_cmds_detail.push(FailedCommand {
+                        command: cmd.clone(),
+                        cwd: cwd_val,
+                        exit_code,
+                    });
+                    stats.failed_commands.push(cmd);
                 }
-                if tool_name == "Edit" || tool_name == "Write" {
-                    if let Some(fp) = extract_file_path(&envelope) {
-                        if !crate::signals::is_noise_file(&fp) {
-                            files_set.insert(fp.clone());
-                            *file_edit_map.entry(fp).or_insert(0) += 1;
-                        }
+            }
+        } else if is_call {
+            stats.tool_calls += 1;
+            // Extract tool_name and accumulate per-tool breakdown
+            let tool_name = tool_name_of(&envelope);
+            if !tool_name.is_empty() {
+                *stats
+                    .tool_call_breakdown
+                    .entry(tool_name.to_string())
+                    .or_insert(0) += 1;
+            }
+            if tool_name == "Edit" || tool_name == "Write" {
+                if let Some(fp) = extract_file_path(&envelope) {
+                    if !crate::signals::is_noise_file(&fp) {
+                        files_set.insert(fp.clone());
+                        *file_edit_map.entry(fp).or_insert(0) += 1;
                     }
                 }
-                if tool_name == "Bash" {
-                    if let Some(cmd) = extract_bash_command(&envelope) {
-                        if cmd.contains("git commit") {
-                            let msg = extract_git_commit_msg(&cmd);
-                            if !msg.is_empty() {
-                                stats.commits_made.push(msg);
-                            }
+            }
+            if tool_name == "Bash" {
+                if let Some(cmd) = extract_bash_command(&envelope) {
+                    if cmd.contains("git commit") {
+                        let msg = extract_git_commit_msg(&cmd);
+                        if !msg.is_empty() {
+                            stats.commits_made.push(msg);
                         }
-                        if let Some(pkg) = crate::nudge::extract_dependency_add(&cmd) {
-                            if !stats.deps_added.contains(&pkg) {
-                                stats.deps_added.push(pkg);
-                            }
+                    }
+                    if let Some(pkg) = crate::nudge::extract_dependency_add(&cmd) {
+                        if !stats.deps_added.contains(&pkg) {
+                            stats.deps_added.push(pkg);
                         }
                     }
                 }
             }
-            "PostToolUseFailure" => {
-                stats.tool_failures += 1;
-                // Extract failed Bash commands
-                let tool_name = envelope
-                    .get("tool_name")
-                    .or_else(|| {
-                        envelope
-                            .get("raw")
-                            .and_then(|r| r.get("toolName").or_else(|| r.get("tool_name")))
-                    })
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                if tool_name == "Bash" {
-                    if let Some(cmd) = extract_bash_command(&envelope) {
-                        let cwd_val = extract_envelope_cwd(&envelope);
-                        let exit_code = extract_exit_code(&envelope);
-                        stats.failed_cmds_detail.push(FailedCommand {
-                            command: cmd.clone(),
-                            cwd: cwd_val,
-                            exit_code,
-                        });
-                        stats.failed_commands.push(cmd);
-                    }
-                }
-            }
-            "UserPromptSubmit" => {
-                stats.user_prompts += 1;
-            }
-            _ => {}
+        } else if is_user_prompt_event(event_name) {
+            stats.user_prompts += 1;
         }
+    }
+
+    if malformed > 0 {
+        tracing::debug!(
+            malformed,
+            path = %session_ledger_path.display(),
+            "skipped malformed lines in session ledger (never destroyed)"
+        );
     }
 
     stats.files_modified = files_set.into_iter().collect();
@@ -146,7 +272,7 @@ pub fn extract_stats(session_ledger_path: &Path) -> anyhow::Result<SessionStats>
     // Determine session outcome
     stats.outcome = if trailing_failures >= 3 {
         SessionOutcome::ErrorStuck
-    } else if last_event_name == "UserPromptSubmit" {
+    } else if is_user_prompt_event(&last_event_name) {
         SessionOutcome::Interrupted
     } else {
         SessionOutcome::Completed
@@ -155,7 +281,7 @@ pub fn extract_stats(session_ledger_path: &Path) -> anyhow::Result<SessionStats>
     // Classify activity based on tool patterns
     stats.activity = classify_activity(&stats);
 
-    Ok(stats)
+    Ok((stats, consumed))
 }
 
 /// Load tasks snapshot from state/active_tasks.json for a project.

--- a/crates/edda-bridge-claude/src/digest/extract.rs
+++ b/crates/edda-bridge-claude/src/digest/extract.rs
@@ -82,7 +82,7 @@ fn tool_name_of(envelope: &serde_json::Value) -> String {
 ///
 /// A ledger that ends mid-line (truncated or concurrently-written final
 /// line, round-1 P0-2) is only ever consumed up to its last complete line.
-fn complete_prefix_len(file: &mut std::fs::File) -> std::io::Result<u64> {
+pub(crate) fn complete_prefix_len(file: &mut std::fs::File) -> std::io::Result<u64> {
     let len = file.metadata()?.len();
     if len == 0 {
         return Ok(0);
@@ -103,6 +103,37 @@ fn complete_prefix_len(file: &mut std::fs::File) -> std::io::Result<u64> {
         }
         pos = start;
     }
+}
+
+/// Proof of file identity: hash of the first `len` bytes of the file
+/// (round-2 ruling: a byte offset alone cannot identify a file — it
+/// silently assumes the file is append-only and never replaced).
+pub(crate) fn hash_prefix(path: &Path, len: u64) -> anyhow::Result<String> {
+    let file = std::fs::File::open(path)?;
+    let mut hasher = blake3::Hasher::new();
+    std::io::copy(&mut file.take(len), &mut hasher)?;
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+/// Validate a watermark candidate against the current file: the offset is
+/// only usable if the file still contains those bytes and they hash to the
+/// recorded proof. A mismatch (replacement, in-place rewrite, shrink,
+/// reused session id) means the position proves nothing and the session
+/// must be re-read from zero — never skipped. Offset 0 consumes nothing
+/// and always matches.
+pub(crate) fn watermark_matches(path: &Path, offset: u64, prefix_hash: &str) -> bool {
+    if offset == 0 {
+        return true;
+    }
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if meta.len() < offset {
+        return false;
+    }
+    hash_prefix(path, offset)
+        .map(|h| h == prefix_hash)
+        .unwrap_or(false)
 }
 
 /// Extract statistics from the delta of a session ledger starting at

--- a/crates/edda-bridge-claude/src/digest/extract.rs
+++ b/crates/edda-bridge-claude/src/digest/extract.rs
@@ -9,7 +9,7 @@ use super::helpers::{
 use super::{ActivityType, DigestTaskSnapshot, FailedCommand, SessionOutcome, SessionStats};
 
 pub fn extract_stats(session_ledger_path: &Path) -> anyhow::Result<SessionStats> {
-    Ok(extract_stats_from(session_ledger_path, 0)?.0)
+    Ok(extract_stats_delta(session_ledger_path, 0)?.stats)
 }
 
 /// Tool-call event names across the bridges that persist session ledgers
@@ -136,81 +136,73 @@ pub(crate) fn watermark_matches(path: &Path, offset: u64, prefix_hash: &str) -> 
         .unwrap_or(false)
 }
 
-/// Extract statistics from the delta of a session ledger starting at
-/// `start_offset` (the digest watermark) up to the end of the last complete
-/// line. Returns the stats and the consumed byte offset.
-///
-/// A trailing unterminated line is NOT consumed: the producer may still be
-/// writing it. Only complete, newline-terminated lines count as consumed,
-/// so a line is digested exactly once, once its write completes.
-pub fn extract_stats_from(
-    session_ledger_path: &Path,
-    start_offset: u64,
-) -> anyhow::Result<(SessionStats, u64)> {
-    let mut stats = SessionStats::default();
-    let mut files_set: BTreeSet<String> = BTreeSet::new();
-    let mut file_edit_map: BTreeMap<String, u64> = BTreeMap::new();
+/// Result of one streaming pass over a session ledger (round-3 P1-1).
+pub struct ExtractedDelta {
+    pub stats: SessionStats,
+    /// Byte offset just past the last consumed complete line.
+    pub consumed: u64,
+    /// BLAKE3 of the first `consumed` bytes, computed over the SAME bytes —
+    /// read through the SAME open file handle — whose content produced
+    /// `stats` (round-3 P1-1 ruling: the note's content and its identity
+    /// proof must not be able to come from different reads). One handle,
+    /// one pass: if the path is atomically replaced mid-digest, the open
+    /// handle keeps following the original inode and BOTH the stats and
+    /// the hash are derived from it, so the emitted watermark always
+    /// proves exactly the bytes that were summarized.
+    pub prefix_hash: String,
+}
 
+/// Incremental parse state for one sequential pass over a session ledger.
+struct StatsParser {
+    stats: SessionStats,
+    files_set: BTreeSet<String>,
+    file_edit_map: BTreeMap<String, u64>,
     // Track session outcome: last event type + trailing failure count
-    let mut last_event_name = String::new();
-    let mut trailing_failures: u32 = 0;
-
+    last_event_name: String,
+    trailing_failures: u32,
     // Track timestamps for duration. Duration is the session's real activity
     // span: consecutive-event gaps are summed with idle gaps capped
     // (GH-578) — not "first timestamp until now".
-    let mut active_secs: i64 = 0;
-    let mut last_seen: Option<time::OffsetDateTime> = None;
+    active_secs: i64,
+    last_seen: Option<time::OffsetDateTime>,
+    malformed: u64,
+}
 
-    if !session_ledger_path.exists() {
-        return Ok((stats, start_offset));
+impl StatsParser {
+    fn new() -> Self {
+        Self {
+            stats: SessionStats::default(),
+            files_set: BTreeSet::new(),
+            file_edit_map: BTreeMap::new(),
+            last_event_name: String::new(),
+            trailing_failures: 0,
+            active_secs: 0,
+            last_seen: None,
+            malformed: 0,
+        }
     }
 
-    let mut file = std::fs::File::open(session_ledger_path)?;
-    let end = complete_prefix_len(&mut file)?;
-    if start_offset >= end {
-        // Nothing new (complete) since the watermark.
-        return Ok((stats, start_offset));
-    }
-
-    file.seek(SeekFrom::Start(start_offset))?;
-    let mut reader = std::io::BufReader::new(file);
-    let mut consumed = start_offset;
-    let mut line_buf: Vec<u8> = Vec::new();
-    let mut malformed: u64 = 0;
-
-    loop {
-        line_buf.clear();
-        let n = reader.read_until(b'\n', &mut line_buf)?;
-        if n == 0 {
-            break;
-        }
-        if line_buf.last() != Some(&b'\n') {
-            // Unterminated tail: the producer is (or was) mid-write.
-            // Not consumed — it will be picked up once complete.
-            break;
-        }
-        consumed += n as u64;
-
-        let line = String::from_utf8_lossy(&line_buf);
+    /// Parse one complete envelope line into the accumulating stats.
+    fn push_line(&mut self, line: &str) {
         let line = line.trim();
         if line.is_empty() {
-            continue;
+            return;
         }
         let envelope: serde_json::Value = match serde_json::from_str(line) {
             Ok(v) => v,
             Err(_) => {
-                malformed += 1;
-                continue; // skip malformed lines
+                self.malformed += 1;
+                return; // skip malformed lines
             }
         };
 
         let ts = envelope.get("ts").and_then(|v| v.as_str()).unwrap_or("");
         if !ts.is_empty() {
-            if stats.first_ts.is_none() {
-                stats.first_ts = Some(ts.to_string());
+            if self.stats.first_ts.is_none() {
+                self.stats.first_ts = Some(ts.to_string());
             }
-            stats.last_ts = Some(ts.to_string());
-            accumulate_active_secs(&mut active_secs, &mut last_seen, ts);
+            self.stats.last_ts = Some(ts.to_string());
+            accumulate_active_secs(&mut self.active_secs, &mut self.last_seen, ts);
         }
 
         let event_name = envelope
@@ -226,36 +218,37 @@ pub fn extract_stats_from(
 
         // Track trailing failures for outcome detection
         if is_failure {
-            trailing_failures += 1;
+            self.trailing_failures += 1;
         } else if is_call {
-            trailing_failures = 0;
+            self.trailing_failures = 0;
         }
         if !event_name.is_empty() {
-            last_event_name = event_name.to_string();
+            self.last_event_name = event_name.to_string();
         }
 
         if is_failure {
-            stats.tool_failures += 1;
+            self.stats.tool_failures += 1;
             // Extract failed Bash commands
             let tool_name = tool_name_of(&envelope);
             if tool_name == "Bash" {
                 if let Some(cmd) = extract_bash_command(&envelope) {
                     let cwd_val = extract_envelope_cwd(&envelope);
                     let exit_code = extract_exit_code(&envelope);
-                    stats.failed_cmds_detail.push(FailedCommand {
+                    self.stats.failed_cmds_detail.push(FailedCommand {
                         command: cmd.clone(),
                         cwd: cwd_val,
                         exit_code,
                     });
-                    stats.failed_commands.push(cmd);
+                    self.stats.failed_commands.push(cmd);
                 }
             }
         } else if is_call {
-            stats.tool_calls += 1;
+            self.stats.tool_calls += 1;
             // Extract tool_name and accumulate per-tool breakdown
             let tool_name = tool_name_of(&envelope);
             if !tool_name.is_empty() {
-                *stats
+                *self
+                    .stats
                     .tool_call_breakdown
                     .entry(tool_name.to_string())
                     .or_insert(0) += 1;
@@ -263,8 +256,8 @@ pub fn extract_stats_from(
             if tool_name == "Edit" || tool_name == "Write" {
                 if let Some(fp) = extract_file_path(&envelope) {
                     if !crate::signals::is_noise_file(&fp) {
-                        files_set.insert(fp.clone());
-                        *file_edit_map.entry(fp).or_insert(0) += 1;
+                        self.files_set.insert(fp.clone());
+                        *self.file_edit_map.entry(fp).or_insert(0) += 1;
                     }
                 }
             }
@@ -273,46 +266,126 @@ pub fn extract_stats_from(
                     if cmd.contains("git commit") {
                         let msg = extract_git_commit_msg(&cmd);
                         if !msg.is_empty() {
-                            stats.commits_made.push(msg);
+                            self.stats.commits_made.push(msg);
                         }
                     }
                     if let Some(pkg) = crate::nudge::extract_dependency_add(&cmd) {
-                        if !stats.deps_added.contains(&pkg) {
-                            stats.deps_added.push(pkg);
+                        if !self.stats.deps_added.contains(&pkg) {
+                            self.stats.deps_added.push(pkg);
                         }
                     }
                 }
             }
         } else if is_user_prompt_event(event_name) {
-            stats.user_prompts += 1;
+            self.stats.user_prompts += 1;
         }
     }
 
-    if malformed > 0 {
+    fn finish(mut self) -> SessionStats {
+        self.stats.files_modified = self.files_set.into_iter().collect();
+        self.stats.file_edit_counts = self.file_edit_map.into_iter().collect();
+        self.stats.duration_minutes = self.active_secs.unsigned_abs() / 60;
+
+        // Determine session outcome
+        self.stats.outcome = if self.trailing_failures >= 3 {
+            SessionOutcome::ErrorStuck
+        } else if is_user_prompt_event(&self.last_event_name) {
+            SessionOutcome::Interrupted
+        } else {
+            SessionOutcome::Completed
+        };
+
+        // Classify activity based on tool patterns
+        self.stats.activity = classify_activity(&self.stats);
+
+        self.stats
+    }
+}
+
+/// Extract the statistics of a session ledger's delta starting at
+/// `start_offset` (the digest watermark) up to the end of the last complete
+/// line, TOGETHER WITH the identity proof of the consumed prefix — derived
+/// from the same single read (round-3 P1-1).
+///
+/// One open file handle, one sequential pass: every consumed byte is hashed,
+/// and the bytes at or after `start_offset` are the bytes parsed into
+/// `stats`. The previous implementation opened the path a second time to
+/// hash the consumed prefix after parsing; an atomic replacement of the path
+/// between the two opens produced a note whose stats summarized one file
+/// while its `prefix_hash` proved another, and the retry then validated
+/// against the replacement and silently skipped every current record. That
+/// possibility is now structurally gone: there is no second read to race
+/// against.
+///
+/// A trailing unterminated line is NOT consumed: the producer may still be
+/// writing it. Only complete, newline-terminated lines count as consumed,
+/// so a line is digested exactly once, once its write completes.
+pub fn extract_stats_delta(
+    session_ledger_path: &Path,
+    start_offset: u64,
+) -> anyhow::Result<ExtractedDelta> {
+    if !session_ledger_path.exists() {
+        return Ok(ExtractedDelta {
+            stats: SessionStats::default(),
+            consumed: start_offset,
+            prefix_hash: String::new(),
+        });
+    }
+
+    let mut file = std::fs::File::open(session_ledger_path)?;
+    let end = complete_prefix_len(&mut file)?;
+    if start_offset >= end {
+        // Nothing new (complete) since the watermark. No proof is derived:
+        // the caller keeps its existing, already proof-validated watermark.
+        return Ok(ExtractedDelta {
+            stats: SessionStats::default(),
+            consumed: start_offset,
+            prefix_hash: String::new(),
+        });
+    }
+
+    // ONE pass over the SAME open handle: hash every consumed byte, parse
+    // the bytes at or after `start_offset`. One buffer of truth.
+    file.seek(SeekFrom::Start(0))?;
+    let mut reader = std::io::BufReader::with_capacity(128 * 1024, file);
+    let mut parser = StatsParser::new();
+    let mut hasher = blake3::Hasher::new();
+    let mut consumed: u64 = 0;
+    let mut line_buf: Vec<u8> = Vec::new();
+
+    loop {
+        line_buf.clear();
+        let n = reader.read_until(b'\n', &mut line_buf)?;
+        if n == 0 {
+            break;
+        }
+        if line_buf.last() != Some(&b'\n') {
+            // Unterminated tail: the producer is (or was) mid-write.
+            // Not consumed — it will be picked up once complete.
+            break;
+        }
+        hasher.update(&line_buf);
+        let line_start = consumed;
+        consumed += n as u64;
+        if line_start >= start_offset {
+            let line = String::from_utf8_lossy(&line_buf);
+            parser.push_line(&line);
+        }
+    }
+
+    if parser.malformed > 0 {
         tracing::debug!(
-            malformed,
+            malformed = parser.malformed,
             path = %session_ledger_path.display(),
             "skipped malformed lines in session ledger (never destroyed)"
         );
     }
 
-    stats.files_modified = files_set.into_iter().collect();
-    stats.file_edit_counts = file_edit_map.into_iter().collect();
-    stats.duration_minutes = active_secs.unsigned_abs() / 60;
-
-    // Determine session outcome
-    stats.outcome = if trailing_failures >= 3 {
-        SessionOutcome::ErrorStuck
-    } else if is_user_prompt_event(&last_event_name) {
-        SessionOutcome::Interrupted
-    } else {
-        SessionOutcome::Completed
-    };
-
-    // Classify activity based on tool patterns
-    stats.activity = classify_activity(&stats);
-
-    Ok((stats, consumed))
+    Ok(ExtractedDelta {
+        stats: parser.finish(),
+        consumed,
+        prefix_hash: hasher.finalize().to_hex().to_string(),
+    })
 }
 
 /// Load tasks snapshot from state/active_tasks.json for a project.

--- a/crates/edda-bridge-claude/src/digest/helpers.rs
+++ b/crates/edda-bridge-claude/src/digest/helpers.rs
@@ -97,20 +97,31 @@ pub(super) fn normalize_path(path: &str) -> String {
     path.to_string()
 }
 
-pub(super) fn compute_duration_minutes(first: &Option<String>, last: &Option<String>) -> u64 {
-    let (Some(first), Some(last)) = (first.as_deref(), last.as_deref()) else {
-        return 0;
-    };
+/// Idle-gap cap for session duration (GH-578): a gap longer than this
+/// between consecutive session events is idle time, not work, and only
+/// contributes this many seconds to the session's active duration.
+pub(super) const MAX_IDLE_GAP_SECS: i64 = 30 * 60;
+
+/// Accumulate active duration across consecutive event timestamps.
+///
+/// Gaps longer than [`MAX_IDLE_GAP_SECS`] are treated as idle and capped,
+/// so an idle-for-ten-days session does not report 14287 minutes of work./// Negative deltas (clock skew) contribute nothing.
+pub(super) fn accumulate_active_secs(
+    active_secs: &mut i64,
+    last_seen: &mut Option<time::OffsetDateTime>,
+    ts: &str,
+) {
     let fmt = &time::format_description::well_known::Rfc3339;
-    let Ok(t1) = time::OffsetDateTime::parse(first, fmt) else {
-        return 0;
+    let Ok(t) = time::OffsetDateTime::parse(ts, fmt) else {
+        return;
     };
-    let Ok(t2) = time::OffsetDateTime::parse(last, fmt) else {
-        return 0;
-    };
-    let diff: time::Duration = t2 - t1;
-    let secs = diff.whole_seconds().unsigned_abs();
-    secs / 60
+    if let Some(prev) = *last_seen {
+        let delta = (t - prev).whole_seconds();
+        if delta > 0 {
+            *active_secs += delta.min(MAX_IDLE_GAP_SECS);
+        }
+    }
+    *last_seen = Some(t);
 }
 
 pub(super) fn now_rfc3339() -> String {

--- a/crates/edda-bridge-claude/src/digest/helpers.rs
+++ b/crates/edda-bridge-claude/src/digest/helpers.rs
@@ -11,9 +11,18 @@ pub(super) fn extract_file_path(envelope: &serde_json::Value) -> Option<String> 
         return Some(normalize_path(fp));
     }
     // Try top-level tool_input (when raw is flattened)
-    envelope
+    if let Some(fp) = envelope
         .get("tool_input")
         .and_then(|ti| ti.get("file_path"))
+        .and_then(|v| v.as_str())
+    {
+        return Some(normalize_path(fp));
+    }
+    // OpenClaw nests tool data under event_data (round-1 P1-1)
+    envelope
+        .get("event_data")
+        .and_then(|d| d.get("tool_input").or_else(|| d.get("toolInput")))
+        .and_then(|ti| ti.get("file_path").or_else(|| ti.get("filePath")))
         .and_then(|v| v.as_str())
         .map(normalize_path)
 }
@@ -67,8 +76,18 @@ pub(super) fn extract_bash_command(envelope: &serde_json::Value) -> Option<Strin
     {
         return Some(cmd.to_string());
     }
-    envelope
+    // Try top-level tool_input (when raw is flattened)
+    if let Some(cmd) = envelope
         .get("tool_input")
+        .and_then(|ti| ti.get("command"))
+        .and_then(|v| v.as_str())
+    {
+        return Some(cmd.to_string());
+    }
+    // OpenClaw nests tool data under event_data (round-1 P1-1)
+    envelope
+        .get("event_data")
+        .and_then(|d| d.get("tool_input").or_else(|| d.get("toolInput")))
         .and_then(|ti| ti.get("command"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())

--- a/crates/edda-bridge-claude/src/digest/mod.rs
+++ b/crates/edda-bridge-claude/src/digest/mod.rs
@@ -144,7 +144,7 @@ mod prev;
 mod render;
 
 // Re-export all public items to preserve API
-pub use extract::{extract_stats, extract_stats_from, load_tasks_for_digest, render_digest_text};
+pub use extract::{extract_stats, extract_stats_delta, load_tasks_for_digest, render_digest_text};
 pub use orchestrate::{
     digest_previous_sessions, digest_previous_sessions_with_opts, digest_session_manual,
     find_all_pending_sessions, load_digest_state, migrate_legacy_state, pending_failure_warning,

--- a/crates/edda-bridge-claude/src/digest/mod.rs
+++ b/crates/edda-bridge-claude/src/digest/mod.rs
@@ -123,6 +123,19 @@ pub struct SessionStats {
     pub activity: ActivityType,
 }
 
+/// The watermark a digest note stamps into its payload (round-2 ruling:
+/// "the ledger is durable truth; the side state file is a cache"). The
+/// note records what it consumed — the byte offset plus a hash of the
+/// consumed prefix — so idempotency is derivable from the workspace
+/// ledger itself: losing the cache costs a re-scan, never a duplicate.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct DigestWatermark {
+    /// Byte offset just past the last consumed complete line.
+    pub offset: u64,
+    /// Hash of the first `offset` bytes of the session ledger.
+    pub prefix_hash: String,
+}
+
 /// Extract statistics from a session ledger file.
 mod extract;
 mod helpers;

--- a/crates/edda-bridge-claude/src/digest/mod.rs
+++ b/crates/edda-bridge-claude/src/digest/mod.rs
@@ -131,11 +131,11 @@ mod prev;
 mod render;
 
 // Re-export all public items to preserve API
-pub use extract::{extract_stats, load_tasks_for_digest, render_digest_text};
+pub use extract::{extract_stats, extract_stats_from, load_tasks_for_digest, render_digest_text};
 pub use orchestrate::{
     digest_previous_sessions, digest_previous_sessions_with_opts, digest_session_manual,
-    find_all_pending_sessions, load_digest_state, pending_failure_warning, save_digest_state,
-    DigestResult, DigestState,
+    find_all_pending_sessions, load_digest_state, migrate_legacy_state, pending_failure_warning,
+    save_digest_state, DigestResult, DigestState, DigestedSession,
 };
 pub use prev::{
     collect_session_ledger_extras, read_prev_digest, write_prev_digest,

--- a/crates/edda-bridge-claude/src/digest/orchestrate.rs
+++ b/crates/edda-bridge-claude/src/digest/orchestrate.rs
@@ -36,17 +36,6 @@ pub struct DigestedSession {
     /// (round-1 P1-4: per-session id, not one global latest id).
     #[serde(default)]
     pub event_id: String,
-    /// True when this watermark was advanced by a ZERO-CALL delta, for
-    /// which no digest note exists (GH-578: an empty summary must not cost
-    /// a ledger event). Its claim — "the proof-validated bytes contained
-    /// no tool calls and no failures" — is a pure function of the bytes
-    /// themselves, so re-reading them under ANY ledger state yields the
-    /// same no-op; this is the only cache watermark allowed to skip the
-    /// ledger check (round-3 P1-2). Old state files deserialize with
-    /// false: pre-round-3 entries are treated as note-backed and can only
-    /// suppress when their note is confirmed in the ledger.
-    #[serde(default)]
-    pub zero_call: bool,
     /// When this watermark was last advanced.
     #[serde(default)]
     pub digested_at: String,
@@ -141,10 +130,6 @@ pub fn migrate_legacy_state(_project_id: &str, state: &mut DigestState) {
                 prefix_hash: String::new(),
                 event_id,
                 digested_at,
-                // The legacy model cannot prove what was consumed (see
-                // above) — treat as note-backed: suppressible only via a
-                // ledger note (round-3 P1-2).
-                zero_call: false,
             },
         );
     }
@@ -165,15 +150,16 @@ fn digest_state_path(project_id: &str) -> std::path::PathBuf {
 }
 
 /// Record how far a session has been digested, which event id it got, and
-/// the identity proof of the consumed prefix. `zero_call` marks a
-/// watermark advanced without a note (see `DigestedSession::zero_call`).
+/// the identity proof of the consumed prefix. The entry is an unverified
+/// hint only: it can never suppress a digest on its own — the workspace
+/// ledger is the sole authority (round-4 ruling
+/// `digest.zero-call-sessions=re-read-every-time-no-cache-authority`).
 fn remember_digested(
     state: &mut DigestState,
     session_id: &str,
     event_id: &str,
     offset: u64,
     prefix_hash: &str,
-    zero_call: bool,
 ) {
     state.sessions.insert(
         session_id.to_string(),
@@ -182,7 +168,6 @@ fn remember_digested(
             prefix_hash: prefix_hash.to_string(),
             event_id: event_id.to_string(),
             digested_at: now_rfc3339(),
-            zero_call,
         },
     );
 }
@@ -207,12 +192,11 @@ struct WatermarkCandidate {
 /// surviving cache), so letting it set the start offset — at any offset,
 /// EOF included — can silently skip content the ledger never recorded as
 /// digested. Because cache state alone can never rule out a relevant note,
-/// there is NO fast path that skips this scan: the scan IS the authority.
-/// The only skip that cannot change the answer is the provably
-/// content-free zero-call watermark in `is_fully_consumed` (its claim is a
-/// pure function of the proof-validated bytes), and even that one
-/// suppresses nothing here — the returned start offset is always
-/// ledger-derived, so a delta whose note was rolled back is re-read.
+/// there is NO fast path that skips this scan: the scan IS the authority
+/// (round-4 ruling
+/// `digest.zero-call-sessions=re-read-every-time-no-cache-authority`).
+/// The returned start offset is always ledger-derived, so a delta whose
+/// note was rolled back is re-read.
 fn effective_watermark(
     ledger: &edda_ledger::Ledger,
     session_id: &str,
@@ -268,59 +252,34 @@ fn stamped_watermark_index(
     index
 }
 
-/// True if the session is PROVABLY fully consumed: some accepted authority
-/// records a watermark whose offset is the whole current file and whose
-/// identity proof re-validates (round-2: position alone is not identity).
+/// True if the session is PROVABLY fully consumed: the workspace ledger
+/// records a stamped digest note whose offset covers the whole current
+/// file and whose identity proof re-validates (round-2: position alone is
+/// not identity).
 ///
-/// Exactly two authorities can say "consumed" (round-3 P1-2):
-///
-/// * a stamped digest note in the workspace ledger — the sole authority
-///   for note-backed watermarks. A surviving cache entry can NEVER claim
-///   one: the round-3 reproduction (note-backed cache at EOF + rolled-back
-///   ledger) suppressed a live Edit prefix precisely because the cache was
-///   verified against the session file but never against the ledger.
-/// * a `zero_call` cache watermark. THE FAST-PATH SKIP CONDITION, stated:
-///   skipping the ledger scan could only be wrong if some ledger state
-///   would change the answer — but this watermark's claim ("the
-///   proof-validated bytes contain no tool calls and no failures") is a
-///   pure function of those bytes, so re-reading them under ANY ledger
-///   state (note present, absent, or rolled back) yields the same no-op.
-///   Skipping therefore cannot change the answer. This is the only skip of
-///   its kind; the condition is proven by the test
-///   `zero_call_cache_skip_is_provable_and_loses_no_content`.
-fn is_fully_consumed(
-    path: &Path,
-    stamped: &[(u64, String, String)],
-    cache: Option<&DigestedSession>,
-) -> bool {
+/// The ledger is the ONLY authority (round-4 ruling
+/// `digest.zero-call-sessions=re-read-every-time-no-cache-authority`):
+/// the cache is never consulted here, so it can shorten nothing the
+/// ledger has not already confirmed. A zero-call session has no note by
+/// design (GH-578), so it is re-read on every call; a note-backed cache
+/// entry can NEVER claim its note — the round-3 reproduction (note-backed
+/// cache at EOF + rolled-back ledger) suppressed a live Edit prefix
+/// precisely because the cache was verified against the session file but
+/// never against the ledger.
+fn is_fully_consumed(path: &Path, stamped: &[(u64, String, String)]) -> bool {
     let Ok(meta) = std::fs::metadata(path) else {
         return false;
     };
     let len = meta.len();
-    // Ledger authority: a stamped note covering the whole current file.
-    if stamped
+    stamped
         .iter()
         .any(|(offset, hash, _)| *offset == len && watermark_matches(path, *offset, hash))
-    {
-        return true;
-    }
-    // The provable content-free skip (see doc comment).
-    if let Some(entry) = cache {
-        if entry.zero_call
-            && entry.offset == len
-            && watermark_matches(path, entry.offset, &entry.prefix_hash)
-        {
-            return true;
-        }
-    }
-    false
 }
 
 /// Find session ledger files in the store, excluding the current session.
 fn find_pending_sessions(
     project_id: &str,
     current_session_id: &str,
-    state: &DigestState,
     ledger: Option<&edda_ledger::Ledger>,
 ) -> Vec<String> {
     let ledger_dir = edda_store::project_dir(project_id).join("ledger");
@@ -331,8 +290,8 @@ fn find_pending_sessions(
 
     let mut sessions = Vec::new();
     // The authoritative stamped watermarks (round-3 P1-2). When no ledger
-    // is available nothing is note-backed-confirmable, so only the provable
-    // zero-call skip in `is_fully_consumed` may suppress.
+    // is available nothing is confirmable, so every session is reported
+    // pending — over-listing costs a scan, never a skipped session.
     let stamped_index = ledger.map(stamped_watermark_index);
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
@@ -344,20 +303,18 @@ fn find_pending_sessions(
         if session_id == current_session_id {
             continue;
         }
-        // Skip only sessions whose consumption is PROVEN: a stamped note
-        // in the workspace ledger (the sole authority for note-backed
-        // watermarks) or a provably content-free zero-call watermark
-        // (round-2: position alone is not identity — a replaced or
-        // rewritten ledger re-opens the digest from zero, and a grown one
-        // is picked up as a delta; round-3: a cache entry without its
-        // ledger note can never suppress).
+        // Skip only sessions whose consumption is PROVEN by a stamped note
+        // in the workspace ledger — the sole authority (round-2: position
+        // alone is not identity — a replaced or rewritten ledger re-opens
+        // the digest from zero, and a grown one is picked up as a delta;
+        // round-4: the cache, zero-call or not, can never suppress).
         let path = ledger_dir.join(&name);
         let stamped: &[(u64, String, String)] = stamped_index
             .as_ref()
             .and_then(|m| m.get(&session_id))
             .map(|v| v.as_slice())
             .unwrap_or(&[]);
-        if is_fully_consumed(&path, stamped, state.sessions.get(&session_id)) {
+        if is_fully_consumed(&path, stamped) {
             continue;
         }
         sessions.push(session_id);
@@ -456,7 +413,7 @@ pub fn digest_previous_sessions_with_opts(
         .and_then(|root| edda_ledger::Ledger::open(&root).ok());
 
     // Find sessions to digest
-    let pending = find_pending_sessions(project_id, current_session_id, &state, ledger.as_ref());
+    let pending = find_pending_sessions(project_id, current_session_id, ledger.as_ref());
     if pending.is_empty() {
         // Check if there's a retry pending
         if !state.pending_session_id.is_empty() && state.retry_count > 0 {
@@ -709,32 +666,17 @@ fn digest_one_session(
         // crash between note-append and cache-save, the ledger note is the
         // watermark and the retry must be a no-op, not a duplicate).
         if let Some(w) = &eff {
-            // The cache is current if it mirrors the ledger note, or if it
-            // is a zero-call watermark at or ahead of the note with a
-            // valid proof — a content-free advance the ledger intentionally
-            // does not record, and "repairing" it would undo the zero-call
-            // skip and re-scan the same tail on every hook (round-3 P1-2).
-            // Only a cache BEHIND the ledger needs repair.
+            // The cache is current only if it exactly mirrors the ledger
+            // note; anything else — including a stale zero-call-advanced
+            // entry from an older state file — is repaired to the note
+            // (round-4: the cache is never an authority on its own).
             let cache_current = prev.as_ref().is_some_and(|c| {
-                (!c.zero_call
-                    && c.offset == w.offset
-                    && c.prefix_hash == w.prefix_hash
-                    && c.event_id == w.event_id)
-                    || (c.zero_call
-                        && c.offset >= w.offset
-                        && watermark_matches(&session_ledger_path, c.offset, &c.prefix_hash))
+                c.offset == w.offset && c.prefix_hash == w.prefix_hash && c.event_id == w.event_id
             });
             if !cache_current {
                 state.session_id = session_id.to_string();
                 state.digested_at = now_rfc3339();
-                remember_digested(
-                    state,
-                    session_id,
-                    &w.event_id,
-                    w.offset,
-                    &w.prefix_hash,
-                    false,
-                );
+                remember_digested(state, session_id, &w.event_id, w.offset, &w.prefix_hash);
                 if let Err(e) = save_digest_state(project_id, state) {
                     tracing::warn!(error = %e, session = %session_id,
                         "watermark cache repair failed; the ledger note remains authoritative");
@@ -747,14 +689,17 @@ fn digest_one_session(
     // Skip deltas with no tool calls and no failures: nothing to summarize
     // (GH-578). A chat-only or idle delta produces a counts-only digest with
     // no information value; it must not cost a ledger event. Failure-only
-    // deltas are kept: their failed commands carry information. The consumed
-    // watermark is still recorded so the same delta is never rescanned.
+    // deltas are kept: their failed commands carry information. The
+    // consumed watermark is recorded as a hint, but it can never suppress a
+    // rescan: with no note in the ledger the session stays pending and is
+    // re-read on every call (round-4 ruling
+    // `digest.zero-call-sessions=re-read-every-time-no-cache-authority`).
     if stats.tool_calls == 0 && stats.tool_failures == 0 {
         let prev_event_id = eff.as_ref().map_or(String::new(), |w| w.event_id.clone());
         // The proof comes from the same single read as the stats (round-3
         // P1-1) — no separate hash of the path.
         state.session_id = session_id.to_string();
-        remember_digested(state, session_id, &prev_event_id, consumed, &proof, true);
+        remember_digested(state, session_id, &prev_event_id, consumed, &proof);
         state.digested_at = now_rfc3339();
         state.retry_count = 0;
         state.pending_session_id = String::new();
@@ -835,7 +780,7 @@ fn digest_one_session(
     state.session_id = session_id.to_string();
     state.event_id = last_event_id.clone();
     state.digested_at = now_rfc3339();
-    remember_digested(state, session_id, &last_event_id, consumed, &proof, false);
+    remember_digested(state, session_id, &last_event_id, consumed, &proof);
     state.retry_count = 0;
     state.pending_session_id = String::new();
     state.last_error = String::new();
@@ -973,20 +918,12 @@ pub fn digest_session_manual(
         // watermark and the retry must be a no-op, not a duplicate), then
         // return this session's own event id (round-1 P1-4).
         if let Some(w) = &eff {
-            // The cache is current if it mirrors the ledger note, or if it
-            // is a zero-call watermark at or ahead of the note with a
-            // valid proof — a content-free advance the ledger intentionally
-            // does not record, and "repairing" it would undo the zero-call
-            // skip and re-scan the same tail on every hook (round-3 P1-2).
-            // Only a cache BEHIND the ledger needs repair.
+            // The cache is current only if it exactly mirrors the ledger
+            // note; anything else — including a stale zero-call-advanced
+            // entry from an older state file — is repaired to the note
+            // (round-4: the cache is never an authority on its own).
             let cache_current = prev.as_ref().is_some_and(|c| {
-                (!c.zero_call
-                    && c.offset == w.offset
-                    && c.prefix_hash == w.prefix_hash
-                    && c.event_id == w.event_id)
-                    || (c.zero_call
-                        && c.offset >= w.offset
-                        && watermark_matches(&session_ledger_path, c.offset, &c.prefix_hash))
+                c.offset == w.offset && c.prefix_hash == w.prefix_hash && c.event_id == w.event_id
             });
             if !cache_current {
                 state.session_id = session_id.to_string();
@@ -997,7 +934,6 @@ pub fn digest_session_manual(
                     &w.event_id,
                     w.offset,
                     &w.prefix_hash,
-                    false,
                 );
                 state.retry_count = 0;
                 state.pending_session_id = String::new();
@@ -1011,23 +947,18 @@ pub fn digest_session_manual(
         return Ok(eff.map_or(String::new(), |w| w.event_id));
     }
 
-    // Zero-call delta (GH-578): no event — there is nothing to summarize —
-    // but the consumed watermark (with identity proof) is recorded so the
-    // same lines are never rescanned; real work appended later still
-    // digests as its own delta.
+    // Zero-call delta (GH-578): no event — there is nothing to summarize.
+    // The consumed watermark (with identity proof) is recorded as a hint,
+    // but it can never suppress a rescan: with no note in the ledger the
+    // session stays pending and these lines are re-read on every call
+    // (round-4 ruling
+    // `digest.zero-call-sessions=re-read-every-time-no-cache-authority`).
     if stats.tool_calls == 0 && stats.tool_failures == 0 {
         let prev_event_id = eff.as_ref().map_or(String::new(), |w| w.event_id.clone());
         // The proof comes from the same single read as the stats (round-3
         // P1-1) — no separate hash of the path.
         state.session_id = session_id.to_string();
-        remember_digested(
-            &mut state,
-            session_id,
-            &prev_event_id,
-            consumed,
-            &proof,
-            true,
-        );
+        remember_digested(&mut state, session_id, &prev_event_id, consumed, &proof);
         state.digested_at = now_rfc3339();
         state.retry_count = 0;
         state.pending_session_id = String::new();
@@ -1070,14 +1001,7 @@ pub fn digest_session_manual(
     state.session_id = session_id.to_string();
     state.event_id = event.event_id.clone();
     state.digested_at = now_rfc3339();
-    remember_digested(
-        &mut state,
-        session_id,
-        &event.event_id,
-        consumed,
-        &proof,
-        false,
-    );
+    remember_digested(&mut state, session_id, &event.event_id, consumed, &proof);
     state.retry_count = 0;
     state.pending_session_id = String::new();
     state.last_error = String::new();
@@ -1125,13 +1049,12 @@ pub fn digest_session_manual(
 /// long-lived session whose delta was digested by the bridges).
 ///
 /// The CLI listing has no workspace-ledger handle, so nothing is
-/// note-backed-confirmable here (round-3 P1-2): only the provably
-/// content-free zero-call skip may suppress. Note-backed sessions may be
-/// listed; each is then resolved by `digest_session_manual`, which is
-/// ledger-authoritative and no-ops them — over-listing costs a scan,
-/// never a skipped session.
+/// note-backed-confirmable here (round-3 P1-2) and NOTHING may suppress
+/// (round-4: the cache is never an authority): every session is listed.
+/// Note-backed sessions are then no-oped by the ledger-authoritative
+/// `digest_session_manual`; a zero-call session is re-read on every call —
+/// over-listing costs a scan, never a skipped session.
 pub fn find_all_pending_sessions(project_id: &str) -> Vec<String> {
-    let state = load_digest_state(project_id);
     let ledger_dir = edda_store::project_dir(project_id).join("ledger");
     let entries = match std::fs::read_dir(&ledger_dir) {
         Ok(e) => e,
@@ -1145,14 +1068,11 @@ pub fn find_all_pending_sessions(project_id: &str) -> Vec<String> {
             continue;
         }
         let session_id = name.trim_end_matches(".jsonl").to_string();
-        // Already digested — but only if consumption is PROVEN: a stamped
-        // note in the workspace ledger (sole authority for note-backed
-        // watermarks; unavailable here, see doc comment) or a provably
-        // content-free zero-call watermark (round-2: position alone is not
-        // identity; round-3: a cache entry without its ledger note can
-        // never suppress).
+        // Nothing may suppress here: no ledger handle, and the cache is
+        // never an authority (round-4 ruling) — every session is listed
+        // and resolved by the ledger-authoritative manual path.
         let path = ledger_dir.join(&name);
-        if is_fully_consumed(&path, &[], state.sessions.get(&session_id)) {
+        if is_fully_consumed(&path, &[]) {
             continue;
         }
         sessions.push(session_id);

--- a/crates/edda-bridge-claude/src/digest/orchestrate.rs
+++ b/crates/edda-bridge-claude/src/digest/orchestrate.rs
@@ -5,7 +5,9 @@ use edda_core::event::finalize_event;
 use edda_core::types::Provenance;
 use serde::{Deserialize, Serialize};
 
-use super::extract::{extract_stats_from, load_tasks_for_digest};
+use super::extract::{
+    complete_prefix_len, extract_stats_from, hash_prefix, load_tasks_for_digest, watermark_matches,
+};
 use super::helpers::now_rfc3339;
 use super::prev::collect_session_ledger_extras;
 use super::render::{build_cmd_milestone_event, build_digest_event};
@@ -26,6 +28,12 @@ pub struct DigestedSession {
     /// picked up once its write completes (round-1 P0-2).
     #[serde(default)]
     pub offset: u64,
+    /// Hash of the first `offset` bytes of the session ledger — the file
+    /// identity proof (round-2 finding 1: a bare offset silently assumes
+    /// the file is append-only and never replaced; on proof mismatch the
+    /// session is re-read from zero, never skipped).
+    #[serde(default)]
+    pub prefix_hash: String,
     /// Event id of the latest digest event written for THIS session
     /// (round-1 P1-4: per-session id, not one global latest id).
     #[serde(default)]
@@ -87,15 +95,19 @@ pub fn load_digest_state(project_id: &str) -> DigestState {
     }
 }
 
-/// Migrate pre-watermark state into the per-session model (round-1 P1-2).
+/// Migrate pre-watermark state into the per-session model.
 ///
-/// A pre-upgrade file records at most one digested session via
-/// `session_id`/`event_id` (and, in intermediate versions, a list of ids in
-/// the deprecated `digested` field) with no watermark. Seeding the map keeps
-/// the recorded sessions digested: the legacy model digested a session's
-/// whole file, so everything currently on disk for it is treated as already
-/// consumed; content appended afterwards is picked up as a normal delta.
-pub fn migrate_legacy_state(project_id: &str, state: &mut DigestState) {
+/// The legacy model records only session ids and event ids — it cannot
+/// prove what bytes were actually consumed at the moment the legacy state
+/// was written (round-2 finding 2: seeding the offset at the ledger's
+/// current EOF silently swallowed everything appended between the legacy
+/// write and the first post-upgrade load). Migration therefore seeds a
+/// zero offset with no identity proof: the first post-upgrade digest
+/// RE-READS the whole ledger — at-least-once, it may duplicate the legacy
+/// digest once — instead of skipping anything. The recorded event id is
+/// kept only so a no-op (empty or unchanged-complete ledger) still returns
+/// that session's own id.
+pub fn migrate_legacy_state(_project_id: &str, state: &mut DigestState) {
     if !state.sessions.is_empty() {
         return;
     }
@@ -106,11 +118,7 @@ pub fn migrate_legacy_state(project_id: &str, state: &mut DigestState) {
     if legacy_ids.is_empty() {
         return;
     }
-    let ledger_dir = edda_store::project_dir(project_id).join("ledger");
     for id in legacy_ids {
-        let offset = std::fs::metadata(ledger_dir.join(format!("{id}.jsonl")))
-            .map(|m| m.len())
-            .unwrap_or(0);
         // Only the single legacy `session_id` slot has a known event id.
         let (event_id, digested_at) = if id == state.session_id {
             (state.event_id.clone(), state.digested_at.clone())
@@ -120,7 +128,8 @@ pub fn migrate_legacy_state(project_id: &str, state: &mut DigestState) {
         state.sessions.insert(
             id,
             DigestedSession {
-                offset,
+                offset: 0,
+                prefix_hash: String::new(),
                 event_id,
                 digested_at,
             },
@@ -142,16 +151,138 @@ fn digest_state_path(project_id: &str) -> std::path::PathBuf {
         .join("last_digested_session.json")
 }
 
-/// Record how far a session has been digested and which event id it got.
-fn remember_digested(state: &mut DigestState, session_id: &str, event_id: &str, offset: u64) {
+/// Record how far a session has been digested, which event id it got, and
+/// the identity proof of the consumed prefix.
+fn remember_digested(
+    state: &mut DigestState,
+    session_id: &str,
+    event_id: &str,
+    offset: u64,
+    prefix_hash: &str,
+) {
     state.sessions.insert(
         session_id.to_string(),
         DigestedSession {
             offset,
+            prefix_hash: prefix_hash.to_string(),
             event_id: event_id.to_string(),
             digested_at: now_rfc3339(),
         },
     );
+}
+
+/// A watermark candidate proven to describe the CURRENT ledger file.
+#[derive(Debug, Clone)]
+struct WatermarkCandidate {
+    offset: u64,
+    prefix_hash: String,
+    event_id: String,
+}
+
+/// Recover the effective digest watermark for a session from every durable
+/// source, validating each against the current file.
+///
+/// Round-2 ruling: a byte offset alone cannot identify a file, and the
+/// ledger — not the side state file — is durable truth. Candidates are the
+/// per-session cache entry and every digest note in the workspace ledger
+/// stamped with a `digest_watermark`; each is accepted only if the file's
+/// first `offset` bytes still hash to the recorded proof, and the highest
+/// validated offset wins. On any mismatch (replacement, same-length
+/// rewrite, shrink, reused session id) the candidate is discarded and the
+/// session is re-read from zero — never skipped.
+///
+/// Crash-window recovery (round-2 finding 3): the note is appended before
+/// the cache is saved, so after a crash or save failure the ledger note is
+/// the only record of the watermark; this scan re-derives it, making a
+/// retry cost a re-scan instead of a duplicate.
+fn effective_watermark(
+    ledger: &edda_ledger::Ledger,
+    session_id: &str,
+    session_ledger_path: &Path,
+    cache: Option<&DigestedSession>,
+) -> Option<WatermarkCandidate> {
+    let cache_candidate = cache.and_then(|c| {
+        if watermark_matches(session_ledger_path, c.offset, &c.prefix_hash) {
+            Some(WatermarkCandidate {
+                offset: c.offset,
+                prefix_hash: c.prefix_hash.clone(),
+                event_id: c.event_id.clone(),
+            })
+        } else {
+            None
+        }
+    });
+
+    // Fast path: a cache entry that already covers the last complete line
+    // cannot be behind the ledger (notes are appended before the cache is
+    // saved, and note watermarks are complete-line boundaries of the same
+    // file), so the ledger scan can be skipped.
+    if let Some(c) = &cache_candidate {
+        if let Ok(mut file) = std::fs::File::open(session_ledger_path) {
+            if let Ok(end) = complete_prefix_len(&mut file) {
+                if c.offset >= end {
+                    return cache_candidate;
+                }
+            }
+        }
+    }
+
+    // Ledger scan: every digest note for this session carrying a stamped
+    // watermark, validated against the current file, highest offset first.
+    let mut stamped: Vec<(u64, String, String)> = Vec::new();
+    if let Ok(notes) = ledger.iter_events_by_type("note") {
+        for event in notes {
+            let payload = &event.payload;
+            if payload.get("source").and_then(|v| v.as_str()) != Some("bridge:session_digest") {
+                continue;
+            }
+            if payload.get("session_id").and_then(|v| v.as_str()) != Some(session_id) {
+                continue;
+            }
+            let Some(wm) = payload.get("digest_watermark") else {
+                continue;
+            };
+            let (Some(offset), Some(hash)) = (
+                wm.get("offset").and_then(|v| v.as_u64()),
+                wm.get("prefix_hash").and_then(|v| v.as_str()),
+            ) else {
+                continue;
+            };
+            stamped.push((offset, hash.to_string(), event.event_id.clone()));
+        }
+    }
+    stamped.sort_by_key(|(offset, _, _)| std::cmp::Reverse(*offset));
+    let ledger_candidate = stamped
+        .into_iter()
+        .find(|(offset, hash, _)| watermark_matches(session_ledger_path, *offset, hash))
+        .map(|(offset, prefix_hash, event_id)| WatermarkCandidate {
+            offset,
+            prefix_hash,
+            event_id,
+        });
+
+    match (cache_candidate, ledger_candidate) {
+        (Some(c), Some(l)) => Some(if l.offset > c.offset { l } else { c }),
+        (Some(c), None) => Some(c),
+        (None, Some(l)) => Some(l),
+        (None, None) => None,
+    }
+}
+
+/// True if `wm` proves the ledger file is fully consumed: its offset is the
+/// whole file AND the prefix still hashes to the recorded identity proof
+/// (round-2: position alone is not identity).
+fn is_fully_consumed(path: &Path, wm: Option<&DigestedSession>) -> bool {
+    let Some(wm) = wm else {
+        return false;
+    };
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if meta.len() != wm.offset {
+        return false;
+    }
+    watermark_matches(path, wm.offset, &wm.prefix_hash)
 }
 
 /// Find session ledger files in the store, excluding the current session.
@@ -177,10 +308,12 @@ fn find_pending_sessions(
         if session_id == current_session_id {
             continue;
         }
-        // Skip already-digested sessions (GH-578; round-1 P1-3: the
-        // per-session map is unbounded, so an entry can never be evicted
-        // back into this list while its ledger still exists).
-        if session_id == state.session_id || state.sessions.contains_key(&session_id) {
+        // Skip only sessions whose watermark PROVES full consumption
+        // (round-2: position alone is not identity — a replaced or
+        // rewritten ledger re-opens the digest from zero, and a grown one
+        // is picked up as a delta).
+        let path = ledger_dir.join(&name);
+        if is_fully_consumed(&path, state.sessions.get(&session_id)) {
             continue;
         }
         sessions.push(session_id);
@@ -487,7 +620,11 @@ fn digest_one_session(
     };
 
     let prev = state.sessions.get(session_id).cloned();
-    let start = prev.as_ref().map_or(0, |e| e.offset);
+    // Effective watermark: validated cache entry and/or the session's own
+    // digest notes in the ledger, highest validated offset wins (round-2:
+    // identity proof + ledger-authoritative recovery).
+    let eff = effective_watermark(&ledger, session_id, &session_ledger_path, prev.as_ref());
+    let start = eff.as_ref().map_or(0, |w| w.offset);
 
     // Extract the delta: everything after the last digested offset, up to
     // the last complete line. A truncated or concurrently-written final line
@@ -507,7 +644,24 @@ fn digest_one_session(
     };
 
     if consumed <= start {
-        // No new complete lines since the last digest.
+        // No new complete lines since the last digest. Repair the cache
+        // from the durable sources if it lags (round-2 finding 3: after a
+        // crash between note-append and cache-save, the ledger note is the
+        // watermark and the retry must be a no-op, not a duplicate).
+        if let Some(w) = &eff {
+            let cache_current = prev.as_ref().is_some_and(|c| {
+                c.offset == w.offset && c.prefix_hash == w.prefix_hash && c.event_id == w.event_id
+            });
+            if !cache_current {
+                state.session_id = session_id.to_string();
+                state.digested_at = now_rfc3339();
+                remember_digested(state, session_id, &w.event_id, w.offset, &w.prefix_hash);
+                if let Err(e) = save_digest_state(project_id, state) {
+                    tracing::warn!(error = %e, session = %session_id,
+                        "watermark cache repair failed; the ledger note remains authoritative");
+                }
+            }
+        }
         return DigestResult::NoPending;
     }
 
@@ -517,9 +671,21 @@ fn digest_one_session(
     // deltas are kept: their failed commands carry information. The consumed
     // watermark is still recorded so the same delta is never rescanned.
     if stats.tool_calls == 0 && stats.tool_failures == 0 {
-        let prev_event_id = prev.map_or(String::new(), |e| e.event_id);
+        let prev_event_id = eff.as_ref().map_or(String::new(), |w| w.event_id.clone());
+        let proof = match hash_prefix(&session_ledger_path, consumed) {
+            Ok(p) => p,
+            Err(e) => {
+                record_failure(
+                    project_id,
+                    session_id,
+                    state,
+                    &format!("cannot hash consumed prefix: {e}"),
+                );
+                return DigestResult::Error(format!("cannot hash consumed prefix: {e}"));
+            }
+        };
         state.session_id = session_id.to_string();
-        remember_digested(state, session_id, &prev_event_id, consumed);
+        remember_digested(state, session_id, &prev_event_id, consumed, &proof);
         state.digested_at = now_rfc3339();
         state.retry_count = 0;
         state.pending_session_id = String::new();
@@ -550,20 +716,45 @@ fn digest_one_session(
     // Collect session notes and decisions from workspace ledger
     let (decisions, notes) = collect_session_ledger_extras(cwd, stats.first_ts.as_deref());
 
+    // Identity proof of the consumed prefix: stamped into the note so the
+    // ledger itself is the durable idempotency record (round-2).
+    let proof = match hash_prefix(&session_ledger_path, consumed) {
+        Ok(p) => p,
+        Err(e) => {
+            record_failure(
+                project_id,
+                session_id,
+                state,
+                &format!("cannot hash consumed prefix: {e}"),
+            );
+            return DigestResult::Error(format!("cannot hash consumed prefix: {e}"));
+        }
+    };
+    let watermark = super::DigestWatermark {
+        offset: consumed,
+        prefix_hash: proof.clone(),
+    };
+
     // Build and append session digest note
-    let event =
-        match build_digest_event(session_id, &stats, &branch, parent_hash.as_deref(), &notes) {
-            Ok(e) => e,
-            Err(e) => {
-                record_failure(
-                    project_id,
-                    session_id,
-                    state,
-                    &format!("build event failed: {e}"),
-                );
-                return DigestResult::Error(format!("build event failed: {e}"));
-            }
-        };
+    let event = match build_digest_event(
+        session_id,
+        &stats,
+        &branch,
+        parent_hash.as_deref(),
+        &notes,
+        Some(&watermark),
+    ) {
+        Ok(e) => e,
+        Err(e) => {
+            record_failure(
+                project_id,
+                session_id,
+                state,
+                &format!("build event failed: {e}"),
+            );
+            return DigestResult::Error(format!("build event failed: {e}"));
+        }
+    };
 
     if let Err(e) = ledger.append_event(&event) {
         record_failure(
@@ -586,14 +777,17 @@ fn digest_one_session(
     state.session_id = session_id.to_string();
     state.event_id = last_event_id.clone();
     state.digested_at = now_rfc3339();
-    remember_digested(state, session_id, &last_event_id, consumed);
+    remember_digested(state, session_id, &last_event_id, consumed, &proof);
     state.retry_count = 0;
     state.pending_session_id = String::new();
     state.last_error = String::new();
     if let Err(e) = save_digest_state(project_id, state) {
+        // Honest, but no longer duplicate-prone: the note above carries its
+        // watermark, so the next run recovers from the ledger instead of
+        // re-appending (round-2 finding 3).
         return DigestResult::Error(format!(
             "digest note {} was appended, but saving the digest state failed: {e}. \
-             Re-running may duplicate the note.",
+             The note remains authoritative in the ledger; re-running will recover from it.",
             event.event_id
         ));
     }
@@ -652,13 +846,21 @@ fn digest_one_session(
 /// Manually digest a specific session (CLI escape hatch, and the path the
 /// openclaw/codex/cursor/hermes bridges hit on agent_end/session_end).
 ///
-/// Idempotent by per-session watermark (GH-578 round-1, ruling
-/// `digest.idempotency=per-session-watermark-never-delete-the-source`):
+/// Idempotent by per-session watermark with file-identity proof (GH-578;
+/// round-2 ruling `digest.watermark-identity=offset-needs-content-proof
+/// -and-ledger-is-the-truth`):
 ///
+/// * the effective watermark is recovered from every durable source — the
+///   cache entry and the session's own stamped digest notes in the ledger —
+///   and each candidate must re-prove file identity (hash of the consumed
+///   prefix); on any mismatch the session is re-read from zero, never
+///   skipped;
 /// * a session with no new complete lines is a no-op and returns THAT
 ///   session's own digest event id (empty if it never produced one);
 /// * a session that grew digests only its delta;
 /// * a zero-call delta writes no event but still advances the watermark;
+/// * the digest note itself carries its watermark, so losing the cache
+///   costs a re-scan and never a duplicate;
 /// * the source ledger is never deleted, so a live producer's future
 ///   appends are always digestable.
 pub fn digest_session_manual(
@@ -690,25 +892,57 @@ pub fn digest_session_manual(
     // stale maps and drop each other's entries.
     let mut state = load_digest_state(project_id);
     let prev = state.sessions.get(session_id).cloned();
-    let start = prev.as_ref().map_or(0, |e| e.offset);
+    // Effective watermark: validated cache entry and/or the session's own
+    // stamped digest notes in the ledger, highest validated offset wins
+    // (round-2: identity proof + ledger-authoritative recovery).
+    let eff = effective_watermark(&ledger, session_id, &session_ledger_path, prev.as_ref());
+    let start = eff.as_ref().map_or(0, |w| w.offset);
 
     // Delta extraction: only complete lines after the last digested offset
     // are consumed (round-1 P0-2); the source is never modified.
     let (mut stats, consumed) = extract_stats_from(&session_ledger_path, start)?;
 
     if consumed <= start {
-        // Nothing new since the last digest: no-op. Return this session's
-        // own event id, not the globally-latest one (round-1 P1-4).
-        return Ok(prev.map_or(String::new(), |e| e.event_id));
+        // Nothing new since the last digest: no-op. Repair the cache if it
+        // lags the durable sources (round-2 finding 3: after a crash
+        // between note-append and cache-save the ledger note IS the
+        // watermark and the retry must be a no-op, not a duplicate), then
+        // return this session's own event id (round-1 P1-4).
+        if let Some(w) = &eff {
+            let cache_current = prev.as_ref().is_some_and(|c| {
+                c.offset == w.offset && c.prefix_hash == w.prefix_hash && c.event_id == w.event_id
+            });
+            if !cache_current {
+                state.session_id = session_id.to_string();
+                state.digested_at = now_rfc3339();
+                remember_digested(
+                    &mut state,
+                    session_id,
+                    &w.event_id,
+                    w.offset,
+                    &w.prefix_hash,
+                );
+                state.retry_count = 0;
+                state.pending_session_id = String::new();
+                state.last_error = String::new();
+                if let Err(e) = save_digest_state(project_id, &state) {
+                    tracing::warn!(error = %e, session = %session_id,
+                        "watermark cache repair failed; the ledger note remains authoritative");
+                }
+            }
+        }
+        return Ok(eff.map_or(String::new(), |w| w.event_id));
     }
 
     // Zero-call delta (GH-578): no event — there is nothing to summarize —
-    // but the consumed watermark is recorded so the same lines are never
-    // rescanned; real work appended later still digests as its own delta.
+    // but the consumed watermark (with identity proof) is recorded so the
+    // same lines are never rescanned; real work appended later still
+    // digests as its own delta.
     if stats.tool_calls == 0 && stats.tool_failures == 0 {
-        let prev_event_id = prev.map_or(String::new(), |e| e.event_id);
+        let prev_event_id = eff.as_ref().map_or(String::new(), |w| w.event_id.clone());
+        let proof = hash_prefix(&session_ledger_path, consumed)?;
         state.session_id = session_id.to_string();
-        remember_digested(&mut state, session_id, &prev_event_id, consumed);
+        remember_digested(&mut state, session_id, &prev_event_id, consumed, &proof);
         state.digested_at = now_rfc3339();
         state.retry_count = 0;
         state.pending_session_id = String::new();
@@ -722,7 +956,22 @@ pub fn digest_session_manual(
 
     stats.tasks_snapshot = load_tasks_for_digest(project_id);
     let (_decisions, notes) = collect_session_ledger_extras(cwd, stats.first_ts.as_deref());
-    let event = build_digest_event(session_id, &stats, &branch, parent_hash.as_deref(), &notes)?;
+
+    // Identity proof of the consumed prefix, stamped into the note so the
+    // ledger itself is the durable idempotency record (round-2).
+    let proof = hash_prefix(&session_ledger_path, consumed)?;
+    let watermark = super::DigestWatermark {
+        offset: consumed,
+        prefix_hash: proof.clone(),
+    };
+    let event = build_digest_event(
+        session_id,
+        &stats,
+        &branch,
+        parent_hash.as_deref(),
+        &notes,
+        Some(&watermark),
+    )?;
     ledger.append_event(&event)?;
 
     // ── Durable idempotency boundary (round-1 P1-5) ──
@@ -736,14 +985,17 @@ pub fn digest_session_manual(
     state.session_id = session_id.to_string();
     state.event_id = event.event_id.clone();
     state.digested_at = now_rfc3339();
-    remember_digested(&mut state, session_id, &event.event_id, consumed);
+    remember_digested(&mut state, session_id, &event.event_id, consumed, &proof);
     state.retry_count = 0;
     state.pending_session_id = String::new();
     state.last_error = String::new();
     save_digest_state(project_id, &state).map_err(|e| {
+        // Honest, but no longer duplicate-prone: the note above carries its
+        // watermark, so the next run recovers from the ledger instead of
+        // re-appending (round-2 finding 3).
         anyhow::anyhow!(
             "digest note {} was appended, but saving the digest state failed: {e}. \
-             Re-running may duplicate the note.",
+             The note remains authoritative in the ledger; re-running will recover from it.",
             event.event_id
         )
     })?;
@@ -794,15 +1046,12 @@ pub fn find_all_pending_sessions(project_id: &str) -> Vec<String> {
             continue;
         }
         let session_id = name.trim_end_matches(".jsonl").to_string();
-        if let Some(watermark) = state.sessions.get(&session_id) {
-            // Already digested; pending only if the file grew past it.
-            if entry
-                .metadata()
-                .map(|m| m.len() <= watermark.offset)
-                .unwrap_or(true)
-            {
-                continue;
-            }
+        // Already digested — but only if the watermark PROVES full
+        // consumption of the current file (round-2: position alone is not
+        // identity; a replaced or rewritten ledger re-opens from zero).
+        let path = ledger_dir.join(&name);
+        if is_fully_consumed(&path, state.sessions.get(&session_id)) {
+            continue;
         }
         sessions.push(session_id);
     }

--- a/crates/edda-bridge-claude/src/digest/orchestrate.rs
+++ b/crates/edda-bridge-claude/src/digest/orchestrate.rs
@@ -5,9 +5,7 @@ use edda_core::event::finalize_event;
 use edda_core::types::Provenance;
 use serde::{Deserialize, Serialize};
 
-use super::extract::{
-    complete_prefix_len, extract_stats_from, hash_prefix, load_tasks_for_digest, watermark_matches,
-};
+use super::extract::{extract_stats_delta, load_tasks_for_digest, watermark_matches};
 use super::helpers::now_rfc3339;
 use super::prev::collect_session_ledger_extras;
 use super::render::{build_cmd_milestone_event, build_digest_event};
@@ -38,6 +36,17 @@ pub struct DigestedSession {
     /// (round-1 P1-4: per-session id, not one global latest id).
     #[serde(default)]
     pub event_id: String,
+    /// True when this watermark was advanced by a ZERO-CALL delta, for
+    /// which no digest note exists (GH-578: an empty summary must not cost
+    /// a ledger event). Its claim — "the proof-validated bytes contained
+    /// no tool calls and no failures" — is a pure function of the bytes
+    /// themselves, so re-reading them under ANY ledger state yields the
+    /// same no-op; this is the only cache watermark allowed to skip the
+    /// ledger check (round-3 P1-2). Old state files deserialize with
+    /// false: pre-round-3 entries are treated as note-backed and can only
+    /// suppress when their note is confirmed in the ledger.
+    #[serde(default)]
+    pub zero_call: bool,
     /// When this watermark was last advanced.
     #[serde(default)]
     pub digested_at: String,
@@ -132,6 +141,10 @@ pub fn migrate_legacy_state(_project_id: &str, state: &mut DigestState) {
                 prefix_hash: String::new(),
                 event_id,
                 digested_at,
+                // The legacy model cannot prove what was consumed (see
+                // above) — treat as note-backed: suppressible only via a
+                // ledger note (round-3 P1-2).
+                zero_call: false,
             },
         );
     }
@@ -152,13 +165,15 @@ fn digest_state_path(project_id: &str) -> std::path::PathBuf {
 }
 
 /// Record how far a session has been digested, which event id it got, and
-/// the identity proof of the consumed prefix.
+/// the identity proof of the consumed prefix. `zero_call` marks a
+/// watermark advanced without a note (see `DigestedSession::zero_call`).
 fn remember_digested(
     state: &mut DigestState,
     session_id: &str,
     event_id: &str,
     offset: u64,
     prefix_hash: &str,
+    zero_call: bool,
 ) {
     state.sessions.insert(
         session_id.to_string(),
@@ -167,6 +182,7 @@ fn remember_digested(
             prefix_hash: prefix_hash.to_string(),
             event_id: event_id.to_string(),
             digested_at: now_rfc3339(),
+            zero_call,
         },
     );
 }
@@ -179,66 +195,57 @@ struct WatermarkCandidate {
     event_id: String,
 }
 
-/// Recover the effective digest watermark for a session from every durable
-/// source, validating each against the current file.
+/// Recover the effective digest watermark for a session from the workspace
+/// ledger — the SOLE authority (round-3 P1-2, ruling
+/// `digest.proof-and-authority=derive-from-one-read-ledger-is-sole-authority`).
 ///
-/// Round-2 ruling: a byte offset alone cannot identify a file, and the
-/// ledger — not the side state file — is durable truth. Candidates are the
-/// per-session cache entry and every digest note in the workspace ledger
-/// stamped with a `digest_watermark`; each is accepted only if the file's
-/// first `offset` bytes still hash to the recorded proof, and the highest
-/// validated offset wins. On any mismatch (replacement, same-length
-/// rewrite, shrink, reused session id) the candidate is discarded and the
-/// session is re-read from zero — never skipped.
-///
-/// Crash-window recovery (round-2 finding 3): the note is appended before
-/// the cache is saved, so after a crash or save failure the ledger note is
-/// the only record of the watermark; this scan re-derives it, making a
-/// retry cost a re-scan instead of a duplicate.
+/// A session counts as digested exactly as far as the highest digest note
+/// for it in the ledger whose stamped `digest_watermark` still validates
+/// against the current file. The side state file is an unverified hint and
+/// is deliberately NOT a source here: a cache entry cannot prove its note
+/// still exists in the ledger (the ledger can be rolled back under a
+/// surviving cache), so letting it set the start offset — at any offset,
+/// EOF included — can silently skip content the ledger never recorded as
+/// digested. Because cache state alone can never rule out a relevant note,
+/// there is NO fast path that skips this scan: the scan IS the authority.
+/// The only skip that cannot change the answer is the provably
+/// content-free zero-call watermark in `is_fully_consumed` (its claim is a
+/// pure function of the proof-validated bytes), and even that one
+/// suppresses nothing here — the returned start offset is always
+/// ledger-derived, so a delta whose note was rolled back is re-read.
 fn effective_watermark(
     ledger: &edda_ledger::Ledger,
     session_id: &str,
     session_ledger_path: &Path,
-    cache: Option<&DigestedSession>,
 ) -> Option<WatermarkCandidate> {
-    let cache_candidate = cache.and_then(|c| {
-        if watermark_matches(session_ledger_path, c.offset, &c.prefix_hash) {
-            Some(WatermarkCandidate {
-                offset: c.offset,
-                prefix_hash: c.prefix_hash.clone(),
-                event_id: c.event_id.clone(),
-            })
-        } else {
-            None
-        }
-    });
+    stamped_watermark_index(ledger)
+        .remove(session_id)
+        .unwrap_or_default()
+        .into_iter()
+        .find(|(offset, hash, _)| watermark_matches(session_ledger_path, *offset, hash))
+        .map(|(offset, prefix_hash, event_id)| WatermarkCandidate {
+            offset,
+            prefix_hash,
+            event_id,
+        })
+}
 
-    // Fast path: a cache entry that already covers the last complete line
-    // cannot be behind the ledger (notes are appended before the cache is
-    // saved, and note watermarks are complete-line boundaries of the same
-    // file), so the ledger scan can be skipped.
-    if let Some(c) = &cache_candidate {
-        if let Ok(mut file) = std::fs::File::open(session_ledger_path) {
-            if let Ok(end) = complete_prefix_len(&mut file) {
-                if c.offset >= end {
-                    return cache_candidate;
-                }
-            }
-        }
-    }
-
-    // Ledger scan: every digest note for this session carrying a stamped
-    // watermark, validated against the current file, highest offset first.
-    let mut stamped: Vec<(u64, String, String)> = Vec::new();
+/// Stamped digest watermarks per session across the whole ledger, highest
+/// offset first — the authoritative idempotency record (round-3 P1-2).
+/// Validation against the current file happens at the caller.
+fn stamped_watermark_index(
+    ledger: &edda_ledger::Ledger,
+) -> BTreeMap<String, Vec<(u64, String, String)>> {
+    let mut index: BTreeMap<String, Vec<(u64, String, String)>> = BTreeMap::new();
     if let Ok(notes) = ledger.iter_events_by_type("note") {
         for event in notes {
             let payload = &event.payload;
             if payload.get("source").and_then(|v| v.as_str()) != Some("bridge:session_digest") {
                 continue;
             }
-            if payload.get("session_id").and_then(|v| v.as_str()) != Some(session_id) {
+            let Some(session_id) = payload.get("session_id").and_then(|v| v.as_str()) else {
                 continue;
-            }
+            };
             let Some(wm) = payload.get("digest_watermark") else {
                 continue;
             };
@@ -248,41 +255,65 @@ fn effective_watermark(
             ) else {
                 continue;
             };
-            stamped.push((offset, hash.to_string(), event.event_id.clone()));
+            index.entry(session_id.to_string()).or_default().push((
+                offset,
+                hash.to_string(),
+                event.event_id.clone(),
+            ));
         }
     }
-    stamped.sort_by_key(|(offset, _, _)| std::cmp::Reverse(*offset));
-    let ledger_candidate = stamped
-        .into_iter()
-        .find(|(offset, hash, _)| watermark_matches(session_ledger_path, *offset, hash))
-        .map(|(offset, prefix_hash, event_id)| WatermarkCandidate {
-            offset,
-            prefix_hash,
-            event_id,
-        });
-
-    match (cache_candidate, ledger_candidate) {
-        (Some(c), Some(l)) => Some(if l.offset > c.offset { l } else { c }),
-        (Some(c), None) => Some(c),
-        (None, Some(l)) => Some(l),
-        (None, None) => None,
+    for candidates in index.values_mut() {
+        candidates.sort_by_key(|(offset, _, _)| std::cmp::Reverse(*offset));
     }
+    index
 }
 
-/// True if `wm` proves the ledger file is fully consumed: its offset is the
-/// whole file AND the prefix still hashes to the recorded identity proof
-/// (round-2: position alone is not identity).
-fn is_fully_consumed(path: &Path, wm: Option<&DigestedSession>) -> bool {
-    let Some(wm) = wm else {
-        return false;
-    };
+/// True if the session is PROVABLY fully consumed: some accepted authority
+/// records a watermark whose offset is the whole current file and whose
+/// identity proof re-validates (round-2: position alone is not identity).
+///
+/// Exactly two authorities can say "consumed" (round-3 P1-2):
+///
+/// * a stamped digest note in the workspace ledger — the sole authority
+///   for note-backed watermarks. A surviving cache entry can NEVER claim
+///   one: the round-3 reproduction (note-backed cache at EOF + rolled-back
+///   ledger) suppressed a live Edit prefix precisely because the cache was
+///   verified against the session file but never against the ledger.
+/// * a `zero_call` cache watermark. THE FAST-PATH SKIP CONDITION, stated:
+///   skipping the ledger scan could only be wrong if some ledger state
+///   would change the answer — but this watermark's claim ("the
+///   proof-validated bytes contain no tool calls and no failures") is a
+///   pure function of those bytes, so re-reading them under ANY ledger
+///   state (note present, absent, or rolled back) yields the same no-op.
+///   Skipping therefore cannot change the answer. This is the only skip of
+///   its kind; the condition is proven by the test
+///   `zero_call_cache_skip_is_provable_and_loses_no_content`.
+fn is_fully_consumed(
+    path: &Path,
+    stamped: &[(u64, String, String)],
+    cache: Option<&DigestedSession>,
+) -> bool {
     let Ok(meta) = std::fs::metadata(path) else {
         return false;
     };
-    if meta.len() != wm.offset {
-        return false;
+    let len = meta.len();
+    // Ledger authority: a stamped note covering the whole current file.
+    if stamped
+        .iter()
+        .any(|(offset, hash, _)| *offset == len && watermark_matches(path, *offset, hash))
+    {
+        return true;
     }
-    watermark_matches(path, wm.offset, &wm.prefix_hash)
+    // The provable content-free skip (see doc comment).
+    if let Some(entry) = cache {
+        if entry.zero_call
+            && entry.offset == len
+            && watermark_matches(path, entry.offset, &entry.prefix_hash)
+        {
+            return true;
+        }
+    }
+    false
 }
 
 /// Find session ledger files in the store, excluding the current session.
@@ -290,6 +321,7 @@ fn find_pending_sessions(
     project_id: &str,
     current_session_id: &str,
     state: &DigestState,
+    ledger: Option<&edda_ledger::Ledger>,
 ) -> Vec<String> {
     let ledger_dir = edda_store::project_dir(project_id).join("ledger");
     let entries = match std::fs::read_dir(&ledger_dir) {
@@ -298,6 +330,10 @@ fn find_pending_sessions(
     };
 
     let mut sessions = Vec::new();
+    // The authoritative stamped watermarks (round-3 P1-2). When no ledger
+    // is available nothing is note-backed-confirmable, so only the provable
+    // zero-call skip in `is_fully_consumed` may suppress.
+    let stamped_index = ledger.map(stamped_watermark_index);
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
         if !name.ends_with(".jsonl") {
@@ -308,12 +344,20 @@ fn find_pending_sessions(
         if session_id == current_session_id {
             continue;
         }
-        // Skip only sessions whose watermark PROVES full consumption
+        // Skip only sessions whose consumption is PROVEN: a stamped note
+        // in the workspace ledger (the sole authority for note-backed
+        // watermarks) or a provably content-free zero-call watermark
         // (round-2: position alone is not identity — a replaced or
         // rewritten ledger re-opens the digest from zero, and a grown one
-        // is picked up as a delta).
+        // is picked up as a delta; round-3: a cache entry without its
+        // ledger note can never suppress).
         let path = ledger_dir.join(&name);
-        if is_fully_consumed(&path, state.sessions.get(&session_id)) {
+        let stamped: &[(u64, String, String)] = stamped_index
+            .as_ref()
+            .and_then(|m| m.get(&session_id))
+            .map(|v| v.as_slice())
+            .unwrap_or(&[]);
+        if is_fully_consumed(&path, stamped, state.sessions.get(&session_id)) {
             continue;
         }
         sessions.push(session_id);
@@ -402,8 +446,17 @@ pub fn digest_previous_sessions_with_opts(
         return DigestResult::PermanentFailure(warning);
     }
 
+    // The pending scan is ledger-authoritative when the workspace ledger
+    // can be opened (round-3 P1-2): a session may only be skipped on a
+    // stamped ledger note or a provably content-free zero-call watermark.
+    // When no ledger is reachable nothing is note-backed-confirmable, so
+    // nothing note-backed may suppress — pending sessions fall through to
+    // digest_one_session, which reports the unreachable workspace honestly.
+    let ledger = edda_ledger::EddaPaths::find_root(Path::new(cwd))
+        .and_then(|root| edda_ledger::Ledger::open(&root).ok());
+
     // Find sessions to digest
-    let pending = find_pending_sessions(project_id, current_session_id, &state);
+    let pending = find_pending_sessions(project_id, current_session_id, &state, ledger.as_ref());
     if pending.is_empty() {
         // Check if there's a retry pending
         if !state.pending_session_id.is_empty() && state.retry_count > 0 {
@@ -620,18 +673,22 @@ fn digest_one_session(
     };
 
     let prev = state.sessions.get(session_id).cloned();
-    // Effective watermark: validated cache entry and/or the session's own
-    // digest notes in the ledger, highest validated offset wins (round-2:
-    // identity proof + ledger-authoritative recovery).
-    let eff = effective_watermark(&ledger, session_id, &session_ledger_path, prev.as_ref());
+    // Effective watermark: the session's own stamped digest notes in the
+    // LEDGER, highest validated offset wins (round-3 P1-2: the ledger is
+    // the sole authority — the cache is an unverified hint and cannot set
+    // the start offset).
+    let eff = effective_watermark(&ledger, session_id, &session_ledger_path);
     let start = eff.as_ref().map_or(0, |w| w.offset);
 
     // Extract the delta: everything after the last digested offset, up to
-    // the last complete line. A truncated or concurrently-written final line
-    // is not consumed (round-1 P0-2) — it is picked up once its write
-    // completes, and the source is never destroyed either way.
-    let (mut stats, consumed) = match extract_stats_from(&session_ledger_path, start) {
-        Ok(r) => r,
+    // the last complete line, plus the identity proof of the consumed
+    // prefix derived from the SAME single read (round-3 P1-1: the note's
+    // content and its proof cannot come from different reads). A truncated
+    // or concurrently-written final line is not consumed (round-1 P0-2) —
+    // it is picked up once its write completes, and the source is never
+    // destroyed either way.
+    let delta = match extract_stats_delta(&session_ledger_path, start) {
+        Ok(d) => d,
         Err(e) => {
             record_failure(
                 project_id,
@@ -642,6 +699,9 @@ fn digest_one_session(
             return DigestResult::Error(format!("extraction failed: {e}"));
         }
     };
+    let mut stats = delta.stats;
+    let consumed = delta.consumed;
+    let proof = delta.prefix_hash;
 
     if consumed <= start {
         // No new complete lines since the last digest. Repair the cache
@@ -649,13 +709,32 @@ fn digest_one_session(
         // crash between note-append and cache-save, the ledger note is the
         // watermark and the retry must be a no-op, not a duplicate).
         if let Some(w) = &eff {
+            // The cache is current if it mirrors the ledger note, or if it
+            // is a zero-call watermark at or ahead of the note with a
+            // valid proof — a content-free advance the ledger intentionally
+            // does not record, and "repairing" it would undo the zero-call
+            // skip and re-scan the same tail on every hook (round-3 P1-2).
+            // Only a cache BEHIND the ledger needs repair.
             let cache_current = prev.as_ref().is_some_and(|c| {
-                c.offset == w.offset && c.prefix_hash == w.prefix_hash && c.event_id == w.event_id
+                (!c.zero_call
+                    && c.offset == w.offset
+                    && c.prefix_hash == w.prefix_hash
+                    && c.event_id == w.event_id)
+                    || (c.zero_call
+                        && c.offset >= w.offset
+                        && watermark_matches(&session_ledger_path, c.offset, &c.prefix_hash))
             });
             if !cache_current {
                 state.session_id = session_id.to_string();
                 state.digested_at = now_rfc3339();
-                remember_digested(state, session_id, &w.event_id, w.offset, &w.prefix_hash);
+                remember_digested(
+                    state,
+                    session_id,
+                    &w.event_id,
+                    w.offset,
+                    &w.prefix_hash,
+                    false,
+                );
                 if let Err(e) = save_digest_state(project_id, state) {
                     tracing::warn!(error = %e, session = %session_id,
                         "watermark cache repair failed; the ledger note remains authoritative");
@@ -672,20 +751,10 @@ fn digest_one_session(
     // watermark is still recorded so the same delta is never rescanned.
     if stats.tool_calls == 0 && stats.tool_failures == 0 {
         let prev_event_id = eff.as_ref().map_or(String::new(), |w| w.event_id.clone());
-        let proof = match hash_prefix(&session_ledger_path, consumed) {
-            Ok(p) => p,
-            Err(e) => {
-                record_failure(
-                    project_id,
-                    session_id,
-                    state,
-                    &format!("cannot hash consumed prefix: {e}"),
-                );
-                return DigestResult::Error(format!("cannot hash consumed prefix: {e}"));
-            }
-        };
+        // The proof comes from the same single read as the stats (round-3
+        // P1-1) — no separate hash of the path.
         state.session_id = session_id.to_string();
-        remember_digested(state, session_id, &prev_event_id, consumed, &proof);
+        remember_digested(state, session_id, &prev_event_id, consumed, &proof, true);
         state.digested_at = now_rfc3339();
         state.retry_count = 0;
         state.pending_session_id = String::new();
@@ -717,19 +786,8 @@ fn digest_one_session(
     let (decisions, notes) = collect_session_ledger_extras(cwd, stats.first_ts.as_deref());
 
     // Identity proof of the consumed prefix: stamped into the note so the
-    // ledger itself is the durable idempotency record (round-2).
-    let proof = match hash_prefix(&session_ledger_path, consumed) {
-        Ok(p) => p,
-        Err(e) => {
-            record_failure(
-                project_id,
-                session_id,
-                state,
-                &format!("cannot hash consumed prefix: {e}"),
-            );
-            return DigestResult::Error(format!("cannot hash consumed prefix: {e}"));
-        }
-    };
+    // ledger itself is the durable idempotency record (round-2), derived
+    // from the same single read as the stats (round-3 P1-1).
     let watermark = super::DigestWatermark {
         offset: consumed,
         prefix_hash: proof.clone(),
@@ -777,7 +835,7 @@ fn digest_one_session(
     state.session_id = session_id.to_string();
     state.event_id = last_event_id.clone();
     state.digested_at = now_rfc3339();
-    remember_digested(state, session_id, &last_event_id, consumed, &proof);
+    remember_digested(state, session_id, &last_event_id, consumed, &proof, false);
     state.retry_count = 0;
     state.pending_session_id = String::new();
     state.last_error = String::new();
@@ -892,15 +950,21 @@ pub fn digest_session_manual(
     // stale maps and drop each other's entries.
     let mut state = load_digest_state(project_id);
     let prev = state.sessions.get(session_id).cloned();
-    // Effective watermark: validated cache entry and/or the session's own
-    // stamped digest notes in the ledger, highest validated offset wins
-    // (round-2: identity proof + ledger-authoritative recovery).
-    let eff = effective_watermark(&ledger, session_id, &session_ledger_path, prev.as_ref());
+    // Effective watermark: the session's own stamped digest notes in the
+    // LEDGER, highest validated offset wins (round-3 P1-2: the ledger is
+    // the sole authority — the cache is an unverified hint and cannot set
+    // the start offset).
+    let eff = effective_watermark(&ledger, session_id, &session_ledger_path);
     let start = eff.as_ref().map_or(0, |w| w.offset);
 
-    // Delta extraction: only complete lines after the last digested offset
-    // are consumed (round-1 P0-2); the source is never modified.
-    let (mut stats, consumed) = extract_stats_from(&session_ledger_path, start)?;
+    // Delta extraction plus the identity proof of the consumed prefix,
+    // derived from the SAME single read (round-3 P1-1): only complete
+    // lines after the last digested offset are consumed (round-1 P0-2);
+    // the source is never modified.
+    let delta = extract_stats_delta(&session_ledger_path, start)?;
+    let mut stats = delta.stats;
+    let consumed = delta.consumed;
+    let proof = delta.prefix_hash;
 
     if consumed <= start {
         // Nothing new since the last digest: no-op. Repair the cache if it
@@ -909,8 +973,20 @@ pub fn digest_session_manual(
         // watermark and the retry must be a no-op, not a duplicate), then
         // return this session's own event id (round-1 P1-4).
         if let Some(w) = &eff {
+            // The cache is current if it mirrors the ledger note, or if it
+            // is a zero-call watermark at or ahead of the note with a
+            // valid proof — a content-free advance the ledger intentionally
+            // does not record, and "repairing" it would undo the zero-call
+            // skip and re-scan the same tail on every hook (round-3 P1-2).
+            // Only a cache BEHIND the ledger needs repair.
             let cache_current = prev.as_ref().is_some_and(|c| {
-                c.offset == w.offset && c.prefix_hash == w.prefix_hash && c.event_id == w.event_id
+                (!c.zero_call
+                    && c.offset == w.offset
+                    && c.prefix_hash == w.prefix_hash
+                    && c.event_id == w.event_id)
+                    || (c.zero_call
+                        && c.offset >= w.offset
+                        && watermark_matches(&session_ledger_path, c.offset, &c.prefix_hash))
             });
             if !cache_current {
                 state.session_id = session_id.to_string();
@@ -921,6 +997,7 @@ pub fn digest_session_manual(
                     &w.event_id,
                     w.offset,
                     &w.prefix_hash,
+                    false,
                 );
                 state.retry_count = 0;
                 state.pending_session_id = String::new();
@@ -940,9 +1017,17 @@ pub fn digest_session_manual(
     // digests as its own delta.
     if stats.tool_calls == 0 && stats.tool_failures == 0 {
         let prev_event_id = eff.as_ref().map_or(String::new(), |w| w.event_id.clone());
-        let proof = hash_prefix(&session_ledger_path, consumed)?;
+        // The proof comes from the same single read as the stats (round-3
+        // P1-1) — no separate hash of the path.
         state.session_id = session_id.to_string();
-        remember_digested(&mut state, session_id, &prev_event_id, consumed, &proof);
+        remember_digested(
+            &mut state,
+            session_id,
+            &prev_event_id,
+            consumed,
+            &proof,
+            true,
+        );
         state.digested_at = now_rfc3339();
         state.retry_count = 0;
         state.pending_session_id = String::new();
@@ -958,8 +1043,8 @@ pub fn digest_session_manual(
     let (_decisions, notes) = collect_session_ledger_extras(cwd, stats.first_ts.as_deref());
 
     // Identity proof of the consumed prefix, stamped into the note so the
-    // ledger itself is the durable idempotency record (round-2).
-    let proof = hash_prefix(&session_ledger_path, consumed)?;
+    // ledger itself is the durable idempotency record (round-2), derived
+    // from the same single read as the stats (round-3 P1-1).
     let watermark = super::DigestWatermark {
         offset: consumed,
         prefix_hash: proof.clone(),
@@ -985,7 +1070,14 @@ pub fn digest_session_manual(
     state.session_id = session_id.to_string();
     state.event_id = event.event_id.clone();
     state.digested_at = now_rfc3339();
-    remember_digested(&mut state, session_id, &event.event_id, consumed, &proof);
+    remember_digested(
+        &mut state,
+        session_id,
+        &event.event_id,
+        consumed,
+        &proof,
+        false,
+    );
     state.retry_count = 0;
     state.pending_session_id = String::new();
     state.last_error = String::new();
@@ -1031,6 +1123,13 @@ pub fn digest_session_manual(
 /// A session counts as pending if it was never digested, or if new content
 /// appeared after its watermark (CLI `--all` is the top-up path for a
 /// long-lived session whose delta was digested by the bridges).
+///
+/// The CLI listing has no workspace-ledger handle, so nothing is
+/// note-backed-confirmable here (round-3 P1-2): only the provably
+/// content-free zero-call skip may suppress. Note-backed sessions may be
+/// listed; each is then resolved by `digest_session_manual`, which is
+/// ledger-authoritative and no-ops them — over-listing costs a scan,
+/// never a skipped session.
 pub fn find_all_pending_sessions(project_id: &str) -> Vec<String> {
     let state = load_digest_state(project_id);
     let ledger_dir = edda_store::project_dir(project_id).join("ledger");
@@ -1046,11 +1145,14 @@ pub fn find_all_pending_sessions(project_id: &str) -> Vec<String> {
             continue;
         }
         let session_id = name.trim_end_matches(".jsonl").to_string();
-        // Already digested — but only if the watermark PROVES full
-        // consumption of the current file (round-2: position alone is not
-        // identity; a replaced or rewritten ledger re-opens from zero).
+        // Already digested — but only if consumption is PROVEN: a stamped
+        // note in the workspace ledger (sole authority for note-backed
+        // watermarks; unavailable here, see doc comment) or a provably
+        // content-free zero-call watermark (round-2: position alone is not
+        // identity; round-3: a cache entry without its ledger note can
+        // never suppress).
         let path = ledger_dir.join(&name);
-        if is_fully_consumed(&path, state.sessions.get(&session_id)) {
+        if is_fully_consumed(&path, &[], state.sessions.get(&session_id)) {
             continue;
         }
         sessions.push(session_id);

--- a/crates/edda-bridge-claude/src/digest/orchestrate.rs
+++ b/crates/edda-bridge-claude/src/digest/orchestrate.rs
@@ -33,7 +33,17 @@ pub struct DigestState {
     /// Last failure message.
     #[serde(default)]
     pub last_error: String,
+    /// Session ids already digested (bounded memory of recent ids).
+    ///
+    /// GH-578: the single `session_id` slot could not remember more than one
+    /// digested session, so an already-digested session re-entered the
+    /// pending list whenever the slot moved on and was re-digested.
+    #[serde(default)]
+    pub digested: Vec<String>,
 }
+
+/// How many recently digested session ids to remember for idempotency.
+const MAX_REMEMBERED_DIGESTS: usize = 64;
 
 /// Load the digest state from the per-user store.
 pub fn load_digest_state(project_id: &str) -> DigestState {
@@ -55,6 +65,28 @@ fn digest_state_path(project_id: &str) -> std::path::PathBuf {
     edda_store::project_dir(project_id)
         .join("state")
         .join("last_digested_session.json")
+}
+
+/// Whether this session already has a digest event in the workspace ledger.
+///
+/// Read on both the auto and the manual digest path so the same session is
+/// never digested twice (GH-578).
+pub fn already_digested_session(project_id: &str, session_id: &str) -> bool {
+    load_digest_state(project_id)
+        .digested
+        .iter()
+        .any(|s| s == session_id)
+}
+
+/// Record a session as digested (bounded, deduplicated).
+fn remember_digested(state: &mut DigestState, session_id: &str) {
+    if !state.digested.iter().any(|s| s == session_id) {
+        state.digested.push(session_id.to_string());
+        if state.digested.len() > MAX_REMEMBERED_DIGESTS {
+            let overflow = state.digested.len() - MAX_REMEMBERED_DIGESTS;
+            state.digested.drain(0..overflow);
+        }
+    }
 }
 
 /// Find session ledger files in the store, excluding the current session.
@@ -80,8 +112,8 @@ fn find_pending_sessions(
         if session_id == current_session_id {
             continue;
         }
-        // Skip already-digested session
-        if session_id == state.session_id {
+        // Skip already-digested sessions (GH-578: full set, not just the last one)
+        if session_id == state.session_id || state.digested.iter().any(|s| s == &session_id) {
             continue;
         }
         sessions.push(session_id);
@@ -325,6 +357,12 @@ fn digest_one_session(
     digest_failed_cmds: bool,
     state: &mut DigestState,
 ) -> DigestResult {
+    // Idempotency guard (GH-578): never digest a session twice, including
+    // via the retry path which bypasses find_pending_sessions.
+    if already_digested_session(project_id, session_id) {
+        return DigestResult::NoPending;
+    }
+
     // Build session ledger path
     let session_ledger_path = edda_store::project_dir(project_id)
         .join("ledger")
@@ -395,10 +433,14 @@ fn digest_one_session(
         }
     };
 
-    // Skip empty sessions (only SessionStart, no actual work)
-    if stats.tool_calls == 0 && stats.tool_failures == 0 && stats.user_prompts == 0 {
+    // Skip sessions with no tool calls and no failures: nothing to summarize
+    // (GH-578). A chat-only or idle session produces a counts-only digest
+    // with no information value; it must not cost a ledger event. Failure-
+    // only sessions are kept: their failed commands carry information.
+    if stats.tool_calls == 0 && stats.tool_failures == 0 {
         let _ = std::fs::remove_file(&session_ledger_path);
         state.session_id = session_id.to_string();
+        remember_digested(state, session_id);
         state.digested_at = now_rfc3339();
         state.retry_count = 0;
         state.pending_session_id = String::new();
@@ -489,6 +531,7 @@ fn digest_one_session(
 
     // Update state: success
     state.session_id = session_id.to_string();
+    remember_digested(state, session_id);
     state.digested_at = now_rfc3339();
     state.event_id = last_event_id.clone();
     state.retry_count = 0;
@@ -509,16 +552,24 @@ fn digest_one_session(
 
 /// Manually digest a specific session (CLI escape hatch).
 ///
-/// Unlike `digest_previous_sessions`, this:
-/// - Does NOT check or update state tracking
-/// - Forces digest even if already digested
-/// - Returns Ok(event_id) on success
+/// Unlike `digest_previous_sessions`, this digests the named session even if
+/// it is not the next pending one. It is still idempotent (GH-578): a session
+/// that already has a digest event is not digested again, and a session with
+/// no tool calls writes no event (returns an empty event id).
 pub fn digest_session_manual(
     project_id: &str,
     session_id: &str,
     cwd: &str,
     digest_failed_cmds: bool,
 ) -> anyhow::Result<String> {
+    // Idempotency guard (GH-578): this is the path the bridge dispatchers hit
+    // on every agent_end/session_end, so it must read the digest state —
+    // previously it unconditionally re-digested, writing one event per call.
+    let mut state = load_digest_state(project_id);
+    if state.digested.iter().any(|s| s == session_id) {
+        return Ok(state.event_id);
+    }
+
     let session_ledger_path = edda_store::project_dir(project_id)
         .join("ledger")
         .join(format!("{session_id}.jsonl"));
@@ -540,6 +591,14 @@ pub fn digest_session_manual(
     let parent_hash = ledger.last_event_hash()?;
 
     let mut stats = extract_stats(&session_ledger_path)?;
+
+    // No tool calls and no failures: nothing to summarize, write no event
+    // (GH-578). Not remembered and not removed, so if real work lands later
+    // the session can still be digested with it.
+    if stats.tool_calls == 0 && stats.tool_failures == 0 {
+        return Ok(String::new());
+    }
+
     stats.tasks_snapshot = load_tasks_for_digest(project_id);
     let (_decisions, notes) = collect_session_ledger_extras(cwd, stats.first_ts.as_deref());
     let event = build_digest_event(session_id, &stats, &branch, parent_hash.as_deref(), &notes)?;
@@ -559,14 +618,19 @@ pub fn digest_session_manual(
     }
 
     // Update state to mark as digested
-    let mut state = load_digest_state(project_id);
     state.session_id = session_id.to_string();
+    remember_digested(&mut state, session_id);
     state.digested_at = now_rfc3339();
     state.event_id = last_event_id.clone();
     state.retry_count = 0;
     state.pending_session_id = String::new();
     state.last_error = String::new();
     let _ = save_digest_state(project_id, &state);
+
+    // Remove the session ledger file after successful digest, mirroring the
+    // auto path: the session data now lives in the workspace ledger's digest
+    // event, and removing the file prevents repeated re-digests (GH-578).
+    let _ = std::fs::remove_file(&session_ledger_path);
 
     Ok(last_event_id)
 }
@@ -587,8 +651,8 @@ pub fn find_all_pending_sessions(project_id: &str) -> Vec<String> {
             continue;
         }
         let session_id = name.trim_end_matches(".jsonl").to_string();
-        // Skip already-digested session
-        if session_id == state.session_id {
+        // Skip already-digested sessions (GH-578: full set, not just the last one)
+        if session_id == state.session_id || state.digested.iter().any(|s| s == &session_id) {
             continue;
         }
         sessions.push(session_id);

--- a/crates/edda-bridge-claude/src/digest/orchestrate.rs
+++ b/crates/edda-bridge-claude/src/digest/orchestrate.rs
@@ -1,10 +1,11 @@
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use edda_core::event::finalize_event;
 use edda_core::types::Provenance;
 use serde::{Deserialize, Serialize};
 
-use super::extract::{extract_stats, load_tasks_for_digest};
+use super::extract::{extract_stats_from, load_tasks_for_digest};
 use super::helpers::now_rfc3339;
 use super::prev::collect_session_ledger_extras;
 use super::render::{build_cmd_milestone_event, build_digest_event};
@@ -12,16 +13,40 @@ use super::SessionStats;
 
 // ── Auto-Digest Orchestration ──
 
+/// Per-session digest watermark (GH-578 round-1).
+///
+/// Idempotency ruling `digest.idempotency=per-session-watermark-never-delete-the-source`:
+/// the digest paths never delete the session ledger, so the watermark — not
+/// the file's disappearance — is what bounds re-digesting.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct DigestedSession {
+    /// Byte offset into the session ledger: everything strictly before this
+    /// offset has been digested. Only complete, newline-terminated lines are
+    /// ever consumed, so a truncated or concurrently-written final line is
+    /// picked up once its write completes (round-1 P0-2).
+    #[serde(default)]
+    pub offset: u64,
+    /// Event id of the latest digest event written for THIS session
+    /// (round-1 P1-4: per-session id, not one global latest id).
+    #[serde(default)]
+    pub event_id: String,
+    /// When this watermark was last advanced.
+    #[serde(default)]
+    pub digested_at: String,
+}
+
 /// State file tracking which sessions have been digested.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct DigestState {
-    /// The last session_id that was successfully digested.
+    /// The most recent session_id that was successfully digested (mirror of
+    /// the latest entry in `sessions`; kept for legacy readers).
     #[serde(default)]
     pub session_id: String,
-    /// When the digest was written.
+    /// When the latest digest was written.
     #[serde(default)]
     pub digested_at: String,
-    /// The event_id of the milestone written to workspace ledger.
+    /// Event id of the latest digest event written (any session; mirror of
+    /// the latest entry in `sessions`). Per-session ids live in `sessions`.
     #[serde(default)]
     pub event_id: String,
     /// Number of consecutive failed digest attempts for the pending session.
@@ -33,25 +58,75 @@ pub struct DigestState {
     /// Last failure message.
     #[serde(default)]
     pub last_error: String,
-    /// Session ids already digested (bounded memory of recent ids).
+    /// Per-session digested watermarks (GH-578 round-1).
     ///
-    /// GH-578: the single `session_id` slot could not remember more than one
-    /// digested session, so an already-digested session re-entered the
-    /// pending list whenever the slot moved on and was re-digested.
+    /// Replaces the previous 64-entry FIFO of session ids: a bounded FIFO
+    /// evicts the oldest id and re-opens the digest loop for a session whose
+    /// ledger still exists (round-1 P1-3). Unbounded per-session entries are
+    /// intentional — the file is small (~100 bytes per session) and written
+    /// atomically, and each entry is what makes retries of a remembered
+    /// session return that session's own event id.
     #[serde(default)]
+    pub sessions: BTreeMap<String, DigestedSession>,
+    /// Deprecated pre-watermark session ids, kept only so old state files
+    /// deserialize; migrated into `sessions` on load and never written back.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub digested: Vec<String>,
 }
-
-/// How many recently digested session ids to remember for idempotency.
-const MAX_REMEMBERED_DIGESTS: usize = 64;
 
 /// Load the digest state from the per-user store.
 pub fn load_digest_state(project_id: &str) -> DigestState {
     let path = digest_state_path(project_id);
     match std::fs::read_to_string(&path) {
-        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+        Ok(content) => {
+            let mut state: DigestState = serde_json::from_str(&content).unwrap_or_default();
+            migrate_legacy_state(project_id, &mut state);
+            state
+        }
         Err(_) => DigestState::default(),
     }
+}
+
+/// Migrate pre-watermark state into the per-session model (round-1 P1-2).
+///
+/// A pre-upgrade file records at most one digested session via
+/// `session_id`/`event_id` (and, in intermediate versions, a list of ids in
+/// the deprecated `digested` field) with no watermark. Seeding the map keeps
+/// the recorded sessions digested: the legacy model digested a session's
+/// whole file, so everything currently on disk for it is treated as already
+/// consumed; content appended afterwards is picked up as a normal delta.
+pub fn migrate_legacy_state(project_id: &str, state: &mut DigestState) {
+    if !state.sessions.is_empty() {
+        return;
+    }
+    let mut legacy_ids = state.digested.clone();
+    if !state.session_id.is_empty() && !legacy_ids.contains(&state.session_id) {
+        legacy_ids.push(state.session_id.clone());
+    }
+    if legacy_ids.is_empty() {
+        return;
+    }
+    let ledger_dir = edda_store::project_dir(project_id).join("ledger");
+    for id in legacy_ids {
+        let offset = std::fs::metadata(ledger_dir.join(format!("{id}.jsonl")))
+            .map(|m| m.len())
+            .unwrap_or(0);
+        // Only the single legacy `session_id` slot has a known event id.
+        let (event_id, digested_at) = if id == state.session_id {
+            (state.event_id.clone(), state.digested_at.clone())
+        } else {
+            (String::new(), String::new())
+        };
+        state.sessions.insert(
+            id,
+            DigestedSession {
+                offset,
+                event_id,
+                digested_at,
+            },
+        );
+    }
+    state.digested.clear();
 }
 
 /// Save the digest state to the per-user store.
@@ -67,26 +142,16 @@ fn digest_state_path(project_id: &str) -> std::path::PathBuf {
         .join("last_digested_session.json")
 }
 
-/// Whether this session already has a digest event in the workspace ledger.
-///
-/// Read on both the auto and the manual digest path so the same session is
-/// never digested twice (GH-578).
-pub fn already_digested_session(project_id: &str, session_id: &str) -> bool {
-    load_digest_state(project_id)
-        .digested
-        .iter()
-        .any(|s| s == session_id)
-}
-
-/// Record a session as digested (bounded, deduplicated).
-fn remember_digested(state: &mut DigestState, session_id: &str) {
-    if !state.digested.iter().any(|s| s == session_id) {
-        state.digested.push(session_id.to_string());
-        if state.digested.len() > MAX_REMEMBERED_DIGESTS {
-            let overflow = state.digested.len() - MAX_REMEMBERED_DIGESTS;
-            state.digested.drain(0..overflow);
-        }
-    }
+/// Record how far a session has been digested and which event id it got.
+fn remember_digested(state: &mut DigestState, session_id: &str, event_id: &str, offset: u64) {
+    state.sessions.insert(
+        session_id.to_string(),
+        DigestedSession {
+            offset,
+            event_id: event_id.to_string(),
+            digested_at: now_rfc3339(),
+        },
+    );
 }
 
 /// Find session ledger files in the store, excluding the current session.
@@ -112,8 +177,10 @@ fn find_pending_sessions(
         if session_id == current_session_id {
             continue;
         }
-        // Skip already-digested sessions (GH-578: full set, not just the last one)
-        if session_id == state.session_id || state.digested.iter().any(|s| s == &session_id) {
+        // Skip already-digested sessions (GH-578; round-1 P1-3: the
+        // per-session map is unbounded, so an entry can never be evicted
+        // back into this list while its ledger still exists).
+        if session_id == state.session_id || state.sessions.contains_key(&session_id) {
             continue;
         }
         sessions.push(session_id);
@@ -357,12 +424,6 @@ fn digest_one_session(
     digest_failed_cmds: bool,
     state: &mut DigestState,
 ) -> DigestResult {
-    // Idempotency guard (GH-578): never digest a session twice, including
-    // via the retry path which bypasses find_pending_sessions.
-    if already_digested_session(project_id, session_id) {
-        return DigestResult::NoPending;
-    }
-
     // Build session ledger path
     let session_ledger_path = edda_store::project_dir(project_id)
         .join("ledger")
@@ -404,6 +465,12 @@ fn digest_one_session(
         }
     };
 
+    // Reload the state under the workspace lock: a concurrent digest (auto on
+    // one session, manual on another) may have advanced watermarks after our
+    // pre-lock snapshot, and stale saves would drop each other's entries
+    // (round-1 P1-3). Loading here keeps the read-modify-write serialized.
+    *state = load_digest_state(project_id);
+
     // Read branch and last hash
     let branch = ledger.head_branch().unwrap_or_else(|_| "main".to_string());
     let parent_hash = match ledger.last_event_hash() {
@@ -419,9 +486,15 @@ fn digest_one_session(
         }
     };
 
-    // Extract stats
-    let mut stats = match extract_stats(&session_ledger_path) {
-        Ok(s) => s,
+    let prev = state.sessions.get(session_id).cloned();
+    let start = prev.as_ref().map_or(0, |e| e.offset);
+
+    // Extract the delta: everything after the last digested offset, up to
+    // the last complete line. A truncated or concurrently-written final line
+    // is not consumed (round-1 P0-2) — it is picked up once its write
+    // completes, and the source is never destroyed either way.
+    let (mut stats, consumed) = match extract_stats_from(&session_ledger_path, start) {
+        Ok(r) => r,
         Err(e) => {
             record_failure(
                 project_id,
@@ -433,19 +506,28 @@ fn digest_one_session(
         }
     };
 
-    // Skip sessions with no tool calls and no failures: nothing to summarize
-    // (GH-578). A chat-only or idle session produces a counts-only digest
-    // with no information value; it must not cost a ledger event. Failure-
-    // only sessions are kept: their failed commands carry information.
+    if consumed <= start {
+        // No new complete lines since the last digest.
+        return DigestResult::NoPending;
+    }
+
+    // Skip deltas with no tool calls and no failures: nothing to summarize
+    // (GH-578). A chat-only or idle delta produces a counts-only digest with
+    // no information value; it must not cost a ledger event. Failure-only
+    // deltas are kept: their failed commands carry information. The consumed
+    // watermark is still recorded so the same delta is never rescanned.
     if stats.tool_calls == 0 && stats.tool_failures == 0 {
-        let _ = std::fs::remove_file(&session_ledger_path);
+        let prev_event_id = prev.map_or(String::new(), |e| e.event_id);
         state.session_id = session_id.to_string();
-        remember_digested(state, session_id);
+        remember_digested(state, session_id, &prev_event_id, consumed);
         state.digested_at = now_rfc3339();
         state.retry_count = 0;
         state.pending_session_id = String::new();
         state.last_error = String::new();
-        let _ = save_digest_state(project_id, state);
+        if let Err(e) = save_digest_state(project_id, state) {
+            tracing::warn!(error = %e, session = %session_id,
+                "zero-call digest watermark save failed; the delta will be rescanned");
+        }
         return DigestResult::NoPending;
     }
 
@@ -496,6 +578,26 @@ fn digest_one_session(
     let mut last_event_id = event.event_id.clone();
     let mut last_hash = event.hash.clone();
 
+    // ── Durable idempotency boundary (round-1 P1-5) ──
+    // The digest note is now in the workspace ledger. Remember it BEFORE
+    // any later step (cmd milestones, passive harvest) can fail; otherwise a
+    // failed milestone append would return without remembering an
+    // already-written digest and the next call would duplicate the note.
+    state.session_id = session_id.to_string();
+    state.event_id = last_event_id.clone();
+    state.digested_at = now_rfc3339();
+    remember_digested(state, session_id, &last_event_id, consumed);
+    state.retry_count = 0;
+    state.pending_session_id = String::new();
+    state.last_error = String::new();
+    if let Err(e) = save_digest_state(project_id, state) {
+        return DigestResult::Error(format!(
+            "digest note {} was appended, but saving the digest state failed: {e}. \
+             Re-running may duplicate the note.",
+            event.event_id
+        ));
+    }
+
     // Append cmd milestone events for failed commands (if enabled)
     if digest_failed_cmds && !stats.failed_cmds_detail.is_empty() {
         for failed_cmd in &stats.failed_cmds_detail {
@@ -529,47 +631,42 @@ fn digest_one_session(
         last_event_id = last_harvest_id.clone();
     }
 
-    // Update state: success
-    state.session_id = session_id.to_string();
-    remember_digested(state, session_id);
-    state.digested_at = now_rfc3339();
-    state.event_id = last_event_id.clone();
-    state.retry_count = 0;
-    state.pending_session_id = String::new();
-    state.last_error = String::new();
-    let _ = save_digest_state(project_id, state);
-
-    // Remove the session ledger file after successful digest.
-    // The session data is now preserved in the workspace ledger's digest event.
-    // Removing the file prevents find_pending_sessions() from re-discovering
-    // and re-digesting this session in future SessionStart calls.
-    let _ = std::fs::remove_file(&session_ledger_path);
+    // Refresh the entry with the final event id. Best-effort: the watermark
+    // is already durable above, only the reported id changes.
+    if last_event_id != event.event_id {
+        state.event_id = last_event_id.clone();
+        if let Some(entry) = state.sessions.get_mut(session_id) {
+            entry.event_id = last_event_id.clone();
+        }
+        if let Err(e) = save_digest_state(project_id, state) {
+            tracing::warn!(error = %e, session = %session_id,
+                "final digest-state refresh failed; the digest watermark is durable");
+        }
+    }
 
     DigestResult::Written {
         event_id: last_event_id,
     }
 }
 
-/// Manually digest a specific session (CLI escape hatch).
+/// Manually digest a specific session (CLI escape hatch, and the path the
+/// openclaw/codex/cursor/hermes bridges hit on agent_end/session_end).
 ///
-/// Unlike `digest_previous_sessions`, this digests the named session even if
-/// it is not the next pending one. It is still idempotent (GH-578): a session
-/// that already has a digest event is not digested again, and a session with
-/// no tool calls writes no event (returns an empty event id).
+/// Idempotent by per-session watermark (GH-578 round-1, ruling
+/// `digest.idempotency=per-session-watermark-never-delete-the-source`):
+///
+/// * a session with no new complete lines is a no-op and returns THAT
+///   session's own digest event id (empty if it never produced one);
+/// * a session that grew digests only its delta;
+/// * a zero-call delta writes no event but still advances the watermark;
+/// * the source ledger is never deleted, so a live producer's future
+///   appends are always digestable.
 pub fn digest_session_manual(
     project_id: &str,
     session_id: &str,
     cwd: &str,
     digest_failed_cmds: bool,
 ) -> anyhow::Result<String> {
-    // Idempotency guard (GH-578): this is the path the bridge dispatchers hit
-    // on every agent_end/session_end, so it must read the digest state —
-    // previously it unconditionally re-digested, writing one event per call.
-    let mut state = load_digest_state(project_id);
-    if state.digested.iter().any(|s| s == session_id) {
-        return Ok(state.event_id);
-    }
-
     let session_ledger_path = edda_store::project_dir(project_id)
         .join("ledger")
         .join(format!("{session_id}.jsonl"));
@@ -587,22 +684,69 @@ pub fn digest_session_manual(
     let ledger = edda_ledger::Ledger::open(&root)?;
     let _lock = edda_ledger::WorkspaceLock::acquire(&ledger.paths)?;
 
+    // Load the state after acquiring the lock so the read-modify-write of
+    // the watermark map is serialized against concurrent digests
+    // (round-1 P1-3); loading before the lock let concurrent sessions save
+    // stale maps and drop each other's entries.
+    let mut state = load_digest_state(project_id);
+    let prev = state.sessions.get(session_id).cloned();
+    let start = prev.as_ref().map_or(0, |e| e.offset);
+
+    // Delta extraction: only complete lines after the last digested offset
+    // are consumed (round-1 P0-2); the source is never modified.
+    let (mut stats, consumed) = extract_stats_from(&session_ledger_path, start)?;
+
+    if consumed <= start {
+        // Nothing new since the last digest: no-op. Return this session's
+        // own event id, not the globally-latest one (round-1 P1-4).
+        return Ok(prev.map_or(String::new(), |e| e.event_id));
+    }
+
+    // Zero-call delta (GH-578): no event — there is nothing to summarize —
+    // but the consumed watermark is recorded so the same lines are never
+    // rescanned; real work appended later still digests as its own delta.
+    if stats.tool_calls == 0 && stats.tool_failures == 0 {
+        let prev_event_id = prev.map_or(String::new(), |e| e.event_id);
+        state.session_id = session_id.to_string();
+        remember_digested(&mut state, session_id, &prev_event_id, consumed);
+        state.digested_at = now_rfc3339();
+        state.retry_count = 0;
+        state.pending_session_id = String::new();
+        state.last_error = String::new();
+        save_digest_state(project_id, &state)?;
+        return Ok(prev_event_id);
+    }
+
     let branch = ledger.head_branch().unwrap_or_else(|_| "main".to_string());
     let parent_hash = ledger.last_event_hash()?;
-
-    let mut stats = extract_stats(&session_ledger_path)?;
-
-    // No tool calls and no failures: nothing to summarize, write no event
-    // (GH-578). Not remembered and not removed, so if real work lands later
-    // the session can still be digested with it.
-    if stats.tool_calls == 0 && stats.tool_failures == 0 {
-        return Ok(String::new());
-    }
 
     stats.tasks_snapshot = load_tasks_for_digest(project_id);
     let (_decisions, notes) = collect_session_ledger_extras(cwd, stats.first_ts.as_deref());
     let event = build_digest_event(session_id, &stats, &branch, parent_hash.as_deref(), &notes)?;
     ledger.append_event(&event)?;
+
+    // ── Durable idempotency boundary (round-1 P1-5) ──
+    // The digest note is now in the workspace ledger: remember it BEFORE the
+    // cmd milestones (whose appends may fail), or a later failure would
+    // return without remembering an already-written digest and the next
+    // call would duplicate the note. State-save errors are propagated
+    // instead of discarded: reporting success without a durable watermark
+    // is what let the old code claim success without the idempotency marker
+    // required by GH-578.
+    state.session_id = session_id.to_string();
+    state.event_id = event.event_id.clone();
+    state.digested_at = now_rfc3339();
+    remember_digested(&mut state, session_id, &event.event_id, consumed);
+    state.retry_count = 0;
+    state.pending_session_id = String::new();
+    state.last_error = String::new();
+    save_digest_state(project_id, &state).map_err(|e| {
+        anyhow::anyhow!(
+            "digest note {} was appended, but saving the digest state failed: {e}. \
+             Re-running may duplicate the note.",
+            event.event_id
+        )
+    })?;
 
     let mut last_event_id = event.event_id.clone();
 
@@ -615,27 +759,26 @@ pub fn digest_session_manual(
             chain_hash = Some(cmd_event.hash.clone());
             last_event_id = cmd_event.event_id.clone();
         }
+        // Refresh the entry with the final (milestone) event id. Best-effort:
+        // the watermark is already durable above, only the reported id changes.
+        state.event_id = last_event_id.clone();
+        if let Some(entry) = state.sessions.get_mut(session_id) {
+            entry.event_id = last_event_id.clone();
+        }
+        if let Err(e) = save_digest_state(project_id, &state) {
+            tracing::warn!(error = %e, session = %session_id,
+                "final digest-state refresh failed; the digest watermark is durable");
+        }
     }
-
-    // Update state to mark as digested
-    state.session_id = session_id.to_string();
-    remember_digested(&mut state, session_id);
-    state.digested_at = now_rfc3339();
-    state.event_id = last_event_id.clone();
-    state.retry_count = 0;
-    state.pending_session_id = String::new();
-    state.last_error = String::new();
-    let _ = save_digest_state(project_id, &state);
-
-    // Remove the session ledger file after successful digest, mirroring the
-    // auto path: the session data now lives in the workspace ledger's digest
-    // event, and removing the file prevents repeated re-digests (GH-578).
-    let _ = std::fs::remove_file(&session_ledger_path);
 
     Ok(last_event_id)
 }
 
 /// Find all undigested sessions in the store for the given project.
+///
+/// A session counts as pending if it was never digested, or if new content
+/// appeared after its watermark (CLI `--all` is the top-up path for a
+/// long-lived session whose delta was digested by the bridges).
 pub fn find_all_pending_sessions(project_id: &str) -> Vec<String> {
     let state = load_digest_state(project_id);
     let ledger_dir = edda_store::project_dir(project_id).join("ledger");
@@ -651,9 +794,15 @@ pub fn find_all_pending_sessions(project_id: &str) -> Vec<String> {
             continue;
         }
         let session_id = name.trim_end_matches(".jsonl").to_string();
-        // Skip already-digested sessions (GH-578: full set, not just the last one)
-        if session_id == state.session_id || state.digested.iter().any(|s| s == &session_id) {
-            continue;
+        if let Some(watermark) = state.sessions.get(&session_id) {
+            // Already digested; pending only if the file grew past it.
+            if entry
+                .metadata()
+                .map(|m| m.len() <= watermark.offset)
+                .unwrap_or(true)
+            {
+                continue;
+            }
         }
         sessions.push(session_id);
     }

--- a/crates/edda-bridge-claude/src/digest/render.rs
+++ b/crates/edda-bridge-claude/src/digest/render.rs
@@ -5,7 +5,7 @@ use edda_core::types::{Event, Provenance, Refs, SCHEMA_VERSION};
 
 use super::extract::{compute_tool_ratios, extract_stats, render_digest_text};
 use super::helpers::now_rfc3339;
-use super::{FailedCommand, SessionStats};
+use super::{DigestWatermark, FailedCommand, SessionStats};
 
 pub fn build_digest_event(
     session_id: &str,
@@ -13,6 +13,7 @@ pub fn build_digest_event(
     branch: &str,
     parent_hash: Option<&str>,
     notes: &[String],
+    watermark: Option<&DigestWatermark>,
 ) -> anyhow::Result<Event> {
     let text = render_digest_text(session_id, stats);
 
@@ -54,6 +55,20 @@ pub fn build_digest_event(
         }
     });
 
+    // Stamp the watermark into the note: the ledger itself must be able to
+    // answer "was this already digested?" (round-2, ledger-authoritative
+    // idempotency) without trusting the side state file.
+    let payload = if let Some(wm) = watermark {
+        let mut p = payload;
+        p["digest_watermark"] = serde_json::json!({
+            "offset": wm.offset,
+            "prefix_hash": wm.prefix_hash,
+        });
+        p
+    } else {
+        payload
+    };
+
     let event_id = format!("evt_{}", ulid::Ulid::new().to_string().to_lowercase());
     let ts = now_rfc3339();
 
@@ -94,7 +109,7 @@ pub fn extract_session_digest(
     parent_hash: Option<&str>,
 ) -> anyhow::Result<Event> {
     let stats = extract_stats(session_ledger_path)?;
-    build_digest_event(session_id, &stats, branch, parent_hash, &[])
+    build_digest_event(session_id, &stats, branch, parent_hash, &[], None)
 }
 
 /// Build a `cmd` milestone event for a failed Bash command.

--- a/crates/edda-bridge-claude/src/digest/tests.rs
+++ b/crates/edda-bridge-claude/src/digest/tests.rs
@@ -266,7 +266,9 @@ fn digest_duration_computed() {
     let path = write_session_ledger(tmp.path(), &lines);
     let stats = extract_stats(&path).unwrap();
 
-    assert_eq!(stats.duration_minutes, 35);
+    // A 35-minute silent gap exceeds the 30-minute idle cap (GH-578):
+    // only 30 minutes of the span counts as activity.
+    assert_eq!(stats.duration_minutes, 30);
 }
 
 #[test]
@@ -730,10 +732,12 @@ fn digest_state_round_trip() {
         retry_count: 0,
         pending_session_id: String::new(),
         last_error: String::new(),
+        digested: vec!["sess-123".to_string()],
     };
     save_digest_state(project_id, &state).unwrap();
 
     let loaded = load_digest_state(project_id);
+    assert_eq!(loaded.digested, vec!["sess-123".to_string()]);
 
     let _ = std::fs::remove_dir_all(edda_store::project_dir(project_id));
 
@@ -966,6 +970,138 @@ fn manual_digest_specific_session() {
     assert!(!events.is_empty());
     assert_eq!(events[0].event_type, "note");
     assert_eq!(events[0].payload["source"], "bridge:session_digest");
+}
+
+// ── GH-578 regression tests ──
+
+#[test]
+fn manual_digest_zero_call_session_writes_no_event() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let (workspace, project_id) = setup_digest_workspace(tmp.path());
+
+    // Session with a user prompt but no tool calls: nothing to summarize.
+    write_store_session_ledger(
+        &project_id,
+        "sess-zero-call",
+        &[make_envelope("UserPromptSubmit", "", serde_json::json!({}))],
+    );
+
+    let event_id = digest_session_manual(
+        &project_id,
+        "sess-zero-call",
+        workspace.to_str().unwrap(),
+        true,
+    )
+    .unwrap();
+    assert!(
+        event_id.is_empty(),
+        "zero-call session must not write a digest"
+    );
+
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let events = ledger.iter_events().unwrap();
+    assert_eq!(
+        events.len(),
+        0,
+        "zero-call session must not write a ledger event"
+    );
+}
+
+#[test]
+fn manual_digest_same_session_twice_writes_one_event() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let (workspace, project_id) = setup_digest_workspace(tmp.path());
+
+    write_store_session_ledger(
+        &project_id,
+        "sess-twice",
+        &[
+            make_envelope("PostToolUse", "Edit", serde_json::json!({})),
+            make_envelope("PostToolUse", "Bash", serde_json::json!({})),
+        ],
+    );
+
+    digest_session_manual(&project_id, "sess-twice", workspace.to_str().unwrap(), true).unwrap();
+    // Second call (e.g. the bridge firing again on agent_end) must be a no-op.
+    digest_session_manual(&project_id, "sess-twice", workspace.to_str().unwrap(), true).unwrap();
+
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let events = ledger.iter_events().unwrap();
+    let digests = events
+        .iter()
+        .filter(|e| e.payload["source"] == "bridge:session_digest")
+        .count();
+    assert_eq!(digests, 1, "same session must not be digested twice");
+}
+
+#[test]
+fn auto_digest_zero_call_session_writes_no_event() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let (workspace, project_id) = setup_digest_workspace(tmp.path());
+
+    // Chat-only session: 1 user prompt, 0 tool calls.
+    write_store_session_ledger(
+        &project_id,
+        "prev-chat-only",
+        &[make_envelope("UserPromptSubmit", "", serde_json::json!({}))],
+    );
+
+    let result = digest_previous_sessions_with_opts(
+        &project_id,
+        "current",
+        workspace.to_str().unwrap(),
+        2000,
+        false,
+    );
+    assert!(matches!(result, DigestResult::NoPending));
+
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let events = ledger.iter_events().unwrap();
+    assert_eq!(
+        events.len(),
+        0,
+        "zero-call session must not write a ledger event"
+    );
+}
+
+#[test]
+fn digest_duration_excludes_idle_gap() {
+    let tmp = tempfile::tempdir().unwrap();
+    let lines = vec![
+        make_envelope_at(
+            "PostToolUse",
+            "Bash",
+            "2026-02-14T10:00:00Z",
+            serde_json::json!({}),
+        ),
+        make_envelope_at(
+            "PostToolUse",
+            "Bash",
+            "2026-02-14T10:05:00Z",
+            serde_json::json!({}),
+        ),
+        // 10 idle days later, two more events one minute apart
+        make_envelope_at(
+            "PostToolUse",
+            "Bash",
+            "2026-02-24T10:05:00Z",
+            serde_json::json!({}),
+        ),
+        make_envelope_at(
+            "PostToolUse",
+            "Bash",
+            "2026-02-24T10:06:00Z",
+            serde_json::json!({}),
+        ),
+    ];
+    let path = write_session_ledger(tmp.path(), &lines);
+    let stats = extract_stats(&path).unwrap();
+
+    // 5m active + 30m idle-gap cap + 1m active = 36, not 1440*10+6
+    assert_eq!(stats.duration_minutes, 36);
 }
 
 // ── PrevDigest tests ──

--- a/crates/edda-bridge-claude/src/digest/tests.rs
+++ b/crates/edda-bridge-claude/src/digest/tests.rs
@@ -749,7 +749,6 @@ fn digest_state_round_trip() {
                 prefix_hash: String::new(),
                 event_id: "evt_abc".to_string(),
                 digested_at: "2026-02-14T10:00:00Z".to_string(),
-                zero_call: false,
             },
         )]),
         digested: Vec::new(),
@@ -2855,96 +2854,87 @@ fn rolled_back_ledger_cannot_be_suppressed_by_cache() {
     );
 }
 
-// The stated fast-path skip condition, proven: a fully-consumed
-// zero-call watermark may skip the ledger scan because its claim ("these
-// proof-validated bytes contained no tool calls and no failures") is a
-// pure function of the bytes themselves — no ledger state can make the
-// skip wrong, and content appended later is still digested.
+// Round-4 P1 (ruling
+// `digest.zero-call-sessions=re-read-every-time-no-cache-authority`):
+// a zero-call watermark is NOT a ledger-independent semantic authority.
+// The reviewer's reproduction: digest a real Edit prefix, append a
+// zero-call prompt tail, digest again so the cache legitimately advances
+// to EOF — then roll the authoritative ledger back past the Edit note
+// while preserving that cache. The cache fact described only the tail,
+// so it must not be trusted for the whole prefix: the session MUST be
+// reported pending and the Edit work MUST be re-emitted.
 #[test]
-fn zero_call_cache_skip_is_provable_and_loses_no_content() {
+fn rolled_back_ledger_with_zero_call_cache_must_re_report_and_re_emit() {
     let _env = env_guard();
     let tmp = tempfile::tempdir().unwrap();
     let (workspace, project_id) = setup_digest_workspace(tmp.path());
+    let session_id = "sess-zc-rollback";
 
     write_store_session_ledger(
         &project_id,
-        "sess-zc-proof",
+        session_id,
         &[make_envelope("PostToolUse", "Edit", serde_json::json!({}))],
     );
-    digest_session_manual(
-        &project_id,
-        "sess-zc-proof",
-        workspace.to_str().unwrap(),
-        true,
-    )
-    .unwrap();
 
-    // Zero-call tail: chat-only lines advance the watermark but write no
-    // note (GH-578: zero-call deltas must not cost a ledger event).
+    // Snapshot the workspace ledger BEFORE any digest note exists.
+    let edda_dir = workspace.join(".edda");
+    let snapshot = tmp.path().join(".edda.snapshot");
+    copy_dir_all(&edda_dir, &snapshot);
+
+    // 1. Digest the real Edit prefix: exactly one note.
+    digest_session_manual(&project_id, session_id, workspace.to_str().unwrap(), true).unwrap();
+
+    // 2. Append a zero-call (chat-only) tail and digest again: the watermark
+    //    cache advances to EOF, GH-578 still forbids a second event.
     let path = edda_store::project_dir(&project_id)
         .join("ledger")
-        .join("sess-zc-proof.jsonl");
-    let mut f = std::fs::OpenOptions::new()
-        .append(true)
-        .open(&path)
-        .unwrap();
-    for ts in ["2026-02-14T11:00:00Z", "2026-02-14T11:01:00Z"] {
-        let e = make_envelope_at("UserPromptSubmit", "", ts, serde_json::json!({}));
-        writeln!(f, "{}", serde_json::to_string(&e).unwrap()).unwrap();
+        .join(format!("{session_id}.jsonl"));
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        for ts in ["2026-02-14T11:00:00Z", "2026-02-14T11:01:00Z"] {
+            let e = make_envelope_at("UserPromptSubmit", "", ts, serde_json::json!({}));
+            writeln!(f, "{}", serde_json::to_string(&e).unwrap()).unwrap();
+        }
     }
-    drop(f);
+    digest_session_manual(&project_id, session_id, workspace.to_str().unwrap(), true).unwrap();
+    {
+        let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+        let count = ledger
+            .iter_events()
+            .unwrap()
+            .iter()
+            .filter(|e| e.payload["source"] == "bridge:session_digest")
+            .count();
+        assert_eq!(
+            count, 1,
+            "a zero-call delta must still write no event (GH-578)"
+        );
+    }
 
-    digest_session_manual(
-        &project_id,
-        "sess-zc-proof",
-        workspace.to_str().unwrap(),
-        true,
-    )
-    .unwrap();
-    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
-    let count = ledger
-        .iter_events()
-        .unwrap()
-        .iter()
-        .filter(|e| e.payload["source"] == "bridge:session_digest")
-        .count();
-    assert_eq!(count, 1, "a zero-call delta must not write an event");
+    // 3. Roll the authoritative ledger back past the Edit note. The digest
+    //    state cache lives in the per-user store, outside the workspace, so
+    //    it survives with its EOF watermark.
+    std::fs::remove_dir_all(&edda_dir).unwrap();
+    copy_dir_all(&snapshot, &edda_dir);
 
-    // The zero-call watermark (cache-only, unconfirmable by the ledger)
-    // may suppress the pending scan: skipping cannot change the answer.
+    // 4. The session MUST be reported pending — no cache fact may suppress
+    //    it, because the ledger contains no note covering the Edit.
     let pending = find_all_pending_sessions(&project_id);
     assert!(
-        !pending.contains(&"sess-zc-proof".to_string()),
-        "a fully-consumed zero-call watermark is provably content-free: skipping it cannot change the answer"
+        pending.contains(&session_id.to_string()),
+        "a zero-call cache watermark is not ledger authority: with no note in the ledger the session must be reported pending"
     );
-
-    // ...and the skip loses nothing: new real work re-opens the digest
-    // and is covered from the authoritative note.
-    let mut f = std::fs::OpenOptions::new()
-        .append(true)
-        .open(&path)
-        .unwrap();
-    let e = make_envelope_at(
-        "PostToolUse",
-        "Edit",
-        "2026-02-14T12:00:00Z",
-        serde_json::json!({}),
-    );
-    writeln!(f, "{}", serde_json::to_string(&e).unwrap()).unwrap();
-    drop(f);
-
-    let pending2 = find_all_pending_sessions(&project_id);
+    let result =
+        digest_previous_sessions(&project_id, "current", workspace.to_str().unwrap(), 2000);
     assert!(
-        pending2.contains(&"sess-zc-proof".to_string()),
-        "appended real work must re-open the digest"
+        matches!(result, DigestResult::Written { .. }),
+        "digest_previous_sessions must re-digest the session (got {result:?}), never report NoPending"
     );
-    digest_session_manual(
-        &project_id,
-        "sess-zc-proof",
-        workspace.to_str().unwrap(),
-        true,
-    )
-    .unwrap();
+
+    // 5. The Edit work must be emitted: exactly one covering note.
     let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
     let notes: Vec<_> = ledger
         .iter_events()
@@ -2952,9 +2942,84 @@ fn zero_call_cache_skip_is_provable_and_loses_no_content() {
         .into_iter()
         .filter(|e| e.payload["source"] == "bridge:session_digest")
         .collect();
-    assert_eq!(notes.len(), 2);
     assert_eq!(
-        notes[1].payload["session_stats"]["tool_call_breakdown"]["Edit"], 1,
-        "the appended Edit must be digested (the zero-call skip lost nothing)"
+        notes.len(),
+        1,
+        "the ledger had zero notes for this session; the Edit work must be re-emitted"
+    );
+    assert_eq!(
+        notes[0].payload["session_stats"]["tool_call_breakdown"]["Edit"], 1,
+        "the re-digest must cover the Edit prefix the rolled-back ledger no longer records"
+    );
+}
+
+// Round-4 P1, second probe: a HAND-EDITED state file claiming a consumed
+// prefix with the CORRECT content hash must not be able to suppress a
+// session the ledger has no note for. An unsigned mutable cache is not a
+// semantic authority.
+#[test]
+fn hand_edited_cache_with_correct_hash_cannot_suppress_unnoted_session() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let (workspace, project_id) = setup_digest_workspace(tmp.path());
+    let session_id = "sess-hand-edited";
+
+    write_store_session_ledger(
+        &project_id,
+        session_id,
+        &[make_envelope("PostToolUse", "Edit", serde_json::json!({}))],
+    );
+    let path = edda_store::project_dir(&project_id)
+        .join("ledger")
+        .join(format!("{session_id}.jsonl"));
+    let len = std::fs::metadata(&path).unwrap().len();
+    let correct_hash = hash_prefix(&path, len).unwrap();
+
+    // Hand-edit the state file: a fully-consumed watermark with the correct
+    // identity proof (and the legacy zero_call flag), but NO ledger note.
+    let state = serde_json::json!({
+        "session_id": session_id,
+        "event_id": "",
+        "sessions": {
+            session_id: {
+                "offset": len,
+                "prefix_hash": correct_hash,
+                "event_id": "",
+                "digested_at": "2026-02-14T10:00:00Z",
+                "zero_call": true,
+            }
+        },
+    });
+    let state_dir = edda_store::project_dir(&project_id).join("state");
+    std::fs::create_dir_all(&state_dir).unwrap();
+    std::fs::write(
+        state_dir.join("last_digested_session.json"),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
+
+    let pending = find_all_pending_sessions(&project_id);
+    assert!(
+        pending.contains(&session_id.to_string()),
+        "a hand-edited cache with a correct content hash is not ledger authority: the session must be reported pending"
+    );
+    let result =
+        digest_previous_sessions(&project_id, "current", workspace.to_str().unwrap(), 2000);
+    assert!(
+        matches!(result, DigestResult::Written { .. }),
+        "digest_previous_sessions must re-digest the session (got {result:?}), never report NoPending"
+    );
+
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let notes: Vec<_> = ledger
+        .iter_events()
+        .unwrap()
+        .into_iter()
+        .filter(|e| e.payload["source"] == "bridge:session_digest")
+        .collect();
+    assert_eq!(notes.len(), 1, "the Edit work must be emitted");
+    assert_eq!(
+        notes[0].payload["session_stats"]["tool_call_breakdown"]["Edit"], 1,
+        "the re-digest must cover the Edit the hand-edited cache claimed consumed"
     );
 }

--- a/crates/edda-bridge-claude/src/digest/tests.rs
+++ b/crates/edda-bridge-claude/src/digest/tests.rs
@@ -389,7 +389,7 @@ fn outcome_in_digest_payload() {
         outcome: SessionOutcome::ErrorStuck,
         ..Default::default()
     };
-    let event = build_digest_event("sess-outcome", &stats, "main", None, &[]).unwrap();
+    let event = build_digest_event("sess-outcome", &stats, "main", None, &[], None).unwrap();
     assert_eq!(
         event.payload["session_stats"]["outcome"].as_str().unwrap(),
         "error_stuck"
@@ -413,7 +413,7 @@ fn digest_tasks_snapshot_in_payload() {
         ..Default::default()
     };
 
-    let event = build_digest_event("sess-tasks", &stats, "main", None, &[]).unwrap();
+    let event = build_digest_event("sess-tasks", &stats, "main", None, &[], None).unwrap();
 
     // Check payload
     let tasks = event.payload["session_stats"]["tasks_snapshot"]
@@ -736,6 +736,7 @@ fn digest_state_round_trip() {
             "sess-123".to_string(),
             DigestedSession {
                 offset: 42,
+                prefix_hash: String::new(),
                 event_id: "evt_abc".to_string(),
                 digested_at: "2026-02-14T10:00:00Z".to_string(),
             },
@@ -1404,7 +1405,7 @@ fn digest_payload_has_recall_fields() {
         decide_count: 1,
         ..Default::default()
     };
-    let event = build_digest_event("sess-recall", &stats, "main", None, &[]).unwrap();
+    let event = build_digest_event("sess-recall", &stats, "main", None, &[], None).unwrap();
     assert_eq!(event.payload["session_stats"]["nudge_count"], 3);
     assert_eq!(event.payload["session_stats"]["decide_count"], 1);
 }
@@ -1420,7 +1421,7 @@ fn digest_event_contains_notes() {
         "Switched to JWT auth approach".to_string(),
         "Need to revisit caching strategy".to_string(),
     ];
-    let event = build_digest_event("sess-notes", &stats, "main", None, &notes).unwrap();
+    let event = build_digest_event("sess-notes", &stats, "main", None, &notes, None).unwrap();
 
     let payload_notes = event.payload["session_stats"]["notes"]
         .as_array()
@@ -1439,7 +1440,7 @@ fn digest_event_contains_notes() {
 #[test]
 fn digest_event_empty_notes_backward_compat() {
     let stats = SessionStats::default();
-    let event = build_digest_event("sess-no-notes", &stats, "main", None, &[]).unwrap();
+    let event = build_digest_event("sess-no-notes", &stats, "main", None, &[], None).unwrap();
 
     let payload_notes = event.payload["session_stats"]["notes"]
         .as_array()
@@ -1480,7 +1481,7 @@ fn digest_payload_has_signal_count() {
         signal_count: 5,
         ..Default::default()
     };
-    let event = build_digest_event("sess-signal", &stats, "main", None, &[]).unwrap();
+    let event = build_digest_event("sess-signal", &stats, "main", None, &[], None).unwrap();
     assert_eq!(event.payload["session_stats"]["signal_count"], 5);
 }
 
@@ -2078,15 +2079,18 @@ fn manual_digest_truncated_final_line_is_not_consumed_early() {
     );
 }
 
-// P1-2: a pre-upgrade state file (session_id/event_id populated, no
-// per-session model) must keep its idempotency semantics after migration.
-
+// P1-2 / round-2 ruling: legacy migration cannot prove what the legacy
+// build had consumed at the moment it wrote its state, so it must RE-READ
+// rather than seed the offset at current EOF — content appended between
+// the legacy state write and the first post-upgrade load must not be
+// swallowed.
 #[test]
-fn manual_digest_does_not_redigest_legacy_recorded_session() {
+fn legacy_migration_re_reads_appended_tail() {
     let _env = env_guard();
     let tmp = tempfile::tempdir().unwrap();
     let (workspace, project_id) = setup_digest_workspace(tmp.path());
 
+    // One tool line on disk when the legacy build digests and records state.
     write_store_session_ledger(
         &project_id,
         "sess-legacy",
@@ -2107,31 +2111,81 @@ fn manual_digest_does_not_redigest_legacy_recorded_session() {
     )
     .unwrap();
 
-    let returned = digest_session_manual(
+    // The producer appends more work AFTER the legacy state was written and
+    // BEFORE the first post-upgrade load. Migration must not treat this
+    // tail as consumed (round-2 finding 2: seeding the offset at current
+    // EOF silently discarded it).
+    let path = edda_store::project_dir(&project_id)
+        .join("ledger")
+        .join("sess-legacy.jsonl");
+    let mut f = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap();
+    let e = make_envelope_at(
+        "PostToolUse",
+        "Edit",
+        "2026-02-14T11:00:00Z",
+        serde_json::json!({}),
+    );
+    writeln!(f, "{}", serde_json::to_string(&e).unwrap()).unwrap();
+    drop(f);
+
+    digest_session_manual(
         &project_id,
         "sess-legacy",
         workspace.to_str().unwrap(),
         true,
     )
     .unwrap();
-    assert_eq!(
-        returned, "evt_legacy000000000000000000000000",
-        "a session recorded by legacy state must not be re-digested (round-1 P1-2)"
-    );
 
     let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let digests: Vec<_> = ledger
+        .iter_events()
+        .unwrap()
+        .into_iter()
+        .filter(|e| e.payload["source"] == "bridge:session_digest")
+        .collect();
     assert_eq!(
-        ledger.iter_events().unwrap().len(),
-        0,
-        "legacy-recorded session must not produce a second digest event"
+        digests.len(),
+        1,
+        "migration must re-read: the post-legacy tail must be digested (round-2 finding 2)"
+    );
+    assert_eq!(
+        digests[0].payload["session_stats"]["tool_calls"], 2,
+        "the re-read must cover the tail appended after the legacy state write"
+    );
+
+    // At-least-once, not at-least-twice: once the re-read watermark is
+    // durable, a retry is a no-op.
+    digest_session_manual(
+        &project_id,
+        "sess-legacy",
+        workspace.to_str().unwrap(),
+        true,
+    )
+    .unwrap();
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let digests: Vec<_> = ledger
+        .iter_events()
+        .unwrap()
+        .into_iter()
+        .filter(|e| e.payload["source"] == "bridge:session_digest")
+        .collect();
+    assert_eq!(
+        digests.len(),
+        1,
+        "the migration re-read happens exactly once"
     );
 }
 
-// P1-3: evicting the oldest remembered id must not resurrect the digest
-// loop for a session whose ledger still exists.
+// P1-3 (round-1 fix, re-pinned under the round-2 identity ruling): the
+// per-session map never evicts, and a legacy-listed session is re-read
+// AT MOST ONCE — after the re-read the watermark carries an identity
+// proof, so repeats cannot resurrect a digest loop.
 
 #[test]
-fn evicting_oldest_remembered_session_cannot_resurrect_a_digest() {
+fn legacy_re_read_cannot_resurrect_a_digest_loop() {
     let _env = env_guard();
     let tmp = tempfile::tempdir().unwrap();
     let (workspace, project_id) = setup_digest_workspace(tmp.path());
@@ -2146,7 +2200,7 @@ fn evicting_oldest_remembered_session_cannot_resurrect_a_digest() {
         );
     }
 
-    // Seed state remembering the first 64 sessions (the FIFO bound).
+    // Seed state remembering the first 64 sessions via the deprecated list.
     let state_dir = edda_store::project_dir(&project_id).join("state");
     std::fs::create_dir_all(&state_dir).unwrap();
     let remembered: Vec<serde_json::Value> = ids[..n - 1]
@@ -2159,10 +2213,12 @@ fn evicting_oldest_remembered_session_cannot_resurrect_a_digest() {
     )
     .unwrap();
 
-    // Digest session 65: the FIFO evicts session 1.
+    // Digest session 65.
     digest_session_manual(&project_id, &ids[64], workspace.to_str().unwrap(), true).unwrap();
 
-    // The evicted session's ledger still exists — it must not be re-digested.
+    // Legacy-listed session 1: migration cannot prove what was consumed, so
+    // the first post-upgrade digest re-reads it once — and only once.
+    digest_session_manual(&project_id, &ids[0], workspace.to_str().unwrap(), true).unwrap();
     digest_session_manual(&project_id, &ids[0], workspace.to_str().unwrap(), true).unwrap();
 
     let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
@@ -2173,8 +2229,8 @@ fn evicting_oldest_remembered_session_cannot_resurrect_a_digest() {
         .filter(|e| e.payload["session_id"] == ids[0])
         .count();
     assert_eq!(
-        count, 0,
-        "an evicted session whose ledger still exists must not be re-digested (round-1 P1-3)"
+        count, 1,
+        "a legacy-listed session is re-read at most once; repeats must be no-ops"
     );
 }
 
@@ -2320,4 +2376,218 @@ fn manual_digest_openclaw_session_writes_event() {
     let events = ledger.iter_events().unwrap();
     assert_eq!(events.len(), 1);
     assert_eq!(events[0].payload["session_stats"]["tool_calls"], 1);
+}
+
+// ── Round-2: watermark identity + ledger-authoritative idempotency ──
+// Ruling: a byte offset alone cannot identify a file (finding 1), and the
+// ledger — not the side state file — is durable truth (finding 3).
+
+// Finding 1a: a ledger replaced under the same session id must be RE-READ
+// from zero, never skipped via the stale offset.
+#[test]
+fn replaced_ledger_same_session_id_is_reread_not_skipped() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let (workspace, project_id) = setup_digest_workspace(tmp.path());
+
+    write_store_session_ledger(
+        &project_id,
+        "sess-repl",
+        &[
+            make_envelope("PostToolUse", "Edit", serde_json::json!({})),
+            make_envelope("PostToolUse", "Bash", serde_json::json!({})),
+        ],
+    );
+    let id1 =
+        digest_session_manual(&project_id, "sess-repl", workspace.to_str().unwrap(), true).unwrap();
+    assert!(!id1.is_empty());
+
+    // The ledger is replaced under the same session id: different, valid,
+    // SHORTER content. The stale offset (past EOF) must not suppress it.
+    write_store_session_ledger(
+        &project_id,
+        "sess-repl",
+        &[make_envelope("PostToolUse", "Edit", serde_json::json!({}))],
+    );
+
+    let id2 =
+        digest_session_manual(&project_id, "sess-repl", workspace.to_str().unwrap(), true).unwrap();
+    assert!(
+        !id2.is_empty() && id2 != id1,
+        "a replaced ledger must be re-read and re-digested, not skipped (round-2 finding 1)"
+    );
+
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let digests: Vec<_> = ledger
+        .iter_events()
+        .unwrap()
+        .into_iter()
+        .filter(|e| e.payload["source"] == "bridge:session_digest")
+        .collect();
+    assert_eq!(
+        digests.len(),
+        2,
+        "the replacement content must get its own digest"
+    );
+    assert_eq!(
+        digests[1].payload["session_stats"]["tool_calls"], 1,
+        "the new digest must cover the replacement content from zero"
+    );
+}
+
+// Finding 1b: a same-length in-place rewrite is invisible to a byte offset
+// and must also be caught by the identity proof.
+#[test]
+fn same_length_rewrite_is_reread_not_skipped() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let (workspace, project_id) = setup_digest_workspace(tmp.path());
+
+    write_store_session_ledger(
+        &project_id,
+        "sess-rewrite",
+        &[
+            make_envelope("PostToolUse", "Edit", serde_json::json!({})),
+            make_envelope_at(
+                "PostToolUse",
+                "Edit",
+                "2026-02-14T10:01:00Z",
+                serde_json::json!({}),
+            ),
+        ],
+    );
+    let id1 = digest_session_manual(
+        &project_id,
+        "sess-rewrite",
+        workspace.to_str().unwrap(),
+        true,
+    )
+    .unwrap();
+    assert!(!id1.is_empty());
+
+    // Rewrite in place: same byte length, different content (the second
+    // envelope's timestamp seconds digit changes 01 -> 02).
+    let path = edda_store::project_dir(&project_id)
+        .join("ledger")
+        .join("sess-rewrite.jsonl");
+    let old = std::fs::read_to_string(&path).unwrap();
+    let new = old.replacen("2026-02-14T10:01:00Z", "2026-02-14T10:02:00Z", 1);
+    assert_eq!(
+        old.len(),
+        new.len(),
+        "fixture must be a same-length rewrite"
+    );
+    std::fs::write(&path, new).unwrap();
+
+    let id2 = digest_session_manual(
+        &project_id,
+        "sess-rewrite",
+        workspace.to_str().unwrap(),
+        true,
+    )
+    .unwrap();
+    assert!(
+        !id2.is_empty() && id2 != id1,
+        "a same-length rewrite must be re-read, not skipped via the stale offset (round-2 finding 1)"
+    );
+
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let digests: Vec<_> = ledger
+        .iter_events()
+        .unwrap()
+        .into_iter()
+        .filter(|e| e.payload["source"] == "bridge:session_digest")
+        .collect();
+    assert_eq!(digests.len(), 2);
+}
+
+// Finding 3: the ledger is durable truth; the side state file is a cache.
+// A crash (or save failure) between the note append and the state save must
+// cost a re-scan on retry — never a duplicate digest note.
+#[test]
+fn lost_cache_recovered_from_ledger_without_duplicate() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let (workspace, project_id) = setup_digest_workspace(tmp.path());
+
+    write_store_session_ledger(
+        &project_id,
+        "sess-crash",
+        &[
+            make_envelope("PostToolUse", "Edit", serde_json::json!({})),
+            make_envelope("PostToolUse", "Bash", serde_json::json!({})),
+        ],
+    );
+    let id1 = digest_session_manual(&project_id, "sess-crash", workspace.to_str().unwrap(), true)
+        .unwrap();
+    assert!(!id1.is_empty());
+
+    // Simulate the crash window: the digest note is durable in the ledger,
+    // but the watermark cache save did not happen (failed/unwritable/lost).
+    let state_path = edda_store::project_dir(&project_id)
+        .join("state")
+        .join("last_digested_session.json");
+    std::fs::remove_file(&state_path).unwrap();
+
+    let id2 = digest_session_manual(&project_id, "sess-crash", workspace.to_str().unwrap(), true)
+        .unwrap();
+    assert_eq!(
+        id2, id1,
+        "the ledger note is authoritative: losing the cache must recover its id, not duplicate"
+    );
+
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let digests: Vec<_> = ledger
+        .iter_events()
+        .unwrap()
+        .into_iter()
+        .filter(|e| e.payload["source"] == "bridge:session_digest")
+        .collect();
+    assert_eq!(
+        digests.len(),
+        1,
+        "retry after cache loss must not append a second digest for the same ledger"
+    );
+
+    // The cache is repaired from the ledger on recovery.
+    let state = load_digest_state(&project_id);
+    assert_eq!(
+        state.sessions["sess-crash"].event_id, id1,
+        "recovery must repair the cache from the ledger note"
+    );
+
+    // And a growth after the crash window digests only the tail.
+    std::fs::remove_file(&state_path).unwrap();
+    let path = edda_store::project_dir(&project_id)
+        .join("ledger")
+        .join("sess-crash.jsonl");
+    let mut f = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap();
+    let e = make_envelope_at(
+        "PostToolUse",
+        "Edit",
+        "2026-02-15T10:00:00Z",
+        serde_json::json!({}),
+    );
+    writeln!(f, "{}", serde_json::to_string(&e).unwrap()).unwrap();
+    drop(f);
+
+    let id3 = digest_session_manual(&project_id, "sess-crash", workspace.to_str().unwrap(), true)
+        .unwrap();
+    assert!(!id3.is_empty() && id3 != id1);
+
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let digests: Vec<_> = ledger
+        .iter_events()
+        .unwrap()
+        .into_iter()
+        .filter(|e| e.payload["source"] == "bridge:session_digest")
+        .collect();
+    assert_eq!(digests.len(), 2);
+    assert_eq!(
+        digests[1].payload["session_stats"]["tool_calls"], 1,
+        "after cache loss plus growth, only the tail beyond the ledger note is digested"
+    );
 }

--- a/crates/edda-bridge-claude/src/digest/tests.rs
+++ b/crates/edda-bridge-claude/src/digest/tests.rs
@@ -588,13 +588,13 @@ fn digest_skips_already_digested() {
     let r1 = digest_previous_sessions(&project_id, "current", workspace.to_str().unwrap(), 2000);
     assert!(matches!(r1, DigestResult::Written { .. }));
 
-    // Session ledger file should be deleted after successful digest
+    // Round-1 P0-1: the session ledger file is NEVER deleted
     assert!(
-        !ledger_dir.join("sess-once.jsonl").exists(),
-        "session ledger file should be removed after successful digest"
+        ledger_dir.join("sess-once.jsonl").exists(),
+        "session ledger file must be kept after successful digest"
     );
 
-    // Digest again — should be NoPending (file is gone, not re-discovered)
+    // Digest again — should be NoPending (watermark covers the file)
     let r2 = digest_previous_sessions(&project_id, "current", workspace.to_str().unwrap(), 2000);
     assert!(matches!(r2, DigestResult::NoPending));
 
@@ -628,10 +628,10 @@ fn digest_no_reduplicate_across_sessions() {
         assert!(matches!(r, DigestResult::Written { .. }));
     }
 
-    // All 3 session ledger files should be removed
-    assert!(!ledger_dir.join("sess-001.jsonl").exists());
-    assert!(!ledger_dir.join("sess-002.jsonl").exists());
-    assert!(!ledger_dir.join("sess-003.jsonl").exists());
+    // Round-1 P0-1: all 3 session ledger files are kept
+    assert!(ledger_dir.join("sess-001.jsonl").exists());
+    assert!(ledger_dir.join("sess-002.jsonl").exists());
+    assert!(ledger_dir.join("sess-003.jsonl").exists());
 
     // Next call: no pending sessions
     let r = digest_previous_sessions(&project_id, "sess-B", ws, 2000);
@@ -732,12 +732,26 @@ fn digest_state_round_trip() {
         retry_count: 0,
         pending_session_id: String::new(),
         last_error: String::new(),
-        digested: vec!["sess-123".to_string()],
+        sessions: BTreeMap::from([(
+            "sess-123".to_string(),
+            DigestedSession {
+                offset: 42,
+                event_id: "evt_abc".to_string(),
+                digested_at: "2026-02-14T10:00:00Z".to_string(),
+            },
+        )]),
+        digested: Vec::new(),
     };
     save_digest_state(project_id, &state).unwrap();
 
     let loaded = load_digest_state(project_id);
-    assert_eq!(loaded.digested, vec!["sess-123".to_string()]);
+    let entry = loaded.sessions.get("sess-123").expect("sess-123 watermark");
+    assert_eq!(entry.offset, 42);
+    assert_eq!(entry.event_id, "evt_abc");
+    assert!(
+        loaded.digested.is_empty(),
+        "deprecated ids are never written"
+    );
 
     let _ = std::fs::remove_dir_all(edda_store::project_dir(project_id));
 
@@ -1023,9 +1037,17 @@ fn manual_digest_same_session_twice_writes_one_event() {
         ],
     );
 
-    digest_session_manual(&project_id, "sess-twice", workspace.to_str().unwrap(), true).unwrap();
-    // Second call (e.g. the bridge firing again on agent_end) must be a no-op.
-    digest_session_manual(&project_id, "sess-twice", workspace.to_str().unwrap(), true).unwrap();
+    let id1 = digest_session_manual(&project_id, "sess-twice", workspace.to_str().unwrap(), true)
+        .unwrap();
+    // Second call (e.g. the bridge firing again on agent_end) must be a no-op
+    // returning the same session's own event id (round-1 P1-4).
+    let id2 = digest_session_manual(&project_id, "sess-twice", workspace.to_str().unwrap(), true)
+        .unwrap();
+    assert_eq!(
+        id2, id1,
+        "retry must return the same session's own event id"
+    );
+    assert!(!id1.is_empty());
 
     let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
     let events = ledger.iter_events().unwrap();
@@ -1357,18 +1379,19 @@ fn digest_skips_empty_session() {
     let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
     assert_eq!(ledger.iter_events().unwrap().len(), 0);
 
-    // Session ledger file should be cleaned up
+    // Round-1 P0-2: the empty session's ledger file is kept, not removed
     let session_path = edda_store::project_dir(&project_id)
         .join("ledger")
         .join("sess-empty-skip.jsonl");
     assert!(
-        !session_path.exists(),
-        "empty session ledger should be removed"
+        session_path.exists(),
+        "empty session ledger must not be deleted"
     );
 
     // State should mark as processed to avoid re-processing
     let state = load_digest_state(&project_id);
     assert_eq!(state.session_id, "sess-empty-skip");
+    assert!(state.sessions.contains_key("sess-empty-skip"));
 }
 
 // ── Recall Rate tests ──
@@ -1785,4 +1808,516 @@ fn classify_chat_low_tools() {
 fn classify_unknown_no_activity() {
     let stats = SessionStats::default();
     assert_eq!(classify_activity(&stats), ActivityType::Unknown);
+}
+
+// ── PR #607 round-1 review: failing-first regression tests ──
+
+fn write_store_session_ledger_bytes(
+    project_id: &str,
+    session_id: &str,
+    chunks: &[&[u8]],
+) -> std::path::PathBuf {
+    let dir = edda_store::project_dir(project_id).join("ledger");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{session_id}.jsonl"));
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .unwrap();
+    for chunk in chunks {
+        f.write_all(chunk).unwrap();
+    }
+    path
+}
+
+// P0-1/P0-2 (dissolved by the no-deletion ruling): the digest paths must
+// never delete the session ledger. A ledger may belong to a live producer
+// (the motivating case, oc-test-3, was appended for ten days) and may end
+// in a truncated, concurrently-written final line.
+
+#[test]
+fn manual_digest_never_deletes_session_ledger() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let (workspace, project_id) = setup_digest_workspace(tmp.path());
+
+    write_store_session_ledger(
+        &project_id,
+        "sess-keep",
+        &[make_envelope("PostToolUse", "Edit", serde_json::json!({}))],
+    );
+    let path = edda_store::project_dir(&project_id)
+        .join("ledger")
+        .join("sess-keep.jsonl");
+
+    digest_session_manual(&project_id, "sess-keep", workspace.to_str().unwrap(), true).unwrap();
+
+    assert!(
+        path.exists(),
+        "manual digest must not delete the session ledger (round-1 P0-1)"
+    );
+}
+
+#[test]
+fn auto_digest_never_deletes_session_ledger() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let (workspace, project_id) = setup_digest_workspace(tmp.path());
+
+    write_store_session_ledger(
+        &project_id,
+        "sess-auto-keep",
+        &[make_envelope("PostToolUse", "Bash", serde_json::json!({}))],
+    );
+    let path = edda_store::project_dir(&project_id)
+        .join("ledger")
+        .join("sess-auto-keep.jsonl");
+
+    let result =
+        digest_previous_sessions(&project_id, "current", workspace.to_str().unwrap(), 2000);
+    assert!(matches!(result, DigestResult::Written { .. }));
+
+    assert!(
+        path.exists(),
+        "auto digest must not delete the session ledger (round-1 P0-1)"
+    );
+}
+
+#[test]
+fn auto_digest_zero_call_keeps_session_ledger() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let (workspace, project_id) = setup_digest_workspace(tmp.path());
+
+    // Chat-only session: zero tool calls, zero failures.
+    write_store_session_ledger(
+        &project_id,
+        "sess-chat-only",
+        &[make_envelope("UserPromptSubmit", "", serde_json::json!({}))],
+    );
+    let path = edda_store::project_dir(&project_id)
+        .join("ledger")
+        .join("sess-chat-only.jsonl");
+
+    let result =
+        digest_previous_sessions(&project_id, "current", workspace.to_str().unwrap(), 2000);
+    assert!(matches!(result, DigestResult::NoPending));
+
+    assert!(
+        path.exists(),
+        "zero-call auto digest must not delete the session ledger (round-1 P0-2)"
+    );
+}
+
+// P1-4: a retry of a remembered session must return THAT session's own
+// digest event id, not the globally-latest one (which belongs to B).
+
+#[test]
+fn manual_digest_retry_returns_that_sessions_own_event_id() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let (workspace, project_id) = setup_digest_workspace(tmp.path());
+
+    for sid in ["sess-aaa", "sess-bbb"] {
+        write_store_session_ledger(
+            &project_id,
+            sid,
+            &[make_envelope("PostToolUse", "Edit", serde_json::json!({}))],
+        );
+    }
+
+    let id_a =
+        digest_session_manual(&project_id, "sess-aaa", workspace.to_str().unwrap(), true).unwrap();
+    let id_b =
+        digest_session_manual(&project_id, "sess-bbb", workspace.to_str().unwrap(), true).unwrap();
+    assert_ne!(id_a, id_b);
+
+    // Retry of A (the bridge fires agent_end again): must return A's id.
+    let retry =
+        digest_session_manual(&project_id, "sess-aaa", workspace.to_str().unwrap(), true).unwrap();
+    assert_eq!(retry, id_a, "retry of A must return A's own event id");
+}
+
+// Watermark: a session that grew digests only its delta.
+
+#[test]
+fn manual_digest_grown_session_digests_only_delta() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let (workspace, project_id) = setup_digest_workspace(tmp.path());
+
+    let lines = vec![
+        make_envelope_at(
+            "PostToolUse",
+            "Edit",
+            "2026-02-14T10:00:00Z",
+            serde_json::json!({}),
+        ),
+        make_envelope_at(
+            "PostToolUse",
+            "Edit",
+            "2026-02-14T10:01:00Z",
+            serde_json::json!({}),
+        ),
+    ];
+    write_store_session_ledger(&project_id, "sess-grow", &lines);
+    let path = edda_store::project_dir(&project_id)
+        .join("ledger")
+        .join("sess-grow.jsonl");
+
+    digest_session_manual(&project_id, "sess-grow", workspace.to_str().unwrap(), true).unwrap();
+
+    // The producer appends more work later (long-lived session).
+    let mut f = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap();
+    for ts in ["2026-02-15T10:00:00Z", "2026-02-15T10:01:00Z"] {
+        let e = make_envelope_at("PostToolUse", "Edit", ts, serde_json::json!({}));
+        writeln!(f, "{}", serde_json::to_string(&e).unwrap()).unwrap();
+    }
+    drop(f);
+
+    digest_session_manual(&project_id, "sess-grow", workspace.to_str().unwrap(), true).unwrap();
+
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let events = ledger.iter_events().unwrap();
+    let digests: Vec<_> = events
+        .iter()
+        .filter(|e| e.payload["source"] == "bridge:session_digest")
+        .collect();
+    assert_eq!(digests.len(), 2, "grown session gets a second delta digest");
+    assert_eq!(
+        digests[0].payload["session_stats"]["tool_calls"], 2,
+        "first digest covers the first span"
+    );
+    assert_eq!(
+        digests[1].payload["session_stats"]["tool_calls"], 2,
+        "second digest must cover only the delta, not the whole span again"
+    );
+}
+
+// P0-2: a truncated / concurrently-written final line is not consumed and
+// not destroyed; it is digested once its write completes.
+
+#[test]
+fn manual_digest_truncated_final_line_is_not_consumed_early() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let (workspace, project_id) = setup_digest_workspace(tmp.path());
+
+    let e1 = make_envelope_at(
+        "PostToolUse",
+        "Edit",
+        "2026-02-14T10:00:00Z",
+        serde_json::json!({}),
+    );
+    let e2 = make_envelope_at(
+        "PostToolUse",
+        "Edit",
+        "2026-02-14T10:01:00Z",
+        serde_json::json!({}),
+    );
+    let e3 = make_envelope_at(
+        "PostToolUse",
+        "Edit",
+        "2026-02-14T10:02:00Z",
+        serde_json::json!({}),
+    );
+    let e3_line = serde_json::to_string(&e3).unwrap();
+
+    let mut full = Vec::new();
+    for e in [&e1, &e2] {
+        full.extend_from_slice(format!("{}\n", serde_json::to_string(e).unwrap()).as_bytes());
+    }
+    // A third line, truncated mid-write (no trailing newline).
+    let truncated_prefix: String = e3_line.chars().take(e3_line.len() / 2).collect();
+
+    let path = write_store_session_ledger_bytes(
+        &project_id,
+        "sess-trunc",
+        &[full.as_slice(), truncated_prefix.as_bytes()],
+    );
+
+    let _id = digest_session_manual(&project_id, "sess-trunc", workspace.to_str().unwrap(), true)
+        .unwrap();
+    assert!(
+        path.exists(),
+        "digest must not delete a ledger with a truncated final line (round-1 P0-2)"
+    );
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let events = ledger.iter_events().unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0].payload["session_stats"]["tool_calls"], 2,
+        "digest must cover only the complete prefix"
+    );
+
+    // The producer finishes writing the third line.
+    let tail = &e3_line[truncated_prefix.len()..];
+    let mut f = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap();
+    f.write_all(tail.as_bytes()).unwrap();
+    writeln!(f).unwrap();
+    drop(f);
+
+    digest_session_manual(&project_id, "sess-trunc", workspace.to_str().unwrap(), true).unwrap();
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let events = ledger.iter_events().unwrap();
+    let digests: Vec<_> = events
+        .iter()
+        .filter(|e| e.payload["source"] == "bridge:session_digest")
+        .collect();
+    assert_eq!(digests.len(), 2, "completed line is digested exactly once");
+    assert_eq!(
+        digests[1].payload["session_stats"]["tool_calls"], 1,
+        "second digest covers only the completed line"
+    );
+}
+
+// P1-2: a pre-upgrade state file (session_id/event_id populated, no
+// per-session model) must keep its idempotency semantics after migration.
+
+#[test]
+fn manual_digest_does_not_redigest_legacy_recorded_session() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let (workspace, project_id) = setup_digest_workspace(tmp.path());
+
+    write_store_session_ledger(
+        &project_id,
+        "sess-legacy",
+        &[make_envelope("PostToolUse", "Edit", serde_json::json!({}))],
+    );
+
+    // Legacy state shape: single session slot, no per-session map.
+    let state_dir = edda_store::project_dir(&project_id).join("state");
+    std::fs::create_dir_all(&state_dir).unwrap();
+    let legacy = serde_json::json!({
+        "session_id": "sess-legacy",
+        "digested_at": "2026-02-14T09:00:00Z",
+        "event_id": "evt_legacy000000000000000000000000"
+    });
+    std::fs::write(
+        state_dir.join("last_digested_session.json"),
+        serde_json::to_string_pretty(&legacy).unwrap(),
+    )
+    .unwrap();
+
+    let returned = digest_session_manual(
+        &project_id,
+        "sess-legacy",
+        workspace.to_str().unwrap(),
+        true,
+    )
+    .unwrap();
+    assert_eq!(
+        returned, "evt_legacy000000000000000000000000",
+        "a session recorded by legacy state must not be re-digested (round-1 P1-2)"
+    );
+
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    assert_eq!(
+        ledger.iter_events().unwrap().len(),
+        0,
+        "legacy-recorded session must not produce a second digest event"
+    );
+}
+
+// P1-3: evicting the oldest remembered id must not resurrect the digest
+// loop for a session whose ledger still exists.
+
+#[test]
+fn evicting_oldest_remembered_session_cannot_resurrect_a_digest() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let (workspace, project_id) = setup_digest_workspace(tmp.path());
+
+    let n: usize = 65;
+    let ids: Vec<String> = (1..=n).map(|i| format!("seed-{i:03}")).collect();
+    for id in &ids {
+        write_store_session_ledger(
+            &project_id,
+            id,
+            &[make_envelope("PostToolUse", "Edit", serde_json::json!({}))],
+        );
+    }
+
+    // Seed state remembering the first 64 sessions (the FIFO bound).
+    let state_dir = edda_store::project_dir(&project_id).join("state");
+    std::fs::create_dir_all(&state_dir).unwrap();
+    let remembered: Vec<serde_json::Value> = ids[..n - 1]
+        .iter()
+        .map(|id| serde_json::Value::String(id.clone()))
+        .collect();
+    std::fs::write(
+        state_dir.join("last_digested_session.json"),
+        serde_json::json!({ "digested": remembered }).to_string(),
+    )
+    .unwrap();
+
+    // Digest session 65: the FIFO evicts session 1.
+    digest_session_manual(&project_id, &ids[64], workspace.to_str().unwrap(), true).unwrap();
+
+    // The evicted session's ledger still exists — it must not be re-digested.
+    digest_session_manual(&project_id, &ids[0], workspace.to_str().unwrap(), true).unwrap();
+
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let count = ledger
+        .iter_events()
+        .unwrap()
+        .iter()
+        .filter(|e| e.payload["session_id"] == ids[0])
+        .count();
+    assert_eq!(
+        count, 0,
+        "an evicted session whose ledger still exists must not be re-digested (round-1 P1-3)"
+    );
+}
+
+// P1-1: extraction must recognize the non-Claude tool event names the
+// bridges actually persist, or real work is classified zero-call.
+
+#[test]
+fn extract_recognizes_openclaw_after_tool_call() {
+    let tmp = tempfile::tempdir().unwrap();
+    let envelope = serde_json::json!({
+        "ts": "2026-02-14T10:00:00Z",
+        "project_id": "p",
+        "session_id": "oc-1",
+        "hook_event_name": "after_tool_call",
+        "agent_id": "main",
+        "event_data": {
+            "tool_name": "bash",
+            "tool_input": { "command": "git commit -m 'feat: bridge digest'" }
+        }
+    });
+    let path = write_session_ledger(tmp.path(), &[envelope]);
+    let stats = extract_stats(&path).unwrap();
+    assert_eq!(
+        stats.tool_calls, 1,
+        "after_tool_call must count as a tool call"
+    );
+    assert_eq!(
+        stats.commits_made.len(),
+        1,
+        "tool data nested under event_data must be parsed"
+    );
+    assert_eq!(stats.commits_made[0], "feat: bridge digest");
+}
+
+#[test]
+fn extract_recognizes_openclaw_after_tool_call_failure() {
+    let tmp = tempfile::tempdir().unwrap();
+    let envelope = serde_json::json!({
+        "ts": "2026-02-14T10:00:00Z",
+        "project_id": "p",
+        "session_id": "oc-2",
+        "hook_event_name": "after_tool_call",
+        "event_data": {
+            "tool_name": "bash",
+            "tool_input": { "command": "cargo build" },
+            "error": "Exit code 101"
+        }
+    });
+    let path = write_session_ledger(tmp.path(), &[envelope]);
+    let stats = extract_stats(&path).unwrap();
+    assert_eq!(
+        stats.tool_failures, 1,
+        "a failed after_tool_call is a failure, not a call"
+    );
+    assert_eq!(stats.failed_commands, vec!["cargo build"]);
+}
+
+#[test]
+fn extract_recognizes_cursor_post_tool_use() {
+    let tmp = tempfile::tempdir().unwrap();
+    let envelope = serde_json::json!({
+        "ts": "2026-02-14T10:00:00Z",
+        "project_id": "p",
+        "session_id": "cur-1",
+        "hook_event_name": "postToolUse",
+        "cwd": "C:/work/proj",
+        "tool_name": "edit_file",
+        "tool_input": { "file_path": "src/main.rs" },
+        "bridge": "cursor"
+    });
+    let path = write_session_ledger(tmp.path(), &[envelope]);
+    let stats = extract_stats(&path).unwrap();
+    assert_eq!(stats.tool_calls, 1, "postToolUse must count as a tool call");
+    assert_eq!(stats.files_modified, vec!["src/main.rs"]);
+}
+
+#[test]
+fn extract_recognizes_hermes_post_tool_call() {
+    let tmp = tempfile::tempdir().unwrap();
+    let envelope = serde_json::json!({
+        "ts": "2026-02-14T10:00:00Z",
+        "project_id": "p",
+        "session_id": "h-1",
+        "hook_event_name": "post_tool_call",
+        "cwd": "/work/proj",
+        "tool_name": "terminal",
+        "bridge": "hermes"
+    });
+    let path = write_session_ledger(tmp.path(), &[envelope]);
+    let stats = extract_stats(&path).unwrap();
+    assert_eq!(
+        stats.tool_calls, 1,
+        "post_tool_call must count as a tool call"
+    );
+}
+
+#[test]
+fn manual_digest_openclaw_session_writes_event() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let (workspace, project_id) = setup_digest_workspace(tmp.path());
+
+    // Real OpenClaw ledger shape (bridge:dispatch persist on every event).
+    write_store_session_ledger(
+        &project_id,
+        "oc-digest-1",
+        &[
+            serde_json::json!({
+                "ts": "2026-02-14T10:00:00Z",
+                "project_id": project_id,
+                "session_id": "oc-digest-1",
+                "hook_event_name": "before_agent_start",
+                "agent_id": "main",
+                "event_data": { "prompt": "do work" }
+            }),
+            serde_json::json!({
+                "ts": "2026-02-14T10:01:00Z",
+                "project_id": project_id,
+                "session_id": "oc-digest-1",
+                "hook_event_name": "after_tool_call",
+                "agent_id": "main",
+                "event_data": {
+                    "tool_name": "bash",
+                    "tool_input": { "command": "cargo test" }
+                }
+            }),
+        ],
+    );
+
+    let event_id = digest_session_manual(
+        &project_id,
+        "oc-digest-1",
+        workspace.to_str().unwrap(),
+        true,
+    )
+    .unwrap();
+    assert!(
+        !event_id.is_empty(),
+        "a session with real OpenClaw tool activity must not be classified zero-call (round-1 P1-1)"
+    );
+
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let events = ledger.iter_events().unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].payload["session_stats"]["tool_calls"], 1);
 }

--- a/crates/edda-bridge-claude/src/digest/tests.rs
+++ b/crates/edda-bridge-claude/src/digest/tests.rs
@@ -649,8 +649,18 @@ fn digest_no_reduplicate_across_sessions() {
 #[test]
 fn digest_no_workspace_records_failure() {
     let _env = env_guard();
+    // Hermetic isolation: `find_root` climbs parents, so a bare tempdir
+    // would silently resolve to whatever workspace exists above %TEMP%
+    // (a probe scratch or the fleet coordination workspace) and the
+    // digest would write THERE. Instead, anchor the climb at this test's
+    // own directory and make the ledger deterministically unopenable:
+    // `.edda/` exists (so find_root stops here) but `ledger.db` is a
+    // directory (so SqliteStore cannot open it). The digest then reports
+    // an unreachable-ledger failure and writes nowhere.
     let tmp = tempfile::tempdir().unwrap();
-    // No workspace created — just a store
+    std::fs::create_dir_all(tmp.path().join(".edda")).unwrap();
+    std::fs::create_dir(tmp.path().join(".edda").join("ledger.db")).unwrap();
+    // Just a store, with the anchored-but-unopenable workspace as cwd
     let project_id = "fake_project_no_workspace";
     let _ = edda_store::ensure_dirs(project_id);
     // Reset state and ledger dir from previous test runs
@@ -739,6 +749,7 @@ fn digest_state_round_trip() {
                 prefix_hash: String::new(),
                 event_id: "evt_abc".to_string(),
                 digested_at: "2026-02-14T10:00:00Z".to_string(),
+                zero_call: false,
             },
         )]),
         digested: Vec::new(),
@@ -2589,5 +2600,361 @@ fn lost_cache_recovered_from_ledger_without_duplicate() {
     assert_eq!(
         digests[1].payload["session_stats"]["tool_calls"], 1,
         "after cache loss plus growth, only the tail beyond the ledger note is digested"
+    );
+}
+
+// ── Round-3: one-read proof (P1-1) + ledger-sole-authority (P1-2) ──
+// Ruling `digest.proof-and-authority=derive-from-one-read-ledger-is-sole-authority`.
+
+fn copy_dir_all(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap().flatten() {
+        let to = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_all(&entry.path(), &to);
+        } else {
+            std::fs::copy(entry.path(), to).unwrap();
+        }
+    }
+}
+
+fn big_envelope_line(tool: &str) -> String {
+    let mut s =
+        String::from("{\"ts\":\"2026-02-14T10:00:00Z\",\"project_id\":\"p\",\"session_id\":\"s\",");
+    s.push_str(&format!(
+        "\"hook_event_name\":\"PostToolUse\",\"tool_name\":\"{tool}\",\"tool_use_id\":\"\",",
+    ));
+    s.push_str(&format!(
+        "\"raw\":{{\"hook_event_name\":\"PostToolUse\",\"tool_name\":\"{tool}\"}}}}\n",
+    ));
+    s
+}
+
+#[test]
+fn digest_note_proof_and_stats_come_from_one_read() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let (workspace, project_id) = setup_digest_workspace(tmp.path());
+
+    // Same shape as the reviewer's reproduction: two same-length large
+    // ledgers, one of Edit calls, one of Bash calls.
+    let n: usize = 300_000;
+    let a_bytes = big_envelope_line("Edit").repeat(n);
+    let b_bytes = big_envelope_line("Bash").repeat(n);
+    assert_eq!(a_bytes.len(), b_bytes.len(), "fixture must be same-length");
+    let hash_a = blake3::hash(a_bytes.as_bytes()).to_hex().to_string();
+    let hash_b = blake3::hash(b_bytes.as_bytes()).to_hex().to_string();
+
+    let dir = edda_store::project_dir(&project_id).join("ledger");
+    std::fs::create_dir_all(&dir).unwrap();
+    let session_path = dir.join("sess-race.jsonl");
+    std::fs::write(&session_path, &a_bytes).unwrap();
+    let b_staging = tmp.path().join("b_version.jsonl");
+    std::fs::write(&b_staging, &b_bytes).unwrap();
+
+    // While extraction holds the file open, atomically replace the path
+    // with the same-length Bash ledger, over and over.
+    let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let swapper = {
+        let stop = std::sync::Arc::clone(&stop);
+        let session_path = session_path.clone();
+        let b_staging = b_staging.clone();
+        std::thread::spawn(move || {
+            let swap_tmp = session_path.with_extension("swap");
+            while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                std::fs::copy(&b_staging, &swap_tmp).unwrap();
+                std::fs::rename(&swap_tmp, &session_path).unwrap();
+            }
+        })
+    };
+
+    let id1 =
+        digest_session_manual(&project_id, "sess-race", workspace.to_str().unwrap(), true).unwrap();
+    assert!(!id1.is_empty());
+    stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    swapper.join().unwrap();
+
+    // The emitted note must be SELF-CONSISTENT: its stats and its
+    // prefix_hash describe the SAME bytes.
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let note1 = ledger
+        .iter_events()
+        .unwrap()
+        .into_iter()
+        .find(|e| e.event_id == id1)
+        .expect("the digest note must exist");
+    let wm_offset = note1.payload["digest_watermark"]["offset"]
+        .as_u64()
+        .unwrap();
+    let wm_hash = note1.payload["digest_watermark"]["prefix_hash"]
+        .as_str()
+        .unwrap();
+    let breakdown = &note1.payload["session_stats"]["tool_call_breakdown"];
+    let edits = breakdown["Edit"].as_u64().unwrap_or(0);
+    let bashes = breakdown["Bash"].as_u64().unwrap_or(0);
+    assert_eq!(
+        wm_offset as usize,
+        a_bytes.len(),
+        "note must claim the full read"
+    );
+    let consistent =
+        (edits == n as u64 && wm_hash == hash_a) || (bashes == n as u64 && wm_hash == hash_b);
+    assert!(
+        consistent,
+        "note stats and proof came from DIFFERENT reads: breakdown={breakdown} hash_matches_a={} hash_matches_b={}",
+        wm_hash == hash_a,
+        wm_hash == hash_b
+    );
+
+    // Settle on the Bash version and digest again: every current record
+    // must be accounted for — no silent skip. Two cases, both correct:
+    // the racy first digest read EITHER version through its single handle.
+    // If it summarized A (Edit), the retry must re-read B from zero and
+    // write a Bash note; if it already summarized B, the retry must be a
+    // no-op returning that note's id — B is fully digested, and a second
+    // note would be a duplicate, not a rescue.
+    let swap_tmp = session_path.with_extension("settle");
+    std::fs::copy(&b_staging, &swap_tmp).unwrap();
+    std::fs::rename(&swap_tmp, &session_path).unwrap();
+    let id2 =
+        digest_session_manual(&project_id, "sess-race", workspace.to_str().unwrap(), true).unwrap();
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let notes: Vec<_> = ledger
+        .iter_events()
+        .unwrap()
+        .into_iter()
+        .filter(|e| e.payload["source"] == "bridge:session_digest")
+        .collect();
+    if edits == n as u64 {
+        // First digest summarized the Edit version; the Bash version is
+        // undigested and the retry must cover it from zero.
+        let note2 = notes
+            .iter()
+            .find(|e| e.event_id == id2 && e.event_id != id1)
+            .unwrap_or_else(|| {
+                panic!(
+                    "retry after replacement wrote nothing: the current {n} Bash records were silently skipped"
+                )
+            });
+        assert_eq!(
+            note2.payload["session_stats"]["tool_call_breakdown"]["Bash"], n as u64,
+            "the current Bash records must be digested, not skipped"
+        );
+    } else {
+        // First digest already summarized the Bash version (the swap landed
+        // before its read): the retry must be a no-op returning that note's
+        // own id, with no duplicate.
+        assert_eq!(
+            notes.len(),
+            1,
+            "B is already fully digested: the retry must not duplicate"
+        );
+        assert_eq!(id2, id1, "the retry must return the covering note's id");
+    }
+}
+
+// P1-2 (round-3): the cache is an unverified hint. A preserved cache
+// watermark must not suppress a digest whose note is ABSENT from the
+// authoritative workspace ledger (rolled back / lost).
+#[test]
+fn rolled_back_ledger_cannot_be_suppressed_by_cache() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let (workspace, project_id) = setup_digest_workspace(tmp.path());
+
+    write_store_session_ledger(
+        &project_id,
+        "sess-rollback",
+        &[make_envelope("PostToolUse", "Edit", serde_json::json!({}))],
+    );
+
+    // Snapshot the workspace ledger immediately BEFORE the digest.
+    let edda_dir = workspace.join(".edda");
+    let snapshot = tmp.path().join(".edda.snapshot");
+    copy_dir_all(&edda_dir, &snapshot);
+
+    let id1 = digest_session_manual(
+        &project_id,
+        "sess-rollback",
+        workspace.to_str().unwrap(),
+        true,
+    )
+    .unwrap();
+    assert!(!id1.is_empty());
+
+    // Restore the immediately-prior valid snapshot: the stamped note is
+    // GONE from the authoritative ledger; the watermark cache survives.
+    std::fs::remove_dir_all(&edda_dir).unwrap();
+    copy_dir_all(&snapshot, &edda_dir);
+
+    let id2 = digest_session_manual(
+        &project_id,
+        "sess-rollback",
+        workspace.to_str().unwrap(),
+        true,
+    )
+    .unwrap();
+
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let notes: Vec<_> = ledger
+        .iter_events()
+        .unwrap()
+        .into_iter()
+        .filter(|e| e.payload["source"] == "bridge:session_digest")
+        .collect();
+    assert_eq!(
+        notes.len(),
+        1,
+        "the authoritative ledger had zero notes for this session; the surviving cache must not suppress the digest"
+    );
+    assert_eq!(
+        notes[0].event_id, id2,
+        "the returned event id must be a note that exists in the authoritative ledger"
+    );
+    assert_eq!(
+        notes[0].payload["session_stats"]["tool_call_breakdown"]["Edit"], 1,
+        "the re-digest must cover the Edit prefix the rolled-back note used to cover"
+    );
+
+    // After appending a Bash line, the whole content is covered — the
+    // Edit prefix must not stay permanently absent.
+    let path = edda_store::project_dir(&project_id)
+        .join("ledger")
+        .join("sess-rollback.jsonl");
+    let mut f = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap();
+    let e = make_envelope_at(
+        "PostToolUse",
+        "Bash",
+        "2026-02-14T11:00:00Z",
+        serde_json::json!({}),
+    );
+    writeln!(f, "{}", serde_json::to_string(&e).unwrap()).unwrap();
+    drop(f);
+
+    digest_session_manual(
+        &project_id,
+        "sess-rollback",
+        workspace.to_str().unwrap(),
+        true,
+    )
+    .unwrap();
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let notes: Vec<_> = ledger
+        .iter_events()
+        .unwrap()
+        .into_iter()
+        .filter(|e| e.payload["source"] == "bridge:session_digest")
+        .collect();
+    assert_eq!(notes.len(), 2, "the tail must be digested");
+    assert_eq!(
+        notes[1].payload["session_stats"]["tool_call_breakdown"]["Bash"], 1,
+        "the tail digest covers the appended Bash line"
+    );
+}
+
+// The stated fast-path skip condition, proven: a fully-consumed
+// zero-call watermark may skip the ledger scan because its claim ("these
+// proof-validated bytes contained no tool calls and no failures") is a
+// pure function of the bytes themselves — no ledger state can make the
+// skip wrong, and content appended later is still digested.
+#[test]
+fn zero_call_cache_skip_is_provable_and_loses_no_content() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let (workspace, project_id) = setup_digest_workspace(tmp.path());
+
+    write_store_session_ledger(
+        &project_id,
+        "sess-zc-proof",
+        &[make_envelope("PostToolUse", "Edit", serde_json::json!({}))],
+    );
+    digest_session_manual(
+        &project_id,
+        "sess-zc-proof",
+        workspace.to_str().unwrap(),
+        true,
+    )
+    .unwrap();
+
+    // Zero-call tail: chat-only lines advance the watermark but write no
+    // note (GH-578: zero-call deltas must not cost a ledger event).
+    let path = edda_store::project_dir(&project_id)
+        .join("ledger")
+        .join("sess-zc-proof.jsonl");
+    let mut f = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap();
+    for ts in ["2026-02-14T11:00:00Z", "2026-02-14T11:01:00Z"] {
+        let e = make_envelope_at("UserPromptSubmit", "", ts, serde_json::json!({}));
+        writeln!(f, "{}", serde_json::to_string(&e).unwrap()).unwrap();
+    }
+    drop(f);
+
+    digest_session_manual(
+        &project_id,
+        "sess-zc-proof",
+        workspace.to_str().unwrap(),
+        true,
+    )
+    .unwrap();
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let count = ledger
+        .iter_events()
+        .unwrap()
+        .iter()
+        .filter(|e| e.payload["source"] == "bridge:session_digest")
+        .count();
+    assert_eq!(count, 1, "a zero-call delta must not write an event");
+
+    // The zero-call watermark (cache-only, unconfirmable by the ledger)
+    // may suppress the pending scan: skipping cannot change the answer.
+    let pending = find_all_pending_sessions(&project_id);
+    assert!(
+        !pending.contains(&"sess-zc-proof".to_string()),
+        "a fully-consumed zero-call watermark is provably content-free: skipping it cannot change the answer"
+    );
+
+    // ...and the skip loses nothing: new real work re-opens the digest
+    // and is covered from the authoritative note.
+    let mut f = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap();
+    let e = make_envelope_at(
+        "PostToolUse",
+        "Edit",
+        "2026-02-14T12:00:00Z",
+        serde_json::json!({}),
+    );
+    writeln!(f, "{}", serde_json::to_string(&e).unwrap()).unwrap();
+    drop(f);
+
+    let pending2 = find_all_pending_sessions(&project_id);
+    assert!(
+        pending2.contains(&"sess-zc-proof".to_string()),
+        "appended real work must re-open the digest"
+    );
+    digest_session_manual(
+        &project_id,
+        "sess-zc-proof",
+        workspace.to_str().unwrap(),
+        true,
+    )
+    .unwrap();
+    let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
+    let notes: Vec<_> = ledger
+        .iter_events()
+        .unwrap()
+        .into_iter()
+        .filter(|e| e.payload["source"] == "bridge:session_digest")
+        .collect();
+    assert_eq!(notes.len(), 2);
+    assert_eq!(
+        notes[1].payload["session_stats"]["tool_call_breakdown"]["Edit"], 1,
+        "the appended Edit must be digested (the zero-call skip lost nothing)"
     );
 }


### PR DESCRIPTION
## What changed

All in `crates/edda-bridge-claude/src/digest/` (the digest render path; the issue pointed at `bg_digest.rs`, but the diagnosis below shows the real writer is the deterministic digest orchestration):

1. **`digest_session_manual` is now idempotent.** It reads the digested set from `last_digested_session.json` and returns the recorded event id instead of re-digesting. It also removes the session file after a successful digest, mirroring the auto path.
2. **`DigestState` gains a bounded `digested` set** (64 ids, `#[serde(default)]` for back-compat). Previously only a single `session_id` slot was remembered, so an already-digested session re-entered the pending list whenever the slot moved on. `find_pending_sessions`, `find_all_pending_sessions` and `digest_one_session` (including the retry path) all honor the set.
3. **Sessions with no tool calls and no failures write no digest event** on either path. Chat-only sessions produced counts-only notes with no information value. Failure-only sessions are still digested (their failed commands carry information).
4. **Duration is the session's real activity span.** Inter-event gaps longer than 30 minutes (`MAX_IDLE_GAP_SECS`) are capped as idle time instead of counting first-timestamp-until-now.

## The real cause (stated, not inferred)

The repeated digests were **not** written by `bg_digest.rs` — its `already_digested` guard works (per-session state file, verified by `idempotency_guard_works`). The repeats came from the deterministic digest path:

- The openclaw/codex/cursor/hermes bridges call `digest_session_manual` on **every** `agent_end`/`session_end` hook (`crates/edda-bridge-openclaw/src/dispatch.rs:300,319`, codex `:327`, hermes `:362,381`, cursor `:106`).
- `digest_session_manual` explicitly did *not* check or update digest state and never removed the session file.
- Evidence in the live store (project `29171131…`): `oc-test-3.jsonl` contains `agent_end` envelopes from 2026-08-22 to 09-02 (31 lines, still appending); the workspace ledger shows the same session digested at 16:45, 16:59, 17:11, 18:01, 19:05, 00:09, 01:53, 02:17, 02:23 with durations 14380m → 14405m → 14455m → 14519m → 14823m → 14927m → 14951m → **14957m**, monotonically increasing by the inter-digest interval — exactly `last_ts − first_ts` growing as each new `agent_end` appended while `first_ts` stayed at Aug 22.
- `last_digested_session.json` recorded `oc-test-3` digested at `2026-09-02T02:23:01.46Z`, matching the last event `02:23:01.43` — **the state was genuinely written; the manual path never read it.** That answers the issue's question ("state not written, or check not applied to this case?"): the check was simply absent on that path.

## doneWhen → evidence

| doneWhen | Evidence |
|---|---|
| Zero-call, nothing-to-summarize session writes no digest event | `manual_digest_zero_call_session_writes_no_event`, `auto_digest_zero_call_session_writes_no_event` — both watched failing before the fix (`zero-call session must not write a digest` / got `Written`, expected `NoPending`), passing after |
| Same session not digested twice; state written **and read** on that path | `manual_digest_same_session_twice_writes_one_event` — failing before (`left: 2, right: 1`), passing after; guard reads `DigestState.digested` on the exact path the bridges hit |
| Duration from real activity span, not start-until-now | `digest_duration_excludes_idle_gap` — failing before with `left: 14406, right: 36` (reproducing the 10-day span), passing after; `digest_duration_computed` updated (35m silent gap now capped at 30m) |
| Regression tests verified FAIL before fix | All four new tests run pre-fix; output quoted above |

## Gate receipt

- Full SHA: `70802d0914aa5eca89b49abc7146bbc060006621` (base `origin/main` = `345bee7`)
- Lane: `worker-2` (`CARGO_TARGET_DIR=%LOCALAPPDATA%\fleet-workstation\lanes\worker-2`), `CARGO_INCREMENTAL=0`
- Toolchain: rustc/cargo 1.93.1 (01f6ddf75 2026-02-11), Windows
- Gates: `cargo fmt --all --check` OK; `cargo clippy --workspace --all-targets -- -D warnings` OK; `cargo test --workspace` **47 targets, 0 failures, exit 0**
- Notes (honest record): two transient `LNK1104` relink failures on `edda_bridge_claude-…exe` (known class; artifact deleted, relinked, no new target dir). After one relink, 8 `cmd_claim` e2e tests failed once with `STATUS_DLL_NOT_FOUND` spawning the freshly relinked exe; verified environmental by re-running green with identical sources (412 passed), and full workspace re-run green. One parallel-flake `bg_scan::tests::draft_storage_roundtrip` passed in isolation and in the final full run. Unrelated pre-existing flakiness classes (runner::sequential timing, secrets_masked_in_output) not observed.

`Fixes #578`

🤖 Generated with [Claude Code](https://claude.com/claude-code)