### PR TITLE
fix(edda-cli): claim check applies the shared peers liveness criterion (GH-617)

### DIFF
--- a/crates/edda-bridge-claude/src/peers/discovery.rs
+++ b/crates/edda-bridge-claude/src/peers/discovery.rs
@@ -4,6 +4,7 @@ use crate::parse::now_rfc3339;
 
 use super::board::compute_board_state;
 use super::helpers::parse_rfc3339_to_epoch;
+use super::liveness::{liveness_from_heartbeat, SessionLiveness};
 use super::{stale_secs, PeerSummary, SessionHeartbeat};
 
 // ── Peer Discovery ──
@@ -11,7 +12,6 @@ use super::{stale_secs, PeerSummary, SessionHeartbeat};
 /// Discover active peer sessions (excluding current session and stale ones).
 pub fn discover_active_peers(project_id: &str, current_session_id: &str) -> Vec<PeerSummary> {
     let state_dir = edda_store::project_dir(project_id).join("state");
-    let stale_threshold = stale_secs();
     let now = parse_rfc3339_to_epoch(&now_rfc3339()).unwrap_or(0);
 
     let board = compute_board_state(project_id);
@@ -45,23 +45,14 @@ pub fn discover_active_peers(project_id: &str, current_session_id: &str) -> Vec<
             Err(_) => continue,
         };
 
-        let hb_epoch = parse_rfc3339_to_epoch(&hb.last_heartbeat).unwrap_or(0);
-        let age = now.saturating_sub(hb_epoch);
-
-        // Sub-agent heartbeats (Claude Code Task tool) still have no in-flight
-        // writer: no hook events fire during their execution, so a fresh
-        // heartbeat written once at spawn would otherwise age out mid-run.
-        // GH-569 narrowed this exception: conductor/dispatch lanes now write
-        // real periodic heartbeats (runner/heartbeat.rs) and use the standard
-        // threshold — only parented sub-agents keep the 15x multiplier.
-        let effective_threshold = if hb.parent_session_id.is_some() {
-            stale_threshold * 15
-        } else {
-            stale_threshold
+        // The GH-617 shared liveness criterion — the same verdict `edda
+        // claim check` applies, so the two verbs can never disagree about
+        // who is dead. The sub-agent 15x multiplier lives inside the
+        // criterion (see `liveness::liveness_from_heartbeat`).
+        let age = match liveness_from_heartbeat(&hb, now) {
+            SessionLiveness::Live { age_secs } => age_secs,
+            _ => continue,
         };
-        if age > effective_threshold {
-            continue;
-        }
 
         let claimed_paths = board
             .claims

--- a/crates/edda-bridge-claude/src/peers/liveness.rs
+++ b/crates/edda-bridge-claude/src/peers/liveness.rs
@@ -1,0 +1,173 @@
+//! The one liveness criterion for peer sessions (GH-617).
+//!
+//! A session is live exactly when its last heartbeat is no older than
+//! [`stale_secs`] (x15 for parented sub-agents, mirroring peer discovery).
+//! `edda peers` and `edda claim check` must both go through this module so
+//! the two verbs can never grow a second, disagreeing notion of "dead".
+//!
+//! There is one liveness surface — the heartbeat file — and one criterion —
+//! [`liveness_from_heartbeat`]. Do not add a parallel one.
+
+use serde::Serialize;
+
+use super::read_heartbeat;
+use super::stale_secs;
+use crate::parse::now_rfc3339;
+use edda_store::SessionHeartbeat;
+
+use super::helpers::parse_rfc3339_to_epoch;
+
+/// Liveness verdict for one session under the shared criterion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum SessionLiveness {
+    /// Heartbeat no older than the staleness threshold.
+    Live {
+        /// Seconds since the last heartbeat.
+        age_secs: u64,
+    },
+    /// Heartbeat older than the staleness threshold.
+    Stale {
+        /// Seconds since the last heartbeat.
+        age_secs: u64,
+    },
+    /// No heartbeat file exists (or it is unreadable/unparseable): the
+    /// session was never heard from.
+    NoHeartbeat,
+}
+
+impl SessionLiveness {
+    pub fn is_live(&self) -> bool {
+        matches!(self, SessionLiveness::Live { .. })
+    }
+}
+
+/// The shared criterion, pure over a heartbeat snapshot.
+///
+/// Mirrors peer discovery exactly: `age <= stale_secs()` is live, and a
+/// parented sub-agent heartbeat gets the same 15x multiplier discovery
+/// applies (no hook events fire during a sub-agent's run, so a heartbeat
+/// written once at spawn would otherwise age out mid-run).
+pub fn liveness_from_heartbeat(hb: &SessionHeartbeat, now_epoch: u64) -> SessionLiveness {
+    let hb_epoch = parse_rfc3339_to_epoch(&hb.last_heartbeat).unwrap_or(0);
+    let age = now_epoch.saturating_sub(hb_epoch);
+    let stale_threshold = stale_secs();
+    let effective_threshold = if hb.parent_session_id.is_some() {
+        stale_threshold * 15
+    } else {
+        stale_threshold
+    };
+    if age > effective_threshold {
+        SessionLiveness::Stale { age_secs: age }
+    } else {
+        SessionLiveness::Live { age_secs: age }
+    }
+}
+
+/// Classify one session's liveness against a caller-supplied now (testable).
+pub fn classify_session_liveness_at(
+    project_id: &str,
+    session_id: &str,
+    now_epoch: u64,
+) -> SessionLiveness {
+    match read_heartbeat(project_id, session_id) {
+        Some(hb) => liveness_from_heartbeat(&hb, now_epoch),
+        None => SessionLiveness::NoHeartbeat,
+    }
+}
+
+/// Classify one session's liveness using the current clock.
+pub fn classify_session_liveness(project_id: &str, session_id: &str) -> SessionLiveness {
+    let now = parse_rfc3339_to_epoch(&now_rfc3339()).unwrap_or(0);
+    classify_session_liveness_at(project_id, session_id, now)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn heartbeat(last_heartbeat: &str, parent: Option<&str>) -> SessionHeartbeat {
+        SessionHeartbeat {
+            session_id: "s".into(),
+            started_at: last_heartbeat.into(),
+            last_heartbeat: last_heartbeat.into(),
+            label: "l".into(),
+            focus_files: vec![],
+            active_tasks: vec![],
+            files_modified_count: 0,
+            total_edits: 0,
+            recent_commits: vec![],
+            branch: None,
+            current_phase: None,
+            parent_session_id: parent.map(str::to_string),
+            plan: None,
+            phase: None,
+            attempt: None,
+            stage: None,
+            pid: None,
+        }
+    }
+
+    #[test]
+    fn fresh_heartbeat_is_live() {
+        // 60s-old heartbeat, default threshold 120s (env unset in tests).
+        let hb = heartbeat("2026-09-02T12:00:00Z", None);
+        assert_eq!(
+            liveness_from_heartbeat(&hb, parse_rfc3339_to_epoch("2026-09-02T12:01:00Z").unwrap()),
+            SessionLiveness::Live { age_secs: 60 }
+        );
+    }
+
+    #[test]
+    fn expired_heartbeat_is_stale() {
+        let hb = heartbeat("2026-09-02T12:00:00Z", None);
+        assert_eq!(
+            liveness_from_heartbeat(&hb, parse_rfc3339_to_epoch("2026-09-02T12:10:00Z").unwrap()),
+            SessionLiveness::Stale { age_secs: 600 }
+        );
+    }
+
+    #[test]
+    fn parented_sub_agent_gets_15x_threshold() {
+        // 25 min old: stale for a normal session (threshold 120s), live at
+        // 15x (1800s) for a parented sub-agent.
+        let hb = heartbeat("2026-09-02T12:00:00Z", Some("parent"));
+        let now = parse_rfc3339_to_epoch("2026-09-02T12:25:00Z").unwrap();
+        assert_eq!(
+            liveness_from_heartbeat(&hb, now),
+            SessionLiveness::Live { age_secs: 1500 }
+        );
+        let orphan = heartbeat("2026-09-02T12:00:00Z", None);
+        assert!(matches!(
+            liveness_from_heartbeat(&orphan, now),
+            SessionLiveness::Stale { .. }
+        ));
+    }
+
+    #[test]
+    fn unparsable_timestamp_counts_as_ancient() {
+        let hb = heartbeat("", None);
+        assert!(matches!(
+            liveness_from_heartbeat(&hb, 1000),
+            SessionLiveness::Stale { .. }
+        ));
+    }
+
+    #[test]
+    fn stale_verdict_is_what_discovery_filters_on() {
+        // Pin the boundary the two verbs share: age == threshold is live,
+        // age == threshold + 1 is stale (discovery uses `age > threshold`).
+        let hb = heartbeat("2026-09-02T12:00:00Z", None);
+        let t0 = parse_rfc3339_to_epoch("2026-09-02T12:00:00Z").unwrap();
+        assert_eq!(
+            liveness_from_heartbeat(&hb, t0 + stale_secs()),
+            SessionLiveness::Live {
+                age_secs: stale_secs()
+            }
+        );
+        assert!(matches!(
+            liveness_from_heartbeat(&hb, t0 + stale_secs() + 1),
+            SessionLiveness::Stale { .. }
+        ));
+    }
+}

--- a/crates/edda-bridge-claude/src/peers/mod.rs
+++ b/crates/edda-bridge-claude/src/peers/mod.rs
@@ -226,6 +226,7 @@ mod board;
 mod discovery;
 mod heartbeat;
 mod helpers;
+pub mod liveness;
 mod render_coord;
 mod render_fleet;
 
@@ -249,6 +250,10 @@ pub use heartbeat::{
 pub use helpers::format_age;
 pub(crate) use helpers::{format_peer_suffix, pending_requests_for_session};
 pub use helpers::{resolve_session_label, session_label_from_board, timestamp_at_or_after};
+pub use liveness::{
+    classify_session_liveness, classify_session_liveness_at, liveness_from_heartbeat,
+    SessionLiveness,
+};
 pub(crate) use render_coord::{render_coord_diff, render_peer_updates_with};
 pub use render_coord::{render_coordination_protocol, render_coordination_protocol_with};
 pub use render_fleet::fleet_section;

--- a/crates/edda-cli/src/cmd_claim.rs
+++ b/crates/edda-cli/src/cmd_claim.rs
@@ -1655,6 +1655,181 @@ mod tests {
         .to_string()
     }
 
+    /// Build an RFC3339 timestamp `secs` seconds before now (UTC, `Z`).
+    /// The peers timestamp parser only reads the wall-clock digits, so any
+    /// correct UTC spelling works.
+    fn rfc3339_now_minus(secs: u64) -> String {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_secs()
+            .saturating_sub(secs);
+        time::OffsetDateTime::from_unix_timestamp(now as i64)
+            .expect("unix timestamp")
+            .format(&time::format_description::well_known::Rfc3339)
+            .expect("rfc3339")
+    }
+
+    /// Write a heartbeat file for `session` whose last beat is `age_secs`
+    /// old, the same shape peer discovery reads (GH-617 consumption proof:
+    /// the test writes the liveness surface, the real binary reads it).
+    fn write_heartbeat(store_root: &Path, project_id: &str, session: &str, age_secs: u64) {
+        let dir = store_root.join("projects").join(project_id).join("state");
+        std::fs::create_dir_all(&dir).expect("state dir");
+        let hb = serde_json::json!({
+            "session_id": session,
+            "started_at": rfc3339_now_minus(age_secs),
+            "last_heartbeat": rfc3339_now_minus(age_secs),
+            "label": session,
+            "focus_files": [],
+            "active_tasks": [],
+            "files_modified_count": 0,
+            "total_edits": 0,
+            "recent_commits": [],
+        });
+        std::fs::write(dir.join(format!("session.{session}.json")), hb.to_string())
+            .expect("heartbeat file");
+    }
+
+    #[test]
+    fn e2e_stale_session_claim_is_not_a_conflict() {
+        // GH-617 consumption proof (write → read): one claim from a session
+        // whose heartbeat expired plus one from a live session, both claiming
+        // the same path. Querying that path must conflict with ONLY the live
+        // session's claim; the stale one must neither appear as a conflict
+        // nor flip the exit code.
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
+        let project_id = edda_store::project_id(repo.path());
+        let store = tempfile::tempdir().expect("store tempdir");
+        write_board(
+            store.path(),
+            &project_id,
+            &[
+                coord_event("dead0001", "ghost-lane", &["src/*"]),
+                coord_event("livetest", "peer-live", &["src/*"]),
+            ],
+        );
+        write_heartbeat(store.path(), &project_id, "dead0001", 3600);
+        write_heartbeat(store.path(), &project_id, "livetest", 0);
+        let (code, stdout, stderr) =
+            run_edda(&["claim", "check", "src/main.rs"], repo.path(), store.path());
+        assert_eq!(
+            code, 1,
+            "the live claim must still conflict; stdout={stdout:?} stderr={stderr:?}"
+        );
+        assert!(
+            stdout.contains("peer-live") && stdout.contains("livetest"),
+            "the live claim must be reported as a conflict, got {stdout:?}"
+        );
+        assert!(
+            !stdout.contains("ghost-lane"),
+            "a stale session's claim must not be reported as a conflict, got {stdout:?}"
+        );
+        assert!(
+            !stdout.contains("dead0001"),
+            "a dead session must not appear in the conflict list, got {stdout:?}"
+        );
+    }
+
+    #[test]
+    fn e2e_stale_claims_are_visible_and_do_not_flip_exit_code() {
+        // GH-617 death visibility: a board holding only a dead session's
+        // claim must exit 0 AND say what was filtered, so "surface is clear"
+        // stays distinguishable from "the liveness judgement broke".
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
+        let project_id = edda_store::project_id(repo.path());
+        let store = tempfile::tempdir().expect("store tempdir");
+        write_board(
+            store.path(),
+            &project_id,
+            &[coord_event("dead0002", "ghost-lane", &["src/*"])],
+        );
+        write_heartbeat(store.path(), &project_id, "dead0002", 3600);
+        let (code, stdout, stderr) =
+            run_edda(&["claim", "check", "src/main.rs"], repo.path(), store.path());
+        assert_eq!(
+            code, 0,
+            "stale claims must not flip the exit code; stdout={stdout:?} stderr={stderr:?}"
+        );
+        assert!(
+            stdout.contains("stale"),
+            "output must reveal that stale claims were filtered, got {stdout:?}"
+        );
+    }
+
+    #[test]
+    fn e2e_claim_from_session_without_heartbeat_is_not_a_conflict() {
+        // A session with no heartbeat file at all was never heard from — the
+        // same verdict `edda peers` reaches — so its claim must not conflict.
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
+        let project_id = edda_store::project_id(repo.path());
+        let store = tempfile::tempdir().expect("store tempdir");
+        write_board(
+            store.path(),
+            &project_id,
+            &[coord_event("lost0003", "ghost-lane", &["src/*"])],
+        );
+        let (code, stdout, stderr) =
+            run_edda(&["claim", "check", "src/main.rs"], repo.path(), store.path());
+        assert_eq!(
+            code, 0,
+            "a never-heartbeated session must not conflict; stdout={stdout:?} stderr={stderr:?}"
+        );
+        assert!(
+            stdout.contains("stale"),
+            "output must reveal that stale claims were filtered, got {stdout:?}"
+        );
+    }
+
+    #[test]
+    fn e2e_stale_claims_appear_in_json_report() {
+        // Machine-readable death visibility: the JSON report must carry the
+        // filtered stale claims alongside the (live-only) conflict list.
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
+        let project_id = edda_store::project_id(repo.path());
+        let store = tempfile::tempdir().expect("store tempdir");
+        write_board(
+            store.path(),
+            &project_id,
+            &[
+                coord_event("dead0004", "ghost-lane", &["src/*"]),
+                coord_event("livetest", "peer-live", &["src/*"]),
+            ],
+        );
+        write_heartbeat(store.path(), &project_id, "dead0004", 3600);
+        write_heartbeat(store.path(), &project_id, "livetest", 0);
+        let (code, stdout, stderr) = run_edda(
+            &["claim", "check", "src/main.rs", "--json"],
+            repo.path(),
+            store.path(),
+        );
+        assert_eq!(
+            code, 1,
+            "the live claim must still conflict; stdout={stdout:?} stderr={stderr:?}"
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON report");
+        let conflicts = parsed["conflicts"].as_array().expect("conflicts array");
+        assert_eq!(
+            conflicts.len(),
+            1,
+            "only the live claim may conflict, got {conflicts:?}"
+        );
+        assert_eq!(conflicts[0]["session_id"], "livetest");
+        let stale = parsed["stale_claims"]
+            .as_array()
+            .expect("stale_claims array in JSON report");
+        assert_eq!(
+            stale.len(),
+            1,
+            "the filtered stale claim must be named in the report, got {parsed:?}"
+        );
+        assert_eq!(stale[0]["session_id"], "dead0004");
+    }
+
     #[test]
     fn e2e_exit_codes_conflict_and_disjoint() {
         let bin = edda_bin();

--- a/crates/edda-cli/src/cmd_claim.rs
+++ b/crates/edda-cli/src/cmd_claim.rs
@@ -19,7 +19,7 @@
 //!   before letting two lanes write the same file.
 
 use anyhow::Context;
-use edda_bridge_claude::peers::ClaimEntry;
+use edda_bridge_claude::peers::{classify_session_liveness, ClaimEntry, SessionLiveness};
 use serde::Serialize;
 use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::io::ErrorKind;
@@ -42,10 +42,27 @@ pub struct ClaimConflict {
     pub intersections: Vec<PathIntersection>,
 }
 
+/// A claim that was filtered out because its session failed the shared
+/// liveness criterion (GH-617). The claim stays on the append-only board —
+/// this is query-side bookkeeping only.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct StaleClaim {
+    pub label: String,
+    pub session_id: String,
+    /// Seconds since the session's last heartbeat, or `None` when the
+    /// session has no heartbeat file at all (never heard from).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub age_secs: Option<u64>,
+}
+
 /// Machine-readable result of a claim check (`--json`).
 #[derive(Debug, Clone, Serialize, Default, PartialEq)]
 pub struct CheckReport {
     pub conflicts: Vec<ClaimConflict>,
+    /// Claims filtered out because their session is dead (GH-617). Reported
+    /// for death visibility — never counted toward the exit code.
+    #[serde(default)]
+    pub stale_claims: Vec<StaleClaim>,
 }
 
 /// `edda claim check <paths|globs>...` — read-only conflict query.
@@ -72,7 +89,36 @@ pub fn claim_check(repo_root: &Path, query: &[String], json: bool) -> anyhow::Re
         }
     };
     let query_refs: Vec<&str> = query.iter().map(String::as_str).collect();
-    let report = match check(&claims, &query_refs) {
+
+    // GH-617: "active" on the board only means "that session's last claim
+    // event" — it says nothing about whether the session is still alive.
+    // Apply the ONE liveness criterion `edda peers` uses (shared via
+    // `peers::liveness`, never re-implemented here): a claim from a session
+    // that is stale (or never heartbeated) is filtered out of the conflict
+    // computation. The claim itself stays on the append-only board; only
+    // this query stops counting it. Stale claims are reported (human and
+    // JSON) so "surface is clear" stays distinguishable from "the liveness
+    // judgement broke", and they never affect the exit code.
+    let board_size = claims.len();
+    let mut live: Vec<ClaimEntry> = Vec::new();
+    let mut stale_claims: Vec<StaleClaim> = Vec::new();
+    for c in claims {
+        match classify_session_liveness(&project_id, &c.session_id) {
+            SessionLiveness::Live { .. } => live.push(c),
+            SessionLiveness::Stale { age_secs } => stale_claims.push(StaleClaim {
+                label: c.label,
+                session_id: c.session_id,
+                age_secs: Some(age_secs),
+            }),
+            SessionLiveness::NoHeartbeat => stale_claims.push(StaleClaim {
+                label: c.label,
+                session_id: c.session_id,
+                age_secs: None,
+            }),
+        }
+    }
+
+    let report = match check(&live, &query_refs) {
         Ok(report) => report,
         Err(err) => {
             eprintln!("error: {err}");
@@ -80,18 +126,24 @@ pub fn claim_check(repo_root: &Path, query: &[String], json: bool) -> anyhow::Re
         }
     };
 
+    let report = CheckReport {
+        conflicts: report.conflicts,
+        stale_claims,
+    };
+
     if json {
         let out = serde_json::to_string_pretty(&report).context("serialize claim check report")?;
         println!("{out}");
     } else if report.conflicts.is_empty() {
-        if claims.is_empty() {
+        if board_size == 0 {
             println!("No active claims on the coordination board; surface is clear.");
         } else {
             println!(
-                "No conflicts: {} active claim(s) checked against {} query path(s).",
-                claims.len(),
+                "No conflicts: {} live claim(s) checked against {} query path(s).",
+                live.len(),
                 query.len()
             );
+            print_stale_claims(&report.stale_claims);
         }
     } else {
         for conflict in &report.conflicts {
@@ -108,6 +160,7 @@ pub fn claim_check(repo_root: &Path, query: &[String], json: bool) -> anyhow::Re
             report.conflicts.len(),
             query.len()
         );
+        print_stale_claims(&report.stale_claims);
     }
 
     if exit_code_for(&report) != 0 {
@@ -117,11 +170,41 @@ pub fn claim_check(repo_root: &Path, query: &[String], json: bool) -> anyhow::Re
 }
 
 /// Exit code for a check result: 0 = disjoint, 1 = conflict.
+///
+/// Stale claims (dead sessions, GH-617) are deliberately not counted here:
+/// they are liveness-filtered bookkeeping, never a conflict signal.
 fn exit_code_for(report: &CheckReport) -> i32 {
     if report.conflicts.is_empty() {
         0
     } else {
         1
+    }
+}
+
+/// Death visibility (GH-617): reveal how many stale claims the liveness
+/// filter removed, so a human can tell "no conflicts" apart from "the
+/// liveness judgement removed everything". The count line goes to stdout
+/// as part of the human report; the per-claim detail (with labels) goes to
+/// stderr so stdout stays free of dead sessions' identifiers.
+fn print_stale_claims(stale: &[StaleClaim]) {
+    if stale.is_empty() {
+        return;
+    }
+    println!(
+        "note: {} stale claim(s) from dead session(s) not counted (--json lists them).",
+        stale.len()
+    );
+    for s in stale {
+        match s.age_secs {
+            Some(age) => eprintln!(
+                "  stale, not counted: claim \"{}\" (session {}) — heartbeat {}s ago",
+                s.label, s.session_id, age
+            ),
+            None => eprintln!(
+                "  stale, not counted: claim \"{}\" (session {}) — no heartbeat",
+                s.label, s.session_id
+            ),
+        }
     }
 }
 
@@ -299,7 +382,10 @@ pub fn check(
             });
         }
     }
-    Ok(CheckReport { conflicts })
+    Ok(CheckReport {
+        conflicts,
+        stale_claims: Vec::new(),
+    })
 }
 
 /// Whether a query token and a claim token can name the same file.
@@ -1307,6 +1393,10 @@ mod tests {
             &project_id,
             &[coord_event("sess-9", "peer-c", &["src/Ä.rs"])],
         );
+        // GH-617: the claim must come from a LIVE session for the engine's
+        // refusal path to be reachable — a dead session's claim is filtered
+        // before any surface comparison.
+        write_heartbeat(store.path(), &project_id, "sess-9", 0);
         let bin = edda_bin();
         assert!(bin.exists(), "edda binary not found at {}", bin.display());
         let out = std::process::Command::new(&bin)
@@ -1620,7 +1710,13 @@ mod tests {
                 session_id: "y".into(),
                 intersections: vec![],
             }],
+            stale_claims: vec![StaleClaim {
+                label: "ghost".into(),
+                session_id: "dead".into(),
+                age_secs: None,
+            }],
         };
+        // Stale claims never affect the exit code (GH-617).
         assert_eq!(exit_code_for(&conflict), 1);
     }
 
@@ -1712,8 +1808,11 @@ mod tests {
         );
         write_heartbeat(store.path(), &project_id, "dead0001", 3600);
         write_heartbeat(store.path(), &project_id, "livetest", 0);
-        let (code, stdout, stderr) =
-            run_edda(&["claim", "check", "src/main.rs"], repo.path(), store.path());
+        let (code, stdout, stderr) = run_edda(
+            &["claim", "check", "src/main.rs"],
+            repo.path(),
+            store.path(),
+        );
         assert_eq!(
             code, 1,
             "the live claim must still conflict; stdout={stdout:?} stderr={stderr:?}"
@@ -1747,8 +1846,11 @@ mod tests {
             &[coord_event("dead0002", "ghost-lane", &["src/*"])],
         );
         write_heartbeat(store.path(), &project_id, "dead0002", 3600);
-        let (code, stdout, stderr) =
-            run_edda(&["claim", "check", "src/main.rs"], repo.path(), store.path());
+        let (code, stdout, stderr) = run_edda(
+            &["claim", "check", "src/main.rs"],
+            repo.path(),
+            store.path(),
+        );
         assert_eq!(
             code, 0,
             "stale claims must not flip the exit code; stdout={stdout:?} stderr={stderr:?}"
@@ -1772,8 +1874,11 @@ mod tests {
             &project_id,
             &[coord_event("lost0003", "ghost-lane", &["src/*"])],
         );
-        let (code, stdout, stderr) =
-            run_edda(&["claim", "check", "src/main.rs"], repo.path(), store.path());
+        let (code, stdout, stderr) = run_edda(
+            &["claim", "check", "src/main.rs"],
+            repo.path(),
+            store.path(),
+        );
         assert_eq!(
             code, 0,
             "a never-heartbeated session must not conflict; stdout={stdout:?} stderr={stderr:?}"
@@ -1847,6 +1952,9 @@ mod tests {
             &project_id,
             &[coord_event("sess-1", "peer-a", &["crates/edda-cli/src/*"])],
         );
+        // GH-617: only a LIVE session's claim conflicts — give sess-1 a
+        // fresh heartbeat.
+        write_heartbeat(store.path(), &project_id, "sess-1", 0);
         let out = std::process::Command::new(&bin)
             .args(["claim", "check", "crates/edda-cli/src/main.rs"])
             .current_dir(repo.path())
@@ -1877,6 +1985,8 @@ mod tests {
                 &["crates/edda-conductor/src/plan/**"],
             )],
         );
+        // GH-617: a live, disjoint claim must keep the surface clear.
+        write_heartbeat(store.path(), &project_id, "sess-2", 0);
         let out = std::process::Command::new(&bin)
             .args(["claim", "check", "crates/edda-cli/src/main.rs"])
             .current_dir(repo.path())


### PR DESCRIPTION
## fix(edda-cli): `claim check` applies the shared peers liveness criterion (GH-617)

Refs #617 (closing keyword removed per the no-auto-close contract — issue closure stays with the operator).

### 缺陷回顧

`claim check` 把 coordination board 上「每個 session 的最後一筆 claim 事件」都當成
active，從不問該 session 是否還活著。任何有歷史的 repo 上，2026-02/03 死 session
的 `**/*` claim 讓所有查詢永遠回 CONFLICT，判別力歸零（issue body 有實測：5 衝突
全來自死 session，exit 1）。

### 做法與設計要求

**不新增第二套 liveness 概念。** 判活判準抽到
`edda_bridge_claude::peers::liveness`（新模組）：

- `liveness_from_heartbeat(&SessionHeartbeat, now_epoch) -> SessionLiveness` —
  heartbeat 不老於 `stale_secs()` 為 live（parented sub-agent 維持 discovery 既有
  的 15x 倍率）；無 heartbeat 檔＝`NoHeartbeat`。
- `classify_session_liveness[_at](project_id, session_id)` — 讀 heartbeat 檔套用判準。
- **`discover_active_peers` 本身重構為呼叫同一個判準**，原本內聯的 age/threshold
  判斷（含 15x 註解）移進判準模組 —— `edda peers` 與 `edda claim check` 從此
  不可能各判各的。

`cmd_claim.rs`：`read_active_claims` 之後、`check()` 之前，用
`classify_session_liveness` 把 claims 分成 live / stale。只有 live 的進交集計算。

### doneWhen 逐條對照

| doneWhen | 落地 |
|---|---|
| 只對活著的 session 的 claim 回報衝突，沿用 `stale_secs()`，不新增第二套判準 | `peers::liveness::liveness_from_heartbeat`；`discover_active_peers` 同步重構上同一判準 |
| 死 session 的 claim 不消失、不刪除，exit code 不受影響 | 只在查詢端過濾；帳本 append-only 不動。`exit_code_for` 只數 `conflicts`；測試 `exit_codes_follow_report` 釘住「conflict + stale 同時存在 → exit 1」 |
| Consumption proof：write → read，過期 heartbeat 的 claim ＋活 session claim 查同一條 path，只有活的算衝突、exit 0/1 正確 | `e2e_stale_session_claim_is_not_a_conflict`（寫 3600s 過期 + 0s 心跳，兩者 claim `src/*`，查 `src/main.rs`：exit 1、stdout 只含 live label）與 `e2e_stale_claims_appear_in_json_report`（JSON 版） |
| Death visibility：輸出能看出篩掉幾筆 stale claim | 人類輸出加 `note: N stale claim(s) from dead session(s) not counted`（stdout），逐筆 label/session/age 明細走 stderr；JSON report 新增 `stale_claims` 陣列 |
| 迴歸測試先驗證 FAIL 再過 | 見下方 FAIL-first |

### FAIL-first 證據

Red commit：**`0157883`**（parent `a1dd3d8`＝完全未修改的 source；commit 內容只有
`crates/edda-cli/src/cmd_claim.rs` 的測試，無 dev-dependency 變更）。對 red commit
跑 `cargo test -p edda --bin edda claim::`，四個新測試全數失敗，原文：

```
failures:

---- cmd_claim::tests::e2e_claim_from_session_without_heartbeat_is_not_a_conflict stdout ----

thread 'cmd_claim::tests::e2e_claim_from_session_without_heartbeat_is_not_a_conflict' (41504) panicked at crates\edda-cli\src\cmd_claim.rs:1777:9:
assertion `left == right` failed: a never-heartbeated session must not conflict; stdout="CONFLICT with claim \"ghost-lane\" (session lost0003)\n  query src/main.rs  <->  claim src/*\n1 conflicting claim(s) across 1 query path(s).\n" stderr=""
  left: 1
 right: 0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- cmd_claim::tests::e2e_stale_claims_are_visible_and_do_not_flip_exit_code stdout ----

thread 'cmd_claim::tests::e2e_stale_claims_are_visible_and_do_not_flip_exit_code' (36416) panicked at crates\edda-cli\src\cmd_claim.rs:1752:9:
assertion `left == right` failed: stale claims must not flip the exit code; stdout="CONFLICT with claim \"ghost-lane\" (session dead0002)\n  query src/main.rs  <->  claim src/*\n1 conflicting claim(s) across 1 query path(s).\n" stderr=""
  left: 1
 right: 0

---- cmd_claim::tests::e2e_stale_session_claim_is_not_a_conflict stdout ----

thread 'cmd_claim::tests::e2e_stale_session_claim_is_not_a_conflict' (38028) panicked at crates\edda-cli\src\cmd_claim.rs:1725:9:
a stale session's claim must not be reported as a conflict, got "CONFLICT with claim \"ghost-lane\" (session dead0001)\n  query src/main.rs  <->  claim src/*\nCONFLICT with claim \"peer-live\" (session livetest)\n  query src/main.rs  <->  claim src/*\n2 conflicting claim(s) across 1 query path(s).\n"

---- cmd_claim::tests::e2e_stale_claims_appear_in_json_report stdout ----

thread 'cmd_claim::tests::e2e_stale_claims_appear_in_json_report' (13720) panicked at crates\edda-cli\src\cmd_claim.rs:1816:9:
assertion `left == right` failed: only the live claim may conflict, got [Object {"intersections": Array [Object {"claim_path": String("src/*"), "query": String("src/main.rs")}], "label": String("ghost-lane"), "session_id": String("dead0004")}, Object {"intersections": Array [Object {"claim_path": String("src/*"), "query": String("src/main.rs")}], "label": String("peer-live"), "session_id": String("livetest")}]
  left: 2
 right: 1


failures:
    cmd_claim::tests::e2e_claim_from_session_without_heartbeat_is_not_a_conflict
    cmd_claim::tests::e2e_stale_claims_appear_in_json_report
    cmd_claim::tests::e2e_stale_claims_are_visible_and_do_not_flip_exit_code
    cmd_claim::tests::e2e_stale_session_claim_is_not_a_conflict

test result: FAILED. 37 passed; 4 failed; 0 ignored; 0 measured; 402 filtered out; finished in 0.90s
```

修正 commit `fa208a3` 後同一組測試 41/41 過，全 crate 綠。

### ⚠ 交互作用：dispatch lane 不寫 peers heartbeat（#569）

**預期後果，不是 bug，本 PR 不處理：** 本單修好後，dispatch 出去的 lane 若沒有
heartbeat（#569 前 dispatch lane 不寫），它的 claim 會被判為 stale、不再產生衝突。
這正是「死 session 的 claim 不再擋路」判準的一致延伸——我們**沒有**為了讓 lane
claim 看起來還活著而放寬判準（那會讓本單白做）。#569 讓 lane 寫真正的心跳後，
live lane 的 claim 自然回到衝突判定內。

### Gate receipt（L1）

- **Full SHA**: `fa208a3ab4911d3fa9f2dcd60fb332a8575f5b69`
- **Gates**: `cargo fmt --all --check` ✅；`cargo clippy --workspace --all-targets -- -D warnings` ✅；
  `cargo test --workspace -- --test-threads=1` ✅（全 crate 0 failed）
- **Toolchain**: rustc/cargo 1.93.1 (01f6ddf75 2026-02-11)
- **Lane**: `C:\ai_agent\fleet-workstation\lanes\worker-1`（`CARGO_INCREMENTAL=0`）

⚠ **既有的（非本 PR 引入）平行測試 flake**：`cargo test -p edda-bridge-claude`
平行跑時每次隨機掛不同測試（bg_scan/bg_detect/agent_phase/dispatch…，全屬
default-store 對 `EDDA_STORE_ROOT` 的跨測試競態；來源 `digest/tests.rs:21-31`
無鎖重導 env）。**在未修改的 base 上重現同樣 22 failed**（red commit `0157883`
上跑出 `test result: FAILED. 592 passed; 22 failed`，該 commit 的 bridge-claude
source 與 base 完全相同），序列跑（`--test-threads=1`）619/619 全綠。建議開
follow-up issue，本 PR 不擴大範圍。

### 範圍

- 改動檔案：`crates/edda-cli/src/cmd_claim.rs`、
  `crates/edda-bridge-claude/src/peers/{liveness.rs(新), discovery.rs, mod.rs}`
- 沒動：`edda-conductor`、`edda-ledger`、`digest/`、operator runbook；
  沒做 #656、#573。

