### PR TITLE
docs(canon): align the canon with fleet.merged-artifact-cleanup and fleet.review-engine-pool; installation typo (#663)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -197,8 +197,13 @@ A fleet session that runs no local build has no lane and needs none.
   names no lane or no lane root and you are about to build for a fleet, ask the
   controller first rather than creating a directory.
 - Verifier lanes and every L1 run set `CARGO_INCREMENTAL=0`.
-- Deleting lane build output is authorized and non-destructive; deleting
-  worktrees, branches, or sources is not.
+- Build output is disposable and non-destructive to delete; per
+  `fleet.merged-artifact-cleanup`, an artifact whose PR is **merged** — the
+  merged PR's remote branch and its lane worktree — may also be reclaimed,
+  because the squash commit is on `main` and GitHub keeps `refs/pull/N/head`,
+  so SHA-pinned verdicts stay resolvable. Anything unmerged stays untouched:
+  open or closed-unmerged branches, worktrees carrying uncommitted work,
+  another session's active branch or worktree, and sources.
 
 #### Footprint and thresholds — measured, and larger than they should be
 
@@ -387,9 +392,14 @@ Rules regulate cost and reclamation, not only evidence:
   and exact-head CI before any RAN, and state the reason whenever you rerun a
   recorded gate.
 - Every worker/verifier brief names a verification budget (L0 while iterating;
-  L1 once per frozen SHA) and cleanup authority (build cache is disposable and
-  stale cache should be reclaimed by age; worktrees, branches, and sources are
-  never deleted). It names a build lane **only when the session compiles
+  L1 once per frozen SHA) and cleanup authority (build output is disposable and
+  stale cache should be reclaimed by age; per `fleet.merged-artifact-cleanup`,
+  an artifact whose PR is **merged** — the merged PR's remote branch and its
+  lane worktree — may be reclaimed, since the squash commit is on `main` and
+  GitHub keeps `refs/pull/N/head`, so SHA-pinned verdicts stay resolvable;
+  anything unmerged — open or closed-unmerged branches, worktrees carrying
+  uncommitted work, another session's active branch or worktree, and sources —
+  stays untouched). It names a build lane **only when the session compiles
   locally** — see Build lanes; a session that builds nothing has no lane and
   reports `n/a`.
 - One verifier identity per PR: rounds resume the same session, and the same

--- a/.claude/skills/coord-orchestrate/SKILL.md
+++ b/.claude/skills/coord-orchestrate/SKILL.md
@@ -113,8 +113,12 @@ Request: audit the whole scoped surface; publish no self-verdict from the implem
    `<lane root>/<lane name>` will invent a directory — the exact failure the
    lane rule exists to prevent), verification budget (focused gates on touched
    units while iterating; the full gate set once per frozen SHA with a receipt;
-   READ receipts before any RAN), cleanup authority (lane build cache is
-   disposable; worktrees, branches, and sources are never deleted), done =
+   READ receipts before any RAN), cleanup authority (lane build output is
+   disposable; per `fleet.merged-artifact-cleanup` the branch and lane worktree
+   of a **merged** PR may be reclaimed — the squash commit is on main and
+   GitHub keeps refs/pull/N/head — anything unmerged stays untouched: open or
+   closed-unmerged branches, worktrees with uncommitted work, another
+   session's active branch or worktree, and sources), done =
    GitHub PR when available,
    otherwise a frozen local branch plus durable review carrier (never invent a
    PR); never merge + `edda task done --receipt`. Include the receiver tie-break

--- a/.claude/skills/fleet-orchestrate/references/playbook.md
+++ b/.claude/skills/fleet-orchestrate/references/playbook.md
@@ -206,8 +206,12 @@ Verification budget: focused gates on touched units while iterating; the full
   gate set once per frozen full SHA with a gate receipt; READ receipts and
   exact-head CI before any RAN; name the coverage the project's CI genuinely
   lacks, since that is the reviewer's legitimate reason to run it
-Cleanup authority: lane build cache is disposable; worktrees, branches, and
-  sources are never deleted
+Cleanup authority: lane build output is disposable; per
+  `fleet.merged-artifact-cleanup`, the branch and lane worktree of a **merged**
+  PR may be reclaimed (squash commit on main, GitHub keeps refs/pull/N/head);
+  anything unmerged — open or closed-unmerged branches, worktrees with
+  uncommitted work, another session's active branch or worktree, and sources —
+  stays untouched
 Drift rule: if HEAD differs, satisfy intent against HEAD and report full SHA
 Done: pushed candidate/PR, frozen full SHA, receipt, no merge
 ```

--- a/.claude/skills/issue-pipeline/SKILL.md
+++ b/.claude/skills/issue-pipeline/SKILL.md
@@ -89,7 +89,11 @@ For each PR meeting every precondition:
 gh pr merge {pr_number} --squash
 ```
 
-Never pass `--delete-branch` — branches and worktrees are never deleted (see
+Pass `--delete-branch` only when the PR is being merged — per
+`fleet.merged-artifact-cleanup`, a merged PR's branch and lane worktree may be
+reclaimed (squash commit on main, GitHub keeps `refs/pull/N/head`); anything
+unmerged — open or closed-unmerged branches, worktrees with uncommitted work,
+another session's active branch or worktree, and sources — stays untouched (see
 `.claude/CLAUDE.md`). If a PR does not meet the preconditions, do not merge it;
 route it back through the `pr-review-loop` skill and report that it is blocked.
 
@@ -103,9 +107,13 @@ Report final status table.
 4. **Wait for ALL agents in a phase before starting the next phase**
 5. **Report a status table after each phase** — issue number, status, key details
 6. **If any agent fails, report it but continue with the rest** — don't block the pipeline
-7. **Never delete branches or worktrees** — worktrees, branches, and sources are
-   never deleted (see `.claude/CLAUDE.md`); `git worktree remove` and
-   `git worktree prune` are forbidden; leave cleanup to the operator
+7. **Never delete anything unmerged** — per `fleet.merged-artifact-cleanup`,
+   only the branch and lane worktree of a **merged** PR may be reclaimed (the
+   squash commit is on main and GitHub keeps `refs/pull/N/head`); anything
+   unmerged — open or closed-unmerged branches, worktrees with uncommitted
+   work, another session's active branch or worktree, and sources — stays
+   untouched; `git worktree remove` and `git worktree prune` are for that
+   reclaim only; otherwise leave cleanup to the operator
 
 ## Status Table Format
 

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -249,7 +249,11 @@ sleep 3
 gh pr view --json state,mergedAt
 ```
 
-Never pass `--delete-branch` — branches and worktrees are never deleted (see
+Pass `--delete-branch` only when the PR is being merged — per
+`fleet.merged-artifact-cleanup`, a merged PR's branch and lane worktree may be
+reclaimed (squash commit on main, GitHub keeps `refs/pull/N/head`); anything
+unmerged — open or closed-unmerged branches, worktrees with uncommitted work,
+another session's active branch or worktree, and sources — stays untouched (see
 `.claude/CLAUDE.md`).
 
 **Why squash merge:**

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -32,7 +32,7 @@ Available targets:
 | macOS ARM64 | `edda-v<VERSION>-aarch64-apple-darwin.tar.gz` |
 | Windows x86_64 | `edda-v<VERSION>-x86_64-pc-windows-msvc.zip` |
 
-Each archive contains the `edda` binary, and a SHA256 checksum sidecar file.
+Each archive contains the `edda` binary and a SHA256 checksum sidecar file.
 
 ## Build from source
 

--- a/docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md
+++ b/docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md
@@ -39,7 +39,7 @@
 |---|---|---|---|---|---|---|---|
 | gpt-5.6-sol | `openai-codex/gpt-5.6-sol` | A: `pi --model openai-codex/gpt-5.6-sol`；B: `edda dispatch --agent codex`（過載時先換這個） | 訂閱內，T$0 | $0.0798 | **全類別（錨，不被取代）** | #582 | `fleet.agent-model-split`＋`fleet.review-provider-overload` 的原裝組合；sol 抓到而他人漏的即成新金絲雀 |
 | Opus 5 | `opus`（`claude -p --model opus`） | **C: Claude Code only**——`claude -p --allowedTools "Read,Grep,Glob,Bash(git *),Bash(sh *)"`；**絕不**經 pi/openrouter | 訂閱內，T$1 | $1.4869 | code-risk + docs-skills（provisional，待操作者裁定） | 訂閱用量 | `fleet.claude-subscription-transport`：pi 顯示 ready 也不准派 |
-| gemini-3.1-pro-preview | `openrouter/google/gemini-3.1-pro-preview`——**catalogue 逐字 id**（RAN `pi --list-models gemini`，該列見 §3）。先前寫的 `google/gemini-3-pro` **不在目錄裡**，pi 會模糊解析成 `google/gemini-3-pro-image`（見 §3 的靜默替換案例） | pi/openrouter：`pi auth check --model openrouter/google/gemini-3.1-pro-preview` → **`ready`**（provider `openrouter` 亦 `ready`），但實際請求仍 `404 … quantization: fp8`（§3）；直連 google 供應商 `pi auth check --provider google` → `not_ready` | — | $0 | **none（not run，R3 實測）** | — | R3（2026-09-02）改用逐字 id 重跑：session 檔記的 `modelId` 與請求**完全一致**（沒有替換），錯的是路由。`auth check` 說 ready ≠ 路由可達——**修好 fp8 路由前不得列入候選**（錯誤原文與探測見 §3、後續見 §7.5） |
+| gemini-3.1-pro-preview——**removed**（`fleet.review-engine-pool`，2026-09-02 操作者裁定移出引擎池） | `openrouter/google/gemini-3.1-pro-preview`——**catalogue 逐字 id**（RAN `pi --list-models gemini`，該列見 §3）。先前寫的 `google/gemini-3-pro` **不在目錄裡**，pi 會模糊解析成 `google/gemini-3-pro-image`（見 §3 的靜默替換案例） | pi/openrouter：`pi auth check --model openrouter/google/gemini-3.1-pro-preview` → **`ready`**（provider `openrouter` 亦 `ready`），但實際請求仍 `404 … quantization: fp8`（§3）；直連 google 供應商 `pi auth check --provider google` → `not_ready` | — | $0 | **none（not run，R3 實測）** | — | R3（2026-09-02）改用逐字 id 重跑：session 檔記的 `modelId` 與請求**完全一致**（沒有替換），錯的是路由。`auth check` 說 ready ≠ 路由可達（錯誤原文與探測見 §3）。**removed**：`fleet.review-engine-pool` 裁定審查很少會用 Gemini，不為它改 pi 的 `openRouterRouting`；§3 的量測敘述保留為它被移出的歷史證據 |
 | glm-5.3-flash | `openrouter/z-ai/glm-5.3-flash` | pi/openrouter | 訂閱外按量，T$0 | $0.00092 | **docs-skills（provisional）**；code-risk 不合格 | #582 | code-risk 不合格的原因與 brief v1 的 `[判斷]` 標籤有關（§3 學習 1），brief v2 修正後重校，不是引擎本身判死 |
 
 成本級定義（提案）：T$0＝邊際成本 < $0.10/次；T$1＝$0.10–2.00/次。以帳本實測值滾動更新。
@@ -289,7 +289,7 @@ edda decide "fleet.review-unreviewed-state=honest-label-blocked-by-merge-gate-58
 4. **brief v2**——把「shell 解析樹＋觸發條件」移出 `[判斷]`（校準學習 1）。
    `model_observed` 註記（以 session 檔／JSON 的 `modelUsage` 為準、環境變數
    身分不算數）已在 v1.1 修掉，不必等 v2。
-5. **gemini 運輸修正**——id 已經確定：`openrouter/google/gemini-3.1-pro-preview`
+5. **gemini 運輸修正**——**已作廢**（`fleet.review-engine-pool`，2026-09-02：Gemini 移出引擎池，#618 的 Gemini 後續作廢；以下保留為歷史紀錄）——id 已經確定：`openrouter/google/gemini-3.1-pro-preview`
    在目錄裡，`pi auth check --model` 與 provider `openrouter` 都回 `ready`。
    剩下的是路由：`404 … quantization: fp8` 表示送出的請求帶著 fp8
    provider preference，而 `google/*` 沒有 fp8 endpoint（同金鑰跑 glm 正常，

--- a/docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md
+++ b/docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md
@@ -255,7 +255,10 @@ Options:
       --reason <REASON>    Reason for the decision
 ```
 
-以下五條可直接複製執行（每條都是一個 `key=value` 引數，不是兩個位置參數）：
+以下五條可直接複製執行（每條都是一個 `key=value` 引數，不是兩個位置參數）。其中
+`fleet.review-engine-pool` 一條在 ratify 時由操作者修訂：**初版值
+`field-of-reviewer-profile-593`（把 gemini-3.1-pro-preview 列入初始池、fp8 路由修好即可列候選）已作廢**，
+下列才是 ratifier 後的版本（`fleet.review-engine-pool`，2026-09-02）；初版值僅存於本段歷史標記：
 
 ```sh
 edda decide "fleet.review-class=two-classes-path-rule" \
@@ -267,8 +270,8 @@ edda decide "fleet.review-canary-protocol=tests-canaries-diff-fixture-expected" 
 edda decide "fleet.review-qualification=p0-full-p1-80-fp-zero-recal-quarterly" \
   --reason "合格門檻＝該類別 P0 金絲雀 100% caught（提出且實質命中）、P1 ≥ 80%、FP=0、清單每項皆回報不得靜默略過。嚴重度低估記 caught 但標「嚴重度不符」，同引擎同金絲雀連續兩次不符視為 missed。重校＝每季＋引擎版次變更後＋brief 版本變更後＋金絲雀新增後 30 天內全池。抓取率進帳本。校準前 qualified=none。"
 
-edda decide "fleet.review-engine-pool=field-of-reviewer-profile-593" \
-  --reason "引擎池是 reviewer profile（#593）底下的一個欄位，不是獨立設定。池條目＝{model_requested, transports_allowed, cost_tier, qualified_classes, quota_signal}。初始池：gpt-5.6-sol（pi 或 edda dispatch --agent codex；全類別錨、不被取代）、Opus 5（claude -p only，絕不經 pi/openrouter）、gemini-3.1-pro-preview（逐字 catalogue id openrouter/google/gemini-3.1-pro-preview；auth check 回 ready 但請求被 openrouter 的 quantization: fp8 provider preference 篩成 404，直連 google 供應商 not_ready；修好路由前不得列候選）、glm-5.3-flash（pi/openrouter；本次校準提議 docs-skills provisional 合格，code-risk 不合格）。替換規則＝依類別取「合格∧運輸可用∧配額在」中最便宜者；model_requested 一律逐字照抄 pi --list-models 的目錄 id（pi 對不存在的 id 不報錯而是模糊解析，google/gemini-3-pro → google/gemini-3-pro-image 即派工端的靜默替換）；派工前以 --no-tools 探測運輸，auth check 回 ready 不保證路由可達；過載先換運輸再換下一合格引擎；重試同引擎一次為限，絕不靜默換模型；無合格引擎→PR 標 review:unreviewed 停住，不合格引擎的 LGTM 不算；[判斷] 項與非平凡 diff 零發現送 sol 抽審；判決帶 model_requested/model_observed（系統取得）、brief 版本、類別、escalations，合併政策讀欄位不讀標頭。model_requested≠model_observed 為 P0 事故。"
+edda decide "fleet.review-engine-pool=sol-anchor-opus-provisional-glm-docs-only-gemini-removed" \
+  --reason "（2026-09-02 ratifier 修訂，取代已作廢的初版 field-of-reviewer-profile-593——初版把 Gemini 列在初始池，與本池相牴觸。）Gemini 從審查引擎池拿掉——審查很少會用 Gemini，不值得為它改 pi 的 openRouterRouting（order=[novita], quantizations=[fp8]，為 glm 設的）。池＝gpt-5.6-sol（錨，openai-codex provider；pi 或 edda dispatch --agent codex）、Opus（暫定合格，只走 claude -p；fleet.claude-subscription-transport，絕不經 pi/openrouter）、glm-5.3-flash（docs/skills 暫定；code-risk 不合格）。池是 reviewer profile（#593）底下的一個欄位，不是獨立設定；池條目＝{model_requested, transports_allowed, cost_tier, qualified_classes, quota_signal}。替換規則＝依類別取「合格∧運輸可用∧配額在」中最便宜者；model_requested 一律逐字照抄 pi --list-models 的目錄 id（pi 對不存在的 id 不報錯而是模糊解析，google/gemini-3-pro → google/gemini-3-pro-image 即派工端的靜默替換）；派工前以 --no-tools 探測運輸，auth check 回 ready 不保證路由可達；過載先換運輸再換下一合格引擎；重試同引擎一次為限，絕不靜默換模型；無合格引擎→PR 標 review:unreviewed 停住，不合格引擎的 LGTM 不算；[判斷] 項與非平凡 diff 零發現送 sol 抽審；判決帶 model_requested/model_observed（系統取得）、brief 版本、類別、escalations，合併政策讀欄位不讀標頭。model_requested≠model_observed 為 P0 事故。"
 
 edda decide "fleet.review-unreviewed-state=honest-label-blocked-by-merge-gate-580" \
   --reason "review:unreviewed 是 label/狀態，不是判決——語意為「審查當下沒有任何合格引擎可用，誠實停住」。#580 合併閘機械化要求 current-head LGTM＋綠 CI，unreviewed 的 PR 不可能有有效 LGTM，閘自然擋住；解鎖唯一路徑是合格引擎真審一輪。不得用降級引擎的判決清除本狀態。依據：fleet.review-provider-overload「unreviewed PR 是誠實的狀態，便宜模型的判決不是」。"


### PR DESCRIPTION
Fixes Round 1 review of PR #664 (issue #663). Surface extended by the controller to the five `.claude/skills/**` files carrying the never-delete rule. Fix head: `dd39c6e01be578ed53282eba42e01dea7bf32bc8`.

Issue: #663

## Changes (Round 2)

1. **P0 #1 — five stale copies of the never-delete rule fixed.** `coord-orchestrate/SKILL.md` (brief template cleanup authority), `fleet-orchestrate/references/playbook.md` (Cleanup authority line), `issue-pipeline/SKILL.md` ×2 (the `--delete-branch` prohibition → now only-when-merging, and Execution Rule 7), `pull-request/SKILL.md` (the `--delete-branch` prohibition). Each now states the ratified rule and names `fleet.merged-artifact-cleanup`: build output is disposable; the branch and lane worktree of a **merged** PR may be reclaimed (squash commit on `main`, GitHub keeps `refs/pull/N/head`); anything **unmerged** — open or closed-unmerged branches, worktrees with uncommitted work, another session's active branch or worktree, sources — stays untouched.
2. **P0 #2 — design doc §6 no longer advertises the obsolete pool.** The `edda decide` line for `fleet.review-engine-pool` now carries the ratified value `sol-anchor-opus-provisional-glm-docs-only-gemini-removed` with a reason matching the ledger (Gemini out of the pool; `openRouterRouting` untouched); the older value `field-of-reviewer-profile-593` is explicitly marked superseded and kept only as a historical marker. Round 1's table-row and §7 markings unchanged.
3. **P0 #3 — PR body evidence rebuilt.** Every command re-run at the final head `dd39c6e01be578ed53282eba42e01dea7bf32bc8`; outputs pasted complete and untrimmed (raw outputs were captured by shell redirection and embedded programmatically, so the transcripts below reproduce byte for byte).

`docs/guides/operator-runbook.md` untouched (owned by lane #606). Commit-title note: the repo's commit-msg hook requires `<type>(<scope>)`; scope `canon` was added, wording otherwise per brief.

## Wiring self-report

| 新面 | Writer & shape | Reader | Failure signal | Layer reach |
|---|---|---|---|---|
| no new surfaces — docs-only change across `.claude/**` and `docs/**`; no new pub fns/fields/variants, CLI flags, config keys, event payload fields, or written files/side-files |

## RAN evidence (all re-run at the final head of this push)

### 1. `git grep -n "never deleted\|branches, or sources is not" -- .claude` — BEFORE (base `d40cd2e`, seven hits)

```text
d40cd2e:.claude/CLAUDE.md:201:  worktrees, branches, or sources is not.
d40cd2e:.claude/CLAUDE.md:392:  never deleted). It names a build lane **only when the session compiles
d40cd2e:.claude/skills/coord-orchestrate/SKILL.md:117:   disposable; worktrees, branches, and sources are never deleted), done =
d40cd2e:.claude/skills/fleet-orchestrate/references/playbook.md:210:  sources are never deleted
d40cd2e:.claude/skills/issue-pipeline/SKILL.md:92:Never pass `--delete-branch` — branches and worktrees are never deleted (see
d40cd2e:.claude/skills/issue-pipeline/SKILL.md:107:   never deleted (see `.claude/CLAUDE.md`); `git worktree remove` and
d40cd2e:.claude/skills/pull-request/SKILL.md:252:Never pass `--delete-branch` — branches and worktrees are never deleted (see
```

### 2. `git grep -n "never deleted\|branches, or sources is not" -- .claude` — AFTER (exit 1, no hits: every one of the seven sites now states the merged/unmerged distinction)

```text
```

(empty output; exit 1 — zero remaining hits)

### 3. `git grep -n "merged-artifact-cleanup" -- .claude` — the key now present at all seven sites

```text
.claude/CLAUDE.md:201:  `fleet.merged-artifact-cleanup`, an artifact whose PR is **merged** — the
.claude/CLAUDE.md:396:  stale cache should be reclaimed by age; per `fleet.merged-artifact-cleanup`,
.claude/skills/coord-orchestrate/SKILL.md:117:   disposable; per `fleet.merged-artifact-cleanup` the branch and lane worktree
.claude/skills/fleet-orchestrate/references/playbook.md:210:  `fleet.merged-artifact-cleanup`, the branch and lane worktree of a **merged**
.claude/skills/issue-pipeline/SKILL.md:93:`fleet.merged-artifact-cleanup`, a merged PR's branch and lane worktree may be
.claude/skills/issue-pipeline/SKILL.md:110:7. **Never delete anything unmerged** — per `fleet.merged-artifact-cleanup`,
.claude/skills/pull-request/SKILL.md:253:`fleet.merged-artifact-cleanup`, a merged PR's branch and lane worktree may be
```

### 4. `git grep -n -i "gemini" -- docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md` — AFTER (complete, 36 lines, untrimmed)

```text
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:42:| gemini-3.1-pro-preview——**removed**（`fleet.review-engine-pool`，2026-09-02 操作者裁定移出引擎池） | `openrouter/google/gemini-3.1-pro-preview`——**catalogue 逐字 id**（RAN `pi --list-models gemini`，該列見 §3）。先前寫的 `google/gemini-3-pro` **不在目錄裡**，pi 會模糊解析成 `google/gemini-3-pro-image`（見 §3 的靜默替換案例） | pi/openrouter：`pi auth check --model openrouter/google/gemini-3.1-pro-preview` → **`ready`**（provider `openrouter` 亦 `ready`），但實際請求仍 `404 … quantization: fp8`（§3）；直連 google 供應商 `pi auth check --provider google` → `not_ready` | — | $0 | **none（not run，R3 實測）** | — | R3（2026-09-02）改用逐字 id 重跑：session 檔記的 `modelId` 與請求**完全一致**（沒有替換），錯的是路由。`auth check` 說 ready ≠ 路由可達（錯誤原文與探測見 §3）。**removed**：`fleet.review-engine-pool` 裁定審查很少會用 Gemini，不為它改 pi 的 `openRouterRouting`；§3 的量測敘述保留為它被移出的歷史證據 |
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:56:三個引擎真的產出了判決，gemini 三輪派工（R1／R2／R3）都在 provider 端失敗，
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:75:# gemini（2026-09-02 R3 重跑，clone＝<worktree>/.tmp/calib-r3——本輪 lane 的
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:80:pi -p --model openrouter/google/gemini-3.1-pro-preview --thinking high \
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:82:   --session-id calib-gemini-r3 "$(cat calib-brief.md)"
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:83:# → 404（見下表；重試一次 calib-gemini-r3b 同錯）。
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:89:| canary | expected | sol | glm-5.3-flash | gemini-3.1-pro-preview | Opus 5 |
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:113:**gemini：R2 的靜默替換，與 R3 用逐字 id 量到的真正可用性**
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:117:*先是 id：R2 根本沒打到請求的引擎。* `google/gemini-3-pro` 不在 pi 的目錄裡，
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:118:pi 沒有報錯，而是**模糊解析成另一個模型** `google/gemini-3-pro-image`（影像模型）。
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:119:`calib-gemini-r2` 與 `calib-gemini-r2b` 兩份 session 檔**確實存在**，裡面記的
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:120:`modelId` 就是 `google/gemini-3-pro-image`，然後才是那則 404——所以 R2 文字裡
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:121:「未產生 session 檔」是錯的，「gemini-3-pro 不可達」也沒有被證明過：那一輪
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:125:*R3 用 catalogue 逐字 id 重跑。* `pi --list-models gemini` 的 pro 級該列（RAN 2026-09-02）：
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:129:openrouter  google/gemini-3.1-pro-preview              1.0M     65.5K    yes       yes
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:134:| 1 | `pi auth check --model openrouter/google/gemini-3.1-pro-preview` | `ready`，exit 0 |
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:137:| 4 | 金絲雀審查：`pi -p --model openrouter/google/gemini-3.1-pro-preview --thinking high --exclude-tools edit,write --session-dir "$CLONE/sessions-r3" --session-id calib-gemini-r3 "$(cat calib-brief.md)"` | `404: {"message":"No endpoints found for the request with quantization: fp8. To learn more about provider routing, visit: https://openrouter.ai/docs/guides/routing/provider-selection","code":404}`，pi exit 1 |
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:138:| 5 | 同 4，重試一次（`--session-id calib-gemini-r3b`） | 同一則 404 fp8，pi exit 1 |
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:139:| 6 | `--model openrouter/google/gemini-3.1-pro-preview --thinking high --no-tools "reply with OK"` | 同一則 404 fp8 |
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:143:R3 的 session 檔（`<CLONE>/sessions-r3/2026-09-02T07-26-41-618Z_calib-gemini-r3.jsonl`）
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:147:{"type":"model_change","modelId":"google/gemini-3.1-pro-preview"}
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:148:{"role":"assistant","model":"google/gemini-3.1-pro-preview","api":"openai-completions",
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:153:判讀（量測到的，取代 R2 那句「Gemini 沒有可達的 OpenRouter 模型」）：
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:155:- **目錄裡有可達的 pro 級 id**：`google/gemini-3.1-pro-preview` 存在，
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:170:gemini 審查花在影像模型上，而且直到審查者去讀 session 檔才發現。
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:181:| gemini | pi session 檔 `<CLONE>/sessions-r3/2026-09-02T07-26-41-618Z_calib-gemini-r3.jsonl`（`modelId` 與 assistant 訊息的 `"model"` 欄） | `google/gemini-3.1-pro-preview`——與 requested **相符**，但 `stopReason:"error"`、`totalTokens` 0、`cost.total` 0，沒有審查輸出，故評分欄記 not run。（對照 R2：requested `google/gemini-3-pro`、observed `google/gemini-3-pro-image`，**不符**） |
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:194:3. **引擎用逐字 catalogue id 定址，不用名字。** `google/gemini-3-pro` 不在 pi
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:195:   目錄裡，pi 不報錯而是模糊解析成 `google/gemini-3-pro-image`，R2 因此把一輪
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:196:   gemini 校準花在影像模型上。規則：派工前跑 `pi --list-models <關鍵字>`，把那一列
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:200:   `pi auth check --model openrouter/google/gemini-3.1-pro-preview` → `ready`，
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:223:     （實證：`google/gemini-3-pro` → `google/gemini-3-pro-image`，§3），
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:260:`field-of-reviewer-profile-593`（把 gemini-3.1-pro-preview 列入初始池、fp8 路由修好即可列候選）已作廢**，
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:273:edda decide "fleet.review-engine-pool=sol-anchor-opus-provisional-glm-docs-only-gemini-removed" \
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:274:  --reason "（2026-09-02 ratifier 修訂，取代已作廢的初版 field-of-reviewer-profile-593——初版把 Gemini 列在初始池，與本池相牴觸。）Gemini 從審查引擎池拿掉——審查很少會用 Gemini，不值得為它改 pi 的 openRouterRouting（order=[novita], quantizations=[fp8]，為 glm 設的）。池＝gpt-5.6-sol（錨，openai-codex provider；pi 或 edda dispatch --agent codex）、Opus（暫定合格，只走 claude -p；fleet.claude-subscription-transport，絕不經 pi/openrouter）、glm-5.3-flash（docs/skills 暫定；code-risk 不合格）。池是 reviewer profile（#593）底下的一個欄位，不是獨立設定；池條目＝{model_requested, transports_allowed, cost_tier, qualified_classes, quota_signal}。替換規則＝依類別取「合格∧運輸可用∧配額在」中最便宜者；model_requested 一律逐字照抄 pi --list-models 的目錄 id（pi 對不存在的 id 不報錯而是模糊解析，google/gemini-3-pro → google/gemini-3-pro-image 即派工端的靜默替換）；派工前以 --no-tools 探測運輸，auth check 回 ready 不保證路由可達；過載先換運輸再換下一合格引擎；重試同引擎一次為限，絕不靜默換模型；無合格引擎→PR 標 review:unreviewed 停住，不合格引擎的 LGTM 不算；[判斷] 項與非平凡 diff 零發現送 sol 抽審；判決帶 model_requested/model_observed（系統取得）、brief 版本、類別、escalations，合併政策讀欄位不讀標頭。model_requested≠model_observed 為 P0 事故。"
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:295:5. **gemini 運輸修正**——**已作廢**（`fleet.review-engine-pool`，2026-09-02：Gemini 移出引擎池，#618 的 Gemini 後續作廢；以下保留為歷史紀錄）——id 已經確定：`openrouter/google/gemini-3.1-pro-preview`
docs/superpowers/specs/2026-09-02-substitutable-reviewer-design.md:301:   修好前 gemini 維持 `not run`，四引擎校準的第四格仍是空的。
```

No line presents Gemini as an available or pending engine: the §2 table row is **removed**; §6 now carries the ratified pool value and marks `field-of-reviewer-profile-593` superseded; §7 item 5 is marked superseded. Remaining mentions are the §3 calibration narrative (kept in one clause as the historical evidence for the removal) and the two explicitly marked historical references to the obsolete pool value (lines 260, 274).

### 5. `edda ask fleet.merged-artifact-cleanup` and `edda ask fleet.review-engine-pool` — first lines (run from `C:\ai_agent\edda`)

```text
  fleet.merged-artifact-cleanup = delete-merged-branches-and-worktrees-keep-everything-unmerged — Tim 2026-09-02 親裁（原話：分支不刪的規則怎來的，不需要這麼嚴格吧／掃）。NARROWS the CLAUDE.md line 'deleting worktrees, branches, or sources is not [authorized]' (written 2026-08-18/19 in the 194 GB over-verification cleanup as a blanket guard around build-cache reclamation, not as a product requirement). New rule: an artifact whose PR is MERGED carries no unique content — the squash commit is on main and GitHub keeps refs/pull/N/head, so SHA-pinned verdicts stay resolvable — therefore the merged PR's remote branch and its lane worktree may be deleted (merge with --delete-branch, or sweep later). UNCHANGED and still forbidden: anything unmerged — open/closed-unmerged PR branches, worktrees with uncommitted work other than lane scratch (pr-body.md/response.md), another session's active branch or worktree, and sources. First sweep on the docs workstation: 42 remote branches deleted (51 -> 8; all 4 open PRs verified intact afterwards), 33 worktrees removed (39 -> 12). Excluded by the rule: fix/gh533-cost-measuredness (active peer session), fix/doctest-harness-hardening (real uncommitted edit), unmerged lanes. The 4090's worktrees are its controller's to reclaim.
  fleet.review-engine-pool = sol-anchor-opus-provisional-glm-docs-only-gemini-removed — Tim 2026-09-02 親裁：Gemini 從審查引擎池拿掉——審查很少會用 Gemini，不值得為它改 pi 的 openRouterRouting（order=[novita], quantizations=[fp8]，為 glm 設的）。池＝gpt-5.6-sol（錨，openai-codex provider）、Opus（暫定合格，只走 claude -p；fleet.claude-subscription-transport）、glm-5.3-flash（docs/skills 暫定；code-risk 不合格）。fleet.review-calibration 的 Gemini 列保留為歷史（unmeasured），#618 的 Gemini 後續作廢。文件面：2026-09-02-substitutable-reviewer-design.md 的引擎池表要在下一批 docs PR 把 Gemini 列標為 removed（與 runbook §六 新規則列同批）。
```

The rewritten passages follow these two ratified wordings.

### 6. `sh scripts/lint-markdown-content.sh`

```text
exit 0 (no output; also re-run by the pre-commit hook at this SHA)
```

### 7. `git status --porcelain` (at head `dd39c6e`, before PR-body update)

```text
?? pr-body.md
?? response.md
```

No modified tracked files; `docs/guides/operator-runbook.md` has no diff. The only untracked entries are this PR's own lane scratch (`pr-body.md`, `response.md`), which `fleet.merged-artifact-cleanup` explicitly exempts from the uncommitted-work prohibition.
