### PR TITLE
ci: merge_group trigger and an aggregate CI Gate job over fmt, clippy, and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  # The merge queue only runs checks that trigger on merge_group; without this
+  # a queued entry would wait forever for the required check to appear.
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always
@@ -81,3 +84,27 @@ jobs:
       - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
       - run: cargo test ${{ matrix.args }}
+
+  # Aggregate gate: the single check the branch ruleset will pin instead of
+  # enumerating the seven individual jobs. `if: always()` keeps it running even
+  # when an upstream job fails, so the verdict table is always printed.
+  # `skipped` counts as failure for now: no path filters exist yet, so a skip
+  # would mean misconfiguration; the path-filter change (#631) relaxes this.
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy, test]
+    if: always()
+    steps:
+      - name: Evaluate upstream job results
+        run: |
+          printf '%-10s -> %s\n' fmt "${{ needs.fmt.result }}"
+          printf '%-10s -> %s\n' clippy "${{ needs.clippy.result }}"
+          printf '%-10s -> %s\n' test "${{ needs.test.result }}"
+          for result in "${{ needs.fmt.result }}" "${{ needs.clippy.result }}" "${{ needs.test.result }}"; do
+            if [ "$result" != "success" ]; then
+              echo "::error::Upstream job did not succeed (result: $result). skipped/failure/cancelled all fail the gate (see #631 for future skipped handling)."
+              exit 1
+            fi
+          done
+          echo "All upstream jobs succeeded."


### PR DESCRIPTION
## 這是什麼

`.github/workflows/ci.yml` 兩處改動（#628 第 1＋第 5 項的 workflow 側）：

1. `on:` 新增 `merge_group:`——GitHub merge queue 只會跑有掛 `merge_group` 觸發的 checks；沒有的話，佇列裡的 entry 永遠等不到 required check，直接卡死。`push: main` 與 `pull_request` 不變。
2. 新增聚合 job `ci-gate`（name `CI Gate`）：`needs: [fmt, clippy, test]`、`if: always()`，逐一判定 `needs.<job>.result`——`success` 通過；`skipped` **暫時視為失敗**（本單不做路徑過濾，允許 skipped 留給 #631 一起改）；`failure` / `cancelled` 失敗。判定前印出 job → result 對照表。

現有 7 個 job（`Format`、`Clippy (…)`×3、`Test (…)`×3）名稱與內容**完全不動**——branch ruleset 在切換前仍釘這 7 個 context。

## 驗證

本機驗證：

`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml', encoding='utf-8'))"` → exit 0, no stdout（controller RAN in the lane worktree; the earlier claimed `YAML_OK` line came from a variant of the command that echoed a marker and was not what the body cited）
- `grep -n "merge_group\|ci-gate\|CI Gate"`：
  ```
  7:  # The merge queue only runs checks that trigger on merge_group; without this
  9:  merge_group:
  93:  ci-gate:
  94:    name: CI Gate
  ```

PR 本身的 CI run 顯示綠的 `CI Gate` 與現有 7 個 checks 並列（`gh pr checks 635` 實際輸出）：

| Check | 結果 |
|---|---|
| CI Gate | pass |
| Clippy (macos-latest) | pass |
| Clippy (ubuntu-latest) | pass |
| Clippy (windows-latest) | pass |
| Format | pass |
| Test (macos-latest) | pass |
| Test (ubuntu-latest) | pass |
| Test (windows-latest) | pass |

## 合併後的 ruleset 順序

控制者執行（自 #630，供稽核）：

1. 本 PR 合併 → main 上首次出現 `CI Gate` check。
2. `PUT /repos/fagemx/edda/rulesets/18852689`：`required_status_checks` 改為只有 `CI Gate`；其餘三條規則（deletion / non_fast_forward / pull_request）不動；PUT 後獨立 GET 確認。記決策 `ci.merge-gate=single-aggregate-ci-gate`（取代 `all-three-platforms-…` 的 7 格列舉，但**涵蓋範圍不變**：三平台 clippy＋test 仍全部在 gate 裡）。
3. 同一次 PUT 加 `merge_queue` 規則：`merge_method: SQUASH`、`max_entries_to_build: 3`、`max_entries_to_merge: 3`、`min_entries_to_merge_wait_minutes: 5`、`grouping_strategy: ALLGREEN`、`check_response_timeout_minutes: 30`——23 crates 較重先設小。
4. 用一張 docs PR 走一次 queue 驗證：entry 拿到 `CI Gate`、合併成功。失敗即回退 PUT（保留 JSON 備份）。

## 關聯

- Issue: #630
- Parent: #628

