### PR TITLE
fix(bridge): session digest cost distinguishes unmeasured from zero (GH-585)

### DIFF
--- a/crates/edda-bridge-claude/src/digest/extract.rs
+++ b/crates/edda-bridge-claude/src/digest/extract.rs
@@ -512,10 +512,12 @@ pub fn render_digest_text(session_id: &str, stats: &SessionStats) -> String {
             stats.model.clone()
         };
         let total = stats.input_tokens + stats.output_tokens;
-        let cost_str = if stats.estimated_cost_usd > 0.0 {
-            format!(", ${:.4}", stats.estimated_cost_usd)
-        } else {
-            String::new()
+        // GH-585: unmeasured (None) and a measured zero both render no
+        // dollar amount — same behavior as before, but now the distinction
+        // is preserved in the payload instead of flattened into 0.0.
+        let cost_str = match stats.estimated_cost_usd {
+            Some(cost) if cost > 0.0 => format!(", ${cost:.4}"),
+            _ => String::new(),
         };
         lines.push(format!(
             "Usage: {model_label} -- {total} tokens (in:{} out:{}){cost_str}",

--- a/crates/edda-bridge-claude/src/digest/helpers.rs
+++ b/crates/edda-bridge-claude/src/digest/helpers.rs
@@ -148,3 +148,14 @@ pub(super) fn now_rfc3339() -> String {
     now.format(&time::format_description::well_known::Rfc3339)
         .expect("RFC3339 formatting should not fail")
 }
+
+/// Honest cost for a usage snapshot (GH-585): `None` when the session has
+/// no usage data (unmeasured), `Some(estimate)` only when tokens were
+/// actually consumed. Never returns `Some(0.0)` for a no-usage session.
+pub(super) fn measured_cost(usage: &crate::signals::UsageSnapshot) -> Option<f64> {
+    let measured = usage.input_tokens > 0
+        || usage.output_tokens > 0
+        || usage.cache_read_tokens > 0
+        || usage.cache_creation_tokens > 0;
+    measured.then(|| crate::signals::estimate_cost(usage))
+}

--- a/crates/edda-bridge-claude/src/digest/helpers.rs
+++ b/crates/edda-bridge-claude/src/digest/helpers.rs
@@ -150,12 +150,20 @@ pub(super) fn now_rfc3339() -> String {
 }
 
 /// Honest cost for a usage snapshot (GH-585): `None` when the session has
-/// no usage data (unmeasured), `Some(estimate)` only when tokens were
-/// actually consumed. Never returns `Some(0.0)` for a no-usage session.
+/// no usage data (unmeasured), `Some(estimate)` when a usage observation
+/// exists — including `Some(0.0)` when every counter is zero (measured
+/// zero, round-2 P1-1).
+///
+/// Measuredness comes from the presence flag the scanner sets exactly when
+/// a `message.usage` record appeared — never inferred from magnitudes.
+/// Nonzero counters also imply observation (they are only accumulated
+/// inside a usage record), which keeps `usage.json` files written before
+/// the flag existed working.
 pub(super) fn measured_cost(usage: &crate::signals::UsageSnapshot) -> Option<f64> {
-    let measured = usage.input_tokens > 0
+    let observed = usage.usage_observed
+        || usage.input_tokens > 0
         || usage.output_tokens > 0
         || usage.cache_read_tokens > 0
         || usage.cache_creation_tokens > 0;
-    measured.then(|| crate::signals::estimate_cost(usage))
+    observed.then(|| crate::signals::estimate_cost(usage))
 }

--- a/crates/edda-bridge-claude/src/digest/mod.rs
+++ b/crates/edda-bridge-claude/src/digest/mod.rs
@@ -118,8 +118,8 @@ pub struct SessionStats {
     /// Total cache-creation input tokens.
     pub cache_creation_tokens: u64,
     /// Estimated cost in USD. `None` means unmeasured — the session has no
-    /// usage data — never a true zero (GH-585: 0.0 must not conflate "free"
-    /// with "nothing was measured").
+    /// usage data. `Some(0.0)` is a measured zero (e.g. zero pricing),
+    /// never conflated with unmeasured (GH-585).
     pub estimated_cost_usd: Option<f64>,
     /// Activity classification for this session.
     pub activity: ActivityType,

--- a/crates/edda-bridge-claude/src/digest/mod.rs
+++ b/crates/edda-bridge-claude/src/digest/mod.rs
@@ -117,8 +117,10 @@ pub struct SessionStats {
     pub cache_read_tokens: u64,
     /// Total cache-creation input tokens.
     pub cache_creation_tokens: u64,
-    /// Estimated cost in USD.
-    pub estimated_cost_usd: f64,
+    /// Estimated cost in USD. `None` means unmeasured — the session has no
+    /// usage data — never a true zero (GH-585: 0.0 must not conflate "free"
+    /// with "nothing was measured").
+    pub estimated_cost_usd: Option<f64>,
     /// Activity classification for this session.
     pub activity: ActivityType,
 }

--- a/crates/edda-bridge-claude/src/digest/orchestrate.rs
+++ b/crates/edda-bridge-claude/src/digest/orchestrate.rs
@@ -724,7 +724,7 @@ fn digest_one_session(
         stats.output_tokens = usage.output_tokens;
         stats.cache_read_tokens = usage.cache_read_tokens;
         stats.cache_creation_tokens = usage.cache_creation_tokens;
-        stats.estimated_cost_usd = crate::signals::estimate_cost(&usage);
+        stats.estimated_cost_usd = super::helpers::measured_cost(&usage);
     }
 
     // Collect session notes and decisions from workspace ledger

--- a/crates/edda-bridge-claude/src/digest/prev.rs
+++ b/crates/edda-bridge-claude/src/digest/prev.rs
@@ -9,6 +9,18 @@ use super::SessionStats;
 
 // ── Previous Session Digest Snapshot ──
 
+/// Deserialize `estimated_cost_usd` with legacy compatibility (GH-585): old
+/// digests wrote a bare `0.0` to mean "unmeasured". Reading one must not
+/// fail, and the value must be treated as unmeasured — so a deserialized
+/// `0.0` is normalized to `None` instead of a measured zero.
+fn deserialize_legacy_cost<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<f64>::deserialize(deserializer)?;
+    Ok(value.filter(|cost| *cost != 0.0))
+}
+
 /// Snapshot of a completed session, persisted for next session's context injection.
 /// Written at SessionEnd, read at next SessionStart, deleted at that session's end.
 #[derive(Debug, Serialize, Deserialize)]
@@ -64,9 +76,12 @@ pub struct PrevDigest {
     /// Total cache-creation input tokens.
     #[serde(default)]
     pub cache_creation_tokens: u64,
-    /// Estimated cost in USD.
-    #[serde(default)]
-    pub estimated_cost_usd: f64,
+    /// Estimated cost in USD. `None` = unmeasured (no usage data), never a
+    /// true zero (GH-585). Legacy digests wrote `0.0` for unmeasured
+    /// sessions; those still deserialize without failure but are normalized
+    /// to `None` (unmeasured) on read.
+    #[serde(default, deserialize_with = "deserialize_legacy_cost")]
+    pub estimated_cost_usd: Option<f64>,
     /// Activity classification for this session.
     #[serde(default)]
     pub activity: String,
@@ -286,7 +301,7 @@ pub fn write_prev_digest_from_store(
         stats.output_tokens = usage.output_tokens;
         stats.cache_read_tokens = usage.cache_read_tokens;
         stats.cache_creation_tokens = usage.cache_creation_tokens;
-        stats.estimated_cost_usd = crate::signals::estimate_cost(&usage);
+        stats.estimated_cost_usd = super::helpers::measured_cost(&usage);
     }
     // Collect decisions + notes from workspace ledger before writing
     let (decisions, notes) = collect_session_ledger_extras(cwd, stats.first_ts.as_deref());

--- a/crates/edda-bridge-claude/src/digest/prev.rs
+++ b/crates/edda-bridge-claude/src/digest/prev.rs
@@ -9,16 +9,54 @@ use super::SessionStats;
 
 // ── Previous Session Digest Snapshot ──
 
-/// Deserialize `estimated_cost_usd` with legacy compatibility (GH-585): old
-/// digests wrote a bare `0.0` to mean "unmeasured". Reading one must not
-/// fail, and the value must be treated as unmeasured — so a deserialized
-/// `0.0` is normalized to `None` instead of a measured zero.
-fn deserialize_legacy_cost<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = Option::<f64>::deserialize(deserializer)?;
-    Ok(value.filter(|cost| *cost != 0.0))
+/// Wire form of `PrevDigest.estimated_cost_usd` (GH-585).
+///
+/// Three shapes appear on disk and each decodes unambiguously —
+/// measuredness is carried by the form, never guessed from the number:
+///
+/// - `null` / missing — unmeasured (no usage data).
+/// - `{"measured_usd": <f64>}` — this version's measured value; the marker
+///   object cannot be produced by any older version, so a measured zero
+///   (`{"measured_usd": 0.0}`) survives the round trip (round-2 P1-2).
+/// - bare number — legacy digest (pre-GH-585), which wrote `0.0` to mean
+///   "unmeasured": bare `0.0` normalizes to `None`, any other bare number
+///   is a measured cost.
+///
+/// The bare-number form is kept for nonzero measured costs because legacy
+/// wire format expresses them unambiguously, so digests written by this
+/// version still read cleanly in an older binary.
+mod cost_repr {
+    use serde::ser::SerializeMap;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub(super) fn serialize<S: Serializer>(cost: &Option<f64>, s: S) -> Result<S::Ok, S::Error> {
+        match cost {
+            None => s.serialize_none(),
+            // Bare 0.0 is reserved for legacy "unmeasured"; a measured zero
+            // needs the marker form to round-trip.
+            Some(c) if *c == 0.0 => {
+                let mut map = s.serialize_map(Some(1))?;
+                map.serialize_entry("measured_usd", c)?;
+                map.end()
+            }
+            Some(c) => s.serialize_f64(*c),
+        }
+    }
+
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<f64>, D::Error> {
+        let value = Option::<serde_json::Value>::deserialize(d)?;
+        Ok(match value {
+            None | Some(serde_json::Value::Null) => None,
+            // Current-format measured value (including measured zero).
+            Some(serde_json::Value::Object(map)) => {
+                map.get("measured_usd").and_then(|v| v.as_f64())
+            }
+            // Legacy wire format: bare 0.0 meant "unmeasured" (GH-585).
+            Some(serde_json::Value::Number(n)) => n.as_f64().filter(|c| *c != 0.0),
+            // Unknown shape: treat like the rest of this best-effort reader.
+            _ => None,
+        })
+    }
 }
 
 /// Snapshot of a completed session, persisted for next session's context injection.
@@ -76,11 +114,11 @@ pub struct PrevDigest {
     /// Total cache-creation input tokens.
     #[serde(default)]
     pub cache_creation_tokens: u64,
-    /// Estimated cost in USD. `None` = unmeasured (no usage data), never a
-    /// true zero (GH-585). Legacy digests wrote `0.0` for unmeasured
-    /// sessions; those still deserialize without failure but are normalized
-    /// to `None` (unmeasured) on read.
-    #[serde(default, deserialize_with = "deserialize_legacy_cost")]
+    /// Estimated cost in USD (GH-585). `None` = unmeasured (no usage data);
+    /// `Some(0.0)` is a measured zero (e.g. zero pricing), never conflated
+    /// with unmeasured. Wire form: see [`cost_repr`] — legacy digests wrote
+    /// a bare `0.0` for unmeasured sessions and still read back as `None`.
+    #[serde(default, with = "cost_repr")]
     pub estimated_cost_usd: Option<f64>,
     /// Activity classification for this session.
     #[serde(default)]

--- a/crates/edda-bridge-claude/src/digest/tests.rs
+++ b/crates/edda-bridge-claude/src/digest/tests.rs
@@ -3023,3 +3023,85 @@ fn hand_edited_cache_with_correct_hash_cannot_suppress_unnoted_session() {
         "the re-digest must cover the Edit the hand-edited cache claimed consumed"
     );
 }
+
+// ── GH-585: estimated_cost_usd must not conflate unmeasured with zero ──
+
+#[test]
+fn digest_cost_is_null_when_session_has_no_usage() {
+    let tmp = tempfile::tempdir().unwrap();
+    let lines = vec![make_envelope("PostToolUse", "Read", serde_json::json!({}))];
+    let path = write_session_ledger(tmp.path(), &lines);
+
+    let event = extract_session_digest(&path, "sess-nousage", "main", None).unwrap();
+    let cost = &event.payload["session_stats"]["estimated_cost_usd"];
+    assert!(
+        cost.is_null(),
+        "a session with no usage data must record null (unmeasured), got {cost}"
+    );
+}
+
+#[test]
+fn digest_text_omits_cost_when_unmeasured() {
+    let tmp = tempfile::tempdir().unwrap();
+    let lines = vec![make_envelope("PostToolUse", "Read", serde_json::json!({}))];
+    let path = write_session_ledger(tmp.path(), &lines);
+
+    let event = extract_session_digest(&path, "sess-nousage", "main", None).unwrap();
+    let text = event.payload["text"].as_str().unwrap();
+    assert!(
+        !text.contains('$'),
+        "unmeasured cost must not render a dollar amount, got: {text}"
+    );
+}
+
+fn legacy_prev_digest_json(cost_field: serde_json::Value) -> String {
+    let mut v = serde_json::json!({
+        "session_id": "sess-legacy",
+        "completed_at": "2026-02-14T10:00:00Z",
+        "outcome": "completed",
+        "duration_minutes": 3,
+        "completed_tasks": [],
+        "pending_tasks": [],
+        "commits": [],
+        "files_modified_count": 0,
+        "total_edits": 0,
+    });
+    if !cost_field.is_null() {
+        v["estimated_cost_usd"] = cost_field;
+    }
+    serde_json::to_string(&v).unwrap()
+}
+
+#[test]
+fn prev_digest_legacy_zero_cost_reads_as_unmeasured() {
+    // Old digests wrote 0.0 for unmeasured sessions. Reading them must not
+    // fail, and the value must be treated as unmeasured (null), not as a
+    // measured zero.
+    let json = legacy_prev_digest_json(serde_json::json!(0.0));
+    let digest: PrevDigest = serde_json::from_str(&json).expect("legacy 0.0 must not fail to read");
+    let round = serde_json::to_value(&digest).unwrap();
+    assert!(
+        round["estimated_cost_usd"].is_null(),
+        "legacy 0.0 must be treated as unmeasured, got {}",
+        round["estimated_cost_usd"]
+    );
+}
+
+#[test]
+fn prev_digest_missing_cost_field_reads_as_unmeasured() {
+    let json = legacy_prev_digest_json(serde_json::Value::Null);
+    let digest: PrevDigest = serde_json::from_str(&json).expect("missing field must not fail");
+    let round = serde_json::to_value(&digest).unwrap();
+    assert!(round["estimated_cost_usd"].is_null());
+}
+
+#[test]
+fn prev_digest_measured_cost_survives_round_trip() {
+    let json = legacy_prev_digest_json(serde_json::json!(0.0125));
+    let digest: PrevDigest = serde_json::from_str(&json).expect("measured cost must not fail");
+    let round = serde_json::to_value(&digest).unwrap();
+    assert_eq!(
+        round["estimated_cost_usd"], 0.0125,
+        "a measured cost must not be rewritten to unmeasured"
+    );
+}

--- a/crates/edda-bridge-claude/src/digest/tests.rs
+++ b/crates/edda-bridge-claude/src/digest/tests.rs
@@ -3114,7 +3114,9 @@ fn write_usage_json(pid: &str, usage: serde_json::Value) {
         "updated_at": "2026-02-14T10:00:00Z",
         "usage": usage,
     });
-    let path = edda_store::project_dir(pid).join("state").join("usage.json");
+    let path = edda_store::project_dir(pid)
+        .join("state")
+        .join("usage.json");
     let _ = std::fs::create_dir_all(path.parent().unwrap());
     std::fs::write(&path, serde_json::to_string_pretty(&usage_json).unwrap()).unwrap();
 }
@@ -3209,7 +3211,9 @@ fn prev_digest_measured_zero_cost_round_trips() {
     };
     write_prev_digest(pid, "test-zero-rt", &stats, vec![], vec![]);
 
-    let path = edda_store::project_dir(pid).join("state").join("prev_digest.json");
+    let path = edda_store::project_dir(pid)
+        .join("state")
+        .join("prev_digest.json");
     let on_disk = std::fs::read_to_string(&path).unwrap();
     assert!(
         on_disk.contains("measured_usd"),
@@ -3229,8 +3233,7 @@ fn prev_digest_measured_zero_cost_round_trips() {
 #[test]
 fn prev_digest_measured_zero_marker_deserializes() {
     let json = legacy_prev_digest_json(serde_json::json!({"measured_usd": 0.0}));
-    let digest: PrevDigest =
-        serde_json::from_str(&json).expect("marker form must deserialize");
+    let digest: PrevDigest = serde_json::from_str(&json).expect("marker form must deserialize");
     assert_eq!(
         digest.estimated_cost_usd,
         Some(0.0),

--- a/crates/edda-bridge-claude/src/digest/tests.rs
+++ b/crates/edda-bridge-claude/src/digest/tests.rs
@@ -3105,3 +3105,153 @@ fn prev_digest_measured_cost_survives_round_trip() {
         "a measured cost must not be rewritten to unmeasured"
     );
 }
+
+// ── GH-585 round 2: measuredness must be carried by presence, not magnitude ──
+
+fn write_usage_json(pid: &str, usage: serde_json::Value) {
+    let usage_json = serde_json::json!({
+        "session_id": "sess-zero",
+        "updated_at": "2026-02-14T10:00:00Z",
+        "usage": usage,
+    });
+    let path = edda_store::project_dir(pid).join("state").join("usage.json");
+    let _ = std::fs::create_dir_all(path.parent().unwrap());
+    std::fs::write(&path, serde_json::to_string_pretty(&usage_json).unwrap()).unwrap();
+}
+
+#[test]
+fn measured_cost_true_zero_usage_state_is_measured_zero() {
+    // The transcript scanner KNOWS whether a `message.usage` record appeared.
+    // A usage observation with all-zero counters (e.g. zero pricing) is a
+    // measured zero and must yield Some(0.0) — not None. Presence must be
+    // carried independently of the counter magnitudes (round-2 P1-1).
+    let _env = env_guard();
+    let pid = "test_gh585_zero_usage_state";
+    let _ = edda_store::ensure_dirs(pid);
+
+    write_usage_json(
+        pid,
+        serde_json::json!({
+            "model": "claude-sonnet-4-20250514",
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_creation_tokens": 0,
+            "usage_observed": true
+        }),
+    );
+
+    let usage = crate::signals::read_usage_state(pid);
+    assert_eq!(
+        measured_cost(&usage),
+        Some(0.0),
+        "usage observed with all-zero counters is a measured zero, not unmeasured"
+    );
+
+    let _ = std::fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn prev_digest_measured_zero_usage_writes_measured_zero_cost() {
+    // End to end: usage.json says usage was observed but every counter is
+    // zero; the snapshot written for the next session must carry the
+    // measured zero, not null (round-2 P1-1).
+    let _env = env_guard();
+    let pid = "test_gh585_prev_zero_usage";
+    let _ = edda_store::ensure_dirs(pid);
+
+    let store_dir = edda_store::project_dir(pid).join("ledger");
+    let _ = std::fs::create_dir_all(&store_dir);
+    let envelope = make_envelope("PostToolUse", "Read", serde_json::json!({}));
+    std::fs::write(
+        store_dir.join("sess-zero.jsonl"),
+        serde_json::to_string(&envelope).unwrap(),
+    )
+    .unwrap();
+
+    write_usage_json(
+        pid,
+        serde_json::json!({
+            "model": "claude-sonnet-4-20250514",
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_creation_tokens": 0,
+            "usage_observed": true
+        }),
+    );
+
+    let cwd = tempfile::tempdir().unwrap();
+    write_prev_digest_from_store(pid, "sess-zero", cwd.path().to_str().unwrap(), 0, 0, 0);
+
+    let digest = read_prev_digest(pid).expect("should read prev_digest");
+    assert_eq!(
+        digest.estimated_cost_usd,
+        Some(0.0),
+        "measured zero must reach the snapshot, not be written as unmeasured"
+    );
+
+    let _ = std::fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn prev_digest_measured_zero_cost_round_trips() {
+    // This version writes measured zero as a distinguishable wire form
+    // (round-2 P1-2); it must read back as Some(0.0), never be swallowed by
+    // the legacy bare-0.0 rule.
+    let _env = env_guard();
+    let pid = "test_gh585_zero_roundtrip";
+    let _ = edda_store::ensure_dirs(pid);
+
+    let stats = SessionStats {
+        estimated_cost_usd: Some(0.0),
+        ..Default::default()
+    };
+    write_prev_digest(pid, "test-zero-rt", &stats, vec![], vec![]);
+
+    let path = edda_store::project_dir(pid).join("state").join("prev_digest.json");
+    let on_disk = std::fs::read_to_string(&path).unwrap();
+    assert!(
+        on_disk.contains("measured_usd"),
+        "measured zero must be written in marker form, got: {on_disk}"
+    );
+
+    let digest = read_prev_digest(pid).expect("should read prev_digest");
+    assert_eq!(
+        digest.estimated_cost_usd,
+        Some(0.0),
+        "a measured zero written by this version must read back as measured zero"
+    );
+
+    let _ = std::fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn prev_digest_measured_zero_marker_deserializes() {
+    let json = legacy_prev_digest_json(serde_json::json!({"measured_usd": 0.0}));
+    let digest: PrevDigest =
+        serde_json::from_str(&json).expect("marker form must deserialize");
+    assert_eq!(
+        digest.estimated_cost_usd,
+        Some(0.0),
+        "the marker form carries a measured zero"
+    );
+}
+
+#[test]
+fn prev_digest_measured_nonzero_cost_round_trips() {
+    let _env = env_guard();
+    let pid = "test_gh585_nonzero_roundtrip";
+    let _ = edda_store::ensure_dirs(pid);
+
+    let stats = SessionStats {
+        estimated_cost_usd: Some(0.0125),
+        ..Default::default()
+    };
+    write_prev_digest(pid, "test-nonzero-rt", &stats, vec![], vec![]);
+
+    let digest = read_prev_digest(pid).expect("should read prev_digest");
+    assert_eq!(digest.estimated_cost_usd, Some(0.0125));
+
+    let _ = std::fs::remove_dir_all(edda_store::project_dir(pid));
+}

--- a/crates/edda-bridge-claude/src/signals.rs
+++ b/crates/edda-bridge-claude/src/signals.rs
@@ -43,6 +43,12 @@ pub struct UsageSnapshot {
     pub cache_read_tokens: u64,
     #[serde(default)]
     pub cache_creation_tokens: u64,
+    /// Whether at least one `message.usage` record was observed in the
+    /// transcript (GH-585 round 2). Presence is recorded independently of
+    /// the token counters so a measured all-zero usage (e.g. zero pricing)
+    /// stays distinguishable from a session with no usage data at all.
+    #[serde(default)]
+    pub usage_observed: bool,
 }
 
 impl UsageSnapshot {
@@ -124,6 +130,10 @@ pub(crate) fn extract_session_signals(transcript_store_path: &Path) -> SessionSi
             "assistant" => {
                 // Accumulate usage from assistant messages
                 if let Some(u) = record.get("message").and_then(|m| m.get("usage")) {
+                    // Record presence independently of the counters (GH-585
+                    // round 2): a usage record with all-zero tokens is a
+                    // measured zero, not an unmeasured session.
+                    usage.usage_observed = true;
                     usage.input_tokens +=
                         u.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
                     usage.output_tokens +=
@@ -1853,6 +1863,7 @@ mod tests {
             output_tokens: 100_000,
             cache_read_tokens: 600_000,
             cache_creation_tokens: 100_000,
+            ..Default::default()
         };
         let cost = estimate_cost(&usage);
         // full-price input: (1M - 600k - 100k) = 300k * $3/M = $0.90
@@ -1918,6 +1929,64 @@ mod tests {
         assert_eq!(signals.usage.cache_read_tokens, 300);
         assert_eq!(signals.usage.cache_creation_tokens, 50);
         assert_eq!(signals.usage.total_tokens(), 4300);
+        assert!(
+            signals.usage.usage_observed,
+            "usage records were present in the transcript"
+        );
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn signals_usage_presence_recorded_independently_of_counters() {
+        // GH-585 round 2 P1-1: presence must not be inferred from the token
+        // counters. A usage record with all-zero tokens still sets the flag.
+        let records = vec![serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "model": "claude-sonnet-4-20250514",
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                    "cache_creation_input_tokens": 0
+                },
+                "content": [{ "type": "text", "text": "Hello" }]
+            }
+        })];
+        let path = make_transcript(&records);
+        let signals = extract_session_signals(&path);
+        assert_eq!(signals.usage.input_tokens, 0);
+        assert_eq!(signals.usage.output_tokens, 0);
+        assert!(
+            signals.usage.usage_observed,
+            "a usage record with all-zero counters is still a usage observation"
+        );
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn signals_no_usage_record_means_no_presence() {
+        let records = vec![
+            serde_json::json!({
+                "type": "system",
+                "model": "claude-sonnet-4-20250514"
+            }),
+            serde_json::json!({
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "model": "claude-sonnet-4-20250514",
+                    "content": [{ "type": "text", "text": "Hello" }]
+                }
+            }),
+        ];
+        let path = make_transcript(&records);
+        let signals = extract_session_signals(&path);
+        assert!(
+            !signals.usage.usage_observed,
+            "no message.usage record in the transcript"
+        );
         let _ = fs::remove_file(&path);
     }
 
@@ -1933,6 +2002,7 @@ mod tests {
                 output_tokens: 2000,
                 cache_read_tokens: 100,
                 cache_creation_tokens: 50,
+                usage_observed: true,
             },
             ..Default::default()
         };
@@ -1944,6 +2014,33 @@ mod tests {
         assert_eq!(loaded.output_tokens, 2000);
         assert_eq!(loaded.cache_read_tokens, 100);
         assert_eq!(loaded.cache_creation_tokens, 50);
+        assert!(loaded.usage_observed, "presence must survive usage.json");
+
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    }
+
+    #[test]
+    fn usage_state_round_trips_measured_zero_presence() {
+        // GH-585 round 2 P1-1: a usage snapshot with usage_observed=true and
+        // all-zero counters must survive usage.json unchanged — that is the
+        // measured-zero case the magnitude-based check used to lose.
+        let pid = "test_usage_zero_rt";
+        let _ = edda_store::ensure_dirs(pid);
+
+        let signals = SessionSignals {
+            usage: UsageSnapshot {
+                model: "claude-sonnet-4-20250514".into(),
+                usage_observed: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        save_session_signals(pid, "test-session", &signals);
+
+        let loaded = read_usage_state(pid);
+        assert!(loaded.usage_observed);
+        assert_eq!(loaded.input_tokens, 0);
+        assert_eq!(loaded.output_tokens, 0);
 
         let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     }


### PR DESCRIPTION
Closes #585

## Summary

`SessionStats.estimated_cost_usd` was a bare `f64` where `0.0` meant both
「免費」and「沒量到」— the same measuredness disease #533 eradicated in
conductor, alive in the bridge digest pipeline, written into the ledger
once per session. Cost is now `Option<f64>`: `None` = unmeasured (no
usage data), `Some` = measured estimate. True zero and unmeasured are
distinguishable again.

## doneWhen 對照

1. **`SessionStats.estimated_cost_usd` 改 `Option<f64>`；無 usage → `None`** ✅
   `digest/mod.rs` — field is now `Option<f64>`. New
   `helpers::measured_cost()` returns `Some(estimate)` only when tokens
   were actually consumed (input/output/cache_read/cache_creation > 0);
   both enrichment sites (`orchestrate.rs`, `prev.rs`) use it. No usage
   data → `None`.
2. **payload 寫入 null 而非 0.0** ✅
   `digest/render.rs` needs no change: `serde_json::json!` serializes
   `Option::None` as `null`. Verified by regression test
   `digest_cost_is_null_when_session_has_no_usage`.
3. **渲染行為不變（None／零皆不顯示）** ✅
   `digest/extract.rs` `render_digest_text` now matches
   `Some(cost) if cost > 0.0` → same visible behavior as the old
   `> 0.0` check on a bare f64. Guard test
   `digest_text_omits_cost_when_unmeasured` pins it. The downstream
   `edda-cli` reader (`cmd_log.rs`) parses the payload via
   `as_f64().unwrap_or(0.0)`, so `null` behaves identically to `0.0`
   there too — no reader changes needed or made.
4. **`prev.rs` 向後相容：舊 digest 的 `0.0` 不失敗、視為 unmeasured** ✅
   `PrevDigest.estimated_cost_usd` is `Option<f64>` with
   `#[serde(default, deserialize_with = "deserialize_legacy_cost")]`:
   a legacy `0.0` deserializes without failure and is normalized to
   `None` (unmeasured); a missing field → `None`; a real measured cost
   round-trips intact. Tests:
   `prev_digest_legacy_zero_cost_reads_as_unmeasured`,
   `prev_digest_missing_cost_field_reads_as_unmeasured`,
   `prev_digest_measured_cost_survives_round_trip`.
5. **迴歸測試：無 usage session → cost null；先 FAIL 再過** ✅ — see below.

## FAIL-first 證據

Red commit (tests only, fails against pre-fix source):
**`90339205b718022d107f52a08903660201a67551`**

Verbatim failure output of `cargo test -p edda-bridge-claude cost` at the red commit:

```
failures:

---- digest::tests::prev_digest_legacy_zero_cost_reads_as_unmeasured stdout ----

thread 'digest::tests::prev_digest_legacy_zero_cost_reads_as_unmeasured' (27808) panicked at crates\edda-bridge-claude\src\digest\tests.rs:3083:5:
legacy 0.0 must be treated as unmeasured, got 0.0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- digest::tests::prev_digest_missing_cost_field_reads_as_unmeasured stdout ----

thread 'digest::tests::prev_digest_missing_cost_field_reads_as_unmeasured' (25928) panicked at crates\edda-bridge-claude\src\digest\tests.rs:3095:5:
assertion failed: round["estimated_cost_usd"].is_null()

---- digest::tests::digest_cost_is_null_when_session_has_no_usage stdout ----

thread 'digest::tests::digest_cost_is_null_when_session_has_no_usage' (34524) panicked at crates\edda-bridge-claude\src\digest\tests.rs:3037:5:
a session with no usage data must record null (unmeasured), got 0.0


failures:
    digest::tests::digest_cost_is_null_when_session_has_no_usage
    digest::tests::prev_digest_legacy_zero_cost_reads_as_unmeasured
    digest::tests::prev_digest_missing_cost_field_reads_as_unmeasured

test result: FAILED. 10 passed; 3 failed; 0 ignored; 0 measured; 593 filtered out; finished in 0.01s

error: test failed, to rerun pass `-p edda-bridge-claude --lib`
```

Fix commit: **`026ecbdb389250a678d2aacf07cb118f63d1818e`** — all 5 new
tests green (`13 passed` for the `cost` filter, including the two
behavior guards that were green before and after).

## Gate receipt (L0 + L1 at frozen SHA `026ecbd`)

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | OK |
| `cargo clippy -p edda-bridge-claude --all-targets -- -D warnings` (L0) | OK, zero warnings |
| `cargo clippy --workspace --all-targets -- -D warnings` (L1) | OK, zero warnings |
| `cargo test -p edda-bridge-claude` (L0, serial `--test-threads=1`) | **606 passed, 0 failed** |
| `cargo test --workspace --no-fail-fast` (L1) | all 23 crates + doctests green **except** `edda-bridge-claude --lib`: 586 passed / 20 failed — see flake note |

- Toolchain: rustc 1.93.1 (01f6ddf75 2026-02-11), cargo 1.93.1
- Lane: `C:\ai_agent\fleet-workstation\lanes\worker-3`, `CARGO_INCREMENTAL=0` for L1
- Worktree: `C:\ai_agent\edda-wt-gh585`, base = current `origin/main` (5a4b5fa, includes #607)

### Pre-existing flake note (NOT introduced by this PR)

The 20 parallel-mode failures in `edda-bridge-claude --lib` are the
pre-existing env-race family (`dispatch::*`, `render::*`,
`state::*`, `bg_scan::*`, `agent_phase::*`): tests mutate
`EDDA_STORE_ROOT`-family env vars under a shared `ENV_LOCK`; one
time/cooldown-sensitive test panics while holding the lock and the
poisoned mutex cascades `PoisonError` into every subsequent
`with_env_guard` test. Failure count varies run-to-run (observed 5–44)
**including with this PR's diff stashed** (red-commit tree: 25 failed,
same family). Serial execution at this exact SHA is fully green
(606/0). These tests live in `bg_scan.rs` / `bg_digest.rs` /
`dispatch.rs` / `render.rs` / `state.rs` — outside this PR's allowed
scope (`digest/` only). **FOLLOW-UP ISSUE candidate**: serialize or
scope-isolate the env-mutating bridge tests; the
`bg_digest::tests::idempotency_guard_works` test additionally writes to
the real user store when `EDDA_STORE_ROOT` is unset and leaves residue
on panic.

## 向後相容怎麼驗的

- `prev_digest_legacy_zero_cost_reads_as_unmeasured`: a legacy
  `prev_digest.json` containing `"estimated_cost_usd": 0.0`
  deserializes successfully (red commit proved it could not fail even
  before the fix — the red failure was the *value*, not the parse) and
  round-trips as `null` (unmeasured).
- `prev_digest_missing_cost_field_reads_as_unmeasured`: legacy files
  predating the field entirely (serde default) also read as unmeasured.
- `prev_digest_measured_cost_survives_round_trip`: a real measured cost
  (`0.0125`) is preserved, not clobbered to `None`.
- Payload consumers: `cmd_log.rs` reads the field via
  `.and_then(|v| v.as_f64()).unwrap_or(0.0)` — `null` and absent both
  degrade to hidden, identical to old `0.0` behavior. No other
  consumers of `estimated_cost_usd` exist outside `digest/`.

## Scope

Only `crates/edda-bridge-claude/src/digest/` (`mod.rs`, `orchestrate.rs`,
`render.rs`, `extract.rs`, `prev.rs`, `helpers.rs`) and `digest/tests.rs`.
No conductor / cli-verify / main.rs changes. #582 read-side reporting not
touched.
