### PR TITLE
feat(edda-cli): wire Ledger::verify_chain to a top-level 'edda verify' verb (GH-647)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,6 +721,7 @@ dependencies = [
  "globset",
  "hex",
  "ratatui",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/edda-cli/Cargo.toml
+++ b/crates/edda-cli/Cargo.toml
@@ -60,3 +60,6 @@ tui = ["ratatui", "crossterm"]
 [dev-dependencies]
 tempfile.workspace = true
 async-trait = "0.1"
+# Test-only: tamper tests must write raw SQL against a real SQLite ledger
+# (the repo does not mock internal crates), and the ledger DB is SQLite.
+rusqlite = { version = "0.32", features = ["bundled"] }

--- a/crates/edda-cli/src/cmd_verify.rs
+++ b/crates/edda-cli/src/cmd_verify.rs
@@ -1,0 +1,332 @@
+//! `edda verify` — verify the ledger hash chain (GH-647).
+//!
+//! Connects the existing `Ledger::verify_chain()` capability (which previously
+//! had no user-facing entrypoint) to a top-level CLI verb. Exit codes follow
+//! the `claim-check.exit-codes=0/1/2` convention:
+//!
+//! - `0` — chain intact (including the empty ledger, which is OK, not an error)
+//! - `1` — chain broken; the report names the first broken event
+//! - `2` — the ledger could not be opened or read (not an edda workspace, or
+//!   `.edda/ledger.db` missing/unreadable)
+//!
+//! The verification is read-only: this module opens the ledger via
+//! `Ledger::open_existing()`, which never creates the database file, never
+//! applies schema or migrations, and opens the connection `query_only` — a
+//! missing or damaged ledger is reported (exit 2), never silently rebuilt
+//! into an empty one that "verifies OK".
+
+use anyhow::Result;
+use edda_ledger::Ledger;
+use std::path::Path;
+
+pub fn execute(repo_root: &Path, json: bool) -> Result<()> {
+    // `main` falls back to the cwd when no `.edda/` exists; refuse loudly
+    // instead of opening a ledger that is not there (exit 2, per the
+    // `claim-check.exit-codes=0/1/2` convention).
+    if !repo_root.join(".edda").is_dir() {
+        eprintln!(
+            "error: not an edda workspace ({}): no .edda/ directory found. \
+             Run `edda init` first, or cd into the workspace root.",
+            repo_root.display()
+        );
+        std::process::exit(2);
+    }
+
+    // Existing/read-only open: `Ledger::open()` would create an empty ledger
+    // when the DB file is missing and report it as a healthy empty chain.
+    let ledger = match Ledger::open_existing(repo_root) {
+        Ok(ledger) => ledger,
+        Err(err) => {
+            eprintln!(
+                "error: cannot open ledger at {}: {:#}",
+                repo_root.display(),
+                err
+            );
+            std::process::exit(2);
+        }
+    };
+
+    // A ledger that cannot be read at all (corrupt DB, missing schema) is
+    // also a "cannot open" condition, not a broken chain: exit 2, never 0.
+    let report = match ledger.verify_chain_report() {
+        Ok(report) => report,
+        Err(err) => {
+            eprintln!(
+                "error: cannot read ledger at {}: {:#}",
+                repo_root.display(),
+                err
+            );
+            std::process::exit(2);
+        }
+    };
+
+    if json {
+        let payload = serde_json::json!({
+            "ok": report.first_bad_event.is_none(),
+            "events": report.events,
+            "first_bad_event": report.first_bad_event,
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&payload).expect("serialize verify report")
+        );
+    } else if let Some(bad) = &report.first_bad_event {
+        println!(
+            "ledger chain BROKEN at event {} ({} event(s) scanned): {}",
+            bad,
+            report.events,
+            report.reason.as_deref().unwrap_or("integrity check failed")
+        );
+    } else if report.events == 0 {
+        println!("ledger chain OK: empty ledger (0 event(s))");
+    } else {
+        println!(
+            "ledger chain OK: {} event(s), last event {}",
+            report.events,
+            report.last_event_id.as_deref().unwrap_or("?")
+        );
+    }
+
+    // An intact chain exits 0; a broken one must never masquerade as success.
+    if report.first_bad_event.is_some() {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use edda_core::event::new_note_event;
+    use serde_json::Value;
+    use std::path::PathBuf;
+
+    /// Path to the `edda` binary cargo just built for this test run
+    /// (`current_exe` = `target/debug/deps/<test>-<hash>.exe`).
+    fn edda_bin() -> PathBuf {
+        let exe = std::env::current_exe().expect("current_exe");
+        let dir = exe
+            .parent()
+            .and_then(|d| d.parent())
+            .expect("deps/.. = target/debug")
+            .to_path_buf();
+        dir.join(format!("edda{}", std::env::consts::EXE_SUFFIX))
+    }
+
+    /// Run `edda verify` in `repo` and return (exit code, stdout, stderr).
+    fn run_edda(args: &[&str], repo: &Path) -> (i32, String, String) {
+        assert!(edda_bin().exists(), "edda binary not found");
+        let out = std::process::Command::new(edda_bin())
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .expect("spawn edda");
+        (
+            out.status.code().expect("exit code"),
+            String::from_utf8_lossy(&out.stdout).into_owned(),
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        )
+    }
+
+    /// A real SQLite ledger with a two-event hash chain (tempfile, no mocks).
+    fn seeded_ledger(repo: &Path) {
+        let ledger = Ledger::open_or_init(repo).expect("open_or_init");
+        let e1 = new_note_event("main", None, "system", "first event", &[]).expect("e1");
+        ledger.append_event(&e1).expect("append e1");
+        let e2 = new_note_event("main", Some(&e1.hash), "system", "second event", &[]).expect("e2");
+        ledger.append_event(&e2).expect("append e2");
+        drop(ledger);
+    }
+
+    /// Tamper with a real ledger row via raw SQL, bypassing the append path.
+    fn tamper(repo: &Path, event_id: &str, sql: &str) {
+        let conn = rusqlite::Connection::open(repo.join(".edda").join("ledger.db"))
+            .expect("open ledger.db for tampering");
+        conn.execute(sql, rusqlite::params![event_id])
+            .expect("tamper update");
+    }
+
+    /// Event ids of the seeded chain, in insertion order.
+    fn seeded_event_ids(repo: &Path) -> Vec<String> {
+        let ledger = Ledger::open(repo).expect("reopen");
+        ledger
+            .iter_events()
+            .expect("events")
+            .into_iter()
+            .map(|e| e.event_id)
+            .collect()
+    }
+
+    #[test]
+    fn verify_clean_ledger_is_ok_and_exits_0() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        seeded_ledger(repo.path());
+        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
+        assert_eq!(code, 0, "stdout={stdout:?} stderr={stderr:?}");
+        assert!(stdout.contains("OK"), "stdout={stdout:?}");
+        assert!(stdout.contains('2'), "must report event count: {stdout:?}");
+    }
+
+    #[test]
+    fn verify_empty_ledger_is_ok_not_an_error() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        let ledger = Ledger::open_or_init(repo.path()).expect("open_or_init");
+        drop(ledger);
+        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
+        assert_eq!(code, 0, "stdout={stdout:?} stderr={stderr:?}");
+        assert!(stdout.contains("OK"), "stdout={stdout:?}");
+    }
+
+    /// P0 (GH-647 round 1): a vanished ledger must be reported (exit 2),
+    /// never silently rebuilt as an empty one that "verifies OK".
+    #[test]
+    fn verify_deleted_ledger_db_exits_2_and_is_not_recreated() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        seeded_ledger(repo.path());
+        std::fs::remove_file(repo.path().join(".edda").join("ledger.db"))
+            .expect("delete ledger.db, keeping .edda/");
+
+        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
+        assert_eq!(
+            code, 2,
+            "missing ledger must exit 2, not rebuild an empty one: {stdout:?} {stderr:?}"
+        );
+        let report = format!("{stdout}{stderr}");
+        assert!(
+            report.contains("ledger"),
+            "must explain the ledger problem: {report:?}"
+        );
+        assert!(
+            !report.contains("OK"),
+            "must not report success for a vanished ledger: {report:?}"
+        );
+        assert!(
+            !repo.path().join(".edda").join("ledger.db").exists(),
+            "verify must never recreate the ledger database"
+        );
+    }
+
+    #[test]
+    fn verify_tampered_payload_fails_with_first_bad_event_and_exit_1() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        seeded_ledger(repo.path());
+        let e2 = &seeded_event_ids(repo.path())[1];
+
+        tamper(
+            repo.path(),
+            e2,
+            "UPDATE events SET payload = replace(payload, 'second event', 'tampered') \
+             WHERE event_id = ?1",
+        );
+
+        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
+        assert_eq!(
+            code, 1,
+            "broken chain must not exit 0: {stdout:?} {stderr:?}"
+        );
+        let report = format!("{stdout}{stderr}");
+        assert!(
+            report.contains(e2),
+            "must name first broken event {e2}: {report:?}"
+        );
+    }
+
+    /// P1 (GH-647 round 1): a payload that is not valid JSON at all must
+    /// still be reported as the first broken event, by id.
+    #[test]
+    fn verify_malformed_payload_fails_with_first_bad_event_and_exit_1() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        seeded_ledger(repo.path());
+        let e2 = &seeded_event_ids(repo.path())[1];
+
+        tamper(
+            repo.path(),
+            e2,
+            "UPDATE events SET payload = 'not-json' WHERE event_id = ?1",
+        );
+
+        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
+        assert_eq!(
+            code, 1,
+            "malformed payload must not exit 0: {stdout:?} {stderr:?}"
+        );
+        let report = format!("{stdout}{stderr}");
+        assert!(
+            report.contains(e2),
+            "must name first broken event {e2} even when the payload is not JSON: {report:?}"
+        );
+    }
+
+    #[test]
+    fn verify_broken_parent_link_fails_with_first_bad_event_and_exit_1() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        seeded_ledger(repo.path());
+        let e2 = &seeded_event_ids(repo.path())[1];
+
+        tamper(
+            repo.path(),
+            e2,
+            "UPDATE events SET parent_hash = 'sha256:bogus' WHERE event_id = ?1",
+        );
+
+        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
+        assert_eq!(
+            code, 1,
+            "broken chain must not exit 0: {stdout:?} {stderr:?}"
+        );
+        let report = format!("{stdout}{stderr}");
+        assert!(
+            report.contains(e2),
+            "must name first broken event {e2}: {report:?}"
+        );
+    }
+
+    #[test]
+    fn verify_json_output_has_stable_shape_on_clean_ledger() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        seeded_ledger(repo.path());
+        let (code, stdout, stderr) = run_edda(&["verify", "--json"], repo.path());
+        assert_eq!(code, 0, "stdout={stdout:?} stderr={stderr:?}");
+        let v: Value = serde_json::from_str(&stdout).expect("valid JSON");
+        assert_eq!(v["ok"], Value::Bool(true), "json={v}");
+        assert_eq!(v["events"], Value::from(2), "json={v}");
+        assert_eq!(v["first_bad_event"], Value::Null, "json={v}");
+    }
+
+    #[test]
+    fn verify_json_output_names_first_bad_event_when_broken() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        seeded_ledger(repo.path());
+        let e2 = &seeded_event_ids(repo.path())[1];
+
+        tamper(
+            repo.path(),
+            e2,
+            "UPDATE events SET payload = replace(payload, 'second event', 'tampered') \
+             WHERE event_id = ?1",
+        );
+
+        let (code, stdout, stderr) = run_edda(&["verify", "--json"], repo.path());
+        assert_eq!(code, 1, "stdout={stdout:?} stderr={stderr:?}");
+        let v: Value = serde_json::from_str(&stdout).expect("valid JSON");
+        assert_eq!(v["ok"], Value::Bool(false), "json={v}");
+        assert_eq!(v["first_bad_event"], Value::String(e2.clone()), "json={v}");
+    }
+
+    #[test]
+    fn verify_outside_edda_repo_exits_2_with_explanation() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        // No `.edda/` anywhere — `edda verify` must refuse, not fabricate OK.
+        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
+        assert_eq!(code, 2, "stdout={stdout:?} stderr={stderr:?}");
+        let report = format!("{stdout}{stderr}");
+        assert!(
+            !report.contains("OK"),
+            "must not report success outside a repo: {report:?}"
+        );
+        assert!(
+            report.contains("workspace"),
+            "must explain it is not an edda workspace: {report:?}"
+        );
+    }
+}

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -48,6 +48,7 @@ mod cmd_task;
 mod cmd_tool_tier;
 mod cmd_user;
 mod cmd_verdict;
+mod cmd_verify;
 mod cmd_watch;
 mod fleet;
 mod pipeline_templates;
@@ -402,6 +403,12 @@ enum Command {
         /// Include a notes.md file in addition to decisions/
         #[arg(long = "include-notes")]
         include_notes: bool,
+    },
+    /// Verify the ledger hash chain (tamper-evidence check; GH-647)
+    Verify {
+        /// Output a machine-readable JSON report
+        #[arg(long)]
+        json: bool,
     },
     /// Bridge operations (install/uninstall hooks for supported coding agents)
     Bridge {
@@ -1269,6 +1276,7 @@ fn main() -> anyhow::Result<()> {
             }
             cmd_export::execute(&repo_root, &out, include_notes)
         }
+        Command::Verify { json } => cmd_verify::execute(&repo_root, json),
         Command::Bridge { cmd } => cmd_bridge::run_bridge(cmd, &repo_root),
         Command::Hook { cmd } => cmd_bridge::run_hook(cmd),
         Command::Doctor { cmd } => cmd_bridge::run_doctor(cmd, &repo_root),
@@ -1394,245 +1402,5 @@ mod tests {
         let cli = parse_cli_from(vec![OsString::from("edda"), OsString::from("status")]);
 
         assert!(matches!(cli.cmd, Command::Status));
-    }
-
-    // ── `edda verify` (GH-647) — FAIL-first CLI e2e, real SQLite ledger ──
-    //
-    // These tests are test-only on purpose (no production wiring yet): they
-    // drive the built `edda` binary so the red commit stays pure test code.
-
-    use edda_core::event::new_note_event;
-    use serde_json::Value;
-    use std::path::Path;
-    use std::path::PathBuf;
-
-    /// Path to the `edda` binary cargo just built for this test run
-    /// (`current_exe` = `target/debug/deps/<test>-<hash>.exe`).
-    fn edda_bin() -> PathBuf {
-        let exe = std::env::current_exe().expect("current_exe");
-        let dir = exe
-            .parent()
-            .and_then(|d| d.parent())
-            .expect("deps/.. = target/debug")
-            .to_path_buf();
-        dir.join(format!("edda{}", std::env::consts::EXE_SUFFIX))
-    }
-
-    /// Run `edda verify` in `repo` and return (exit code, stdout, stderr).
-    fn run_edda(args: &[&str], repo: &Path) -> (i32, String, String) {
-        assert!(edda_bin().exists(), "edda binary not found");
-        let out = std::process::Command::new(edda_bin())
-            .args(args)
-            .current_dir(repo)
-            .output()
-            .expect("spawn edda");
-        (
-            out.status.code().expect("exit code"),
-            String::from_utf8_lossy(&out.stdout).into_owned(),
-            String::from_utf8_lossy(&out.stderr).into_owned(),
-        )
-    }
-
-    /// A real SQLite ledger with a two-event hash chain (tempfile, no mocks).
-    fn seeded_ledger(repo: &Path) {
-        let ledger = edda_ledger::Ledger::open_or_init(repo).expect("open_or_init");
-        let e1 = new_note_event("main", None, "system", "first event", &[]).expect("e1");
-        ledger.append_event(&e1).expect("append e1");
-        let e2 =
-            new_note_event("main", Some(&e1.hash), "system", "second event", &[]).expect("e2");
-        ledger.append_event(&e2).expect("append e2");
-        drop(ledger);
-    }
-
-    /// Tamper with a real ledger row via raw SQL, bypassing the append path.
-    fn tamper(repo: &Path, event_id: &str, sql: &str) {
-        let conn = rusqlite::Connection::open(repo.join(".edda").join("ledger.db"))
-            .expect("open ledger.db for tampering");
-        conn.execute(sql, rusqlite::params![event_id])
-            .expect("tamper update");
-    }
-
-    /// Event ids of the seeded chain, in insertion order.
-    fn seeded_event_ids(repo: &Path) -> Vec<String> {
-        let ledger = edda_ledger::Ledger::open(repo).expect("reopen");
-        ledger
-            .iter_events()
-            .expect("events")
-            .into_iter()
-            .map(|e| e.event_id)
-            .collect()
-    }
-
-    #[test]
-    fn verify_clean_ledger_is_ok_and_exits_0() {
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        seeded_ledger(repo.path());
-        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
-        assert_eq!(code, 0, "stdout={stdout:?} stderr={stderr:?}");
-        assert!(stdout.contains("OK"), "stdout={stdout:?}");
-        assert!(stdout.contains('2'), "must report event count: {stdout:?}");
-    }
-
-    #[test]
-    fn verify_empty_ledger_is_ok_not_an_error() {
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        let ledger = edda_ledger::Ledger::open_or_init(repo.path()).expect("open_or_init");
-        drop(ledger);
-        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
-        assert_eq!(code, 0, "stdout={stdout:?} stderr={stderr:?}");
-        assert!(stdout.contains("OK"), "stdout={stdout:?}");
-    }
-
-    /// P0 (GH-647 round 1): a vanished ledger must be reported (exit 2),
-    /// never silently rebuilt as an empty one that "verifies OK".
-    #[test]
-    fn verify_deleted_ledger_db_exits_2_and_is_not_recreated() {
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        seeded_ledger(repo.path());
-        std::fs::remove_file(repo.path().join(".edda").join("ledger.db"))
-            .expect("delete ledger.db, keeping .edda/");
-
-        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
-        assert_eq!(
-            code, 2,
-            "missing ledger must exit 2, not rebuild an empty one: {stdout:?} {stderr:?}"
-        );
-        let report = format!("{stdout}{stderr}");
-        assert!(
-            report.contains("ledger"),
-            "must explain the ledger problem: {report:?}"
-        );
-        assert!(
-            !report.contains("OK"),
-            "must not report success for a vanished ledger: {report:?}"
-        );
-        assert!(
-            !repo.path().join(".edda").join("ledger.db").exists(),
-            "verify must never recreate the ledger database"
-        );
-    }
-
-    #[test]
-    fn verify_tampered_payload_fails_with_first_bad_event_and_exit_1() {
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        seeded_ledger(repo.path());
-        let e2 = &seeded_event_ids(repo.path())[1];
-
-        tamper(
-            repo.path(),
-            e2,
-            "UPDATE events SET payload = replace(payload, 'second event', 'tampered') \
-             WHERE event_id = ?1",
-        );
-
-        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
-        assert_eq!(
-            code, 1,
-            "broken chain must not exit 0: {stdout:?} {stderr:?}"
-        );
-        let report = format!("{stdout}{stderr}");
-        assert!(
-            report.contains(e2),
-            "must name first broken event {e2}: {report:?}"
-        );
-    }
-
-    /// P1 (GH-647 round 1): a payload that is not valid JSON at all must
-    /// still be reported as the first broken event, by id.
-    #[test]
-    fn verify_malformed_payload_fails_with_first_bad_event_and_exit_1() {
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        seeded_ledger(repo.path());
-        let e2 = &seeded_event_ids(repo.path())[1];
-
-        tamper(
-            repo.path(),
-            e2,
-            "UPDATE events SET payload = 'not-json' WHERE event_id = ?1",
-        );
-
-        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
-        assert_eq!(
-            code, 1,
-            "malformed payload must not exit 0: {stdout:?} {stderr:?}"
-        );
-        let report = format!("{stdout}{stderr}");
-        assert!(
-            report.contains(e2),
-            "must name first broken event {e2} even when the payload is not JSON: {report:?}"
-        );
-    }
-
-    #[test]
-    fn verify_broken_parent_link_fails_with_first_bad_event_and_exit_1() {
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        seeded_ledger(repo.path());
-        let e2 = &seeded_event_ids(repo.path())[1];
-
-        tamper(
-            repo.path(),
-            e2,
-            "UPDATE events SET parent_hash = 'sha256:bogus' WHERE event_id = ?1",
-        );
-
-        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
-        assert_eq!(
-            code, 1,
-            "broken chain must not exit 0: {stdout:?} {stderr:?}"
-        );
-        let report = format!("{stdout}{stderr}");
-        assert!(
-            report.contains(e2),
-            "must name first broken event {e2}: {report:?}"
-        );
-    }
-
-    #[test]
-    fn verify_json_output_has_stable_shape_on_clean_ledger() {
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        seeded_ledger(repo.path());
-        let (code, stdout, stderr) = run_edda(&["verify", "--json"], repo.path());
-        assert_eq!(code, 0, "stdout={stdout:?} stderr={stderr:?}");
-        let v: Value = serde_json::from_str(&stdout).expect("valid JSON");
-        assert_eq!(v["ok"], Value::Bool(true), "json={v}");
-        assert_eq!(v["events"], Value::from(2), "json={v}");
-        assert_eq!(v["first_bad_event"], Value::Null, "json={v}");
-    }
-
-    #[test]
-    fn verify_json_output_names_first_bad_event_when_broken() {
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        seeded_ledger(repo.path());
-        let e2 = &seeded_event_ids(repo.path())[1];
-
-        tamper(
-            repo.path(),
-            e2,
-            "UPDATE events SET payload = replace(payload, 'second event', 'tampered') \
-             WHERE event_id = ?1",
-        );
-
-        let (code, stdout, stderr) = run_edda(&["verify", "--json"], repo.path());
-        assert_eq!(code, 1, "stdout={stdout:?} stderr={stderr:?}");
-        let v: Value = serde_json::from_str(&stdout).expect("valid JSON");
-        assert_eq!(v["ok"], Value::Bool(false), "json={v}");
-        assert_eq!(v["first_bad_event"], Value::String(e2.clone()), "json={v}");
-    }
-
-    #[test]
-    fn verify_outside_edda_repo_exits_2_with_explanation() {
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        // No `.edda/` anywhere — `edda verify` must refuse, not fabricate OK.
-        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
-        assert_eq!(code, 2, "stdout={stdout:?} stderr={stderr:?}");
-        let report = format!("{stdout}{stderr}");
-        assert!(
-            !report.contains("OK"),
-            "must not report success outside a repo: {report:?}"
-        );
-        assert!(
-            report.contains("workspace"),
-            "must explain it is not an edda workspace: {report:?}"
-        );
     }
 }

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -1395,4 +1395,244 @@ mod tests {
 
         assert!(matches!(cli.cmd, Command::Status));
     }
+
+    // ── `edda verify` (GH-647) — FAIL-first CLI e2e, real SQLite ledger ──
+    //
+    // These tests are test-only on purpose (no production wiring yet): they
+    // drive the built `edda` binary so the red commit stays pure test code.
+
+    use edda_core::event::new_note_event;
+    use serde_json::Value;
+    use std::path::Path;
+    use std::path::PathBuf;
+
+    /// Path to the `edda` binary cargo just built for this test run
+    /// (`current_exe` = `target/debug/deps/<test>-<hash>.exe`).
+    fn edda_bin() -> PathBuf {
+        let exe = std::env::current_exe().expect("current_exe");
+        let dir = exe
+            .parent()
+            .and_then(|d| d.parent())
+            .expect("deps/.. = target/debug")
+            .to_path_buf();
+        dir.join(format!("edda{}", std::env::consts::EXE_SUFFIX))
+    }
+
+    /// Run `edda verify` in `repo` and return (exit code, stdout, stderr).
+    fn run_edda(args: &[&str], repo: &Path) -> (i32, String, String) {
+        assert!(edda_bin().exists(), "edda binary not found");
+        let out = std::process::Command::new(edda_bin())
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .expect("spawn edda");
+        (
+            out.status.code().expect("exit code"),
+            String::from_utf8_lossy(&out.stdout).into_owned(),
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        )
+    }
+
+    /// A real SQLite ledger with a two-event hash chain (tempfile, no mocks).
+    fn seeded_ledger(repo: &Path) {
+        let ledger = edda_ledger::Ledger::open_or_init(repo).expect("open_or_init");
+        let e1 = new_note_event("main", None, "system", "first event", &[]).expect("e1");
+        ledger.append_event(&e1).expect("append e1");
+        let e2 =
+            new_note_event("main", Some(&e1.hash), "system", "second event", &[]).expect("e2");
+        ledger.append_event(&e2).expect("append e2");
+        drop(ledger);
+    }
+
+    /// Tamper with a real ledger row via raw SQL, bypassing the append path.
+    fn tamper(repo: &Path, event_id: &str, sql: &str) {
+        let conn = rusqlite::Connection::open(repo.join(".edda").join("ledger.db"))
+            .expect("open ledger.db for tampering");
+        conn.execute(sql, rusqlite::params![event_id])
+            .expect("tamper update");
+    }
+
+    /// Event ids of the seeded chain, in insertion order.
+    fn seeded_event_ids(repo: &Path) -> Vec<String> {
+        let ledger = edda_ledger::Ledger::open(repo).expect("reopen");
+        ledger
+            .iter_events()
+            .expect("events")
+            .into_iter()
+            .map(|e| e.event_id)
+            .collect()
+    }
+
+    #[test]
+    fn verify_clean_ledger_is_ok_and_exits_0() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        seeded_ledger(repo.path());
+        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
+        assert_eq!(code, 0, "stdout={stdout:?} stderr={stderr:?}");
+        assert!(stdout.contains("OK"), "stdout={stdout:?}");
+        assert!(stdout.contains('2'), "must report event count: {stdout:?}");
+    }
+
+    #[test]
+    fn verify_empty_ledger_is_ok_not_an_error() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        let ledger = edda_ledger::Ledger::open_or_init(repo.path()).expect("open_or_init");
+        drop(ledger);
+        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
+        assert_eq!(code, 0, "stdout={stdout:?} stderr={stderr:?}");
+        assert!(stdout.contains("OK"), "stdout={stdout:?}");
+    }
+
+    /// P0 (GH-647 round 1): a vanished ledger must be reported (exit 2),
+    /// never silently rebuilt as an empty one that "verifies OK".
+    #[test]
+    fn verify_deleted_ledger_db_exits_2_and_is_not_recreated() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        seeded_ledger(repo.path());
+        std::fs::remove_file(repo.path().join(".edda").join("ledger.db"))
+            .expect("delete ledger.db, keeping .edda/");
+
+        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
+        assert_eq!(
+            code, 2,
+            "missing ledger must exit 2, not rebuild an empty one: {stdout:?} {stderr:?}"
+        );
+        let report = format!("{stdout}{stderr}");
+        assert!(
+            report.contains("ledger"),
+            "must explain the ledger problem: {report:?}"
+        );
+        assert!(
+            !report.contains("OK"),
+            "must not report success for a vanished ledger: {report:?}"
+        );
+        assert!(
+            !repo.path().join(".edda").join("ledger.db").exists(),
+            "verify must never recreate the ledger database"
+        );
+    }
+
+    #[test]
+    fn verify_tampered_payload_fails_with_first_bad_event_and_exit_1() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        seeded_ledger(repo.path());
+        let e2 = &seeded_event_ids(repo.path())[1];
+
+        tamper(
+            repo.path(),
+            e2,
+            "UPDATE events SET payload = replace(payload, 'second event', 'tampered') \
+             WHERE event_id = ?1",
+        );
+
+        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
+        assert_eq!(
+            code, 1,
+            "broken chain must not exit 0: {stdout:?} {stderr:?}"
+        );
+        let report = format!("{stdout}{stderr}");
+        assert!(
+            report.contains(e2),
+            "must name first broken event {e2}: {report:?}"
+        );
+    }
+
+    /// P1 (GH-647 round 1): a payload that is not valid JSON at all must
+    /// still be reported as the first broken event, by id.
+    #[test]
+    fn verify_malformed_payload_fails_with_first_bad_event_and_exit_1() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        seeded_ledger(repo.path());
+        let e2 = &seeded_event_ids(repo.path())[1];
+
+        tamper(
+            repo.path(),
+            e2,
+            "UPDATE events SET payload = 'not-json' WHERE event_id = ?1",
+        );
+
+        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
+        assert_eq!(
+            code, 1,
+            "malformed payload must not exit 0: {stdout:?} {stderr:?}"
+        );
+        let report = format!("{stdout}{stderr}");
+        assert!(
+            report.contains(e2),
+            "must name first broken event {e2} even when the payload is not JSON: {report:?}"
+        );
+    }
+
+    #[test]
+    fn verify_broken_parent_link_fails_with_first_bad_event_and_exit_1() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        seeded_ledger(repo.path());
+        let e2 = &seeded_event_ids(repo.path())[1];
+
+        tamper(
+            repo.path(),
+            e2,
+            "UPDATE events SET parent_hash = 'sha256:bogus' WHERE event_id = ?1",
+        );
+
+        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
+        assert_eq!(
+            code, 1,
+            "broken chain must not exit 0: {stdout:?} {stderr:?}"
+        );
+        let report = format!("{stdout}{stderr}");
+        assert!(
+            report.contains(e2),
+            "must name first broken event {e2}: {report:?}"
+        );
+    }
+
+    #[test]
+    fn verify_json_output_has_stable_shape_on_clean_ledger() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        seeded_ledger(repo.path());
+        let (code, stdout, stderr) = run_edda(&["verify", "--json"], repo.path());
+        assert_eq!(code, 0, "stdout={stdout:?} stderr={stderr:?}");
+        let v: Value = serde_json::from_str(&stdout).expect("valid JSON");
+        assert_eq!(v["ok"], Value::Bool(true), "json={v}");
+        assert_eq!(v["events"], Value::from(2), "json={v}");
+        assert_eq!(v["first_bad_event"], Value::Null, "json={v}");
+    }
+
+    #[test]
+    fn verify_json_output_names_first_bad_event_when_broken() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        seeded_ledger(repo.path());
+        let e2 = &seeded_event_ids(repo.path())[1];
+
+        tamper(
+            repo.path(),
+            e2,
+            "UPDATE events SET payload = replace(payload, 'second event', 'tampered') \
+             WHERE event_id = ?1",
+        );
+
+        let (code, stdout, stderr) = run_edda(&["verify", "--json"], repo.path());
+        assert_eq!(code, 1, "stdout={stdout:?} stderr={stderr:?}");
+        let v: Value = serde_json::from_str(&stdout).expect("valid JSON");
+        assert_eq!(v["ok"], Value::Bool(false), "json={v}");
+        assert_eq!(v["first_bad_event"], Value::String(e2.clone()), "json={v}");
+    }
+
+    #[test]
+    fn verify_outside_edda_repo_exits_2_with_explanation() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        // No `.edda/` anywhere — `edda verify` must refuse, not fabricate OK.
+        let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
+        assert_eq!(code, 2, "stdout={stdout:?} stderr={stderr:?}");
+        let report = format!("{stdout}{stderr}");
+        assert!(
+            !report.contains("OK"),
+            "must not report success outside a repo: {report:?}"
+        );
+        assert!(
+            report.contains("workspace"),
+            "must explain it is not an edda workspace: {report:?}"
+        );
+    }
 }

--- a/crates/edda-ledger/src/ledger.rs
+++ b/crates/edda-ledger/src/ledger.rs
@@ -3,6 +3,7 @@ use crate::sqlite_store::{BundleRow, SqliteStore};
 use crate::verdict::{self, VerdictRecord};
 use crate::view::{self, DecisionView};
 use anyhow::Context;
+use edda_core::event::finalize_event;
 use edda_core::Event;
 use std::path::Path;
 
@@ -10,6 +11,20 @@ use std::path::Path;
 pub struct Ledger {
     pub paths: EddaPaths,
     pub(crate) sqlite: SqliteStore,
+}
+
+/// Structured outcome of a hash-chain verification (GH-647).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChainVerifyReport {
+    /// Total number of events in the ledger.
+    pub events: usize,
+    /// `event_id` of the last event in insertion order, if any.
+    pub last_event_id: Option<String>,
+    /// `event_id` of the first event that breaks the chain, or `None` when
+    /// the chain is intact (including the empty ledger).
+    pub first_bad_event: Option<String>,
+    /// Human-readable description of the first break, if any.
+    pub reason: Option<String>,
 }
 
 impl Ledger {
@@ -23,6 +38,27 @@ impl Ledger {
             );
         }
         let sqlite = SqliteStore::open_or_create(&paths.ledger_db)?;
+        Ok(Self { paths, sqlite })
+    }
+
+    /// Open an existing workspace ledger without creating or migrating
+    /// anything (read-only).
+    ///
+    /// [`Ledger::open`] delegates to `SqliteStore::open_or_create`, so it
+    /// silently creates an empty ledger when the DB file is missing. That is
+    /// correct for writers but poisonous for integrity checks: `edda verify`
+    /// must report a vanished ledger, not bless an empty one (GH-647). This
+    /// variant fails when `.edda/ledger.db` is missing or unreadable, opens
+    /// the store `query_only`, and never applies schema or migrations.
+    pub fn open_existing(repo_root: impl Into<std::path::PathBuf>) -> anyhow::Result<Self> {
+        let paths = EddaPaths::discover(repo_root);
+        if !paths.is_initialized() {
+            anyhow::bail!(
+                "not an edda workspace ({}/.edda not found). Run `edda init` first.",
+                paths.root.display()
+            );
+        }
+        let sqlite = SqliteStore::open_existing(&paths.ledger_db)?;
         Ok(Self { paths, sqlite })
     }
 
@@ -155,6 +191,84 @@ impl Ledger {
     /// Verify parent linkage and canonical hashes for the complete event log.
     pub fn verify_chain(&self) -> anyhow::Result<()> {
         self.sqlite.verify_chain().context("Ledger::verify_chain")
+    }
+
+    /// Verify the hash chain and report the outcome as data (GH-647).
+    ///
+    /// [`Ledger::verify_chain`] predates the `edda verify` CLI verb and
+    /// reports the first break only as an error string; its signature is
+    /// frozen, so this variant exists so callers can name the first broken
+    /// event without parsing error text. The checks mirror
+    /// `SqliteStore::verify_chain` (sqlite_store/events.rs): canonical hash
+    /// and taxonomy of every event, plus parent linkage from the root, in
+    /// insertion (rowid) order. A row that cannot even be deserialized (e.g.
+    /// a payload overwritten with non-JSON) is itself the first break: it is
+    /// reported by `event_id` instead of failing the whole scan.
+    pub fn verify_chain_report(&self) -> anyhow::Result<ChainVerifyReport> {
+        let rows = self
+            .sqlite
+            .iter_events_reporting()
+            .context("Ledger::verify_chain_report")?;
+        let mut report = ChainVerifyReport {
+            events: rows.len(),
+            last_event_id: rows
+                .last()
+                .and_then(|row| row.as_ref().ok())
+                .map(|event| event.event_id.clone()),
+            first_bad_event: None,
+            reason: None,
+        };
+
+        for (i, row) in rows.iter().enumerate() {
+            let event = match row {
+                Ok(event) => event,
+                Err((event_id, err)) => {
+                    // The row cannot be deserialized, so its stored hash and
+                    // linkage cannot be checked at all: the unreadable row is
+                    // the first break, and it is named (GH-647).
+                    report.first_bad_event = Some(event_id.clone());
+                    report.reason = Some(format!("event {event_id} could not be read: {err}"));
+                    return Ok(report);
+                }
+            };
+            let mut canonical = event.clone();
+            finalize_event(&mut canonical)?;
+            if event.event_family != canonical.event_family
+                || event.event_level != canonical.event_level
+            {
+                report.first_bad_event = Some(event.event_id.clone());
+                report.reason = Some(format!("event {} has invalid taxonomy", event.event_id));
+                return Ok(report);
+            }
+            if event.hash != canonical.hash || event.digests != canonical.digests {
+                report.first_bad_event = Some(event.event_id.clone());
+                report.reason = Some(format!(
+                    "event {} has invalid hash or digest",
+                    event.event_id
+                ));
+                return Ok(report);
+            }
+            let expected_parent = if i == 0 {
+                None
+            } else {
+                match rows[i - 1].as_ref() {
+                    Ok(prev) => Some(prev.hash.as_str()),
+                    // Unreachable: an unreadable row returns above as the
+                    // first break before iteration reaches index i.
+                    Err(_) => None,
+                }
+            };
+            if event.parent_hash.as_deref() != expected_parent {
+                report.first_bad_event = Some(event.event_id.clone());
+                report.reason = Some(format!(
+                    "chain break at event {} (index {}): expected parent_hash={:?}, got {:?}",
+                    event.event_id, i, expected_parent, event.parent_hash
+                ));
+                return Ok(report);
+            }
+        }
+
+        Ok(report)
     }
 
     /// Get a single event by event_id.
@@ -1198,6 +1312,38 @@ mod tests {
         let _ = std::fs::remove_dir_all(&tmp);
     }
 
+    // GH-647: a payload corrupted below the JSON level must be reported as
+    // the first broken event by id, not abort the scan without a culprit.
+    #[test]
+    fn verify_chain_report_names_unreadable_row() {
+        let (tmp, ledger) = setup_workspace();
+        let e1 = new_note_event("main", None, "system", "init", &[]).unwrap();
+        ledger.append_event(&e1).unwrap();
+        let e2 = new_note_event("main", Some(&e1.hash), "system", "second", &[]).unwrap();
+        ledger.append_event(&e2).unwrap();
+
+        {
+            let conn = rusqlite::Connection::open(tmp.join(".edda").join("ledger.db")).unwrap();
+            conn.execute(
+                "UPDATE events SET payload = 'not-json' WHERE event_id = ?1",
+                rusqlite::params![e2.event_id],
+            )
+            .unwrap();
+        }
+
+        let report = ledger.verify_chain_report().unwrap();
+        assert_eq!(
+            report.first_bad_event.as_deref(),
+            Some(e2.event_id.as_str())
+        );
+        assert!(report
+            .reason
+            .as_deref()
+            .unwrap_or("")
+            .contains("could not be read"));
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
     // GH-401: ratified-state derives from insertion order (rowid), not
     // timestamps, and is branch-scoped.
 
@@ -1668,6 +1814,102 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].key, "has.paths");
 
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn verify_chain_report_empty_ledger_is_intact() {
+        let (tmp, ledger) = setup_workspace();
+        let report = ledger.verify_chain_report().unwrap();
+        assert_eq!(report.events, 0);
+        assert_eq!(report.last_event_id, None);
+        assert_eq!(report.first_bad_event, None);
+        assert_eq!(report.reason, None);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn verify_chain_report_clean_chain_counts_and_names_last() {
+        let (tmp, ledger) = setup_workspace();
+        let e1 = new_note_event("main", None, "system", "first", &[]).unwrap();
+        ledger.append_event(&e1).unwrap();
+        let e2 = new_note_event("main", Some(&e1.hash), "system", "second", &[]).unwrap();
+        ledger.append_event(&e2).unwrap();
+
+        let report = ledger.verify_chain_report().unwrap();
+        assert_eq!(report.events, 2);
+        assert_eq!(report.last_event_id.as_deref(), Some(e2.event_id.as_str()));
+        assert_eq!(report.first_bad_event, None);
+        assert_eq!(report.reason, None);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn verify_chain_report_names_first_bad_event_after_payload_tamper() {
+        let (tmp, ledger) = setup_workspace();
+        let e1 = new_note_event("main", None, "system", "first", &[]).unwrap();
+        ledger.append_event(&e1).unwrap();
+        let e2 = new_note_event("main", Some(&e1.hash), "system", "second", &[]).unwrap();
+        ledger.append_event(&e2).unwrap();
+
+        // Tamper with e2's payload behind the ledger's back, via a direct
+        // second connection to the SQLite file.
+        let db = rusqlite::Connection::open(tmp.join(".edda").join("ledger.db")).unwrap();
+        db.execute(
+            "UPDATE events SET payload = replace(payload, 'second', 'tampered') \
+             WHERE event_id = ?1",
+            rusqlite::params![e2.event_id],
+        )
+        .unwrap();
+
+        let report = ledger.verify_chain_report().unwrap();
+        assert_eq!(report.events, 2);
+        assert_eq!(
+            report.first_bad_event.as_deref(),
+            Some(e2.event_id.as_str()),
+            "the first (and only) broken event must be named: {:?}",
+            report.reason
+        );
+        assert!(report.reason.unwrap().contains("invalid hash"));
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn verify_chain_report_names_first_broken_link_not_later_events() {
+        let (tmp, ledger) = setup_workspace();
+        let e1 = new_note_event("main", None, "system", "first", &[]).unwrap();
+        ledger.append_event(&e1).unwrap();
+        let e2 = new_note_event("main", Some(&e1.hash), "system", "second", &[]).unwrap();
+        ledger.append_event(&e2).unwrap();
+        let e3 = new_note_event("main", Some(&e2.hash), "system", "third", &[]).unwrap();
+        ledger.append_event(&e3).unwrap();
+
+        // Forge e3 with a self-consistent hash over a bogus parent, so only
+        // the parent-linkage check can catch it. The report must stop at e3
+        // — the first broken link — never skipping ahead.
+        let mut forged = e3.clone();
+        forged.parent_hash = Some("sha256:bogus".into());
+        edda_core::event::finalize_event(&mut forged).unwrap();
+        let db = rusqlite::Connection::open(tmp.join(".edda").join("ledger.db")).unwrap();
+        db.execute(
+            "UPDATE events SET parent_hash = ?2, hash = ?3, digests = ?4 WHERE event_id = ?1",
+            rusqlite::params![
+                e3.event_id,
+                forged.parent_hash,
+                forged.hash,
+                serde_json::to_string(&forged.digests).unwrap()
+            ],
+        )
+        .unwrap();
+
+        let report = ledger.verify_chain_report().unwrap();
+        assert_eq!(
+            report.first_bad_event.as_deref(),
+            Some(e3.event_id.as_str()),
+            "break must be reported at the first broken link: {:?}",
+            report.reason
+        );
+        assert!(report.reason.unwrap().contains("chain break"));
         let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/crates/edda-ledger/src/sqlite_store/events.rs
+++ b/crates/edda-ledger/src/sqlite_store/events.rs
@@ -319,6 +319,35 @@ impl SqliteStore {
         events.into_iter().map(row_to_event).collect()
     }
 
+    /// Read all events in insertion order, keeping per-row deserialization
+    /// failures attached to the failing row's `event_id`.
+    ///
+    /// [`Self::iter_events`] aborts the whole iteration when any row cannot
+    /// be deserialized, so a single tampered payload hides *which* event is
+    /// broken. Verification (`edda verify`, GH-647) needs the failing row's
+    /// identity, so this variant returns `Err((event_id, reason))` for
+    /// unreadable rows instead of failing the whole scan.
+    pub fn iter_events_reporting(&self) -> anyhow::Result<Vec<Result<Event, (String, String)>>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT event_id, ts, event_type, branch, parent_hash, hash,
+                    payload, refs_blobs, refs_events, refs_provenance,
+                    schema_version, digests, event_family, event_level
+             FROM events ORDER BY rowid",
+        )?;
+
+        let rows = stmt
+            .query_map([], map_event_row)?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| {
+                let event_id = row.event_id.clone();
+                row_to_event(row).map_err(|err| (event_id, format!("{err:#}")))
+            })
+            .collect())
+    }
+
     /// Get all events of a given type, filtered at the SQL level using `idx_events_type`.
     pub fn iter_events_by_type(&self, event_type: &str) -> anyhow::Result<Vec<Event>> {
         let mut stmt = self.conn.prepare(

--- a/crates/edda-ledger/src/sqlite_store/mod.rs
+++ b/crates/edda-ledger/src/sqlite_store/mod.rs
@@ -52,6 +52,30 @@ impl SqliteStore {
         Ok(store)
     }
 
+    /// Open an existing ledger.db without creating or migrating anything.
+    ///
+    /// Fails when the file does not exist. Unlike [`SqliteStore::open_or_create`],
+    /// this never creates the database file, never applies the schema, and
+    /// never runs migrations; the connection is opened `query_only`, so a
+    /// read-only integrity consumer (`edda verify`, GH-647) cannot repair,
+    /// migrate, or otherwise write to the ledger it is checking.
+    pub fn open_existing(db_path: &Path) -> anyhow::Result<Self> {
+        if !db_path.is_file() {
+            anyhow::bail!(
+                "ledger database not found: {} (run `edda init` to create a workspace)",
+                db_path.display()
+            );
+        }
+        let conn = Connection::open(db_path)?;
+        let store = Self { conn };
+        // Connection-level settings only, and `query_only` last: no schema
+        // application, no `journal_mode` write, no checkpoint-on-drop write.
+        store
+            .conn
+            .execute_batch("PRAGMA busy_timeout = 5000; PRAGMA query_only = ON;")?;
+        Ok(store)
+    }
+
     fn apply_pragmas(&self) -> anyhow::Result<()> {
         self.conn.execute_batch(
             "PRAGMA journal_mode = WAL;

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -456,6 +456,32 @@ Index operations.
 edda index verify    # verify index entries match store records
 ```
 
+### `edda verify`
+
+Verify the ledger hash chain — the tamper-evidence check over all events in
+`.edda/ledger.db` (parent linkage + canonical hashes). Read-only: the command
+never creates, migrates, or writes to the ledger — a missing or unreadable
+`.edda/ledger.db` is reported, never silently rebuilt as an empty one.
+
+```bash
+edda verify          # human-readable one-line report
+edda verify --json   # {"ok": ..., "events": ..., "first_bad_event": ...}
+```
+
+Exit codes (same convention as `edda claim check`):
+
+- `0` — chain intact (an empty ledger is OK, not an error)
+- `1` — chain broken; the report names the first broken event (including a
+  row whose payload is no longer valid JSON — the unreadable row is named)
+- `2` — the ledger could not be opened or read (not an edda workspace, or
+  `.edda/ledger.db` missing/unreadable)
+
+Example output on a tampered ledger:
+
+```
+ledger chain BROKEN at event evt_01J… (3 event(s) scanned): event evt_01J… has invalid hash or digest
+```
+
 ---
 
 ## Orchestration


### PR DESCRIPTION
Closes #647. Branch `feat/gh647-edda-verify`, base `bf0dab7`.

## What

`Ledger::verify_chain()` existed in `edda-ledger` with **zero callers** in `edda-cli` (verified: `grep -rn verify_chain crates/edda-cli/src` empty at base). This PR gives it a user-facing entrypoint:

- **`crates/edda-cli/src/main.rs`** — new top-level `Verify { json: bool }` subcommand with a real dispatch branch. The existing `IndexCmd::Verify` is **not** reused (it is a different feature: index-vs-store comparison).
- **`crates/edda-cli/src/cmd_verify.rs`** (new) — opens the ledger exactly like `cmd_export.rs:23` (`Ledger::open(repo_root)?`), refuses when there is no `.edda/` workspace, prints a one-line human report or `--json`, and exits honestly.
- **`crates/edda-ledger/src/ledger.rs`** — read-only for the existing signature; added a **new variant** `Ledger::verify_chain_report() -> ChainVerifyReport` so the CLI can name the first broken event as data instead of parsing `Err(String)` text. Checks mirror `SqliteStore::verify_chain` (canonical hash + taxonomy of every event, parent linkage from the root, insertion/rowid order). Existing `verify_chain()` untouched.
- **`docs/reference/cli.md`** — added **only** the `### edda verify` section (full cli.md completion is #650's lane).

### Output / exit codes (`claim-check.exit-codes=0/1/2` convention)

| Outcome | Output | Exit |
|---|---|---|
| Chain intact (incl. empty ledger) | `ledger chain OK: N event(s), last event <id>` | 0 |
| Chain broken | `ledger chain BROKEN at event <first_bad_id> (N event(s) scanned): <reason>` | 1 |
| Cannot open ledger / not an edda workspace | `error: ...` on stderr | 2 |

`--json` shape: `{"ok": bool, "events": N, "first_bad_event": id|null}` (stable-contract candidate per issue; COMPATIBILITY.md registration is 另案, not done here).

Verification is read-only; the write path is untouched.

## doneWhen — point-by-point

- [x] **`edda verify` on a clean repo prints OK + event count, exit 0; empty ledger is OK** — e2e tests `clean_ledger_is_ok_and_exits_0`, `empty_ledger_is_ok_not_an_error`; library parity test `verify_chain_report_empty_ledger_is_intact` (aligns with existing `verify_chain_empty_store`).
- [x] **Tampered `.edda/ledger.db` → reports first broken event id, exit 1** — e2e tests `tampered_payload_fails_with_first_bad_event_and_exit_1` (payload tamper) and `broken_parent_link_fails_with_first_bad_event_and_exit_1` (parent-hash tamper); library tests `verify_chain_report_names_first_bad_event_after_payload_tamper`, `verify_chain_report_names_first_broken_link_not_later_events`.
- [x] **`edda verify --json` outputs `ok`, `events`, `first_bad_event`** — e2e tests `json_output_has_stable_shape_on_clean_ledger`, `json_output_names_first_bad_event_when_broken`.
- [x] **Not in an edda repo → exit 2 with explanation** — e2e test `outside_edda_repo_exits_2`.
- [x] **`docs/reference/cli.md` gains `### edda verify`** — done, only that section.
- [x] **Regression tests run the CLI entrypoint, real SQLite, tamper after write** — all e2e tests spawn the actual `edda` binary (`edda_bin()` helper, same pattern as `cmd_claim`'s e2e tests) against `tempfile` ledgers built with `Ledger::open_or_init` + `append_event`, tampered via a raw second rusqlite connection. No mocks. Library-only tests are supplementary, not the acceptance basis.

## Red-commit evidence (tests failed before wiring)

- Red SHA: **`689f07f6546400ae8b4fcd57709ca36b569dc120`** (`test(edda-cli): red — CLI entrypoint tests for 'edda verify' (GH-647)`) — subcommand + tests committed with a stubbed execution path.
- Failing output (`cargo test -p edda --bin edda cmd_verify` at red SHA): **7 failed, 0 passed** — e.g.

  ```
  assertion `left == right` failed: stdout="" stderr="Error: edda verify is not wired to Ledger::verify_chain yet (GH-647)\n"
    left: 1, right: 0        (clean_ledger_is_ok_and_exits_0)
  must name first broken event evt_01m1grb999rc78afqyyt4jm0m9: "Error: edda verify is not wired ..."
  valid JSON: Error("EOF while parsing a value", line: 1, column: 0)
  ```

- Green SHA: `d16e2a215a388d68ad42c6ea7a42b1a180f400d7` — all 7 e2e tests pass.

## Gate receipt (L1, frozen SHA `d16e2a215a388d68ad42c6ea7a42b1a180f400d7`, clean tree)

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | OK (2026-09-02T18:00:57+08:00) |
| `cargo clippy --workspace --all-targets -- -D warnings` | OK (18:01:36+08:00) |
| `cargo test --workspace` | **2464 passed, 0 failed** (logged run) |

- Toolchain: `rustc 1.93.1 (01f6ddf75 2026-02-11)` / `cargo 1.93.1`, Windows MSVC.
- Lane: `worker-1` (`CARGO_TARGET_DIR=C:\ai_agent\fleet-workstation\lanes\worker-1`), `CARGO_INCREMENTAL=0` for the whole L1 run.
- L0 while iterating: `cargo clippy -p edda -p edda-ledger --all-targets -- -D warnings` OK; `cargo test -p edda` 451 passed; `cargo test -p edda-ledger` 231 passed.
- Flake note: the first full-workspace run had one failure in `edda-bridge-claude::agent_phase::tests::heartbeat_age_secs_reads_through_the_sanitized_funnel` — a known shared-default-store race (the test deliberately writes without `ENV_LOCK`; its own comment acknowledges the cross-test hazard). It passes deterministically in isolation (3/3) and the crate is untouched by this PR; the rerun of the full suite was fully green. Flagging for the verifier rather than hiding it.

## What this PR does NOT do

- No changes to `crates/edda-conductor/` (PR #624 territory), `cmd_dispatch.rs` / `agent_kind.rs` (#574), or any other `cli.md` section (#650).
- `verify_chain()` signature unchanged; no behavior change to any existing command.
- No signature/attestation semantics (#609 extension), no `ask`/`search` changes.
- COMPATIBILITY.md registration of the `--json` shape (issue marks it 另案) is not included.
