### PR TITLE
fix(conductor): check capture records executed shell line and keeps stream heads (GH-558)

### DIFF
--- a/crates/edda-conductor/src/check/cmd_succeeds.rs
+++ b/crates/edda-conductor/src/check/cmd_succeeds.rs
@@ -11,6 +11,12 @@ use tokio::process::Command;
 /// live (LNK1104's payload, `error: test failed`).
 const OUTPUT_TAIL_CHARS: usize = 2000;
 
+/// Per-stream capture cap for the HEAD (GH-558): some failure families put
+/// the fatal line FIRST — cargo-fmt prints the actual reason before its
+/// help/usage block, so tail-only capture kept the block and dropped the
+/// reason, which is exactly the shape GH-558 was filed from. Keep both ends.
+const OUTPUT_HEAD_CHARS: usize = 400;
+
 /// Output substrings that identify a machine-layer build failure (GH-540).
 /// The full linker-fatal signature — not the bare code — is required (review
 /// round 1): a bare `LNK1104` token also shows up in agent output that merely
@@ -74,6 +80,13 @@ fn which_exists(name: &str) -> bool {
 pub async fn check_cmd_succeeds(cmd: &str, timeout_sec: u64, cwd: &Path) -> CheckOutput {
     let start = Instant::now();
     let (shell, args) = shell_cmd(cmd);
+    // GH-558 doneWhen 1: record the exact shell line the harness executes, so
+    // a harness-side invocation difference is visible in the captured output
+    // instead of being inferred (wrongly, in the original report) from the
+    // child's output.
+    // mask_secrets: the spec string itself may embed a credential (caught by
+    // the GH-558 round-0 test `secrets_masked_in_output`).
+    let executed = mask_secrets(&shell_line(&shell, &args));
 
     let result = Command::new(&shell)
         .args(&args)
@@ -92,18 +105,26 @@ pub async fn check_cmd_succeeds(cmd: &str, timeout_sec: u64, cwd: &Path) -> Chec
             // link.exe puts "cannot open file '...'" at the very end of
             // stderr — so a tail of one stream reproduces the same useless
             // message the issue was filed with.
+            // GH-558: keep the HEAD of both streams too — cargo-fmt prints
+            // its failure reason BEFORE the usage block, and tail-only
+            // capture reduced the observed output to the bare usage text.
             let stderr = mask_secrets(&String::from_utf8_lossy(&output.stderr));
             let stdout = mask_secrets(&String::from_utf8_lossy(&output.stdout));
+            let stderr_cap = bounded_stream(&stderr);
+            let stdout_cap = bounded_stream(&stdout);
             let stderr_tail = output_tail(&stderr, OUTPUT_TAIL_CHARS);
             let stdout_tail = output_tail(&stdout, OUTPUT_TAIL_CHARS);
-            let mut message = format!("exit {}", output.status.code().unwrap_or(-1));
-            if !stderr_tail.trim().is_empty() {
-                message.push_str(": ");
-                message.push_str(stderr_tail.trim_end());
+            let mut message = format!(
+                "executed: {executed}\nexit {}",
+                output.status.code().unwrap_or(-1)
+            );
+            if !stderr_cap.trim().is_empty() {
+                message.push_str("\n--- stderr ---\n");
+                message.push_str(stderr_cap.trim_end());
             }
-            if !stdout_tail.trim().is_empty() {
-                message.push_str("\n--- stdout (tail) ---\n");
-                message.push_str(stdout_tail.trim_end());
+            if !stdout_cap.trim().is_empty() {
+                message.push_str("\n--- stdout ---\n");
+                message.push_str(stdout_cap.trim_end());
             }
             let detail = message.trim().to_string();
             if is_environmental(stderr_tail, stdout_tail) {
@@ -112,12 +133,43 @@ pub async fn check_cmd_succeeds(cmd: &str, timeout_sec: u64, cwd: &Path) -> Chec
                 CheckOutput::failed(detail, start.elapsed())
             }
         }
-        Ok(Err(e)) => CheckOutput::failed(format!("spawn error: {e}"), start.elapsed()),
+        Ok(Err(e)) => CheckOutput::failed(
+            format!("executed: {executed}\nspawn error: {e}"),
+            start.elapsed(),
+        ),
         Err(_) => CheckOutput::timed_out(
-            format!("command timed out after {timeout_sec}s: {cmd}"),
+            format!("command timed out after {timeout_sec}s: {cmd} (executed: {executed})"),
             start.elapsed(),
         ),
     }
+}
+
+/// Render the executed shell line for check diagnostics (GH-558).
+fn shell_line(shell: &str, args: &[String]) -> String {
+    let mut parts = vec![shell.to_string()];
+    for arg in args {
+        if arg.contains(' ') {
+            parts.push(format!("\"{arg}\""));
+        } else {
+            parts.push(arg.clone());
+        }
+    }
+    parts.join(" ")
+}
+
+/// Keep the head and the tail of a captured stream, bounded (GH-558).
+/// Short streams pass through unchanged; long ones keep the first
+/// `OUTPUT_HEAD_CHARS` and last `OUTPUT_TAIL_CHARS` characters with an
+/// explicit truncation marker between them. Char-boundary safe.
+fn bounded_stream(s: &str) -> String {
+    let total = s.chars().count();
+    if total <= OUTPUT_TAIL_CHARS {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(OUTPUT_HEAD_CHARS).collect();
+    let tail = output_tail(s, OUTPUT_TAIL_CHARS);
+    let skipped = total - OUTPUT_HEAD_CHARS - OUTPUT_TAIL_CHARS;
+    format!("{head}\n...[{skipped} chars truncated]...\n{tail}")
 }
 
 #[cfg(test)]

--- a/crates/edda-conductor/src/check/cmd_succeeds.rs
+++ b/crates/edda-conductor/src/check/cmd_succeeds.rs
@@ -411,6 +411,90 @@ mod tests {
         );
     }
 
+    /// GH-558 review round 1 (P1-1): a stream of 2001–2399 chars sits in the
+    /// gap between the tail cap (2000) and the head+tail sum (2400). The old
+    /// arithmetic entered the truncation branch as soon as `total > 2000` but
+    /// computed `skipped = total - HEAD - TAIL`, which is a usize underflow —
+    /// a debug-build panic and a release-build wrap that also made head and
+    /// tail overlap. Streams no longer than HEAD+TAIL pass through unchanged.
+    #[test]
+    fn bounded_stream_keeps_boundary_lengths_whole() {
+        let boundary_lengths = [
+            OUTPUT_TAIL_CHARS,
+            OUTPUT_TAIL_CHARS + 1,
+            OUTPUT_HEAD_CHARS + OUTPUT_TAIL_CHARS - 1,
+            OUTPUT_HEAD_CHARS + OUTPUT_TAIL_CHARS,
+        ];
+        for len in boundary_lengths {
+            let s = "x".repeat(len);
+            assert_eq!(
+                bounded_stream(&s),
+                s,
+                "a stream of {len} chars must pass through unchanged"
+            );
+        }
+    }
+
+    /// GH-558 review round 1 (P1-1): above the HEAD+TAIL sum the capture is
+    /// head + explicit marker + tail, the skipped count is exact, and the
+    /// head/tail regions do not overlap. Chars are drawn from a distinct-per-
+    /// position Hangul range, so any overlap would surface as a duplicated
+    /// or out-of-place character; multibyte chars also re-check boundaries.
+    #[test]
+    fn bounded_stream_splits_above_head_tail_sum_without_overlap() {
+        let extra = 500;
+        let total = OUTPUT_HEAD_CHARS + OUTPUT_TAIL_CHARS + extra;
+        let s: String = (0..total)
+            .map(|i| char::from_u32(0xAC00 + i as u32).unwrap())
+            .collect();
+        let captured = bounded_stream(&s);
+        let head: String = s.chars().take(OUTPUT_HEAD_CHARS).collect();
+        let tail: String = s.chars().skip(total - OUTPUT_TAIL_CHARS).collect();
+        assert!(captured.starts_with(&head), "head must be kept verbatim");
+        assert!(captured.ends_with(&tail), "tail must be kept verbatim");
+        assert!(
+            captured.contains(&format!("[{extra} chars truncated]")),
+            "skipped count must be exact: {captured}"
+        );
+        // Each char is unique, so the first SKIPPED char appearing anywhere
+        // in the capture would prove head/tail overlap.
+        let first_skipped = char::from_u32(0xAC00 + OUTPUT_HEAD_CHARS as u32).unwrap();
+        assert!(
+            !captured.contains(first_skipped),
+            "head and tail regions must not overlap"
+        );
+    }
+
+    /// GH-558 review round 1 (P1-2): the timeout detail must not leak the
+    /// raw command line. The executed-line work added a masked `executed`,
+    /// but the format string still carried a raw `{cmd}` copy in front of
+    /// it — a command embedding a credential that timed out produced BOTH
+    /// the plaintext secret and the masked line, breaking the PR's
+    /// "every non-passing result masks the actual command" contract.
+    #[tokio::test]
+    async fn timeout_detail_masks_secret_in_command() {
+        let dir = tempfile::tempdir().unwrap();
+        #[cfg(not(windows))]
+        let cmd = "sleep 60 # token=abc123supersecret";
+        #[cfg(windows)]
+        let cmd = if which_exists("pwsh") || which_exists("powershell") {
+            "while ($true) { Start-Sleep -Milliseconds 100 } # token=abc123supersecret"
+        } else {
+            "rem token=abc123supersecret & ping -n 60 127.0.0.1 > nul"
+        };
+        let out = check_cmd_succeeds(cmd, 1, dir.path()).await;
+        assert!(out.timed_out, "test requires the command to time out");
+        let detail = out.detail.unwrap();
+        assert!(
+            !detail.contains("abc123supersecret"),
+            "timeout detail must not contain the plaintext secret: {detail}"
+        );
+        assert!(
+            detail.contains("token=[MASKED]"),
+            "timeout detail must keep the masked executed line: {detail}"
+        );
+    }
+
     /// GH-558 doneWhen 3: a multi-flag command must pass through the check
     /// runner from a REAL git worktree cwd (`.git` is a file, not a
     /// directory) — the cwd shape reported in the issue. Witness test: the

--- a/crates/edda-conductor/src/check/cmd_succeeds.rs
+++ b/crates/edda-conductor/src/check/cmd_succeeds.rs
@@ -138,7 +138,11 @@ pub async fn check_cmd_succeeds(cmd: &str, timeout_sec: u64, cwd: &Path) -> Chec
             start.elapsed(),
         ),
         Err(_) => CheckOutput::timed_out(
-            format!("command timed out after {timeout_sec}s: {cmd} (executed: {executed})"),
+            // Round-1 P1-2: only the masked `executed` line carries the
+            // command here. The raw `{cmd}` copy that used to sit in front
+            // of it leaked plaintext credentials from timed-out commands,
+            // breaking the non-passing-results masking contract.
+            format!("command timed out after {timeout_sec}s (executed: {executed})"),
             start.elapsed(),
         ),
     }
@@ -158,12 +162,16 @@ fn shell_line(shell: &str, args: &[String]) -> String {
 }
 
 /// Keep the head and the tail of a captured stream, bounded (GH-558).
-/// Short streams pass through unchanged; long ones keep the first
+/// Streams no longer than `OUTPUT_HEAD_CHARS + OUTPUT_TAIL_CHARS` pass
+/// through unchanged — that sum, not the tail cap, is the truncation
+/// threshold, because `skipped = total - HEAD - TAIL` is only defined
+/// above it (round-1 P1-1: at 2001–2399 chars the old `total > TAIL`
+/// gate produced a usize underflow). Long streams keep the first
 /// `OUTPUT_HEAD_CHARS` and last `OUTPUT_TAIL_CHARS` characters with an
 /// explicit truncation marker between them. Char-boundary safe.
 fn bounded_stream(s: &str) -> String {
     let total = s.chars().count();
-    if total <= OUTPUT_TAIL_CHARS {
+    if total <= OUTPUT_HEAD_CHARS + OUTPUT_TAIL_CHARS {
         return s.to_string();
     }
     let head: String = s.chars().take(OUTPUT_HEAD_CHARS).collect();

--- a/crates/edda-conductor/src/check/cmd_succeeds.rs
+++ b/crates/edda-conductor/src/check/cmd_succeeds.rs
@@ -1,4 +1,8 @@
+#[cfg(test)]
+use crate::check::engine::CheckEngine;
 use crate::check::{mask_secrets, output_tail, CheckOutput};
+#[cfg(test)]
+use crate::plan::schema::CheckSpec;
 use std::path::Path;
 use std::time::{Duration, Instant};
 use tokio::process::Command;
@@ -289,6 +293,138 @@ mod tests {
         assert!(
             !out.environmental,
             "a bare LNK1104 mention is not a linker fault"
+        );
+    }
+
+    /// GH-558: a non-passing check result must record the exact shell line
+    /// the harness executed, so a harness-side invocation difference is
+    /// visible in the captured output (doneWhen 1). Before the fix the
+    /// failure detail carried only the child's output — when cargo-fmt
+    /// prints its usage block, there is no way to tell what argv actually
+    /// reached it.
+    #[tokio::test]
+    async fn failure_detail_records_executed_shell_line() {
+        let dir = tempfile::tempdir().unwrap();
+        #[cfg(not(windows))]
+        let cmd = "exit 1";
+        #[cfg(windows)]
+        let cmd = "exit 1";
+        let out = check_cmd_succeeds(cmd, 10, dir.path()).await;
+        assert!(!out.passed);
+        let detail = out.detail.unwrap();
+        assert!(
+            detail.contains("executed:"),
+            "failure detail must record the executed shell line, got: {detail}"
+        );
+        assert!(
+            detail.contains(cmd),
+            "executed line must contain the literal command, got: {detail}"
+        );
+    }
+
+    /// GH-558: the observed failure was cargo-fmt printing its help/usage
+    /// block — which it does for ANY internal io failure, with the actual
+    /// REASON line printed BEFORE the block. A tail-only capture keeps the
+    /// block and drops the reason, turning a diagnosable failure into the
+    /// mystery this issue was filed as. The capture must keep the HEAD of a
+    /// stream too, not only the tail.
+    #[tokio::test]
+    async fn failure_keeps_head_of_stream_when_output_exceeds_tail() {
+        let dir = tempfile::tempdir().unwrap();
+        // Diagnostic at the START of stderr, then >2000 chars of filler: a
+        // tail-only capture keeps only filler.
+        #[cfg(not(windows))]
+        let cmd = concat!(
+            "echo 'fatal: the real reason is at the head' 1>&2 ; ",
+            "yes x | head -c 4000 1>&2 ; ",
+            "exit 1"
+        );
+        #[cfg(windows)]
+        let cmd = concat!(
+            "[Console]::Error.WriteLine('fatal: the real reason is at the head') ; ",
+            "[Console]::Error.WriteLine(('x' * 4000)) ; ",
+            "exit 1"
+        );
+        let out = check_cmd_succeeds(cmd, 10, dir.path()).await;
+        assert!(!out.passed);
+        let detail = out.detail.unwrap();
+        assert!(
+            detail.contains("the real reason is at the head"),
+            "head of the stream must be kept, got: {detail}"
+        );
+        assert!(
+            detail.chars().count() < 5200,
+            "capture must stay bounded, got {} chars",
+            detail.chars().count()
+        );
+    }
+
+    /// GH-558 doneWhen 3: a multi-flag command must pass through the check
+    /// runner from a REAL git worktree cwd (`.git` is a file, not a
+    /// directory) — the cwd shape reported in the issue. Witness test: the
+    /// harness passes the literal spec string regardless of cwd, verified to
+    /// run green here both before and after the fix (the bug itself was not
+    /// reproducible — see the PR for the full reproduction record).
+    #[tokio::test]
+    async fn multi_flag_cmd_succeeds_from_real_worktree_cwd() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        // A tiny standalone cargo project, independent of this workspace.
+        let proj = tmp.path().join("proj");
+        std::fs::create_dir_all(proj.join("src")).unwrap();
+        std::fs::write(
+            proj.join("Cargo.toml"),
+            "[package]\nname = \"gh558diag\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+        std::fs::write(proj.join("src/main.rs"), "fn main() {}\n").unwrap();
+
+        let git = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&proj)
+                .output()
+                .expect("git must be available");
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        git(&["init"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "test"]);
+        git(&["add", "-A"]);
+        git(&["commit", "-m", "init"]);
+
+        // The worktree: cwd shape whose .git is a FILE.
+        let wt = tmp.path().join("proj-wt");
+        git(&[
+            "worktree",
+            "add",
+            wt.to_str().unwrap(),
+            "-b",
+            "gh558-witness",
+        ]);
+        assert!(
+            wt.join(".git").is_file(),
+            "worktree .git must be a file — that is the cwd shape from GH-558"
+        );
+
+        let engine = CheckEngine::new(wt);
+        let checks = vec![CheckSpec::CmdSucceeds {
+            cmd: "cargo fmt --all --check".into(),
+            timeout_sec: 300,
+        }];
+        let result = engine.run_all(&checks, None).await;
+        assert!(
+            result.all_passed,
+            "multi-flag command must pass from a worktree cwd: {:?}",
+            result
+                .results
+                .iter()
+                .map(|r| (&r.status, &r.detail))
+                .collect::<Vec<_>>()
         );
     }
 }


### PR DESCRIPTION
Closes #558

## Root cause — verified on the reporting machine (4090), not guessed

**The harness does not garble the command. The issue's premise (bad tokenization/invocation in worktree cwds) is disproven. What the observed output actually was, and what was fixed, is below.**

1. **The spec string reaches the child verbatim.** `plan/parser.rs` does no interpolation on `cmd` (string in → `CheckSpec::CmdSucceeds` string out, byte-identical); `runner/sequential.rs` never mutates it; `check/cmd_succeeds.rs` wraps the whole string as ONE argument: `powershell -NoProfile -Command "cargo fmt --all --check"` (pwsh is not installed on 4090; `where powershell` resolves Windows PowerShell 5.1, present in the fleet lane PATH). No `cmd.exe` path, no re-tokenization, no env→argv leakage anywhere.

2. **Reproduction attempt: negative (full record in the issue comment).** Spawned exactly what the harness spawns — both via a standalone replication of `check_cmd_succeeds`' spawn and via the real `CheckEngine` — against (a) the main repo cwd, (b) a real `git worktree` (`.git` as a **file**), with `CARGO_TARGET_DIR` set. Both exit 0 in both cwd shapes. A regression test pinning this is included (`multi_flag_cmd_succeeds_from_real_worktree_cwd`).

3. **The observed help/usage text is not evidence of bad argv.** cargo-fmt (clap-based) prints reason + full usage block via `handle_command_status` → `print_usage_to_stderr` for **any internal io failure** — including `cargo metadata` failing and rustfmt failing to spawn — not only for unrecognized arguments. The fragments in the issue (`--message-format <message-format>`, `--all`, `--check`, `-h, --help`) are the fixed Options section of that block. The actual reason line prints **before** the block, and the harness's 2000-char **tail-only** capture (GH-540) dropped it when the output exceeded the cap — leaving the bare usage block, from which "garbled arguments" was the only remaining inference. The underlying failure was transient/environmental (first parallel worktree-lane run; consistent with the LNK1104-class machine contention this workstation exhibits — reproduced live twice during this very PR's test runs), not reproducible post-hoc because the worktree and its state are gone.

## What changed (scoped to doneWhen)

- **doneWhen 1** — every non-passing `cmd_succeeds` result now records `executed: <shell line>` (timeout and spawn-error details too). Masked through `mask_secrets`: the spec string itself may embed credentials (the pre-existing `secrets_masked_in_output` test caught exactly that during development — the executed line initially bypassed masking).
- **Capture integrity** — per-stream capture now keeps the HEAD (400 chars) as well as the TAIL (2000 chars), with an explicit `...[N chars truncated]...` marker. GH-540's tail rule stands (LNK1104's payload lives at the end); GH-558's failure family puts the diagnostic at the head. Both ends survive; capture stays bounded.
- **doneWhen 3** — `multi_flag_cmd_succeeds_from_real_worktree_cwd`: builds a standalone cargo project in `tempfile`, runs real `git worktree add` (`.git` is a file — pinned by assertion), runs `cargo fmt --all --check` through `CheckEngine` from that cwd, asserts pass.
- **doneWhen 2** — verified, not modified: with the string passed verbatim and no cwd-sensitive code in the path, `cargo fmt --all --check` executes with the same semantics as typing it in the plan cwd, for both launch cwd shapes and with `CARGO_TARGET_DIR` set. The witness test now guards it.

## Red-first evidence

Red commit **`5a8143f`** (tests only, parent = unfixed source `5a8143f~1` = `efbcea7`):

```
failures:
---- check::cmd_succeeds::tests::failure_detail_records_executed_shell_line ----
failure detail must record the executed shell line, got: exit 1
---- check::cmd_succeeds::tests::failure_keeps_head_of_stream_when_output_exceeds_tail ----
head of the stream must be kept, got: exit 1: xxxx…(tail-only capture kept 2000 x's,
dropped 'fatal: the real reason is at the head' from the START of stderr)
test result: FAILED. 10 passed; 2 failed
```

`multi_flag_cmd_succeeds_from_real_worktree_cwd` passes in the red commit by design — the reported bug itself is not reproducible; per doneWhen 4 the argv-logging requirement stands as the testable part.

## Gate receipt (L1, frozen SHA `2b90f69f65b9566e1e141c0c5c7efcc7d3bd6b73`)

- Toolchain: rustc/cargo 1.93.1; lane `worker-2`; `CARGO_INCREMENTAL=0`; clean tree.
- `cargo fmt --all --check` — **PASS**
- `cargo clippy --workspace --all-targets -- -D warnings` — **PASS**
- `cargo test --workspace --no-fail-fast` — **all crates PASS** except `edda-bridge-claude --lib`: pre-existing test-isolation flakiness (failure count 23/20/22/3 nondeterministic across runs of the same SHA; all tests pass solo; 25 test-side `set_var` calls → env races; crate has **no** dependency on `edda-conductor` and is untouched by this diff). `edda-conductor`: 333 passed / 0 failed incl. the 3 new tests. Windows CI (which covers this crate) is the authoritative re-check at exact head.

FOLLOW-UP ISSUE candidate: `edda-bridge-claude` test env-var races under parallel threads (not part of this PR's scope).

## doneWhen checklist

- [x] Exact shell line logged with the check result — `executed: …` on failure/timeout/spawn-error.
- [x] `cargo fmt --all --check` semantics identical to typing it in the plan cwd, regardless of launch cwd / `CARGO_TARGET_DIR` — verified by direct spawn replication + pinned by the worktree witness test.
- [x] Regression test runs a multi-flag command through the check runner from a non-main-repo (real worktree) cwd and asserts success.
- [x] Red commit + full failure output above.
