### PR TITLE
fix(skills): issue-pipeline and pull-request stop skipping review, deleting branches, and removing worktrees

### DIFF
--- a/.claude/skills/issue-pipeline/SKILL.md
+++ b/.claude/skills/issue-pipeline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-pipeline
-description: "End-to-end issue pipeline: plan → implement → review → merge. Dispatches parallel sub-agents with worktree isolation. Usage: /issue-pipeline 566 567 568 [--skip-plan] [--skip-review] [--no-merge]"
+description: "End-to-end issue pipeline: plan → implement → review → merge. Dispatches parallel sub-agents with worktree isolation. Usage: /issue-pipeline 566 567 568 [--skip-plan] [--no-merge]"
 ---
 
 # Issue Pipeline Skill
@@ -15,8 +15,11 @@ You orchestrate the full lifecycle of GitHub issues through parallel sub-agents.
 
 **Flags:**
 - `--skip-plan` — Skip plan phase, go straight to implement (issues already have plans)
-- `--skip-review` — Skip review phase, merge after implement
 - `--no-merge` — Stop after review, don't auto-merge
+
+There is deliberately no `--skip-review` flag: review can never be skipped. Merging
+requires a final current-head LGTM (see Phase 4); work that fails or lacks review
+routes through the `pr-review-loop` skill instead.
 
 ## Prerequisites
 
@@ -74,11 +77,21 @@ prompt: |
 
 ### Phase 4: Merge
 
-For each PR with LGTM verdict:
+**Merge preconditions** (`pr.merge-policy`): a PR may be merged only when all of the
+following hold —
+- A final **current-head** LGTM from review (Phase 3, latest pushed SHA)
+- P0 = 0 and P1 = 0 blocking findings
+- All required checks green
+
+For each PR meeting every precondition:
 
 ```bash
-gh pr merge {pr_number} --squash --delete-branch
+gh pr merge {pr_number} --squash
 ```
+
+Never pass `--delete-branch` — branches and worktrees are never deleted (see
+`.claude/CLAUDE.md`). If a PR does not meet the preconditions, do not merge it;
+route it back through the `pr-review-loop` skill and report that it is blocked.
 
 Report final status table.
 
@@ -90,7 +103,9 @@ Report final status table.
 4. **Wait for ALL agents in a phase before starting the next phase**
 5. **Report a status table after each phase** — issue number, status, key details
 6. **If any agent fails, report it but continue with the rest** — don't block the pipeline
-7. **Clean up worktrees after merge phase** — `git worktree remove` + `git worktree prune`
+7. **Never delete branches or worktrees** — worktrees, branches, and sources are
+   never deleted (see `.claude/CLAUDE.md`); `git worktree remove` and
+   `git worktree prune` are forbidden; leave cleanup to the operator
 
 ## Status Table Format
 

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -237,18 +237,24 @@ gh pr view --json title -q '.title'
 
 ### Step 3: Merge the PR
 
+**Merge preconditions** (`pr.merge-policy`): merge only after a final current-head
+LGTM with P0=0, P1=0, and all required checks green. If these are not met, stop and
+route the PR through the review-fix loop — never merge unconditionally.
+
 **Strategy**: Squash and merge
 
 ```bash
-gh pr merge --squash --delete-branch
+gh pr merge --squash
 sleep 3
 gh pr view --json state,mergedAt
 ```
 
+Never pass `--delete-branch` — branches and worktrees are never deleted (see
+`.claude/CLAUDE.md`).
+
 **Why squash merge:**
 - Keeps main branch history clean and linear
 - Combines all commits into single commit
-- Automatically deletes feature branch
 
 ### Step 4: Switch to Main and Pull Latest
 
@@ -327,9 +333,9 @@ Changes Summary:
    Deletions: -<count>
 
 Actions Completed:
-   1. CI checks validated
-   2. PR squash merged
-   3. Feature branch deleted
+   1. Merge preconditions verified (final current-head LGTM, P0=0, P1=0, required checks green)
+   2. CI checks validated
+   3. PR squash merged
    4. Switched to main
    5. Pulled latest changes
 


### PR DESCRIPTION
## 這是什麼

Fixes the P1 from post-merge review of PR #587: two tracked, user-invocable skills instructed agents to do things `.claude/CLAUDE.md` forbids.

Changes, per issue #597's doneWhen:

- `.claude/skills/issue-pipeline/SKILL.md`
  - Removed the `--skip-review` flag (frontmatter usage, flags list). The skill now states there is deliberately no such flag and that failing review routes through `pr-review-loop`.
  - Phase 4 no longer merges unconditionally: it states the `pr.merge-policy` preconditions — final **current-head** LGTM, P0=0, P1=0, required checks green — and PRs that don't meet them are routed back to review, not merged.
  - `gh pr merge ... --delete-branch` → `gh pr merge --squash`, with an explicit "never pass `--delete-branch`" note.
  - Execution rule 7 ("Clean up worktrees after merge phase — `git worktree remove` + `git worktree prune`") replaced with a never-delete rule.
- `.claude/skills/pull-request/SKILL.md`
  - Operation 2 (merge) now states the same `pr.merge-policy` preconditions and stops on unmet ones instead of merging unconditionally.
  - `gh pr merge --squash --delete-branch` → `gh pr merge --squash`, with an explicit "never pass `--delete-branch`" note; removed "Automatically deletes feature branch" rationale and "Feature branch deleted" from the output template.

Everything else in both skills is unchanged.

## 驗證（docs-only 階梯）

- `sh scripts/lint-markdown-content.sh` → exit 0 (RAN).
- `grep -rn -e "--delete-branch" -e "worktree remove" -e "worktree prune" -e "--skip-review" .claude/skills/issue-pipeline .claude/skills/pull-request` (RAN) returns only negated/explanatory lines, all identified as such:
  - `issue-pipeline/SKILL.md:20` — "There is deliberately no `--skip-review` flag: review can never be skipped." (negation)
  - `issue-pipeline/SKILL.md:92` and `pull-request/SKILL.md:252` — "Never pass `--delete-branch` — branches and worktrees are never deleted" (negation)
  - `issue-pipeline/SKILL.md:107-108` — "`git worktree remove` and `git worktree prune` are forbidden" (negation)
- No Cargo gate: docs-only change per lane brief.

## 對齊的 repo 規則

Quoted from `.claude/CLAUDE.md`:

> "Merge still requires explicit operator authority." (CLAUDE.md:377)
>
> "worktrees, branches, and sources are never deleted" (CLAUDE.md:392)

The merge steps keep the standing `pr.merge-policy=auto-after-final-current-head-LGTM-P0-0-P1-0-required-gates-and-acceptance` authorization (operator, 2026-08-17) by stating its preconditions explicitly, and the never-delete rule is now stated in both skills instead of violated by them.

## 關聯

Issue: #597
