### PR TITLE
feat(conductor): phase terminal-state notifications through edda-notify (GH-564)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,6 +893,7 @@ dependencies = [
  "async-trait",
  "edda-core",
  "edda-ledger",
+ "edda-notify",
  "edda-store",
  "regex",
  "serde",

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -6,7 +6,7 @@ use edda_conductor::agent::launcher::phase_session_id;
 use edda_conductor::check::engine::CheckEngine;
 use edda_conductor::plan::parser::load_plan;
 use edda_conductor::plan::schema::{GateKind, OnReject, Phase, Plan};
-use edda_conductor::runner::notify::StdoutNotifier;
+use edda_conductor::runner::notify::ChannelNotifier;
 use edda_conductor::runner::sequential::{run_plan, RunContext};
 use edda_conductor::state::machine::{PhaseStatus, PlanState, PlanStatus};
 use edda_conductor::state::persist::{load_state, save_state};
@@ -241,7 +241,10 @@ pub fn run(
         },
     )?;
     let engine = CheckEngine::new(cwd.clone());
-    let notifier = StdoutNotifier;
+    // GH-564 P1-1: the run notifier must deliver configured channel events —
+    // a bare StdoutNotifier silently drops every phase terminal event. With
+    // no channels configured this is behaviorally identical to stdout-only.
+    let notifier = ChannelNotifier::for_repo(&cwd);
     let mut budget = BudgetTracker::new(plan.budget_usd);
     let cancel = CancellationToken::new();
 
@@ -779,6 +782,7 @@ mod tests {
     /// every event being dropped by a bare `StdoutNotifier`.
     #[test]
     fn run_notifier_delivers_phase_terminal_to_configured_channel() {
+        use edda_conductor::runner::notify::Notifier;
         use std::io::Read;
         use std::time::Duration;
 
@@ -811,7 +815,9 @@ mod tests {
         // Dispatch finished before notify_phase_terminal returned; the local
         // webhook must have received the event.
         let (mut stream, _) = listener.accept().unwrap();
-        stream.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
         let mut request = String::new();
         let mut buf = [0u8; 8192];
         loop {

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -772,4 +772,61 @@ mod tests {
         // the model now distinguishes it from "nobody measured anything".
         assert_eq!(cost_line(0.0, true), "$0.00");
     }
+
+    /// GH-564 P1-1: `conduct run` builds its notifier through
+    /// `ChannelNotifier::for_repo`, so a `phase_terminal` channel configured
+    /// in `.edda/config.json` actually receives terminal events instead of
+    /// every event being dropped by a bare `StdoutNotifier`.
+    #[test]
+    fn run_notifier_delivers_phase_terminal_to_configured_channel() {
+        use std::io::Read;
+        use std::time::Duration;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".edda")).unwrap();
+        std::fs::write(
+            dir.path().join(".edda").join("config.json"),
+            format!(
+                r#"{{"notify_channels":[{{"type":"webhook","url":"http://127.0.0.1:{port}","events":["phase_terminal"]}}]}}"#
+            ),
+        )
+        .unwrap();
+
+        let notifier = ChannelNotifier::for_repo(dir.path());
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            notifier
+                .notify_phase_terminal(edda_notify::NotifyEvent::PhaseTerminal {
+                    plan: "gh564".into(),
+                    phase: "implement".into(),
+                    state: "Passed".into(),
+                    attempt: 1,
+                    final_output: Some("PR: https://github.com/x/y/pull/620".into()),
+                })
+                .await;
+        });
+
+        // Dispatch finished before notify_phase_terminal returned; the local
+        // webhook must have received the event.
+        let (mut stream, _) = listener.accept().unwrap();
+        stream.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
+        let mut request = String::new();
+        let mut buf = [0u8; 8192];
+        loop {
+            match stream.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => request.push_str(&String::from_utf8_lossy(&buf[..n])),
+            }
+            if request.contains("phase_terminal") {
+                break;
+            }
+        }
+        assert!(
+            request.contains("phase_terminal")
+                && request.contains("PR: https://github.com/x/y/pull/620"),
+            "configured webhook channel must receive the terminal event, got: {request}"
+        );
+    }
 }

--- a/crates/edda-conductor/Cargo.toml
+++ b/crates/edda-conductor/Cargo.toml
@@ -13,6 +13,7 @@ keywords.workspace = true
 edda-store = { path = "../edda-store", version = "0.4.0" }
 edda-core = { path = "../edda-core", version = "0.4.0" }
 edda-ledger = { path = "../edda-ledger", version = "0.4.0" }
+edda-notify = { path = "../edda-notify", version = "0.4.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/edda-conductor/src/runner/notify.rs
+++ b/crates/edda-conductor/src/runner/notify.rs
@@ -1,7 +1,20 @@
+use edda_notify::NotifyEvent;
+
 /// Notification interface for plan events.
 #[async_trait::async_trait]
 pub trait Notifier: Send + Sync {
     async fn notify(&self, message: &str);
+
+    /// GH-564: exactly one notification per phase terminal transition
+    /// (Passed / Failed / Stale / Skipped / Aborted), carrying plan / phase /
+    /// state / attempt and the agent's final output line when available.
+    ///
+    /// This is the same interface seam #545 defines — the [`Notifier`] trait
+    /// in `runner/notify.rs`, with a channel-backed implementation dispatching
+    /// through `edda_notify` — not a second mechanism. The default is a no-op
+    /// so existing implementations stay unaffected and stdout behavior is
+    /// byte-identical ([`StdoutNotifier`] keeps its default).
+    async fn notify_phase_terminal(&self, _event: NotifyEvent) {}
 }
 
 /// Prints to stdout.
@@ -14,9 +27,42 @@ impl Notifier for StdoutNotifier {
     }
 }
 
+/// GH-564/#545 seam: a [`Notifier`] backed by edda-notify channel dispatch.
+/// Plain messages fall through to the fallback notifier (stdout stays the
+/// always-on channel per #545); phase terminal events go to every configured
+/// channel whose `events` list matches `phase_terminal`. Channel selection
+/// (`NotifyConfig`, loaded from `.edda/config.json`) and wiring this into
+/// `conduct run` via flag/config is #545's remaining work — this type only
+/// provides the implementation behind that seam.
+pub struct ChannelNotifier {
+    config: edda_notify::NotifyConfig,
+    fallback: Box<dyn Notifier>,
+}
+
+impl ChannelNotifier {
+    pub fn new(config: edda_notify::NotifyConfig, fallback: Box<dyn Notifier>) -> Self {
+        Self { config, fallback }
+    }
+}
+
+#[async_trait::async_trait]
+impl Notifier for ChannelNotifier {
+    async fn notify(&self, message: &str) {
+        self.fallback.notify(message).await;
+    }
+
+    async fn notify_phase_terminal(&self, event: NotifyEvent) {
+        let config = self.config.clone();
+        // Dispatch is synchronous HTTP (bounded per channel by edda-notify's
+        // global timeout); keep it off the async executor threads.
+        let _ = tokio::task::spawn_blocking(move || edda_notify::dispatch(&config, &event)).await;
+    }
+}
+
 /// Collects messages in memory (for testing).
 pub struct CollectNotifier {
     messages: std::sync::Mutex<Vec<String>>,
+    terminal_events: std::sync::Mutex<Vec<NotifyEvent>>,
 }
 
 impl Default for CollectNotifier {
@@ -29,11 +75,17 @@ impl CollectNotifier {
     pub fn new() -> Self {
         Self {
             messages: std::sync::Mutex::new(Vec::new()),
+            terminal_events: std::sync::Mutex::new(Vec::new()),
         }
     }
 
     pub fn messages(&self) -> Vec<String> {
         self.messages.lock().unwrap().clone()
+    }
+
+    /// GH-564: phase terminal events observed by this notifier.
+    pub fn terminal_events(&self) -> Vec<NotifyEvent> {
+        self.terminal_events.lock().unwrap().clone()
     }
 }
 
@@ -41,5 +93,9 @@ impl CollectNotifier {
 impl Notifier for CollectNotifier {
     async fn notify(&self, message: &str) {
         self.messages.lock().unwrap().push(message.to_string());
+    }
+
+    async fn notify_phase_terminal(&self, event: NotifyEvent) {
+        self.terminal_events.lock().unwrap().push(event);
     }
 }

--- a/crates/edda-conductor/src/runner/notify.rs
+++ b/crates/edda-conductor/src/runner/notify.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use edda_notify::NotifyEvent;
 
 /// Notification interface for plan events.
@@ -30,10 +32,7 @@ impl Notifier for StdoutNotifier {
 /// GH-564/#545 seam: a [`Notifier`] backed by edda-notify channel dispatch.
 /// Plain messages fall through to the fallback notifier (stdout stays the
 /// always-on channel per #545); phase terminal events go to every configured
-/// channel whose `events` list matches `phase_terminal`. Channel selection
-/// (`NotifyConfig`, loaded from `.edda/config.json`) and wiring this into
-/// `conduct run` via flag/config is #545's remaining work — this type only
-/// provides the implementation behind that seam.
+/// channel whose `events` list matches `phase_terminal`.
 pub struct ChannelNotifier {
     config: edda_notify::NotifyConfig,
     fallback: Box<dyn Notifier>,
@@ -42,6 +41,19 @@ pub struct ChannelNotifier {
 impl ChannelNotifier {
     pub fn new(config: edda_notify::NotifyConfig, fallback: Box<dyn Notifier>) -> Self {
         Self { config, fallback }
+    }
+
+    /// GH-564 P1-1: build the production notifier for `conduct run`.
+    /// Loads the channel configuration from `{repo}/.edda/config.json` and
+    /// keeps stdout as the always-on fallback. With no channels configured
+    /// this behaves exactly like a bare [`StdoutNotifier`]: plain messages
+    /// print as before and terminal dispatch is a no-op over zero channels.
+    pub fn for_repo(repo_root: &Path) -> Self {
+        let paths = edda_ledger::EddaPaths::discover(repo_root);
+        Self::new(
+            edda_notify::NotifyConfig::load(&paths),
+            Box::new(StdoutNotifier),
+        )
     }
 }
 

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -23,6 +23,7 @@ use anyhow::Context;
 use anyhow::Result;
 use edda_core::VerdictPayload;
 use edda_ledger::VerdictRecord;
+use edda_notify::NotifyEvent;
 use std::path::Path;
 use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
@@ -120,6 +121,17 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                             phase_id: failed_id.clone(),
                             reason: "manually skipped (interactive)".into(),
                         });
+                        let attempt_now =
+                            state.get_phase(&failed_id).map(|p| p.attempts).unwrap_or(0);
+                        notifier
+                            .notify_phase_terminal(phase_terminal_event(
+                                &plan.name,
+                                &failed_id,
+                                "Skipped",
+                                attempt_now,
+                                None,
+                            ))
+                            .await;
                         println!("  ⊘ Skipped \"{failed_id}\"");
                         continue;
                     }
@@ -139,6 +151,17 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                                 .filter(|p| p.status == PhaseStatus::Pending)
                                 .count(),
                         });
+                        let attempt_now =
+                            state.get_phase(&failed_id).map(|p| p.attempts).unwrap_or(0);
+                        notifier
+                            .notify_phase_terminal(phase_terminal_event(
+                                &plan.name,
+                                &failed_id,
+                                "Aborted",
+                                attempt_now,
+                                None,
+                            ))
+                            .await;
                         println!("  ✗ Plan aborted.");
                         break;
                     }
@@ -260,6 +283,16 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                         &format!("Gate \"{subject}\" approved (sha {gate_sha})"),
                         &["conductor", "verdict"],
                     );
+                    let approved_ps = state.get_phase(&gated_id)?;
+                    notifier
+                        .notify_phase_terminal(phase_terminal_event(
+                            &plan.name,
+                            &gated_id,
+                            "Passed",
+                            approved_ps.attempts,
+                            None,
+                        ))
+                        .await;
                 }
                 GateVerdict::Rejected(record) => {
                     let comment = record.payload.comment.clone().unwrap_or_default();
@@ -325,6 +358,15 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                             env_retries: gate_ps.env_retries,
                             attempt_charged: true,
                         });
+                        notifier
+                            .notify_phase_terminal(phase_terminal_event(
+                                &plan.name,
+                                &gated_id,
+                                "Failed",
+                                gate_ps.attempts,
+                                None,
+                            ))
+                            .await;
                     } else {
                         // Redispatch (D3): ONE more agent turn in the SAME
                         // session — do NOT increment attempt; the rejection
@@ -423,6 +465,15 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                         env_retries: gate_ps.env_retries,
                         attempt_charged: true,
                     });
+                    notifier
+                        .notify_phase_terminal(phase_terminal_event(
+                            &plan.name,
+                            &gated_id,
+                            "Failed",
+                            gate_ps.attempts,
+                            None,
+                        ))
+                        .await;
                 }
                 GateVerdict::Cancelled => {
                     // The loop top sees the cancelled token and shuts down;
@@ -734,6 +785,7 @@ async fn fail_checking_phase(
     check_result: &CheckRunResult,
     err_override: Option<&str>,
     elapsed: Duration,
+    final_output: Option<&str>,
     notifier: &dyn Notifier,
     event_log: &mut EventLogger,
     tmux_session: Option<&TmuxSession>,
@@ -808,6 +860,15 @@ async fn fail_checking_phase(
         env_retries: ps.env_retries,
         attempt_charged,
     });
+    notifier
+        .notify_phase_terminal(phase_terminal_event(
+            plan.name.as_str(),
+            phase_id,
+            "Failed",
+            ps.attempts,
+            final_output,
+        ))
+        .await;
     handle_on_fail(
         plan,
         phase,
@@ -938,6 +999,7 @@ async fn process_phase_result(
                                 &check_result,
                                 Some(&msg),
                                 phase_start.elapsed(),
+                                final_output_line(result_text.as_deref()).as_deref(),
                                 notifier,
                                 event_log,
                                 tmux_session,
@@ -974,6 +1036,15 @@ async fn process_phase_result(
                         duration_ms: elapsed_ms,
                         cost_usd,
                     });
+                    notifier
+                        .notify_phase_terminal(phase_terminal_event(
+                            &plan.name,
+                            phase_id,
+                            "Passed",
+                            attempt,
+                            final_output_line(result_text.as_deref()).as_deref(),
+                        ))
+                        .await;
                 }
             } else {
                 fail_checking_phase(
@@ -985,6 +1056,7 @@ async fn process_phase_result(
                     &check_result,
                     None,
                     phase_start.elapsed(),
+                    final_output_line(result_text.as_deref()).as_deref(),
                     notifier,
                     event_log,
                     tmux_session,
@@ -1027,6 +1099,11 @@ async fn process_phase_result(
                 env_retries: phase_env_retries(state, phase_id),
                 attempt_charged: true,
             });
+            notifier
+                .notify_phase_terminal(phase_terminal_event(
+                    &plan.name, phase_id, "Stale", attempt, None,
+                ))
+                .await;
         }
         PhaseResult::AgentCrash { error } => {
             transition(
@@ -1063,6 +1140,11 @@ async fn process_phase_result(
                 env_retries: phase_env_retries(state, phase_id),
                 attempt_charged: true,
             });
+            notifier
+                .notify_phase_terminal(phase_terminal_event(
+                    &plan.name, phase_id, "Failed", attempt, None,
+                ))
+                .await;
             // For crash, use empty check results
             let empty_result = CheckRunResult {
                 all_passed: false,
@@ -1112,6 +1194,11 @@ async fn process_phase_result(
                 env_retries: phase_env_retries(state, phase_id),
                 attempt_charged: true,
             });
+            notifier
+                .notify_phase_terminal(phase_terminal_event(
+                    &plan.name, phase_id, "Failed", attempt, None,
+                ))
+                .await;
         }
     }
     Ok(())
@@ -1125,6 +1212,38 @@ fn phase_env_retries(state: &PlanState, phase_id: &str) -> u32 {
         .get_phase(phase_id)
         .map(|p| p.env_retries)
         .unwrap_or(0)
+}
+
+/// GH-564: build the phase terminal-state notification payload. `state` is
+/// the terminal status name ("Passed" | "Failed" | "Stale" | "Skipped" |
+/// "Aborted"); "Aborted" is plan-level and names the phase that forced the
+/// abort. `final_output` carries the agent's last output line when the
+/// transition site has one (by convention it contains the PR URL).
+fn phase_terminal_event(
+    plan_name: &str,
+    phase_id: &str,
+    state: &str,
+    attempt: u32,
+    final_output: Option<&str>,
+) -> NotifyEvent {
+    NotifyEvent::PhaseTerminal {
+        plan: plan_name.to_string(),
+        phase: phase_id.to_string(),
+        state: state.to_string(),
+        attempt,
+        final_output: final_output.map(str::to_string),
+    }
+}
+
+/// Last non-empty line of the agent's result text (GH-564: by convention it
+/// contains the PR URL).
+fn final_output_line(result_text: Option<&str>) -> Option<String> {
+    result_text?
+        .lines()
+        .rev()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .map(str::to_string)
 }
 
 async fn handle_on_fail(
@@ -1243,6 +1362,16 @@ async fn handle_on_fail(
                 phase_id: phase_id.to_string(),
                 reason: "auto-skipped by on_fail policy".into(),
             });
+            let attempt_now = state.get_phase(phase_id).map(|p| p.attempts).unwrap_or(0);
+            notifier
+                .notify_phase_terminal(phase_terminal_event(
+                    &plan.name,
+                    phase_id,
+                    "Skipped",
+                    attempt_now,
+                    None,
+                ))
+                .await;
             println!("  → Auto-skipped (on_fail: skip)");
         }
         OnFail::Abort => {
@@ -1260,6 +1389,16 @@ async fn handle_on_fail(
                     .filter(|p| p.status == PhaseStatus::Pending)
                     .count(),
             });
+            let attempt_now = state.get_phase(phase_id).map(|p| p.attempts).unwrap_or(0);
+            notifier
+                .notify_phase_terminal(phase_terminal_event(
+                    &plan.name,
+                    phase_id,
+                    "Aborted",
+                    attempt_now,
+                    None,
+                ))
+                .await;
             println!("  → Plan aborted (on_fail: abort)");
         }
         OnFail::Ask => {
@@ -1466,7 +1605,10 @@ pub(crate) mod tests {
     use crate::plan::parser::parse_plan;
     use crate::runner::notify::CollectNotifier;
 
-    async fn run_test_plan(yaml: &str, launcher: &dyn AgentLauncher) -> (PlanState, Vec<String>) {
+    async fn run_test_plan_notifier(
+        yaml: &str,
+        launcher: &dyn AgentLauncher,
+    ) -> (PlanState, CollectNotifier) {
         let plan = parse_plan(yaml).unwrap();
         let dir = tempfile::tempdir().unwrap();
         let mut state = PlanState::from_plan(&plan, "test.yaml");
@@ -1493,8 +1635,234 @@ pub(crate) mod tests {
         .await
         .unwrap();
 
-        let msgs = notifier.messages();
-        (state, msgs)
+        (state, notifier)
+    }
+
+    async fn run_test_plan(yaml: &str, launcher: &dyn AgentLauncher) -> (PlanState, Vec<String>) {
+        let (state, notifier) = run_test_plan_notifier(yaml, launcher).await;
+        (state, notifier.messages())
+    }
+
+    /// GH-564: flatten the observed phase terminal events for assertions.
+    fn terminal_view(
+        events: &[edda_notify::NotifyEvent],
+    ) -> Vec<(String, String, String, u32, Option<String>)> {
+        events
+            .iter()
+            .map(|e| match e {
+                edda_notify::NotifyEvent::PhaseTerminal {
+                    plan,
+                    phase,
+                    state,
+                    attempt,
+                    final_output,
+                } => (
+                    plan.clone(),
+                    phase.clone(),
+                    state.clone(),
+                    *attempt,
+                    final_output.clone(),
+                ),
+                other => panic!(
+                    "unexpected non-terminal NotifyEvent: {}",
+                    other.event_name()
+                ),
+            })
+            .collect()
+    }
+
+    // ── GH-564: exactly one notification per phase terminal transition ──
+
+    #[tokio::test]
+    async fn terminal_notify_passed_exactly_one() {
+        let yaml = r#"
+name: notifytest
+phases:
+  - id: a
+    prompt: "do it"
+"#;
+        let launcher = MockLauncher::new();
+        launcher.set_results(
+            "a",
+            vec![PhaseResult::AgentDone {
+                cost_usd: None,
+                result_text: Some("worked hard\nPR: https://github.com/x/y/pull/9".into()),
+            }],
+        );
+        let (state, notifier) = run_test_plan_notifier(yaml, &launcher).await;
+
+        assert_eq!(state.phases[0].status, PhaseStatus::Passed);
+        let tv = terminal_view(&notifier.terminal_events());
+        assert_eq!(tv.len(), 1, "exactly one terminal notification: {tv:?}");
+        assert_eq!(tv[0].0, "notifytest");
+        assert_eq!(tv[0].1, "a");
+        assert_eq!(tv[0].2, "Passed");
+        assert_eq!(tv[0].3, 1);
+        assert_eq!(
+            tv[0].4.as_deref(),
+            Some("PR: https://github.com/x/y/pull/9")
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_notify_one_per_transition_crash_retry_pass() {
+        let yaml = r#"
+name: notifytest
+max_attempts: 2
+on_fail: auto_retry
+phases:
+  - id: a
+    prompt: "crash then succeed"
+"#;
+        let launcher = MockLauncher::new();
+        launcher.set_results(
+            "a",
+            vec![
+                PhaseResult::AgentCrash {
+                    error: "oops".into(),
+                },
+                PhaseResult::AgentDone {
+                    cost_usd: Some(0.5),
+                    result_text: Some("done".into()),
+                },
+            ],
+        );
+        let (state, notifier) = run_test_plan_notifier(yaml, &launcher).await;
+
+        assert_eq!(state.phases[0].status, PhaseStatus::Passed);
+        assert_eq!(state.phases[0].attempts, 2);
+        let tv = terminal_view(&notifier.terminal_events());
+        assert_eq!(tv.len(), 2, "one per terminal transition: {tv:?}");
+        assert_eq!(
+            (tv[0].1.as_str(), tv[0].2.as_str(), tv[0].3),
+            ("a", "Failed", 1)
+        );
+        assert_eq!(tv[0].4, None);
+        assert_eq!(
+            (tv[1].1.as_str(), tv[1].2.as_str(), tv[1].3),
+            ("a", "Passed", 2)
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_notify_stale_on_timeout() {
+        let yaml = r#"
+name: notifytest
+phases:
+  - id: a
+    prompt: "hang"
+"#;
+        let launcher = MockLauncher::new();
+        launcher.set_results("a", vec![PhaseResult::Timeout]);
+        let (state, notifier) = run_test_plan_notifier(yaml, &launcher).await;
+
+        assert_eq!(state.phases[0].status, PhaseStatus::Stale);
+        let tv = terminal_view(&notifier.terminal_events());
+        assert_eq!(tv.len(), 1, "exactly one terminal notification: {tv:?}");
+        assert_eq!(
+            (tv[0].1.as_str(), tv[0].2.as_str(), tv[0].3),
+            ("a", "Stale", 1)
+        );
+        assert_eq!(tv[0].4, None);
+    }
+
+    #[tokio::test]
+    async fn terminal_notify_failed_then_skipped_on_fail_skip() {
+        let yaml = r#"
+name: notifytest
+on_fail: skip
+phases:
+  - id: a
+    prompt: "crash"
+  - id: b
+    prompt: "should still run"
+"#;
+        let launcher = MockLauncher::new();
+        launcher.set_results(
+            "a",
+            vec![PhaseResult::AgentCrash {
+                error: "boom".into(),
+            }],
+        );
+        let (state, notifier) = run_test_plan_notifier(yaml, &launcher).await;
+
+        assert_eq!(state.phases[0].status, PhaseStatus::Skipped);
+        assert_eq!(state.phases[1].status, PhaseStatus::Passed);
+        let tv = terminal_view(&notifier.terminal_events());
+        // Two terminal transitions for "a": the crash failure, then the
+        // on_fail re-classification to Skipped — one notification each.
+        // Phase "b" contributes its own Passed notification.
+        assert_eq!(tv.len(), 3, "one per terminal transition: {tv:?}");
+        assert_eq!(tv[0].2, "Failed");
+        assert_eq!(tv[1].2, "Skipped");
+        assert_eq!(tv[2].2, "Passed");
+    }
+
+    #[tokio::test]
+    async fn terminal_notify_failed_then_aborted_on_fail_abort() {
+        let yaml = r#"
+name: notifytest
+on_fail: abort
+phases:
+  - id: a
+    prompt: "crash"
+"#;
+        let launcher = MockLauncher::new();
+        launcher.set_results(
+            "a",
+            vec![PhaseResult::AgentCrash {
+                error: "boom".into(),
+            }],
+        );
+        let (state, notifier) = run_test_plan_notifier(yaml, &launcher).await;
+
+        assert_eq!(state.phases[0].status, PhaseStatus::Failed);
+        assert_eq!(state.plan_status, PlanStatus::Aborted);
+        let tv = terminal_view(&notifier.terminal_events());
+        assert_eq!(tv.len(), 2, "one per terminal transition: {tv:?}");
+        assert_eq!((tv[0].2.as_str(), tv[0].3), ("Failed", 1));
+        assert_eq!(
+            (tv[1].1.as_str(), tv[1].2.as_str(), tv[1].3),
+            ("a", "Aborted", 1)
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_notify_check_failure_carries_final_output() {
+        let yaml = r#"
+name: notifytest
+on_fail: skip
+phases:
+  - id: a
+    prompt: "make file"
+    check:
+      - file_exists: "output.txt"
+"#;
+        let launcher = MockLauncher::new();
+        launcher.set_results(
+            "a",
+            vec![PhaseResult::AgentDone {
+                cost_usd: None,
+                result_text: Some("built everything\nPR: https://github.com/x/y/pull/7".into()),
+            }],
+        );
+        let (state, notifier) = run_test_plan_notifier(yaml, &launcher).await;
+
+        assert_eq!(state.phases[0].status, PhaseStatus::Skipped);
+        let tv = terminal_view(&notifier.terminal_events());
+        assert_eq!(
+            tv.len(),
+            2,
+            "check-fail Failed, then on_fail Skipped: {tv:?}"
+        );
+        assert_eq!((tv[0].2.as_str(), tv[0].3), ("Failed", 1));
+        assert_eq!(
+            tv[0].4.as_deref(),
+            Some("PR: https://github.com/x/y/pull/7"),
+            "check-failure notification carries the agent's final output line"
+        );
+        assert_eq!(tv[1].2, "Skipped");
+        assert_eq!(tv[1].4, None);
     }
 
     #[tokio::test]
@@ -2592,7 +2960,7 @@ phases:
         assert_eq!(shas[0], head, "gate_sha must be the phase cwd's git HEAD");
         record_verdict(&root, "gated/a", &shas[0], VerdictDecision::Approved, None);
 
-        let (state, _notifier, launcher) = tokio::time::timeout(GATE_TEST_DEADLINE, handle)
+        let (state, notifier, launcher) = tokio::time::timeout(GATE_TEST_DEADLINE, handle)
             .await
             .expect("gate test exceeded 30s")
             .unwrap()
@@ -2606,6 +2974,21 @@ phases:
         );
         assert_eq!(launcher.call_count("a"), 1);
         assert_eq!(launcher.call_count("b"), 1);
+        // GH-564: one terminal notification per terminal transition — the
+        // gate-approved phase and the follow-on phase. The approved phase's
+        // agent output is not retained at the verdict site, so its
+        // final_output is None.
+        let tv = terminal_view(&notifier.terminal_events());
+        assert_eq!(tv.len(), 2, "one per terminal transition: {tv:?}");
+        assert_eq!(
+            (tv[0].1.as_str(), tv[0].2.as_str(), tv[0].3),
+            ("a", "Passed", 1)
+        );
+        assert_eq!(tv[0].4, None);
+        assert_eq!(
+            (tv[1].1.as_str(), tv[1].2.as_str(), tv[1].3),
+            ("b", "Passed", 1)
+        );
         let _ = std::fs::remove_dir_all(&root);
     }
 
@@ -2702,7 +3085,7 @@ phases:
             Some("wrong approach"),
         );
 
-        let (state, _notifier, launcher) = tokio::time::timeout(GATE_TEST_DEADLINE, handle)
+        let (state, notifier, launcher) = tokio::time::timeout(GATE_TEST_DEADLINE, handle)
             .await
             .expect("gate test exceeded 30s")
             .unwrap()
@@ -2719,6 +3102,13 @@ phases:
         );
         assert_eq!(state.plan_status, PlanStatus::Blocked);
         assert_eq!(launcher.call_count("a"), 1, "no redispatch turn on halt");
+        // GH-564: the halt failure emits exactly one terminal notification.
+        let tv = terminal_view(&notifier.terminal_events());
+        assert_eq!(tv.len(), 1, "exactly one terminal notification: {tv:?}");
+        assert_eq!(
+            (tv[0].1.as_str(), tv[0].2.as_str(), tv[0].3),
+            ("a", "Failed", 1)
+        );
         let _ = std::fs::remove_dir_all(&root);
     }
 
@@ -2854,7 +3244,7 @@ phases:
 "#;
         let plan = parse_plan(yaml).unwrap();
         let state = PlanState::from_plan(&plan, "test.yaml");
-        let (state, _notifier, _launcher) = tokio::time::timeout(
+        let (state, notifier, _launcher) = tokio::time::timeout(
             GATE_TEST_DEADLINE,
             spawn_runner(yaml, root.clone(), launcher, state),
         )
@@ -2876,6 +3266,14 @@ phases:
             err.message
         );
         assert_eq!(state.plan_status, PlanStatus::Blocked);
+        // GH-564: the gate timeout failure emits exactly one terminal
+        // notification.
+        let tv = terminal_view(&notifier.terminal_events());
+        assert_eq!(tv.len(), 1, "exactly one terminal notification: {tv:?}");
+        assert_eq!(
+            (tv[0].1.as_str(), tv[0].2.as_str(), tv[0].3),
+            ("a", "Failed", 1)
+        );
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -24,7 +24,7 @@ use anyhow::Result;
 use edda_core::VerdictPayload;
 use edda_ledger::VerdictRecord;
 use edda_notify::NotifyEvent;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
@@ -63,7 +63,16 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
     edda::ensure_init(cwd);
 
     // Detect stale phases from previous run
-    detect_stale_phases(state, plan);
+    // GH-564 P1-2: each Running/Checking → Stale transition on resume is a
+    // terminal transition — notify so the controller reacts instead of
+    // polling stdout tails.
+    for (phase_id, attempts) in detect_stale_phases(state, plan) {
+        notifier
+            .notify_phase_terminal(phase_terminal_event(
+                &plan.name, &phase_id, "Stale", attempts, None,
+            ))
+            .await;
+    }
 
     // Record plan start
     if state.started_at.is_none() {
@@ -284,13 +293,18 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                         &["conductor", "verdict"],
                     );
                     let approved_ps = state.get_phase(&gated_id)?;
+                    // GH-564 P1-3: the approved phase's agent final output
+                    // (last line = PR URL by convention) was parked at gate
+                    // entry and survives restarts — restore it, never drop
+                    // it to null.
+                    let final_output = load_gate_output(cwd, &plan.name, &gated_id);
                     notifier
                         .notify_phase_terminal(phase_terminal_event(
                             &plan.name,
                             &gated_id,
                             "Passed",
                             approved_ps.attempts,
-                            None,
+                            final_output.as_deref(),
                         ))
                         .await;
                 }
@@ -358,13 +372,17 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                             env_retries: gate_ps.env_retries,
                             attempt_charged: true,
                         });
+                        // GH-564 P1-3: same parked output as the approved
+                        // branch — the agent did produce a final line before
+                        // the gate rejected it.
+                        let final_output = load_gate_output(cwd, &plan.name, &gated_id);
                         notifier
                             .notify_phase_terminal(phase_terminal_event(
                                 &plan.name,
                                 &gated_id,
                                 "Failed",
                                 gate_ps.attempts,
-                                None,
+                                final_output.as_deref(),
                             ))
                             .await;
                     } else {
@@ -465,13 +483,15 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                         env_retries: gate_ps.env_retries,
                         attempt_charged: true,
                     });
+                    // GH-564 P1-3: same parked output as the approved branch.
+                    let final_output = load_gate_output(cwd, &plan.name, &gated_id);
                     notifier
                         .notify_phase_terminal(phase_terminal_event(
                             &plan.name,
                             &gated_id,
                             "Failed",
                             gate_ps.attempts,
-                            None,
+                            final_output.as_deref(),
                         ))
                         .await;
                 }
@@ -960,6 +980,15 @@ async fn process_phase_result(
                                     ..Default::default()
                                 }),
                             )?;
+                            // GH-564 P1-3: park the agent's final output so
+                            // the verdict site can still report it after a
+                            // restart.
+                            persist_gate_output(
+                                cwd,
+                                &plan.name,
+                                phase_id,
+                                final_output_line(result_text.as_deref()).as_deref(),
+                            );
                             println!("\n  ⏸ Phase \"{phase_id}\" AWAITING_VERDICT — waiting for an external verdict");
                             println!("    subject:  {subject}");
                             println!("    gate_sha: {gate_sha}");
@@ -1244,6 +1273,43 @@ fn final_output_line(result_text: Option<&str>) -> Option<String> {
         .map(str::trim)
         .find(|l| !l.is_empty())
         .map(str::to_string)
+}
+
+/// GH-564 P1-3: where a gated phase's agent final output is parked while the
+/// plan waits for the external verdict. `{cwd}/.edda/conductor/{plan}/{phase}.gate_output`.
+/// Survives a conductor restart, so the verdict site can restore the output
+/// into the terminal notification instead of dropping it to `null`.
+fn gate_output_path(cwd: &Path, plan_name: &str, phase_id: &str) -> PathBuf {
+    cwd.join(".edda")
+        .join("conductor")
+        .join(plan_name)
+        .join(format!("{phase_id}.gate_output"))
+}
+
+/// GH-564 P1-3: persist the agent's final output line when the phase enters
+/// AWAITING_VERDICT. Overwritten on every gate (re-)entry, so a redispatch
+/// cycle always leaves the latest output here. Best-effort: a failed write
+/// degrades to the previous (null) behavior, never to a wrong output.
+fn persist_gate_output(cwd: &Path, plan_name: &str, phase_id: &str, final_output: Option<&str>) {
+    let Some(output) = final_output else {
+        return;
+    };
+    let path = gate_output_path(cwd, plan_name, phase_id);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = edda_store::write_atomic(&path, output.as_bytes());
+}
+
+/// GH-564 P1-3: read back the parked final output at the gate verdict site.
+fn load_gate_output(cwd: &Path, plan_name: &str, phase_id: &str) -> Option<String> {
+    let output = std::fs::read_to_string(gate_output_path(cwd, plan_name, phase_id)).ok()?;
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 async fn handle_on_fail(
@@ -2955,7 +3021,9 @@ phases:
             "a",
             vec![PhaseResult::AgentDone {
                 cost_usd: None,
-                result_text: Some("opened pull request\nPR: https://github.com/x/y/pull/620".into()),
+                result_text: Some(
+                    "opened pull request\nPR: https://github.com/x/y/pull/620".into(),
+                ),
             }],
         );
         let plan = parse_plan(GATED_YAML).unwrap();

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -66,7 +66,20 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
     // GH-564 P1-2: each Running/Checking → Stale transition on resume is a
     // terminal transition — notify so the controller reacts instead of
     // polling stdout tails.
-    for (phase_id, attempts) in detect_stale_phases(state, plan) {
+    // GH-564 Round-2 P1-2 (exactly-once): persist the transitions BEFORE
+    // notifying. The stale mutation otherwise lives only in memory until
+    // some later save — a real resume (plan already started) that hits the
+    // non-interactive blocked branch never saves, so the next run would
+    // re-detect the same orphan transition and send a duplicate Stale
+    // notification. Persisting first makes each transition's notification
+    // exactly-once across repeated `edda conduct run` invocations.
+    let stale_transitions = detect_stale_phases(state, plan);
+    if !stale_transitions.is_empty() {
+        save_state(cwd, state)?;
+        event_log::write_runner_status(cwd, state, None);
+        write_brief(cwd, state, None);
+    }
+    for (phase_id, attempts) in stale_transitions {
         notifier
             .notify_phase_terminal(phase_terminal_event(
                 &plan.name, &phase_id, "Stale", attempts, None,
@@ -296,8 +309,10 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                     // GH-564 P1-3: the approved phase's agent final output
                     // (last line = PR URL by convention) was parked at gate
                     // entry and survives restarts — restore it, never drop
-                    // it to null.
+                    // it to null. GH-564 Round-2 P1: consume the sidecar —
+                    // its lifecycle ends with this verdict.
                     let final_output = load_gate_output(cwd, &plan.name, &gated_id);
+                    clear_gate_output(cwd, &plan.name, &gated_id);
                     notifier
                         .notify_phase_terminal(phase_terminal_event(
                             &plan.name,
@@ -374,8 +389,10 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                         });
                         // GH-564 P1-3: same parked output as the approved
                         // branch — the agent did produce a final line before
-                        // the gate rejected it.
+                        // the gate rejected it. Consume the sidecar with the
+                        // verdict (GH-564 Round-2 P1).
                         let final_output = load_gate_output(cwd, &plan.name, &gated_id);
+                        clear_gate_output(cwd, &plan.name, &gated_id);
                         notifier
                             .notify_phase_terminal(phase_terminal_event(
                                 &plan.name,
@@ -484,7 +501,9 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                         attempt_charged: true,
                     });
                     // GH-564 P1-3: same parked output as the approved branch.
+                    // Consume the sidecar with the verdict (GH-564 Round-2 P1).
                     let final_output = load_gate_output(cwd, &plan.name, &gated_id);
+                    clear_gate_output(cwd, &plan.name, &gated_id);
                     notifier
                         .notify_phase_terminal(phase_terminal_event(
                             &plan.name,
@@ -967,6 +986,41 @@ async fn process_phase_result(
                     // notifier message, then wait (the loop's gate-wait branch).
                     match capture_git_head(phase_cwd) {
                         Ok(gate_sha) => {
+                            // GH-564 P1-3 / Round-2 P1: park the agent's final
+                            // output BEFORE the phase enters AWAITING_VERDICT.
+                            // Every gate entry atomically rewrites the sidecar
+                            // — the last non-empty agent line when there is
+                            // one, an empty file when there is none — so it
+                            // always represents THIS entry's output and a
+                            // previous cycle's value can never be read back.
+                            // The error is NOT swallowed: a failed write would
+                            // leave the previous cycle's file in place, which
+                            // the verdict site could read back as this
+                            // entry's output — fail the entry instead.
+                            if let Err(e) = persist_gate_output(
+                                cwd,
+                                &plan.name,
+                                phase_id,
+                                final_output_line(result_text.as_deref()).as_deref(),
+                            ) {
+                                let msg = format!("failed to persist gate final output: {e}");
+                                fail_checking_phase(
+                                    plan,
+                                    phase,
+                                    state,
+                                    phase_id,
+                                    cwd,
+                                    &check_result,
+                                    Some(&msg),
+                                    phase_start.elapsed(),
+                                    final_output_line(result_text.as_deref()).as_deref(),
+                                    notifier,
+                                    event_log,
+                                    tmux_session,
+                                )
+                                .await?;
+                                return Ok(());
+                            }
                             let subject = gate_subject(&plan.name, phase_id);
                             transition(
                                 state,
@@ -980,15 +1034,6 @@ async fn process_phase_result(
                                     ..Default::default()
                                 }),
                             )?;
-                            // GH-564 P1-3: park the agent's final output so
-                            // the verdict site can still report it after a
-                            // restart.
-                            persist_gate_output(
-                                cwd,
-                                &plan.name,
-                                phase_id,
-                                final_output_line(result_text.as_deref()).as_deref(),
-                            );
                             println!("\n  ⏸ Phase \"{phase_id}\" AWAITING_VERDICT — waiting for an external verdict");
                             println!("    subject:  {subject}");
                             println!("    gate_sha: {gate_sha}");
@@ -1286,19 +1331,33 @@ fn gate_output_path(cwd: &Path, plan_name: &str, phase_id: &str) -> PathBuf {
         .join(format!("{phase_id}.gate_output"))
 }
 
-/// GH-564 P1-3: persist the agent's final output line when the phase enters
-/// AWAITING_VERDICT. Overwritten on every gate (re-)entry, so a redispatch
-/// cycle always leaves the latest output here. Best-effort: a failed write
-/// degrades to the previous (null) behavior, never to a wrong output.
-fn persist_gate_output(cwd: &Path, plan_name: &str, phase_id: &str, final_output: Option<&str>) {
-    let Some(output) = final_output else {
-        return;
-    };
+/// GH-564 P1-3 / Round-2 P1: park the agent's final output when the phase
+/// enters AWAITING_VERDICT. EVERY gate entry atomically rewrites the sidecar
+/// so it represents THIS entry's output and only this entry's: the last
+/// non-empty agent line when there is one, an EMPTY file when there is none
+/// (`load_gate_output` maps empty to `None`). A previous redispatch cycle's
+/// value can therefore never be read back as the current output.
+///
+/// Errors are NOT swallowed: a failed write would leave the previous cycle's
+/// file in place, which the verdict site could read back as this entry's
+/// output — the caller must fail the gate entry instead of waiting on a
+/// verdict against a possibly wrong payload.
+fn persist_gate_output(
+    cwd: &Path,
+    plan_name: &str,
+    phase_id: &str,
+    final_output: Option<&str>,
+) -> anyhow::Result<()> {
     let path = gate_output_path(cwd, plan_name, phase_id);
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    let _ = edda_store::write_atomic(&path, output.as_bytes());
+    edda_store::write_atomic(&path, final_output.unwrap_or("").as_bytes())
+}
+
+/// GH-564 Round-2 P1: consume the parked output at the verdict site, so the
+/// sidecar only exists between a gate entry and its verdict. Best-effort: a
+/// failed removal cannot produce a wrong payload because every gate entry
+/// rewrites the sidecar atomically before any verdict is waited on.
+fn clear_gate_output(cwd: &Path, plan_name: &str, phase_id: &str) {
+    let _ = std::fs::remove_file(gate_output_path(cwd, plan_name, phase_id));
 }
 
 /// GH-564 P1-3: read back the parked final output at the gate verdict site.
@@ -3266,13 +3325,7 @@ phases:
 
         // Second gate: approve.
         let shas = wait_for_gate_events(&root, "gated", 2).await;
-        record_verdict(
-            &root,
-            "gated/a",
-            &shas[1],
-            VerdictDecision::Approved,
-            None,
-        );
+        record_verdict(&root, "gated/a", &shas[1], VerdictDecision::Approved, None);
 
         let (state, notifier, launcher) = tokio::time::timeout(GATE_TEST_DEADLINE, handle)
             .await

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -3123,6 +3123,281 @@ phases:
         );
     }
 
+    /// GH-564 Round-2 P1-2 (exactly-once): a REAL persisted resume — the
+    /// plan already started, an expired Running phase sits on disk — must
+    /// notify Stale exactly once across repeated `edda conduct run`
+    /// invocations. The transition must be persisted before the
+    /// notification fires, so run 2 (a fresh conductor reloading the
+    /// persisted state) finds no orphan Running phase and sends nothing.
+    #[tokio::test]
+    async fn resume_stale_notifies_exactly_once_across_reruns() {
+        let yaml = r#"
+name: resumestale
+timeout_sec: 1
+phases:
+  - id: a
+    prompt: "do it"
+"#;
+        let plan = parse_plan(yaml).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let launcher = MockLauncher::new();
+
+        // A conductor died mid-run: the persisted state has an expired
+        // Running phase and the plan already started (real resume — NOT a
+        // fresh PlanState::from_plan whose started_at is None).
+        let mut persisted = PlanState::from_plan(&plan, "test.yaml");
+        persisted.started_at = Some(now_rfc3339());
+        persisted.plan_status = PlanStatus::Running;
+        persisted.phases[0].status = PhaseStatus::Running;
+        persisted.phases[0].started_at = Some(
+            (time::OffsetDateTime::now_utc() - time::Duration::seconds(3600))
+                .format(&time::format_description::well_known::Rfc3339)
+                .unwrap_or_default(),
+        );
+        save_state(dir.path(), &persisted).unwrap();
+
+        // Run 1: a fresh conductor process loads the persisted state.
+        let mut state = crate::state::persist::load_state(dir.path(), &plan.name)
+            .unwrap()
+            .expect("persisted resume state");
+        let notifier1 = CollectNotifier::new();
+        let engine = CheckEngine::new(dir.path().to_path_buf());
+        let mut budget = BudgetTracker::new(plan.budget_usd);
+        run_plan(
+            &plan,
+            &mut state,
+            RunContext {
+                launcher: &launcher,
+                check_engine: &engine,
+                notifier: &notifier1,
+                budget: &mut budget,
+                cancel: CancellationToken::new(),
+                cwd: dir.path(),
+                interactive: false,
+                json_events: false,
+                tmux_session: None,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(state.phases[0].status, PhaseStatus::Stale);
+        let tv1 = terminal_view(&notifier1.terminal_events());
+        let stale1 = tv1.iter().filter(|e| e.1 == "a" && e.2 == "Stale").count();
+        assert_eq!(
+            stale1, 1,
+            "run 1 notifies the Stale transition exactly once: {tv1:?}"
+        );
+
+        // Run 2: ANOTHER fresh conductor process re-reads the disk state.
+        let mut state2 = crate::state::persist::load_state(dir.path(), &plan.name)
+            .unwrap()
+            .expect("state must survive run 1");
+        assert_eq!(
+            state2.phases[0].status,
+            PhaseStatus::Stale,
+            "the Stale transition must be PERSISTED by run 1, not left in memory"
+        );
+        let notifier2 = CollectNotifier::new();
+        let engine2 = CheckEngine::new(dir.path().to_path_buf());
+        let mut budget2 = BudgetTracker::new(plan.budget_usd);
+        run_plan(
+            &plan,
+            &mut state2,
+            RunContext {
+                launcher: &launcher,
+                check_engine: &engine2,
+                notifier: &notifier2,
+                budget: &mut budget2,
+                cancel: CancellationToken::new(),
+                cwd: dir.path(),
+                interactive: false,
+                json_events: false,
+                tmux_session: None,
+            },
+        )
+        .await
+        .unwrap();
+        let tv2 = terminal_view(&notifier2.terminal_events());
+        assert!(
+            tv2.iter().all(|e| !(e.1 == "a" && e.2 == "Stale")),
+            "run 2 must NOT re-notify the already-persisted Stale transition: {tv2:?}"
+        );
+    }
+
+    /// GH-564 Round-2 new P1: after a redispatch cycle, the SECOND gate
+    /// entry's output (here: none — the redispatched turn produced no final
+    /// text) must replace the first cycle's parked output. Approving the
+    /// regate must never deliver the PREVIOUS cycle's PR URL as the final
+    /// output.
+    #[tokio::test]
+    async fn gate_redispatch_none_output_never_reuses_previous_cycles_output() {
+        let root = fresh_root("redispatch-none");
+        init_git_repo(&root);
+        let launcher = MockLauncher::new();
+        launcher.set_results(
+            "a",
+            vec![
+                PhaseResult::AgentDone {
+                    cost_usd: None,
+                    result_text: Some(
+                        "opened pull request\nPR: https://github.com/x/y/pull/100".into(),
+                    ),
+                },
+                // The redispatched turn produced NO final text at all.
+                PhaseResult::AgentDone {
+                    cost_usd: None,
+                    result_text: None,
+                },
+            ],
+        );
+        let plan = parse_plan(GATED_YAML).unwrap();
+        let state = PlanState::from_plan(&plan, "test.yaml");
+        let handle = spawn_runner(GATED_YAML, root.clone(), launcher, state);
+
+        // First gate: reject with a comment → redispatch.
+        let shas = wait_for_gate_events(&root, "gated", 1).await;
+        record_verdict(
+            &root,
+            "gated/a",
+            &shas[0],
+            VerdictDecision::Rejected,
+            Some("redo it"),
+        );
+
+        // Second gate: approve.
+        let shas = wait_for_gate_events(&root, "gated", 2).await;
+        record_verdict(
+            &root,
+            "gated/a",
+            &shas[1],
+            VerdictDecision::Approved,
+            None,
+        );
+
+        let (state, notifier, launcher) = tokio::time::timeout(GATE_TEST_DEADLINE, handle)
+            .await
+            .expect("gate test exceeded 30s")
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.phases[0].status, PhaseStatus::Passed);
+        assert_eq!(launcher.call_count("a"), 2);
+        let tv = terminal_view(&notifier.terminal_events());
+        let passed = tv
+            .iter()
+            .find(|e| e.1 == "a" && e.2 == "Passed")
+            .expect("approved gate must emit a Passed terminal event");
+        assert_eq!(
+            passed.4, None,
+            "a redispatch turn with no output must NOT inherit the previous cycle's parked PR URL"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// GH-564 Round-2 new P1: when a gate entry CANNOT persist its output
+    /// (here the atomic write fails because a directory blocks the sidecar
+    /// path), the entry must fail the phase instead of silently waiting on a
+    /// verdict whose approve branch would read back the PREVIOUS cycle's
+    /// parked output.
+    #[tokio::test]
+    async fn gate_redispatch_write_failure_fails_instead_of_stale_output() {
+        let root = fresh_root("redispatch-writefail");
+        init_git_repo(&root);
+        let launcher = MockLauncher::new();
+        launcher.set_results(
+            "a",
+            vec![PhaseResult::AgentDone {
+                cost_usd: None,
+                result_text: Some(
+                    "opened pull request\nPR: https://github.com/x/y/pull/100".into(),
+                ),
+            }],
+            // The redispatched turn falls through to the mock default.
+        );
+        let yaml = r#"
+name: gated
+phases:
+  - id: a
+    prompt: "do it"
+    gate: verdict
+    gate_timeout_sec: 1
+    on_fail: abort
+"#;
+        let plan = parse_plan(yaml).unwrap();
+        let state = PlanState::from_plan(&plan, "test.yaml");
+        let handle = spawn_runner(yaml, root.clone(), launcher, state);
+
+        // Gate entry 1 parks its output successfully.
+        let shas = wait_for_gate_events(&root, "gated", 1).await;
+        let sidecar = root
+            .join(".edda")
+            .join("conductor")
+            .join("gated")
+            .join("a.gate_output");
+        assert_eq!(
+            std::fs::read_to_string(&sidecar).unwrap(),
+            "PR: https://github.com/x/y/pull/100",
+            "entry 1 must have parked its output"
+        );
+        // Sabotage the NEXT atomic write: a directory where the file must go.
+        std::fs::remove_file(&sidecar).unwrap();
+        std::fs::create_dir(&sidecar).unwrap();
+
+        // Reject → redispatch → gate entry 2 hits the write failure.
+        record_verdict(
+            &root,
+            "gated/a",
+            &shas[0],
+            VerdictDecision::Rejected,
+            Some("redo it"),
+        );
+
+        let (state, _notifier, launcher) = tokio::time::timeout(GATE_TEST_DEADLINE, handle)
+            .await
+            .expect("gate test exceeded 30s")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            launcher.call_count("a"),
+            2,
+            "reject still redispatches one turn"
+        );
+        assert_eq!(
+            state.phases[0].status,
+            PhaseStatus::Failed,
+            "a gate entry that cannot persist its output must fail, not wait on a verdict against a stale sidecar"
+        );
+        let err = state.phases[0]
+            .error
+            .as_ref()
+            .expect("Failed phase carries an error");
+        assert!(
+            err.message.contains("failed to persist gate final output"),
+            "the persist failure must surface as the phase error, got: {}",
+            err.message
+        );
+        // The sabotaged entry never reaches AWAITING_VERDICT: still exactly
+        // one gate_entered event.
+        let events_path = root
+            .join(".edda")
+            .join("conductor")
+            .join("gated")
+            .join("events.jsonl");
+        let content = std::fs::read_to_string(&events_path).unwrap();
+        let gate_enters = content
+            .lines()
+            .filter(|l| {
+                serde_json::from_str::<serde_json::Value>(l)
+                    .map(|v| v["type"] == "gate_entered")
+                    .unwrap_or(false)
+            })
+            .count();
+        assert_eq!(
+            gate_enters, 1,
+            "the failed entry must not enter the gate again"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     #[tokio::test]
     async fn gate_reject_redispatches_same_session_then_regates() {
         let root = fresh_root("redispatch");

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -2951,6 +2951,13 @@ phases:
         let root = fresh_root("approve");
         let head = init_git_repo(&root);
         let launcher = MockLauncher::new();
+        launcher.set_results(
+            "a",
+            vec![PhaseResult::AgentDone {
+                cost_usd: None,
+                result_text: Some("opened pull request\nPR: https://github.com/x/y/pull/620".into()),
+            }],
+        );
         let plan = parse_plan(GATED_YAML).unwrap();
         let state = PlanState::from_plan(&plan, "test.yaml");
         let handle = spawn_runner(GATED_YAML, root.clone(), launcher, state);
@@ -2974,22 +2981,78 @@ phases:
         );
         assert_eq!(launcher.call_count("a"), 1);
         assert_eq!(launcher.call_count("b"), 1);
-        // GH-564: one terminal notification per terminal transition — the
-        // gate-approved phase and the follow-on phase. The approved phase's
-        // agent output is not retained at the verdict site, so its
-        // final_output is None.
+        // GH-564 P1-3: the gate-approved phase's agent final output (its
+        // last line, the PR URL by convention) must survive until the
+        // verdict site and ride on the Passed terminal notification.
         let tv = terminal_view(&notifier.terminal_events());
         assert_eq!(tv.len(), 2, "one per terminal transition: {tv:?}");
         assert_eq!(
             (tv[0].1.as_str(), tv[0].2.as_str(), tv[0].3),
             ("a", "Passed", 1)
         );
-        assert_eq!(tv[0].4, None);
+        assert_eq!(
+            tv[0].4.as_deref(),
+            Some("PR: https://github.com/x/y/pull/620"),
+            "gate-approved Passed event must carry the agent's final output"
+        );
         assert_eq!(
             (tv[1].1.as_str(), tv[1].2.as_str(), tv[1].3),
             ("b", "Passed", 1)
         );
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// GH-564 P1-2: a phase left Running by a previous conductor run, past
+    /// its timeout, becomes Stale on resume — and that terminal transition
+    /// must reach the controller as a notification.
+    #[tokio::test]
+    async fn resume_stale_phase_notifies_terminal() {
+        let yaml = r#"
+name: resumestale
+timeout_sec: 1
+phases:
+  - id: a
+    prompt: "do it"
+"#;
+        let plan = parse_plan(yaml).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = PlanState::from_plan(&plan, "test.yaml");
+        state.phases[0].status = PhaseStatus::Running;
+        state.phases[0].started_at = Some(
+            (time::OffsetDateTime::now_utc() - time::Duration::seconds(3600))
+                .format(&time::format_description::well_known::Rfc3339)
+                .unwrap_or_default(),
+        );
+        let engine = CheckEngine::new(dir.path().to_path_buf());
+        let notifier = CollectNotifier::new();
+        let mut budget = BudgetTracker::new(plan.budget_usd);
+        let cancel = CancellationToken::new();
+        let launcher = MockLauncher::new();
+
+        run_plan(
+            &plan,
+            &mut state,
+            RunContext {
+                launcher: &launcher,
+                check_engine: &engine,
+                notifier: &notifier,
+                budget: &mut budget,
+                cancel,
+                cwd: dir.path(),
+                interactive: false,
+                json_events: false,
+                tmux_session: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(state.phases[0].status, PhaseStatus::Stale);
+        let tv = terminal_view(&notifier.terminal_events());
+        assert!(
+            tv.iter().any(|e| e.1 == "a" && e.2 == "Stale"),
+            "resume must notify the Running→Stale transition: {tv:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/edda-conductor/src/state/derive.rs
+++ b/crates/edda-conductor/src/state/derive.rs
@@ -47,8 +47,12 @@ pub fn is_plan_blocked(state: &PlanState) -> bool {
 
 /// Detect stale phases: phases marked Running/Checking whose start time
 /// exceeds the timeout. Called on plan resume to handle orphaned states.
-pub fn detect_stale_phases(state: &mut PlanState, plan: &Plan) {
+/// Returns `(phase_id, attempts)` for every phase transitioned to Stale so
+/// the caller can notify the terminal transition (GH-564 P1-2: resume-time
+/// Running/Checking → Stale is a terminal transition and must be reported).
+pub fn detect_stale_phases(state: &mut PlanState, plan: &Plan) -> Vec<(String, u32)> {
     let now = time::OffsetDateTime::now_utc();
+    let mut stale = Vec::new();
 
     for phase_state in &mut state.phases {
         if phase_state.status != PhaseStatus::Running && phase_state.status != PhaseStatus::Checking
@@ -85,8 +89,11 @@ pub fn detect_stale_phases(state: &mut PlanState, plan: &Plan) {
                     .format(&time::format_description::well_known::Rfc3339)
                     .unwrap_or_default(),
             });
+            stale.push((phase_state.id.clone(), phase_state.attempts));
         }
     }
+
+    stale
 }
 
 /// Find the next runnable phase: Pending with all dependencies satisfied.
@@ -335,6 +342,40 @@ phases:
         detect_stale_phases(&mut state, &plan);
         assert_eq!(state.get_phase("a").unwrap().status, PhaseStatus::Stale);
         assert!(state.get_phase("a").unwrap().error.is_some());
+    }
+
+    #[test]
+    fn detect_stale_reports_transitioned_phase_ids_and_attempts() {
+        // GH-564 P1-2: the caller needs (phase_id, attempts) for every
+        // Running/Checking → Stale transition so it can emit the terminal
+        // notification.
+        let yaml = r#"
+name: test
+timeout_sec: 60
+phases:
+  - id: a
+    prompt: "x"
+"#;
+        let plan = parse_plan(yaml).unwrap();
+        let mut state = PlanState::from_plan(&plan, "plan.yaml");
+
+        let old_time = (time::OffsetDateTime::now_utc() - time::Duration::hours(2))
+            .format(&time::format_description::well_known::Rfc3339)
+            .unwrap();
+        transition(
+            &mut state,
+            "a",
+            PhaseStatus::Pending,
+            PhaseStatus::Running,
+            Some(PhaseUpdate {
+                started_at: Some(old_time),
+                ..Default::default()
+            }),
+        )
+        .unwrap();
+
+        let stale = detect_stale_phases(&mut state, &plan);
+        assert_eq!(stale, vec![("a".to_string(), 0)]);
     }
 
     #[test]

--- a/crates/edda-notify/src/lib.rs
+++ b/crates/edda-notify/src/lib.rs
@@ -77,6 +77,7 @@ impl NotifyConfig {
 // ── Notification Events ──
 
 /// Notification event types mapped from edda domain events.
+#[derive(Clone)]
 pub enum NotifyEvent {
     ApprovalPending {
         draft_id: String,
@@ -111,6 +112,18 @@ pub enum NotifyEvent {
         title: String,
         assignee: String,
     },
+    /// GH-564: one notification per phase terminal transition. `state` is
+    /// the terminal status name ("Passed" | "Failed" | "Stale" | "Skipped" |
+    /// "Aborted"); "Aborted" is plan-level and names the phase that forced
+    /// the abort. `final_output` carries the agent's last output line when
+    /// the transition site has one (by convention it contains the PR URL).
+    PhaseTerminal {
+        plan: String,
+        phase: String,
+        state: String,
+        attempt: u32,
+        final_output: Option<String>,
+    },
 }
 
 impl NotifyEvent {
@@ -122,6 +135,7 @@ impl NotifyEvent {
             NotifyEvent::Anomaly { .. } => "anomaly",
             NotifyEvent::RequestPending { .. } => "request_pending",
             NotifyEvent::TaskAssigned { .. } => "task_assigned",
+            NotifyEvent::PhaseTerminal { .. } => "phase_terminal",
         }
     }
 
@@ -186,6 +200,19 @@ impl NotifyEvent {
                 "task_id": task_id,
                 "title": title,
                 "assignee": assignee,
+            }),
+            NotifyEvent::PhaseTerminal {
+                plan,
+                phase,
+                state,
+                attempt,
+                final_output,
+            } => serde_json::json!({
+                "plan": plan,
+                "phase": phase,
+                "state": state,
+                "attempt": attempt,
+                "final_output": final_output,
             }),
         }
     }
@@ -320,6 +347,29 @@ fn format_ntfy(event: &NotifyEvent) -> (String, String, String) {
             format!("#{task_id} assigned to {assignee}"),
             "default".to_string(),
         ),
+        NotifyEvent::PhaseTerminal {
+            plan,
+            phase,
+            state,
+            attempt,
+            final_output,
+        } => {
+            let priority = match state.as_str() {
+                "Failed" | "Aborted" | "Stale" => "high",
+                "Skipped" => "low",
+                _ => "default",
+            };
+            let mut body = format!("plan {plan} · attempt {attempt}");
+            if let Some(out) = final_output {
+                body.push('\n');
+                body.push_str(out);
+            }
+            (
+                format!("Phase {phase}: {state}"),
+                body,
+                priority.to_string(),
+            )
+        }
     }
 }
 
@@ -426,6 +476,26 @@ fn format_telegram(event: &NotifyEvent) -> String {
             escape_html(title),
             escape_html(assignee)
         ),
+        NotifyEvent::PhaseTerminal {
+            plan,
+            phase,
+            state,
+            attempt,
+            final_output,
+        } => {
+            let mut text = format!(
+                "<b>Phase {}: {}</b>\nplan {} · attempt {}",
+                escape_html(phase),
+                escape_html(state),
+                escape_html(plan),
+                attempt
+            );
+            if let Some(out) = final_output {
+                text.push('\n');
+                text.push_str(&escape_html(out));
+            }
+            text
+        }
     }
 }
 
@@ -534,6 +604,91 @@ mod tests {
             summary: String::new(),
         };
         assert!(ch.matches(&event));
+    }
+
+    #[test]
+    fn phase_terminal_has_stable_name_payload_and_matching() {
+        let event = NotifyEvent::PhaseTerminal {
+            plan: "gh564".into(),
+            phase: "implement".into(),
+            state: "Passed".into(),
+            attempt: 2,
+            final_output: Some("PR: https://github.com/x/y/pull/9".into()),
+        };
+        assert_eq!(event.event_name(), "phase_terminal");
+        assert_eq!(event.to_json()["state"], "Passed");
+        assert_eq!(event.to_json()["attempt"], 2);
+        assert_eq!(
+            event.to_json()["final_output"],
+            "PR: https://github.com/x/y/pull/9"
+        );
+
+        let ch: Channel = serde_json::from_value(serde_json::json!({
+            "type": "ntfy",
+            "url": "https://ntfy.sh/test",
+            "events": ["phase_terminal"]
+        }))
+        .unwrap();
+        assert!(ch.matches(&event));
+    }
+
+    #[test]
+    fn phase_terminal_none_final_output_serializes_to_null() {
+        let event = NotifyEvent::PhaseTerminal {
+            plan: "p".into(),
+            phase: "a".into(),
+            state: "Stale".into(),
+            attempt: 1,
+            final_output: None,
+        };
+        assert!(event.to_json()["final_output"].is_null());
+    }
+
+    #[test]
+    fn format_ntfy_phase_terminal_priority_by_state() {
+        let mk = |state: &str| NotifyEvent::PhaseTerminal {
+            plan: "p".into(),
+            phase: "a".into(),
+            state: state.into(),
+            attempt: 1,
+            final_output: Some("PR: https://x/1".into()),
+        };
+        let (title, body, priority) = format_ntfy(&mk("Failed"));
+        assert!(title.contains("Phase a: Failed"));
+        assert!(body.contains("PR: https://x/1"));
+        assert_eq!(priority, "high");
+        assert_eq!(format_ntfy(&mk("Passed")).2, "default");
+        assert_eq!(format_ntfy(&mk("Skipped")).2, "low");
+        assert_eq!(format_ntfy(&mk("Aborted")).2, "high");
+    }
+
+    #[test]
+    fn format_telegram_phase_terminal_escapes_html() {
+        let event = NotifyEvent::PhaseTerminal {
+            plan: "p".into(),
+            phase: "<a>".into(),
+            state: "Failed".into(),
+            attempt: 1,
+            final_output: Some("err <&>".into()),
+        };
+        let text = format_telegram(&event);
+        assert!(text.contains("Phase &lt;a&gt;: Failed"));
+        assert!(text.contains("err &lt;&amp;&gt;"));
+    }
+
+    #[test]
+    fn format_webhook_phase_terminal_payload() {
+        let event = NotifyEvent::PhaseTerminal {
+            plan: "p".into(),
+            phase: "a".into(),
+            state: "Skipped".into(),
+            attempt: 3,
+            final_output: None,
+        };
+        let payload = format_webhook(&event);
+        assert_eq!(payload["event_type"], "phase_terminal");
+        assert_eq!(payload["data"]["plan"], "p");
+        assert_eq!(payload["data"]["attempt"], 3);
     }
 
     #[test]


### PR DESCRIPTION
Closes #564. Epic #560 (Stage 2).

## #545 seam judgment (the gate this issue hinges on)

#545 is **not merged**, but its interface design is stated in its issue body: *\"A \`Notifier\` implementation backed by edda-notify dispatch, selected via config or a \`--notify <channel>\` flag on \`conduct run\`, with stdout kept as the always-on fallback... plan-blocked/completed messages ride along for free since they already go through the same \`Notifier\` trait.\"*

That seam **exists and is sufficient** — no second mechanism invented. This PR delivers exactly behind it:

1. **edda-notify** (\`crates/edda-notify/src/lib.rs\`): \`NotifyEvent::PhaseTerminal { plan, phase, state, attempt, final_output }\` (event name \`phase_terminal\`) joins the **existing** channel surface — \`Channel\` event matching, \`format_ntfy\` / \`format_webhook\` / \`format_telegram\` formatters, priority \`high\` for Failed/Aborted/Stale, \`low\` for Skipped, \`default\` otherwise. \`NotifyEvent\` gains \`Clone\` (String fields only). No new dispatch path, no new config type.
2. **edda-conductor \`runner/notify.rs\`**: a **defaulted** \`Notifier::notify_phase_terminal\` method on the same trait #545 routes gate-entry through. Default = no-op, so \`StdoutNotifier\` keeps its default and stdout stays byte-identical. \`ChannelNotifier\` is the #545-shaped implementation: plain \`notify()\` falls through to a fallback notifier (stdout, the always-on channel per #545); terminal events go through \`edda_notify::dispatch\` on all configured channels matching \`phase_terminal\` (dispatch is sync HTTP — run via \`spawn_blocking\`).
3. **What remains for #545** (deliberately not done here, it is #545's ask): loading \`NotifyConfig\` from config / a \`--notify\` flag and wiring \`ChannelNotifier\` into \`cmd_conduct.rs\` where \`StdoutNotifier\` is hardcoded. \`cmd_conduct.rs\` is outside this lane's allowed files.

External crates only *construct* \`NotifyEvent\` (edda-cli, edda-bridge-claude); none match it exhaustively, so the new variant is additive.

## doneWhen checklist

- [x] **Every phase terminal transition emits exactly one notification** with plan/phase/state/attempt and final-output line — emission sites (all in \`runner/sequential.rs\`, none in gh584's files): gate approved → Passed; gate rejected-halt → Failed; gate timed-out → Failed; checks pass → Passed (final_output = last non-empty line of \`result_text\`, by convention the PR URL); check failure → Failed (final_output threaded through \`fail_checking_phase\`); agent timeout → Stale; agent crash / max-turns / budget-exceeded → Failed; \`on_fail: skip\` → Skipped; \`on_fail: abort\` → Aborted; interactive skip → Skipped; interactive abort → Aborted.
  - Semantics note: one notification **per terminal transition**. A phase re-classified by its \`on_fail\` policy (Failed → Skipped/Aborted) emits twice — once per terminal state it actually entered; auto-retry (Failed → Pending) is not a terminal transition and emits nothing extra. The regression tests pin this exact sequence.
  - \`Aborted\` is a \`PlanStatus\`, not a \`PhaseStatus\` (state/machine.rs is gh584's, untouched) — the abort notification names the phase that forced the abort, with state \`\"Aborted\"\`.
  - Gate-verdict sites cannot carry \`final_output\` (the phase's agent \`result_text\` is not retained into the gate-wait branch) — payload carries \`None\` there; pinned in the gate test.
- [x] **Stdout behavior unchanged (additive)** — no new \`println!\`; the default trait method is a no-op; \`StdoutNotifier\` untouched. All pre-existing stdout assertions in the suite still pass (284 tests).
- [x] **#545 seam, not a parallel mechanism** — see above.
- [x] **Regression test asserts one notification per terminal state; verified to FAIL before the fix** — 6 new tests (\`terminal_notify_*\`) plus assertions added to 3 gate tests. Pre-fix run: all 6 new tests failed with \`[]\` (zero terminal notifications observed), e.g. \`assertion \`left == right\` failed: one per terminal transition: []  left: 0  right: 2\`. Post-fix: all pass. (One early assertion bug of mine — forgetting phase \`b\`'s own Passed notification in the skip test — was a test expectation fix, not a product fix; the product FAIL evidence above predates any emission code.)

## FORBIDDEN-surface respect

\`runner/edda.rs\`, \`runner/event_log.rs\`, \`state/machine.rs\` (gh584), \`edda-cli/cmd_dispatch.rs\`, \`edda-cli/agent_kind.rs\`, \`conductor/agent/\` (gh574) — untouched. The gh584 \`record_phase_done\` / \`record_phase_failed\` calls in \`sequential.rs\` are untouched; notifications were only added adjacent to terminal transitions. \`Cargo.toml\`/\`Cargo.lock\` change is the new \`edda-conductor → edda-notify\` dependency the seam requires.

## Gate receipt (L1 — once per frozen SHA)

| field | value |
|---|---|
| full SHA | \`88312a883e72290e515a54f7d1ae445314d8d23e\` (clean tree) |
| gates | \`cargo fmt --all --check\` OK · \`cargo clippy --workspace --all-targets -- -D warnings\` OK · \`cargo test --workspace\` OK (all 39 suites, 0 failures; incl. edda-conductor 284 passed / 1 ignored, edda-notify 16 passed) |
| toolchain | rustc 1.93.1 (01f6ddf75 2026-02-11), cargo 1.93.1 |
| lane | \`CARGO_TARGET_DIR=C:\ai_agent\fleet-workstation\lanes\worker-4\`, \`CARGO_INCREMENTAL=0\` for the whole L1 run |
| result | green |

L0 while iterating: fmt + \`clippy -p edda-conductor -p edda-notify\` + \`cargo test -p\` both crates, all green before freeze.

## Notes / follow-ups (not this PR's scope)

- \`detect_stale_phases\` (state/derive.rs) re-marks phases Stale at plan start from a previous run — a detection path outside \`sequential.rs\` and outside this lane's file scope; it does not emit a \`phase_terminal\` notification. Candidate follow-up issue if a controller needs restart-time stale signals on the channel.
- Interactive skip/abort emission sites are exercised by the same code path shape but not covered by an automated test (stdin-prompt branch, untestable via the current \`run_test_plan\` harness); on_fail skip/abort (same helper, same payload shape) are covered.