### PR TITLE
fix(skills): intel-scan branch bootstrap — group the orphan path; pop the stash only if one was pushed

### DIFF
--- a/.claude/skills/intel-scan/SKILL.md
+++ b/.claude/skills/intel-scan/SKILL.md
@@ -378,16 +378,20 @@ In the local clone of the target repo:
 
 ```bash
 cd <local-clone-path>
+stash_before=$(git stash list | wc -l)
 git stash --include-untracked 2>/dev/null
 git fetch origin
-git checkout intel 2>/dev/null || git checkout --orphan intel && git rm -rf . 2>/dev/null
+git checkout intel 2>/dev/null || { git checkout --orphan intel && git rm -rf . 2>/dev/null ; }
 mkdir -p intel/profiles intel/threads
 # ... write files ...
 git add intel/
 git commit -m "intel: scan $(date +%Y-%m-%d), PR #<from>~#<to>"
 git push origin intel
 git checkout - 2>/dev/null
-git stash pop 2>/dev/null
+# pop only if the stash above actually created an entry (never pop a pre-existing stash)
+if [ "$(git stash list | wc -l)" -gt "$stash_before" ]; then
+  git stash pop 2>/dev/null
+fi
 ```
 
 #### 5c. Update edda issue


### PR DESCRIPTION
## 這是什麼

修正 `.claude/skills/intel-scan/SKILL.md`（5b 節 branch-bootstrap block）的兩個缺陷（#595，P0）：

1. **`A || B && C` 優先序**：原本 `git checkout intel 2>/dev/null || git checkout --orphan intel && git rm -rf . 2>/dev/null` 在 POSIX shell 解析為 `(A || B) && C` —— 即使 `git checkout intel` 成功（`intel` branch 已存在），`git rm -rf .` 仍會執行並刪掉整棵 intel tree，隨後的 `git commit` + `git push` 會把清除出版。改為以 `{ }` 分組，讓 `git rm -rf .` 只在 orphan（首次建立）路徑執行。
2. **無條件 `git stash pop`**：tree 乾淨時 `git stash` 不會建立新 entry，但結尾的 `git stash pop` 仍會把使用者**既有的** stash pop 出來套上。改為先記錄 `git stash list` 筆數，結尾僅在筆數增加（本次確實有 push stash）時才 pop。

其餘內容（intent 與檔案其他部分）未動。docs-only 變更，未觸及任何 crate。

## 驗證（docs-only 階梯）

- 在 `$TEMP` 拋棄式 repo 重現（既有 `intel` branch 含 tracked 檔案、`git push` 以 stub 無效化）：
  - **現行 block**：`git checkout intel` 成功後 `git rm -rf .` 照跑，`README.md` 與 `intel/threads/main.md` 被刪除並寫入 commit（FAIL，先重現）。
  - **修正後 block**：檔案全部存活，commit 只新增 `intel/report-latest.md`（1 file changed, 1 insertion，無刪除）；預先存在的 stash entry 完好、未被 pop。
- `sh -n` 於抽出的修正後 block（佔位符 `cd <local-clone-path>` 代換為實際路徑）：**exit 0**。
- `sh scripts/lint-markdown-content.sh`：**exit 0**。
- 無 Cargo gate 適用（僅 skill 文字變更，未動任何 crate）。

### 重現 transcript — 現行（缺陷）block

```text
$ git stash --include-untracked 2>/dev/null
No local changes to save
$ git fetch origin
fatal: 'origin' does not appear to be a git repository
$ git checkout intel 2>/dev/null || git checkout --orphan intel && git rm -rf . 2>/dev/null
rm 'README.md'
rm 'intel/threads/main.md'
$ git add intel/ && git commit -m "intel: scan ..."
[intel 3f3ce80] intel: scan 2026-09-02, PR #1~#2
 3 files changed, 1 insertion(+), 2 deletions(-)
 delete mode 100644 README.md
 create mode 100644 intel/report-latest.md
 delete mode 100644 intel/threads/main.md
$ git push origin intel
(stub push)
--- AFTER ---
README.md DELETED
```

`git checkout intel` 成功（branch 已存在），`git rm -rf .` 仍執行 —— tracked 檔案被刪除並 commit（非 stub 情境下會被 push）。

### 驗證 transcript — 修正後 block

```text
setup: main 上 tracked README.md；intel branch tracked README.md + intel/threads/main.md；
       一筆使用者既有 stash（stash@{0}: WIP on main）
--- BEFORE fixed block: tracked files on intel ---
README.md
intel/threads/main.md
--- BEFORE: stash list ---
stash@{0}: WIP on main: 380386f main seed
$ <fixed block>
No local changes to save          # block 的 stash 未建立新 entry
$ git checkout intel              # 成功，不再觸發 git rm -rf .
[intel 4dee1fd] intel: scan 2026-09-02, PR #1~#2
 1 file changed, 1 insertion(+)
 create mode 100644 intel/report-latest.md
(stub push)
--- AFTER: stash list ---         # 既有 stash 未被 pop
stash@{0}: WIP on main: 380386f main seed
--- AFTER: intel tree ---
README.md
intel/report-latest.md
intel/threads/main.md
README.md SURVIVED
intel/threads/main.md SURVIVED
```

## 關聯

Issue: #595
