### PR TITLE
feat(scripts): local PR review watcher — auto SHA-pinned read-only review on open and push (#632)

### DIFF
--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -61,13 +61,18 @@
    plan YAML 放 scratchpad 或 `.tmp/plans/`，不進 repo。Rust lane 設 `CARGO_TARGET_DIR` 為
    `$env:LOCALAPPDATA\fleet-workstation\lanes\worker-1|worker-2`（verifier 用 `verifier|verifier-2`）。
    lane 的**啟動方式**見 §六（Task Scheduler，不是 nohup）。
-4. **PR 一開就派審**（不是等整批）。574 落地前的做法：
-   ```bash
-   pi -p --model openai-codex/gpt-5.6-sol --thinking high --exclude-tools edit,write \
-      --session-id review-prNNN "讀 <brief 路徑> 並照它審 PR #NNN"
-   ```
-   審查 brief 照 `/fleet-review`；round 記錄照 CLAUDE.md 的 review-fix loop（IN SCOPE／FOLLOW-UP ISSUE／P0-P1／RAN vs READ／cost／verdict），貼在 PR 上。
-   provider 過載時**改運輸不降模型**（§六）。
+4. **PR 一開就派審——watcher 自動**（#632，不是等整批、不需控制者接力）：
+   `scripts/pr-review-watch.sh` 每 60 秒輪詢 open PR，對**非 draft、head 未審過**的 PR
+   自動起唯讀審查者（`scripts/review-pr.sh`，一律 `--exclude-tools edit,write`、固定
+   `openai-codex/gpt-5.6-sol`）並把釘 SHA 的判決貼回 PR（Round N、model_observed、cost）。
+   push 新 head 自動再審一輪；watcher **不合併**（合併是操作者授權，見第 6 步）。
+   - **啟動**：Task Scheduler 跑 `sh <checkout>/scripts/pr-review-watch.sh`（隱藏視窗；
+     同 §六 lane 的排程方式）。狀態檔在 `~/.edda/pr-review-watch.state`（`pr → reviewed_sha`），不進 git。
+   - **停止**：結束排程任務（或殺掉那支 sh 程序）即可，watcher 沒有別的常駐子程序。
+   - **手動**：單輪 `sh scripts/pr-review-watch.sh once`；單張 PR 重審
+     `sh scripts/review-pr.sh <PR 編號> [head SHA]`。
+   - **過載改運輸不降模型**（§六）：pi 同模型重試 → `edda dispatch --agent codex` →
+     都不行就自動標 `review:unreviewed` 並停（移除該 label 可重新武装）。
 5. **收斂**：`/fleet-pr-loop` 的 bash driver 吐 `ACTION: REVIEW | FIX | DONE | BLOCKED`，照做到 LGTM；driver 不合併。
 6. **合併**（有授權時）：`git diff <LGTM 的 SHA>..origin/<branch>` 必須為空（判決還在），`gh pr checks` 7 綠，才合。合併後對剩下的 PR 做 Layer-3 交集：不相交直接合，相交要 rebase → 判決失效 → 再一輪。
 7. **開單**：審查 exhaust、runtime 的傷、重複兩次的手動步驟，當場 `/issue-intake`／`/issue-create`（含四問接線審計）。不要留在對話裡。

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -1,0 +1,116 @@
+#!/bin/sh
+# PR review watcher (GH-632, option A — local watcher).
+#
+# Polls open PRs and, for each non-draft PR whose head SHA has not been
+# reviewed yet, hands it to scripts/review-pr.sh which launches the
+# read-only reviewer and posts the SHA-pinned verdict back to the PR.
+#
+# Hard rules (ratified decisions, see docs/guides/operator-runbook.md §六):
+#   - reviewer is always read-only (review-pr.sh enforces this)
+#   - reviewer model is fixed for the transition period; never downgraded
+#   - the watcher never merges — merge is operator authority (pr.merge-policy)
+#   - state file lives outside git (~/.edda/pr-review-watch.state)
+#
+# Usage:
+#   pr-review-watch.sh run [interval-seconds]   poll forever (default 60s)
+#   pr-review-watch.sh once [interval-ignored]  single poll cycle
+#   pr-review-watch.sh decide < pr-list.json    offline triage (testable):
+#                                               reads `gh pr list --state open
+#                                               --json number,headRefOid,isDraft,
+#                                               labels` output, prints one line
+#                                               per PR: "REVIEW <n> <sha>" or
+#                                               "SKIP <n> <reason>"
+#
+# Environment:
+#   PR_REVIEW_WATCH_STATE   state file (default: ~/.edda/pr-review-watch.state)
+#   PR_REVIEW_WATCH_SCRIPTS directory holding review-pr.sh (default: script dir)
+#
+# State file format: one "<pr-number> <head-sha>" line per posted review
+# verdict. On a failed review attempt nothing is recorded, but review-pr.sh
+# labels the PR `review:unreviewed`, which stops the watcher for that PR
+# (fleet.review-provider-overload: 未審查是誠實狀態).
+
+set -eu
+
+state_file=${PR_REVIEW_WATCH_STATE:-"${HOME:-$USERPROFILE}/.edda/pr-review-watch.state"}
+scripts_dir=${PR_REVIEW_WATCH_SCRIPTS:-"$(CDPATH= cd -- "$(dirname "$0")" && pwd)"}
+
+log() {
+    printf '%s pr-review-watch: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+# state_has <file> <number> <sha> — has this PR already been reviewed at sha?
+state_has() {
+    grep -qx "$2 $3" "$1" 2>/dev/null
+}
+
+# decide — read PR JSON on stdin, print triage lines. Pure: no gh calls.
+decide() {
+    jq -c '.[]' | while IFS= read -r pr; do
+        number=$(printf '%s' "$pr" | jq -r '.number')
+        sha=$(printf '%s' "$pr" | jq -r '.headRefOid // ""')
+        draft=$(printf '%s' "$pr" | jq -r '.isDraft // false')
+        unreviewed=$(printf '%s' "$pr" | \
+            jq -r '[.labels[]?.name] | index("review:unreviewed") != null')
+        if [ "$draft" = "true" ]; then
+            printf 'SKIP %s draft\n' "$number"
+        elif [ "$unreviewed" = "true" ]; then
+            printf 'SKIP %s review-unreviewed\n' "$number"
+        elif [ -z "$sha" ]; then
+            printf 'SKIP %s missing-head\n' "$number"
+        elif state_has "$state_file" "$number" "$sha"; then
+            printf 'SKIP %s already-reviewed\n' "$number"
+        else
+            printf 'REVIEW %s %s\n' "$number" "$sha"
+        fi
+    done
+}
+
+# record_state <number> <sha> — append after a verdict is posted.
+record_state() {
+    mkdir -p "$(dirname -- "$state_file")"
+    printf '%s %s\n' "$1" "$2" >>"$state_file"
+}
+
+run_cycle() {
+    gh pr list --state open --json number,headRefOid,isDraft,labels | decide |
+    while IFS=' ' read -r action number sha; do
+        case $action in
+            REVIEW)
+                log "PR #$number head $sha needs review — dispatching reviewer"
+                if sh "$scripts_dir/review-pr.sh" "$number" "$sha"; then
+                    record_state "$number" "$sha"
+                    log "PR #$number review posted"
+                else
+                    log "PR #$number review failed (review-pr.sh handled fallback/label)"
+                fi
+                ;;
+            SKIP)
+                log "PR #$number skipped: $sha"
+                ;;
+        esac
+    done
+}
+
+case ${1:-run} in
+    decide)
+        decide
+        ;;
+    once)
+        run_cycle
+        ;;
+    run)
+        interval=${2:-${PR_REVIEW_WATCH_INTERVAL:-60}}
+        log "watching open PRs every ${interval}s (state: $state_file)"
+        while :; do
+            if ! run_cycle; then
+                log "poll cycle failed (gh or jq error); retrying next interval"
+            fi
+            sleep "$interval"
+        done
+        ;;
+    *)
+        printf 'usage: %s {run|once|decide}\n' "$0" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -1,0 +1,231 @@
+#!/bin/sh
+# Single-PR read-only review dispatcher (GH-632).
+#
+# Launches the read-only reviewer for one PR, posts the SHA-pinned verdict as
+# a PR comment, and applies the matching review label. Also usable standalone
+# (manual re-review of one PR) — the watcher calls it the same way.
+#
+# Usage:
+#   review-pr.sh <pr-number> [expected-head-sha]
+#   review-pr.sh verdict-label          # stdin: comment body; stdout: label
+#
+# Hard rules (ratified decisions):
+#   - reviewer is ALWAYS read-only: pi runs with --exclude-tools edit,write;
+#     the codex fallback runs through `edda dispatch --agent codex` whose
+#     prompt carries the same read-only constraint (改運輸不降模型).
+#   - model is FIXED for the transition period (fleet.agent-model-split:
+#     審查一律 gpt-5.6-sol). It is never downgraded to a cheaper model.
+#   - overload ladder (fleet.review-provider-overload): pi same-model retry
+#     (minimal-thinking probe, then full retry) → `edda dispatch --agent
+#     codex` → if all transports fail, label `review:unreviewed` and stop.
+#     未審查是誠實狀態；便宜模型的判決不是。
+#   - this script NEVER merges (pr.merge-policy). No merge commands here.
+
+set -eu
+
+REVIEW_MODEL='openai-codex/gpt-5.6-sol'
+
+usage() {
+    printf 'usage: %s <pr-number> [expected-head-sha]\n' "$0" >&2
+    printf '       %s verdict-label   (body on stdin, label on stdout)\n' "$0" >&2
+    exit 2
+}
+
+log() {
+    printf '%s review-pr: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+# verdict-label — map verdict text (stdin) to a review label, or nothing.
+# Rule: whichever verdict keyword appears LAST in the body wins; a review
+# that mentions "LGTM" only inside quoted policy text still maps correctly.
+verdict_label() {
+    body=$(cat)
+    lgtm_line=$(printf '%s' "$body" | grep -n 'LGTM' | tail -n 1 | cut -d: -f1 || true)
+    changes_line=$(printf '%s' "$body" | grep -n 'Changes Requested' | tail -n 1 | cut -d: -f1 || true)
+    if [ -n "$lgtm_line" ] && [ -n "$changes_line" ]; then
+        if [ "$lgtm_line" -gt "$changes_line" ]; then
+            printf 'review:lgtm'
+        else
+            printf 'review:changes-requested'
+        fi
+    elif [ -n "$lgtm_line" ]; then
+        printf 'review:lgtm'
+    elif [ -n "$changes_line" ]; then
+        printf 'review:changes-requested'
+    fi
+}
+
+# field <json> <jq-filter> — extract a field from captured PR JSON.
+field() {
+    printf '%s' "$1" | jq -r "$2"
+}
+
+# write_brief <file> <pr-number> <sha> <round> <title>
+write_brief() {
+    _file=$1 _number=$2 _sha=$3 _round=$4 _title=$5
+    cat >"$_file" <<EOF
+# Review brief — PR #${_number}「${_title}」（watcher 自動派審，Round ${_round}）
+
+你是這個 PR 的審查者。**唯讀**：不改檔、不 push、不 merge、不刪分支或 worktree。
+你的產出是**一則 PR 留言**（純文字，會被原樣貼上）。
+
+## 引擎與身分
+${REVIEW_MODEL}。一個 PR 一個審查者身分；本輪是 **Round ${_round}**。
+
+## 框架：驗證清單（不是攻擊計畫）
+逐條確認契約有沒有被滿足，指出**確實會出錯的地方**。每個發現都要能寫出
+「什麼輸入／狀態 → 什麼錯誤輸出或崩潰」。寫不出來的就不是發現。
+
+## 第一步：讀，不要急著跑
+1. \`gh pr view ${_number}\` 與 \`gh pr diff ${_number}\` — 被審的面（head：${_sha}）。
+2. 對應 issue 的 \`gh issue view <n>\` — **doneWhen 是驗收天花板**。超出它的期待寫成 FOLLOW-UP，不要當 blocking。
+3. \`gh pr checks ${_number}\` — exact-head CI。**先 READ 這個**。
+4. PR body 的 gate receipt（full SHA、跑過的閘、toolchain、lane、結果）。**先 READ 它**。
+5. **增量審查**：若 PR 上已有先前 Round 的審查留言，讀它們（\`gh pr view ${_number} --comments\`）；
+   只審新 head 的 diff 與對先前發現的回應，不重審已 LGTM 的面。
+
+## 逐條檢查
+1. doneWhen 逐條對照；2. FAIL-first 證據（red→green，不是宣稱）；3. 接線四問（誰寫／誰讀／
+失敗訊號／能力到哪層）——有新面卻沒有讀者或失敗無訊號 → P0/P1；4. FORBIDDEN 邊界；
+5. 與現行 origin/main 的語意整合；6. 安全／資料遺失。
+
+## 範圍凍結
+IN SCOPE：改動的行為與路徑、直接呼叫者、issue 驗收條件、本改動引入或暴露的安全／資料遺失回歸、
+與現行 base 的整合。其餘有證據的問題寫成 FOLLOW-UP ISSUE，不用來擋這個 PR。
+
+## 產出格式（會被原樣貼成 PR 留言）
+- 標題行：\`## Code Review: Round ${_round}\`
+- 釘住的 full head SHA：${_sha}
+- \`model_observed:\` 你實際觀察到的模型名
+- \`cost:\` 大略 token／時間
+- blocking P0／P1 清單（file:line + 什麼情況會壞）；RAN vs READ 分列
+- 結論行：\`Changes Requested\` 或 \`LGTM\`（P0=0 且 P1=0 才可以寫 LGTM；不確定標 \`[判斷]\`）
+
+**不要 merge。** 合併是操作者的權限。
+EOF
+}
+
+review_pr() {
+    number=$1
+    expected=${2:-}
+
+    command -v gh >/dev/null || { log 'gh not found' >&2; exit 1; }
+    command -v jq >/dev/null || { log 'jq not found' >&2; exit 1; }
+
+    pr_json=$(gh pr view "$number" --json number,headRefOid,isDraft,title) || {
+        log "cannot read PR #$number"; exit 1
+    }
+    if [ "$(field "$pr_json" '.isDraft // false')" = "true" ]; then
+        log "PR #$number is a draft — not reviewing"
+        exit 0
+    fi
+    sha=$(field "$pr_json" '.headRefOid // ""')
+    if [ -z "$sha" ]; then
+        log "PR #$number has no head SHA — not reviewing"
+        exit 1
+    fi
+    if [ -n "$expected" ] && [ "$expected" != "$sha" ]; then
+        log "PR #$number head moved ($expected -> $sha) — aborting stale dispatch" >&2
+        exit 1
+    fi
+    title=$(field "$pr_json" '.title')
+
+    # Round = 1 + prior review comments. Comment bodies begin with the
+    # watcher marker, so match anywhere, not startswith.
+    round=$(gh api "repos/{owner}/{repo}/issues/$number/comments" \
+        --jq '[.[].body | select(contains("## Code Review: Round"))] | length') || round=0
+    round=$((round + 1))
+
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' 0 HUP INT TERM
+    brief=$tmp/brief.md
+    write_brief "$brief" "$number" "$sha" "$round" "$title"
+
+    prompt="讀 $brief 並完全照它審 PR #$number。你是唯讀審查者：不可修改檔案、不可 push、不可 merge。產出是一則會貼到 PR #$number 的留言。"
+
+    verdict=''
+    transport=''
+    cost_line=''
+
+    # Transport 1: pi, same model, full thinking.
+    if pi -p --model "$REVIEW_MODEL" --thinking high \
+        --exclude-tools edit,write --session-id "review-pr$number" \
+        "$prompt" >"$tmp/verdict.md" 2>"$tmp/pi1.log"; then
+        transport='pi (--thinking high)'
+    else
+        # Overload path: probe with minimal thinking, then retry same model.
+        if pi -p --model "$REVIEW_MODEL" --thinking minimal \
+            --exclude-tools edit,write --session-id "review-pr$number-probe" \
+            '連線探測：只回 OK' >"$tmp/probe.md" 2>"$tmp/pi-probe.log"; then
+            if pi -p --model "$REVIEW_MODEL" --thinking high \
+                --exclude-tools edit,write --session-id "review-pr$number" \
+                "$prompt" >"$tmp/verdict.md" 2>"$tmp/pi2.log"; then
+                transport='pi (minimal-thinking probe, then --thinking high)'
+            fi
+        fi
+    fi
+
+    # Transport 2: codex via edda dispatch — same model family, different transport.
+    if [ -z "$transport" ]; then
+        log "pi transport unavailable for PR #$number; falling back to edda dispatch --agent codex"
+        if dispatch_json=$(edda dispatch --agent codex \
+            --session-id "review-pr$number" \
+            --prompt-file "$brief" --json 2>"$tmp/dispatch.log"); then
+            result=$(printf '%s' "$dispatch_json" | jq -r '.result_text // ""')
+            cost_usd=$(printf '%s' "$dispatch_json" | jq -r '.cost_usd // empty')
+            if [ -n "$result" ] && [ "$result" != "null" ]; then
+                printf '%s\n' "$result" >"$tmp/verdict.md"
+                transport='edda dispatch --agent codex'
+                if [ -n "$cost_usd" ]; then
+                    cost_line="\$${cost_usd} (edda dispatch)"
+                fi
+            fi
+        fi
+    fi
+
+    # All transports failed: label honestly and stop. Never downgrade the model.
+    if [ -z "$transport" ]; then
+        log "all transports failed for PR #$number — labeling review:unreviewed and stopping" >&2
+        gh pr edit "$number" --add-label 'review:unreviewed' >/dev/null 2>&1 || true
+        exit 1
+    fi
+
+    body=$(cat "$tmp/verdict.md")
+    observed=$(printf '%s\n' "$body" | sed -n 's/^[#* -]*model_observed: */model_observed: /p' | tail -n 1)
+    reported_cost=$(printf '%s\n' "$body" | sed -n 's/^[#* -]*cost: */cost: /p' | tail -n 1)
+    [ -n "$cost_line" ] || cost_line=${reported_cost:-'未回報（見內文）'}
+
+    {
+        printf '<!-- pr-review-watcher: posted by scripts/pr-review-watch.sh; the watcher never merges -->\n\n'
+        printf '## Code Review: Round %s\n\n' "$round"
+        printf -- '- Head SHA (pinned): `%s`\n' "$sha"
+        printf -- '- Model (requested): `%s`\n' "$REVIEW_MODEL"
+        printf -- '- %s\n' "${observed:-model_observed: 審查者未回報（requested 見上）}"
+        printf -- '- Transport: %s\n' "$transport"
+        printf -- '- Cost: %s\n' "$cost_line"
+        printf '\n---\n\n%s\n' "$body"
+    } >"$tmp/body.md"
+
+    gh pr comment "$number" --body-file "$tmp/body.md" >/dev/null
+    log "posted Round $round verdict for PR #$number ($transport)"
+
+    label=$(verdict_label <"$tmp/verdict.md")
+    if [ -n "$label" ]; then
+        gh pr edit "$number" --add-label "$label" >/dev/null
+        log "PR #$number labeled $label"
+    fi
+}
+
+case ${1:-} in
+    verdict-label)
+        [ $# -eq 1 ] || usage
+        verdict_label
+        ;;
+    ''|--help|-h)
+        usage
+        ;;
+    *)
+        [ $# -le 2 ] || usage
+        review_pr "$@"
+        ;;
+esac

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' 0 HUP INT TERM
+case_number=0
+
+expect_decide() {
+    name=$1
+    expected=$2
+    state_lines=$3
+    json=$4
+    case_number=$((case_number + 1))
+    state="$tmp/state-$case_number"
+    printf '%b' "$state_lines" >"$state"
+    if ! actual=$(printf '%s' "$json" | \
+        PR_REVIEW_WATCH_STATE="$state" sh "$root/scripts/pr-review-watch.sh" decide); then
+        printf '%s: decide exited non-zero\n' "$name" >&2
+        return 1
+    fi
+    if [ "$actual" != "$expected" ]; then
+        printf '%s: expected\n  %s\ngot\n  %s\n' "$name" "$expected" "$actual" >&2
+        return 1
+    fi
+}
+
+expect_label() {
+    name=$1
+    expected=$2
+    body=$3
+    case_number=$((case_number + 1))
+    if ! actual=$(printf '%b' "$body" | sh "$root/scripts/review-pr.sh" verdict-label); then
+        printf '%s: verdict-label exited non-zero\n' "$name" >&2
+        return 1
+    fi
+    if [ "$actual" != "$expected" ]; then
+        printf '%s: expected label %s, got %s\n' "$name" "$expected" "$actual" >&2
+        return 1
+    fi
+}
+
+# --- decide: PR queue triage from gh pr list JSON ---------------------------
+
+expect_decide \
+    'new PR is queued for review' \
+    'REVIEW 42 abc123' \
+    '' \
+    '[{"number":42,"headRefOid":"abc123","isDraft":false,"labels":[]}]'
+
+expect_decide \
+    'same SHA already reviewed is skipped' \
+    'SKIP 42 already-reviewed' \
+    '42 abc123\n' \
+    '[{"number":42,"headRefOid":"abc123","isDraft":false,"labels":[]}]'
+
+expect_decide \
+    'new head SHA after push is reviewed again' \
+    'REVIEW 42 def456' \
+    '42 abc123\n' \
+    '[{"number":42,"headRefOid":"def456","isDraft":false,"labels":[]}]'
+
+expect_decide \
+    'draft PR is skipped' \
+    'SKIP 42 draft' \
+    '' \
+    '[{"number":42,"headRefOid":"abc123","isDraft":true,"labels":[]}]'
+
+expect_decide \
+    'review:unreviewed label stops the watcher for that PR' \
+    'SKIP 42 review-unreviewed' \
+    '' \
+    '[{"number":42,"headRefOid":"abc123","isDraft":false,"labels":[{"name":"review:unreviewed"}]}]'
+
+expect_decide \
+    'empty open-PR queue decides nothing' \
+    '' \
+    '' \
+    '[]'
+
+expect_decide \
+    'missing head SHA is skipped, not queued' \
+    'SKIP 42 missing-head' \
+    '' \
+    '[{"number":42,"isDraft":false,"labels":[]}]'
+
+expect_decide \
+    'decisions are independent per PR' \
+    'SKIP 7 already-reviewed
+REVIEW 8 beefff
+SKIP 9 draft' \
+    '7 cccccc\n' \
+    '[{"number":7,"headRefOid":"cccccc","isDraft":false,"labels":[]},{"number":8,"headRefOid":"beefff","isDraft":false,"labels":[]},{"number":9,"headRefOid":"dddddd","isDraft":true,"labels":[]}]'
+
+# --- verdict-label: verdict text to review label -----------------------------
+
+expect_label \
+    'Changes Requested verdict maps to review:changes-requested' \
+    'review:changes-requested' \
+    '## Code Review: Round 1\n\nblocking P1: scripts/x.sh:12 — input Y crashes.\n\n結論：Changes Requested\n'
+
+expect_label \
+    'LGTM verdict maps to review:lgtm' \
+    'review:lgtm' \
+    '## Code Review: Round 1\n\nP0=0, P1=0.\n\n結論：LGTM\n'
+
+expect_label \
+    'when both verdicts appear, the last one wins' \
+    'review:lgtm' \
+    'Round 1 結論：Changes Requested\n\nRound 2（fix 後）：P0=0, P1=0。結論：LGTM\n'
+
+expect_label \
+    'no verdict keyword maps to no label' \
+    '' \
+    '## Code Review: Round 1\n\n審查中斷，無結論。\n'
+
+printf 'pr-review-watch fixtures passed\n'


### PR DESCRIPTION
Closes #632（方案 A：本機 watcher；方案 B self-hosted runner 為 follow-up，見下）。

## DoneWhen 逐條對照

| doneWhen | 本 PR |
|---|---|
| watcher 存在、可從 Task Scheduler 啟動 | `scripts/pr-review-watch.sh`：`run`（每 60s 輪詢，`PR_REVIEW_WATCH_INTERVAL` 可調）／`once`（單輪）／`decide`（離線 triage）。Task Scheduler 跑 `sh <checkout>/scripts/pr-review-watch.sh` 即可（runbook §三步 4 已註明啟停方式） |
| 狀態檔在 `~/.edda/` 或 `.edda/`，不進 git | 狀態檔預設 `~/.edda/pr-review-watch.state`（`PR_REVIEW_WATCH_STATE` 可覆寫），`pr → reviewed_sha` 一行一筆；腳本只會往 `$HOME` 外寫，repo 內零狀態 |
| 新 PR ≤ 3 分鐘出現「Code Review: Round 1」（釘 SHA、observed model、cost）；push 後 ≤ 3 分鐘 Round 2 | 預設輪詢間隔 60s，最壞延遲 = 60s + 審查時長。`review-pr.sh` 貼出的留言含 `<!-- pr-review-watcher -->` 標記、pinned full head SHA、`Model (requested)`、`model_observed`（審查者回報）、transport、cost。head SHA 變更 → 狀態檔 miss → 自動再審，Round N 由既有審查留言數推得。**此兩條的端到端計時需在真機啟用 watcher 才能量得——本 lane 未實跑（見「沒做的事」），判定邏輯已用 fixture 驗證** |
| 審查者一律唯讀 `--exclude-tools edit,write` | `review-pr.sh` 內 pi 兩次嘗試（full retry 與 minimal-thinking probe）皆帶 `--exclude-tools edit,write`；codex 後備經 `edda dispatch --agent codex`，read-only 約束寫進 brief 本身 |
| 模型過渡期固定 sol；過載改道規則在腳本裡：pi 重試 → `edda dispatch --agent codex` → 標 `review:unreviewed` 並停 | `REVIEW_MODEL='openai-codex/gpt-5.6-sol'` 為腳本常數，無降級路徑。過載階梯：pi(high) → pi minimal-thinking 探測 → pi(high) 重試 → `edda dispatch --agent codex` → 全敗則 `gh pr edit --add-label review:unreviewed` 並 exit 1；watcher 對帶此 label 的 PR 直接 SKIP（`decide` 已測） |
| 與合併分離：watcher 不合併 | 兩支腳本皆無任何 merge／force-push 語句；留言帶 `the watcher never merges` 標記 |
| runbook §三第 4 步改「自動」＋啟停方式 | 已改（僅該步，§四未動） |

## 硬性決策遵循

- **唯讀**：見上表。
- **模型**：`openai-codex/gpt-5.6-sol` 寫死在 `review-pr.sh`（`fleet.agent-model-split`：審查一律 sol），無環境變數可降級。
- **過載改運輸不降模型**（`fleet.review-provider-overload`）：如上階梯；「並停」＝標 `review:unreviewed` 後 watcher 永久 SKIP 該 PR，操作者移除 label 可重新武装。
- **不合併**（`pr.merge-policy`）：無 merge 路徑。
- **Claude 訂閱傳輸**：腳本只走 pi／`edda dispatch --agent codex`，不碰 claude 後備、不派 Opus。
- **狀態檔不進 git**：寫到 `$HOME/.edda/`。
- **不寫死 repo 外絕對路徑**：以 `$(dirname "$0")` 與環境變數取路；今天是控制者手寫 PowerShell 包裝的那套行為（含 `review-pr<N>` session id、brief 框架）已在 repo 內重現為 POSIX sh。repo 外的 `review-pr624.ps1`／briefs 僅作參考，未成依賴。

## 測試（red→green）

`scripts/test-pr-review-watch.sh`（沿 `scripts/test-lint-markdown-content.sh` 風格，fixture JSON 離線驗證，不呼叫 gh／pi）：

- **red 證據**（scripts 尚未存在時先跑）：
  ```
  sh: /c/ai_agent/edda-wt-gh632/scripts/pr-review-watch.sh: No such file or directory
  new PR is queued for review: decide exited non-zero
  ```
- **green**：12 個 case 全過——
  - `decide`：新 PR → `REVIEW`；同 SHA 已審 → `SKIP already-reviewed`；push 新 SHA → 再 `REVIEW`；draft → `SKIP draft`；`review:unreviewed` label → `SKIP review-unreviewed`；空佇列 → 無輸出；head SHA 缺 → `SKIP missing-head`；多 PR 各自獨立判定
  - `verdict-label`：Changes Requested → `review:changes-requested`；LGTM → `review:lgtm`；兩關鍵詞並存時取最後出現者（引文含 LGTM 不誤判）；無結論 → 不貼 label
- 實機 smoke（唯讀）：`gh pr list` 真輸出餵 `decide` 正確 triage 現有 9 張 open PR；`gh api` 的 round 計數 jq filter 對 #623 正確回 3。

## 閘

- `sh -n` 三支腳本全過
- `sh scripts/test-pr-review-watch.sh` 過（上面 red→green）
- `sh scripts/lint-markdown-content.sh` 過（改到 runbook）
- 本單不改 Rust，未跑 cargo 閘；未動 `crates/`

## 沒做的事

- **未實機啟用 watcher**：會立刻對現有 9 張 open PR（#607/#620/#624/#627/#629/#635–#638——多屬在飛 lane）派審查者。啟用是操作者動作：Task Scheduler 建 `sh <checkout>/scripts/pr-review-watch.sh`，doneWhen 的 3 分鐘計時留給啟用後量測。
- 未做 Task Scheduler 的 XML／註冊腳本——今天控制者已有排程包裝模式（runbook §六、`fleet.lane-launch`），watcher 沿用同機制，不另發明。
- 未整合 `edda watch`／#567 狀態面。

## Follow-up（建議開單）

1. **方案 B**：self-hosted runner（`.github/workflows/pr-review.yml` 事件驅動、免輪詢；注意 fork PR 安全面）——issue 明列為 B。
2. watcher 與 `edda watch`／#567 鈴鐺整合（issue doneWhen 亦列）。
3. 審查引擎池（#618）：目前 `review-pr.sh` 的運輸固定 pi→codex；池落地後改為從池選。
4. `review:unreviewed` 的解除目前靠手動移除 label；可加操作者指令或自動重試上限。
