### PR TITLE
chore(repo): git-native pre-commit and commit-msg hooks via core.hooksPath

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,19 @@ lefthook install
 This runs `cargo fmt --check` on commit and `cargo clippy --workspace -- -D warnings` on push.
 Lefthook is local-only and does not affect CI.
 
+### Git hooks (no extra tools)
+
+Edda also ships zero-dependency POSIX `sh` hooks that enforce the checks locally:
+
+```bash
+sh scripts/githooks/install.sh
+```
+
+This sets `git config core.hooksPath scripts/githooks` (idempotent; uninstall with `git config --unset core.hooksPath`).
+
+- `pre-commit` — from the staged paths: runs `cargo fmt --all --check` when any `*.rs` or `Cargo.toml`/`Cargo.lock` is staged; runs `cargo clippy -p <crate> --all-targets -- -D warnings` for each touched `crates/<crate>/` (set `SKIP_CLIPPY=1` to skip — the commit message is then tagged `[skip-clippy]`); runs `sh scripts/lint-markdown-content.sh` when any `*.md` is staged; rejects any staged file larger than 1 MB.
+- `commit-msg` — enforces `<type>(<scope>): <desc>` or `<type>: <desc>` (types: `feat fix docs refactor test chore ci perf style build`); merge commits, `wip(` lane checkpoints, and `Revert ` messages are allowed.
+
 ## Build and Test
 
 ```bash

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -78,9 +78,10 @@
 ## 四、Lane 的三件事
 
 1. 在指定 worktree 與分支上做 brief 說的那一件事——不 checkout main、不 pull、不開別的分支。
-2. L0 閘（`cargo fmt --all --check`；`cargo clippy -p <crate> --all-targets -- -D warnings`；`cargo test -p <crate>`），
+2. 開工先 `sh scripts/githooks/install.sh`（裝 git 原生 pre-commit／commit-msg hooks，見 CONTRIBUTING.md「Git hooks」）。
+3. L0 閘（`cargo fmt --all --check`；`cargo clippy -p <crate> --all-targets -- -D warnings`；`cargo test -p <crate>`），
    凍結 SHA 前跑一次 L1（`CARGO_INCREMENTAL=0`，workspace 全套），記 gate receipt（SHA、閘、toolchain、lane、結果）。
-3. `git push -u origin <branch>`、開 PR、**停**。不合併、不刪分支、不刪 worktree。
+4. `git push -u origin <branch>`、開 PR、**停**。不合併、不刪分支、不刪 worktree。
 
 Brief 必含：assigned build lane、verification budget（L0 while iterating；L1 once per frozen SHA）、cleanup authority（build cache 可清；worktree／branch／source 不刪）。
 

--- a/scripts/githooks/commit-msg
+++ b/scripts/githooks/commit-msg
@@ -1,0 +1,38 @@
+#!/bin/sh
+# git commit-msg hook — conventional commits + [skip-clippy] tag.
+# POSIX sh only; install via scripts/githooks/install.sh.
+set -u
+
+msg_file=$1
+subject=$(head -n 1 "$msg_file")
+
+# Allowed: <type>(<scope>): <desc> or <type>: <desc>; merge commits, "Revert ",
+# and lane checkpoint "wip(" prefixes pass as-is.
+if ! printf '%s\n' "$subject" |
+    grep -Eq '^(feat|fix|docs|refactor|test|chore|ci|perf|style|build)(\([^)]*\))?: .+'; then
+    case "$subject" in
+    Merge* | Revert\ * | wip\(* ) ;;
+    *)
+        echo "commit-msg: REJECT — '$subject'" >&2
+        echo "commit-msg: expected <type>(<scope>): <desc> or <type>: <desc>, e.g. 'feat(cli): add --json flag'" >&2
+        exit 1
+        ;;
+    esac
+fi
+
+# pre-commit sets this marker when SKIP_CLIPPY=1 skipped clippy; tag the
+# message so reviewers can see it.
+gitdir=$(git rev-parse --git-dir)
+marker="$gitdir/skip-clippy-marker"
+if [ -f "$marker" ]; then
+    rm -f "$marker"
+    case "$subject" in
+    *"[skip-clippy]"*) ;;
+    *)
+        tmp="$msg_file.skip-clippy.tmp"
+        awk 'NR == 1 { print $0 " [skip-clippy]"; next } { print }' "$msg_file" >"$tmp" &&
+            mv "$tmp" "$msg_file"
+        ;;
+    esac
+fi
+exit 0

--- a/scripts/githooks/install.sh
+++ b/scripts/githooks/install.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Install git-native hooks (core.hooksPath). POSIX sh; idempotent.
+set -eu
+cd "$(git rev-parse --show-toplevel)"
+chmod +x scripts/githooks/pre-commit scripts/githooks/commit-msg scripts/githooks/install.sh
+git config core.hooksPath scripts/githooks
+echo "githooks installed: core.hooksPath = scripts/githooks"
+echo "uninstall: git config --unset core.hooksPath"

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -1,0 +1,91 @@
+#!/bin/sh
+# git pre-commit hook — fmt / clippy (touched crates) / markdown lint / 1 MB cap.
+# POSIX sh only; install via scripts/githooks/install.sh. Uninstall:
+# git config --unset core.hooksPath
+set -u
+
+gitdir=$(git rev-parse --git-dir)
+marker="$gitdir/skip-clippy-marker"
+rm -f "$marker"
+
+list=$(mktemp)
+trap 'rm -f "$list"' EXIT HUP INT TERM
+git diff --cached --name-only >"$list"
+
+[ -s "$list" ] || exit 0
+
+need_fmt=0
+need_md=0
+crates=""
+
+while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    case "$f" in
+    *.rs) need_fmt=1 ;;
+    Cargo.toml | Cargo.lock | */Cargo.toml | */Cargo.lock) need_fmt=1 ;;
+    *.md) need_md=1 ;;
+    esac
+    case "$f" in
+    crates/*/*)
+        c=${f#crates/}
+        c=${c%%/*}
+        case ",$crates," in
+        *,"$c",*) ;;
+        *) crates="$crates,$c" ;;
+        esac
+        ;;
+    esac
+    if [ -f "$f" ]; then
+        size=$(wc -c <"$f")
+        if [ "$size" -gt 1048576 ]; then
+            echo "pre-commit: REJECT — staged file larger than 1 MB: $f ($size bytes)" >&2
+            status=1
+        fi
+    fi
+done <"$list"
+crates=${crates#,}
+
+run() {
+    label=$1
+    shift
+    printf 'pre-commit: running %s\n' "$label"
+    "$@"
+    rc=$?
+    if [ "$rc" -eq 0 ]; then
+        printf 'pre-commit: %s — exit 0 (ok)\n' "$label"
+        return 0
+    fi
+    printf 'pre-commit: %s — exit %d (FAILED)\n' "$label" "$rc"
+    return 1
+}
+
+status=${status:-0}
+
+if [ "$need_fmt" -eq 1 ]; then
+    run "cargo fmt --all --check" cargo fmt --all --check || status=1
+fi
+
+if [ -n "$crates" ]; then
+    if [ "${SKIP_CLIPPY:-0}" = "1" ]; then
+        echo "pre-commit: *** SKIP_CLIPPY=1 — skipping cargo clippy for:$(printf '%s' "$crates" | tr ',' ' ') ***" >&2
+        echo "pre-commit: *** the commit message will be tagged [skip-clippy] for reviewers ***" >&2
+        : >"$marker"
+    else
+        for c in $(printf '%s' "$crates" | tr ',' ' '); do
+            [ -d "crates/$c" ] || continue
+            run "cargo clippy -p $c --all-targets -- -D warnings" \
+                cargo clippy -p "$c" --all-targets -- -D warnings || status=1
+        done
+    fi
+fi
+
+if [ "$need_md" -eq 1 ] && [ -f scripts/lint-markdown-content.sh ]; then
+    run "sh scripts/lint-markdown-content.sh" sh scripts/lint-markdown-content.sh || status=1
+fi
+
+if [ "$status" -ne 0 ]; then
+    echo "pre-commit: FAILED — commit aborted (fix the above or see CONTRIBUTING.md)" >&2
+    exit 1
+fi
+echo "pre-commit: all checks passed"
+exit 0


### PR DESCRIPTION
## 這是什麼

#634（#628 第 4 項）：把 L0 從「記得跑」變成「不跑就 commit 不了」。git 原生 hooks（POSIX `sh`，零外部執行期相依，Git Bash 與 Linux 都能跑），以 `git config core.hooksPath scripts/githooks` 啟用；lefthook 留作 follow-up。

- `scripts/githooks/pre-commit` — 依 staged 路徑：有 `*.rs`／`Cargo.toml`／`Cargo.lock` → `cargo fmt --all --check`；每個受影響 `crates/<c>/` → `cargo clippy -p <c> --all-targets -- -D warnings`（`SKIP_CLIPPY=1` 可跳過，訊息自動加 `[skip-clippy]`，經 `.git/skip-clippy-marker` 傳遞）；有 `*.md` → `sh scripts/lint-markdown-content.sh`；任何 staged 檔 > 1 MB 拒絕。印出每個檢查與 exit code。
- `scripts/githooks/commit-msg` — 強制 `<type>(<scope>): <desc>`／`<type>: <desc>`（type：feat fix docs refactor test chore ci perf style build）；合併 commit、`Revert `、`wip(` 檢查點放行；拒絕時印一行原因與範例；偵測到 marker 時在訊息第一行加 ` [skip-clippy]`。
- `scripts/githooks/install.sh` — 設 `core.hooksPath` 並 `chmod +x`；冪等；印解除安裝方式。
- `CONTRIBUTING.md` — 新增「Git hooks (no extra tools)」小節（安裝指令、各 hook 檢查內容）。
- `docs/guides/operator-runbook.md` — §四 Lane 的三件事加一行「開工先 `sh scripts/githooks/install.sh`」。

## 驗證

在 `$TEMP` 下的 throwaway repo（只複製 `scripts/githooks/` 與 `scripts/lint-markdown-content.sh`），`sh scripts/githooks/install.sh` 安裝後逐項實測。cargo workspace：root `Cargo.toml` + `crates/fmtpkg`（fmt 髒、clippy 乾淨）＋ `crates/clippybad`（clippy 髒、fmt 乾淨），五種情境互相隔離。

### (1) 壞訊息拒絕

```
$ git commit --allow-empty -m "updated some stuff"
commit-msg: REJECT — 'updated some stuff'
commit-msg: expected <type>(<scope>): <desc> or <type>: <desc>, e.g. 'feat(cli): add --json flag'
exit=1
```

（`wip(`、`Merge`、`Revert ` 開頭另測三種皆放行。）

### (2) fmt 不過拒絕（只 stage fmtpkg）

```
$ git add Cargo.toml crates/fmtpkg && git commit -m "test: add tiny cargo packages"
pre-commit: running cargo fmt --all --check
Diff in C:\Users\...\crates\fmtpkg\src\lib.rs:1:
-pub fn add(x: i32,y: i32) -> i32 {
+pub fn add(x: i32, y: i32) -> i32 {
     x + y
 }
pre-commit: cargo fmt --all --check — exit 1 (FAILED)
pre-commit: running cargo clippy -p fmtpkg --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
pre-commit: cargo clippy -p fmtpkg --all-targets -- -D warnings — exit 0 (ok)
pre-commit: FAILED — commit aborted (fix the above or see CONTRIBUTING.md)
exit=1
```

### (3a) clippy 不過拒絕（只 stage clippybad）

```
$ git add crates/clippybad && git commit -m "test: add clippybad crate"
pre-commit: running cargo fmt --all --check
pre-commit: cargo fmt --all --check — exit 0 (ok)
pre-commit: running cargo clippy -p clippybad --all-targets -- -D warnings
    Checking clippybad v0.1.0 (...)
error: unneeded `return` statement
 --> crates\clippybad\src\lib.rs:2:5
  |
2 |     return x + y;
  |     ^^^^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#needless_return
  = note: `-D clippy::needless-return` implied by `-D warnings`
error: could not compile `clippybad` (lib) due to 1 previous error
error: could not compile `clippybad` (lib test) due to 1 previous error
pre-commit: cargo clippy -p clippybad --all-targets -- -D warnings — exit 101 (FAILED)
pre-commit: FAILED — commit aborted (fix the above or see CONTRIBUTING.md)
exit=1
```

### (3b) `SKIP_CLIPPY=1` 放行並在訊息加 `[skip-clippy]`

```
$ SKIP_CLIPPY=1 git commit -m "wip(lane): checkpoint with bad clippy"
pre-commit: running cargo fmt --all --check
pre-commit: cargo fmt --all --check — exit 0 (ok)
pre-commit: *** SKIP_CLIPPY=1 — skipping cargo clippy for: clippybad ***
pre-commit: *** the commit message will be tagged [skip-clippy] for reviewers ***
pre-commit: all checks passed
[master 5817f9e] wip(lane): checkpoint with bad clippy [skip-clippy]
git-exit=0

$ git log -1 --format=%s
wip(lane): checkpoint with bad clippy [skip-clippy]
```

（下一個 commit 無殘留 marker，不會誤加標記——已實測。）

### (4) 2 MB 檔案拒絕

```
$ dd if=/dev/zero of=blob.bin bs=1M count=2 && git add blob.bin && git commit -m "chore: add big blob"
pre-commit: REJECT — staged file larger than 1 MB: blob.bin (2097152 bytes)
pre-commit: FAILED — commit aborted (fix the above or see CONTRIBUTING.md)
git-exit=1
```

### (5) `.md` 檔的良好 conventional commit 放行（lint exit 0）

```
$ git add README.md && git commit -m "docs: add readme"
pre-commit: running sh scripts/lint-markdown-content.sh
pre-commit: sh scripts/lint-markdown-content.sh — exit 0 (ok)
pre-commit: all checks passed
[master 75765f0] docs: add readme
 1 file changed, 7 insertions(+)
 create mode 100644 README.md
exit=0
```

另：`sh scripts/githooks/install.sh` 連跑兩次冪等；本 PR 的 commit 也通過了它自己的 hook（`.md` staged → markdown lint exit 0）。

## 關聯

Issue: #634
Parent: #628
