### PR TITLE
ci: path-aware CI — detect job skips clippy/test for docs-only changes; CI Gate accepts those skips (#631)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ env:
 jobs:
   # Path-aware triage (#631): decide once whether the diff touches code. If it
   # does not (docs-only), clippy/test are skipped and the CI Gate treats those
-  # skips as a pass. When in doubt — any diff-computation error, unknown base,
-  # or non-empty push `before` — we set code=true and run everything.
+  # skips as a pass. When in doubt — any diff-computation error or unknown
+  # base — we set code=true and run everything.
   detect:
     name: Detect code changes
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,71 @@ env:
   CARGO_PROFILE_TEST_DEBUG: line-tables-only
 
 jobs:
+  # Path-aware triage (#631): decide once whether the diff touches code. If it
+  # does not (docs-only), clippy/test are skipped and the CI Gate treats those
+  # skips as a pass. When in doubt — any diff-computation error, unknown base,
+  # or non-empty push `before` — we set code=true and run everything.
+  detect:
+    name: Detect code changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.diff.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so the merge-base SHAs below always resolve.
+          fetch-depth: 0
+      - name: Diff base..head against the code whitelist
+        id: diff
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          MG_BASE: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD: ${{ github.event.merge_group.head_sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_HEAD: ${{ github.sha }}
+        run: |
+          set -u
+          zero=0000000000000000000000000000000000000000
+          case "$EVENT_NAME" in
+            pull_request)
+              base=$PR_BASE head=$PR_HEAD ;;
+            merge_group)
+              base=$MG_BASE head=$MG_HEAD ;;
+            push)
+              head=$PUSH_HEAD
+              if [ -z "$PUSH_BEFORE" ] || [ "$PUSH_BEFORE" = "$zero" ]; then
+                base=   # unknown previous commit: assume code changed
+              else
+                base=$PUSH_BEFORE
+              fi
+              ;;
+            *)
+              base= head= ;;  # unknown event: assume code changed
+          esac
+          code=true
+          files='(diff computation failed)'
+          if [ -n "$base" ] \
+            && git cat-file -e "$base" 2>/dev/null \
+            && git cat-file -e "$head" 2>/dev/null \
+            && files=$(git diff --name-only "$base..$head"); then
+            code=false
+            while IFS= read -r f; do
+              [ -n "$f" ] || continue
+              # Whitelist: any match means code changed (err on running more).
+              case "$f" in
+                crates/*|Cargo.toml|Cargo.lock|rust-toolchain*|.cargo/*|.github/workflows/*|scripts/*|install.sh|build.rs)
+                  code=true ;;
+              esac
+            done <<< "$files"
+          else
+            echo "Diff could not be computed (base: '${base:-none}'); assuming code changed."
+          fi
+          echo "--- changed files ($base..$head) ---"
+          printf '%s\n' "$files"
+          echo "code=$code" | tee -a "$GITHUB_OUTPUT"
+
   fmt:
     name: Format
     runs-on: ubuntu-latest
@@ -37,6 +102,8 @@ jobs:
 
   clippy:
     name: Clippy (${{ matrix.os }})
+    needs: [detect]
+    if: needs.detect.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -50,6 +117,8 @@ jobs:
 
   test:
     name: Test (${{ matrix.os }})
+    needs: [detect]
+    if: needs.detect.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -87,24 +156,37 @@ jobs:
 
   # Aggregate gate: the single check the branch ruleset will pin instead of
   # enumerating the seven individual jobs. `if: always()` keeps it running even
-  # when an upstream job fails, so the verdict table is always printed.
-  # `skipped` counts as failure for now: no path filters exist yet, so a skip
-  # would mean misconfiguration; the path-filter change (#631) relaxes this.
+  # when an upstream job fails or is skipped, so the verdict table is always
+  # printed. #631: clippy/test being skipped is accepted only when detect
+  # decided the change was docs-only (code=false); any other skip, failure,
+  # or cancellation still fails the gate.
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
-    needs: [fmt, clippy, test]
+    needs: [detect, fmt, clippy, test]
     if: always()
     steps:
       - name: Evaluate upstream job results
+        env:
+          DETECT_RESULT: ${{ needs.detect.result }}
+          CODE: ${{ needs.detect.outputs.code }}
+          FMT_RESULT: ${{ needs.fmt.result }}
+          CLIPPY_RESULT: ${{ needs.clippy.result }}
+          TEST_RESULT: ${{ needs.test.result }}
         run: |
-          printf '%-10s -> %s\n' fmt "${{ needs.fmt.result }}"
-          printf '%-10s -> %s\n' clippy "${{ needs.clippy.result }}"
-          printf '%-10s -> %s\n' test "${{ needs.test.result }}"
-          for result in "${{ needs.fmt.result }}" "${{ needs.clippy.result }}" "${{ needs.test.result }}"; do
-            if [ "$result" != "success" ]; then
-              echo "::error::Upstream job did not succeed (result: $result). skipped/failure/cancelled all fail the gate (see #631 for future skipped handling)."
-              exit 1
-            fi
-          done
-          echo "All upstream jobs succeeded."
+          fail() { echo "::error::$1"; exit 1; }
+          printf '%-10s -> %s\n' detect "$DETECT_RESULT"
+          printf '%-10s -> %s\n' fmt "$FMT_RESULT"
+          printf '%-10s -> %s\n' clippy "$CLIPPY_RESULT"
+          printf '%-10s -> %s\n' test "$TEST_RESULT"
+          [ "$DETECT_RESULT" = "success" ] || fail "detect did not succeed (result: $DETECT_RESULT)."
+          [ "$FMT_RESULT" = "success" ] || fail "fmt did not succeed (result: $FMT_RESULT)."
+          if [ "$CLIPPY_RESULT" = "success" ] && [ "$TEST_RESULT" = "success" ]; then
+            echo "All upstream jobs succeeded."
+            exit 0
+          fi
+          if [ "$CLIPPY_RESULT" = "skipped" ] && [ "$TEST_RESULT" = "skipped" ] && [ "$CODE" = "false" ]; then
+            echo "Docs-only change (detect: code=false): clippy/test skipped, gate passes."
+            exit 0
+          fi
+          fail "clippy/test did not succeed (clippy: $CLIPPY_RESULT, test: $TEST_RESULT, detect.code: $CODE)."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,10 @@ jobs:
               base=$MG_BASE head=$MG_HEAD ;;
             push)
               head=$PUSH_HEAD
+              # An EMPTY or all-zero `before` (new branch, or unknown previous
+              # commit) forces code=true; a valid `before` is diffed normally.
               if [ -z "$PUSH_BEFORE" ] || [ "$PUSH_BEFORE" = "$zero" ]; then
-                base=   # unknown previous commit: assume code changed
+                base=
               else
                 base=$PUSH_BEFORE
               fi
@@ -61,25 +63,33 @@ jobs:
               base= head= ;;  # unknown event: assume code changed
           esac
           code=true
-          files='(diff computation failed)'
           if [ -n "$base" ] \
             && git cat-file -e "$base" 2>/dev/null \
-            && git cat-file -e "$head" 2>/dev/null \
-            && files=$(git diff --name-only "$base..$head"); then
-            code=false
-            while IFS= read -r f; do
-              [ -n "$f" ] || continue
-              # Whitelist: any match means code changed (err on running more).
-              case "$f" in
-                crates/*|Cargo.toml|Cargo.lock|rust-toolchain*|.cargo/*|.github/workflows/*|scripts/*|install.sh|build.rs)
-                  code=true ;;
-              esac
-            done <<< "$files"
+            && git cat-file -e "$head" 2>/dev/null; then
+            diffout=$(mktemp)
+            # -z: NUL-delimited output, so git's C-quoting of non-ASCII or
+            # control characters ("crates/\303\251.rs") and embedded newlines
+            # in pathnames cannot corrupt the matcher.
+            # --no-renames: a crates/ -> docs/ rename lists BOTH sides, so the
+            # deleted code path still trips the whitelist.
+            if git diff --name-only -z --no-renames "$base" "$head" > "$diffout"; then
+              code=false
+              echo "--- changed files ($base..$head) ---"
+              while IFS= read -r -d '' f; do
+                printf '%s\n' "$f"
+                # Whitelist: any match means code changed (err on running more).
+                case "$f" in
+                  crates/*|Cargo.toml|Cargo.lock|rust-toolchain*|.cargo/*|.github/workflows/*|scripts/*|install.sh|build.rs)
+                    code=true ;;
+                esac
+              done < "$diffout"
+            else
+              echo "git diff failed; assuming code changed."
+            fi
+            rm -f "$diffout"
           else
             echo "Diff could not be computed (base: '${base:-none}'); assuming code changed."
           fi
-          echo "--- changed files ($base..$head) ---"
-          printf '%s\n' "$files"
           echo "code=$code" | tee -a "$GITHUB_OUTPUT"
 
   fmt:


### PR DESCRIPTION
Issue: #631

## What

- New first job `detect` (ubuntu, `actions/checkout` with `fetch-depth: 0`) computes `code=true|false` from `git diff --name-only -z --no-renames <base> <head>`:
  - `pull_request`: `github.event.pull_request.base.sha` → `github.event.pull_request.head.sha`
  - `merge_group`: `github.event.merge_group.base_sha` → `github.event.merge_group.head_sha`
  - `push`: `github.event.before` → `github.sha`; an EMPTY or all-zero `before` forces `code=true`; a valid `before` is diffed normally
- Whitelist (any match → `code=true`, err on running too much): `crates/**`, `Cargo.toml`, `Cargo.lock`, `rust-toolchain*`, `.cargo/**`, `.github/workflows/**`, `scripts/**`, `install.sh`, `build.rs`. Any diff-computation error → `code=true`. Output via `$GITHUB_OUTPUT`; changed-file list printed one path per line (NUL-safe read), decision last.
- NUL-safe (`-z`) so git's C-quoting of non-ASCII/control pathnames (`"crates/\303\251.rs"`) cannot corrupt the matcher; `--no-renames` so a `crates/` → `docs/` rename lists BOTH sides and the deleted code path still trips the whitelist.
- `clippy`/`test`: `needs: [detect]`, `if: needs.detect.outputs.code == 'true'`. `fmt` unchanged, runs unconditionally.
- `CI Gate`: `needs: [detect, fmt, clippy, test]`, `if: always()`. Passes when all upstreams succeed, OR fmt=success + clippy/test=skipped + `detect.outputs.code == 'false'`. Any other skip/failure/cancellation fails.
- Matrix, crate lists, Windows subset untouched.

## Wiring self-report

| Field | Value |
|---|---|
| New surface | `detect` job output `code` (`steps.diff.outputs.code`, written via `$GITHUB_OUTPUT`) |
| Writer | `detect` job, step `Diff base..head against the code whitelist` |
| Readers | `clippy`/`test` `if: needs.detect.outputs.code == 'true'`; `ci-gate` paired-skip condition `[ "$CLIPPY_RESULT" = "skipped" ] && [ "$TEST_RESULT" = "skipped" ] && [ "$CODE" = "false" ]` |
| Failure signal | any diff-computation error, unknown base SHA, or unknown event → `code=true` (full run, never a silent docs-only pass) |
| Layer reach | PR run evidence below (workflow-change head: 9 checks green; docs-only head: detect/fmt/gate green, clippy/test skipped) |

## Proof (RAN)

**Local (worktree, matcher extracted verbatim from the fixed ci.yml; throwaway commits discarded with `git reset --hard`):**

P0-1 quoted pathnames — old line-oriented matcher vs new NUL-safe matcher on a throwaway commit adding `crates/é.rs`:

```
-- old line-oriented output (the P0 bug):
"crates/\303\251.rs"
-- new detect script, HEAD~1..HEAD:
--- changed files (9275abf5038f743a2a47939ca1e58d427219b612..eb4fab96e2a8ac7aa25a28f35759ea06df77c1ae) ---
crates/é.rs
code=true
-- GITHUB_OUTPUT: code=true
```

P0-2 rename collapsing — throwaway rename `crates/probe-src.txt` → `docs/probe-dst.md`:

```
-- default rename-collapsing output (the other P0 bug):
docs/probe-dst.md
-- new detect script (--no-renames -z), HEAD~1..HEAD:
--- changed files (9b447c7b9dc8fef921db3d3bd723295b69021090..41663e0092ce3dc7aa673af29cac252639151b5b) ---
crates/probe-src.txt
docs/probe-dst.md
code=true
-- GITHUB_OUTPUT: code=true
```

**Head 1 — workflow change** `9275abf5038f743a2a47939ca1e58d427219b612` (PR #643 head, run 33605422301): workflow change → `detect` printed `.github/workflows/ci.yml` and `code=true`, full suite ran, all green.

```
CI Gate                     pass    2s     https://github.com/fagemx/edda/actions/runs/33605422301/job/100169884948
Clippy (macos-latest)       pass    1m0s   https://github.com/fagemx/edda/actions/runs/33605422301/job/100168219046
Clippy (ubuntu-latest)      pass    30s    https://github.com/fagemx/edda/actions/runs/33605422301/job/100168219110
Clippy (windows-latest)     pass    2m3s   https://github.com/fagemx/edda/actions/runs/33605422301/job/100168219034
Detect code changes         pass    4s     https://github.com/fagemx/edda/actions/runs/33605422301/job/100168167302
Format                      pass    8s     https://github.com/fagemx/edda/actions/runs/33605422301/job/100168167080
Test (macos-latest)         pass    2m22s  https://github.com/fagemx/edda/actions/runs/33605422301/job/100168219133
Test (ubuntu-latest)        pass    2m23s  https://github.com/fagemx/edda/actions/runs/33605422301/job/100168219078
Test (windows-latest)       pass    6m15s  https://github.com/fagemx/edda/actions/runs/33605422301/job/100168219045
```

**Head 2 — docs-only** `4598118810b85ffdbf743b7652a4ea5106a011d3` (probe PR #645 head after merging this branch, base = `9275abf…`, run 33606032506): docs-only diff → `detect` printed `docs/getting-started/installation.md` and `code=false`, clippy/test skipped, `Format` and `CI Gate` green.

```
CI Gate                     pass       4s  https://github.com/fagemx/edda/actions/runs/33606032506/job/100170158210
Clippy (${{ matrix.os }})   skipping   0   https://github.com/fagemx/edda/actions/runs/33606032506/job/100170146534
Test (${{ matrix.os }})     skipping   0   https://github.com/fagemx/edda/actions/runs/33606032506/job/100170146475
Detect code changes         pass       8s  https://github.com/fagemx/edda/actions/runs/33606032506/job/100170100611
Format                      pass       9s  https://github.com/fagemx/edda/actions/runs/33606032506/job/100170100964
```

**Why the probe PR's base is `ci/gh631-path-aware-ci`, not `main` (stated plainly):** for same-repo PRs GitHub executes the workflow from the PR's merge ref — this PR's own runs execute this branch's `detect` job. A probe branch cut from the workflow branch and opened against `main` diffs `main..head` including `.github/workflows/ci.yml`, so `detect` would (correctly) output `code=true` and run everything — proving nothing about the docs-only path. With the base pinned to the workflow head, the event diff is docs-only and exercises exactly the path #631 adds. The probe commit (`docs/getting-started/installation.md`, one comma removed) is a real fix kept in PR #645.

