### PR TITLE
feat(edda-cli): wire launcher capabilities through edda dispatch — model, thinking, tool policy, session-dir, model listing (GH-574)

### DIFF
--- a/crates/edda-cli/src/agent_kind.rs
+++ b/crates/edda-cli/src/agent_kind.rs
@@ -56,7 +56,9 @@ impl AgentKind {
     /// (`pi --tools/--exclude-tools`, `claude --tools/--disallowedTools`).
     /// Both are capability restrictions: claude's `--allowedTools` is only
     /// a permission-prompt rule and is never spawned (GH-574 round 2,
-    /// P1-1) — the restricting flag is `--tools`.
+    /// P1-1) — the restricting flag is `--tools`, which covers only the
+    /// built-in set, so claude allowlist spawns also deny all unlisted MCP
+    /// tools via `--disallowedTools "mcp__*"` (GH-574 round 3, P1-1).
     pub fn supports_tool_policy(self) -> bool {
         matches!(self, AgentKind::Claude | AgentKind::Pi)
     }

--- a/crates/edda-cli/src/agent_kind.rs
+++ b/crates/edda-cli/src/agent_kind.rs
@@ -3,7 +3,7 @@
 //! transcript capability flag, and the launcher construct-and-probe factory
 //! live here so neither command duplicates the other's backend list.
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use edda_conductor::agent::codex_rpc::CodexLauncher;
 use edda_conductor::agent::launcher::{AgentLauncher, ClaudeCodeLauncher};
 use edda_conductor::agent::pi_rpc::PiRpcLauncher;
@@ -38,13 +38,109 @@ impl AgentKind {
             AgentKind::Codex => false,
         }
     }
+
+    /// Whether the backend can select a model via a flag edda controls
+    /// (`pi --model`, `claude --model`). codex's app-server exposes no
+    /// verifiable model-selection path, so declaring one there is refused,
+    /// never ignored (GH-574).
+    pub fn supports_model(self) -> bool {
+        matches!(self, AgentKind::Claude | AgentKind::Pi)
+    }
+
+    /// Whether the backend has a thinking-level flag. Only pi does today.
+    pub fn supports_thinking(self) -> bool {
+        matches!(self, AgentKind::Pi)
+    }
+
+    /// Whether the backend takes tool allow/deny lists
+    /// (`pi --tools/--exclude-tools`, `claude --allowedTools/--disallowedTools`).
+    pub fn supports_tool_policy(self) -> bool {
+        matches!(self, AgentKind::Claude | AgentKind::Pi)
+    }
+
+    /// Whether the backend takes a session-storage directory (`pi
+    /// --session-dir`). claude and codex manage their own session storage.
+    pub fn supports_session_dir(self) -> bool {
+        matches!(self, AgentKind::Pi)
+    }
+
+    /// Whether the backend exposes a provider/model listing query
+    /// (`pi --list-models`).
+    pub fn supports_model_listing(self) -> bool {
+        matches!(self, AgentKind::Pi)
+    }
+}
+
+// ── Backend × option support matrix (GH-574) ──
+
+/// The launcher-capability flags `edda dispatch` accepts, before they are
+/// copied onto the synthetic phase.
+#[derive(Debug, Default)]
+pub(crate) struct DispatchOptions<'a> {
+    pub model: Option<&'a str>,
+    pub thinking: Option<&'a str>,
+    pub tools: Option<&'a [String]>,
+    pub exclude_tools: Option<&'a [String]>,
+    pub session_dir: Option<&'a str>,
+}
+
+/// Reject unsupported backend/option combinations with an explicit error.
+/// Silent acceptance would recreate the exact GH-574 failure mode: a flag
+/// the caller believes is enforced, quietly doing nothing.
+pub(crate) fn validate_dispatch_options(
+    agent: AgentKind,
+    options: &DispatchOptions<'_>,
+) -> Result<()> {
+    let unsupported = [
+        (
+            "--model",
+            options.model.map(|m| format!("{m:?}")),
+            agent.supports_model(),
+        ),
+        (
+            "--thinking",
+            options.thinking.map(|t| format!("{t:?}")),
+            agent.supports_thinking(),
+        ),
+        (
+            "--tools",
+            options.tools.map(|t| format!("{t:?}")),
+            agent.supports_tool_policy(),
+        ),
+        (
+            "--exclude-tools",
+            options.exclude_tools.map(|t| format!("{t:?}")),
+            agent.supports_tool_policy(),
+        ),
+        (
+            "--session-dir",
+            options.session_dir.map(|d| format!("{d:?}")),
+            agent.supports_session_dir(),
+        ),
+    ];
+    let refused: Vec<String> = unsupported
+        .into_iter()
+        .filter_map(|(flag, value, supported)| match (value, supported) {
+            (Some(v), false) => Some(format!("{flag} {v}")),
+            _ => None,
+        })
+        .collect();
+    if !refused.is_empty() {
+        bail!(
+            "agent \"{}\" does not support: {}. edda refuses to silently ignore \
+             unsupported options — drop them or dispatch with a backend that supports them",
+            agent.as_str(),
+            refused.join(", ")
+        );
+    }
+    Ok(())
 }
 
 // ── Launcher factory ──
 
 /// Per-backend options for [`build_launcher`]: verbose streaming, the
-/// transcript directory for the backend that tees transcripts, and whether
-/// codex thread persistence is enabled.
+/// transcript directory for the backend that tees transcripts, whether
+/// codex thread persistence is enabled, and pi's session storage directory.
 pub(crate) struct LauncherOptions {
     /// Stream live agent activity while the phase runs.
     pub verbose: bool,
@@ -57,6 +153,9 @@ pub(crate) struct LauncherOptions {
     /// — conduct session ids are deterministic per plan/phase/attempt and
     /// its behavior must stay byte-identical with the pre-persistence path.
     pub persistent_codex_threads: bool,
+    /// pi `--session-dir` (GH-574). Other backends manage their own session
+    /// storage; dispatch rejects the flag for them before reaching here.
+    pub session_dir: Option<PathBuf>,
 }
 
 /// Construct and probe (`verify_available`) the launcher for `agent`.
@@ -79,7 +178,10 @@ pub(crate) fn build_launcher(
             Box::new(launcher)
         }
         AgentKind::Pi => {
-            let launcher = PiRpcLauncher::new().with_verbose(options.verbose);
+            let mut launcher = PiRpcLauncher::new().with_verbose(options.verbose);
+            if let Some(dir) = options.session_dir {
+                launcher = launcher.with_session_dir(dir);
+            }
             launcher.verify_available()?;
             Box::new(launcher)
         }
@@ -108,5 +210,111 @@ mod tests {
         assert_eq!(AgentKind::Claude.as_str(), "claude");
         assert_eq!(AgentKind::Pi.as_str(), "pi");
         assert_eq!(AgentKind::Codex.as_str(), "codex");
+    }
+
+    // ── GH-574 backend × option support matrix ──
+
+    fn options_for<'a>(
+        model: Option<&'a str>,
+        thinking: Option<&'a str>,
+        tools: Option<&'a [String]>,
+        exclude_tools: Option<&'a [String]>,
+        session_dir: Option<&'a str>,
+    ) -> DispatchOptions<'a> {
+        DispatchOptions {
+            model,
+            thinking,
+            tools,
+            exclude_tools,
+            session_dir,
+        }
+    }
+
+    #[test]
+    fn support_matrix_matches_per_backend_reality() {
+        use AgentKind::*;
+        // model: claude + pi
+        assert!(Claude.supports_model());
+        assert!(Pi.supports_model());
+        assert!(!Codex.supports_model());
+        // thinking: pi only
+        assert!(!Claude.supports_thinking());
+        assert!(Pi.supports_thinking());
+        assert!(!Codex.supports_thinking());
+        // tool policy: claude + pi
+        assert!(Claude.supports_tool_policy());
+        assert!(Pi.supports_tool_policy());
+        assert!(!Codex.supports_tool_policy());
+        // session-dir and model listing: pi only
+        assert!(Pi.supports_session_dir());
+        assert!(!Claude.supports_session_dir());
+        assert!(!Codex.supports_session_dir());
+        assert!(Pi.supports_model_listing());
+        assert!(!Claude.supports_model_listing());
+        assert!(!Codex.supports_model_listing());
+    }
+
+    #[test]
+    fn validation_accepts_every_supported_combination() {
+        let tools = vec!["read".to_string()];
+        for (agent, opts) in [
+            (
+                AgentKind::Claude,
+                options_for(Some("m"), None, Some(&tools), Some(&tools), None),
+            ),
+            (
+                AgentKind::Pi,
+                options_for(
+                    Some("m"),
+                    Some("high"),
+                    Some(&tools),
+                    Some(&tools),
+                    Some("d"),
+                ),
+            ),
+            (AgentKind::Codex, options_for(None, None, None, None, None)),
+        ] {
+            validate_dispatch_options(agent, &opts)
+                .unwrap_or_else(|e| panic!("{agent:?} combination should pass: {e}"));
+        }
+    }
+
+    #[test]
+    fn validation_refuses_unsupported_combinations_explicitly() {
+        let tools = vec!["read".to_string()];
+        let codex_all = options_for(
+            Some("anthropic/claude-opus-5"),
+            Some("high"),
+            Some(&tools),
+            Some(&tools),
+            Some("dir"),
+        );
+        let error = validate_dispatch_options(AgentKind::Codex, &codex_all)
+            .expect_err("codex supports none of these");
+        let text = error.to_string();
+        for flag in [
+            "--model",
+            "--thinking",
+            "--tools",
+            "--exclude-tools",
+            "--session-dir",
+        ] {
+            assert!(text.contains(flag), "must name {flag}: {text}");
+        }
+        assert!(text.contains("silently ignore"), "{text}");
+
+        // claude: thinking and session-dir only.
+        let claude_partial = options_for(Some("m"), Some("high"), None, None, Some("d"));
+        let error = validate_dispatch_options(AgentKind::Claude, &claude_partial)
+            .expect_err("claude refuses thinking + session-dir");
+        let text = error.to_string();
+        assert!(
+            text.contains("--thinking") && text.contains("--session-dir"),
+            "{text}"
+        );
+        assert!(
+            !text.contains("--model"),
+            "supported flag must not be refused: {text}"
+        );
     }
 }

--- a/crates/edda-cli/src/agent_kind.rs
+++ b/crates/edda-cli/src/agent_kind.rs
@@ -53,9 +53,20 @@ impl AgentKind {
     }
 
     /// Whether the backend takes tool allow/deny lists
-    /// (`pi --tools/--exclude-tools`, `claude --allowedTools/--disallowedTools`).
+    /// (`pi --tools/--exclude-tools`, `claude --tools/--disallowedTools`).
+    /// Both are capability restrictions: claude's `--allowedTools` is only
+    /// a permission-prompt rule and is never spawned (GH-574 round 2,
+    /// P1-1) — the restricting flag is `--tools`.
     pub fn supports_tool_policy(self) -> bool {
         matches!(self, AgentKind::Claude | AgentKind::Pi)
+    }
+
+    /// Whether the backend consumes a permission-mode contract
+    /// (`claude --permission-mode`). pi and codex have no permission-mode
+    /// concept at all, so an explicitly passed value is refused rather
+    /// than accepted and silently dropped (GH-574 round 2, P1-2).
+    pub fn supports_permission_mode(self) -> bool {
+        matches!(self, AgentKind::Claude)
     }
 
     /// Whether the backend takes a session-storage directory (`pi
@@ -82,6 +93,10 @@ pub(crate) struct DispatchOptions<'a> {
     pub tools: Option<&'a [String]>,
     pub exclude_tools: Option<&'a [String]>,
     pub session_dir: Option<&'a str>,
+    /// An explicitly passed permission mode. `None` means the flag was
+    /// absent — there is no clap default masking explicitness, so nothing
+    /// is claimed or dropped for backends that ignore the concept.
+    pub permission_mode: Option<&'a str>,
 }
 
 /// Reject unsupported backend/option combinations with an explicit error.
@@ -116,6 +131,11 @@ pub(crate) fn validate_dispatch_options(
             "--session-dir",
             options.session_dir.map(|d| format!("{d:?}")),
             agent.supports_session_dir(),
+        ),
+        (
+            "--permission-mode",
+            options.permission_mode.map(|m| format!("{m:?}")),
+            agent.supports_permission_mode(),
         ),
     ];
     let refused: Vec<String> = unsupported
@@ -220,6 +240,7 @@ mod tests {
         tools: Option<&'a [String]>,
         exclude_tools: Option<&'a [String]>,
         session_dir: Option<&'a str>,
+        permission_mode: Option<&'a str>,
     ) -> DispatchOptions<'a> {
         DispatchOptions {
             model,
@@ -227,6 +248,7 @@ mod tests {
             tools,
             exclude_tools,
             session_dir,
+            permission_mode,
         }
     }
 
@@ -241,10 +263,13 @@ mod tests {
         assert!(!Claude.supports_thinking());
         assert!(Pi.supports_thinking());
         assert!(!Codex.supports_thinking());
-        // tool policy: claude + pi
+        // tool policy: claude + pi; permission mode: claude only
         assert!(Claude.supports_tool_policy());
         assert!(Pi.supports_tool_policy());
         assert!(!Codex.supports_tool_policy());
+        assert!(Claude.supports_permission_mode());
+        assert!(!Pi.supports_permission_mode());
+        assert!(!Codex.supports_permission_mode());
         // session-dir and model listing: pi only
         assert!(Pi.supports_session_dir());
         assert!(!Claude.supports_session_dir());
@@ -260,7 +285,14 @@ mod tests {
         for (agent, opts) in [
             (
                 AgentKind::Claude,
-                options_for(Some("m"), None, Some(&tools), Some(&tools), None),
+                options_for(
+                    Some("m"),
+                    None,
+                    Some(&tools),
+                    Some(&tools),
+                    None,
+                    Some("bypassPermissions"),
+                ),
             ),
             (
                 AgentKind::Pi,
@@ -270,9 +302,13 @@ mod tests {
                     Some(&tools),
                     Some(&tools),
                     Some("d"),
+                    None,
                 ),
             ),
-            (AgentKind::Codex, options_for(None, None, None, None, None)),
+            (
+                AgentKind::Codex,
+                options_for(None, None, None, None, None, None),
+            ),
         ] {
             validate_dispatch_options(agent, &opts)
                 .unwrap_or_else(|e| panic!("{agent:?} combination should pass: {e}"));
@@ -288,6 +324,9 @@ mod tests {
             Some(&tools),
             Some(&tools),
             Some("dir"),
+            // The exact P1-2 repro: the value that used to be the clap
+            // default, silently dropped by every non-claude backend.
+            Some("bypassPermissions"),
         );
         let error = validate_dispatch_options(AgentKind::Codex, &codex_all)
             .expect_err("codex supports none of these");
@@ -298,13 +337,14 @@ mod tests {
             "--tools",
             "--exclude-tools",
             "--session-dir",
+            "--permission-mode",
         ] {
             assert!(text.contains(flag), "must name {flag}: {text}");
         }
         assert!(text.contains("silently ignore"), "{text}");
 
-        // claude: thinking and session-dir only.
-        let claude_partial = options_for(Some("m"), Some("high"), None, None, Some("d"));
+        // claude: thinking, session-dir and pi's session storage only.
+        let claude_partial = options_for(Some("m"), Some("high"), None, None, Some("d"), None);
         let error = validate_dispatch_options(AgentKind::Claude, &claude_partial)
             .expect_err("claude refuses thinking + session-dir");
         let text = error.to_string();
@@ -313,8 +353,15 @@ mod tests {
             "{text}"
         );
         assert!(
-            !text.contains("--model"),
-            "supported flag must not be refused: {text}"
+            !text.contains("--model") && !text.contains("--permission-mode"),
+            "supported flags must not be refused: {text}"
         );
+
+        // pi: no permission-mode concept; an explicit value is refused
+        // even the default-looking one (GH-574 round 2, P1-2).
+        let pi_pm = options_for(None, None, None, None, None, Some("bypassPermissions"));
+        let error = validate_dispatch_options(AgentKind::Pi, &pi_pm)
+            .expect_err("pi has no permission-mode concept");
+        assert!(error.to_string().contains("--permission-mode"), "{error}");
     }
 }

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -238,6 +238,9 @@ pub fn run(
             // persisted binding could leak a stale thread/resume into a
             // later invocation and every turn would gain store I/O.
             persistent_codex_threads: false,
+            // Conduct has no session-dir surface (GH-574); pi uses its own
+            // default session storage under conduct.
+            session_dir: None,
         },
     )?;
     let engine = CheckEngine::new(cwd.clone());

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -50,11 +50,12 @@ pub struct DispatchArgs {
     /// Turn timeout in seconds (default: 1800, like a conduct phase)
     #[arg(long)]
     pub timeout_sec: Option<u64>,
-    /// Permission mode carried on the synthetic phase verbatim (default:
-    /// bypassPermissions). Only the claude backend consumes this today;
-    /// pi and codex ignore it (a non-default value prints a warning).
-    #[arg(long, default_value = "bypassPermissions")]
-    pub permission_mode: String,
+    /// Permission mode for the claude backend (`claude --permission-mode`,
+    /// default bypassPermissions). pi and codex have no permission-mode
+    /// concept; an explicitly passed value is refused, never accepted and
+    /// silently dropped (GH-574).
+    #[arg(long)]
+    pub permission_mode: Option<String>,
     /// Model selection passed to the backend verbatim (GH-574): pi gets
     /// `--model <pattern>` (e.g. `openai-codex/gpt-5.6-sol`), claude gets
     /// `--model`. codex has no verifiable selection path and refuses the
@@ -66,9 +67,9 @@ pub struct DispatchArgs {
     #[arg(long)]
     pub thinking: Option<String>,
     /// Tool allowlist, comma-separated (GH-574): pi `--tools`, claude
-    /// `--allowedTools`. An allowlist replaces the backend's default tool
-    /// set — e.g. `--tools read,grep,find,ls` makes the turn structurally
-    /// read-only. codex refuses it.
+    /// `--tools`. Both restrict capabilities — the listed tools are the
+    /// only ones the backend can use — so e.g. `--tools read,grep,find,ls`
+    /// makes the turn structurally read-only. codex refuses it.
     #[arg(long, value_delimiter = ',')]
     pub tools: Option<Vec<String>>,
     /// Tool denylist, comma-separated (GH-574): pi `--exclude-tools`, claude
@@ -84,6 +85,8 @@ pub struct DispatchArgs {
     /// List available provider/model pairs for the backend and exit, instead
     /// of dispatching. Optional search term filters the listing (pi
     /// `--list-models [search]`); other backends refuse it. Requires --agent.
+    /// The listing is text: combining it with --json is an explicit
+    /// conflict error, because --json promises exactly one JSON object.
     #[arg(long, num_args = 0..=1, default_missing_value = "")]
     pub list_models: Option<String>,
     /// Print one JSON object to stdout instead of text lines
@@ -352,6 +355,15 @@ fn run_inner(args: DispatchArgs) -> Result<i32> {
     // and exit 0 (GH-574 — callers look up patterns instead of guessing a
     // provider prefix).
     if let Some(search) = args.list_models.as_deref() {
+        // GH-574 round 2 (P1-3): the listing is text, but --json promises
+        // "exactly one object" on stdout. Refuse the combination instead of
+        // printing a text table that breaks every JSON consumer.
+        if args.json {
+            bail!(
+                "--json cannot be combined with --list-models: the model listing is \
+                 text, and --json promises exactly one JSON object on stdout"
+            );
+        }
         if !args.agent.supports_model_listing() {
             bail!(
                 "--list-models is only available for the pi backend; agent \"{}\" \
@@ -372,7 +384,10 @@ fn run_inner(args: DispatchArgs) -> Result<i32> {
         .with_context(|| format!("--prompt-file not readable: {prompt_file}"))?;
 
     // GH-574 honesty gate: refuse unsupported backend/option combinations
-    // instead of accepting them and silently doing nothing.
+    // instead of accepting them and silently doing nothing. An explicitly
+    // passed --permission-mode on a backend with no permission concept is
+    // refused here too (GH-574 round 2, P1-2) — there is no clap default,
+    // so an absent flag claims nothing and drops nothing.
     validate_dispatch_options(
         args.agent,
         &DispatchOptions {
@@ -381,6 +396,7 @@ fn run_inner(args: DispatchArgs) -> Result<i32> {
             tools: args.tools.as_deref(),
             exclude_tools: args.exclude_tools.as_deref(),
             session_dir: args.session_dir.as_deref(),
+            permission_mode: args.permission_mode.as_deref(),
         },
     )?;
 
@@ -402,14 +418,12 @@ fn run_inner(args: DispatchArgs) -> Result<i32> {
         eprintln!("{warning}");
     }
 
-    // A non-default permission mode is only consumed by claude (GH-574
-    // audit): warn rather than let the caller believe it is enforced.
-    if args.permission_mode != "bypassPermissions" && args.agent != AgentKind::Claude {
-        eprintln!(
-            "Warning: agent \"{}\" ignores --permission-mode; only claude consumes it.",
-            args.agent.as_str()
-        );
-    }
+    // Permission mode is a claude-only contract (refused above for the
+    // other backends); an absent flag falls back to claude's default.
+    let permission_mode = args
+        .permission_mode
+        .clone()
+        .unwrap_or_else(|| "bypassPermissions".to_owned());
 
     let launcher = build_launcher(
         args.agent,
@@ -427,7 +441,7 @@ fn run_inner(args: DispatchArgs) -> Result<i32> {
         &prompt,
         args.budget_usd,
         args.timeout_sec,
-        &args.permission_mode,
+        &permission_mode,
         CapabilityOptions {
             model: args.model,
             thinking: args.thinking,
@@ -1184,9 +1198,11 @@ mod tests {
     // ── --permission-mode flag ──
 
     #[test]
-    fn dispatch_defaults_permission_mode_to_bypass() {
+    fn dispatch_permission_mode_is_none_when_not_passed() {
+        // No clap default: an absent flag claims nothing, so backends that
+        // ignore permission modes drop nothing silently (GH-574 round 2).
         let args = parse(&["edda", "--agent", "claude", "--prompt-file", "p.txt"]);
-        assert_eq!(args.permission_mode, "bypassPermissions");
+        assert_eq!(args.permission_mode, None);
     }
 
     #[test]
@@ -1200,7 +1216,40 @@ mod tests {
             "--permission-mode",
             "default",
         ]);
-        assert_eq!(args.permission_mode, "default");
+        assert_eq!(args.permission_mode.as_deref(), Some("default"));
+    }
+
+    /// The P1-2 repro, at the run_inner level: an explicit --permission-mode
+    /// on codex is refused before any launcher is built. (The cross-process
+    /// form lives in tests/dispatch_permission_mode.rs; this in-process form
+    /// needs no fake binary because the refusal fires first.)
+    #[test]
+    fn run_inner_refuses_permission_mode_on_backends_without_a_permission_concept() {
+        let dir = std::env::temp_dir().join(format!(
+            "edda-dispatch-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let prompt = dir.join("prompt.txt");
+        std::fs::write(&prompt, "p").expect("prompt written");
+        let prompt = prompt.to_string_lossy().into_owned();
+        let args = parse(&[
+            "edda",
+            "--agent",
+            "codex",
+            "--permission-mode",
+            "bypassPermissions",
+            "--prompt-file",
+            &prompt,
+        ]);
+        let error = run_inner(args)
+            .expect_err("codex has no permission-mode concept; the value must be refused");
+        assert!(error.to_string().contains("--permission-mode"), "{error}");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // ── End-to-end-ish run through MockLauncher ──

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -11,9 +11,11 @@
 //! - 3 = budget exceeded
 //! - 4 = max turns
 
-use crate::agent_kind::{build_launcher, AgentKind, LauncherOptions};
+use crate::agent_kind::{
+    build_launcher, validate_dispatch_options, AgentKind, DispatchOptions, LauncherOptions,
+};
 use crate::cmd_conduct::{budget_warning_for_agent, cost_line, NO_USAGE_COST_TEXT};
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use clap::Args;
 use edda_conductor::agent::launcher::{phase_session_id, AgentLauncher, PhaseResult};
 use edda_conductor::plan::schema::Phase as PhaseSchema;
@@ -27,9 +29,10 @@ pub struct DispatchArgs {
     /// Agent backend that runs the turn
     #[arg(long, value_enum)]
     pub agent: AgentKind,
-    /// Path to a file containing the prompt (read verbatim)
-    #[arg(long)]
-    pub prompt_file: String,
+    /// Path to a file containing the prompt (read verbatim). Required
+    /// unless --list-models is given.
+    #[arg(long, required_unless_present = "list_models")]
+    pub prompt_file: Option<String>,
     /// Session id passed to the backend verbatim. Continuity semantics are
     /// per-backend, and all three persist conversations across invocations:
     /// claude and pi delegate to their backends, and codex's session→thread
@@ -49,9 +52,40 @@ pub struct DispatchArgs {
     pub timeout_sec: Option<u64>,
     /// Permission mode carried on the synthetic phase verbatim (default:
     /// bypassPermissions). Only the claude backend consumes this today;
-    /// pi and codex ignore it.
+    /// pi and codex ignore it (a non-default value prints a warning).
     #[arg(long, default_value = "bypassPermissions")]
     pub permission_mode: String,
+    /// Model selection passed to the backend verbatim (GH-574): pi gets
+    /// `--model <pattern>` (e.g. `openai-codex/gpt-5.6-sol`), claude gets
+    /// `--model`. codex has no verifiable selection path and refuses the
+    /// flag. Run `--list-models` to look up valid patterns.
+    #[arg(long)]
+    pub model: Option<String>,
+    /// Thinking level passed to pi verbatim via `--thinking`
+    /// (off|minimal|low|medium|high|xhigh|max). claude and codex refuse it.
+    #[arg(long)]
+    pub thinking: Option<String>,
+    /// Tool allowlist, comma-separated (GH-574): pi `--tools`, claude
+    /// `--allowedTools`. An allowlist replaces the backend's default tool
+    /// set — e.g. `--tools read,grep,find,ls` makes the turn structurally
+    /// read-only. codex refuses it.
+    #[arg(long, value_delimiter = ',')]
+    pub tools: Option<Vec<String>>,
+    /// Tool denylist, comma-separated (GH-574): pi `--exclude-tools`, claude
+    /// `--disallowedTools`. Structural enforcement, not prompt discipline:
+    /// e.g. `--exclude-tools edit,write` removes file-modification tools
+    /// from the agent entirely. codex refuses it.
+    #[arg(long, value_delimiter = ',')]
+    pub exclude_tools: Option<Vec<String>>,
+    /// Session storage directory (pi only, `--session-dir`). claude and
+    /// codex manage their own session storage and refuse the flag.
+    #[arg(long)]
+    pub session_dir: Option<String>,
+    /// List available provider/model pairs for the backend and exit, instead
+    /// of dispatching. Optional search term filters the listing (pi
+    /// `--list-models [search]`); other backends refuse it. Requires --agent.
+    #[arg(long, num_args = 0..=1, default_missing_value = "")]
+    pub list_models: Option<String>,
     /// Print one JSON object to stdout instead of text lines
     #[arg(long)]
     pub json: bool,
@@ -95,7 +129,9 @@ pub fn exit_code_for(outcome: Outcome) -> i32 {
 }
 
 /// Everything the caller needs after one dispatched turn: the outcome class,
-/// the agent's summary, the honest cost figure, and the session id to reuse.
+/// the agent's summary, the honest cost figure, the session id to reuse, and
+/// the model story — what edda requested and what the backend reported
+/// observing in-band (GH-574).
 #[derive(Debug, Clone)]
 pub struct DispatchOutput {
     pub outcome: Outcome,
@@ -103,10 +139,23 @@ pub struct DispatchOutput {
     pub cost_usd: Option<f64>,
     pub session_id: String,
     pub error: Option<String>,
+    /// The model edda actually passed to the backend, or the literal
+    /// "inherited" when no --model was given (the backend's own default
+    /// applies — visible instead of silently identical).
+    pub model_requested: String,
+    /// The model the backend reported in-band, or the literal "unknown"
+    /// when it reported nothing. Observed, never inferred from config or
+    /// session files (GH-574 honesty rule).
+    pub model_observed: String,
 }
 
 impl DispatchOutput {
-    pub fn from_result(result: PhaseResult, session_id: String) -> Self {
+    pub fn from_result(
+        result: PhaseResult,
+        session_id: String,
+        model_requested: String,
+        model_observed: String,
+    ) -> Self {
         match result {
             PhaseResult::AgentDone {
                 cost_usd,
@@ -117,6 +166,8 @@ impl DispatchOutput {
                 cost_usd,
                 session_id,
                 error: None,
+                model_requested,
+                model_observed,
             },
             PhaseResult::AgentCrash { error } => Self {
                 outcome: Outcome::Crash,
@@ -124,6 +175,8 @@ impl DispatchOutput {
                 cost_usd: None,
                 session_id,
                 error: Some(error),
+                model_requested,
+                model_observed,
             },
             PhaseResult::Timeout => Self {
                 outcome: Outcome::Timeout,
@@ -131,6 +184,8 @@ impl DispatchOutput {
                 cost_usd: None,
                 session_id,
                 error: None,
+                model_requested,
+                model_observed,
             },
             PhaseResult::MaxTurns { cost_usd } => Self {
                 outcome: Outcome::MaxTurns,
@@ -138,6 +193,8 @@ impl DispatchOutput {
                 cost_usd,
                 session_id,
                 error: None,
+                model_requested,
+                model_observed,
             },
             PhaseResult::BudgetExceeded { cost_usd } => Self {
                 outcome: Outcome::BudgetExceeded,
@@ -145,6 +202,8 @@ impl DispatchOutput {
                 cost_usd,
                 session_id,
                 error: None,
+                model_requested,
+                model_observed,
             },
         }
     }
@@ -163,7 +222,8 @@ impl DispatchOutput {
             .unwrap_or_else(|| NO_USAGE_COST_TEXT.to_owned())
     }
 
-    /// Text-mode stdout: result text, then `Cost:`, then `Session:`.
+    /// Text-mode stdout: result text, then `Cost:`, then the model story
+    /// (GH-574), then `Session:`.
     pub fn render_text(&self) -> String {
         let mut out = String::new();
         if let Some(text) = &self.result_text {
@@ -173,6 +233,8 @@ impl DispatchOutput {
             }
         }
         out.push_str(&format!("Cost: {}\n", self.cost_text()));
+        out.push_str(&format!("Model requested: {}\n", self.model_requested));
+        out.push_str(&format!("Model observed: {}\n", self.model_observed));
         out.push_str(&format!("Session: {}\n", self.session_id));
         out
     }
@@ -185,6 +247,8 @@ impl DispatchOutput {
             "cost_usd": self.cost_usd,
             "session_id": self.session_id,
             "error": self.error,
+            "model_requested": self.model_requested,
+            "model_observed": self.model_observed,
         })
         .to_string()
     }
@@ -192,16 +256,37 @@ impl DispatchOutput {
 
 // ── Phase + launcher construction ──
 
+/// The GH-574 launcher-capability options a dispatched turn carries on its
+/// synthetic phase: model selection, thinking level, and tool policy.
+/// Declared but unsupported backend combinations are rejected by
+/// [`crate::agent_kind::validate_dispatch_options`] before this reaches a
+/// launcher.
+#[derive(Debug, Default, Clone)]
+pub struct CapabilityOptions {
+    pub model: Option<String>,
+    pub thinking: Option<String>,
+    pub tools: Option<Vec<String>>,
+    pub exclude_tools: Option<Vec<String>>,
+}
+
 /// Build the synthetic single-turn phase, mapping flags exactly the way a
-/// conduct phase's fields map: budget, timeout, and permission mode land on
-/// the phase, and a missing timeout falls back to the launcher's 1800 s
-/// default — the same default a plan-level `timeout_sec` would supply.
+/// conduct phase's fields map: budget, timeout, permission mode, model,
+/// thinking level, and tool policy land on the phase, and a missing timeout
+/// falls back to the launcher's 1800 s default — the same default a
+/// plan-level `timeout_sec` would supply.
 pub fn build_phase(
     prompt: &str,
     budget_usd: Option<f64>,
     timeout_sec: Option<u64>,
     permission_mode: &str,
+    capabilities: CapabilityOptions,
 ) -> PhaseSchema {
+    let CapabilityOptions {
+        model,
+        thinking,
+        tools,
+        exclude_tools,
+    } = capabilities;
     PhaseSchema {
         id: "dispatch".to_owned(),
         prompt: prompt.to_owned(),
@@ -214,7 +299,10 @@ pub fn build_phase(
         context: None,
         env: std::collections::HashMap::new(),
         budget_usd,
-        allowed_tools: None,
+        tools,
+        exclude_tools,
+        model,
+        thinking,
         permission_mode: permission_mode.to_owned(),
         gate: None,
         gate_timeout_sec: None,
@@ -260,8 +348,41 @@ pub fn run(args: DispatchArgs) -> Result<()> {
 }
 
 fn run_inner(args: DispatchArgs) -> Result<i32> {
-    let prompt = std::fs::read_to_string(&args.prompt_file)
-        .with_context(|| format!("--prompt-file not readable: {}", args.prompt_file))?;
+    // --list-models short-circuits dispatch: print the provider/model table
+    // and exit 0 (GH-574 — callers look up patterns instead of guessing a
+    // provider prefix).
+    if let Some(search) = args.list_models.as_deref() {
+        if !args.agent.supports_model_listing() {
+            bail!(
+                "--list-models is only available for the pi backend; agent \"{}\" \
+                 exposes no provider/model listing query",
+                args.agent.as_str()
+            );
+        }
+        let text = edda_conductor::agent::pi_rpc::list_models(None, Some(search))?;
+        print!("{text}");
+        return Ok(0);
+    }
+
+    let prompt_file = args
+        .prompt_file
+        .as_deref()
+        .context("--prompt-file is required unless --list-models is given")?;
+    let prompt = std::fs::read_to_string(prompt_file)
+        .with_context(|| format!("--prompt-file not readable: {prompt_file}"))?;
+
+    // GH-574 honesty gate: refuse unsupported backend/option combinations
+    // instead of accepting them and silently doing nothing.
+    validate_dispatch_options(
+        args.agent,
+        &DispatchOptions {
+            model: args.model.as_deref(),
+            thinking: args.thinking.as_deref(),
+            tools: args.tools.as_deref(),
+            exclude_tools: args.exclude_tools.as_deref(),
+            session_dir: args.session_dir.as_deref(),
+        },
+    )?;
 
     let session_id = args.session_id.clone().unwrap_or_else(generate_session_id);
 
@@ -281,6 +402,15 @@ fn run_inner(args: DispatchArgs) -> Result<i32> {
         eprintln!("{warning}");
     }
 
+    // A non-default permission mode is only consumed by claude (GH-574
+    // audit): warn rather than let the caller believe it is enforced.
+    if args.permission_mode != "bypassPermissions" && args.agent != AgentKind::Claude {
+        eprintln!(
+            "Warning: agent \"{}\" ignores --permission-mode; only claude consumes it.",
+            args.agent.as_str()
+        );
+    }
+
     let launcher = build_launcher(
         args.agent,
         LauncherOptions {
@@ -290,6 +420,7 @@ fn run_inner(args: DispatchArgs) -> Result<i32> {
             // --session-id must resume the conversation a previous dispatch
             // recorded.
             persistent_codex_threads: true,
+            session_dir: args.session_dir.map(std::path::PathBuf::from),
         },
     )?;
     let phase = build_phase(
@@ -297,6 +428,12 @@ fn run_inner(args: DispatchArgs) -> Result<i32> {
         args.budget_usd,
         args.timeout_sec,
         &args.permission_mode,
+        CapabilityOptions {
+            model: args.model,
+            thinking: args.thinking,
+            tools: args.tools,
+            exclude_tools: args.exclude_tools,
+        },
     );
     let cancel = CancellationToken::new();
 
@@ -357,7 +494,22 @@ pub async fn run_with_launcher(
         )
         .await?
     };
-    Ok(DispatchOutput::from_result(result, session_id.to_owned()))
+    // GH-574: requested comes from the phase edda built (what was actually
+    // passed to the backend); observed is whatever the backend reported
+    // in-band, "unknown" when it reported nothing.
+    let model_requested = phase
+        .model
+        .clone()
+        .unwrap_or_else(|| "inherited".to_owned());
+    let model_observed = launcher
+        .last_observed_model()
+        .unwrap_or_else(|| "unknown".to_owned());
+    Ok(DispatchOutput::from_result(
+        result,
+        session_id.to_owned(),
+        model_requested,
+        model_observed,
+    ))
 }
 
 #[cfg(test)]
@@ -433,6 +585,217 @@ mod tests {
         );
     }
 
+    #[test]
+    fn dispatch_prompt_file_optional_when_listing_models() {
+        let args = parse(&["edda", "--agent", "pi", "--list-models"]);
+        assert!(args.prompt_file.is_none());
+        assert_eq!(args.list_models.as_deref(), Some(""));
+        let args = parse(&["edda", "--agent", "pi", "--list-models", "sol"]);
+        assert_eq!(args.list_models.as_deref(), Some("sol"));
+    }
+
+    // ── GH-574: launcher-capability flags ──
+
+    #[test]
+    fn dispatch_parses_model_thinking_and_tool_flags() {
+        let args = parse(&[
+            "edda",
+            "--agent",
+            "pi",
+            "--prompt-file",
+            "p.txt",
+            "--model",
+            "openai-codex/gpt-5.6-sol",
+            "--thinking",
+            "high",
+            "--tools",
+            "read,grep",
+            "--exclude-tools",
+            "edit,write",
+            "--session-dir",
+            "/tmp/pi-sessions",
+        ]);
+        assert_eq!(args.model.as_deref(), Some("openai-codex/gpt-5.6-sol"));
+        assert_eq!(args.thinking.as_deref(), Some("high"));
+        assert_eq!(args.tools, Some(vec!["read".into(), "grep".into()]));
+        assert_eq!(
+            args.exclude_tools,
+            Some(vec!["edit".into(), "write".into()])
+        );
+        assert_eq!(args.session_dir.as_deref(), Some("/tmp/pi-sessions"));
+    }
+
+    #[test]
+    fn phase_carries_model_thinking_and_tool_policy() {
+        let phase = build_phase(
+            "p",
+            None,
+            None,
+            "bypassPermissions",
+            CapabilityOptions {
+                model: Some("anthropic/claude-opus-5".into()),
+                thinking: Some("high".into()),
+                tools: Some(vec!["read".into(), "grep".into()]),
+                exclude_tools: Some(vec!["edit".into(), "write".into()]),
+            },
+        );
+        assert_eq!(phase.model.as_deref(), Some("anthropic/claude-opus-5"));
+        assert_eq!(phase.thinking.as_deref(), Some("high"));
+        assert_eq!(phase.tools, Some(vec!["read".into(), "grep".into()]));
+        assert_eq!(
+            phase.exclude_tools,
+            Some(vec!["edit".into(), "write".into()])
+        );
+    }
+
+    #[test]
+    fn model_report_defaults_to_inherited_and_unknown() {
+        let out = DispatchOutput::from_result(
+            PhaseResult::AgentDone {
+                cost_usd: None,
+                result_text: None,
+            },
+            "s".into(),
+            "inherited".into(),
+            "unknown".into(),
+        );
+        let text = out.render_text();
+        assert!(text.contains("Model requested: inherited"), "{text}");
+        assert!(text.contains("Model observed: unknown"), "{text}");
+        let value: serde_json::Value = serde_json::from_str(&out.to_json()).unwrap();
+        assert_eq!(value["model_requested"], "inherited");
+        assert_eq!(value["model_observed"], "unknown");
+    }
+
+    #[test]
+    fn model_report_carries_requested_and_observed() {
+        let out = DispatchOutput::from_result(
+            PhaseResult::AgentDone {
+                cost_usd: Some(0.2),
+                result_text: None,
+            },
+            "s".into(),
+            "openai-codex/gpt-5.6-sol".into(),
+            "openai-codex/gpt-5.6-sol".into(),
+        );
+        let text = out.render_text();
+        assert!(
+            text.contains("Model requested: openai-codex/gpt-5.6-sol"),
+            "{text}"
+        );
+        assert!(
+            text.contains("Model observed: openai-codex/gpt-5.6-sol"),
+            "{text}"
+        );
+        let value: serde_json::Value = serde_json::from_str(&out.to_json()).unwrap();
+        assert_eq!(value["model_requested"], "openai-codex/gpt-5.6-sol");
+    }
+
+    /// Incident counterexample (GH-574): the 2026-09-02 review degradation
+    /// produced byte-identical stdout whether the review model was applied
+    /// or silently dropped. After the fix, the requested-model line alone
+    /// makes the two dispatches distinguishable.
+    #[test]
+    fn stdout_differs_between_a_dispatched_model_and_the_inherited_default() {
+        let result = PhaseResult::AgentDone {
+            cost_usd: Some(0.2),
+            result_text: Some("review done".into()),
+        };
+        let with_model = DispatchOutput::from_result(
+            result.clone(),
+            "s".into(),
+            "openai-codex/gpt-5.6-sol".into(),
+            "unknown".into(),
+        );
+        let without_model =
+            DispatchOutput::from_result(result, "s".into(), "inherited".into(), "unknown".into());
+        assert_ne!(
+            with_model.render_text(),
+            without_model.render_text(),
+            "dispatch stdout must differ between --model X and no --model"
+        );
+    }
+
+    #[test]
+    fn run_with_launcher_reports_inherited_when_no_model_declared() {
+        let launcher = MockLauncher::new();
+        launcher.set_results(
+            "dispatch",
+            vec![PhaseResult::AgentDone {
+                cost_usd: None,
+                result_text: None,
+            }],
+        );
+        let phase = build_phase(
+            "prompt",
+            None,
+            None,
+            "bypassPermissions",
+            CapabilityOptions::default(),
+        );
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let out = rt.block_on(run_with_launcher(
+            &launcher,
+            &phase,
+            "s",
+            Path::new("."),
+            CancellationToken::new(),
+        ));
+        let out = out.unwrap();
+        assert_eq!(out.model_requested, "inherited");
+        // MockLauncher reports nothing in-band: unknown, honestly.
+        assert_eq!(out.model_observed, "unknown");
+    }
+
+    #[test]
+    fn run_with_launcher_reports_the_declared_model_as_requested() {
+        let launcher = MockLauncher::new();
+        launcher.set_results(
+            "dispatch",
+            vec![PhaseResult::AgentDone {
+                cost_usd: None,
+                result_text: None,
+            }],
+        );
+        let phase = build_phase(
+            "prompt",
+            None,
+            None,
+            "bypassPermissions",
+            CapabilityOptions {
+                model: Some("openai-codex/gpt-5.6-sol".into()),
+                thinking: None,
+                tools: None,
+                exclude_tools: None,
+            },
+        );
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let out = rt.block_on(run_with_launcher(
+            &launcher,
+            &phase,
+            "s",
+            Path::new("."),
+            CancellationToken::new(),
+        ));
+        let out = out.unwrap();
+        assert_eq!(out.model_requested, "openai-codex/gpt-5.6-sol");
+    }
+
+    /// The --list-models gate lives in run_inner ahead of any spawn, so the
+    /// refusal is testable without a backend: a backend without a listing
+    /// query is an explicit error, never a silent fallthrough.
+    #[test]
+    fn list_models_refuses_backends_without_a_listing_query() {
+        let args = parse(&["edda", "--agent", "claude", "--list-models"]);
+        let error = run_inner(args).expect_err("claude has no model listing");
+        assert!(
+            error
+                .to_string()
+                .contains("only available for the pi backend"),
+            "{error}"
+        );
+    }
+
     // ── Outcome → exit-code mapping (all five PhaseResult variants) ──
 
     #[test]
@@ -458,7 +821,12 @@ mod tests {
             (PhaseResult::MaxTurns { cost_usd: None }, 4),
         ];
         for (result, expected) in cases {
-            let out = DispatchOutput::from_result(result, "s".into());
+            let out = DispatchOutput::from_result(
+                result,
+                "s".into(),
+                "inherited".into(),
+                "unknown".into(),
+            );
             assert_eq!(
                 exit_code_for(out.outcome),
                 expected,
@@ -477,6 +845,8 @@ mod tests {
                 result_text: Some("ok".into()),
             },
             "s".into(),
+            "inherited".into(),
+            "unknown".into(),
         );
         assert_eq!(out.exit_code(), 0);
         assert_eq!(out.outcome, Outcome::Done);
@@ -508,7 +878,12 @@ mod tests {
             ),
         ];
         for (result, expected_outcome) in cases {
-            let out = DispatchOutput::from_result(result, "sess-1".into());
+            let out = DispatchOutput::from_result(
+                result,
+                "sess-1".into(),
+                "inherited".into(),
+                "unknown".into(),
+            );
             let value: serde_json::Value =
                 serde_json::from_str(&out.to_json()).expect("json parses");
             assert_eq!(value["outcome"].as_str(), Some(expected_outcome));
@@ -525,7 +900,15 @@ mod tests {
             keys.sort_unstable();
             assert_eq!(
                 keys,
-                vec!["cost_usd", "error", "outcome", "result_text", "session_id"]
+                vec![
+                    "cost_usd",
+                    "error",
+                    "model_observed",
+                    "model_requested",
+                    "outcome",
+                    "result_text",
+                    "session_id"
+                ]
             );
         }
     }
@@ -537,6 +920,8 @@ mod tests {
                 error: "exit 3".into(),
             },
             "s".into(),
+            "inherited".into(),
+            "unknown".into(),
         );
         let value: serde_json::Value = serde_json::from_str(&crash.to_json()).unwrap();
         assert_eq!(value["outcome"].as_str(), Some("crash"));
@@ -550,6 +935,8 @@ mod tests {
                 result_text: None,
             },
             "s".into(),
+            "inherited".into(),
+            "unknown".into(),
         );
         let value: serde_json::Value = serde_json::from_str(&done.to_json()).expect("json parses");
         assert_eq!(value["outcome"].as_str(), Some("done"));
@@ -568,6 +955,8 @@ mod tests {
                 result_text: Some("done deal".into()),
             },
             "abc-123".into(),
+            "inherited".into(),
+            "unknown".into(),
         );
         let text = out.render_text();
         assert!(text.contains("done deal\n"), "{text}");
@@ -582,7 +971,12 @@ mod tests {
 
     #[test]
     fn text_render_reports_na_when_no_usage() {
-        let out = DispatchOutput::from_result(PhaseResult::MaxTurns { cost_usd: None }, "s".into());
+        let out = DispatchOutput::from_result(
+            PhaseResult::MaxTurns { cost_usd: None },
+            "s".into(),
+            "inherited".into(),
+            "unknown".into(),
+        );
         let text = out.render_text();
         assert!(
             text.contains("Cost: n/a (no usage data reported)"),
@@ -609,6 +1003,8 @@ mod tests {
                 result_text: None,
             },
             "my-session-42".into(),
+            "inherited".into(),
+            "unknown".into(),
         );
         assert!(out.render_text().contains("Session: my-session-42"));
         assert!(out.to_json().contains("my-session-42"));
@@ -649,7 +1045,13 @@ mod tests {
         let recorder = RecordingLauncher {
             session_ids: Mutex::new(Vec::new()),
         };
-        let phase = build_phase("prompt", None, None, "bypassPermissions");
+        let phase = build_phase(
+            "prompt",
+            None,
+            None,
+            "bypassPermissions",
+            CapabilityOptions::default(),
+        );
         let cancel = CancellationToken::new();
 
         run_with_launcher(
@@ -690,7 +1092,13 @@ mod tests {
         let launcher = RecordingLauncher {
             session_ids: Mutex::new(Vec::new()),
         };
-        let phase = build_phase("prompt", None, None, "bypassPermissions");
+        let phase = build_phase(
+            "prompt",
+            None,
+            None,
+            "bypassPermissions",
+            CapabilityOptions::default(),
+        );
         let sid = "x\\..\\..\\..\\escaped";
         run_with_launcher(
             &launcher,
@@ -726,7 +1134,13 @@ mod tests {
 
     #[test]
     fn phase_maps_budget_and_timeout_flags_like_conduct() {
-        let phase = build_phase("do the thing", Some(1.5), Some(60), "bypassPermissions");
+        let phase = build_phase(
+            "do the thing",
+            Some(1.5),
+            Some(60),
+            "bypassPermissions",
+            CapabilityOptions::default(),
+        );
         assert_eq!(phase.id, "dispatch");
         assert_eq!(phase.prompt, "do the thing");
         assert_eq!(phase.budget_usd, Some(1.5));
@@ -734,7 +1148,13 @@ mod tests {
 
         // Omitted flags stay None, exactly like a conduct phase without
         // them; the launcher then applies its 1800 s default.
-        let phase = build_phase("p", None, None, "bypassPermissions");
+        let phase = build_phase(
+            "p",
+            None,
+            None,
+            "bypassPermissions",
+            CapabilityOptions::default(),
+        );
         assert_eq!(phase.budget_usd, None);
         assert_eq!(phase.timeout_sec, None);
         assert_eq!(phase.permission_mode, "bypassPermissions");
@@ -746,7 +1166,7 @@ mod tests {
     fn phase_carries_permission_mode_verbatim() {
         // The flag lands on the synthetic phase the way a conduct phase
         // carries its own permission_mode.
-        let phase = build_phase("p", None, None, "acceptEdits");
+        let phase = build_phase("p", None, None, "acceptEdits", CapabilityOptions::default());
         assert_eq!(phase.permission_mode, "acceptEdits");
     }
 
@@ -784,7 +1204,13 @@ mod tests {
                 result_text: Some("(mock) finished".into()),
             }],
         );
-        let phase = build_phase("prompt", None, None, "bypassPermissions");
+        let phase = build_phase(
+            "prompt",
+            None,
+            None,
+            "bypassPermissions",
+            CapabilityOptions::default(),
+        );
         let out = run_with_launcher(
             &launcher,
             &phase,
@@ -805,7 +1231,13 @@ mod tests {
     async fn mock_timeout_maps_to_exit_code_2() {
         let launcher = MockLauncher::new();
         launcher.set_results("dispatch", vec![PhaseResult::Timeout]);
-        let phase = build_phase("prompt", None, None, "bypassPermissions");
+        let phase = build_phase(
+            "prompt",
+            None,
+            None,
+            "bypassPermissions",
+            CapabilityOptions::default(),
+        );
         let out = run_with_launcher(
             &launcher,
             &phase,

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -810,6 +810,27 @@ mod tests {
         );
     }
 
+    /// GH-574 round 3 (P1-2): the --list-models short-circuit must not
+    /// bypass the capability gate. An explicit --permission-mode on pi is
+    /// refused even in listing mode, before any model query runs. Pre-fix,
+    /// this combination reached the pi backend and exited 0 with no
+    /// permission signal at all.
+    #[test]
+    fn list_models_does_not_short_circuit_capability_validation() {
+        let args = parse(&[
+            "edda",
+            "--agent",
+            "pi",
+            "--list-models",
+            "definitely-no-such-model-8f3a",
+            "--permission-mode",
+            "bypassPermissions",
+        ]);
+        let error = run_inner(args)
+            .expect_err("an explicit permission-mode on pi must be refused in listing mode too");
+        assert!(error.to_string().contains("--permission-mode"), "{error}");
+    }
+
     /// GH-574 round 2 (P1-3): with --json, stdout must be exactly one JSON
     /// object. A text model listing printed at exit 0 breaks every JSON
     /// consumer mid-stream, so the combination must be an explicit conflict

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -796,6 +796,17 @@ mod tests {
         );
     }
 
+    /// GH-574 round 2 (P1-3): with --json, stdout must be exactly one JSON
+    /// object. A text model listing printed at exit 0 breaks every JSON
+    /// consumer mid-stream, so the combination must be an explicit conflict
+    /// error — never a successful listing that silently ignores --json.
+    #[test]
+    fn list_models_with_json_is_refused_as_a_conflict() {
+        let args = parse(&["edda", "--agent", "pi", "--list-models", "--json"]);
+        let error = run_inner(args).expect_err("--json + --list-models must be refused");
+        assert!(error.to_string().contains("--json"), "{error}");
+    }
+
     // ── Outcome → exit-code mapping (all five PhaseResult variants) ──
 
     #[test]

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -69,7 +69,10 @@ pub struct DispatchArgs {
     /// Tool allowlist, comma-separated (GH-574): pi `--tools`, claude
     /// `--tools`. Both restrict capabilities — the listed tools are the
     /// only ones the backend can use — so e.g. `--tools read,grep,find,ls`
-    /// makes the turn structurally read-only. codex refuses it.
+    /// makes the turn structurally read-only. claude's `--tools` covers
+    /// only the built-in set, so the spawn also denies all unlisted MCP
+    /// tools (`--disallowedTools "mcp__*"`); pi's has no MCP leak. codex
+    /// refuses the flag.
     #[arg(long, value_delimiter = ',')]
     pub tools: Option<Vec<String>>,
     /// Tool denylist, comma-separated (GH-574): pi `--exclude-tools`, claude
@@ -351,6 +354,25 @@ pub fn run(args: DispatchArgs) -> Result<()> {
 }
 
 fn run_inner(args: DispatchArgs) -> Result<i32> {
+    // GH-574 honesty gate: refuse unsupported backend/option combinations
+    // instead of accepting them and silently doing nothing. An explicitly
+    // passed --permission-mode on a backend with no permission concept is
+    // refused here too (GH-574 round 2, P1-2) — there is no clap default,
+    // so an absent flag claims nothing and drops nothing. Round 3 (P1-2):
+    // this gate runs before EVERY short-circuit, including --list-models —
+    // listing mode must not accept and drop a permission contract either.
+    validate_dispatch_options(
+        args.agent,
+        &DispatchOptions {
+            model: args.model.as_deref(),
+            thinking: args.thinking.as_deref(),
+            tools: args.tools.as_deref(),
+            exclude_tools: args.exclude_tools.as_deref(),
+            session_dir: args.session_dir.as_deref(),
+            permission_mode: args.permission_mode.as_deref(),
+        },
+    )?;
+
     // --list-models short-circuits dispatch: print the provider/model table
     // and exit 0 (GH-574 — callers look up patterns instead of guessing a
     // provider prefix).
@@ -382,23 +404,6 @@ fn run_inner(args: DispatchArgs) -> Result<i32> {
         .context("--prompt-file is required unless --list-models is given")?;
     let prompt = std::fs::read_to_string(prompt_file)
         .with_context(|| format!("--prompt-file not readable: {prompt_file}"))?;
-
-    // GH-574 honesty gate: refuse unsupported backend/option combinations
-    // instead of accepting them and silently doing nothing. An explicitly
-    // passed --permission-mode on a backend with no permission concept is
-    // refused here too (GH-574 round 2, P1-2) — there is no clap default,
-    // so an absent flag claims nothing and drops nothing.
-    validate_dispatch_options(
-        args.agent,
-        &DispatchOptions {
-            model: args.model.as_deref(),
-            thinking: args.thinking.as_deref(),
-            tools: args.tools.as_deref(),
-            exclude_tools: args.exclude_tools.as_deref(),
-            session_dir: args.session_dir.as_deref(),
-            permission_mode: args.permission_mode.as_deref(),
-        },
-    )?;
 
     let session_id = args.session_id.clone().unwrap_or_else(generate_session_id);
 

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -473,7 +473,10 @@ enum Command {
     /// With --json, exactly one object is printed to stdout:
     ///   {"outcome":"done|crash|timeout|max_turns|budget_exceeded",
     ///    "result_text":string|null,"cost_usd":number|null,
-    ///    "session_id":string,"error":string|null}
+    ///    "session_id":string,"error":string|null,
+    ///    "model_requested":string,"model_observed":string}
+    /// model_requested is the --model value or "inherited"; model_observed
+    /// is what the backend reported in-band or "unknown".
     Dispatch {
         #[command(flatten)]
         args: cmd_dispatch::DispatchArgs,

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -476,7 +476,8 @@ enum Command {
     ///    "session_id":string,"error":string|null,
     ///    "model_requested":string,"model_observed":string}
     /// model_requested is the --model value or "inherited"; model_observed
-    /// is what the backend reported in-band or "unknown".
+    /// is what the backend reported in-band or "unknown". --json cannot be
+    /// combined with --list-models (the listing is text) and is refused.
     Dispatch {
         #[command(flatten)]
         args: cmd_dispatch::DispatchArgs,

--- a/crates/edda-cli/tests/dispatch_permission_mode.rs
+++ b/crates/edda-cli/tests/dispatch_permission_mode.rs
@@ -1,0 +1,46 @@
+//! Cross-process honesty checks for `edda dispatch` permission contracts
+//! (GH-574, round 2 — P1-2).
+//!
+//! The refusal of an unusable `--permission-mode` value must happen before
+//! anything is spawned, and its message only exists on the real stderr of a
+//! real process, so these behaviors are asserted through the actual binary:
+//! `EDDA_CODEX_BIN` points at a path that cannot exist, so a pre-fix binary
+//! fails at launcher construction (a different message) instead of spawning
+//! codex, while a post-fix binary refuses the combination explicitly.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+#[test]
+fn explicit_permission_mode_on_codex_is_refused_not_silently_dropped() {
+    let root = tempfile::tempdir().expect("test root");
+    let prompt = root.path().join("prompt.txt");
+    std::fs::write(&prompt, "do the thing").expect("prompt written");
+
+    let edda_bin = PathBuf::from(env!("CARGO_BIN_EXE_edda"));
+    let output = Command::new(&edda_bin)
+        .args([
+            "dispatch",
+            "--agent",
+            "codex",
+            "--permission-mode",
+            "bypassPermissions",
+            "--prompt-file",
+        ])
+        .arg(&prompt)
+        .env("EDDA_CODEX_BIN", root.path().join("no-such-codex"))
+        .env("EDDA_STORE_ROOT", root.path().join("store"))
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("edda binary runs");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "an unusable permission contract must not exit 0"
+    );
+    assert!(
+        stderr.contains("--permission-mode") && stderr.contains("does not support"),
+        "stderr must explicitly refuse --permission-mode for codex, got:\n{stderr}"
+    );
+}

--- a/crates/edda-cli/tests/dispatch_permission_mode.rs
+++ b/crates/edda-cli/tests/dispatch_permission_mode.rs
@@ -1,12 +1,12 @@
 //! Cross-process honesty checks for `edda dispatch` permission contracts
-//! (GH-574, round 2 — P1-2).
+//! (GH-574, round 2 — P1-2; round 3 adds the --list-models path).
 //!
 //! The refusal of an unusable `--permission-mode` value must happen before
 //! anything is spawned, and its message only exists on the real stderr of a
 //! real process, so these behaviors are asserted through the actual binary:
-//! `EDDA_CODEX_BIN` points at a path that cannot exist, so a pre-fix binary
-//! fails at launcher construction (a different message) instead of spawning
-//! codex, while a post-fix binary refuses the combination explicitly.
+//! the backend bin env var points at a path that cannot exist, so a pre-fix
+//! binary fails at the backend call (a different message) instead of
+//! spawning it, while a post-fix binary refuses the combination explicitly.
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -42,5 +42,42 @@ fn explicit_permission_mode_on_codex_is_refused_not_silently_dropped() {
     assert!(
         stderr.contains("--permission-mode") && stderr.contains("does not support"),
         "stderr must explicitly refuse --permission-mode for codex, got:\n{stderr}"
+    );
+}
+
+/// The reviewer's round-3 repro, cross-process: the --list-models
+/// short-circuit must not bypass the capability gate. `EDDA_PI_BIN` points
+/// at a path that cannot exist, so a pre-fix binary fails inside the model
+/// query (a different message) instead of spawning pi, while a post-fix
+/// binary refuses the combination explicitly before any query.
+#[test]
+fn list_models_permission_mode_on_pi_is_refused_not_silently_dropped() {
+    let root = tempfile::tempdir().expect("test root");
+
+    let edda_bin = PathBuf::from(env!("CARGO_BIN_EXE_edda"));
+    let output = Command::new(&edda_bin)
+        .args([
+            "dispatch",
+            "--agent",
+            "pi",
+            "--list-models",
+            "definitely-no-such-model-8f3a",
+            "--permission-mode",
+            "bypassPermissions",
+        ])
+        .env("EDDA_PI_BIN", root.path().join("no-such-pi"))
+        .env("EDDA_STORE_ROOT", root.path().join("store"))
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("edda binary runs");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "an unusable permission contract must not exit 0"
+    );
+    assert!(
+        stderr.contains("--permission-mode") && stderr.contains("does not support"),
+        "stderr must explicitly refuse --permission-mode for pi in listing mode, got:\n{stderr}"
     );
 }

--- a/crates/edda-conductor/src/agent/codex_rpc.rs
+++ b/crates/edda-conductor/src/agent/codex_rpc.rs
@@ -260,6 +260,30 @@ impl AgentLauncher for CodexLauncher {
         cwd: &Path,
         cancel: CancellationToken,
     ) -> Result<PhaseResult> {
+        // GH-574 honesty: the codex app-server exposes no model/thinking/
+        // tool-policy selection path edda can verify, so a phase declaring
+        // any of them would be silently ignored — the exact failure mode
+        // GH-574 removes. Refuse with an explicit error instead of guessing
+        // at an unverified configuration channel.
+        let declared: Vec<&str> = [
+            ("model", phase.model.is_some()),
+            ("thinking", phase.thinking.is_some()),
+            ("tools", phase.tools.is_some()),
+            ("exclude_tools", phase.exclude_tools.is_some()),
+        ]
+        .into_iter()
+        .filter(|(_, present)| *present)
+        .map(|(name, _)| name)
+        .collect();
+        if !declared.is_empty() {
+            anyhow::bail!(
+                "codex does not support phase-declared {} (the app-server exposes no \
+                 verifiable selection path); refusing to silently ignore them — \
+                 remove the declaration or dispatch with a backend that supports it",
+                declared.join(", ")
+            );
+        }
+
         // The app-server has no system-prompt channel; carry plan context
         // inline, same as the pi launcher.
         let message = if plan_context.is_empty() {
@@ -585,6 +609,40 @@ mod tests {
             .expect("fake spawned");
         (dir, server)
     }
+
+    /// GH-574: codex has no verifiable model/thinking/tool-policy selection
+    /// path, so each declared capability must be refused explicitly — never
+    /// accepted and silently ignored. The refusal fires before any server
+    /// spawn, so the test runs against a bare launcher.
+    #[tokio::test]
+    async fn codex_refuses_phase_declared_capabilities() {
+        let launcher = CodexLauncher::new();
+        for yaml in [
+            "  - id: a\n    prompt: x\n    model: anthropic/claude-opus-5\n",
+            "  - id: a\n    prompt: x\n    thinking: high\n",
+            "  - id: a\n    prompt: x\n    tools: [read]\n",
+            "  - id: a\n    prompt: x\n    exclude_tools: [write]\n",
+        ] {
+            let phase = phase_from_yaml(yaml);
+            let error = launcher
+                .run_phase(
+                    &phase,
+                    "p",
+                    "",
+                    "s",
+                    Path::new("."),
+                    CancellationToken::new(),
+                )
+                .await
+                .expect_err("codex must refuse declared capabilities");
+            let text = error.to_string();
+            assert!(
+                text.contains("codex does not support"),
+                "expected explicit refusal, got: {text}"
+            );
+        }
+    }
+
     #[test]
     fn codex_bin_falls_back_to_the_platform_install() {
         // npm ships codex as an extensionless sh launcher plus codex.cmd on

--- a/crates/edda-conductor/src/agent/launcher.rs
+++ b/crates/edda-conductor/src/agent/launcher.rs
@@ -142,11 +142,25 @@ impl ClaudeCodeLauncher {
         // available tools from the built-in set", while `--allowedTools` is
         // only a permission-prompt rule and leaves Write/Edit/Bash reachable
         // under bypassPermissions — the fake allowlist GH-574 round 2
-        // (P1-1) called out. `--disallowedTools` is a genuine deny rule.
+        // (P1-1) called out. Round 3: `--tools` restricts only the built-in
+        // set and leaves every MCP tool reachable (e.g.
+        // `mcp__filesystem__write_file` under bypassPermissions), so an
+        // allowlist claim also denies all unlisted MCP tools via the
+        // genuine deny rule `--disallowedTools "mcp__*"`, merged with any
+        // explicit exclude_tools entries into one flag. A denylist-only
+        // phase claims nothing about MCP tools and keeps its exact list.
         if let Some(tools) = &phase.tools {
             cmd.arg("--tools").arg(tools.join(","));
-        }
-        if let Some(tools) = &phase.exclude_tools {
+            let mut denied: Vec<&str> = phase
+                .exclude_tools
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .map(String::as_str)
+                .collect();
+            denied.push("mcp__*");
+            cmd.arg("--disallowedTools").arg(denied.join(","));
+        } else if let Some(tools) = &phase.exclude_tools {
             cmd.arg("--disallowedTools").arg(tools.join(","));
         }
 
@@ -458,7 +472,21 @@ mod tests {
             .iter()
             .position(|a| a == "--disallowedTools")
             .expect("--disallowedTools");
-        assert_eq!(args[deny + 1], "Write,Edit");
+        assert_eq!(args[deny + 1], "Write,Edit,mcp__*");
+    }
+
+    /// GH-574 round 3: a denylist-only phase claims nothing about MCP
+    /// tools, so no mcp__* entry appears — the list keeps its exact value.
+    #[test]
+    fn claude_denylist_without_allowlist_keeps_its_exact_value() {
+        let args = args_of(&claude_command_for(
+            "  - id: a\n    prompt: x\n    exclude_tools: [Write]\n",
+        ));
+        let deny = args
+            .iter()
+            .position(|a| a == "--disallowedTools")
+            .expect("--disallowedTools");
+        assert_eq!(args[deny + 1], "Write");
     }
 
     /// GH-574 round 3 (P1-1): claude's `--tools` restricts only the built-in
@@ -482,7 +510,8 @@ mod tests {
             .position(|a| a == "--disallowedTools")
             .expect("an allowlist phase must also deny unlisted MCP tools");
         assert_eq!(
-            args[deny + 1], "mcp__*",
+            args[deny + 1],
+            "mcp__*",
             "the allowlist claim must hold against MCP tools too: {args:?}"
         );
     }

--- a/crates/edda-conductor/src/agent/launcher.rs
+++ b/crates/edda-conductor/src/agent/launcher.rs
@@ -137,9 +137,14 @@ impl ClaudeCodeLauncher {
             cmd.arg("--model").arg(model);
         }
 
-        // Optional: tool allowlist / denylist
+        // Optional: tool allowlist / denylist. The allowlist must be the
+        // capability-restricting flag: claude's `--tools` sets "the list of
+        // available tools from the built-in set", while `--allowedTools` is
+        // only a permission-prompt rule and leaves Write/Edit/Bash reachable
+        // under bypassPermissions — the fake allowlist GH-574 round 2
+        // (P1-1) called out. `--disallowedTools` is a genuine deny rule.
         if let Some(tools) = &phase.tools {
-            cmd.arg("--allowedTools").arg(tools.join(","));
+            cmd.arg("--tools").arg(tools.join(","));
         }
         if let Some(tools) = &phase.exclude_tools {
             cmd.arg("--disallowedTools").arg(tools.join(","));

--- a/crates/edda-conductor/src/agent/launcher.rs
+++ b/crates/edda-conductor/src/agent/launcher.rs
@@ -40,6 +40,17 @@ pub trait AgentLauncher: Send + Sync {
         cwd: &Path,
         cancel: CancellationToken,
     ) -> Result<PhaseResult>;
+
+    /// The model the backend reported **in-band** during the most recent
+    /// turn on this launcher, if any. Observation, not inference: a
+    /// launcher reports only what the backend itself carried in its
+    /// protocol stream (claude stream-json `system/init`, pi RPC
+    /// `get_state`); `None` means the backend reported nothing and callers
+    /// must render `"unknown"`, never a guess from config or session files
+    /// (GH-574 honesty rule).
+    fn last_observed_model(&self) -> Option<String> {
+        None
+    }
 }
 
 /// Fixed namespace UUID for conductor sessions.
@@ -67,6 +78,9 @@ pub struct ClaudeCodeLauncher {
     pub verbose: bool,
     /// If set, raw agent stdout is captured to `{transcript_dir}/{phase_id}-{session_id_prefix}.jsonl`.
     pub transcript_dir: Option<PathBuf>,
+    /// In-band model report from the most recent turn (stream-json
+    /// `system/init`), for [`AgentLauncher::last_observed_model`].
+    observed_model: std::sync::Mutex<Option<String>>,
 }
 
 impl Default for ClaudeCodeLauncher {
@@ -76,11 +90,74 @@ impl Default for ClaudeCodeLauncher {
 }
 
 impl ClaudeCodeLauncher {
+    /// Assemble the `claude -p` command line for one phase. Split out from
+    /// [`AgentLauncher::run_phase`] so tests can assert the exact spawn
+    /// arguments without launching a real backend (GH-574).
+    fn build_command(
+        &self,
+        phase: &Phase,
+        prompt: &str,
+        plan_context: &str,
+        session_id: &str,
+        cwd: &Path,
+    ) -> tokio::process::Command {
+        let mut cmd = tokio::process::Command::new(&self.claude_bin);
+        cmd.arg("-p")
+            .arg(prompt)
+            .arg("--verbose")
+            .arg("--output-format")
+            .arg("stream-json")
+            .arg("--session-id")
+            .arg(session_id)
+            .arg("--permission-mode")
+            .arg(&phase.permission_mode)
+            .current_dir(cwd)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            // Allow nesting — remove markers that prevent Claude Code from spawning
+            .env_remove("CLAUDE_CODE")
+            .env_remove("CLAUDECODE")
+            // Tell edda hooks to use conductor-optimized injection
+            .env("EDDA_CONDUCTOR_MODE", "1")
+            // Propagate session_id so agent-spawned `edda decide` etc. can resolve identity
+            .env("EDDA_SESSION_ID", session_id);
+
+        // Optional: per-phase budget
+        if let Some(budget) = phase.budget_usd {
+            cmd.arg("--max-budget-usd").arg(budget.to_string());
+        }
+
+        // Optional: plan context as system prompt
+        if !plan_context.is_empty() {
+            cmd.arg("--append-system-prompt").arg(plan_context);
+        }
+
+        // Optional: model selection, carried verbatim (GH-574)
+        if let Some(model) = &phase.model {
+            cmd.arg("--model").arg(model);
+        }
+
+        // Optional: tool allowlist / denylist
+        if let Some(tools) = &phase.tools {
+            cmd.arg("--allowedTools").arg(tools.join(","));
+        }
+        if let Some(tools) = &phase.exclude_tools {
+            cmd.arg("--disallowedTools").arg(tools.join(","));
+        }
+
+        // Merge plan-level + phase-level env
+        for (k, v) in &phase.env {
+            cmd.env(k, v);
+        }
+        cmd
+    }
+
     pub fn new() -> Self {
         Self {
             claude_bin: PathBuf::from("claude"),
             verbose: false,
             transcript_dir: None,
+            observed_model: std::sync::Mutex::new(None),
         }
     }
 
@@ -89,6 +166,13 @@ impl ClaudeCodeLauncher {
             claude_bin,
             verbose: false,
             transcript_dir: None,
+            observed_model: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn record_observed_model(&self, model: Option<String>) {
+        if let Ok(mut slot) = self.observed_model.lock() {
+            *slot = model;
         }
     }
 
@@ -127,46 +211,17 @@ impl AgentLauncher for ClaudeCodeLauncher {
         cwd: &Path,
         cancel: CancellationToken,
     ) -> Result<PhaseResult> {
-        let mut cmd = tokio::process::Command::new(&self.claude_bin);
-        cmd.arg("-p")
-            .arg(prompt)
-            .arg("--verbose")
-            .arg("--output-format")
-            .arg("stream-json")
-            .arg("--session-id")
-            .arg(session_id)
-            .arg("--permission-mode")
-            .arg(&phase.permission_mode)
-            .current_dir(cwd)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            // Allow nesting — remove markers that prevent Claude Code from spawning
-            .env_remove("CLAUDE_CODE")
-            .env_remove("CLAUDECODE")
-            // Tell edda hooks to use conductor-optimized injection
-            .env("EDDA_CONDUCTOR_MODE", "1")
-            // Propagate session_id so agent-spawned `edda decide` etc. can resolve identity
-            .env("EDDA_SESSION_ID", session_id);
-
-        // Optional: per-phase budget
-        if let Some(budget) = phase.budget_usd {
-            cmd.arg("--max-budget-usd").arg(budget.to_string());
+        if phase.thinking.is_some() {
+            // GH-574 honesty: claude's CLI exposes no thinking-level flag,
+            // so a phase that declares one would otherwise be silently
+            // ignored — exactly the failure mode this flag exists to end.
+            anyhow::bail!(
+                "claude does not support a thinking-level flag; remove `thinking: {}` from phase {:?} or dispatch with --agent pi",
+                phase.thinking.as_deref().unwrap_or(""),
+                phase.id
+            );
         }
-
-        // Optional: plan context as system prompt
-        if !plan_context.is_empty() {
-            cmd.arg("--append-system-prompt").arg(plan_context);
-        }
-
-        // Optional: allowed tools
-        if let Some(tools) = &phase.allowed_tools {
-            cmd.arg("--allowedTools").arg(tools.join(","));
-        }
-
-        // Merge plan-level + phase-level env
-        for (k, v) in &phase.env {
-            cmd.env(k, v);
-        }
+        let mut cmd = self.build_command(phase, prompt, plan_context, session_id, cwd);
 
         let mut child = cmd.spawn()?;
         let stdout = child
@@ -183,9 +238,12 @@ impl AgentLauncher for ClaudeCodeLauncher {
             .with_tee(tee_path);
         let timeout_sec = phase.timeout_sec.unwrap_or(1800);
 
-        tokio::select! {
+        let result = tokio::select! {
             result = monitor.run() => {
                 let monitor_result = result?;
+                // In-band model observation: whatever the backend itself
+                // reported, or nothing. Never inferred from config.
+                self.record_observed_model(monitor_result.model.clone());
                 let exit = child.wait().await?;
                 Ok(classify_result(&monitor_result, exit.code()))
             }
@@ -197,7 +255,15 @@ impl AgentLauncher for ClaudeCodeLauncher {
                 child.kill().await.ok();
                 Ok(PhaseResult::AgentCrash { error: "conductor shutdown".into() })
             }
-        }
+        };
+        result
+    }
+
+    fn last_observed_model(&self) -> Option<String> {
+        self.observed_model
+            .lock()
+            .ok()
+            .and_then(|slot| slot.clone())
     }
 }
 
@@ -317,6 +383,95 @@ mod tests {
         let id = phase_session_id("test", "phase");
         // UUID v5 has version nibble = 5
         assert_eq!(id.get_version_num(), 5);
+    }
+
+    // ── GH-574: phase-declared launcher capabilities reach the spawn line ──
+
+    fn args_of(cmd: &tokio::process::Command) -> Vec<String> {
+        cmd.as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    fn claude_command_for(yaml: &str) -> tokio::process::Command {
+        let launcher = ClaudeCodeLauncher::with_bin(PathBuf::from("claude"));
+        let phase = phase_from_yaml(yaml);
+        launcher.build_command(&phase, "do the task", "", "sess-1", Path::new("."))
+    }
+
+    fn phase_from_yaml(yaml: &str) -> Phase {
+        parse_plan(&format!("name: t\nphases:\n{yaml}"))
+            .expect("test plan parses")
+            .phases
+            .remove(0)
+    }
+
+    #[test]
+    fn claude_phase_model_reaches_the_spawn_line() {
+        let args = args_of(&claude_command_for(
+            "  - id: a\n    prompt: x\n    model: anthropic/claude-opus-5\n",
+        ));
+        let model_pos = args
+            .iter()
+            .position(|a| a == "--model")
+            .expect("--model must appear in the claude spawn command line");
+        assert_eq!(args[model_pos + 1], "anthropic/claude-opus-5");
+    }
+
+    #[test]
+    fn claude_without_model_spawns_no_model_flag() {
+        let args = args_of(&claude_command_for("  - id: a\n    prompt: x\n"));
+        assert!(
+            !args.contains(&"--model".to_string()),
+            "no phase model must mean no --model flag: {args:?}"
+        );
+    }
+
+    #[test]
+    fn claude_tool_policy_reaches_the_spawn_line() {
+        let args = args_of(&claude_command_for(
+            "  - id: a\n    prompt: x\n    tools: [Read, Grep]\n    exclude_tools: [Write, Edit]\n",
+        ));
+        let allow = args
+            .iter()
+            .position(|a| a == "--allowedTools")
+            .expect("--allowedTools");
+        assert_eq!(args[allow + 1], "Read,Grep");
+        let deny = args
+            .iter()
+            .position(|a| a == "--disallowedTools")
+            .expect("--disallowedTools");
+        assert_eq!(args[deny + 1], "Write,Edit");
+    }
+
+    /// GH-574: claude's CLI exposes no thinking-level flag, so a phase that
+    /// declares one must be refused, never silently ignored. The refusal
+    /// fires before any spawn, so a bare launcher suffices.
+    #[tokio::test]
+    async fn claude_refuses_phase_declared_thinking() {
+        let launcher = ClaudeCodeLauncher::with_bin(PathBuf::from("claude"));
+        let phase = phase_from_yaml("  - id: a\n    prompt: x\n    thinking: high\n");
+        let error = launcher
+            .run_phase(
+                &phase,
+                "p",
+                "",
+                "s",
+                Path::new("."),
+                CancellationToken::new(),
+            )
+            .await
+            .expect_err("claude must refuse a declared thinking level");
+        assert!(error.to_string().contains("does not support"), "{error}");
+    }
+
+    /// GH-574: the in-band observation starts empty and is only filled by
+    /// what the backend itself reports — never from config or session files.
+    #[test]
+    fn claude_observed_model_starts_unknown() {
+        let launcher = ClaudeCodeLauncher::with_bin(PathBuf::from("claude"));
+        assert_eq!(launcher.last_observed_model(), None);
     }
 
     #[tokio::test]

--- a/crates/edda-conductor/src/agent/launcher.rs
+++ b/crates/edda-conductor/src/agent/launcher.rs
@@ -461,6 +461,53 @@ mod tests {
         assert_eq!(args[deny + 1], "Write,Edit");
     }
 
+    /// GH-574 round 3 (P1-1): claude's `--tools` restricts only the built-in
+    /// tool set and leaves every MCP tool reachable under bypassPermissions
+    /// (e.g. `mcp__filesystem__write_file`). A phase that claims a tool
+    /// allowlist must therefore also spawn the deny rule for all unlisted
+    /// MCP tools, or the "listed tools are the only ones the backend can
+    /// use" claim is false.
+    #[test]
+    fn claude_allowlist_also_denies_unlisted_mcp_tools() {
+        let args = args_of(&claude_command_for(
+            "  - id: a\n    prompt: x\n    tools: [Read]\n",
+        ));
+        let allow = args
+            .iter()
+            .position(|a| a == "--tools")
+            .expect("--tools must appear in the claude spawn command line");
+        assert_eq!(args[allow + 1], "Read");
+        let deny = args
+            .iter()
+            .position(|a| a == "--disallowedTools")
+            .expect("an allowlist phase must also deny unlisted MCP tools");
+        assert_eq!(
+            args[deny + 1], "mcp__*",
+            "the allowlist claim must hold against MCP tools too: {args:?}"
+        );
+    }
+
+    /// The MCP deny rule merges with an explicit exclude_tools denylist
+    /// into exactly one `--disallowedTools` flag (never two).
+    #[test]
+    fn claude_allowlist_merges_the_mcp_deny_with_the_exclude_list() {
+        let args = args_of(&claude_command_for(
+            "  - id: a\n    prompt: x\n    tools: [Read]\n    exclude_tools: [Write, Edit]\n",
+        ));
+        let deny_positions: Vec<usize> = args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| *a == "--disallowedTools")
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(
+            deny_positions.len(),
+            1,
+            "the deny list must be a single flag, got: {args:?}"
+        );
+        assert_eq!(args[deny_positions[0] + 1], "Write,Edit,mcp__*");
+    }
+
     /// GH-574: claude's CLI exposes no thinking-level flag, so a phase that
     /// declares one must be refused, never silently ignored. The refusal
     /// fires before any spawn, so a bare launcher suffices.

--- a/crates/edda-conductor/src/agent/launcher.rs
+++ b/crates/edda-conductor/src/agent/launcher.rs
@@ -430,14 +430,25 @@ mod tests {
 
     #[test]
     fn claude_tool_policy_reaches_the_spawn_line() {
+        // GH-574 round 2 (P1-1): claude's `--allowedTools` is a
+        // permission-prompt rule, not a capability restriction — under
+        // bypassPermissions Write/Edit/Bash stay reachable. The
+        // capability-restricting flag is `--tools` ("Specify the list of
+        // available tools from the built-in set"), so the phase allowlist
+        // must spawn `--tools` and must never spawn `--allowedTools` while
+        // claiming a structural allowlist.
         let args = args_of(&claude_command_for(
             "  - id: a\n    prompt: x\n    tools: [Read, Grep]\n    exclude_tools: [Write, Edit]\n",
         ));
         let allow = args
             .iter()
-            .position(|a| a == "--allowedTools")
-            .expect("--allowedTools");
+            .position(|a| a == "--tools")
+            .expect("--tools must appear in the claude spawn command line");
         assert_eq!(args[allow + 1], "Read,Grep");
+        assert!(
+            !args.contains(&"--allowedTools".to_string()),
+            "--allowedTools does not restrict capabilities; it must not be spawned: {args:?}"
+        );
         let deny = args
             .iter()
             .position(|a| a == "--disallowedTools")

--- a/crates/edda-conductor/src/agent/pi_rpc.rs
+++ b/crates/edda-conductor/src/agent/pi_rpc.rs
@@ -58,10 +58,14 @@ fn default_pi_bin() -> PathBuf {
 pub struct PiRpcLauncher {
     pub pi_bin: PathBuf,
     pub verbose: bool,
-    /// Optional `--model` pattern (e.g. `provider/id`).
+    /// Optional `--model` pattern (e.g. `provider/id`). Fallback for the
+    /// per-phase `phase.model` declaration, which takes precedence (GH-574).
     pub model: Option<String>,
     /// Optional `--session-dir` for pi session storage.
     pub session_dir: Option<PathBuf>,
+    /// In-band model report from the most recent settled turn (RPC
+    /// `get_state`), for [`AgentLauncher::last_observed_model`].
+    observed_model: std::sync::Mutex<Option<String>>,
 }
 
 impl Default for PiRpcLauncher {
@@ -77,6 +81,7 @@ impl PiRpcLauncher {
             verbose: false,
             model: None,
             session_dir: None,
+            observed_model: std::sync::Mutex::new(None),
         }
     }
 
@@ -86,6 +91,13 @@ impl PiRpcLauncher {
             verbose: false,
             model: None,
             session_dir: None,
+            observed_model: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn record_observed_model(&self, model: Option<String>) {
+        if let Ok(mut slot) = self.observed_model.lock() {
+            *slot = model;
         }
     }
 
@@ -122,6 +134,32 @@ impl PiRpcLauncher {
         }
     }
 
+    /// Resolve the effective model for one phase: the per-phase declaration
+    /// wins (it is the more specific, per-turn contract); the builder value
+    /// is the fallback. Callers must have rejected the thinking-level /
+    /// model-suffix conflict beforehand.
+    fn effective_model(&self, phase: &Phase) -> Option<String> {
+        phase.model.clone().or_else(|| self.model.clone())
+    }
+
+    /// GH-574: pi's model pattern can embed a thinking level
+    /// (`provider/id:high`) and pi also has a separate `--thinking` flag.
+    /// edda refuses the ambiguous combination instead of guessing which
+    /// one wins.
+    fn validate_phase(&self, phase: &Phase) -> Result<()> {
+        if let (Some(level), Some(model)) = (&phase.thinking, &self.effective_model(phase)) {
+            if model.contains(':') {
+                anyhow::bail!(
+                    "phase {:?} declares both thinking level {level:?} and model pattern \
+                     {model:?} with an embedded `:<thinking>` suffix; drop one — they are two \
+                     spellings of the same setting and edda refuses to guess",
+                    phase.id
+                );
+            }
+        }
+        Ok(())
+    }
+
     fn build_command(&self, phase: &Phase, session_id: &str, cwd: &Path) -> Command {
         let mut cmd = Command::new(&self.pi_bin);
         cmd.arg("--mode")
@@ -141,11 +179,24 @@ impl PiRpcLauncher {
             // Propagate session_id so agent-spawned `edda decide` etc. can resolve identity
             .env("EDDA_SESSION_ID", session_id);
 
-        if let Some(model) = &self.model {
+        if let Some(model) = &self.effective_model(phase) {
             cmd.arg("--model").arg(model);
         }
         if let Some(dir) = &self.session_dir {
             cmd.arg("--session-dir").arg(dir);
+        }
+        // GH-574: per-phase model / thinking / tool policy. Tools are
+        // comma-joined per pi's own `--tools a,b` syntax. Note `--tools` is
+        // an allowlist that replaces pi's default tool set, while
+        // `--exclude-tools` only removes from it.
+        if let Some(level) = &phase.thinking {
+            cmd.arg("--thinking").arg(level);
+        }
+        if let Some(tools) = &phase.tools {
+            cmd.arg("--tools").arg(tools.join(","));
+        }
+        if let Some(tools) = &phase.exclude_tools {
+            cmd.arg("--exclude-tools").arg(tools.join(","));
         }
 
         for (k, v) in &phase.env {
@@ -166,9 +217,10 @@ impl AgentLauncher for PiRpcLauncher {
         cwd: &Path,
         cancel: CancellationToken,
     ) -> Result<PhaseResult> {
+        self.validate_phase(phase)?;
         let command = self.build_command(phase, session_id, cwd);
         let timeout_sec = phase.timeout_sec.unwrap_or(1800);
-        run_command(
+        let (result, observed) = run_command(
             command,
             phase,
             prompt,
@@ -177,11 +229,24 @@ impl AgentLauncher for PiRpcLauncher {
             Duration::from_secs(timeout_sec),
             cancel,
         )
-        .await
+        .await?;
+        // In-band model observation: whatever pi itself reported via RPC
+        // `get_state`, or nothing. Never inferred from config or sessions.
+        self.record_observed_model(observed);
+        Ok(result)
+    }
+
+    fn last_observed_model(&self) -> Option<String> {
+        self.observed_model
+            .lock()
+            .ok()
+            .and_then(|slot| slot.clone())
     }
 }
 
 /// Run one phase against a pre-built command (injectable for tests).
+/// Returns the phase result plus the model pi reported in-band via RPC
+/// `get_state`, if the turn settled and pi exposed one (GH-574).
 async fn run_command(
     command: Command,
     phase: &Phase,
@@ -190,7 +255,7 @@ async fn run_command(
     verbose: bool,
     timeout: Duration,
     cancel: CancellationToken,
-) -> Result<PhaseResult> {
+) -> Result<(PhaseResult, Option<String>)> {
     let mut session = PiRpcSession::spawn_command(command).await?;
     // pi has no system-prompt flag in RPC mode; carry plan context inline.
     let message = if plan_context.is_empty() {
@@ -201,8 +266,42 @@ async fn run_command(
     let result = session
         .run_turn(&message, phase.budget_usd, timeout, verbose, &cancel)
         .await;
+    // Only a settled turn is asked for state; a crashed turn has nothing
+    // trustworthy to report.
+    let observed = if matches!(result, Ok(PhaseResult::AgentDone { .. })) {
+        session.observed_model().await
+    } else {
+        None
+    };
     session.terminate().await;
-    result
+    let result = result?;
+    Ok((result, observed))
+}
+
+/// Run `pi --list-models [search]` and return its stdout verbatim — the
+/// query path that lets callers look up available provider/model pairs
+/// instead of guessing a provider prefix (GH-574).
+pub fn list_models(pi_bin: Option<PathBuf>, search: Option<&str>) -> Result<String> {
+    let mut cmd = std::process::Command::new(pi_bin.unwrap_or_else(default_pi_bin));
+    cmd.arg("--list-models");
+    if let Some(term) = search {
+        if !term.is_empty() {
+            cmd.arg(term);
+        }
+    }
+    let output = cmd
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .context("failed to run pi --list-models")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "pi --list-models failed ({}): {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
 /// One live `pi --mode rpc` process speaking JSONL.
@@ -426,6 +525,18 @@ impl PiRpcSession {
         })
     }
 
+    /// Ask pi for its current state and extract the in-band model report
+    /// (`provider/id`) per the RPC `get_state` contract. Any failure —
+    /// transport error, missing fields — renders as `None` ("unknown"),
+    /// never a guess (GH-574 honesty rule).
+    async fn observed_model(&mut self) -> Option<String> {
+        let state = self.request(json!({ "type": "get_state" })).await.ok()?;
+        let model = state.get("model")?;
+        let provider = model.get("provider").and_then(Value::as_str)?;
+        let id = model.get("id").and_then(Value::as_str)?;
+        Some(format!("{provider}/{id}"))
+    }
+
     /// Send one RPC command and wait for its matching response.
     /// Events interleaved before the response are ignored.
     async fn request(&mut self, mut command: Value) -> Result<Value> {
@@ -639,6 +750,8 @@ mod tests {
     const SETTLED: &str = r#"{"type":"agent_settled"}"#;
     const STATS_042: &str = r#"{"id":"req-2","type":"response","command":"get_session_stats","success":true,"data":{"cost":0.42}}"#;
     const STATS_990: &str = r#"{"id":"req-2","type":"response","command":"get_session_stats","success":true,"data":{"cost":9.9}}"#;
+    const STATE_GPT56: &str = r#"{"id":"req-3","type":"response","command":"get_state","success":true,"data":{"model":{"provider":"openai-codex","id":"gpt-5.6-sol"},"thinkingLevel":"high"}}"#;
+    const STATE_NULL: &str = r#"{"id":"req-3","type":"response","command":"get_state","success":true,"data":{"model":null}}"#;
     const STARTUP_DIAGNOSTIC: &str = "pi: no API key configured for provider openrouter";
 
     fn delta_line(usage_cost: &str, text: &str) -> String {
@@ -650,6 +763,8 @@ mod tests {
     #[derive(Clone, Copy)]
     enum FakeScenario {
         Normal,
+        /// Like Normal, but pi reports no model in `get_state`.
+        NormalNoModel,
         BudgetAfterSettle,
         BudgetMidRun,
         PromptRejected,
@@ -668,7 +783,11 @@ mod tests {
     fn body_for(scenario: FakeScenario) -> String {
         match scenario {
             FakeScenario::Normal => format!(
-                "read_cmd\nwrite_line '{PROMPT_OK}'\nwrite_line '{}'\nwrite_line '{SETTLED}'\nread_cmd\nwrite_line '{STATS_042}'\nsleep 60",
+                "read_cmd\nwrite_line '{PROMPT_OK}'\nwrite_line '{}'\nwrite_line '{SETTLED}'\nread_cmd\nwrite_line '{STATS_042}'\nread_cmd\nwrite_line '{STATE_GPT56}'\nsleep 60",
+                delta_line("0.10", "phase done")
+            ),
+            FakeScenario::NormalNoModel => format!(
+                "read_cmd\nwrite_line '{PROMPT_OK}'\nwrite_line '{}'\nwrite_line '{SETTLED}'\nread_cmd\nwrite_line '{STATS_042}'\nread_cmd\nwrite_line '{STATE_NULL}'\nsleep 60",
                 delta_line("0.10", "phase done")
             ),
             FakeScenario::BudgetAfterSettle => format!(
@@ -694,7 +813,7 @@ mod tests {
             FakeScenario::CloseStdoutAndLive => "exec 1>&-\nsleep 60".to_owned(),
             #[cfg(unix)]
             FakeScenario::Utf8Framing => format!(
-                "read_cmd\nwrite_line '{PROMPT_OK}'\nprintf '%s\\n' '{}'\nwrite_line '{SETTLED}'\nread_cmd\nwrite_line '{STATS_042}'\nsleep 60",
+                "read_cmd\nwrite_line '{PROMPT_OK}'\nprintf '%s\\n' '{}'\nwrite_line '{SETTLED}'\nread_cmd\nwrite_line '{STATS_042}'\nread_cmd\nwrite_line '{STATE_GPT56}'\nsleep 60",
                 delta_line("0.10", "a\u{2028}b")
             ),
         }
@@ -763,9 +882,12 @@ mod tests {
             .remove(0)
     }
 
-    async fn run_fake(scenario: FakeScenario, phase: &Phase) -> Result<PhaseResult> {
+    async fn run_fake(
+        scenario: FakeScenario,
+        phase: &Phase,
+    ) -> Result<(PhaseResult, Option<String>)> {
         let (_dir, command) = fake_pi_command(scenario)?;
-        let result = tokio::time::timeout(
+        let outcome = tokio::time::timeout(
             Duration::from_secs(30),
             run_command(
                 command,
@@ -779,13 +901,13 @@ mod tests {
         )
         .await
         .context("test timed out waiting for run_command")??;
-        Ok(result)
+        Ok(outcome)
     }
 
     #[tokio::test]
     async fn completes_phase_via_agent_settled() -> Result<()> {
         let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
-        let result = run_fake(FakeScenario::Normal, &phase).await?;
+        let (result, observed) = run_fake(FakeScenario::Normal, &phase).await?;
         match result {
             PhaseResult::AgentDone {
                 cost_usd,
@@ -796,13 +918,24 @@ mod tests {
             }
             other => panic!("expected AgentDone, got {other:?}"),
         }
+        // GH-574: the model pi reported in-band via get_state.
+        assert_eq!(observed.as_deref(), Some("openai-codex/gpt-5.6-sol"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn no_in_band_model_report_is_none_not_a_guess() -> Result<()> {
+        let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
+        let (result, observed) = run_fake(FakeScenario::NormalNoModel, &phase).await?;
+        assert!(matches!(result, PhaseResult::AgentDone { .. }));
+        assert!(observed.is_none(), "null model must render as unknown");
         Ok(())
     }
 
     #[tokio::test]
     async fn budget_exceeded_after_settle() -> Result<()> {
         let phase = phase_from_yaml("  - id: a\n    prompt: x\n    budget_usd: 1.0\n");
-        let result = run_fake(FakeScenario::BudgetAfterSettle, &phase).await?;
+        let (result, _observed) = run_fake(FakeScenario::BudgetAfterSettle, &phase).await?;
         match result {
             PhaseResult::BudgetExceeded { cost_usd } => {
                 assert!((cost_usd.unwrap() - 9.9).abs() < 1e-9);
@@ -815,7 +948,7 @@ mod tests {
     #[tokio::test]
     async fn budget_exceeded_mid_run_sends_abort() -> Result<()> {
         let phase = phase_from_yaml("  - id: a\n    prompt: x\n    budget_usd: 1.0\n");
-        let result = run_fake(FakeScenario::BudgetMidRun, &phase).await?;
+        let (result, _observed) = run_fake(FakeScenario::BudgetMidRun, &phase).await?;
         match result {
             PhaseResult::BudgetExceeded { cost_usd } => {
                 assert!((cost_usd.unwrap() - 5.0).abs() < 1e-9);
@@ -829,7 +962,7 @@ mod tests {
     async fn timeout_returns_timeout_result() -> Result<()> {
         let phase = phase_from_yaml("  - id: a\n    prompt: x\n    timeout_sec: 2\n");
         let started = tokio::time::Instant::now();
-        let result = run_fake(FakeScenario::Idle, &phase).await?;
+        let (result, _observed) = run_fake(FakeScenario::Idle, &phase).await?;
         assert!(matches!(result, PhaseResult::Timeout));
         assert!(started.elapsed() < Duration::from_secs(15));
         Ok(())
@@ -859,6 +992,8 @@ mod tests {
         )
         .await
         .context("test timed out waiting for run_command")??;
+        let (result, observed) = result;
+        assert!(observed.is_none(), "a cancelled turn reports no model");
         match result {
             PhaseResult::AgentCrash { error } => assert_eq!(error, "conductor shutdown"),
             other => panic!("expected AgentCrash, got {other:?}"),
@@ -869,7 +1004,7 @@ mod tests {
     #[tokio::test]
     async fn prompt_rejection_is_agent_crash() -> Result<()> {
         let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
-        let result = run_fake(FakeScenario::PromptRejected, &phase).await?;
+        let (result, _observed) = run_fake(FakeScenario::PromptRejected, &phase).await?;
         match result {
             PhaseResult::AgentCrash { error } => {
                 assert!(error.contains("rejected prompt"), "{error}");
@@ -883,7 +1018,7 @@ mod tests {
     #[tokio::test]
     async fn malformed_jsonl_line_is_agent_crash() -> Result<()> {
         let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
-        let result = run_fake(FakeScenario::Malformed, &phase).await?;
+        let (result, _observed) = run_fake(FakeScenario::Malformed, &phase).await?;
         match result {
             PhaseResult::AgentCrash { error } => {
                 assert!(error.contains("invalid pi RPC JSON"), "{error}");
@@ -897,7 +1032,7 @@ mod tests {
     #[tokio::test]
     async fn crlf_and_u2028_do_not_split_records() -> Result<()> {
         let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
-        let result = run_fake(FakeScenario::Utf8Framing, &phase).await?;
+        let (result, _observed) = run_fake(FakeScenario::Utf8Framing, &phase).await?;
         match result {
             PhaseResult::AgentDone { result_text, .. } => {
                 // The fake writes CRLF via sh (printf adds LF; sh keeps LF) and
@@ -995,7 +1130,7 @@ mod tests {
         // every run, not whenever the drain task happens to win.
         let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
         for attempt in 0..5 {
-            let result = run_fake(FakeScenario::StderrThenDie, &phase).await?;
+            let (result, _observed) = run_fake(FakeScenario::StderrThenDie, &phase).await?;
             match result {
                 PhaseResult::AgentCrash { error } => {
                     assert!(
@@ -1060,7 +1195,7 @@ mod tests {
     async fn reap_grace_expiry_reports_instead_of_hanging() -> Result<()> {
         let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
         let started = std::time::Instant::now();
-        let result = run_fake(FakeScenario::CloseStdoutAndLive, &phase).await?;
+        let (result, _observed) = run_fake(FakeScenario::CloseStdoutAndLive, &phase).await?;
         assert!(
             started.elapsed() < Duration::from_secs(25),
             "reap grace expiry must be prompt"
@@ -1115,6 +1250,94 @@ mod tests {
         let tail = format_stderr_tail(raw);
         assert_eq!(tail, "second | third | fourth | fifth | sixth");
         assert!(!tail.contains("first"), "only the last 5 lines are kept");
+    }
+
+    // ── GH-574: phase-declared capabilities reach the pi spawn line ──
+
+    fn pi_args_for(launcher: &PiRpcLauncher, yaml: &str) -> Vec<String> {
+        let phase = phase_from_yaml(yaml);
+        let cmd = launcher.build_command(&phase, "sess-1", Path::new("."));
+        cmd.as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn pi_phase_capabilities_reach_the_spawn_line() {
+        let launcher = PiRpcLauncher::new();
+        let args = pi_args_for(
+            &launcher,
+            "  - id: a\n    prompt: x\n    model: anthropic/claude-opus-5\n    thinking: high\n    tools: [read, grep]\n    exclude_tools: [edit, write]\n",
+        );
+        for (flag, value) in [
+            ("--model", "anthropic/claude-opus-5"),
+            ("--thinking", "high"),
+            ("--tools", "read,grep"),
+            ("--exclude-tools", "edit,write"),
+        ] {
+            let pos = args
+                .iter()
+                .position(|a| a == flag)
+                .unwrap_or_else(|| panic!("{flag} must appear in the pi spawn line: {args:?}"));
+            assert_eq!(args[pos + 1], value, "value after {flag}");
+        }
+    }
+
+    #[test]
+    fn pi_phase_model_wins_over_the_builder_fallback() {
+        let launcher = PiRpcLauncher::new().with_model("openai-codex/gpt-5.6-sol");
+        let args = pi_args_for(&launcher, "  - id: a\n    prompt: x\n");
+        let pos = args.iter().position(|a| a == "--model").expect("--model");
+        assert_eq!(args[pos + 1], "openai-codex/gpt-5.6-sol");
+
+        let args = pi_args_for(
+            &launcher,
+            "  - id: a\n    prompt: x\n    model: anthropic/claude-opus-5\n",
+        );
+        let pos = args.iter().position(|a| a == "--model").expect("--model");
+        assert_eq!(args[pos + 1], "anthropic/claude-opus-5");
+    }
+
+    #[test]
+    fn pi_no_declarations_spawn_no_capability_flags() {
+        let args = pi_args_for(&PiRpcLauncher::new(), "  - id: a\n    prompt: x\n");
+        for flag in ["--model", "--thinking", "--tools", "--exclude-tools"] {
+            assert!(
+                !args.contains(&flag.to_string()),
+                "{flag} must be absent without a declaration: {args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn pi_refuses_thinking_flag_plus_model_suffix() {
+        let launcher = PiRpcLauncher::new();
+        let phase = phase_from_yaml(
+            "  - id: a\n    prompt: x\n    model: openai-codex/gpt-5.6-sol:high\n    thinking: low\n",
+        );
+        let error = launcher
+            .validate_phase(&phase)
+            .expect_err("the ambiguous combination must be refused");
+        assert!(error.to_string().contains("refuses to guess"), "{error}");
+    }
+
+    #[test]
+    fn pi_accepts_thinking_flag_without_model_suffix() {
+        let launcher = PiRpcLauncher::new();
+        let phase = phase_from_yaml(
+            "  - id: a\n    prompt: x\n    model: openai-codex/gpt-5.6-sol\n    thinking: low\n",
+        );
+        launcher
+            .validate_phase(&phase)
+            .expect("a plain provider/id pattern with --thinking is unambiguous");
+    }
+
+    #[test]
+    fn list_models_fails_loudly_when_pi_is_missing() {
+        let error = list_models(Some(PathBuf::from("definitely-not-pi-xyz-8f3a")), None)
+            .expect_err("a missing pi binary must be an explicit error");
+        assert!(error.to_string().contains("list-models"), "{error}");
     }
 
     #[test]

--- a/crates/edda-conductor/src/agent/stream.rs
+++ b/crates/edda-conductor/src/agent/stream.rs
@@ -59,6 +59,10 @@ pub struct MonitorResult {
     pub total_cost_usd: f64,
     pub result: Option<ResultInfo>,
     pub result_text: Option<String>,
+    /// The model the backend itself reported in the `system/init` message,
+    /// if any. In-band observation only — `None` means claude did not
+    /// report one (GH-574).
+    pub model: Option<String>,
 }
 
 /// Reads Claude Code's `--output-format stream-json` stdout line by line,
@@ -158,11 +162,16 @@ impl StreamMonitor {
             _ => None,
         });
         let result_text = result_info.as_ref().and_then(|r| r.result_text.clone());
+        let model = self.messages.iter().rev().find_map(|m| match m {
+            StreamMessage::System { model: Some(m), .. } => Some(m.clone()),
+            _ => None,
+        });
 
         Ok(MonitorResult {
             total_cost_usd: self.total_cost_usd,
             result: result_info,
             result_text,
+            model,
         })
     }
 }
@@ -375,6 +384,7 @@ mod tests {
                 result_text: None,
             }),
             result_text: None,
+            model: None,
         };
         let r = classify_result(&monitor, Some(0));
         assert!(
@@ -393,6 +403,7 @@ mod tests {
                 result_text: None,
             }),
             result_text: None,
+            model: None,
         };
         let r = classify_result(&monitor, Some(1));
         assert!(matches!(r, PhaseResult::MaxTurns { .. }));
@@ -409,6 +420,7 @@ mod tests {
                 result_text: None,
             }),
             result_text: None,
+            model: None,
         };
         let r = classify_result(&monitor, Some(1));
         assert!(matches!(r, PhaseResult::BudgetExceeded { .. }));
@@ -425,6 +437,7 @@ mod tests {
                 result_text: None,
             }),
             result_text: None,
+            model: None,
         };
         let r = classify_result(&monitor, Some(1));
         match r {
@@ -444,6 +457,7 @@ mod tests {
                 result_text: None,
             }),
             result_text: None,
+            model: None,
         };
         let r = classify_result(&monitor, Some(2));
         assert!(matches!(r, PhaseResult::AgentCrash { .. }));
@@ -455,6 +469,7 @@ mod tests {
             total_cost_usd: 0.0,
             result: None,
             result_text: None,
+            model: None,
         };
         let r = classify_result(&monitor, Some(137));
         match r {
@@ -471,6 +486,7 @@ mod tests {
             total_cost_usd: 0.0,
             result: None,
             result_text: None,
+            model: None,
         };
         let r = classify_result(&monitor, None);
         match r {

--- a/crates/edda-conductor/src/plan/schema.rs
+++ b/crates/edda-conductor/src/plan/schema.rs
@@ -52,8 +52,32 @@ pub struct Phase {
     pub env: HashMap<String, String>,
     #[serde(default)]
     pub budget_usd: Option<f64>,
-    #[serde(default)]
-    pub allowed_tools: Option<Vec<String>>,
+    /// Tool allowlist, passed to the backend verbatim (pi `--tools`, claude
+    /// `--allowedTools`). The historical YAML spelling `allowed_tools` still
+    /// parses (GH-574 compatibility); both spellings in one phase is a
+    /// deserialization error, not a merge.
+    #[serde(
+        default,
+        alias = "allowed_tools",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub tools: Option<Vec<String>>,
+    /// Tool denylist (pi `--exclude-tools`, claude `--disallowedTools`).
+    /// Structural enforcement, not prompt discipline: a denied tool never
+    /// reaches the agent, regardless of what the prompt says.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exclude_tools: Option<Vec<String>>,
+    /// Model selection passed to the backend verbatim (pi `--model
+    /// <pattern>`, claude `--model`). Per-backend support varies;
+    /// unsupported combinations must be rejected with an explicit error,
+    /// never silently ignored (GH-574).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Thinking level (pi `--thinking`: off, minimal, low, medium, high,
+    /// xhigh, max). Only pi supports it today; other backends must reject a
+    /// phase that declares it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<String>,
     #[serde(default = "default_permission_mode")]
     pub permission_mode: String,
     /// Verdict gate: after checks pass, the phase pauses in AWAITING_VERDICT
@@ -296,6 +320,101 @@ phases:
         assert_eq!(phase.on_fail, Some(OnFail::Abort));
         assert_eq!(phase.check.len(), 2);
         assert_eq!(phase.env.get("FOO").unwrap(), "bar");
+    }
+
+    // ── Model / thinking / tool policy (GH-574) ──────────────────────
+
+    #[test]
+    fn phase_allowed_tools_yaml_still_parses_as_tools() {
+        // Compat: every existing plan YAML spells the allowlist
+        // `allowed_tools`; it must keep parsing after the rename to `tools`.
+        let yaml = r#"
+name: compat
+phases:
+  - id: a
+    prompt: "x"
+    allowed_tools: [Read, Grep]
+"#;
+        let plan: Plan = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(
+            plan.phases[0].tools,
+            Some(vec!["Read".into(), "Grep".into()])
+        );
+    }
+
+    #[test]
+    fn phase_tools_is_the_new_canonical_spelling() {
+        let yaml = r#"
+name: canonical
+phases:
+  - id: a
+    prompt: "x"
+    tools: [read, grep]
+"#;
+        let plan: Plan = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(
+            plan.phases[0].tools,
+            Some(vec!["read".into(), "grep".into()])
+        );
+    }
+
+    #[test]
+    fn phase_both_tool_spellings_fail_loudly() {
+        // The two spellings are one field: an alias pair, not a merge.
+        let yaml = r#"
+name: ambiguous
+phases:
+  - id: a
+    prompt: "x"
+    allowed_tools: [Read]
+    tools: [Write]
+"#;
+        assert!(serde_yml::from_str::<Plan>(yaml).is_err());
+    }
+
+    #[test]
+    fn phase_model_thinking_and_exclude_tools_parse() {
+        let yaml = r#"
+name: reviewer
+phases:
+  - id: review
+    prompt: "x"
+    model: anthropic/claude-opus-5
+    thinking: high
+    exclude_tools: [edit, write]
+"#;
+        let plan: Plan = serde_yml::from_str(yaml).unwrap();
+        let phase = &plan.phases[0];
+        assert_eq!(phase.model.as_deref(), Some("anthropic/claude-opus-5"));
+        assert_eq!(phase.thinking.as_deref(), Some("high"));
+        assert_eq!(
+            phase.exclude_tools,
+            Some(vec!["edit".into(), "write".into()])
+        );
+        assert!(phase.tools.is_none());
+    }
+
+    #[test]
+    fn phase_model_fields_default_to_none_and_skip_serialization() {
+        let yaml = r#"
+name: minimal
+phases:
+  - id: a
+    prompt: "x"
+"#;
+        let plan: Plan = serde_yml::from_str(yaml).unwrap();
+        let phase = &plan.phases[0];
+        assert!(phase.model.is_none());
+        assert!(phase.thinking.is_none());
+        assert!(phase.tools.is_none());
+        assert!(phase.exclude_tools.is_none());
+        let json = serde_json::to_string(phase).unwrap();
+        for absent in ["model", "thinking", "tools", "exclude_tools"] {
+            assert!(
+                !json.contains(absent),
+                "unset {absent} must not serialize: {json}"
+            );
+        }
     }
 
     // ── Gate fields (D2) ─────────────────────────────────────────────

--- a/crates/edda-conductor/src/plan/schema.rs
+++ b/crates/edda-conductor/src/plan/schema.rs
@@ -53,9 +53,11 @@ pub struct Phase {
     #[serde(default)]
     pub budget_usd: Option<f64>,
     /// Tool allowlist, passed to the backend verbatim (pi `--tools`, claude
-    /// `--allowedTools`). The historical YAML spelling `allowed_tools` still
-    /// parses (GH-574 compatibility); both spellings in one phase is a
-    /// deserialization error, not a merge.
+    /// `--tools` — the capability-restricting flag; `--allowedTools` is only
+    /// a permission-prompt rule and is never spawned, GH-574 round 2). The
+    /// historical YAML spelling `allowed_tools` still parses (GH-574
+    /// compatibility); both spellings in one phase is a deserialization
+    /// error, not a merge.
     #[serde(
         default,
         alias = "allowed_tools",


### PR DESCRIPTION
Closes #574 (epic #560). Base: origin/main @ d09fd37.

## doneWhen 逐條對照

**1. `edda dispatch --agent pi --model anthropic/claude-opus-5 ...` 實際把 `--model` 傳給 pi**
- `PiRpcLauncher::build_command` emits `--model <pattern>` from the phase declaration (phase wins over the builder fallback). Live-verified end to end:
  ```
  $ edda dispatch --agent pi --prompt-file p.txt --model openai-codex/gpt-5.6-sol --thinking low --exclude-tools edit,write
  ok
  Cost: $0.07
  Model requested: openai-codex/gpt-5.6-sol
  Model observed: openai-codex/gpt-5.6-sol
  ```
- claude gets `--model` too (spawn-line test `claude_phase_model_reaches_the_spawn_line`).

**2. 不支援的 backend/選項組合以明確錯誤拒絕，絕不默默忽略**
- `validate_dispatch_options` (agent_kind.rs) refuses before any spawn; each launcher also defends at `run_phase` (codex bails on all four declarations; claude bails on thinking). Live-verified:
  ```
  codex + --model       → Error: agent "codex" does not support: --model "openai-codex/gpt-5.6-sol". ...
  claude + --thinking   → Error: agent "claude" does not support: --thinking "high". ...
  codex + --session-dir → Error: agent "codex" does not support: --session-dir "...". ...
  claude + --list-models→ Error: --list-models is only available for the pi backend; ...
  ```
- Support matrix pinned by test (`support_matrix_matches_per_backend_reality`, `validation_refuses_unsupported_combinations_explicitly`).

**3. `--thinking` 與工具允許/拒絕清單可從 dispatch 指定，並在 launcher 建模**
- `--thinking` → pi `--thinking`; `--tools`/`--exclude-tools` → pi `--tools`/`--exclude-tools`, claude `--allowedTools`/`--disallowedTools`. pi refuses the ambiguous `--thinking` + model-`:suffix` combination (two spellings of one setting — edda refuses to guess).
- The 2026-09-02 `--exclude-tools edit,write` read-only guarantee now reaches dispatch verbatim (verified live above).

**4. conduct 的 plan phase 能宣告同一組選項**
- `Phase` gains `model`/`thinking`/`exclude_tools`; `allowed_tools` renamed to `tools` with a serde alias — every existing YAML still parses (`phase_allowed_tools_yaml_still_parses_as_tools`), both spellings at once is a loud error (`phase_both_tool_spellings_fail_loudly`).
- Launchers read the phase fields, so conduct plans get the same capabilities; unsupported phase/backend combos crash the phase with an explicit error (never silently ignored).

**5. 迴歸測試先 FAIL + spawn 命令列斷言 + 不支援組合明確錯誤**
- Red-first evidence: `claude_phase_model_reaches_the_spawn_line` was run against the unwired launcher and FAILED with `--model must appear in the claude spawn command line` before `--model` was added to `ClaudeCodeLauncher::build_command`.
- Spawn-command-line assertions for pi (`pi_phase_capabilities_reach_the_spawn_line`, `pi_no_declarations_spawn_no_capability_flags`, `pi_phase_model_wins_over_the_builder_fallback`) and claude (model + tool policy).

**doneWhen 追加（implementation brief v1）**

- `--json` contains `model_requested` / `model_observed`; stdout summary has both lines. Unset `--model` → `"inherited"`; no in-band report → `"unknown"`. Honesty rule enforced: observation comes only from claude stream-json `system/init` and pi RPC `get_state` — never from `~/.pi` config or session files.
- **事故反例測試**：`stdout_differs_between_a_dispatched_model_and_the_inherited_default`. Live counterexample against the real incident shape — same prompt, two dispatches:
  - without `--model`: `model_requested:"inherited"`, `model_observed:"openrouter/z-ai/glm-5.3-flash"` — the exact silent degradation from the 2026-09-02 incident, now visible in one line of dispatch output.
  - with `--model openai-codex/gpt-5.6-sol`: both fields report the requested model.
- Support matrix tests: see (2)/(5). `build_phase` no longer hardcodes the tool fields; conduct YAML compat tested.
- pi RPC in-band model verified against the real protocol (RPC `get_state` → `data.model.{provider,id}`) and via the fake-pi harness (`observed == openai-codex/gpt-5.6-sol`; null model → `None` → "unknown").

**Brief 追加（lane brief 超出 issue body 的部分）**
- `--session-dir` wired to pi via `LauncherOptions` (issue comment suggested deferring to #575; the lane brief mandates it — implemented pi-only, other backends refuse explicitly).
- 「列出可用 provider/model」查詢路徑：`edda dispatch --agent pi --list-models [search]` passes `pi --list-models` through verbatim (`edda_conductor::agent::pi_rpc::list_models`, `pub`); other backends refuse. The issue comment suggested a separate issue; the lane brief mandates it here. Live-verified (table with `openai-codex/gpt-5.6-sol`).

## 誠實規則落地
- `model_requested`: what edda actually passed, else literal `inherited`.
- `model_observed`: backend in-band report only, else literal `unknown`.
- `--permission-mode` for pi/codex: preexisting accepted-but-ignored behavior kept (rejection would break every existing dispatch); now prints an explicit warning that only claude consumes it.
- Ledger event writing is #582's territory — deliberately untouched.

## 範圍外 / 沒做的事
- `--fork`：等 #575。
- profile / 決策自動套用（#593）。
- 帳本事件（#582 消費 `model_requested`/`model_observed`）。
- codex model/thinking/tool-policy selection: the app-server exposes no verifiable selection path — refused, not guessed.

## FORBIDDEN 界線遵守
- `crates/edda-conductor/src/runner/`、`state/machine.rs`、`edda-notify/`：零改動。`PhaseResult` 故意未動（新增欄位會強制改 runner/ 測試字面值）— in-band model observation instead flows through a new `AgentLauncher::last_observed_model()` trait method (default `None`), so runner/ and its tests compile untouched.
- `plan/schema.rs` is outside the brief's allowed-files list but is required by the issue's S4 (conduct parity) and is in no lane's forbidden set; no other session was active (`edda peers`).
- claude 注意事項：claude CLI 不在本機 PATH，`claude --help` 無法在本工作站驗證；`--model`/`--disallowedTools` 採 Claude Code 公開文件旗標。失敗模式是 claude 立即退出並 crash（可見），不是靜默忽略。請驗證者留意此點。

## Gate receipt (L1)
- **Full SHA**: `df4a143e1cd1648838ef1ab97ff51b33b9b3f3ba` (clean tree)
- **Gates**: `cargo fmt --all --check` = PASS; `cargo clippy --workspace --all-targets -- -D warnings` = PASS; `cargo test --workspace` = PASS (all suites, 0 failures; incl. all 16 crates outside the CI Windows subset)
- **Toolchain**: rustc/cargo 1.93.1 (01f6ddf75 2026-02-11)
- **Lane**: `worker-1` (`CARGO_TARGET_DIR=...\fleet-workstation\lanes\worker-1`), `CARGO_INCREMENTAL=0`
- **L0 during iteration**: fmt + clippy `-p edda -p edda-conductor` + `cargo test -p edda -p edda-conductor` — all green before freeze.

## Review evidence summary
- Red-first regression: FAIL captured pre-fix (see doneWhen 5).
- Live end-to-end: two real pi dispatches (subscription gpt-5.6-sol turn + inherited glm fallback), outputs above.