### PR TITLE
fix(gitignore): ignore backups inside the re-included .claude trees; anchor the CLAUDE.md pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,23 @@
 /target
 .edda/
 .agents/
-CLAUDE.md
+/CLAUDE.md
 docs/archive/
 /tmp/
 .tmp/
 push.log
 .env
-nul
 
 # Claude project config: track skills and commands, ignore runtime state
 .claude/*
 !.claude/CLAUDE.md
 !.claude/skills/
 !.claude/commands/
+
+# editor / edda-hook backups inside the re-included trees
+.claude/skills/**/*.bak
+.claude/skills/**/*~
+.claude/skills/**/*.edda.bak.*
+.claude/commands/**/*.bak
+.claude/commands/**/*~
+.claude/commands/**/*.edda.bak.*


### PR DESCRIPTION
# fix(gitignore): .claude 子樹備份檔忽略 + CLAUDE.md 樣式收窄

## 這是什麼

單檔 `.gitignore` 修改，合併修復 #596（P1）與 #590，並順手刪除 line 10 的 Windows `> nul` 殘留 `nul` 條目：

- **#596**：`!.claude/skills/`、`!.claude/commands/` 把整個子樹救回可追蹤後，子樹內的備份檔（`*.bak`、`*~`、`*.edda.bak.*`）沒有任何規則忽略，會被 `git add -A` 靜默掃進 commit。新增 6 條規則，分別覆蓋兩個子樹的三種備份樣式。
- **#590**：`.gitignore:4` 的 `CLAUDE.md` 是 unanchored basename 樣式，會命中任何層級的同名檔，使 skill 子樹未來的嵌套指示檔靜默不入庫。採用 issue 建議的選項 2：收窄為 `/CLAUDE.md`（原意即忽略 repo 根那份），而非再疊否定規則。

## 驗證（config-only）

無程式碼變更，不跑 Cargo gate；以下均為本 worktree @ `047c086` 實測（RAN）。

**Baseline（未修改檔案上，RAN）：**

```
$ git check-ignore -v .claude/skills/x/SKILL.md.bak ".claude/skills/x/SKILL.md~" .claude/commands/x.md.bak .claude/skills/x/SKILL.md.edda.bak.1; echo exit=$?
exit=1        # 備份檔未被 ignore —— #596 缺陷重現
$ git check-ignore -v .claude/skills/foo/CLAUDE.md; echo exit=$?
.gitignore:4:CLAUDE.md	.claude/skills/foo/CLAUDE.md
exit=0        # unanchored 樣式命中 —— #590 缺陷重現
```

**修正後：**

```
$ git check-ignore -v .claude/skills/x/SKILL.md.bak ".claude/skills/x/SKILL.md~" .claude/commands/x.md.bak .claude/skills/x/SKILL.md.edda.bak.1; echo exit=$?
.gitignore:18:.claude/skills/**/*.bak	.claude/skills/x/SKILL.md.bak
.gitignore:19:.claude/skills/**/*~	.claude/skills/x/SKILL.md~
.gitignore:21:.claude/commands/**/*.bak	.claude/commands/x.md.bak
.gitignore:20:.claude/skills/**/*.edda.bak.*	.claude/skills/x/SKILL.md.edda.bak.1
exit=0
```

```
$ git check-ignore -v .claude/skills/commit/SKILL.md .claude/commands/pr-create.md .claude/CLAUDE.md; echo exit=$?
exit=1        # tracked 內容維持不被 ignore
```

**#590 doneWhen：**

```
$ git check-ignore -v .claude/skills/foo/CLAUDE.md; echo exit=$?
exit=1        # 嵌套指示檔不再被靜默忽略
$ git check-ignore -v CLAUDE.md; echo exit=$?
.gitignore:4:/CLAUDE.md	CLAUDE.md
exit=0        # repo 根的 CLAUDE.md 仍被 ignore，原意不回歸
```

**其他：**

- `sh scripts/lint-markdown-content.sh` → exit 0
- `git status --short` 修正後僅顯示 ` M .gitignore`，無非預期新增待追蹤檔

## 關聯

Issue: #596
Issue: #590
