### PR TITLE
feat(fleet): pr-review watcher — launches the read-only reviewer on PR open and on push, posts the SHA-pinned verdict

### DIFF
--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -111,7 +111,7 @@ Brief 必含：assigned build lane、verification budget（L0 while iterating；
 | 規則 | 決策 key |
 |---|---|
 | 執行用便宜模型（pi 預設 glm-5.3-flash）；**審查一律 gpt-5.6-sol**（codex／pi 皆是） | `fleet.agent-model-split` |
-| 審查 provider 過載：**改運輸不降模型**——(1) 同 `--model` 先用 `--thinking minimal` 探測再重試 pi；(2) `edda dispatch --agent codex`；(3) 都不行就把 PR 標為**未審查**並停——未審查是誠實狀態，便宜模型的判決不是 | `fleet.review-provider-overload` |
+| 審查 provider 過載：**改運輸不降模型**——(1) 同 `--model` 先用 `--thinking minimal` 探測，通了才重試 pi 一次；(2) 仍沒有判決就對該 head 標 `review:unreviewed` 並停——未審查是誠實狀態，便宜模型的判決不是。watcher 無 Codex 路線（superseding 決策 `…codex-route-withdrawn-for-automated-watcher`：Codex 對 watcher 做不到唯讀；人類控制者仍可手動用 Codex） | `fleet.review-provider-overload` |
 | **lane 啟動走 Task Scheduler，不走 nohup／Start-Process**：Claude Code 的工具 shell 在 Windows Job Object 裡，nohup 的子程序仍隨 session 死。`Register-ScheduledTask` + `Start-ScheduledTask`（父程序是 svchost）；該環境 `CARGO_TARGET_DIR` 與 `HOME` 為空，lane wrapper 必須顯式設；`Get-ScheduledTaskInfo` 可輪詢，`Unregister-ScheduledTask` 清理。重派前先讀 worktree／branch／PR 狀態，不信任 live handle | `fleet.lane-launch`、`fleet.lane-dispatch` |
 | 一 issue ＝ 一單 phase plan ＝ 一 worktree ＝ 一 build lane；並行在 plan 之間；plan 裡不寫沒理由的 `depends_on`；並行 plan 不用 verdict gate | `cleanup.parallel-exec`、`cleanup.review-gate` |
 | build lane 只用 `worker-1|worker-2|verifier|verifier-2`；永不建 ad-hoc `CARGO_TARGET_DIR`；L1 與 verifier 設 `CARGO_INCREMENTAL=0` | `verification.cost-discipline` |

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -63,13 +63,14 @@
    lane 的**啟動方式**見 §六（Task Scheduler，不是 nohup）。
 4. **PR 一開就派審（自動，不用人手）**：本機 watcher（`scripts/pr-review-watch.sh`，由
    `scripts/pr-review-launch.ps1` 註冊成隱藏排程任務 `edda-pr-review-watcher`）每 60 秒掃 open PR：
-   非 draft、head 沒審過的 PR 自動起唯讀審查者（gpt-5.6-sol，Task Scheduler 隱藏視窗，
-   worktree 在 `$EDDA_FLEET_SCRATCH/wt-review-prN`），判決（含 observed model、cost、釘死的 head SHA）
-   自動貼上 PR，並加 label `review:lgtm`／`review:changes-requested`；push 後 head 變了自動再審一輪。
+   非 draft、head 沒審過的 PR 在 **3 分鐘內**自動起唯讀審查者（gpt-5.6-sol，Task Scheduler 隱藏視窗，
+   worktree 在 `$EDDA_FLEET_SCRATCH/wt-review-prN`）並貼確認留言 `review: started on <full sha>`；
+   判決（含 observed model、cost、釘死的 head SHA）在審查者跑完後（約 5–15 分鐘）自動貼上 PR，
+   並加 label `review:lgtm`／`review:changes-requested`；push 後 head 變了自動再審一輪。
    檢查方式：`Get-ScheduledTask edda-pr-review-watcher`、`tail ~/.edda/fleet/watch.log`、PR 留言與 label。
-   provider 過載的改道規則（§六 `fleet.review-provider-overload`：pi 重試 → `edda dispatch --agent codex`
-   → 標 `review:unreviewed` 並停）內建在 watcher 裡。啟停、狀態檔與疑難排解見
-   `docs/guides/pr-review-watcher.md`。watcher **不合併**——合併仍在第 6 步、要授權。
+   provider 過載時：pi 重試一次，仍沒有判決就標 `review:unreviewed` 並對該 head 停手
+   （v1 無 codex 後備——它做不到唯讀；§六 `fleet.review-provider-overload` 的決策全文仍可 `edda ask` 查）。
+   啟停、狀態檔與疑難排解見 `docs/guides/pr-review-watcher.md`。watcher **不合併**——合併仍在第 6 步、要授權。
 5. **收斂**：`/fleet-pr-loop` 的 bash driver 吐 `ACTION: REVIEW | FIX | DONE | BLOCKED`，照做到 LGTM；driver 不合併。
 6. **合併**（有授權時）：`git diff <LGTM 的 SHA>..origin/<branch>` 必須為空（判決還在），`gh pr checks` 7 綠，才合。合併後對剩下的 PR 做 Layer-3 交集：不相交直接合，相交要 rebase → 判決失效 → 再一輪。
 7. **開單**：審查 exhaust、runtime 的傷、重複兩次的手動步驟，當場 `/issue-intake`／`/issue-create`（含四問接線審計）。不要留在對話裡。
@@ -94,7 +95,7 @@ Brief 必含：assigned build lane、verification budget（L0 while iterating；
 |---|---|---|
 | 觀測 | `edda watch`、`edda peers`、`edda conduct status`、`gh pr checks`、`edda status` | dispatch lane 不在 peers（#569）；統一狀態面（#567）；孤兒回收（#573）；freshness（#604） |
 | 進度追蹤 | issue 標籤（pending → ready → PR → merged）；`edda task new <title> --after <id> --assignee <label>`、`edda task start <id>`、`edda task done <id> --receipt "<可驗的話>" --evidence <path>`；PR 上的審查輪 | 成本與模型不進帳本（#582、#574） |
-｜ 派發 ｜ `edda dispatch --agent <claude|pi|codex> --prompt-file <f> [--session-id] [--cwd] [--budget-usd] [--timeout-sec] [--permission-mode] [--json]`；`edda conduct run <plan> --agent <x> [--cwd] [--dry-run] [--tmux] [--json]`；審查由本機 watcher 自動起並貼判決（`scripts/pr-review-watch.sh`，#632） ｜ 選模型/思考深度/工具(#574);角色 profile(#593);批次發射(`edda wave`,等 #576 與 #599) |
+| 派發 | `edda dispatch --agent <claude|pi|codex> --prompt-file <f> [--session-id] [--cwd] [--budget-usd] [--timeout-sec] [--permission-mode] [--json]`；`edda conduct run <plan> --agent <x> [--cwd] [--dry-run] [--tmux] [--json]`；審查由本機 watcher 自動起並貼判決（`scripts/pr-review-watch.sh`，#632） | 選模型/思考深度/工具(#574);角色 profile(#593);批次發射(`edda wave`,等 #576 與 #599) |
 | 討論提問 | 你 ↔ 控制者對話；控制者 ↔ 其他 Claude session 用跨 session 訊息；對 lane 用 `edda request "<label>" "<msg>"`（門鈴；lane 沒心跳時要 `--force` 排隊）；耐久的寫 issue／PR 留言 | 事件驅動門鈴（#545）；lane 心跳（#569） |
 | 決策 | `edda ask "<domain>"` → `edda decide "k=v" --reason "…"`（agent，unratified）→ `edda ratify <key>`（你） | 簽章身分（#609） |
 | 開單 | `/issue-intake`、`/issue-create`（四問接線審計必填） | 批次進料與確認表（#599）；驗收端 wiring verdict（#594） |

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -61,13 +61,15 @@
    plan YAML 放 scratchpad 或 `.tmp/plans/`，不進 repo。Rust lane 設 `CARGO_TARGET_DIR` 為
    `$env:LOCALAPPDATA\fleet-workstation\lanes\worker-1|worker-2`（verifier 用 `verifier|verifier-2`）。
    lane 的**啟動方式**見 §六（Task Scheduler，不是 nohup）。
-4. **PR 一開就派審**（不是等整批）。574 落地前的做法：
-   ```bash
-   pi -p --model openai-codex/gpt-5.6-sol --thinking high --exclude-tools edit,write \
-      --session-id review-prNNN "讀 <brief 路徑> 並照它審 PR #NNN"
-   ```
-   審查 brief 照 `/fleet-review`；round 記錄照 CLAUDE.md 的 review-fix loop（IN SCOPE／FOLLOW-UP ISSUE／P0-P1／RAN vs READ／cost／verdict），貼在 PR 上。
-   provider 過載時**改運輸不降模型**（§六）。
+4. **PR 一開就派審（自動，不用人手）**：本機 watcher（`scripts/pr-review-watch.sh`，由
+   `scripts/pr-review-launch.ps1` 註冊成隱藏排程任務 `edda-pr-review-watcher`）每 60 秒掃 open PR：
+   非 draft、head 沒審過的 PR 自動起唯讀審查者（gpt-5.6-sol，Task Scheduler 隱藏視窗，
+   worktree 在 `$EDDA_FLEET_SCRATCH/wt-review-prN`），判決（含 observed model、cost、釘死的 head SHA）
+   自動貼上 PR，並加 label `review:lgtm`／`review:changes-requested`；push 後 head 變了自動再審一輪。
+   檢查方式：`Get-ScheduledTask edda-pr-review-watcher`、`tail ~/.edda/fleet/watch.log`、PR 留言與 label。
+   provider 過載的改道規則（§六 `fleet.review-provider-overload`：pi 重試 → `edda dispatch --agent codex`
+   → 標 `review:unreviewed` 並停）內建在 watcher 裡。啟停、狀態檔與疑難排解見
+   `docs/guides/pr-review-watcher.md`。watcher **不合併**——合併仍在第 6 步、要授權。
 5. **收斂**：`/fleet-pr-loop` 的 bash driver 吐 `ACTION: REVIEW | FIX | DONE | BLOCKED`，照做到 LGTM；driver 不合併。
 6. **合併**（有授權時）：`git diff <LGTM 的 SHA>..origin/<branch>` 必須為空（判決還在），`gh pr checks` 7 綠，才合。合併後對剩下的 PR 做 Layer-3 交集：不相交直接合，相交要 rebase → 判決失效 → 再一輪。
 7. **開單**：審查 exhaust、runtime 的傷、重複兩次的手動步驟，當場 `/issue-intake`／`/issue-create`（含四問接線審計）。不要留在對話裡。
@@ -92,7 +94,7 @@ Brief 必含：assigned build lane、verification budget（L0 while iterating；
 |---|---|---|
 | 觀測 | `edda watch`、`edda peers`、`edda conduct status`、`gh pr checks`、`edda status` | dispatch lane 不在 peers（#569）；統一狀態面（#567）；孤兒回收（#573）；freshness（#604） |
 | 進度追蹤 | issue 標籤（pending → ready → PR → merged）；`edda task new <title> --after <id> --assignee <label>`、`edda task start <id>`、`edda task done <id> --receipt "<可驗的話>" --evidence <path>`；PR 上的審查輪 | 成本與模型不進帳本（#582、#574） |
-| 派發 | `edda dispatch --agent <claude|pi|codex> --prompt-file <f> [--session-id] [--cwd] [--budget-usd] [--timeout-sec] [--permission-mode] [--json]`；`edda conduct run <plan> --agent <x> [--cwd] [--dry-run] [--tmux] [--json]`；審查手動起 pi | 選模型／思考深度／工具（#574）；角色 profile（#593）；批次發射（`edda wave`，等 #576 與 #599） |
+｜ 派發 ｜ `edda dispatch --agent <claude|pi|codex> --prompt-file <f> [--session-id] [--cwd] [--budget-usd] [--timeout-sec] [--permission-mode] [--json]`；`edda conduct run <plan> --agent <x> [--cwd] [--dry-run] [--tmux] [--json]`；審查由本機 watcher 自動起並貼判決（`scripts/pr-review-watch.sh`，#632） ｜ 選模型/思考深度/工具(#574);角色 profile(#593);批次發射(`edda wave`,等 #576 與 #599) |
 | 討論提問 | 你 ↔ 控制者對話；控制者 ↔ 其他 Claude session 用跨 session 訊息；對 lane 用 `edda request "<label>" "<msg>"`（門鈴；lane 沒心跳時要 `--force` 排隊）；耐久的寫 issue／PR 留言 | 事件驅動門鈴（#545）；lane 心跳（#569） |
 | 決策 | `edda ask "<domain>"` → `edda decide "k=v" --reason "…"`（agent，unratified）→ `edda ratify <key>`（你） | 簽章身分（#609） |
 | 開單 | `/issue-intake`、`/issue-create`（四問接線審計必填） | 批次進料與確認表（#599）；驗收端 wiring verdict（#594） |

--- a/docs/guides/pr-review-watcher.md
+++ b/docs/guides/pr-review-watcher.md
@@ -113,9 +113,11 @@ sh scripts/test-pr-review-watch.sh         # 離線測試：審/跳過決策 + v
 
 ## 離線測試
 
-`sh scripts/test-pr-review-watch.sh`（移植自 PR #639，Round 2/3 擴充）：**完全離線**——
-`gh`／`pi`／review-pr 全是 stub，狀態目錄與 `PR_REVIEW_WATCH_LOG` 都指向暫存目錄，
-並守住「真實 `~/.edda/fleet/watch.log` 在整輪測試前後大小不變」；每個場景都包
+`sh scripts/test-pr-review-watch.sh`（移植自 PR #639，Round 2–4 擴充）：**完全離線**——
+`gh` 與 `pi` 是 stub（記錄 argv、回罐頭輸出），重試的審查發射目標也以 stub 取代；
+但 **verdict-label 場景執行的是真的 `scripts/review-pr.sh` 離線 helper**（不碰網路）。
+狀態目錄與 `PR_REVIEW_WATCH_LOG` 都指向暫存目錄，並守住「真實
+`~/.edda/fleet/watch.log` 在整輪測試前後大小不變」；每個場景都包
 `timeout`，卡住＝FAIL，不會吊住呼叫端。實況：
 
 - `decide` 子命令吃的是 `gh pr list --jq '… \| @tsv'` 產出的 **TSV** 行（draft 在

--- a/docs/guides/pr-review-watcher.md
+++ b/docs/guides/pr-review-watcher.md
@@ -21,8 +21,9 @@
      session 的 Job Object 牽連）；Linux 上退化成 `nohup`。
 2. **確認**：排程任務確認進入 `Running` 之後（起不來就不記 pending、下一輪重試），貼確認留言
    `review: started on <full sha>`（SHA-pinned）。ack **不是 best-effort**：貼失敗會記在
-   `review-acks.tsv`（"launched, ack pending"），每一輪重試，3 次都失敗就 label
-   `review:post-failed` 並記 log；成功才從 acks 檔移除。判決留言等審查者跑完
+   `review-acks.tsv`（"launched, ack pending"），每一輪重試；3 次都失敗就加 label
+   `review:post-failed`，且 **acks 條目不會被默默丟掉**——label 加成功才把條目標記為
+   `post-failed`（終態）；label 呼叫也失敗的話，條目保留、下一輪再試。判決留言等審查者跑完
    （典型 5–15 分鐘）才貼。
 3. 判決出現後（log 裡 `<<<VERDICT ... VERDICT>>>` 區塊），貼 PR 留言：表頭一行含
    **model_observed（從 pi session 檔讀，不是從 brief 宣稱；session 檔不存在就明寫
@@ -38,7 +39,9 @@
 
 判決死掉或空白（log 沒有 verdict 區塊、zero-byte log、或超過 45 分鐘沒有 `.done`）時：
 
-1. **pi 重試一次**（同一個 `--model`，session 續用）；
+1. **pi 重試一次**（同一個 `--model`，session 續用）；重試**之前**先跑帳本決策指定的探測：
+   `pi -p --model $EDDA_REVIEW_MODEL --thinking minimal "reply OK"`（60 秒逾時）——
+   探測失敗就直接對該 head 標 `review:unreviewed` 並停，不浪費第二次完整審查；探測通過才重試；
 2. 還是拿不到判決：label `review:unreviewed`，**該 head 停手**。
    未審查是誠實的狀態，便宜模型的判決不是。
    （`edda dispatch --agent codex` 這條運輸在 v1 移除：Codex 設定為
@@ -93,7 +96,7 @@ sh scripts/test-pr-review-watch.sh         # 離線測試：審/跳過決策 + v
 |---|---|
 | `review-state.tsv` | `pr<TAB>reviewed_sha<TAB>round`——每張 PR 已審到哪個 head |
 | `review-pending.tsv` | `pr<TAB>round<TAB>sha<TAB>attempts<TAB>launched<TAB>postfails`——在途審查（attempts 0=首次 pi，1=pi 重試；postfails=判決貼文失敗次數）；**只在排程任務確認 Running 後才會寫入** |
-| `review-acks.tsv` | `pr<TAB>sha<TAB>attempts`——已啟動但 ack 未貼出的 head；成功即移除，3 次失敗 → `review:post-failed` |
+| `review-acks.tsv` | `pr<TAB>sha<TAB>attempts<TAB>status`——已啟動但 ack 未貼出的 head；成功即移除；3 次失敗 → 加 `review:post-failed`，條目標記 `post-failed`（終態）；label 呼叫也失敗則條目保留、下一輪重試 |
 | `review-fails.tsv` | `pr<TAB>sha<TAB>count`——連續啟動失敗次數（連續 3 次 → `review:unreviewed` 並停） |
 | `watch.log` | watcher 每一步的時間戳紀錄 |
 | `review-prN-rR-brief.md` / `.log` / `.done` / `-verdict.md`（`.posted`） / `-comment.md` | 每輪審查的 brief、pi 轉錄、結束旗標、抽出來的判決（`.posted` = 留言已貼出）、貼出的留言 |
@@ -110,9 +113,23 @@ sh scripts/test-pr-review-watch.sh         # 離線測試：審/跳過決策 + v
 
 ## 離線測試
 
-`sh scripts/test-pr-review-watch.sh`（移植自 PR #639）：用 fixture 的 `gh pr list`
-JSON 驗證「新 PR → 審；同 SHA 已審 → 跳過；push 新 head → 再審；draft → 跳過；
-`review:unreviewed` → 跳過」的決策，以及判決文字 → label 的映射（後者贏）。
+`sh scripts/test-pr-review-watch.sh`（移植自 PR #639，Round 2/3 擴充）：**完全離線**——
+`gh`／`pi`／review-pr 全是 stub，狀態目錄與 `PR_REVIEW_WATCH_LOG` 都指向暫存目錄，
+並守住「真實 `~/.edda/fleet/watch.log` 在整輪測試前後大小不變」；每個場景都包
+`timeout`，卡住＝FAIL，不會吊住呼叫端。實況：
+
+- `decide` 子命令吃的是 `gh pr list --jq '… \| @tsv'` 產出的 **TSV** 行（draft 在
+  `--jq` 的 `select(.isDraft\|not)` 就被濾掉，套件中沒有 draft fixture）：新 PR → 審、
+  同 SHA 已審 → 跳過、push 新 head → 再審、label 逐 PR 判讀（無 label 的 PR 1 不被
+  PR 2 的 `review:unreviewed` 壓住）、`review:unreviewed` per head（同 head 擋、
+  新 head 摘 label 重審、無記錄 head 保守擋）、空佇列、缺 head SHA。
+- `verdict-label`：判決文字 → label，後者贏。
+- `label-verdict`：verdict label 只在「目前 head == 被審 SHA」時套用；head 未知也跳過。
+- `ack-try`（stub gh）：失敗記 "launched, ack pending" → 成功才清；3 次都失敗且
+  `review:post-failed` 也加不上 → 條目保留、下一輪重試；label 加成功 → 條目標記 `post-failed` 終態。
+- live 迴圈（stub gh/pi + stub review-pr，一次 `--once`）：head 查詢失敗 → 判決留在
+  pending、不記 reviewed、不加 label、log `head unknown, retry`；provider 探測失敗 →
+  不發第二次審查、直接 `review:unreviewed`；探測通過 → 恰好一次 pi 重試。
 
 ## 它不做什麼
 

--- a/docs/guides/pr-review-watcher.md
+++ b/docs/guides/pr-review-watcher.md
@@ -19,14 +19,19 @@
    - Windows 上照決策 `fleet.lane-launch` 用 Task Scheduler 起隱藏排程任務
      `edda-review-prN-rR`（wrapper 設 `HOME`、UTF-8；父程序是 svchost，不受
      session 的 Job Object 牽連）；Linux 上退化成 `nohup`。
-2. **確認**：排程任務確認進入 `Running` 之後（起不來就不記 pending、下一輪重試），
-   3 分鐘內貼確認留言 `review: started on <full sha>`（SHA-pinned）。
-   判決留言等審查者跑完（典型 5–15 分鐘）才貼。
+2. **確認**：排程任務確認進入 `Running` 之後（起不來就不記 pending、下一輪重試），貼確認留言
+   `review: started on <full sha>`（SHA-pinned）。ack **不是 best-effort**：貼失敗會記在
+   `review-acks.tsv`（"launched, ack pending"），每一輪重試，3 次都失敗就 label
+   `review:post-failed` 並記 log；成功才從 acks 檔移除。判決留言等審查者跑完
+   （典型 5–15 分鐘）才貼。
 3. 判決出現後（log 裡 `<<<VERDICT ... VERDICT>>>` 區塊），貼 PR 留言：表頭一行含
    **model_observed（從 pi session 檔讀，不是從 brief 宣稱；session 檔不存在就明寫
-   `unknown`，絕不編造）**、cost（session 檔加總）、釘死的 head SHA；然後加 label
-   `review:lgtm` 或 `review:changes-requested`。**留言與 label 都成功才記 state**；
-   留言失敗就保留判決檔、下一輪重貼（重試 5 次仍失敗 → label `review:post-failed`）。
+   `unknown`，絕不編造）**、cost（session 檔加總）、釘死的 head SHA。**label 只在 PR
+   目前 head 仍等於被審的 SHA 時才加**（`review:lgtm` 或 `review:changes-requested`）；
+   head 已移走時判決留言照貼（它釘在被審的 SHA），但不加 label、記 log
+   `head moved: reviewed <sha> current <sha>`，由重掃描開下一輪。**留言與 label
+   都成功才記 state**；留言失敗就保留判決檔、下一輪重貼（重試 5 次仍失敗 →
+   label `review:post-failed`）。
 4. head 被 push 之後（SHA 變了）自動再審一輪（round+1，delta brief，`prev-sha` 帶入）。
 
 ## Provider 過載怎麼辦（v1：無 codex 後備）
@@ -39,9 +44,10 @@
    （`edda dispatch --agent codex` 這條運輸在 v1 移除：Codex 設定為
    `danger-full-access`，做不到唯讀審查。）
 
-`review:unreviewed` 會**一直擋住那張 PR**，直到有人手動摘掉 label——摘掉後 watcher
-對新的掃描結果重新判斷（同 SHA 仍在 state 裡就還是跳過，push 了新 head 就會重審）。
-要手動救：手動跑一輪審查、貼上判決、把 `review-state.tsv` 補成該 head、摘 label。
+`review:unreviewed` 是 **per head**：只擋「目前 head == 被記錄為 unreviewed 的那個
+head」。push 了新 head，watcher 會摘掉過期的 label、自動再審一輪。label 存在但
+state 裡沒有對應 head 時（例如人工加的），視為仍在擋，不會自動摘。要手動救：
+手動跑一輪審查、貼上判決、把 `review-state.tsv` 補成該 head、摘 label。
 
 ## 啟動 / 停止
 
@@ -87,6 +93,7 @@ sh scripts/test-pr-review-watch.sh         # 離線測試：審/跳過決策 + v
 |---|---|
 | `review-state.tsv` | `pr<TAB>reviewed_sha<TAB>round`——每張 PR 已審到哪個 head |
 | `review-pending.tsv` | `pr<TAB>round<TAB>sha<TAB>attempts<TAB>launched<TAB>postfails`——在途審查（attempts 0=首次 pi，1=pi 重試；postfails=判決貼文失敗次數）；**只在排程任務確認 Running 後才會寫入** |
+| `review-acks.tsv` | `pr<TAB>sha<TAB>attempts`——已啟動但 ack 未貼出的 head；成功即移除，3 次失敗 → `review:post-failed` |
 | `review-fails.tsv` | `pr<TAB>sha<TAB>count`——連續啟動失敗次數（連續 3 次 → `review:unreviewed` 並停） |
 | `watch.log` | watcher 每一步的時間戳紀錄 |
 | `review-prN-rR-brief.md` / `.log` / `.done` / `-verdict.md`（`.posted`） / `-comment.md` | 每輪審查的 brief、pi 轉錄、結束旗標、抽出來的判決（`.posted` = 留言已貼出）、貼出的留言 |
@@ -98,8 +105,8 @@ sh scripts/test-pr-review-watch.sh         # 離線測試：審/跳過決策 + v
 |---|---|
 | `review:lgtm` | 判決 LGTM（P0=0, P1=0） |
 | `review:changes-requested` | 判決 Changes Requested |
-| `review:unreviewed` | pi 重試後仍無判決（或連續 3 次啟動失敗）；擋住該 PR 直到人工摘除 |
-| `review:post-failed` | 判決連續 5 次貼不出去；判決檔留在 scratch 目錄，人工補貼後照 `review:unreviewed` 的救法收尾 |
+| `review:unreviewed` | pi 重試後仍無判決（或連續 3 次啟動失敗）；**per head**——只擋被記錄的那個 head，新 head 會自動摘 label 重審 |
+| `review:post-failed` | 判決或 ack 連續多次貼不出去（判決 5 次／ack 3 次）；判決檔留在 scratch 目錄，人工補貼後照 `review:unreviewed` 的救法收尾 |
 
 ## 離線測試
 
@@ -125,4 +132,4 @@ JSON 驗證「新 PR → 審；同 SHA 已審 → 跳過；push 新 head → 再
 | 任務卡住不結束 | pi 的排程任務有 30 分鐘上限；watcher 45 分鐘沒看到 `.done` 會自動當死掉的判決，走 pi 重試 → `review:unreviewed`。手動救：`Get-ScheduledTask edda-review-prN-rR`、`Stop-ScheduledTask`、刪掉該輪 `.done` 後重跑 `scripts/review-pr.sh N R --sha <sha>` |
 | 判決一直貼不出去（`review:post-failed`） | 查 `watch.log` 裡 `gh pr comment` 的失敗原因（網路／token）；判決檔在 `$EDDA_FLEET_SCRATCH/review-prN-rR-verdict.md`，手動貼上後把 `review-state.tsv` 補成該 head 並摘 label |
 | 想重審某個 head | 改 `review-state.tsv` 裡該 PR 的 `reviewed_sha`（或刪掉該行），下一輪就會重審 |
-| `review:unreviewed` 之後想手動審 | 手動跑 `scripts/review-pr.sh N R --sha <sha>`、把判決貼上 PR，然後把 `review-state.tsv` 補成該 head 並摘 label；watcher 就不會再起一輪 |
+| `review:unreviewed` 之後 push 了新 head | 不用做事：watcher 會自動摘掉過期 label、對新 head 起下一輪（`watch.log` 會記 `stale review:unreviewed label … removed`）。label 存在但 state 沒記錄 head 時視為仍在擋，需人工處理 |

--- a/docs/guides/pr-review-watcher.md
+++ b/docs/guides/pr-review-watcher.md
@@ -1,38 +1,47 @@
 # PR 審查 watcher：一開 PR 就有審查（#632）
 
 > 這支 watcher 回答一個問題：**PR 一開就有人審，不用控制者接力。**
-> 它每 60 秒掃一次 open PR，對沒審過的 head 自動起唯讀審查者（gpt-5.6-sol），
-> 把 SHA-pinned 判決貼上 PR、加 label。它**不合併**——合併仍照 `pr.merge-policy`
+> 它每 60 秒掃一次 open PR，對沒審過的 head 在 **3 分鐘內**起唯讀審查者（gpt-5.6-sol）
+> 並貼確認留言，判決跑完後接著貼上、加 label。它**不合併**——合併仍照 `pr.merge-policy`
 > 由操作者授權。
 
 ## 它做什麼
 
 1. `gh pr list --state open` 對每張**非 draft**、head SHA 沒審過（狀態檔比對）的 PR，
-   呼叫 `scripts/review-pr.sh`：
+   呼叫 `scripts/review-pr.sh <PR> <round> <prev> --sha <掃到的 SHA>`：
    - 從 PR body 的 `Issue: #N` 行抽出 issue，取其 `## doneWhen`；
    - 從 PR changed files 推導 allowed surface；
    - 產生「驗證清單」框架的審查 brief（決策 `fleet.review-brief-framing`：
      契約項目＋零裁量指令檢查＋severity 規則＋固定的 `<<<VERDICT ... VERDICT>>>` 輸出形狀）；
-   - 在 `$EDDA_FLEET_SCRATCH/wt-review-prN` 建立/更新 PR head 的 detached worktree；
+   - 在 `$EDDA_FLEET_SCRATCH/wt-review-prN` 建立/更新 **--sha 指定那個 SHA** 的 detached
+     worktree；若 PR head 已經移走（第二次讀 head 只用來拒審，不用來選審什麼）就拒絕、
+     下一輪掃描重來——審什麼由 watcher 掃描當下釘死，不會有兩次獨立讀 head 的 race；
    - Windows 上照決策 `fleet.lane-launch` 用 Task Scheduler 起隱藏排程任務
      `edda-review-prN-rR`（wrapper 設 `HOME`、UTF-8；父程序是 svchost，不受
      session 的 Job Object 牽連）；Linux 上退化成 `nohup`。
-2. 判決出現後（log 裡 `<<<VERDICT ... VERDICT>>>` 區塊），貼 PR 留言：表頭一行含
-   **reviewer model（從 pi session 檔觀察，不是從 brief 宣稱）**、cost（session 檔加總）、
-   釘死的 head SHA；然後加 label `review:lgtm` 或 `review:changes-requested`。
-3. head 被 push 之後（SHA 變了）自動再審一輪（round+1，delta brief，`prev-sha` 帶入）。
+2. **確認**：排程任務確認進入 `Running` 之後（起不來就不記 pending、下一輪重試），
+   3 分鐘內貼確認留言 `review: started on <full sha>`（SHA-pinned）。
+   判決留言等審查者跑完（典型 5–15 分鐘）才貼。
+3. 判決出現後（log 裡 `<<<VERDICT ... VERDICT>>>` 區塊），貼 PR 留言：表頭一行含
+   **model_observed（從 pi session 檔讀，不是從 brief 宣稱；session 檔不存在就明寫
+   `unknown`，絕不編造）**、cost（session 檔加總）、釘死的 head SHA；然後加 label
+   `review:lgtm` 或 `review:changes-requested`。**留言與 label 都成功才記 state**；
+   留言失敗就保留判決檔、下一輪重貼（重試 5 次仍失敗 → label `review:post-failed`）。
+4. head 被 push 之後（SHA 變了）自動再審一輪（round+1，delta brief，`prev-sha` 帶入）。
 
-## Provider 過載怎麼辦（決策 `fleet.review-provider-overload`：改運輸，不降模型）
+## Provider 過載怎麼辦（v1：無 codex 後備）
 
 判決死掉或空白（log 沒有 verdict 區塊、zero-byte log、或超過 45 分鐘沒有 `.done`）時：
 
 1. **pi 重試一次**（同一個 `--model`，session 續用）；
-2. 還是死的話改運輸：`edda dispatch --agent codex`（同一個訂閱的 gpt-5.6-sol，走另一條路）；
-3. 兩條都拿不到判決：label `review:unreviewed`，**該 head 停手**。
+2. 還是拿不到判決：label `review:unreviewed`，**該 head 停手**。
    未審查是誠實的狀態，便宜模型的判決不是。
+   （`edda dispatch --agent codex` 這條運輸在 v1 移除：Codex 設定為
+   `danger-full-access`，做不到唯讀審查。）
 
-`review:unreviewed` 只擋它記錄的那個 head；之後 push 新 head，watcher 會自動再審
-（先摘掉 label）。
+`review:unreviewed` 會**一直擋住那張 PR**，直到有人手動摘掉 label——摘掉後 watcher
+對新的掃描結果重新判斷（同 SHA 仍在 state 裡就還是跳過，push 了新 head 就會重審）。
+要手動救：手動跑一輪審查、貼上判決、把 `review-state.tsv` 補成該 head、摘 label。
 
 ## 啟動 / 停止
 
@@ -42,6 +51,10 @@ pwsh -NoProfile -ExecutionPolicy Bypass -File scripts\pr-review-launch.ps1
 
 # 停止並解除註冊
 pwsh -NoProfile -ExecutionPolicy Bypass -File scripts\pr-review-launch.ps1 -Stop
+
+# 乾跑證據：註冊成 --once --dry-run 模式、啟動、印 Get-ScheduledTaskInfo
+# （LastTaskResult 必須是 0）、然後自動解除註冊
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts\pr-review-launch.ps1 -DryRun
 ```
 
 參數（都可省略，預設值見腳本）：`-RepoRoot`（repo 主 checkout）、`-Scratch`
@@ -55,6 +68,7 @@ scripts/pr-review-watch.sh                 # 前景無限輪詢
 scripts/pr-review-watch.sh --once          # 只跑一輪
 scripts/pr-review-watch.sh --once --dry-run   # 只印會做什麼，不動 GitHub、不發審查
 scripts/review-pr.sh 625 --dry-run         # 只產 brief 並印出會註冊什麼
+sh scripts/test-pr-review-watch.sh         # 離線測試：審/跳過決策 + verdict→label（移植自 #639）
 ```
 
 ## 環境變數
@@ -72,9 +86,10 @@ scripts/review-pr.sh 625 --dry-run         # 只產 brief 並印出會註冊什�
 | 檔案 | 內容 |
 |---|---|
 | `review-state.tsv` | `pr<TAB>reviewed_sha<TAB>round`——每張 PR 已審到哪個 head |
-| `review-pending.tsv` | `pr<TAB>round<TAB>sha<TAB>attempts<TAB>launched`——審查在途帳本（attempts 0=首次 pi，1=pi 重試，2=codex 運輸） |
+| `review-pending.tsv` | `pr<TAB>round<TAB>sha<TAB>attempts<TAB>launched<TAB>postfails`——在途審查（attempts 0=首次 pi，1=pi 重試；postfails=判決貼文失敗次數）；**只在排程任務確認 Running 後才會寫入** |
+| `review-fails.tsv` | `pr<TAB>sha<TAB>count`——連續啟動失敗次數（連續 3 次 → `review:unreviewed` 並停） |
 | `watch.log` | watcher 每一步的時間戳紀錄 |
-| `review-prN-rR-brief.md` / `.log` / `.done` / `-verdict.md` / `-comment.md` | 每輪審查的 brief、pi 轉錄、結束旗標、抽出來的判決、貼出的留言 |
+| `review-prN-rR-brief.md` / `.log` / `.done` / `-verdict.md`（`.posted`） / `-comment.md` | 每輪審查的 brief、pi 轉錄、結束旗標、抽出來的判決（`.posted` = 留言已貼出）、貼出的留言 |
 | `wt-review-prN/` | 該 PR 的 detached worktree |
 
 ## Labels（watcher 啟動時自動建立，缺了才建）
@@ -83,25 +98,31 @@ scripts/review-pr.sh 625 --dry-run         # 只產 brief 並印出會註冊什�
 |---|---|
 | `review:lgtm` | 判決 LGTM（P0=0, P1=0） |
 | `review:changes-requested` | 判決 Changes Requested |
-| `review:unreviewed` | pi＋codex 兩條運輸都拿不到判決；該 head 停手 |
+| `review:unreviewed` | pi 重試後仍無判決（或連續 3 次啟動失敗）；擋住該 PR 直到人工摘除 |
+| `review:post-failed` | 判決連續 5 次貼不出去；判決檔留在 scratch 目錄，人工補貼後照 `review:unreviewed` 的救法收尾 |
 
-Label 只在「留言當下 PR head 仍等於被審的 SHA」時才加——head 已經跑走的話，
-判決照貼（它釘死在被審的 SHA），但 label 留給下一輪。
+## 離線測試
+
+`sh scripts/test-pr-review-watch.sh`（移植自 PR #639）：用 fixture 的 `gh pr list`
+JSON 驗證「新 PR → 審；同 SHA 已審 → 跳過；push 新 head → 再審；draft → 跳過；
+`review:unreviewed` → 跳過」的決策，以及判決文字 → label 的映射（後者贏）。
 
 ## 它不做什麼
 
 - **不合併**。合併永遠照 `pr.merge-policy`（final current-head LGTM、P0=0/P1=0、
   7 格 CI 綠、SHA 窗檢查）由操作者授權後執行。
 - 不 push、不開 issue、不回留言、不動 `.github/workflows/**`。
+- 不用 codex 當審查運輸（做不到唯讀）；不編造 model_observed／cost。
 - 不審 draft PR；fork PR 的 head 拿不到 worktree 時會在 watch.log 留下失敗紀錄。
 
 ## Troubleshooting
 
 | 症狀 | 查什麼 |
 |---|---|
-| 懷疑 watcher 沒在跑 | `Get-ScheduledTask edda-pr-review-watcher`（State 應為 Running）；`Get-ScheduledTaskInfo edda-pr-review-watcher`（LastTaskResult、LastRunTime） |
-| PR 開了 5 分鐘沒審 | `tail $EDDA_FLEET_SCRATCH/watch.log`——看是沒掃到（draft？label `review:unreviewed`？head 等於 reviewed_sha？）還是 review-pr.sh 失敗（其輸出也接進同一個 log） |
-| 想看審查者實際在幹嘛 | `$EDDA_FLEET_SCRATCH/review-prN-rR.log`（pi 轉錄全文）；pi session 檔在 `~/.pi/agent/sessions/*/…_review-prN.jsonl`（model_observed 與 cost 的來源） |
-| 任務卡住不結束 | pi 的排程任務有 30 分鐘上限；watcher 45 分鐘沒看到 `.done` 會自動當死掉的判決，走過載改道鏈。手動救：`Get-ScheduledTask edda-review-prN-rR`、`Stop-ScheduledTask`、刪掉該輪 `.done` 後重跑 `scripts/review-pr.sh N R` |
+| 懷疑 watcher 沒在跑 | `Get-ScheduledTask edda-pr-review-watcher`（State 應為 Running）；`Get-ScheduledTaskInfo edda-pr-review-watcher`（LastRunTime、LastTaskResult）；註冊路徑的乾跑證據用 `-DryRun` |
+| PR 開了 5 分鐘沒有 `review: started on …` 留言 | `tail $EDDA_FLEET_SCRATCH/watch.log`——看是沒掃到（draft？label `review:unreviewed`？head 等於 reviewed_sha？）還是 review-pr.sh 啟動失敗（其輸出也接進同一個 log；連續 3 次啟動失敗會標 `review:unreviewed`） |
+| 想看審查者實際在幹嘛 | `$EDDA_FLEET_SCRATCH/review-prN-rR.log`（pi 轉錄全文）；pi session 檔在 `~/.pi/agent/sessions/*/…_review-prN.jsonl`（model_observed 與 cost 的來源；不存在時留言會明寫 unknown） |
+| 任務卡住不結束 | pi 的排程任務有 30 分鐘上限；watcher 45 分鐘沒看到 `.done` 會自動當死掉的判決，走 pi 重試 → `review:unreviewed`。手動救：`Get-ScheduledTask edda-review-prN-rR`、`Stop-ScheduledTask`、刪掉該輪 `.done` 後重跑 `scripts/review-pr.sh N R --sha <sha>` |
+| 判決一直貼不出去（`review:post-failed`） | 查 `watch.log` 裡 `gh pr comment` 的失敗原因（網路／token）；判決檔在 `$EDDA_FLEET_SCRATCH/review-prN-rR-verdict.md`，手動貼上後把 `review-state.tsv` 補成該 head 並摘 label |
 | 想重審某個 head | 改 `review-state.tsv` 裡該 PR 的 `reviewed_sha`（或刪掉該行），下一輪就會重審 |
-| `review:unreviewed` 之後想手動審 | 判決手動貼上 PR 後，把 `review-state.tsv` 補成該 head 並摘 label，watcher 就不會再起一輪 |
+| `review:unreviewed` 之後想手動審 | 手動跑 `scripts/review-pr.sh N R --sha <sha>`、把判決貼上 PR，然後把 `review-state.tsv` 補成該 head 並摘 label；watcher 就不會再起一輪 |

--- a/docs/guides/pr-review-watcher.md
+++ b/docs/guides/pr-review-watcher.md
@@ -1,0 +1,107 @@
+# PR 審查 watcher：一開 PR 就有審查（#632）
+
+> 這支 watcher 回答一個問題：**PR 一開就有人審，不用控制者接力。**
+> 它每 60 秒掃一次 open PR，對沒審過的 head 自動起唯讀審查者（gpt-5.6-sol），
+> 把 SHA-pinned 判決貼上 PR、加 label。它**不合併**——合併仍照 `pr.merge-policy`
+> 由操作者授權。
+
+## 它做什麼
+
+1. `gh pr list --state open` 對每張**非 draft**、head SHA 沒審過（狀態檔比對）的 PR，
+   呼叫 `scripts/review-pr.sh`：
+   - 從 PR body 的 `Issue: #N` 行抽出 issue，取其 `## doneWhen`；
+   - 從 PR changed files 推導 allowed surface；
+   - 產生「驗證清單」框架的審查 brief（決策 `fleet.review-brief-framing`：
+     契約項目＋零裁量指令檢查＋severity 規則＋固定的 `<<<VERDICT ... VERDICT>>>` 輸出形狀）；
+   - 在 `$EDDA_FLEET_SCRATCH/wt-review-prN` 建立/更新 PR head 的 detached worktree；
+   - Windows 上照決策 `fleet.lane-launch` 用 Task Scheduler 起隱藏排程任務
+     `edda-review-prN-rR`（wrapper 設 `HOME`、UTF-8；父程序是 svchost，不受
+     session 的 Job Object 牽連）；Linux 上退化成 `nohup`。
+2. 判決出現後（log 裡 `<<<VERDICT ... VERDICT>>>` 區塊），貼 PR 留言：表頭一行含
+   **reviewer model（從 pi session 檔觀察，不是從 brief 宣稱）**、cost（session 檔加總）、
+   釘死的 head SHA；然後加 label `review:lgtm` 或 `review:changes-requested`。
+3. head 被 push 之後（SHA 變了）自動再審一輪（round+1，delta brief，`prev-sha` 帶入）。
+
+## Provider 過載怎麼辦（決策 `fleet.review-provider-overload`：改運輸，不降模型）
+
+判決死掉或空白（log 沒有 verdict 區塊、zero-byte log、或超過 45 分鐘沒有 `.done`）時：
+
+1. **pi 重試一次**（同一個 `--model`，session 續用）；
+2. 還是死的話改運輸：`edda dispatch --agent codex`（同一個訂閱的 gpt-5.6-sol，走另一條路）；
+3. 兩條都拿不到判決：label `review:unreviewed`，**該 head 停手**。
+   未審查是誠實的狀態，便宜模型的判決不是。
+
+`review:unreviewed` 只擋它記錄的那個 head；之後 push 新 head，watcher 會自動再審
+（先摘掉 label）。
+
+## 啟動 / 停止
+
+```powershell
+# 註冊成隱藏排程任務 edda-pr-review-watcher，登入時自動重啟，並立刻啟動
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts\pr-review-launch.ps1
+
+# 停止並解除註冊
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts\pr-review-launch.ps1 -Stop
+```
+
+參數（都可省略，預設值見腳本）：`-RepoRoot`（repo 主 checkout）、`-Scratch`
+（預設 `$env:USERPROFILE\.edda\fleet`）、`-BashPath`（Git Bash 的 bash.exe）、
+`-Repo`（預設 `fagemx/edda`）、`-Model`（預設 `openai-codex/gpt-5.6-sol`）。
+
+不註冊、手動跑（或試跑）：
+
+```bash
+scripts/pr-review-watch.sh                 # 前景無限輪詢
+scripts/pr-review-watch.sh --once          # 只跑一輪
+scripts/pr-review-watch.sh --once --dry-run   # 只印會做什麼，不動 GitHub、不發審查
+scripts/review-pr.sh 625 --dry-run         # 只產 brief 並印出會註冊什麼
+```
+
+## 環境變數
+
+| 變數 | 預設 | 意義 |
+|---|---|---|
+| `EDDA_REPO` | `fagemx/edda` | owner/repo |
+| `EDDA_FLEET_ROOT` | 自 git 推導（主 checkout） | 建立 detached worktree 用的主 repo |
+| `EDDA_FLEET_SCRATCH` | `$HOME/.edda/fleet` | 狀態檔、brief、log、worktree 的目錄（**不進 git**） |
+| `EDDA_REVIEW_MODEL` | `openai-codex/gpt-5.6-sol` | 審查模型（決策 `fleet.agent-model-split`：審查一律訂閱的 gpt-5.6-sol） |
+| `EDDA_REVIEW_POLL_SECONDS` | `60` | 輪詢間隔 |
+
+## 狀態檔（`$EDDA_FLEET_SCRATCH` 下，不進 git）
+
+| 檔案 | 內容 |
+|---|---|
+| `review-state.tsv` | `pr<TAB>reviewed_sha<TAB>round`——每張 PR 已審到哪個 head |
+| `review-pending.tsv` | `pr<TAB>round<TAB>sha<TAB>attempts<TAB>launched`——審查在途帳本（attempts 0=首次 pi，1=pi 重試，2=codex 運輸） |
+| `watch.log` | watcher 每一步的時間戳紀錄 |
+| `review-prN-rR-brief.md` / `.log` / `.done` / `-verdict.md` / `-comment.md` | 每輪審查的 brief、pi 轉錄、結束旗標、抽出來的判決、貼出的留言 |
+| `wt-review-prN/` | 該 PR 的 detached worktree |
+
+## Labels（watcher 啟動時自動建立，缺了才建）
+
+| Label | 意義 |
+|---|---|
+| `review:lgtm` | 判決 LGTM（P0=0, P1=0） |
+| `review:changes-requested` | 判決 Changes Requested |
+| `review:unreviewed` | pi＋codex 兩條運輸都拿不到判決；該 head 停手 |
+
+Label 只在「留言當下 PR head 仍等於被審的 SHA」時才加——head 已經跑走的話，
+判決照貼（它釘死在被審的 SHA），但 label 留給下一輪。
+
+## 它不做什麼
+
+- **不合併**。合併永遠照 `pr.merge-policy`（final current-head LGTM、P0=0/P1=0、
+  7 格 CI 綠、SHA 窗檢查）由操作者授權後執行。
+- 不 push、不開 issue、不回留言、不動 `.github/workflows/**`。
+- 不審 draft PR；fork PR 的 head 拿不到 worktree 時會在 watch.log 留下失敗紀錄。
+
+## Troubleshooting
+
+| 症狀 | 查什麼 |
+|---|---|
+| 懷疑 watcher 沒在跑 | `Get-ScheduledTask edda-pr-review-watcher`（State 應為 Running）；`Get-ScheduledTaskInfo edda-pr-review-watcher`（LastTaskResult、LastRunTime） |
+| PR 開了 5 分鐘沒審 | `tail $EDDA_FLEET_SCRATCH/watch.log`——看是沒掃到（draft？label `review:unreviewed`？head 等於 reviewed_sha？）還是 review-pr.sh 失敗（其輸出也接進同一個 log） |
+| 想看審查者實際在幹嘛 | `$EDDA_FLEET_SCRATCH/review-prN-rR.log`（pi 轉錄全文）；pi session 檔在 `~/.pi/agent/sessions/*/…_review-prN.jsonl`（model_observed 與 cost 的來源） |
+| 任務卡住不結束 | pi 的排程任務有 30 分鐘上限；watcher 45 分鐘沒看到 `.done` 會自動當死掉的判決，走過載改道鏈。手動救：`Get-ScheduledTask edda-review-prN-rR`、`Stop-ScheduledTask`、刪掉該輪 `.done` 後重跑 `scripts/review-pr.sh N R` |
+| 想重審某個 head | 改 `review-state.tsv` 裡該 PR 的 `reviewed_sha`（或刪掉該行），下一輪就會重審 |
+| `review:unreviewed` 之後想手動審 | 判決手動貼上 PR 後，把 `review-state.tsv` 補成該 head 並摘 label，watcher 就不會再起一輪 |

--- a/scripts/pr-review-launch.ps1
+++ b/scripts/pr-review-launch.ps1
@@ -6,6 +6,8 @@
 # usage:
 #   pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/pr-review-launch.ps1            # register + start
 #   pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/pr-review-launch.ps1 -Stop      # unregister
+#   pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/pr-review-launch.ps1 -DryRun    # register + start in
+#       # --once --dry-run mode, print Get-ScheduledTaskInfo (LastTaskResult must be 0), unregister
 #
 # The watcher runs scripts/pr-review-watch.sh (Git Bash) in an endless poll
 # loop; it restarts at logon and on failure. Logs: $HOME\.edda\fleet\watch.log
@@ -16,7 +18,8 @@ param(
   [string]$Repo = "fagemx/edda",
   [string]$Model = "openai-codex/gpt-5.6-sol",
   [string]$TaskName = "edda-pr-review-watcher",
-  [switch]$Stop
+  [switch]$Stop,
+  [switch]$DryRun
 )
 
 $ErrorActionPreference = "Stop"
@@ -42,12 +45,14 @@ $drive = $RepoRoot.Substring(0, 1).ToLower()
 $rest = $RepoRoot.Substring(2) -replace '\\', '/'
 $RepoRootPosix = "/$drive$rest"
 $WatchSh = "$RepoRootPosix/scripts/pr-review-watch.sh"
+if ($DryRun) { $WatchArgs = "--once --dry-run" } else { $WatchArgs = "" }
 
 New-Item -ItemType Directory -Force -Path $Scratch | Out-Null
 
 # Wrapper the scheduled task actually runs: outside any job object, so it
 # survives this session; HOME and encoding set explicitly (fleet.lane-launch).
-$Wrapper = Join-Path $Scratch "pr-review-watch-wrapper.ps1"
+$wrapperName = if ($DryRun) { "pr-review-watch-wrapper-dryrun.ps1" } else { "pr-review-watch-wrapper.ps1" }
+$Wrapper = Join-Path $Scratch $wrapperName
 @"
 [Console]::InputEncoding = [System.Text.UTF8Encoding]::new(`$false)
 [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(`$false)
@@ -57,13 +62,14 @@ $Wrapper = Join-Path $Scratch "pr-review-watch-wrapper.ps1"
 `$env:EDDA_REPO = '$Repo'
 `$env:EDDA_REVIEW_MODEL = '$Model'
 Set-Location '$RepoRoot'
-& '$BashPath' -l -c 'exec $WatchSh'
+& '$BashPath' -l -c 'exec $WatchSh $WatchArgs'
+exit `$LASTEXITCODE
 "@ | Out-File -FilePath $Wrapper -Encoding utf8
 
 $action = New-ScheduledTaskAction -Execute "pwsh.exe" `
   -Argument "-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$Wrapper`"" `
   -WorkingDirectory $RepoRoot
-$trigger = New-ScheduledTaskTrigger -AtLogOn
+$trigger = New-ScheduledTaskTrigger -AtLogOn -User "$env:USERDOMAIN\$env:USERNAME"  # any-user trigger needs admin
 $settings = New-ScheduledTaskSettingsSet `
   -ExecutionTimeLimit ([TimeSpan]::Zero) `
   -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 1) `
@@ -73,6 +79,22 @@ $settings = New-ScheduledTaskSettingsSet `
 Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
 Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger -Settings $settings -RunLevel Limited | Out-Null
 Start-ScheduledTask -TaskName $TaskName
+
+if ($DryRun) {
+  # Wait for the one-shot dry-run watcher cycle to finish, then report and clean up.
+  $deadline = (Get-Date).AddSeconds(180)
+  do {
+    Start-Sleep -Seconds 3
+    $st = (Get-ScheduledTask -TaskName $TaskName).State
+  } while ($st -eq "Running" -and (Get-Date) -lt $deadline)
+  $info = Get-ScheduledTaskInfo -TaskName $TaskName
+  "dry-run task=$TaskName state=$st"
+  "LastRunTime=$($info.LastRunTime) LastTaskResult=$($info.LastTaskResult)"
+  Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+  "task=$TaskName unregistered (dry-run)"
+  exit 0
+}
+
 Start-Sleep -Seconds 5
 $st = (Get-ScheduledTask -TaskName $TaskName).State
 "task=$TaskName state=$st wrapper=$Wrapper log=$Scratch\watch.log"

--- a/scripts/pr-review-launch.ps1
+++ b/scripts/pr-review-launch.ps1
@@ -1,0 +1,78 @@
+# pr-review-launch.ps1 — register/start (or stop) the PR review watcher as a
+# hidden Windows scheduled task. Per fleet.lane-launch the watcher is launched
+# by Task Scheduler (parent svchost), not by a shell inside a job object, and
+# the task wrapper sets HOME and UTF-8 explicitly (both are empty/CP950 there).
+#
+# usage:
+#   pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/pr-review-launch.ps1            # register + start
+#   pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/pr-review-launch.ps1 -Stop      # unregister
+#
+# The watcher runs scripts/pr-review-watch.sh (Git Bash) in an endless poll
+# loop; it restarts at logon and on failure. Logs: $HOME\.edda\fleet\watch.log
+param(
+  [string]$RepoRoot = "",
+  [string]$Scratch = "$env:USERPROFILE\.edda\fleet",
+  [string]$BashPath = "",
+  [string]$Repo = "fagemx/edda",
+  [string]$Model = "openai-codex/gpt-5.6-sol",
+  [string]$TaskName = "edda-pr-review-watcher",
+  [switch]$Stop
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($Stop) {
+  Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
+  "task=$TaskName unregistered"
+  exit 0
+}
+
+# Defaults that depend on context
+if (-not $RepoRoot) {
+  $RepoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)  # scripts/.. = repo root
+}
+if (-not $BashPath) {
+  $cmd = Get-Command bash.exe -ErrorAction SilentlyContinue
+  if ($cmd) { $BashPath = $cmd.Source }
+  elseif (Test-Path "C:\Program Files\Git\bin\bash.exe") { $BashPath = "C:\Program Files\Git\bin\bash.exe" }
+  else { throw "bash.exe not found; pass -BashPath" }
+}
+# C:\foo\bar -> /c/foo/bar for Git Bash
+$drive = $RepoRoot.Substring(0, 1).ToLower()
+$rest = $RepoRoot.Substring(2) -replace '\\', '/'
+$RepoRootPosix = "/$drive$rest"
+$WatchSh = "$RepoRootPosix/scripts/pr-review-watch.sh"
+
+New-Item -ItemType Directory -Force -Path $Scratch | Out-Null
+
+# Wrapper the scheduled task actually runs: outside any job object, so it
+# survives this session; HOME and encoding set explicitly (fleet.lane-launch).
+$Wrapper = Join-Path $Scratch "pr-review-watch-wrapper.ps1"
+@"
+[Console]::InputEncoding = [System.Text.UTF8Encoding]::new(`$false)
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(`$false)
+`$OutputEncoding = [System.Text.UTF8Encoding]::new(`$false)
+`$env:HOME = `$env:USERPROFILE
+`$env:EDDA_FLEET_SCRATCH = '$Scratch'
+`$env:EDDA_REPO = '$Repo'
+`$env:EDDA_REVIEW_MODEL = '$Model'
+Set-Location '$RepoRoot'
+& '$BashPath' -l -c 'exec $WatchSh'
+"@ | Out-File -FilePath $Wrapper -Encoding utf8
+
+$action = New-ScheduledTaskAction -Execute "pwsh.exe" `
+  -Argument "-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$Wrapper`"" `
+  -WorkingDirectory $RepoRoot
+$trigger = New-ScheduledTaskTrigger -AtLogOn
+$settings = New-ScheduledTaskSettingsSet `
+  -ExecutionTimeLimit ([TimeSpan]::Zero) `
+  -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 1) `
+  -MultipleInstances IgnoreNew `
+  -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable
+
+Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
+Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger -Settings $settings -RunLevel Limited | Out-Null
+Start-ScheduledTask -TaskName $TaskName
+Start-Sleep -Seconds 5
+$st = (Get-ScheduledTask -TaskName $TaskName).State
+"task=$TaskName state=$st wrapper=$Wrapper log=$Scratch\watch.log"

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -1,0 +1,305 @@
+#!/bin/sh
+# pr-review-watch.sh — local watcher: for every open non-draft PR whose head SHA
+# has not been reviewed yet, launch the read-only reviewer (scripts/review-pr.sh),
+# post the SHA-pinned verdict as a PR comment, and set review:* labels.
+#
+# usage: pr-review-watch.sh [--once] [--dry-run]
+#
+# Environment:
+#   EDDA_REPO                  owner/repo            (default fagemx/edda)
+#   EDDA_FLEET_ROOT            main checkout path    (default: derived from git)
+#   EDDA_FLEET_SCRATCH         state/log dir         (default $HOME/.edda/fleet)
+#   EDDA_REVIEW_MODEL          review model          (default openai-codex/gpt-5.6-sol)
+#   EDDA_REVIEW_POLL_SECONDS   poll interval         (default 60)
+#
+# State (under $EDDA_FLEET_SCRATCH, not in git):
+#   review-state.tsv     pr<TAB>reviewed_sha<TAB>round
+#   review-pending.tsv   pr<TAB>round<TAB>sha<TAB>attempts<TAB>launched_epoch
+#   watch.log            everything the watcher did
+#
+# Provider-overload rule (fleet.review-provider-overload — change transport,
+# never the model): on a dead/empty verdict, retry pi once, then
+# `edda dispatch --agent codex`; if that also yields no verdict, label the PR
+# `review:unreviewed` and stop for that head. An unreviewed PR is an honest
+# state; a cheap-model verdict is not.
+#
+# The watcher NEVER merges. Merge stays behind operator authorization
+# (pr.merge-policy).
+set -u
+
+REPO=${EDDA_REPO:-fagemx/edda}
+MODEL=${EDDA_REVIEW_MODEL:-openai-codex/gpt-5.6-sol}
+POLL=${EDDA_REVIEW_POLL_SECONDS:-60}
+SCRATCH=${EDDA_FLEET_SCRATCH:-$HOME/.edda/fleet}
+STALE=${EDDA_REVIEW_STALE_SECONDS:-2700}   # 45 min: pi task limit is 30 min
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REVIEW_PR="$SCRIPT_DIR/review-pr.sh"
+
+ONCE=0
+DRY=0
+TAB=$(printf '\t')   # literal tab; "\t" inside quotes is backslash-t in POSIX sh
+for a in "$@"; do
+  case "$a" in
+    --once) ONCE=1 ;;
+    --dry-run) DRY=1 ;;
+    -h|--help) echo "usage: pr-review-watch.sh [--once] [--dry-run]"; exit 0 ;;
+    *) echo "pr-review-watch.sh: unexpected argument '$a'" >&2; exit 1 ;;
+  esac
+done
+
+mkdir -p "$SCRATCH"
+STATE="$SCRATCH/review-state.tsv"
+PENDING="$SCRATCH/review-pending.tsv"
+WATCHLOG="$SCRATCH/watch.log"
+touch "$STATE" "$PENDING"
+
+log() { echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') $*" >> "$WATCHLOG"; }
+
+ensure_labels() {
+  gh label create "review:lgtm"             --repo "$REPO" --color 0e8a16 --description "Automatic review verdict: LGTM (P0=0, P1=0)"            --force >/dev/null 2>&1 || true
+  gh label create "review:changes-requested" --repo "$REPO" --color d93f0b --description "Automatic review verdict: Changes Requested"            --force >/dev/null 2>&1 || true
+  gh label create "review:unreviewed"        --repo "$REPO" --color d4c5f9 --description "Review provider exhausted; verdict pending human/retry" --force >/dev/null 2>&1 || true
+}
+
+state_field() { # $1=pr  $2=field index (2=sha,3=round)
+  awk -F'\t' -v pr="$1" -v f="$2" '$1==pr {print $f; found=1} END{if(!found) print ""}' "$STATE"
+}
+
+pending_has() { awk -F'\t' -v pr="$1" '$1==pr{found=1} END{exit !found}' "$PENDING" 2>/dev/null; }
+
+pending_update() { # $1=pr $2=round $3=sha $4=attempts $5=launched
+  awk -F'\t' -v pr="$1" '$1!=pr' "$PENDING" > "$PENDING.tmp"
+  printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5" >> "$PENDING.tmp"
+  mv "$PENDING.tmp" "$PENDING"
+}
+
+pending_drop() {
+  awk -F'\t' -v pr="$1" '$1!=pr' "$PENDING" > "$PENDING.tmp"
+  mv "$PENDING.tmp" "$PENDING"
+}
+
+state_set() { # $1=pr $2=sha $3=round
+  awk -F'\t' -v pr="$1" '$1!=pr' "$STATE" > "$STATE.tmp"
+  printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$STATE.tmp"
+  mv "$STATE.tmp" "$STATE"
+}
+
+# Extract the LAST verdict block between the fixed markers from a transcript.
+extract_verdict() { # $1=log file, $2=out file
+  tr -d '\r' < "$1" 2>/dev/null | awk '
+    /<<<VERDICT/ {f=1; buf=""; next}
+    /VERDICT>>>/ {if (f) {last=buf; f=0} next}
+    f {buf = buf $0 "\n"}
+    END {printf "%s", last}' > "$2"
+  [ -s "$2" ]
+}
+
+verdict_ok() { # $1=verdict file
+  grep -qE '^(LGTM|Changes Requested)' "$1" 2>/dev/null
+}
+
+# Model observed + cost, read from the pi session files (never from what the
+# brief asked for).
+session_model_cost() { # $1=session id -> sets OBSERVED, COST
+  files=$(find "$HOME/.pi/agent/sessions" -name "*_$1.jsonl" 2>/dev/null)
+  if [ -n "$files" ]; then
+    OBSERVED=$(cat $files 2>/dev/null | grep -o '"modelId":"[^"]*"' | tail -1 | sed 's/.*:"//;s/"$//')
+    COST=$(cat $files 2>/dev/null | grep -o '"cost":{[^}]*}' | sed 's/.*"total"://' \
+      | awk '{s+=$1} END{if (s=="") s=0; printf "%.2f", s}')
+  else
+    OBSERVED=""
+    COST=""
+  fi
+  [ -n "${OBSERVED:-}" ] || OBSERVED="unknown"
+  [ -n "${COST:-}" ] || COST="?"
+}
+
+pr_is_open() { # $1=pr
+  [ "$(gh pr view "$1" --repo "$REPO" --json state --jq .state 2>/dev/null)" = "OPEN" ]
+}
+
+pr_labels() { # $1=pr
+  gh pr view "$1" --repo "$REPO" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null
+}
+
+pr_head() { # $1=pr
+  gh pr view "$1" --repo "$REPO" --json headRefOid --jq .headRefOid 2>/dev/null
+}
+
+# Post a verdict (or the honest unreviewed outcome) and update state.
+post_verdict() { # $1=pr $2=round $3=sha $4=verdict file $5=transport note
+  COMMENT="$SCRATCH/review-pr$1-r$2-comment.md"
+  {
+    echo "> **Round $2 review** — automatic watcher (\`scripts/pr-review-watch.sh\`): $5, read-only, detached worktree at \`$3\`. Model observed in the pi session file: \`$OBSERVED\`. Cost: \$$COST. Reviewed head SHA: \`$3\`."
+    echo
+    cat "$4"
+  } > "$COMMENT"
+  if [ "$DRY" = "1" ]; then
+    echo "dry-run: would post $COMMENT to PR #$1 and set a review:* label"
+    return 0
+  fi
+  gh pr comment "$1" --repo "$REPO" --body-file "$COMMENT" >/dev/null &&
+    log "pr$1 r$2 posted verdict comment ($4)"
+  if pr_is_open "$1" && [ "$(pr_head "$1")" = "$3" ]; then
+    if grep -q '^LGTM' "$4"; then
+      gh pr edit "$1" --repo "$REPO" --add-label "review:lgtm" >/dev/null 2>&1 &&
+        log "pr$1 labeled review:lgtm"
+      gh pr edit "$1" --repo "$REPO" --remove-label "review:changes-requested" >/dev/null 2>&1 || true
+      gh pr edit "$1" --repo "$REPO" --remove-label "review:unreviewed" >/dev/null 2>&1 || true
+    else
+      gh pr edit "$1" --repo "$REPO" --add-label "review:changes-requested" >/dev/null 2>&1 &&
+        log "pr$1 labeled review:changes-requested"
+      gh pr edit "$1" --repo "$REPO" --remove-label "review:lgtm" >/dev/null 2>&1 || true
+      gh pr edit "$1" --repo "$REPO" --remove-label "review:unreviewed" >/dev/null 2>&1 || true
+    fi
+  else
+    log "pr$1 head moved or PR closed; verdict stays pinned to $3, label skipped"
+  fi
+  state_set "$1" "$3" "$2"
+}
+
+mark_unreviewed() { # $1=pr $2=sha $3=round $4=reason
+  log "pr$1 review exhausted: $4 — labeling review:unreviewed and stopping for head $2"
+  if [ "$DRY" = "1" ]; then
+    echo "dry-run: would label PR #$1 review:unreviewed ($4)"
+    return 0
+  fi
+  gh pr edit "$1" --repo "$REPO" --add-label "review:unreviewed" >/dev/null 2>&1 || true
+  state_set "$1" "$2" "$3"
+}
+
+# ---- in-flight handling ------------------------------------------------------
+settle_pending() {
+  [ -s "$PENDING" ] || return 0
+  now=$(date +%s)
+  while IFS="$TAB" read -r pr round sha attempts launched < "$PENDING"; do
+    [ -n "${pr:-}" ] || continue
+
+    if ! pr_is_open "$pr"; then
+      log "pr$pr closed/merged while review in flight; dropping pending entry"
+      pending_drop "$pr"
+      continue
+    fi
+
+    DONE="$SCRATCH/review-pr$pr-r$round.done"
+    LOG="$SCRATCH/review-pr$pr-r$round.log"
+    VERDICT="$SCRATCH/review-pr$pr-r$round-verdict.md"
+    CODEXLOG="$SCRATCH/review-pr$pr-r$round-codex.log"
+
+    is_done=0
+    is_stale=0
+    [ -f "$DONE" ] && is_done=1
+    if [ "$is_done" = "0" ] && [ $((now - launched)) -gt "$STALE" ]; then
+      is_stale=1
+      log "pr$pr r$round review stale (${STALE}s, no .done); treating as dead"
+    fi
+
+    if [ "$is_done" = "1" ] || [ "$is_stale" = "1" ]; then
+      if extract_verdict "$LOG" "$VERDICT" && verdict_ok "$VERDICT"; then
+        session_model_cost "review-pr$pr"
+        post_verdict "$pr" "$round" "$sha" "$VERDICT" \
+          "pi -p --model $MODEL --thinking high --exclude-tools edit,write --session-id review-pr$pr"
+        pending_drop "$pr"
+      else
+        case "$attempts" in
+          0)
+            log "pr$pr r$round dead/empty verdict (attempt 0) — retrying once with pi (same model, fleet.review-provider-overload)"
+            if [ "$DRY" = "1" ]; then
+              echo "dry-run: would retry PR #$pr r$round with pi"
+              pending_drop "$pr"
+            else
+              "$REVIEW_PR" "$pr" "$round" "$sha" >> "$WATCHLOG" 2>&1 &&
+                log "pr$pr r$round pi retry launched"
+              pending_update "$pr" "$round" "$sha" 1 "$(date +%s)"
+            fi
+            ;;
+          1)
+            log "pr$pr r$round pi retry also dead (attempt 1) — switching transport: edda dispatch --agent codex (same subscribed model)"
+            if [ "$DRY" = "1" ]; then
+              echo "dry-run: would run edda dispatch --agent codex for PR #$pr r$round"
+              pending_drop "$pr"
+            else
+              WT="$SCRATCH/wt-review-pr$pr"
+              BRIEF="$SCRATCH/review-pr$pr-r$round-brief.md"
+              rm -f "$CODEXLOG"
+              if edda dispatch --agent codex --prompt-file "$BRIEF" --cwd "$WT" > "$CODEXLOG" 2>&1; then
+                if extract_verdict "$CODEXLOG" "$VERDICT" && verdict_ok "$VERDICT"; then
+                  OBSERVED="via edda dispatch --agent codex (pi session unavailable)"
+                  COST="?"
+                  post_verdict "$pr" "$round" "$sha" "$VERDICT" \
+                    "edda dispatch --agent codex (transport fallback after pi overload)"
+                  pending_drop "$pr"
+                  continue
+                fi
+              fi
+              mark_unreviewed "$pr" "$sha" "$round" "pi retry and codex dispatch both yielded no verdict"
+              pending_drop "$pr"
+            fi
+            ;;
+          *)
+            mark_unreviewed "$pr" "$sha" "$round" "no verdict after pi retry and codex dispatch"
+            pending_drop "$pr"
+            ;;
+        esac
+      fi
+    fi
+  done
+}
+
+# ---- open-PR scan ------------------------------------------------------------
+scan_open_prs() {
+  rows=$(gh pr list --state open --repo "$REPO" --json number,headRefOid,isDraft,labels \
+    --jq '.[] | select(.isDraft|not) | [.number, .headRefOid, ([.labels[].name] | join(","))] | @tsv' 2>/dev/null) || {
+    log "gh pr list failed; skipping this cycle"
+    return 0
+  }
+  printf '%s\n' "$rows" | while IFS="$TAB" read -r pr sha labels; do
+    [ -n "${pr:-}" ] || continue
+    pending_has "$pr" && continue
+
+    reviewed=$(state_field "$pr" 2)
+    round=$(state_field "$pr" 3)
+    [ -n "$round" ] || round=0
+
+    [ "$sha" = "$reviewed" ] && continue
+    case ",$labels," in
+      *,review:unreviewed,*)
+        # unreviewed blocks only the head it was recorded for (per-head stop)
+        if [ "$sha" = "$reviewed" ]; then continue; fi
+        if [ "$DRY" != "1" ]; then
+          gh pr edit "$pr" --repo "$REPO" --remove-label "review:unreviewed" >/dev/null 2>&1 || true
+        fi
+        ;;
+    esac
+
+    newround=$((round + 1))
+    if [ "$DRY" = "1" ]; then
+      prev=$(state_field "$pr" 2)
+      [ -n "$prev" ] || prev=""
+      echo "dry-run: would launch review for PR #$pr round $newround (head $sha${prev:+, prev $prev}): $REVIEW_PR $pr $newround $prev"
+      log "dry-run: would launch review for pr$pr r$newround (head $sha)"
+    else
+      log "pr$pr head $sha differs from reviewed '${reviewed:-none}' — launching review r$newround"
+      "$REVIEW_PR" "$pr" "$newround" "$reviewed" >> "$WATCHLOG" 2>&1 &&
+        log "pr$pr r$newround launched (task edda-review-pr$pr-r$newround)"
+      pending_update "$pr" "$newround" "$sha" 0 "$(date +%s)"
+    fi
+  done
+}
+
+cleanup() { log "watcher stopping (signal)"; exit 0; }
+trap cleanup INT TERM
+
+log "watcher starting (repo=$REPO poll=${POLL}s scratch=$SCRATCH once=$ONCE dry=$DRY)"
+if [ "$DRY" != "1" ]; then
+  ensure_labels
+fi
+
+while :; do
+  settle_pending
+  scan_open_prs
+  [ "$ONCE" = "1" ] && break
+  sleep "$POLL"
+done
+log "watcher cycle complete (once=$ONCE dry=$DRY)"

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -21,9 +21,12 @@
 # State (under $EDDA_FLEET_SCRATCH, not in git):
 #   review-state.tsv     pr<TAB>reviewed_sha<TAB>round
 #   review-pending.tsv   pr<TAB>round<TAB>sha<TAB>attempts<TAB>launched_epoch<TAB>postfails
-#   review-acks.tsv      pr<TAB>sha<TAB>attempts  — heads launched but not yet acked;
-#                        the entry exists only while the ack is pending (removed on
-#                        success; after 3 failed attempts -> review:post-failed)
+#   review-acks.tsv      pr<TAB>sha<TAB>attempts<TAB>status — heads launched but not
+#                        yet acked; the entry exists while the ack is pending
+#                        (removed on success). After 3 failed attempts the entry is
+#                        RETAINED as a durable record: marked "post-failed" once the
+#                        review:post-failed label is applied; if that label call also
+#                        fails, the unmarked entry stays for the next poll.
 #   review-fails.tsv     pr<TAB>sha<TAB>consecutive launch failures
 #   watch.log            everything the watcher did
 #
@@ -275,9 +278,9 @@ pr_head() { # $1=pr
 # --thinking minimal with the SAME --model (never a cheaper model).
 probe_review_provider() {
   if command -v timeout >/dev/null 2>&1; then
-    timeout 60 pi -p --model "$MODEL" --thinking minimal "reply OK" >/dev/null 2>&1
+    timeout 60 pi -p --model "$MODEL" --thinking minimal --exclude-tools edit,write "reply OK" >/dev/null 2>&1
   else
-    pi -p --model "$MODEL" --thinking minimal "reply OK" >/dev/null 2>&1
+    pi -p --model "$MODEL" --thinking minimal --exclude-tools edit,write "reply OK" >/dev/null 2>&1
   fi
 }
 

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
 # pr-review-watch.sh — local watcher: for every open non-draft PR whose head SHA
 # has not been reviewed yet, launch the read-only reviewer (scripts/review-pr.sh),
-# post `review: started on <sha>` as an acknowledgement, then post the
-# SHA-pinned verdict when the reviewer finishes, and set review:* labels.
+# post `review: started on <sha>` as an acknowledgement (retried, bounded), then
+# post the SHA-pinned verdict when the reviewer finishes and set review:* labels.
 #
 # usage: pr-review-watch.sh [--once] [--dry-run]
-#        pr-review-watch.sh decide            (offline helper; JSON on stdin)
+#        pr-review-watch.sh decide                 (offline helper; TSV on stdin)
+#        pr-review-watch.sh label-verdict <reviewed-sha> <current-head>
+#        pr-review-watch.sh ack-try <pr> <sha> <attempts>
 #
 # Environment:
 #   EDDA_REPO                  owner/repo            (default fagemx/edda)
@@ -14,19 +16,31 @@
 #   EDDA_REVIEW_MODEL          review model          (default openai-codex/gpt-5.6-sol)
 #   EDDA_REVIEW_POLL_SECONDS   poll interval         (default 60)
 #   PR_REVIEW_WATCH_STATE      state file override   (used by tests)
+#   PR_REVIEW_WATCH_ACKS       acks file override    (used by tests)
 #
 # State (under $EDDA_FLEET_SCRATCH, not in git):
 #   review-state.tsv     pr<TAB>reviewed_sha<TAB>round
 #   review-pending.tsv   pr<TAB>round<TAB>sha<TAB>attempts<TAB>launched_epoch<TAB>postfails
+#   review-acks.tsv      pr<TAB>sha<TAB>attempts  — heads launched but not yet acked;
+#                        the entry exists only while the ack is pending (removed on
+#                        success; after 3 failed attempts -> review:post-failed)
 #   review-fails.tsv     pr<TAB>sha<TAB>consecutive launch failures
 #   watch.log            everything the watcher did
 #
-# Provider-overload rule, v1 (no Codex fallback — it cannot be made read-only):
+# Provider-overload rule, v1 (no Codex fallback — it cannot be made read-only;
+# fleet.review-provider-overload=…codex-route-withdrawn-for-automated-watcher):
 # on a dead/empty verdict, retry pi once with the same model; if that also
 # yields no verdict, label the PR `review:unreviewed`, log it, and stop for
-# that head. An unreviewed PR is an honest state; a cheap-model verdict is not.
-# model_observed and cost are read from the pi session file and are NEVER
-# fabricated — a missing session file is reported as unknown.
+# that head. model_observed and cost are read from the pi session file and are
+# NEVER fabricated — a missing session file is reported as unknown.
+#
+# review:unreviewed is per head: it blocks only while the PR's current head
+# equals the head recorded as unreviewed. A new head drops the label and is
+# reviewed again.
+#
+# The verdict comment is SHA-pinned; its label is applied only if the PR's
+# current head still equals the reviewed SHA (a moved head gets the comment
+# without the label, and the rescan launches the next round).
 #
 # A failed comment post or label update does NOT mark the head reviewed: the
 # verdict is kept and posting retries on the next poll; after 5 failed
@@ -43,6 +57,7 @@ POLL=${EDDA_REVIEW_POLL_SECONDS:-60}
 SCRATCH=${EDDA_FLEET_SCRATCH:-$HOME/.edda/fleet}
 STALE=${EDDA_REVIEW_STALE_SECONDS:-2700}   # 45 min: pi task limit is 30 min
 POSTFAIL_CAP=5
+ACK_CAP=3
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 REVIEW_PR="$SCRIPT_DIR/review-pr.sh"
@@ -50,56 +65,101 @@ REVIEW_PR="$SCRIPT_DIR/review-pr.sh"
 ONCE=0
 DRY=0
 TAB=$(printf '\t')   # literal tab; "\t" inside quotes is backslash-t in POSIX sh
+log() { echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') $*" >> "$WATCHLOG"; }
 
-# ---- offline helper: decide which PRs to review ------------------------------
-# Reads `gh pr list --json number,headRefOid,isDraft,labels` JSON on stdin and
-# prints one decision line per PR: "REVIEW <pr> <sha>" or "SKIP <pr> <reason>".
-# Pure: no network, no state mutation; the state file is read-only here.
+# ---- offline helpers (unit-tested by scripts/test-pr-review-watch.sh) --------
+
+# decide: PR queue triage. Input: one TSV row per open non-draft PR from
+#   gh pr list --repo R --state open --json number,headRefOid,isDraft,labels,updatedAt \
+#     --jq '.[] | select(.isDraft|not) | [.number, .headRefOid, ([.labels[].name]|join(",")), .updatedAt] | @tsv'
+# (row: number<TAB>sha<TAB>labels<TAB>updatedAt; drafts are filtered by the --jq).
+# Output per PR: "REVIEW <n> <sha>" (+" drop-unreviewed-label" when a stale
+# review:unreviewed label must be removed) or "SKIP <n> <reason>". Pure: no
+# network, no state mutation; the state file is read-only here.
 decide() {
   state=${PR_REVIEW_WATCH_STATE:-$SCRATCH/review-state.tsv}
   # Pass the state path via the environment, not -v: gawk processes escape
   # sequences in -v values, which mangles Windows paths (C:\Users\...).
-  EDDA_REVIEW_STATE_TMP="$state" awk '
-    { raw = raw $0 }
-    function jval(o, k,   s, v) {
-      if (!match(o, "\"" k "\"[ ]*:[ ]*")) return ""
-      v = substr(o, RSTART + RLENGTH)
-      if (substr(v, 1, 1) == "\"") {
-        v = substr(v, 2)
-        if (match(v, /^[^"]*/)) return substr(v, RSTART, RLENGTH)
-        return ""
-      }
-      if (match(v, /^[^,}\]]*/)) return substr(v, RSTART, RLENGTH)
-      return ""
-    }
-    END {
-      statefile = ENVIRON["EDDA_REVIEW_STATE_TMP"]
-      while ((getline line < statefile) > 0) {
-        split(line, f, "\t")
-        rev[f[1]] = f[2]
-      }
-      close(statefile)
-      rest = raw
-      while (match(rest, /\{[ \t\n]*"(number|headRefOid)"/)) {
-        obj = substr(rest, RSTART)
-        rest = substr(rest, RSTART + RLENGTH)
-        num = jval(obj, "number")
-        if (num == "") continue
-        if (jval(obj, "isDraft") == "true") { print "SKIP " num " draft"; continue }
-        sha = jval(obj, "headRefOid")
-        if (sha == "") { print "SKIP " num " missing-head"; continue }
-        if (obj ~ /"labels"[ ]*:[ ]*\[[^]]*review:unreviewed/) {
-          print "SKIP " num " review-unreviewed"; continue
+  PR_REVIEW_STATE_TMP="$state" awk -F'\t' '
+    BEGIN {
+      sf = ENVIRON["PR_REVIEW_STATE_TMP"]
+      if (sf != "") {
+        while ((getline line < sf) > 0) {
+          split(line, s, "\t")
+          rev[s[1]] = s[2]
         }
-        if (rev[num] == sha) { print "SKIP " num " already-reviewed"; continue }
-        print "REVIEW " num " " sha
+        close(sf)
       }
+    }
+    {
+      num = $1; sha = $2; labels = $3
+      if (num !~ /^[0-9]+$/) next
+      if (sha == "") { print "SKIP " num " missing-head"; next }
+      if (("," labels ",") ~ /,review:unreviewed,/) {
+        if (rev[num] == sha || rev[num] == "") {
+          print "SKIP " num " review-unreviewed"; next
+        }
+        print "REVIEW " num " " sha " drop-unreviewed-label"; next
+      }
+      if (rev[num] == sha) { print "SKIP " num " already-reviewed"; next }
+      print "REVIEW " num " " sha
     }
   '
 }
 
+# label-verdict: should the verdict label be applied? Only when the PR's
+# current head still equals the reviewed SHA (and is known).
+label_verdict() { # $1=reviewed sha  $2=current head
+  if [ -n "${2:-}" ] && [ "$2" = "$1" ]; then echo apply; else echo skip; fi
+}
+
+# ---- acknowledgement (retried, bounded; never best-effort) -------------------
+
+ack_register() { # $1=pr $2=sha $3=attempts — record "launched, ack pending"
+  awk -F'\t' -v pr="$1" '$1!=pr' "$ACKS" > "$ACKS.tmp"
+  printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$ACKS.tmp"
+  mv "$ACKS.tmp" "$ACKS"
+}
+
+ack_drop() { # $1=pr
+  awk -F'\t' -v pr="$1" '$1!=pr' "$ACKS" > "$ACKS.tmp"
+  mv "$ACKS.tmp" "$ACKS"
+}
+
+ack_try() { # $1=pr $2=sha $3=attempts — one attempt.
+  # exit 0 = posted (pending entry cleared); 1 = failed, retries remain;
+  # 2 = failed after the bound (entry dropped, review:post-failed label).
+  if printf 'review: started on %s\n' "$2" \
+      | gh pr comment "$1" --repo "$REPO" --body-file - >/dev/null 2>&1; then
+    ack_drop "$1"
+    log "pr$1 ack posted: review: started on $2"
+    return 0
+  fi
+  attempts=$((${3:-0} + 1))
+  if [ "$attempts" -ge "$ACK_CAP" ]; then
+    ack_drop "$1"
+    log "pr$1 ack failed $ACK_CAP times — labeling review:post-failed"
+    gh pr edit "$1" --repo "$REPO" --add-label "review:post-failed" >/dev/null 2>&1 || true
+    return 2
+  fi
+  ack_register "$1" "$2" "$attempts"
+  log "pr$1 ack failed (attempt $attempts/$ACK_CAP); will retry next poll"
+  return 1
+}
+
+# ---- offline subcommand dispatch (after all definitions) ---------------------
 case "${1:-}" in
   decide) decide; exit 0 ;;
+  label-verdict) label_verdict "${2:-}" "${3:-}"; exit 0 ;;
+  ack-try)
+    if [ $# -lt 4 ]; then echo "usage: pr-review-watch.sh ack-try <pr> <sha> <attempts>" >&2; exit 1; fi
+    mkdir -p "$SCRATCH"
+    ACKS=${PR_REVIEW_WATCH_ACKS:-$SCRATCH/review-acks.tsv}
+    WATCHLOG=${PR_REVIEW_WATCH_LOG:-$SCRATCH/watch.log}
+    touch "$ACKS"
+    ack_try "$2" "$3" "$4"
+    exit $?
+    ;;
 esac
 
 for a in "$@"; do
@@ -112,19 +172,19 @@ for a in "$@"; do
 done
 
 mkdir -p "$SCRATCH"
-STATE="$SCRATCH/review-state.tsv"
+STATE=${PR_REVIEW_WATCH_STATE:-$SCRATCH/review-state.tsv}
+ACKS=${PR_REVIEW_WATCH_ACKS:-$SCRATCH/review-acks.tsv}
 PENDING="$SCRATCH/review-pending.tsv"
 FAILS="$SCRATCH/review-fails.tsv"
 WATCHLOG="$SCRATCH/watch.log"
-touch "$STATE" "$PENDING" "$FAILS"
+touch "$STATE" "$ACKS" "$PENDING" "$FAILS"
 
-log() { echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') $*" >> "$WATCHLOG"; }
 
 ensure_labels() {
   gh label create "review:lgtm"              --repo "$REPO" --color 0e8a16 --description "Automatic review verdict: LGTM (P0=0, P1=0)"            --force >/dev/null 2>&1 || true
   gh label create "review:changes-requested" --repo "$REPO" --color d93f0b --description "Automatic review verdict: Changes Requested"            --force >/dev/null 2>&1 || true
   gh label create "review:unreviewed"        --repo "$REPO" --color d4c5f9 --description "Review provider exhausted; verdict pending human/retry" --force >/dev/null 2>&1 || true
-  gh label create "review:post-failed"       --repo "$REPO" --color b60205 --description "Verdict could not be posted; see watcher scratch dir"   --force >/dev/null 2>&1 || true
+  gh label create "review:post-failed"       --repo "$REPO" --color b60205 --description "Verdict/ack could not be posted; see watcher scratch dir" --force >/dev/null 2>&1 || true
 }
 
 state_field() { # $1=pr  $2=field index (2=sha,3=round)
@@ -198,17 +258,18 @@ pr_is_open() { # $1=pr
   [ "$(gh pr view "$1" --repo "$REPO" --json state --jq .state 2>/dev/null)" = "OPEN" ]
 }
 
-ack_comment() { # $1=pr $2=sha — the ≤3-minute acknowledgement
-  if [ "$DRY" = "1" ]; then
-    echo "dry-run: would post 'review: started on $2' to PR #$1"
-    return 0
-  fi
-  if printf 'review: started on %s\n' "$2" \
-      | gh pr comment "$1" --repo "$REPO" --body-file - >/dev/null 2>&1; then
-    log "pr$1 ack posted: review: started on $2"
-  else
-    log "pr$1 ack comment failed (non-fatal; verdict still follows)"
-  fi
+pr_head() { # $1=pr
+  gh pr view "$1" --repo "$REPO" --json headRefOid --jq .headRefOid 2>/dev/null
+}
+
+
+process_acks() {
+  [ -s "$ACKS" ] || return 0
+  [ "$DRY" = "1" ] && return 0
+  while IFS="$TAB" read -r pr sha attempts < "$ACKS"; do
+    [ -n "${pr:-}" ] || continue
+    ack_try "$pr" "$sha" "$attempts" || true
+  done
 }
 
 mark_unreviewed() { # $1=pr $2=sha $3=round $4=reason
@@ -249,16 +310,22 @@ settle_pending() {
     VERDICT="$SCRATCH/review-pr$pr-r$round-verdict.md"
     POSTED="$VERDICT.posted"
 
-    # Comment already posted; only labels + state remain.
-    if [ -f "$POSTED" ]; then
-      vl=$(sh "$REVIEW_PR" verdict-label < "$POSTED")
-      if [ "$DRY" = "1" ]; then
-        echo "dry-run: would set label '$vl' on PR #$pr and record it reviewed"
-        continue
+    # Apply the verdict label + record reviewed. The label goes on only if the
+    # PR's current head still equals the reviewed SHA; a moved head keeps the
+    # SHA-pinned comment but gets no label, and the rescan launches the next
+    # round.
+    finish_verdict() { # $1=SRC verdict file (already posted)
+      cur=$(pr_head "$pr")
+      if [ "$(label_verdict "$sha" "$cur")" != "apply" ]; then
+        log "pr$pr head moved: reviewed $sha current ${cur:-unknown} — verdict comment stays pinned, no label; rescan will launch the next round"
+        state_set "$pr" "$sha" "$round"
+        pending_drop "$pr"
+        return 0
       fi
+      vl=$(sh "$REVIEW_PR" verdict-label < "$1")
       if [ -n "$vl" ] && gh pr edit "$pr" --repo "$REPO" --add-label "$vl" >/dev/null 2>&1; then
-        gh pr edit "$pr" --repo "$REPO" --remove-label "review:unreviewed"   >/dev/null 2>&1 || true
-        gh pr edit "$pr" --repo "$REPO" --remove-label "review:post-failed"  >/dev/null 2>&1 || true
+        gh pr edit "$pr" --repo "$REPO" --remove-label "review:unreviewed"  >/dev/null 2>&1 || true
+        gh pr edit "$pr" --repo "$REPO" --remove-label "review:post-failed" >/dev/null 2>&1 || true
         if [ "$vl" = "review:lgtm" ]; then
           gh pr edit "$pr" --repo "$REPO" --remove-label "review:changes-requested" >/dev/null 2>&1 || true
         else
@@ -271,12 +338,21 @@ settle_pending() {
         postfails=$((postfails + 1))
         log "pr$pr r$round label update failed (attempt $postfails)"
         if [ "$postfails" -ge "$POSTFAIL_CAP" ]; then
-          mark_post_failed "$pr" "$sha" "$round" "$POSTED"
+          mark_post_failed "$pr" "$sha" "$round" "$1"
           pending_drop "$pr"
         else
           pending_update "$pr" "$round" "$sha" "$attempts" "$launched" "$postfails"
         fi
       fi
+    }
+
+    # Comment already posted; only the label + state remain.
+    if [ -f "$POSTED" ]; then
+      if [ "$DRY" = "1" ]; then
+        echo "dry-run: would finish verdict posting for PR #$pr (label + state)"
+        continue
+      fi
+      finish_verdict "$POSTED"
       continue
     fi
 
@@ -306,6 +382,7 @@ settle_pending() {
           log "pr$pr r$round posted verdict comment"
           mv "$VERDICT" "$POSTED"
           pending_update "$pr" "$round" "$sha" "$attempts" "$launched" 0
+          finish_verdict "$POSTED"
         else
           postfails=$((postfails + 1))
           log "pr$pr r$round comment post failed (attempt $postfails); verdict kept at $VERDICT"
@@ -350,15 +427,17 @@ settle_pending() {
 
 # ---- open-PR scan ------------------------------------------------------------
 scan_open_prs() {
-  rows_json=$(gh pr list --state open --repo "$REPO" --json number,headRefOid,isDraft,labels 2>/dev/null) || {
+  rows=$(gh pr list --state open --repo "$REPO" \
+      --json number,headRefOid,isDraft,labels,updatedAt \
+      --jq '.[] | select(.isDraft|not) | [.number, .headRefOid, ([.labels[].name]|join(",")), .updatedAt] | @tsv' 2>/dev/null) || {
     log "gh pr list failed; skipping this cycle"
     return 0
   }
-  decisions=$(printf '%s\n' "$rows_json" | decide) || {
+  decisions=$(printf '%s\n' "$rows" | decide) || {
     log "decide failed; skipping this cycle"
     return 0
   }
-  printf '%s\n' "$decisions" | while read -r verb pr sha; do
+  printf '%s\n' "$decisions" | while read -r verb pr sha extra; do
     [ "${verb:-}" = "REVIEW" ] || continue
     [ -n "${pr:-}" ] || continue
     pending_has "$pr" && continue
@@ -369,9 +448,17 @@ scan_open_prs() {
     newround=$((round + 1))
 
     if [ "$DRY" = "1" ]; then
-      echo "dry-run: would launch review for PR #$pr round $newround (head $sha${prev:+, prev $prev}): $REVIEW_PR $pr $newround $prev --sha $sha"
+      echo "dry-run: would launch review for PR #$pr round $newround (head $sha${prev:+, prev $prev}${extra:+, $extra}): $REVIEW_PR $pr $newround $prev --sha $sha"
       log "dry-run: would launch review for pr$pr r$newround (head $sha)"
       continue
+    fi
+
+    if [ "${extra:-}" = "drop-unreviewed-label" ]; then
+      if gh pr edit "$pr" --repo "$REPO" --remove-label "review:unreviewed" >/dev/null 2>&1; then
+        log "pr$pr new head $sha — stale review:unreviewed label (recorded for ${prev:-none}) removed"
+      else
+        log "pr$pr could not remove the stale review:unreviewed label (continuing)"
+      fi
     fi
 
     log "pr$pr new head $sha (reviewed: '${prev:-none}') — launching review r$newround"
@@ -381,7 +468,9 @@ scan_open_prs() {
       fail_clear "$pr"
       log "pr$pr r$newround launched and confirmed running (task edda-review-pr$pr-r$newround)"
       pending_update "$pr" "$newround" "$sha" 0 "$(date +%s)" 0
-      ack_comment "$pr" "$sha"
+      ack_register "$pr" "$sha" 0
+      log "pr$pr launched, ack pending (review: started on $sha)"
+      ack_try "$pr" "$sha" 0 || true
     elif [ "$rc" = "3" ]; then
       log "pr$pr head moved between scan and launch ($sha); will rescan"
     else
@@ -405,6 +494,7 @@ if [ "$DRY" != "1" ]; then
 fi
 
 while :; do
+  process_acks
   settle_pending
   scan_open_prs
   [ "$ONCE" = "1" ] && break

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -60,7 +60,8 @@ POSTFAIL_CAP=5
 ACK_CAP=3
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
-REVIEW_PR="$SCRIPT_DIR/review-pr.sh"
+REVIEW_PR=${PR_REVIEW_WATCH_REVIEW_PR:-$SCRIPT_DIR/review-pr.sh}   # overridable for offline tests
+LABEL_PR="$SCRIPT_DIR/review-pr.sh"   # always the real script (verdict-label is offline-safe)
 
 ONCE=0
 DRY=0
@@ -115,9 +116,9 @@ label_verdict() { # $1=reviewed sha  $2=current head
 
 # ---- acknowledgement (retried, bounded; never best-effort) -------------------
 
-ack_register() { # $1=pr $2=sha $3=attempts — record "launched, ack pending"
+ack_register() { # $1=pr $2=sha $3=attempts $4=status(""=pending, "post-failed"=terminal)
   awk -F'\t' -v pr="$1" '$1!=pr' "$ACKS" > "$ACKS.tmp"
-  printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$ACKS.tmp"
+  printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "${4:-}" >> "$ACKS.tmp"
   mv "$ACKS.tmp" "$ACKS"
 }
 
@@ -128,7 +129,10 @@ ack_drop() { # $1=pr
 
 ack_try() { # $1=pr $2=sha $3=attempts — one attempt.
   # exit 0 = posted (pending entry cleared); 1 = failed, retries remain;
-  # 2 = failed after the bound (entry dropped, review:post-failed label).
+  # 2 = failed after the bound. The entry is a durable record: after the bound
+  # it is only marked "post-failed" once review:post-failed is APPLIED; if the
+  # label call fails too, the entry stays for the next poll (no silent
+  # terminal state).
   if printf 'review: started on %s\n' "$2" \
       | gh pr comment "$1" --repo "$REPO" --body-file - >/dev/null 2>&1; then
     ack_drop "$1"
@@ -137,12 +141,16 @@ ack_try() { # $1=pr $2=sha $3=attempts — one attempt.
   fi
   attempts=$((${3:-0} + 1))
   if [ "$attempts" -ge "$ACK_CAP" ]; then
-    ack_drop "$1"
-    log "pr$1 ack failed $ACK_CAP times — labeling review:post-failed"
-    gh pr edit "$1" --repo "$REPO" --add-label "review:post-failed" >/dev/null 2>&1 || true
+    if gh pr edit "$1" --repo "$REPO" --add-label "review:post-failed" >/dev/null 2>&1; then
+      ack_register "$1" "$2" "$attempts" "post-failed"
+      log "pr$1 ack failed $ACK_CAP times — review:post-failed applied; ack entry marked post-failed"
+    else
+      ack_register "$1" "$2" "$attempts" ""
+      log "pr$1 ack failed $ACK_CAP times AND review:post-failed label failed — ack entry kept for next poll"
+    fi
     return 2
   fi
-  ack_register "$1" "$2" "$attempts"
+  ack_register "$1" "$2" "$attempts" ""
   log "pr$1 ack failed (attempt $attempts/$ACK_CAP); will retry next poll"
   return 1
 }
@@ -176,7 +184,7 @@ STATE=${PR_REVIEW_WATCH_STATE:-$SCRATCH/review-state.tsv}
 ACKS=${PR_REVIEW_WATCH_ACKS:-$SCRATCH/review-acks.tsv}
 PENDING="$SCRATCH/review-pending.tsv"
 FAILS="$SCRATCH/review-fails.tsv"
-WATCHLOG="$SCRATCH/watch.log"
+WATCHLOG=${PR_REVIEW_WATCH_LOG:-$SCRATCH/watch.log}
 touch "$STATE" "$ACKS" "$PENDING" "$FAILS"
 
 
@@ -262,14 +270,29 @@ pr_head() { # $1=pr
   gh pr view "$1" --repo "$REPO" --json headRefOid --jq .headRefOid 2>/dev/null
 }
 
+# Trivial probe from the superseding fleet.review-provider-overload decision:
+# before spending a full retry, check the review provider answers at
+# --thinking minimal with the SAME --model (never a cheaper model).
+probe_review_provider() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 60 pi -p --model "$MODEL" --thinking minimal "reply OK" >/dev/null 2>&1
+  else
+    pi -p --model "$MODEL" --thinking minimal "reply OK" >/dev/null 2>&1
+  fi
+}
+
 
 process_acks() {
   [ -s "$ACKS" ] || return 0
   [ "$DRY" = "1" ] && return 0
-  while IFS="$TAB" read -r pr sha attempts < "$ACKS"; do
+  # NOTE: the redirect belongs on `done`, not on `read` — on `read` it re-opens
+  # the file every iteration and a kept entry (unknown head, retrying ack)
+  # spins forever.
+  while IFS="$TAB" read -r pr sha attempts status; do
     [ -n "${pr:-}" ] || continue
+    [ "${status:-}" = "post-failed" ] && continue   # terminal, already labeled
     ack_try "$pr" "$sha" "$attempts" || true
-  done
+  done < "$ACKS"
 }
 
 mark_unreviewed() { # $1=pr $2=sha $3=round $4=reason
@@ -296,7 +319,7 @@ mark_post_failed() { # $1=pr $2=sha $3=round $4=verdict file
 settle_pending() {
   [ -s "$PENDING" ] || return 0
   now=$(date +%s)
-  while IFS="$TAB" read -r pr round sha attempts launched postfails < "$PENDING"; do
+  while IFS="$TAB" read -r pr round sha attempts launched postfails; do
     [ -n "${pr:-}" ] || continue
 
     if ! pr_is_open "$pr"; then
@@ -316,13 +339,19 @@ settle_pending() {
     # round.
     finish_verdict() { # $1=SRC verdict file (already posted)
       cur=$(pr_head "$pr")
+      if [ -z "$cur" ]; then
+        # A failed/empty head query is NOT evidence the head moved: keep the
+        # verdict pending and retry on the next poll.
+        log "pr$pr head unknown, retry — head query failed after posting the verdict; pending entry kept"
+        return 0
+      fi
       if [ "$(label_verdict "$sha" "$cur")" != "apply" ]; then
         log "pr$pr head moved: reviewed $sha current ${cur:-unknown} — verdict comment stays pinned, no label; rescan will launch the next round"
         state_set "$pr" "$sha" "$round"
         pending_drop "$pr"
         return 0
       fi
-      vl=$(sh "$REVIEW_PR" verdict-label < "$1")
+      vl=$(sh "$LABEL_PR" verdict-label < "$1")
       if [ -n "$vl" ] && gh pr edit "$pr" --repo "$REPO" --add-label "$vl" >/dev/null 2>&1; then
         gh pr edit "$pr" --repo "$REPO" --remove-label "review:unreviewed"  >/dev/null 2>&1 || true
         gh pr edit "$pr" --repo "$REPO" --remove-label "review:post-failed" >/dev/null 2>&1 || true
@@ -396,23 +425,28 @@ settle_pending() {
       else
         case "$attempts" in
           0)
-            log "pr$pr r$round dead/empty verdict — retrying once with pi (same model, fleet.review-provider-overload)"
             if [ "$DRY" = "1" ]; then
-              echo "dry-run: would retry PR #$pr r$round with pi"
+              echo "dry-run: would probe the provider and retry PR #$pr r$round with pi"
               pending_drop "$pr"
+              continue
+            fi
+            if ! probe_review_provider; then
+              mark_unreviewed "$pr" "$sha" "$round" "provider probe (--thinking minimal) failed before the pi retry"
+              pending_drop "$pr"
+              continue
+            fi
+            log "pr$pr r$round provider probe OK — retrying once with pi (same model, fleet.review-provider-overload)"
+            if "$REVIEW_PR" "$pr" "$round" "$sha" --sha "$sha" >> "$WATCHLOG" 2>&1; then
+              log "pr$pr r$round pi retry launched"
+              pending_update "$pr" "$round" "$sha" 1 "$(date +%s)" "$postfails"
             else
-              if "$REVIEW_PR" "$pr" "$round" "$sha" --sha "$sha" >> "$WATCHLOG" 2>&1; then
-                log "pr$pr r$round pi retry launched"
-                pending_update "$pr" "$round" "$sha" 1 "$(date +%s)" "$postfails"
+              rc=$?
+              if [ "$rc" = "3" ]; then
+                log "pr$pr head moved before pi retry; dropping pending entry (rescan will re-review)"
               else
-                rc=$?
-                if [ "$rc" = "3" ]; then
-                  log "pr$pr head moved before pi retry; dropping pending entry (rescan will re-review)"
-                else
-                  log "pr$pr r$round pi retry launch failed (rc=$rc)"
-                fi
-                pending_drop "$pr"
+                log "pr$pr r$round pi retry launch failed (rc=$rc)"
               fi
+              pending_drop "$pr"
             fi
             ;;
           *)
@@ -422,7 +456,7 @@ settle_pending() {
         esac
       fi
     fi
-  done
+  done < "$PENDING"
 }
 
 # ---- open-PR scan ------------------------------------------------------------

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 # pr-review-watch.sh — local watcher: for every open non-draft PR whose head SHA
 # has not been reviewed yet, launch the read-only reviewer (scripts/review-pr.sh),
-# post the SHA-pinned verdict as a PR comment, and set review:* labels.
+# post `review: started on <sha>` as an acknowledgement, then post the
+# SHA-pinned verdict when the reviewer finishes, and set review:* labels.
 #
 # usage: pr-review-watch.sh [--once] [--dry-run]
+#        pr-review-watch.sh decide            (offline helper; JSON on stdin)
 #
 # Environment:
 #   EDDA_REPO                  owner/repo            (default fagemx/edda)
@@ -11,17 +13,25 @@
 #   EDDA_FLEET_SCRATCH         state/log dir         (default $HOME/.edda/fleet)
 #   EDDA_REVIEW_MODEL          review model          (default openai-codex/gpt-5.6-sol)
 #   EDDA_REVIEW_POLL_SECONDS   poll interval         (default 60)
+#   PR_REVIEW_WATCH_STATE      state file override   (used by tests)
 #
 # State (under $EDDA_FLEET_SCRATCH, not in git):
 #   review-state.tsv     pr<TAB>reviewed_sha<TAB>round
-#   review-pending.tsv   pr<TAB>round<TAB>sha<TAB>attempts<TAB>launched_epoch
+#   review-pending.tsv   pr<TAB>round<TAB>sha<TAB>attempts<TAB>launched_epoch<TAB>postfails
+#   review-fails.tsv     pr<TAB>sha<TAB>consecutive launch failures
 #   watch.log            everything the watcher did
 #
-# Provider-overload rule (fleet.review-provider-overload — change transport,
-# never the model): on a dead/empty verdict, retry pi once, then
-# `edda dispatch --agent codex`; if that also yields no verdict, label the PR
-# `review:unreviewed` and stop for that head. An unreviewed PR is an honest
-# state; a cheap-model verdict is not.
+# Provider-overload rule, v1 (no Codex fallback — it cannot be made read-only):
+# on a dead/empty verdict, retry pi once with the same model; if that also
+# yields no verdict, label the PR `review:unreviewed`, log it, and stop for
+# that head. An unreviewed PR is an honest state; a cheap-model verdict is not.
+# model_observed and cost are read from the pi session file and are NEVER
+# fabricated — a missing session file is reported as unknown.
+#
+# A failed comment post or label update does NOT mark the head reviewed: the
+# verdict is kept and posting retries on the next poll; after 5 failed
+# attempts the PR is labeled `review:post-failed` (verdict file kept in
+# $EDDA_FLEET_SCRATCH for manual posting).
 #
 # The watcher NEVER merges. Merge stays behind operator authorization
 # (pr.merge-policy).
@@ -32,6 +42,7 @@ MODEL=${EDDA_REVIEW_MODEL:-openai-codex/gpt-5.6-sol}
 POLL=${EDDA_REVIEW_POLL_SECONDS:-60}
 SCRATCH=${EDDA_FLEET_SCRATCH:-$HOME/.edda/fleet}
 STALE=${EDDA_REVIEW_STALE_SECONDS:-2700}   # 45 min: pi task limit is 30 min
+POSTFAIL_CAP=5
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 REVIEW_PR="$SCRIPT_DIR/review-pr.sh"
@@ -39,6 +50,58 @@ REVIEW_PR="$SCRIPT_DIR/review-pr.sh"
 ONCE=0
 DRY=0
 TAB=$(printf '\t')   # literal tab; "\t" inside quotes is backslash-t in POSIX sh
+
+# ---- offline helper: decide which PRs to review ------------------------------
+# Reads `gh pr list --json number,headRefOid,isDraft,labels` JSON on stdin and
+# prints one decision line per PR: "REVIEW <pr> <sha>" or "SKIP <pr> <reason>".
+# Pure: no network, no state mutation; the state file is read-only here.
+decide() {
+  state=${PR_REVIEW_WATCH_STATE:-$SCRATCH/review-state.tsv}
+  # Pass the state path via the environment, not -v: gawk processes escape
+  # sequences in -v values, which mangles Windows paths (C:\Users\...).
+  EDDA_REVIEW_STATE_TMP="$state" awk '
+    { raw = raw $0 }
+    function jval(o, k,   s, v) {
+      if (!match(o, "\"" k "\"[ ]*:[ ]*")) return ""
+      v = substr(o, RSTART + RLENGTH)
+      if (substr(v, 1, 1) == "\"") {
+        v = substr(v, 2)
+        if (match(v, /^[^"]*/)) return substr(v, RSTART, RLENGTH)
+        return ""
+      }
+      if (match(v, /^[^,}\]]*/)) return substr(v, RSTART, RLENGTH)
+      return ""
+    }
+    END {
+      statefile = ENVIRON["EDDA_REVIEW_STATE_TMP"]
+      while ((getline line < statefile) > 0) {
+        split(line, f, "\t")
+        rev[f[1]] = f[2]
+      }
+      close(statefile)
+      rest = raw
+      while (match(rest, /\{[ \t\n]*"(number|headRefOid)"/)) {
+        obj = substr(rest, RSTART)
+        rest = substr(rest, RSTART + RLENGTH)
+        num = jval(obj, "number")
+        if (num == "") continue
+        if (jval(obj, "isDraft") == "true") { print "SKIP " num " draft"; continue }
+        sha = jval(obj, "headRefOid")
+        if (sha == "") { print "SKIP " num " missing-head"; continue }
+        if (obj ~ /"labels"[ ]*:[ ]*\[[^]]*review:unreviewed/) {
+          print "SKIP " num " review-unreviewed"; continue
+        }
+        if (rev[num] == sha) { print "SKIP " num " already-reviewed"; continue }
+        print "REVIEW " num " " sha
+      }
+    }
+  '
+}
+
+case "${1:-}" in
+  decide) decide; exit 0 ;;
+esac
+
 for a in "$@"; do
   case "$a" in
     --once) ONCE=1 ;;
@@ -51,15 +114,17 @@ done
 mkdir -p "$SCRATCH"
 STATE="$SCRATCH/review-state.tsv"
 PENDING="$SCRATCH/review-pending.tsv"
+FAILS="$SCRATCH/review-fails.tsv"
 WATCHLOG="$SCRATCH/watch.log"
-touch "$STATE" "$PENDING"
+touch "$STATE" "$PENDING" "$FAILS"
 
 log() { echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') $*" >> "$WATCHLOG"; }
 
 ensure_labels() {
-  gh label create "review:lgtm"             --repo "$REPO" --color 0e8a16 --description "Automatic review verdict: LGTM (P0=0, P1=0)"            --force >/dev/null 2>&1 || true
+  gh label create "review:lgtm"              --repo "$REPO" --color 0e8a16 --description "Automatic review verdict: LGTM (P0=0, P1=0)"            --force >/dev/null 2>&1 || true
   gh label create "review:changes-requested" --repo "$REPO" --color d93f0b --description "Automatic review verdict: Changes Requested"            --force >/dev/null 2>&1 || true
   gh label create "review:unreviewed"        --repo "$REPO" --color d4c5f9 --description "Review provider exhausted; verdict pending human/retry" --force >/dev/null 2>&1 || true
+  gh label create "review:post-failed"       --repo "$REPO" --color b60205 --description "Verdict could not be posted; see watcher scratch dir"   --force >/dev/null 2>&1 || true
 }
 
 state_field() { # $1=pr  $2=field index (2=sha,3=round)
@@ -68,9 +133,9 @@ state_field() { # $1=pr  $2=field index (2=sha,3=round)
 
 pending_has() { awk -F'\t' -v pr="$1" '$1==pr{found=1} END{exit !found}' "$PENDING" 2>/dev/null; }
 
-pending_update() { # $1=pr $2=round $3=sha $4=attempts $5=launched
+pending_update() { # $1=pr $2=round $3=sha $4=attempts $5=launched $6=postfails
   awk -F'\t' -v pr="$1" '$1!=pr' "$PENDING" > "$PENDING.tmp"
-  printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5" >> "$PENDING.tmp"
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5" "$6" >> "$PENDING.tmp"
   mv "$PENDING.tmp" "$PENDING"
 }
 
@@ -83,6 +148,20 @@ state_set() { # $1=pr $2=sha $3=round
   awk -F'\t' -v pr="$1" '$1!=pr' "$STATE" > "$STATE.tmp"
   printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$STATE.tmp"
   mv "$STATE.tmp" "$STATE"
+}
+
+fail_clear() { # $1=pr
+  awk -F'\t' -v pr="$1" '$1!=pr' "$FAILS" > "$FAILS.tmp"
+  mv "$FAILS.tmp" "$FAILS"
+}
+
+fail_bump() { # $1=pr $2=sha — exits 0 when the cap is reached
+  c=$(awk -F'\t' -v pr="$1" '$1==pr{print $3; found=1} END{if(!found) print 0}' "$FAILS")
+  c=$((c + 1))
+  awk -F'\t' -v pr="$1" '$1!=pr' "$FAILS" > "$FAILS.tmp"
+  printf '%s\t%s\t%s\n' "$1" "$2" "$c" >> "$FAILS.tmp"
+  mv "$FAILS.tmp" "$FAILS"
+  [ "$c" -ge 3 ]
 }
 
 # Extract the LAST verdict block between the fixed markers from a transcript.
@@ -100,7 +179,7 @@ verdict_ok() { # $1=verdict file
 }
 
 # Model observed + cost, read from the pi session files (never from what the
-# brief asked for).
+# brief asked for). Missing session file => explicitly "unknown", never made up.
 session_model_cost() { # $1=session id -> sets OBSERVED, COST
   files=$(find "$HOME/.pi/agent/sessions" -name "*_$1.jsonl" 2>/dev/null)
   if [ -n "$files" ]; then
@@ -119,44 +198,17 @@ pr_is_open() { # $1=pr
   [ "$(gh pr view "$1" --repo "$REPO" --json state --jq .state 2>/dev/null)" = "OPEN" ]
 }
 
-pr_labels() { # $1=pr
-  gh pr view "$1" --repo "$REPO" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null
-}
-
-pr_head() { # $1=pr
-  gh pr view "$1" --repo "$REPO" --json headRefOid --jq .headRefOid 2>/dev/null
-}
-
-# Post a verdict (or the honest unreviewed outcome) and update state.
-post_verdict() { # $1=pr $2=round $3=sha $4=verdict file $5=transport note
-  COMMENT="$SCRATCH/review-pr$1-r$2-comment.md"
-  {
-    echo "> **Round $2 review** — automatic watcher (\`scripts/pr-review-watch.sh\`): $5, read-only, detached worktree at \`$3\`. Model observed in the pi session file: \`$OBSERVED\`. Cost: \$$COST. Reviewed head SHA: \`$3\`."
-    echo
-    cat "$4"
-  } > "$COMMENT"
+ack_comment() { # $1=pr $2=sha — the ≤3-minute acknowledgement
   if [ "$DRY" = "1" ]; then
-    echo "dry-run: would post $COMMENT to PR #$1 and set a review:* label"
+    echo "dry-run: would post 'review: started on $2' to PR #$1"
     return 0
   fi
-  gh pr comment "$1" --repo "$REPO" --body-file "$COMMENT" >/dev/null &&
-    log "pr$1 r$2 posted verdict comment ($4)"
-  if pr_is_open "$1" && [ "$(pr_head "$1")" = "$3" ]; then
-    if grep -q '^LGTM' "$4"; then
-      gh pr edit "$1" --repo "$REPO" --add-label "review:lgtm" >/dev/null 2>&1 &&
-        log "pr$1 labeled review:lgtm"
-      gh pr edit "$1" --repo "$REPO" --remove-label "review:changes-requested" >/dev/null 2>&1 || true
-      gh pr edit "$1" --repo "$REPO" --remove-label "review:unreviewed" >/dev/null 2>&1 || true
-    else
-      gh pr edit "$1" --repo "$REPO" --add-label "review:changes-requested" >/dev/null 2>&1 &&
-        log "pr$1 labeled review:changes-requested"
-      gh pr edit "$1" --repo "$REPO" --remove-label "review:lgtm" >/dev/null 2>&1 || true
-      gh pr edit "$1" --repo "$REPO" --remove-label "review:unreviewed" >/dev/null 2>&1 || true
-    fi
+  if printf 'review: started on %s\n' "$2" \
+      | gh pr comment "$1" --repo "$REPO" --body-file - >/dev/null 2>&1; then
+    log "pr$1 ack posted: review: started on $2"
   else
-    log "pr$1 head moved or PR closed; verdict stays pinned to $3, label skipped"
+    log "pr$1 ack comment failed (non-fatal; verdict still follows)"
   fi
-  state_set "$1" "$3" "$2"
 }
 
 mark_unreviewed() { # $1=pr $2=sha $3=round $4=reason
@@ -169,11 +221,21 @@ mark_unreviewed() { # $1=pr $2=sha $3=round $4=reason
   state_set "$1" "$2" "$3"
 }
 
+mark_post_failed() { # $1=pr $2=sha $3=round $4=verdict file
+  log "pr$1 posting failed $POSTFAIL_CAP times — labeling review:post-failed; verdict kept at $4"
+  if [ "$DRY" = "1" ]; then
+    echo "dry-run: would label PR #$1 review:post-failed"
+    return 0
+  fi
+  gh pr edit "$1" --repo "$REPO" --add-label "review:post-failed" >/dev/null 2>&1 || true
+  state_set "$1" "$2" "$3"
+}
+
 # ---- in-flight handling ------------------------------------------------------
 settle_pending() {
   [ -s "$PENDING" ] || return 0
   now=$(date +%s)
-  while IFS="$TAB" read -r pr round sha attempts launched < "$PENDING"; do
+  while IFS="$TAB" read -r pr round sha attempts launched postfails < "$PENDING"; do
     [ -n "${pr:-}" ] || continue
 
     if ! pr_is_open "$pr"; then
@@ -185,7 +247,38 @@ settle_pending() {
     DONE="$SCRATCH/review-pr$pr-r$round.done"
     LOG="$SCRATCH/review-pr$pr-r$round.log"
     VERDICT="$SCRATCH/review-pr$pr-r$round-verdict.md"
-    CODEXLOG="$SCRATCH/review-pr$pr-r$round-codex.log"
+    POSTED="$VERDICT.posted"
+
+    # Comment already posted; only labels + state remain.
+    if [ -f "$POSTED" ]; then
+      vl=$(sh "$REVIEW_PR" verdict-label < "$POSTED")
+      if [ "$DRY" = "1" ]; then
+        echo "dry-run: would set label '$vl' on PR #$pr and record it reviewed"
+        continue
+      fi
+      if [ -n "$vl" ] && gh pr edit "$pr" --repo "$REPO" --add-label "$vl" >/dev/null 2>&1; then
+        gh pr edit "$pr" --repo "$REPO" --remove-label "review:unreviewed"   >/dev/null 2>&1 || true
+        gh pr edit "$pr" --repo "$REPO" --remove-label "review:post-failed"  >/dev/null 2>&1 || true
+        if [ "$vl" = "review:lgtm" ]; then
+          gh pr edit "$pr" --repo "$REPO" --remove-label "review:changes-requested" >/dev/null 2>&1 || true
+        else
+          gh pr edit "$pr" --repo "$REPO" --remove-label "review:lgtm" >/dev/null 2>&1 || true
+        fi
+        log "pr$pr r$round labeled $vl and recorded reviewed at $sha"
+        state_set "$pr" "$sha" "$round"
+        pending_drop "$pr"
+      else
+        postfails=$((postfails + 1))
+        log "pr$pr r$round label update failed (attempt $postfails)"
+        if [ "$postfails" -ge "$POSTFAIL_CAP" ]; then
+          mark_post_failed "$pr" "$sha" "$round" "$POSTED"
+          pending_drop "$pr"
+        else
+          pending_update "$pr" "$round" "$sha" "$attempts" "$launched" "$postfails"
+        fi
+      fi
+      continue
+    fi
 
     is_done=0
     is_stale=0
@@ -198,47 +291,55 @@ settle_pending() {
     if [ "$is_done" = "1" ] || [ "$is_stale" = "1" ]; then
       if extract_verdict "$LOG" "$VERDICT" && verdict_ok "$VERDICT"; then
         session_model_cost "review-pr$pr"
-        post_verdict "$pr" "$round" "$sha" "$VERDICT" \
-          "pi -p --model $MODEL --thinking high --exclude-tools edit,write --session-id review-pr$pr"
-        pending_drop "$pr"
+        if [ "$COST" = "?" ]; then costline='cost: unknown'; else costline='cost: $'"$COST"; fi
+        COMMENT="$SCRATCH/review-pr$pr-r$round-comment.md"
+        {
+          echo "> **Round $round review** — automatic watcher (\`scripts/pr-review-watch.sh\`): pi -p --model $MODEL --thinking high --exclude-tools edit,write --session-id review-pr$pr, read-only, detached worktree at \`$sha\`. Model observed in the pi session file: \`$OBSERVED\`. $costline. Reviewed head SHA: \`$sha\`."
+          echo
+          cat "$VERDICT"
+        } > "$COMMENT"
+        if [ "$DRY" = "1" ]; then
+          echo "dry-run: would post $COMMENT to PR #$pr and set a review:* label"
+          continue
+        fi
+        if gh pr comment "$pr" --repo "$REPO" --body-file "$COMMENT" >/dev/null 2>&1; then
+          log "pr$pr r$round posted verdict comment"
+          mv "$VERDICT" "$POSTED"
+          pending_update "$pr" "$round" "$sha" "$attempts" "$launched" 0
+        else
+          postfails=$((postfails + 1))
+          log "pr$pr r$round comment post failed (attempt $postfails); verdict kept at $VERDICT"
+          if [ "$postfails" -ge "$POSTFAIL_CAP" ]; then
+            mark_post_failed "$pr" "$sha" "$round" "$VERDICT"
+            pending_drop "$pr"
+          else
+            pending_update "$pr" "$round" "$sha" "$attempts" "$launched" "$postfails"
+          fi
+        fi
       else
         case "$attempts" in
           0)
-            log "pr$pr r$round dead/empty verdict (attempt 0) — retrying once with pi (same model, fleet.review-provider-overload)"
+            log "pr$pr r$round dead/empty verdict — retrying once with pi (same model, fleet.review-provider-overload)"
             if [ "$DRY" = "1" ]; then
               echo "dry-run: would retry PR #$pr r$round with pi"
               pending_drop "$pr"
             else
-              "$REVIEW_PR" "$pr" "$round" "$sha" >> "$WATCHLOG" 2>&1 &&
+              if "$REVIEW_PR" "$pr" "$round" "$sha" --sha "$sha" >> "$WATCHLOG" 2>&1; then
                 log "pr$pr r$round pi retry launched"
-              pending_update "$pr" "$round" "$sha" 1 "$(date +%s)"
-            fi
-            ;;
-          1)
-            log "pr$pr r$round pi retry also dead (attempt 1) — switching transport: edda dispatch --agent codex (same subscribed model)"
-            if [ "$DRY" = "1" ]; then
-              echo "dry-run: would run edda dispatch --agent codex for PR #$pr r$round"
-              pending_drop "$pr"
-            else
-              WT="$SCRATCH/wt-review-pr$pr"
-              BRIEF="$SCRATCH/review-pr$pr-r$round-brief.md"
-              rm -f "$CODEXLOG"
-              if edda dispatch --agent codex --prompt-file "$BRIEF" --cwd "$WT" > "$CODEXLOG" 2>&1; then
-                if extract_verdict "$CODEXLOG" "$VERDICT" && verdict_ok "$VERDICT"; then
-                  OBSERVED="via edda dispatch --agent codex (pi session unavailable)"
-                  COST="?"
-                  post_verdict "$pr" "$round" "$sha" "$VERDICT" \
-                    "edda dispatch --agent codex (transport fallback after pi overload)"
-                  pending_drop "$pr"
-                  continue
+                pending_update "$pr" "$round" "$sha" 1 "$(date +%s)" "$postfails"
+              else
+                rc=$?
+                if [ "$rc" = "3" ]; then
+                  log "pr$pr head moved before pi retry; dropping pending entry (rescan will re-review)"
+                else
+                  log "pr$pr r$round pi retry launch failed (rc=$rc)"
                 fi
+                pending_drop "$pr"
               fi
-              mark_unreviewed "$pr" "$sha" "$round" "pi retry and codex dispatch both yielded no verdict"
-              pending_drop "$pr"
             fi
             ;;
           *)
-            mark_unreviewed "$pr" "$sha" "$round" "no verdict after pi retry and codex dispatch"
+            mark_unreviewed "$pr" "$sha" "$round" "no verdict after one pi retry (v1 has no codex fallback)"
             pending_drop "$pr"
             ;;
         esac
@@ -249,41 +350,48 @@ settle_pending() {
 
 # ---- open-PR scan ------------------------------------------------------------
 scan_open_prs() {
-  rows=$(gh pr list --state open --repo "$REPO" --json number,headRefOid,isDraft,labels \
-    --jq '.[] | select(.isDraft|not) | [.number, .headRefOid, ([.labels[].name] | join(","))] | @tsv' 2>/dev/null) || {
+  rows_json=$(gh pr list --state open --repo "$REPO" --json number,headRefOid,isDraft,labels 2>/dev/null) || {
     log "gh pr list failed; skipping this cycle"
     return 0
   }
-  printf '%s\n' "$rows" | while IFS="$TAB" read -r pr sha labels; do
+  decisions=$(printf '%s\n' "$rows_json" | decide) || {
+    log "decide failed; skipping this cycle"
+    return 0
+  }
+  printf '%s\n' "$decisions" | while read -r verb pr sha; do
+    [ "${verb:-}" = "REVIEW" ] || continue
     [ -n "${pr:-}" ] || continue
     pending_has "$pr" && continue
 
-    reviewed=$(state_field "$pr" 2)
+    prev=$(state_field "$pr" 2)
     round=$(state_field "$pr" 3)
     [ -n "$round" ] || round=0
-
-    [ "$sha" = "$reviewed" ] && continue
-    case ",$labels," in
-      *,review:unreviewed,*)
-        # unreviewed blocks only the head it was recorded for (per-head stop)
-        if [ "$sha" = "$reviewed" ]; then continue; fi
-        if [ "$DRY" != "1" ]; then
-          gh pr edit "$pr" --repo "$REPO" --remove-label "review:unreviewed" >/dev/null 2>&1 || true
-        fi
-        ;;
-    esac
-
     newround=$((round + 1))
+
     if [ "$DRY" = "1" ]; then
-      prev=$(state_field "$pr" 2)
-      [ -n "$prev" ] || prev=""
-      echo "dry-run: would launch review for PR #$pr round $newround (head $sha${prev:+, prev $prev}): $REVIEW_PR $pr $newround $prev"
+      echo "dry-run: would launch review for PR #$pr round $newround (head $sha${prev:+, prev $prev}): $REVIEW_PR $pr $newround $prev --sha $sha"
       log "dry-run: would launch review for pr$pr r$newround (head $sha)"
+      continue
+    fi
+
+    log "pr$pr new head $sha (reviewed: '${prev:-none}') — launching review r$newround"
+    out=$("$REVIEW_PR" "$pr" "$newround" "$prev" --sha "$sha" 2>&1); rc=$?
+    [ -n "$out" ] && printf '%s\n' "$out" >> "$WATCHLOG"
+    if [ "$rc" -eq 0 ]; then
+      fail_clear "$pr"
+      log "pr$pr r$newround launched and confirmed running (task edda-review-pr$pr-r$newround)"
+      pending_update "$pr" "$newround" "$sha" 0 "$(date +%s)" 0
+      ack_comment "$pr" "$sha"
+    elif [ "$rc" = "3" ]; then
+      log "pr$pr head moved between scan and launch ($sha); will rescan"
     else
-      log "pr$pr head $sha differs from reviewed '${reviewed:-none}' — launching review r$newround"
-      "$REVIEW_PR" "$pr" "$newround" "$reviewed" >> "$WATCHLOG" 2>&1 &&
-        log "pr$pr r$newround launched (task edda-review-pr$pr-r$newround)"
-      pending_update "$pr" "$newround" "$sha" 0 "$(date +%s)"
+      log "pr$pr r$newround launch failed (rc=$rc)"
+      if fail_bump "$pr" "$sha"; then
+        mark_unreviewed "$pr" "$sha" "$newround" "reviewer launch failed 3 times in a row"
+        fail_clear "$pr"
+      else
+        log "pr$pr launch failure recorded; will retry next poll"
+      fi
     fi
   done
 }

--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -1,0 +1,205 @@
+#!/bin/sh
+# review-pr.sh — launch one read-only review of a PR (gpt-5.6-sol via pi), per
+# fleet.lane-launch (Task Scheduler, hidden), fleet.review-brief-framing
+# (validation-checklist brief) and fleet.agent-model-split (review model is fixed).
+#
+# usage: review-pr.sh <PR> [round] [prev-sha] [--dry-run]
+#
+# Environment:
+#   EDDA_REPO              owner/repo              (default fagemx/edda)
+#   EDDA_FLEET_ROOT        main checkout path      (default: derived from git)
+#   EDDA_FLEET_SCRATCH     state/log dir           (default $HOME/.edda/fleet)
+#   EDDA_REVIEW_MODEL      review model            (default openai-codex/gpt-5.6-sol)
+#
+# Outputs (under $EDDA_FLEET_SCRATCH):
+#   review-pr<N>-r<R>-brief.md     the review brief fed to the reviewer
+#   review-pr<N>-r<R>.log          pi console transcript (verdict is between
+#                                  <<<VERDICT and VERDICT>>> markers)
+#   review-pr<N>-r<R>.done         written when pi exits ("PI_EXIT=<code>")
+#   wt-review-pr<N>/               detached worktree at the PR head
+#
+# --dry-run generates the brief and prints what would be launched, but does not
+# create the worktree, register the scheduled task, or start any process.
+set -u
+
+usage() {
+  echo "usage: review-pr.sh <PR> [round] [prev-sha] [--dry-run]" >&2
+}
+
+REPO=${EDDA_REPO:-fagemx/edda}
+MODEL=${EDDA_REVIEW_MODEL:-openai-codex/gpt-5.6-sol}
+MODEL_SHORT=${MODEL##*/}
+SCRATCH=${EDDA_FLEET_SCRATCH:-$HOME/.edda/fleet}
+
+PR=""
+ROUND=1
+PREV=""
+DRY=0
+for a in "$@"; do
+  case "$a" in
+    --dry-run) DRY=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      if [ -z "$PR" ]; then PR=$a
+      elif [ "$ROUND" = "1" ] && [ -z "${ROUND_SET:-}" ]; then ROUND=$a; ROUND_SET=1
+      elif [ -z "$PREV" ]; then PREV=$a
+      else echo "review-pr.sh: unexpected argument '$a'" >&2; usage; exit 1; fi
+      ;;
+  esac
+done
+if [ -z "$PR" ]; then usage; exit 1; fi
+case "$PR$ROUND" in
+  *[!0-9]*) echo "review-pr.sh: PR and round must be numeric" >&2; exit 1 ;;
+esac
+
+# ---- platform ---------------------------------------------------------------
+IS_WIN=0
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) IS_WIN=1 ;;
+esac
+
+# ---- repo root (main checkout; needed for the detached worktree) ------------
+ROOT=${EDDA_FLEET_ROOT:-}
+if [ -z "$ROOT" ]; then
+  common=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || common=""
+  [ -n "$common" ] && ROOT=$(dirname "$common")
+fi
+
+# ---- PR facts ---------------------------------------------------------------
+gh_ok() { gh "$@" >/dev/null 2>&1; }
+SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid) ||
+  { echo "review-pr.sh: cannot read PR #$PR (repo $REPO)" >&2; exit 1; }
+BR=$(gh pr view "$PR" --repo "$REPO" --json headRefName --jq .headRefName)
+TITLE=$(gh pr view "$PR" --repo "$REPO" --json title --jq .title)
+BODY=$(gh pr view "$PR" --repo "$REPO" --json body --jq .body)
+
+# Issue numbers from the PR body's "Issue: #N" lines.
+ISSUES=$(printf '%s\n' "$BODY" \
+  | awk 'tolower($0) ~ /^issue[[:space:]]*:/ || tolower($0) ~ /^issues[[:space:]]*:/' \
+  | grep -Eo '#[0-9]+' | tr -d '#' | sort -u)
+# Allowed surface = the PR's changed files.
+SURFACE=$(gh pr diff "$PR" --repo "$REPO" --name-only | paste -sd, - | sed 's/,$//')
+
+# ---- brief (validation-checklist framing, fleet.review-brief-framing) -------
+mkdir -p "$SCRATCH"
+BRIEF="$SCRATCH/review-pr$PR-r$ROUND-brief.md"
+SID="review-pr$PR"
+{
+  echo "# Review brief — PR #$PR, Round $ROUND (read-only, $MODEL_SHORT, session $SID)"
+  echo
+  echo "You stand in a detached worktree at PR head **$SHA** (branch \`$BR\`). The workspace ledger is reachable (\`edda ask\` works). Title: $TITLE. Issue(s): ${ISSUES:-none}. Files changed by the PR: ${SURFACE:-none}"
+  if [ -n "$PREV" ]; then
+    echo "This is a DELTA round: your prior verdict on $PREV is posted on the PR; review \`git diff $PREV..$SHA\` and RAN-confirm each prior finding is resolved; do not re-review the whole PR."
+  fi
+  echo
+  echo "## Contract (validation checklist — properties the PR must hold, zero discretion)"
+  echo "The PR is correct when: (1) every doneWhen item below is met with RAN evidence (run the commands the issue names; paste outputs); (2) the changed files are within the allowed surface: \`${SURFACE:-<empty>}\` — any file outside it is a P0 (lane boundary violation); (3) \`sh scripts/lint-markdown-content.sh\` exits 0; (4) no GitHub closing keywords (closes/fixes/resolves #N) in the PR body or commits; (5) every sentence added to a document that says 'run X and Y happens' is true on this workstation — for EVERY backticked \`edda <word>\`, \`gh <word>\`, \`git <word>\` invocation added by the diff, run it (or its --help) and report the exit code (zero discretion); (6) claims in the PR body (baseline/after transcripts, grep outputs) reproduce when you run them; (7) every shell script added by the diff passes \`sh -n\`."
+  for i in $ISSUES; do
+    echo
+    echo "### Issue #$i doneWhen"
+    gh issue view "$i" --repo "$REPO" --json body --jq .body 2>/dev/null \
+      | awk '/^## doneWhen/{f=1;next} /^## /{f=0} f' || echo "(issue #$i could not be read)"
+  done
+  echo
+  echo "## Severity"
+  echo "P0 = doneWhen item not met, surface violated, or a false command claim that would mislead; P1 = contradiction with .claude/CLAUDE.md rules or a ledger decision, or overclaim; P2 = drift."
+  echo "## Rules"
+  echo "READ-ONLY: no edits, no pushes, no GitHub posts, no cargo. Budget ~6 minutes."
+  echo
+  echo "## Output — exactly this shape, between the markers"
+  echo "<<<VERDICT"
+  echo "## Code Review: Round $ROUND — PR #$PR @ $SHA ($MODEL_SHORT, read-only)"
+  echo
+  echo "### IN SCOPE"
+  echo "<one line per contract item and per doneWhen item: PASS/FAIL + evidence>"
+  echo "### Findings"
+  echo "<P0/P1/P2 with path:line + RAN/READ, or \"none\">"
+  echo "### FOLLOW-UP ISSUE"
+  echo "<or \"none\">"
+  echo "### RAN vs READ"
+  echo "<commands and key outputs>"
+  echo "### Verdict"
+  echo "LGTM (P0=0, P1=0) — or — Changes Requested, P0=<n>, P1=<n>"
+  echo "VERDICT>>>"
+} > "$BRIEF"
+
+echo "brief=$BRIEF"
+echo "sha=$SHA"
+echo "issues=${ISSUES:-none}"
+echo "surface=${SURFACE:-none}"
+
+if [ "$DRY" = "1" ]; then
+  echo "dry-run: brief generated; nothing launched, no worktree, no scheduled task."
+  exit 0
+fi
+
+if [ -z "$ROOT" ]; then
+  echo "review-pr.sh: cannot locate the main checkout (set EDDA_FLEET_ROOT)" >&2
+  exit 1
+fi
+
+# ---- detached worktree at the PR head ---------------------------------------
+WT="$SCRATCH/wt-review-pr$PR"
+git -C "$ROOT" fetch -q origin "$BR"
+if [ -d "$WT" ]; then
+  git -C "$WT" checkout -q --detach "$SHA"
+else
+  git -C "$ROOT" worktree add --detach "$WT" "$SHA" >/dev/null
+fi
+
+PROMPT="Use your read tool to read $BRIEF and follow it exactly. Work read-only in the current directory (a detached worktree at PR #$PR head). Finish by printing the verdict between the <<<VERDICT and VERDICT>>> markers."
+
+if [ "$IS_WIN" = "1" ]; then
+  # Windows: Task Scheduler, not nohup (fleet.lane-launch). HOME and UTF-8 are
+  # empty/CP950 in the scheduled-task environment and must be set explicitly.
+  command -v pwsh >/dev/null 2>&1 || { echo "review-pr.sh: pwsh not found" >&2; exit 1; }
+  command -v cygpath >/dev/null 2>&1 || { echo "review-pr.sh: cygpath not found" >&2; exit 1; }
+  WTW=$(cygpath -w "$WT")
+  BRIEFW=$(cygpath -w "$BRIEF")
+  LOGW=$(cygpath -w "$SCRATCH\\review-pr$PR-r$ROUND.log")
+  DONEW=$(cygpath -w "$SCRATCH\\review-pr$PR-r$ROUND.done")
+  TASK="edda-review-pr$PR-r$ROUND"
+
+  cat > "$SCRATCH/review-pr$PR-r$ROUND-lane.ps1" <<PS
+[Console]::InputEncoding = [System.Text.UTF8Encoding]::new(\$false)
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(\$false)
+\$OutputEncoding = [System.Text.UTF8Encoding]::new(\$false)
+\$env:HOME = \$env:USERPROFILE
+Set-Location '$WTW'
+\$prompt = "$PROMPT"
+& pi -p --model $MODEL --thinking high --exclude-tools edit,write --session-id $SID \$prompt 2>&1 | Out-File -FilePath "$LOGW" -Encoding utf8
+"PI_EXIT=\$LASTEXITCODE" | Out-File "$DONEW" -Encoding utf8
+PS
+
+  cat > "$SCRATCH/review-pr$PR-r$ROUND-launch.ps1" <<PS
+foreach (\$f in @("$LOGW", "$DONEW")) { if (Test-Path \$f) { [System.IO.File]::Delete(\$f) } }
+Unregister-ScheduledTask -TaskName '$TASK' -Confirm:\$false -ErrorAction SilentlyContinue
+\$action = New-ScheduledTaskAction -Execute "pwsh.exe" -Argument "-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File \`"$SCRATCH\\review-pr$PR-r$ROUND-lane.ps1\`"" -WorkingDirectory '$WTW'
+\$settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Minutes 30) -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
+Register-ScheduledTask -TaskName '$TASK' -Action \$action -Settings \$settings -RunLevel Limited | Out-Null
+Start-ScheduledTask -TaskName '$TASK'
+Start-Sleep -Seconds 6
+"task=$TASK state=\$((Get-ScheduledTask -TaskName '$TASK').State)"
+PS
+
+  pwsh -NoProfile -ExecutionPolicy Bypass -File "$SCRATCH/review-pr$PR-r$ROUND-launch.ps1"
+else
+  # Linux: no job-object trap, plain nohup is enough.
+  RUNNER="$SCRATCH/review-pr$PR-r$ROUND-run.sh"
+  cat > "$RUNNER" <<RUN
+#!/bin/sh
+export HOME="\${HOME:-$(getent passwd "\$(id -u)" 2>/dev/null | cut -d: -f6)}"
+cd '$WT' || exit 1
+pi -p --model '$MODEL' --thinking high --exclude-tools edit,write --session-id '$SID' "$PROMPT" > '$SCRATCH/review-pr$PR-r$ROUND.log' 2>&1
+echo "PI_EXIT=\$?" > '$SCRATCH/review-pr$PR-r$ROUND.done'
+RUN
+  sh -n "$RUNNER" || exit 1
+  chmod +x "$RUNNER"
+  rm -f "$SCRATCH/review-pr$PR-r$ROUND.log" "$SCRATCH/review-pr$PR-r$ROUND.done"
+  nohup "$RUNNER" >/dev/null 2>&1 &
+  echo "task=nohup pid=$! log=$SCRATCH/review-pr$PR-r$ROUND.log"
+fi
+
+echo "log=$SCRATCH/review-pr$PR-r$ROUND.log"
+echo "done=$SCRATCH/review-pr$PR-r$ROUND.done"
+echo "session=$SID"

--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -3,7 +3,8 @@
 # fleet.lane-launch (Task Scheduler, hidden), fleet.review-brief-framing
 # (validation-checklist brief) and fleet.agent-model-split (review model is fixed).
 #
-# usage: review-pr.sh <PR> [round] [prev-sha] [--dry-run]
+# usage: review-pr.sh <PR> [round] [prev-sha] [--sha <full-sha>] [--dry-run]
+#        review-pr.sh verdict-label < verdict-text        (offline helper)
 #
 # Environment:
 #   EDDA_REPO              owner/repo              (default fagemx/edda)
@@ -35,22 +36,44 @@ PR=""
 ROUND=1
 PREV=""
 DRY=0
-for a in "$@"; do
-  case "$a" in
+SHA_GIVEN=""
+
+# Offline helper: map verdict text (stdin) to a review:* label; the LAST
+# verdict keyword in the text wins. No network, no state.
+if [ "${1:-}" = "verdict-label" ]; then
+  v=$(cat)
+  lcs=$(printf '%s\n' "$v" | grep -bo "Changes Requested" | tail -1 | cut -d: -f1)
+  llg=$(printf '%s\n' "$v" | grep -bo "LGTM" | tail -1 | cut -d: -f1)
+  if [ -n "$lcs" ] && [ -n "$llg" ] && [ "$llg" -gt "$lcs" ]; then echo "review:lgtm"
+  elif [ -n "$lcs" ]; then echo "review:changes-requested"
+  elif [ -n "$llg" ]; then echo "review:lgtm"
+  fi
+  exit 0
+fi
+
+while [ $# -gt 0 ]; do
+  case "$1" in
     --dry-run) DRY=1 ;;
+    --sha) SHA_GIVEN=${2:-}; shift ;;
     -h|--help) usage; exit 0 ;;
     *)
-      if [ -z "$PR" ]; then PR=$a
-      elif [ "$ROUND" = "1" ] && [ -z "${ROUND_SET:-}" ]; then ROUND=$a; ROUND_SET=1
-      elif [ -z "$PREV" ]; then PREV=$a
-      else echo "review-pr.sh: unexpected argument '$a'" >&2; usage; exit 1; fi
+      if [ -z "$PR" ]; then PR=$1
+      elif [ "$ROUND" = "1" ] && [ -z "${ROUND_SET:-}" ]; then ROUND=$1; ROUND_SET=1
+      elif [ -z "$PREV" ]; then PREV=$1
+      else echo "review-pr.sh: unexpected argument '$1'" >&2; usage; exit 1; fi
       ;;
   esac
+  shift
 done
 if [ -z "$PR" ]; then usage; exit 1; fi
 case "$PR$ROUND" in
   *[!0-9]*) echo "review-pr.sh: PR and round must be numeric" >&2; exit 1 ;;
 esac
+if [ -n "$SHA_GIVEN" ]; then
+  printf '%s\n' "$SHA_GIVEN" | grep -qE '^[0-9a-f]{40}$' || {
+    echo "review-pr.sh: --sha must be a full 40-hex SHA" >&2; exit 1;
+  }
+fi
 
 # ---- platform ---------------------------------------------------------------
 IS_WIN=0
@@ -66,9 +89,20 @@ if [ -z "$ROOT" ]; then
 fi
 
 # ---- PR facts ---------------------------------------------------------------
-gh_ok() { gh "$@" >/dev/null 2>&1; }
-SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid) ||
-  { echo "review-pr.sh: cannot read PR #$PR (repo $REPO)" >&2; exit 1; }
+# The reviewed SHA is pinned by the caller (--sha from the watcher's scan); a
+# second head read is used ONLY to refuse a stale pin (head moved), never to
+# pick what gets reviewed.
+if [ -n "$SHA_GIVEN" ]; then
+  SHA=$SHA_GIVEN
+  CUR=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid 2>/dev/null) || CUR=""
+  if [ "$CUR" != "$SHA" ]; then
+    echo "review-pr.sh: head moved — refusing to review pinned $SHA; PR head is ${CUR:-unknown}" >&2
+    exit 3
+  fi
+else
+  SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid) ||
+    { echo "review-pr.sh: cannot read PR #$PR (repo $REPO)" >&2; exit 1; }
+fi
 BR=$(gh pr view "$PR" --repo "$REPO" --json headRefName --jq .headRefName)
 TITLE=$(gh pr view "$PR" --repo "$REPO" --json title --jq .title)
 BODY=$(gh pr view "$PR" --repo "$REPO" --json body --jq .body)
@@ -178,11 +212,22 @@ Unregister-ScheduledTask -TaskName '$TASK' -Confirm:\$false -ErrorAction Silentl
 \$settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Minutes 30) -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
 Register-ScheduledTask -TaskName '$TASK' -Action \$action -Settings \$settings -RunLevel Limited | Out-Null
 Start-ScheduledTask -TaskName '$TASK'
-Start-Sleep -Seconds 6
-"task=$TASK state=\$((Get-ScheduledTask -TaskName '$TASK').State)"
+\$st = ""
+for (\$i = 0; \$i -lt 20; \$i++) {
+  Start-Sleep -Seconds 1
+  \$st = (Get-ScheduledTask -TaskName '$TASK').State
+  if (\$st -eq 'Running') { break }
+}
+"task=$TASK state=\$st"
 PS
 
-  pwsh -NoProfile -ExecutionPolicy Bypass -File "$SCRATCH/review-pr$PR-r$ROUND-launch.ps1"
+  out=$(pwsh -NoProfile -ExecutionPolicy Bypass -File "$SCRATCH/review-pr$PR-r$ROUND-launch.ps1" 2>&1); rc=$?
+  echo "$out"
+  [ $rc -eq 0 ] || exit 1
+  case "$out" in
+    *state=Running*) : ;;
+    *) echo "review-pr.sh: scheduled task did not reach Running" >&2; exit 1 ;;
+  esac
 else
   # Linux: no job-object trap, plain nohup is enough.
   RUNNER="$SCRATCH/review-pr$PR-r$ROUND-run.sh"
@@ -197,7 +242,14 @@ RUN
   chmod +x "$RUNNER"
   rm -f "$SCRATCH/review-pr$PR-r$ROUND.log" "$SCRATCH/review-pr$PR-r$ROUND.done"
   nohup "$RUNNER" >/dev/null 2>&1 &
-  echo "task=nohup pid=$! log=$SCRATCH/review-pr$PR-r$ROUND.log"
+  pid=$!
+  sleep 1
+  if kill -0 "$pid" 2>/dev/null; then
+    echo "task=nohup pid=$pid state=Running"
+  else
+    echo "review-pr.sh: nohup process $pid died immediately" >&2
+    exit 1
+  fi
 fi
 
 echo "log=$SCRATCH/review-pr$PR-r$ROUND.log"

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -1,15 +1,113 @@
 #!/bin/sh
 # Offline fixtures for the pr-review watcher (ported from PR #639, extended in
-# Round 2): review-or-skip decisions from `gh pr list --jq @tsv` rows, verdict
-# text -> review:* label mapping, unreviewed-is-per-head semantics, verdict
-# label only on the reviewed head, and ack retry with a stubbed gh.
+# Rounds 2–3): review-or-skip decisions from `gh pr list --jq @tsv` rows,
+# verdict text -> review:* label mapping, per-head review:unreviewed semantics,
+# verdict label only on the reviewed head, retried acknowledgement with a
+# stubbed gh (including its terminal failure path), and the provider probe
+# before the single pi retry.
+#
+# Everything is offline: EDDA_FLEET_SCRATCH, PR_REVIEW_WATCH_LOG and all state
+# files are redirected into a temp dir, and `gh`/`pi`/review-pr are stubs —
+# the real ~/.edda/fleet/watch.log must be byte-for-byte unchanged across a
+# full run (guarded below).
 # Style follows scripts/test-lint-markdown-content.sh — no new tooling.
 set -eu
 
 root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' 0 HUP INT TERM
+
+REAL_WATCHLOG="$HOME/.edda/fleet/watch.log"
+size_before=0
+[ -f "$REAL_WATCHLOG" ] && size_before=$(stat -c %s "$REAL_WATCHLOG")
+
 case_number=0
+
+# --- offline guarantees -------------------------------------------------------
+export EDDA_FLEET_SCRATCH="$tmp/scratch"
+export PR_REVIEW_WATCH_LOG="$tmp/watch.log"
+mkdir -p "$EDDA_FLEET_SCRATCH"
+
+# --- stubs: gh, pi, review-pr -------------------------------------------------
+STUBBIN="$tmp/bin"
+mkdir -p "$STUBBIN"
+cat >"$STUBBIN/gh" <<'EOF'
+#!/bin/sh
+echo "gh $*" >>"$GH_STUB_LOG"
+case "$1" in
+  pr)
+    case "$2" in
+      list)
+        [ -n "${GH_PR_LIST_FILE:-}" ] && cat "$GH_PR_LIST_FILE"
+        exit 0
+        ;;
+      comment)
+        if [ -n "${GH_FAIL_COMMENT_FIRST:-}" ] && [ -f "$GH_FAIL_COMMENT_FIRST" ]; then
+            rm -f "$GH_FAIL_COMMENT_FIRST"
+            exit 1
+        fi
+        [ -n "${GH_FAIL_COMMENT_ALWAYS:-}" ] && exit 1
+        exit 0
+        ;;
+      edit)
+        [ -n "${GH_FAIL_EDIT:-}" ] && exit 1
+        exit 0
+        ;;
+      view)
+        case "$*" in
+          *headRefOid*)
+            [ -n "${GH_FAIL_HEAD:-}" ] && exit 1
+            if [ -n "${GH_HEAD_FILE:-}" ]; then cat "$GH_HEAD_FILE"; else echo "${GH_HEAD:-}"; fi
+            exit 0
+            ;;
+          *state*)
+            echo "OPEN"
+            exit 0
+            ;;
+        esac
+        exit 0
+        ;;
+    esac
+    exit 0
+    ;;
+  label) exit 0 ;;
+esac
+exit 0
+EOF
+cat >"$STUBBIN/pi" <<'EOF'
+#!/bin/sh
+echo "pi $*" >>"$PI_STUB_LOG"
+case "$*" in
+  *--thinking\ minimal*)
+    [ -n "${PI_FAIL_PROBE:-}" ] && exit 1
+    exit 0
+    ;;
+esac
+exit 0
+EOF
+cat >"$STUBBIN/review-pr-stub" <<'EOF'
+#!/bin/sh
+echo "REVIEW_LAUNCH $*" >>"$REVIEW_STUB_LOG"
+exit 0
+EOF
+chmod +x "$STUBBIN/gh" "$STUBBIN/pi" "$STUBBIN/review-pr-stub"
+
+export GH_STUB_LOG="$tmp/gh-stub.log"
+export PI_STUB_LOG="$tmp/pi-stub.log"
+export REVIEW_STUB_LOG="$tmp/review-stub.log"
+: >"$GH_STUB_LOG"; : >"$PI_STUB_LOG"; : >"$REVIEW_STUB_LOG"
+export PATH="$STUBBIN:$PATH"
+
+reset_stubs() {
+    : >"$GH_STUB_LOG"; : >"$PI_STUB_LOG"; : >"$REVIEW_STUB_LOG"
+    unset GH_FAIL_COMMENT_FIRST GH_FAIL_COMMENT_ALWAYS GH_FAIL_EDIT GH_FAIL_HEAD \
+          GH_PR_LIST_FILE GH_HEAD GH_HEAD_FILE PI_FAIL_PROBE 2>/dev/null || true
+    rm -f "$EDDA_FLEET_SCRATCH"/review-* 2>/dev/null || true
+    : >"$EDDA_FLEET_SCRATCH/review-state.tsv"
+    : >"$EDDA_FLEET_SCRATCH/review-acks.tsv"
+    : >"$EDDA_FLEET_SCRATCH/review-pending.tsv"
+    : >"$EDDA_FLEET_SCRATCH/review-fails.tsv"
+}
 
 # --- decide: PR queue triage from `gh pr list --jq @tsv` rows -----------------
 # Each input line: number<TAB>headRefOid<TAB>labels(joined by ",")<TAB>updatedAt
@@ -22,7 +120,7 @@ expect_decide() {
     state="$tmp/state-$case_number"
     printf '%b' "$state_lines" >"$state"
     if ! actual=$(printf '%b' "$rows" | \
-        PR_REVIEW_WATCH_STATE="$state" sh "$root/scripts/pr-review-watch.sh" decide); then
+        PR_REVIEW_WATCH_STATE="$state" timeout 60 sh "$root/scripts/pr-review-watch.sh" decide); then
         printf '%s: decide exited non-zero\n' "$name" >&2
         return 1
     fi
@@ -39,7 +137,7 @@ expect_label() {
     expected=$2
     body=$3
     case_number=$((case_number + 1))
-    if ! actual=$(printf '%b' "$body" | sh "$root/scripts/review-pr.sh" verdict-label); then
+    if ! actual=$(printf '%b' "$body" | timeout 60 sh "$root/scripts/review-pr.sh" verdict-label); then
         printf '%s: verdict-label exited non-zero\n' "$name" >&2
         return 1
     fi
@@ -57,7 +155,7 @@ expect_label_verdict() {
     reviewed=$3
     current=$4
     case_number=$((case_number + 1))
-    if ! actual=$(sh "$root/scripts/pr-review-watch.sh" label-verdict "$reviewed" "$current"); then
+    if ! actual=$(timeout 60 sh "$root/scripts/pr-review-watch.sh" label-verdict </dev/null "$reviewed" "$current"); then
         printf '%s: label-verdict exited non-zero\n' "$name" >&2
         return 1
     fi
@@ -69,36 +167,6 @@ expect_label_verdict() {
 
 # --- ack: retried acknowledgement with a stubbed gh ---------------------------
 
-# stub gh: `pr comment` fails once (GH_FAIL_FIRST marker) or always
-# (GH_FAIL_ALWAYS), everything else succeeds; every call is logged.
-STUBBIN="$tmp/bin"
-mkdir -p "$STUBBIN"
-cat >"$STUBBIN/gh" <<'EOF'
-#!/bin/sh
-echo "gh $*" >>"$GH_STUB_LOG"
-if [ "$1 $2" = "pr comment" ]; then
-    if [ -n "${GH_FAIL_FIRST:-}" ] && [ -f "$GH_FAIL_FIRST" ]; then
-        rm -f "$GH_FAIL_FIRST"
-        exit 1
-    fi
-    if [ -n "${GH_FAIL_ALWAYS:-}" ]; then
-        exit 1
-    fi
-    exit 0
-fi
-exit 0
-EOF
-chmod +x "$STUBBIN/gh"
-
-export GH_STUB_LOG="$tmp/gh-stub.log"
-: >"$GH_STUB_LOG"
-export PATH="$STUBBIN:$PATH"
-export PR_REVIEW_WATCH_ACKS="$tmp/acks.tsv"
-
-# first `pr comment` call fails, subsequent ones succeed
-touch "$tmp/fail-first"
-export GH_FAIL_FIRST="$tmp/fail-first"
-
 expect_ack() {
     name=$1
     expected_rc=$2
@@ -107,7 +175,7 @@ expect_ack() {
     attempts=$5
     case_number=$((case_number + 1))
     rc=0
-    sh "$root/scripts/pr-review-watch.sh" ack-try "$pr" "$sha" "$attempts" || rc=$?
+    timeout 60 sh "$root/scripts/pr-review-watch.sh" ack-try "$pr" "$sha" "$attempts" </dev/null || rc=$?
     if [ "$rc" != "$expected_rc" ]; then
         printf '%s: expected rc %s, got %s\n' "$name" "$expected_rc" "$rc" >&2
         return 1
@@ -115,8 +183,23 @@ expect_ack() {
 }
 
 ack_state() {
-    cat "$PR_REVIEW_WATCH_ACKS" 2>/dev/null || true
+    cat "$EDDA_FLEET_SCRATCH/review-acks.tsv" 2>/dev/null || true
 }
+
+# --- live loop: run one watcher cycle against the stubs -----------------------
+
+run_watch_once() {
+    PR_REVIEW_WATCH_REVIEW_PR="$STUBBIN/review-pr-stub" \
+        timeout 120 sh "$root/scripts/pr-review-watch.sh" --once </dev/null
+}
+
+pending_set() { # pr round sha attempts postfails
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$(date +%s)" "$5" \
+        >"$EDDA_FLEET_SCRATCH/review-pending.tsv"
+}
+
+pending_get() { cat "$EDDA_FLEET_SCRATCH/review-pending.tsv" 2>/dev/null || true; }
+state_get()   { cat "$EDDA_FLEET_SCRATCH/review-state.tsv" 2>/dev/null || true; }
 
 # --- decide -------------------------------------------------------------------
 
@@ -227,8 +310,12 @@ expect_label_verdict \
 
 # --- ack retry ----------------------------------------------------------------
 
+# first `pr comment` call fails, subsequent ones succeed
+touch "$tmp/fail-first"
+export GH_FAIL_COMMENT_FIRST="$tmp/fail-first"
+
 expect_ack 'ack failure (attempt 0) is reported, not acked' 1 42 abc123 0
-if [ "$(ack_state)" != "$(printf '42\tabc123\t1')" ]; then
+if [ "$(ack_state)" != "$(printf '42\tabc123\t1\t')" ]; then
     printf 'ack: state after failed attempt should record "launched, ack pending", got:\n%s\n' \
         "$(ack_state)" >&2
     exit 1
@@ -243,17 +330,127 @@ if [ -n "$(ack_state)" ]; then
     printf 'ack: state should be empty after a successful ack, got:\n%s\n' "$(ack_state)" >&2
     exit 1
 fi
+unset GH_FAIL_COMMENT_FIRST
 
-export GH_FAIL_ALWAYS=1
-expect_ack 'ack exhausted after the bound is labeled review:post-failed' 2 42 def456 2
-if [ -n "$(ack_state)" ]; then
-    printf 'ack: exhausted entry should be dropped from the acks file, got:\n%s\n' "$(ack_state)" >&2
+# terminal ack failure: comment fails after the bound AND the label call fails
+export GH_FAIL_COMMENT_ALWAYS=1
+export GH_FAIL_EDIT=1
+expect_ack 'ack exhausted with a failing label call keeps its durable record' 2 42 def456 2
+if [ "$(ack_state)" != "$(printf '42\tdef456\t3\t')" ]; then
+    printf 'ack: terminal attempt with failing label must KEEP the unmarked entry, got:\n%s\n' "$(ack_state)" >&2
     exit 1
 fi
-if ! grep -q 'review:post-failed' "$GH_STUB_LOG"; then
-    printf 'ack: exhausted ack should label review:post-failed\n' >&2
+if ! grep -q 'review:post-failed label failed' "$PR_REVIEW_WATCH_LOG"; then
+    printf 'ack: terminal attempt with failing label must log the failure\n' >&2
     exit 1
 fi
-unset GH_FAIL_ALWAYS
+
+# gh recovers: the next poll applies the label and marks the entry post-failed
+unset GH_FAIL_EDIT
+expect_ack 'ack terminal attempt applies review:post-failed and marks the entry' 2 42 def456 3
+if [ "$(ack_state)" != "$(printf '42\tdef456\t4\tpost-failed')" ]; then
+    printf 'ack: applied terminal state should mark the entry post-failed, got:\n%s\n' "$(ack_state)" >&2
+    exit 1
+fi
+unset GH_FAIL_COMMENT_ALWAYS
+
+# --- live loop: unknown head stays pending (P0) --------------------------------
+
+reset_stubs
+sha=d29dc8f5861322ed664e39900273b0681396da50
+pending_set 42 1 "$sha" 0 0
+printf '## Code Review: Round 1 — PR #42 @ %s (gpt-5.6-sol, read-only)\n\n### Verdict\nLGTM (P0=0, P1=0)\n' "$sha" \
+    >"$EDDA_FLEET_SCRATCH/review-pr42-r1-verdict.md.posted"
+export GH_FAIL_HEAD=1
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (unknown head)\n' >&2; exit 1; }
+if [ -z "$(pending_get)" ]; then
+    printf 'live: unknown head must KEEP the pending entry for retry, got empty\n' >&2
+    exit 1
+fi
+if [ -n "$(state_get)" ]; then
+    printf 'live: unknown head must NOT record the head as reviewed, got:\n%s\n' "$(state_get)" >&2
+    exit 1
+fi
+if grep -qF -- '--add-label review:lgtm' "$GH_STUB_LOG"; then
+    printf 'live: unknown head must not apply the verdict label\n' >&2
+    exit 1
+fi
+if ! grep -q 'head unknown, retry' "$PR_REVIEW_WATCH_LOG"; then
+    printf 'live: unknown head must log "head unknown, retry"\n' >&2
+    exit 1
+fi
+
+# gh recovers and the head still matches: label applied, state recorded
+unset GH_FAIL_HEAD
+export GH_HEAD="$sha"
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (head recovered)\n' >&2; exit 1; }
+if [ "$(state_get)" != "$(printf '42\t%s\t1' "$sha")" ]; then
+    printf 'live: head recovered should record reviewed, got:\n%s\n' "$(state_get)" >&2
+    exit 1
+fi
+if ! grep -qF -- '--add-label review:lgtm' "$GH_STUB_LOG"; then
+    printf 'live: head recovered should apply the verdict label\n' >&2
+    exit 1
+fi
+
+# --- live loop: provider probe before the single pi retry (P1) -----------------
+
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+printf 'PI_EXIT=0\n' >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
+printf 'Codex error: our servers are currently overloaded, please try again later.\n' \
+    >"$EDDA_FLEET_SCRATCH/review-pr42-r1.log"
+
+export PI_FAIL_PROBE=1
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (probe fails)\n' >&2; exit 1; }
+if [ -n "$(pending_get)" ]; then
+    printf 'live: failed probe should stop for that head (pending dropped), got:\n%s\n' "$(pending_get)" >&2
+    exit 1
+fi
+if [ "$(state_get)" != "$(printf '42\t%s\t1' "$sha")" ]; then
+    printf 'live: failed probe should record review:unreviewed state, got:\n%s\n' "$(state_get)" >&2
+    exit 1
+fi
+if [ -n "$(cat "$REVIEW_STUB_LOG")" ]; then
+    printf 'live: failed probe must NOT launch a second review, got:\n%s\n' "$(cat "$REVIEW_STUB_LOG")" >&2
+    exit 1
+fi
+if ! grep -qF -- '--add-label review:unreviewed' "$GH_STUB_LOG"; then
+    printf 'live: failed probe should label review:unreviewed\n' >&2
+    exit 1
+fi
+unset PI_FAIL_PROBE
+
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+printf 'PI_EXIT=0\n' >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
+printf 'Codex error: our servers are currently overloaded, please try again later.\n' \
+    >"$EDDA_FLEET_SCRATCH/review-pr42-r1.log"
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (probe OK)\n' >&2; exit 1; }
+if [ "$(grep -c 'thinking minimal' "$PI_STUB_LOG")" -lt 1 ]; then
+    printf 'live: the --thinking minimal probe must run before the retry\n' >&2
+    exit 1
+fi
+if [ "$(grep -c '^REVIEW_LAUNCH' "$REVIEW_STUB_LOG")" != "1" ]; then
+    printf 'live: a passing probe must lead to exactly one pi retry, got:\n%s\n' "$(cat "$REVIEW_STUB_LOG")" >&2
+    exit 1
+fi
+if [ -z "$(pending_get)" ]; then
+    printf 'live: after a launched retry the pending entry should remain (attempts=1), got empty\n' >&2
+    exit 1
+fi
+if [ "$(printf '%s' "$(pending_get)" | cut -f4)" != "1" ]; then
+    printf 'live: pending attempts should be 1 after the retry, got:\n%s\n' "$(pending_get)" >&2
+    exit 1
+fi
+
+# --- offline guarantee: the real watcher log was never touched -----------------
+size_after=0
+[ -f "$REAL_WATCHLOG" ] && size_after=$(stat -c %s "$REAL_WATCHLOG")
+if [ "$size_before" != "$size_after" ]; then
+    printf 'offline guarantee violated: %s grew from %s to %s bytes\n' \
+        "$REAL_WATCHLOG" "$size_before" "$size_after" >&2
+    exit 1
+fi
 
 printf 'pr-review-watch fixtures passed\n'

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' 0 HUP INT TERM
+case_number=0
+
+expect_decide() {
+    name=$1
+    expected=$2
+    state_lines=$3
+    json=$4
+    case_number=$((case_number + 1))
+    state="$tmp/state-$case_number"
+    printf '%b' "$state_lines" >"$state"
+    if ! actual=$(printf '%s' "$json" | \
+        PR_REVIEW_WATCH_STATE="$state" sh "$root/scripts/pr-review-watch.sh" decide); then
+        printf '%s: decide exited non-zero\n' "$name" >&2
+        return 1
+    fi
+    if [ "$actual" != "$expected" ]; then
+        printf '%s: expected\n  %s\ngot\n  %s\n' "$name" "$expected" "$actual" >&2
+        return 1
+    fi
+}
+
+expect_label() {
+    name=$1
+    expected=$2
+    body=$3
+    case_number=$((case_number + 1))
+    if ! actual=$(printf '%b' "$body" | sh "$root/scripts/review-pr.sh" verdict-label); then
+        printf '%s: verdict-label exited non-zero\n' "$name" >&2
+        return 1
+    fi
+    if [ "$actual" != "$expected" ]; then
+        printf '%s: expected label %s, got %s\n' "$name" "$expected" "$actual" >&2
+        return 1
+    fi
+}
+
+# --- decide: PR queue triage from gh pr list JSON ---------------------------
+
+expect_decide \
+    'new PR is queued for review' \
+    'REVIEW 42 abc123' \
+    '' \
+    '[{"number":42,"headRefOid":"abc123","isDraft":false,"labels":[]}]'
+
+expect_decide \
+    'same SHA already reviewed is skipped' \
+    'SKIP 42 already-reviewed' \
+    '42\tabc123\n' \
+    '[{"number":42,"headRefOid":"abc123","isDraft":false,"labels":[]}]'
+
+expect_decide \
+    'new head SHA after push is reviewed again' \
+    'REVIEW 42 def456' \
+    '42\tabc123\n' \
+    '[{"number":42,"headRefOid":"def456","isDraft":false,"labels":[]}]'
+
+expect_decide \
+    'draft PR is skipped' \
+    'SKIP 42 draft' \
+    '' \
+    '[{"number":42,"headRefOid":"abc123","isDraft":true,"labels":[]}]'
+
+expect_decide \
+    'review:unreviewed label stops the watcher for that PR' \
+    'SKIP 42 review-unreviewed' \
+    '' \
+    '[{"number":42,"headRefOid":"abc123","isDraft":false,"labels":[{"name":"review:unreviewed"}]}]'
+
+expect_decide \
+    'empty open-PR queue decides nothing' \
+    '' \
+    '' \
+    '[]'
+
+expect_decide \
+    'missing head SHA is skipped, not queued' \
+    'SKIP 42 missing-head' \
+    '' \
+    '[{"number":42,"isDraft":false,"labels":[]}]'
+
+expect_decide \
+    'decisions are independent per PR' \
+    'SKIP 7 already-reviewed
+REVIEW 8 beefff
+SKIP 9 draft' \
+    '7\tcccccc\n' \
+    '[{"number":7,"headRefOid":"cccccc","isDraft":false,"labels":[]},{"number":8,"headRefOid":"beefff","isDraft":false,"labels":[]},{"number":9,"headRefOid":"dddddd","isDraft":true,"labels":[]}]'
+
+# --- verdict-label: verdict text to review label -----------------------------
+
+expect_label \
+    'Changes Requested verdict maps to review:changes-requested' \
+    'review:changes-requested' \
+    '## Code Review: Round 1\n\nblocking P1: scripts/x.sh:12 — input Y crashes.\n\n結論：Changes Requested\n'
+
+expect_label \
+    'LGTM verdict maps to review:lgtm' \
+    'review:lgtm' \
+    '## Code Review: Round 1\n\nP0=0, P1=0.\n\n結論：LGTM\n'
+
+expect_label \
+    'when both verdicts appear, the last one wins' \
+    'review:lgtm' \
+    'Round 1 結論：Changes Requested\n\nRound 2（fix 後）：P0=0, P1=0。結論：LGTM\n'
+
+expect_label \
+    'no verdict keyword maps to no label' \
+    '' \
+    '## Code Review: Round 1\n\n審查中斷，無結論。\n'
+
+printf 'pr-review-watch fixtures passed\n'

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -431,6 +431,10 @@ if [ "$(grep -c 'thinking minimal' "$PI_STUB_LOG")" -lt 1 ]; then
     printf 'live: the --thinking minimal probe must run before the retry\n' >&2
     exit 1
 fi
+if ! grep -q 'thinking minimal.*--exclude-tools edit,write' "$PI_STUB_LOG"; then
+    printf 'live: the provider probe must be read-only (--exclude-tools edit,write)\n' >&2
+    exit 1
+fi
 if [ "$(grep -c '^REVIEW_LAUNCH' "$REVIEW_STUB_LOG")" != "1" ]; then
     printf 'live: a passing probe must lead to exactly one pi retry, got:\n%s\n' "$(cat "$REVIEW_STUB_LOG")" >&2
     exit 1

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+# Offline fixtures for the pr-review watcher (ported from PR #639, extended in
+# Round 2): review-or-skip decisions from `gh pr list --jq @tsv` rows, verdict
+# text -> review:* label mapping, unreviewed-is-per-head semantics, verdict
+# label only on the reviewed head, and ack retry with a stubbed gh.
+# Style follows scripts/test-lint-markdown-content.sh — no new tooling.
 set -eu
 
 root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
@@ -6,15 +11,17 @@ tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' 0 HUP INT TERM
 case_number=0
 
+# --- decide: PR queue triage from `gh pr list --jq @tsv` rows -----------------
+# Each input line: number<TAB>headRefOid<TAB>labels(joined by ",")<TAB>updatedAt
 expect_decide() {
     name=$1
     expected=$2
     state_lines=$3
-    json=$4
+    rows=$4
     case_number=$((case_number + 1))
     state="$tmp/state-$case_number"
     printf '%b' "$state_lines" >"$state"
-    if ! actual=$(printf '%s' "$json" | \
+    if ! actual=$(printf '%b' "$rows" | \
         PR_REVIEW_WATCH_STATE="$state" sh "$root/scripts/pr-review-watch.sh" decide); then
         printf '%s: decide exited non-zero\n' "$name" >&2
         return 1
@@ -24,6 +31,8 @@ expect_decide() {
         return 1
     fi
 }
+
+# --- verdict-label: verdict text to review label ------------------------------
 
 expect_label() {
     name=$1
@@ -40,59 +49,141 @@ expect_label() {
     fi
 }
 
-# --- decide: PR queue triage from gh pr list JSON ---------------------------
+# --- label-verdict: apply the verdict label only on the reviewed head ---------
+
+expect_label_verdict() {
+    name=$1
+    expected=$2
+    reviewed=$3
+    current=$4
+    case_number=$((case_number + 1))
+    if ! actual=$(sh "$root/scripts/pr-review-watch.sh" label-verdict "$reviewed" "$current"); then
+        printf '%s: label-verdict exited non-zero\n' "$name" >&2
+        return 1
+    fi
+    if [ "$actual" != "$expected" ]; then
+        printf '%s: expected %s, got %s\n' "$name" "$expected" "$actual" >&2
+        return 1
+    fi
+}
+
+# --- ack: retried acknowledgement with a stubbed gh ---------------------------
+
+# stub gh: `pr comment` fails once (GH_FAIL_FIRST marker) or always
+# (GH_FAIL_ALWAYS), everything else succeeds; every call is logged.
+STUBBIN="$tmp/bin"
+mkdir -p "$STUBBIN"
+cat >"$STUBBIN/gh" <<'EOF'
+#!/bin/sh
+echo "gh $*" >>"$GH_STUB_LOG"
+if [ "$1 $2" = "pr comment" ]; then
+    if [ -n "${GH_FAIL_FIRST:-}" ] && [ -f "$GH_FAIL_FIRST" ]; then
+        rm -f "$GH_FAIL_FIRST"
+        exit 1
+    fi
+    if [ -n "${GH_FAIL_ALWAYS:-}" ]; then
+        exit 1
+    fi
+    exit 0
+fi
+exit 0
+EOF
+chmod +x "$STUBBIN/gh"
+
+export GH_STUB_LOG="$tmp/gh-stub.log"
+: >"$GH_STUB_LOG"
+export PATH="$STUBBIN:$PATH"
+export PR_REVIEW_WATCH_ACKS="$tmp/acks.tsv"
+
+# first `pr comment` call fails, subsequent ones succeed
+touch "$tmp/fail-first"
+export GH_FAIL_FIRST="$tmp/fail-first"
+
+expect_ack() {
+    name=$1
+    expected_rc=$2
+    pr=$3
+    sha=$4
+    attempts=$5
+    case_number=$((case_number + 1))
+    rc=0
+    sh "$root/scripts/pr-review-watch.sh" ack-try "$pr" "$sha" "$attempts" || rc=$?
+    if [ "$rc" != "$expected_rc" ]; then
+        printf '%s: expected rc %s, got %s\n' "$name" "$expected_rc" "$rc" >&2
+        return 1
+    fi
+}
+
+ack_state() {
+    cat "$PR_REVIEW_WATCH_ACKS" 2>/dev/null || true
+}
+
+# --- decide -------------------------------------------------------------------
 
 expect_decide \
     'new PR is queued for review' \
     'REVIEW 42 abc123' \
     '' \
-    '[{"number":42,"headRefOid":"abc123","isDraft":false,"labels":[]}]'
+    '42\tabc123\t\t2026-09-02T00:00:00Z'
 
 expect_decide \
     'same SHA already reviewed is skipped' \
     'SKIP 42 already-reviewed' \
     '42\tabc123\n' \
-    '[{"number":42,"headRefOid":"abc123","isDraft":false,"labels":[]}]'
+    '42\tabc123\t\t2026-09-02T00:00:00Z'
 
 expect_decide \
     'new head SHA after push is reviewed again' \
     'REVIEW 42 def456' \
     '42\tabc123\n' \
-    '[{"number":42,"headRefOid":"def456","isDraft":false,"labels":[]}]'
+    '42\tdef456\t\t2026-09-02T00:00:00Z'
 
 expect_decide \
-    'draft PR is skipped' \
-    'SKIP 42 draft' \
+    'labels are scoped per PR: unlabeled PR 1 is REVIEW while PR 2 has review:unreviewed' \
+    'REVIEW 1 aaa111
+SKIP 2 review-unreviewed' \
     '' \
-    '[{"number":42,"headRefOid":"abc123","isDraft":true,"labels":[]}]'
+    '1\taaa111\t\t2026-09-02T00:00:00Z\n2\tbbb222\treview:unreviewed\t2026-09-02T00:00:00Z'
 
 expect_decide \
-    'review:unreviewed label stops the watcher for that PR' \
+    'review:unreviewed blocks the head it was recorded for' \
+    'SKIP 42 review-unreviewed' \
+    '42\tabc123\t2\n' \
+    '42\tabc123\treview:unreviewed\t2026-09-02T00:00:00Z'
+
+expect_decide \
+    'a new head after review:unreviewed is reviewed again and drops the stale label' \
+    'REVIEW 42 def456 drop-unreviewed-label' \
+    '42\tabc123\t2\n' \
+    '42\tdef456\treview:unreviewed\t2026-09-02T00:00:00Z'
+
+expect_decide \
+    'review:unreviewed with no recorded head still blocks' \
     'SKIP 42 review-unreviewed' \
     '' \
-    '[{"number":42,"headRefOid":"abc123","isDraft":false,"labels":[{"name":"review:unreviewed"}]}]'
+    '42\tabc123\treview:unreviewed\t2026-09-02T00:00:00Z'
 
 expect_decide \
     'empty open-PR queue decides nothing' \
     '' \
     '' \
-    '[]'
+    ''
 
 expect_decide \
     'missing head SHA is skipped, not queued' \
     'SKIP 42 missing-head' \
     '' \
-    '[{"number":42,"isDraft":false,"labels":[]}]'
+    '42\t\t\t2026-09-02T00:00:00Z'
 
 expect_decide \
     'decisions are independent per PR' \
     'SKIP 7 already-reviewed
 REVIEW 8 beefff
-SKIP 9 draft' \
+SKIP 9 review-unreviewed' \
     '7\tcccccc\n' \
-    '[{"number":7,"headRefOid":"cccccc","isDraft":false,"labels":[]},{"number":8,"headRefOid":"beefff","isDraft":false,"labels":[]},{"number":9,"headRefOid":"dddddd","isDraft":true,"labels":[]}]'
+    '7\tcccccc\t\t2026-09-02T00:00:00Z\n8\tbeefff\t\t2026-09-02T00:00:00Z\n9\tdddddd\treview:unreviewed\t2026-09-02T00:00:00Z'
 
-# --- verdict-label: verdict text to review label -----------------------------
+# --- verdict-label ------------------------------------------------------------
 
 expect_label \
     'Changes Requested verdict maps to review:changes-requested' \
@@ -113,5 +204,56 @@ expect_label \
     'no verdict keyword maps to no label' \
     '' \
     '## Code Review: Round 1\n\n審查中斷，無結論。\n'
+
+# --- label-verdict ------------------------------------------------------------
+
+expect_label_verdict \
+    'verdict label applies when current head equals the reviewed SHA' \
+    'apply' \
+    'aaa111' \
+    'aaa111'
+
+expect_label_verdict \
+    'verdict label is skipped when the head has moved' \
+    'skip' \
+    'aaa111' \
+    'bbb222'
+
+expect_label_verdict \
+    'verdict label is skipped when the current head is unknown' \
+    'skip' \
+    'aaa111' \
+    ''
+
+# --- ack retry ----------------------------------------------------------------
+
+expect_ack 'ack failure (attempt 0) is reported, not acked' 1 42 abc123 0
+if [ "$(ack_state)" != "$(printf '42\tabc123\t1')" ]; then
+    printf 'ack: state after failed attempt should record "launched, ack pending", got:\n%s\n' \
+        "$(ack_state)" >&2
+    exit 1
+fi
+if ! grep -q 'gh pr comment 42' "$GH_STUB_LOG"; then
+    printf 'ack: stub log should contain the ack comment call\n' >&2
+    exit 1
+fi
+
+expect_ack 'ack succeeds on the next poll and the pending entry is cleared' 0 42 abc123 1
+if [ -n "$(ack_state)" ]; then
+    printf 'ack: state should be empty after a successful ack, got:\n%s\n' "$(ack_state)" >&2
+    exit 1
+fi
+
+export GH_FAIL_ALWAYS=1
+expect_ack 'ack exhausted after the bound is labeled review:post-failed' 2 42 def456 2
+if [ -n "$(ack_state)" ]; then
+    printf 'ack: exhausted entry should be dropped from the acks file, got:\n%s\n' "$(ack_state)" >&2
+    exit 1
+fi
+if ! grep -q 'review:post-failed' "$GH_STUB_LOG"; then
+    printf 'ack: exhausted ack should label review:post-failed\n' >&2
+    exit 1
+fi
+unset GH_FAIL_ALWAYS
 
 printf 'pr-review-watch fixtures passed\n'


### PR DESCRIPTION
# 這是什麼

實作 #632 的 v1（路線 A：本機 watcher）。PR 一開（或 push 新 head）就自動出現「Code Review: Round N」留言——不經控制者派工。組成：

- `scripts/review-pr.sh <PR> [round] [prev-sha] [--dry-run]`：從 PR body 的 `Issue: #N` 行抽 issue 並取其 `## doneWhen`、從 PR changed files 推導 allowed surface、產生「驗證清單」框架的審查 brief（決策 `fleet.review-brief-framing`：契約項目＋零裁量指令檢查＋severity＋固定 `<<<VERDICT ... VERDICT>>>` 輸出形狀）、在 `$EDDA_FLEET_SCRATCH/wt-review-prN` 建 detached worktree、Windows 上照決策 `fleet.lane-launch` 註冊並啟動隱藏排程任務 `edda-review-prN-rR`（wrapper 設 `HOME`、UTF-8；Linux 退化成 `nohup`）。
- `scripts/pr-review-watch.sh [--once] [--dry-run]`：每 `EDDA_REVIEW_POLL_SECONDS`（預設 60）輪詢 `gh pr list`，對非 draft、head 未審過、無 `review:unreviewed` 擋單的 PR 呼叫 `review-pr.sh`；判決出現後 `gh pr comment` 貼上（表頭含 **model observed from the pi session file**、cost（session 檔加總）、釘死的 head SHA）並加 label `review:lgtm`／`review:changes-requested`，狀態檔記 `pr<TAB>reviewed_sha<TAB>round`。**永不合併**。
- Provider 過載照決策 `fleet.review-provider-overload`（改運輸不降模型）實作在腳本裡：判決死掉 → pi 重試一次 → `edda dispatch --agent codex` → 兩條都沒判決就 label `review:unreviewed` 並對該 head 停手。
- `scripts/pr-review-launch.ps1 [-Stop]`：把 watcher 本身註冊成隱藏排程任務 `edda-pr-review-watcher`（登入重啟、失敗自動重拉）；`-Stop` 解除註冊。
- `docs/guides/pr-review-watcher.md`：啟停、狀態檔、labels、過載規則、「不做什麼」、troubleshooting。`docs/guides/operator-runbook.md` §三第 4 步改為「自動」並註明啟停與檢查方式；§五「派發」列改為「審查由本機 watcher 自動起並貼判決」。
- 全部路徑／模型／輪詢參數化：`EDDA_REPO`、`EDDA_FLEET_ROOT`、`EDDA_FLEET_SCRATCH`（預設 `$HOME/.edda/fleet`，不進 git）、`EDDA_REVIEW_MODEL`（預設 `openai-codex/gpt-5.6-sol`）、`EDDA_REVIEW_POLL_SECONDS`。

Labels 已在本分支工作時建立（腳本啟動時也會自動補建）：`review:lgtm`、`review:changes-requested`、`review:unreviewed`。

# 驗證

- `sh -n` 對兩支新 shell 腳本：exit 0；`sh scripts/lint-markdown-content.sh`：exit 0。
- `scripts/pr-review-launch.ps1 -Stop` 實跑：`task=edda-pr-review-watcher unregistered`（腳本語法與參數路徑驗證；watcher 本身依指示**未註冊**）。
- doneWhen 證據（watcher 未註冊狀態下的 dry-run，未發起任何真審查）：
  - `scripts/review-pr.sh 625 --dry-run`（PR #625 已合併）：
    ```text
    brief=/c/Users/synvoke/.edda/fleet/review-pr625-r1-brief.md
    sha=d29dc8f5861322ed664e39900273b0681396da50
    issues=595
    surface=.claude/skills/intel-scan/SKILL.md
    dry-run: brief generated; nothing launched, no worktree, no scheduled task.
    ```
    brief 正確抽出 #595 的 `## doneWhen` 四項與 allowed surface。
  - `scripts/pr-review-watch.sh --once --dry-run`（對線上 open PR 清單）：
    ```text
    dry-run: would launch review for PR #638 round 1 (head c23f447cd56093633b9a632d7490a28b2b72c571): .../scripts/review-pr.sh 638 1
    dry-run: would launch review for PR #637 round 1 (head 1853326bcf202cd1c33a62e9634e6045b07d7e3a): .../scripts/review-pr.sh 637 1
    dry-run: would launch review for PR #636 round 1 (head fab9118f9c69f1e9336ffe3d2c54d36025c8531f): .../scripts/review-pr.sh 636 1
    dry-run: would launch review for PR #635 round 1 (head 7ec217d4f58c8925b32d294679cf467425e8025f): .../scripts/review-pr.sh 635 1
    dry-run: would launch review for PR #629 round 1 (head dbe59dbc0a5869cc86750294066f8d3e328e9670): .../scripts/review-pr.sh 629 1
    dry-run: would launch review for PR #627 round 1 (head 6144bac181c0199a0fc8d86966df00abb28fa176): .../scripts/review-pr.sh 627 1
    dry-run: would launch review for PR #624 round 1 (head 53359557e47a2e948a4ed0a64fe88fcf09187e1c): .../scripts/review-pr.sh 624 1
    dry-run: would launch review for PR #620 round 1 (head 88312a883e72290e515a54f7d1ae445314d8d23e): .../scripts/review-pr.sh 620 1
    dry-run: would launch review for PR #607 round 1 (head 88f803eb89c6f5933071cc8917d6b0e875eece70): .../scripts/review-pr.sh 607 1
    ```
- 判決抽取與 session 來源離線驗證（用控制者已有的 PR #625 轉錄與 pi session 檔，未啟動任何程序）：verdict 區塊抽出的結尾為 `LGTM (P0=0, P1=0)`；session 檔讀出 model observed `gpt-5.6-sol`、cost `0.89`（與 #625 實貼判決的 $0.89 一致）。
- 文件引用的指令實跑過：`Get-ScheduledTask`／`Get-ScheduledTaskInfo`（列出 edda-* 任務）、`Stop-ScheduledTask`（對 Ready 狀態的 `edda-review-pr629-r1`，no-op）。

# 關聯

Issue: #632
Parent: #628

Follow-up（不在本 PR）：路線 B（GitHub self-hosted runner 的 `pr-review.yml`）、與 `edda watch`／#567 狀態面的整合。
