### PR TITLE
fix(fleet): lane-stop.ps1 — Stop-ScheduledTask does not kill the lane process tree (GH-672)

### DIFF
--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -40,6 +40,15 @@
    ```bash
    pwsh -NoProfile -File scripts/fleet/lane-status.ps1
    ```
+5. **停 lane**（只有這個動作是真的停）：
+   ```bash
+   pwsh -NoProfile -File scripts/fleet/lane-stop.ps1 -Name <lane>
+   ```
+   `Stop-ScheduledTask` 與 `Unregister-ScheduledTask` **都不殺子程序樹**（GH-672）：
+   它們只終止 wrapper，`edda dispatch` 子程序會繼續跑到 commit／push／開 PR，
+   而任務顯示 `State = Ready`。停 lane 一律走 `lane-stop.ps1`：它停任務、殺整棵
+   process tree、依 `CommandLine` 比對 wrapper／brief 路徑驗證無殘留，並補寫
+   wrapper 已寫不出的結束記錄（done-file + `=== EXIT ===` 行）。
 
 ---
 
@@ -148,6 +157,7 @@ Brief 必含：assigned build lane、verification budget（L0 while iterating；
 | 執行用便宜模型（pi 預設 glm-5.3-flash）；**審查一律 gpt-5.6-sol**（codex／pi 皆是） | `fleet.agent-model-split` |
 | 審查 provider 過載：**改運輸不降模型**——(1) 同 `--model` 先用 `--thinking minimal` 探測，通了才重試 pi 一次；(2) 仍沒有判決就對該 head 標 `review:unreviewed` 並停——未審查是誠實狀態，便宜模型的判決不是。watcher 無 Codex 路線（superseding 決策 `…codex-route-withdrawn-for-automated-watcher`：Codex 對 watcher 做不到唯讀；人類控制者仍可手動用 Codex） | `fleet.review-provider-overload` |
 | **lane 啟動走 Task Scheduler，不走 nohup／Start-Process**：Claude Code 的工具 shell 在 Windows Job Object 裡，nohup 的子程序仍隨 session 死。`Register-ScheduledTask` + `Start-ScheduledTask`（父程序是 svchost）；該環境 `HOME` 為空，lane wrapper 必須顯式設；`CARGO_TARGET_DIR` 只在 `-BuildLane` 指名四個允許 build lane 之一時設（不編譯的 session 沒有 build lane——`.claude/CLAUDE.md`、`verification.cost-discipline`；要編譯的必須給四擇一，launcher 拒絕其他名字）。`lane-launch.ps1` 不合成 build lane：`-BuildLane` 只收 `worker-1|worker-2|verifier|verifier-2`，設 `CARGO_TARGET_DIR`＝lane root（`$env:LOCALAPPDATA\fleet-workstation\lanes`，可用 `FLEET_LANE_ROOT` 改）\`<BuildLane>`；docs lane 不傳，wrapper 不設。`Get-ScheduledTaskInfo` 可輪詢，`Unregister-ScheduledTask` 清理。重派前先讀 worktree／branch／PR 狀態，不信任 live handle。**手續已脚本化**：用 `scripts/fleet/lane-launch.ps1` 註冊起 lane、`scripts/fleet/lane-status.ps1` 盯狀態（用法見 START HERE），不要再手寫 wrapper | `fleet.lane-launch`、`fleet.lane-dispatch` |
+| **停 lane 一律走 `scripts/fleet/lane-stop.ps1 -Name <lane>`**：`Stop-ScheduledTask` 與 `Unregister-ScheduledTask` 都只終止任務的 wrapper，**不殺它 spawn 的 process tree**（GH-672：被「停」的 lane 照樣 commit／push／開 PR，任務卻顯示 `State = Ready`）。`lane-stop.ps1` 停任務、殺整棵樹（wrapper 已死時依 `CommandLine` 比對 wrapper／brief 路徑抓孤兒）、驗證無殘留、回報實際終止了什麼，並補寫結束記錄（done-file + lane log 的 `=== EXIT ===` 行）——wrapper 本身也在 `finally` 寫同樣的結束記錄，所以正常結束、出錯、被停三種 endings 都有 EXIT | `fleet.lane-stop-4090` |
 | 一 issue ＝ 一單 phase plan ＝ 一 worktree ＝ 一 build lane；並行在 plan 之間；plan 裡不寫沒理由的 `depends_on`；並行 plan 不用 verdict gate | `cleanup.parallel-exec`、`cleanup.review-gate` |
 | build lane 只用 `worker-1|worker-2|verifier|verifier-2`；永不建 ad-hoc `CARGO_TARGET_DIR`；L1 與 verifier 設 `CARGO_INCREMENTAL=0` | `verification.cost-discipline` |
 | 審查釘 full SHA；**每次 push 使前一個判決失效**；一個 PR 一個審查者身分 | `fleet.review-protocol` |

--- a/scripts/fleet/lane-launch.ps1
+++ b/scripts/fleet/lane-launch.ps1
@@ -31,7 +31,14 @@
 #
 # Prints, one line each: task name, state, wrapper path, log path, done path.
 # Poll with scripts/fleet/lane-status.ps1; the done-file appears (containing
-# the exit code) when the lane finishes.
+# the exit code) when the lane finishes. The wrapper writes its end record
+# (=== EXIT === log line + done-file) no matter how the run ends; when the
+# lane is stopped with scripts/fleet/lane-stop.ps1 the wrapper is killed and
+# cannot write it, so lane-stop.ps1 writes the end record instead (GH-672).
+#
+# The task action executes pwsh via its full resolved path: in the Task
+# Scheduler environment the bare name 'pwsh.exe' (a WindowsApps execution
+# alias) does not resolve and the task fails with 0x80070002.
 #
 # -DryRun needs no caller input: it generates its own temporary brief inside
 # -LogDir, builds the exact wrapper and `edda dispatch` command line a real
@@ -98,6 +105,11 @@ $Log = Join-Path $LogDir "$Name.log"
 $Done = Join-Path $LogDir "$Name.done"
 $Wrapper = Join-Path $LogDir "$Name.wrapper.ps1"
 
+# Full path for the task action — 'pwsh.exe' does not resolve in the task
+# environment (0x80070002).
+$PwshExe = (Get-Command pwsh.exe -ErrorAction SilentlyContinue).Source
+if (-not $PwshExe) { Fail 'pwsh.exe not found on PATH; cannot register the task' }
+
 # The real `edda dispatch` command line (also printed verbatim by -DryRun).
 $argLine = "dispatch --agent $Agent --prompt-file $(PsQuote $Brief) --session-id $(PsQuote $SessionId) --cwd $(PsQuote $Cwd) --timeout-sec $TimeoutSec"
 if ($BudgetUsd -gt 0) { $argLine += " --budget-usd $BudgetUsd" }
@@ -115,9 +127,18 @@ $env:HOME = $env:USERPROFILE
 $env:GIT_CONFIG_PARAMETERS = "'help.format=man'"
 $env:CARGO_TARGET_DIR = __CARGO__
 Set-Location -LiteralPath __CWD__
-__RUN__
-$code = $LASTEXITCODE
-Set-Content -LiteralPath __DONE__ -Value $code -Encoding ascii
+$code = $null
+try {
+  __RUN__
+  $code = $LASTEXITCODE
+} catch {
+  $code = 1
+} finally {
+  # The end record is written no matter how the run ends (GH-672): a log
+  # with START but no === EXIT === line means the lane was killed mid-flight.
+  Add-Content -LiteralPath __LOG__ -Value "=== EXIT code=$code ===" -Encoding utf8
+  Set-Content -LiteralPath __DONE__ -Value $code -Encoding ascii
+}
 exit $code
 '@
 $runReal = "& edda $argLine 2>&1 | Tee-Object -FilePath $(PsQuote $Log) -Append"
@@ -141,11 +162,11 @@ if ($DryRun) {
   } else {
     $wrapperText = $wrapperText -replace '(?m)^.*__CARGO__.*\r?\n', ''
   }
-  $wrapperText.Replace('__CWD__', (PsQuote $Cwd)).Replace('__RUN__', $runDry).Replace('__DONE__', (PsQuote $Done)) |
+  $wrapperText.Replace('__CWD__', (PsQuote $Cwd)).Replace('__LOG__', (PsQuote $Log)).Replace('__RUN__', $runDry).Replace('__DONE__', (PsQuote $Done)) |
     Set-Content -LiteralPath $Wrapper -Encoding utf8
   "dry-run wrapper=$Wrapper (identical to the real wrapper except __RUN__ runs the trivial process)"
 
-  $action = New-ScheduledTaskAction -Execute 'pwsh.exe' `
+  $action = New-ScheduledTaskAction -Execute $PwshExe `
     -Argument "-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$Wrapper`"" `
     -WorkingDirectory $Cwd
   $settings = New-ScheduledTaskSettingsSet `
@@ -198,12 +219,12 @@ if ($BuildLane) {
 } else {
   $wrapperText = $wrapperText -replace '(?m)^.*__CARGO__.*\r?\n', ''
 }
-$wrapperText.Replace('__CWD__', (PsQuote $Cwd)).Replace('__RUN__', $runReal).Replace('__DONE__', (PsQuote $Done)) |
+$wrapperText.Replace('__CWD__', (PsQuote $Cwd)).Replace('__LOG__', (PsQuote $Log)).Replace('__RUN__', $runReal).Replace('__DONE__', (PsQuote $Done)) |
   Set-Content -LiteralPath $Wrapper -Encoding utf8
 
 Remove-Item -LiteralPath $Done -ErrorAction SilentlyContinue  # stale done-file from a previous run must not masquerade as this run
 
-$action = New-ScheduledTaskAction -Execute 'pwsh.exe' `
+$action = New-ScheduledTaskAction -Execute $PwshExe `
   -Argument "-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$Wrapper`"" `
   -WorkingDirectory $Cwd
 $settings = New-ScheduledTaskSettingsSet `

--- a/scripts/fleet/lane-stop.ps1
+++ b/scripts/fleet/lane-stop.ps1
@@ -1,0 +1,156 @@
+# lane-stop.ps1 — actually stop a fleet lane launched by lane-launch.ps1.
+#
+# Stop-ScheduledTask (and Unregister-ScheduledTask) terminate only the task's
+# wrapper process, NOT the process tree the wrapper spawned (GH-672): the
+# lane's `edda dispatch` child kept running to commit / push / open a PR while
+# the task reported State = Ready. This script is the only sanctioned way to
+# stop a lane. It
+#   1. stops the scheduled task (best-effort, kills the wrapper only),
+#   2. kills the lane's whole process tree — the wrapper plus, even after the
+#      wrapper is already dead (the orphan case above), every process still
+#      identifiable by CommandLine as the lane: the wrapper path and the
+#      brief path the wrapper was launched with — including each match's
+#      descendants,
+#   3. verifies by CommandLine match (wrapper path + brief path) that nothing
+#      survived, and
+#   4. writes the end record the killed wrapper can no longer write: the
+#      done-file (sentinel "stopped") and a === EXIT === line in the lane log,
+#      so a lane log with START but no EXIT is never left ambiguous (GH-672).
+#
+# usage:
+#   pwsh -NoProfile -File scripts/fleet/lane-stop.ps1 -Name <lane> [-LogDir <dir>]
+#
+# Prints what was terminated, one line each. Exit codes (style of
+# lane-status.ps1): 0 = stopped (N processes terminated, or the lane was not
+# running); 1 = error: no matching task, wrapper missing, or processes
+# survived the kill.
+#
+# Never points at another lane: -Name selects exactly one edda-lane-* task,
+# and the CommandLine matches are the lane's own wrapper and brief paths.
+param(
+  [Parameter(Mandatory = $true)][string]$Name,
+  [string]$LogDir = "$env:TEMP\edda-lanes"
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Fail([string]$Msg) {
+  [Console]::Error.WriteLine("lane-stop: $Msg")
+  exit 1
+}
+
+if ($Name -notmatch '^[A-Za-z0-9][A-Za-z0-9._-]*$') {
+  Fail "-Name '$Name' may contain only letters, digits, dot, underscore, hyphen"
+}
+$TaskName = "edda-lane-$Name"
+$task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if (-not $task) { Fail "no scheduled task $TaskName (scripts/fleet/lane-status.ps1 lists what exists)" }
+
+$Wrapper = Join-Path $LogDir "$Name.wrapper.ps1"
+$Log = Join-Path $LogDir "$Name.log"
+$Done = Join-Path $LogDir "$Name.done"
+if (-not (Test-Path -LiteralPath $Wrapper -PathType Leaf)) {
+  Fail "wrapper not found: $Wrapper; cannot verify the lane's process tree by CommandLine"
+}
+
+# What the lane's processes look like on the command line. The wrapper path
+# matches the wrapper itself; the brief path (extracted from the wrapper the
+# same way the #606 clobber-guard does) matches the `edda dispatch` child and
+# stays identifiable after the wrapper is already dead — exactly the
+# State=Ready-but-still-working orphan Stop-ScheduledTask leaves behind.
+$wrapperBody = Get-Content -LiteralPath $Wrapper -Raw
+$brief = if ($wrapperBody -match "--prompt-file '([^']+)'") { $Matches[1] } else { $null }
+
+# Snapshot once; index children by parent PID so the whole tree below any
+# match (cargo, git, the agent runtime) is reachable even though none of
+# those children's own command lines mention the lane.
+$allProcs = @(Get-CimInstance Win32_Process)
+$childrenOf = @{}
+foreach ($p in $allProcs) {
+  if (-not $childrenOf.ContainsKey($p.ParentProcessId)) {
+    $childrenOf[$p.ParentProcessId] = New-Object System.Collections.Generic.List[int]
+  }
+  $childrenOf[$p.ParentProcessId].Add($p.ProcessId)
+}
+
+function Find-LaneProcessIds {
+  # Seed = processes whose command line names this lane; then their whole
+  # descendant trees. Never this process ($PID) and never a PID twice.
+  $seeds = @($allProcs | Where-Object {
+    $_.ProcessId -ne $PID -and $_.CommandLine -and (
+      $_.CommandLine.Contains($Wrapper) -or
+      ($brief -and $_.CommandLine.Contains($brief)))
+  })
+  $ids = New-Object System.Collections.Generic.HashSet[int]
+  $queue = New-Object System.Collections.Generic.Queue[int]
+  foreach ($s in $seeds) { [void]$ids.Add($s.ProcessId); $queue.Enqueue($s.ProcessId) }
+  while ($queue.Count -gt 0) {
+    $currentPid = $queue.Dequeue()
+    if (-not $childrenOf.ContainsKey($currentPid)) { continue }
+    foreach ($c in $childrenOf[$currentPid]) {
+      if ($c -ne $PID -and $ids.Add($c)) { $queue.Enqueue($c) }
+    }
+  }
+  return @($ids)
+}
+
+# --- 1. stop the task (kills the wrapper only — never the tree, GH-672) -----
+
+if ($task.State -eq 'Running') {
+  Stop-ScheduledTask -TaskName $TaskName
+  Start-Sleep -Seconds 1
+}
+
+# --- 2. kill the whole tree -------------------------------------------------
+
+$targets = Find-LaneProcessIds
+$terminated = New-Object System.Collections.Generic.List[int]
+if ($targets.Count -gt 0) {
+  foreach ($t in $targets) {
+    Stop-Process -Id $t -Force -ErrorAction SilentlyContinue
+  }
+  Start-Sleep -Seconds 2
+  # Anything that ignored Stop-Process gets taskkill /T /F, then one final
+  # accounting pass.
+  $survivors = @(Get-Process -Id $targets -ErrorAction SilentlyContinue)
+  foreach ($s in $survivors) {
+    & taskkill /PID $s.Id /T /F 2>$null | Out-Null
+  }
+  if ($survivors.Count -gt 0) { Start-Sleep -Seconds 2 }
+  foreach ($t in $targets) {
+    if (-not (Get-Process -Id $t -ErrorAction SilentlyContinue)) { $terminated.Add($t) }
+  }
+}
+
+# --- 3. verify by CommandLine: nothing matching the lane remains ------------
+
+$residual = @(Get-CimInstance Win32_Process | Where-Object {
+  $_.ProcessId -ne $PID -and $_.CommandLine -and (
+    $_.CommandLine.Contains($Wrapper) -or
+    ($brief -and $_.CommandLine.Contains($brief)))
+})
+if ($residual.Count -gt 0) {
+  Fail "residual lane processes survive the kill: $(($residual | ForEach-Object { $_.ProcessId }) -join ',')"
+}
+$task = Get-ScheduledTask -TaskName $TaskName
+if ($task.State -eq 'Running') { Fail "task $TaskName still reports State = Running after the stop" }
+
+# --- 4. write the end record the killed wrapper cannot write ----------------
+
+if ($terminated.Count -gt 0 -or ((Test-Path -LiteralPath $Log) -and -not (Test-Path -LiteralPath $Done))) {
+  Add-Content -LiteralPath $Log -Value "=== EXIT (stopped by lane-stop.ps1; terminated $($terminated.Count) process(es)) ===" -Encoding utf8
+  if (-not (Test-Path -LiteralPath $Done)) {
+    Set-Content -LiteralPath $Done -Value 'stopped' -Encoding ascii
+  }
+}
+
+# --- report -----------------------------------------------------------------
+
+"task=$TaskName state=$($task.State)"
+if ($terminated.Count -gt 0) {
+  "terminated=$($terminated.Count) pids=$($terminated -join ',')"
+} else {
+  "terminated=0 (lane was not running)"
+}
+"residual=$($residual.Count) (CommandLine match: wrapper path$(if ($brief) { ' + brief path' } else { '' }))"
+exit 0


### PR DESCRIPTION
GH-672 (do not auto-close: see review Round 1 contract item 4)

## 交付物

- `scripts/fleet/lane-stop.ps1`（新，與 `lane-launch.ps1`／`lane-status.ps1` 配對）：停排程任務 → 殺整棵 process tree（wrapper 死掉的孤兒情境用 `CommandLine` 比對 wrapper 路徑＋brief 路徑抓，含各比對命中的全部子孫）→ 依同樣的比對驗證殘留為 0 → 回報實際終止了什麼（`terminated=N pids=…` 或 `terminated=0 (lane was not running)`）→ 補寫 wrapper 已寫不出的結束記錄（done-file 哨兵 `stopped` + lane log 的 `=== EXIT ===` 行）。退出碼：0＝已停或本來就沒在跑；1＝無此任務／wrapper 遺失／殺後仍有殘留。
- `scripts/fleet/lane-launch.ps1`：wrapper 的結束記錄移進 `finally`——正常結束、出錯、被停三種 endings 都有 `=== EXIT code=… ===` 行與 done-file；另修 task action 的 `pwsh.exe` 改完整路徑（裸名在排程任務環境解析不到，0x80070002，見下方閘收據）。
- `docs/guides/operator-runbook.md`：START HERE 新增第 5 步「停 lane」，§六硬規則表明寫 `Stop-ScheduledTask`／`Unregister-ScheduledTask` 都不殺子程序樹、停 lane 一律走 `lane-stop.ps1`（決策 `fleet.lane-stop-4090`）。

## 逐字收據

### 修好前（FAIL 重現，`Stop-ScheduledTask` 對測試任務 `edda-lane-gh672-test`，wrapper 內 spawn 一個 child pwsh `Start-Sleep`）

```
BEFORE: wrapper pid=41052
BEFORE child: pid=43568 name=conhost.exe cmd=\??\C:\WINDOWS\system32\conhost.exe 0x4
BEFORE child: pid=8568 name=pwsh.exe cmd="…pwsh.exe" -NoProfile -NonInteractive -Command "Start-Sleep -Seconds 120"
task.State=Ready
wrapper alive=False
child pid=43568 alive=True
child pid=8568 alive=True
done-file exists=False
log bytes=0
```

→ 任務 `State = Ready`，wrapper 已死，**child 與 conhost 仍存活**，done-file 沒寫、log 無 EXIT——與 gh650／gh651 觀測一致。

### 孤兒情境（先 `Stop-ScheduledTask` 再接手）

```
after Stop-ScheduledTask: state=Ready
wrapper alive=False
orphan (cmdline has brief path) alive=True pid=41408
```

### 修好後（同一情境改跑 `lane-stop.ps1 -Name gh672-test`）

情境 A（lane 在跑，wrapper＋child＋conhost 活著）：

```
task=edda-lane-gh672-test state=Ready
terminated=2 pids=40204,42896
residual=0 (CommandLine match: wrapper path + brief path)
```

情境 B（孤兒：wrapper 已被 Stop-ScheduledTask 殺死、child pid=41408 存活）：

```
task=edda-lane-gh672-test state=Ready
terminated=1 pids=41408
residual=0 (CommandLine match: wrapper path + brief path)
```

（殘留 N 個 → 殘留 0；孤兒 pid=41408 事後複查 `alive=False`。）

情境「本來就沒在跑」（重複呼叫）：

```
task=edda-lane-gh672-test state=Ready
terminated=0 (lane was not running)
residual=0 (CommandLine match: wrapper path + brief path)
```

結束記錄（被殺的 wrapper 寫不出來，由 lane-stop 補寫）：

```
done content: stopped
log tail: === EXIT (stopped by lane-stop.ps1; terminated 2 process(es)) ===
```

新 wrapper 正常結束路徑（DryRun 的 log）：

```
=== EXIT code=0 ===
done content: 0
```

錯誤路徑：

```
lane-stop: no scheduled task edda-lane-gh672-nonexistent (scripts/fleet/lane-status.ps1 lists what exists)   → exit 1
lane-stop: -Name 'bad name!' may contain only letters, digits, dot, underscore, hyphen                        → exit 1
```

## 閘收據

- `pwsh -NoProfile -File scripts/fleet/lane-status.ps1` → exit 0（29 條 lane 全數照列）。
- `pwsh -NoProfile -File scripts/fleet/lane-launch.ps1 -Name gh672-test-dryrun -Cwd … -DryRun`：
  - 改前基準 **FAIL**：`lane-launch: dry-run task process not found; cannot prove the scheduler parent`（exit 1）——裸 `pwsh.exe` 在排程任務環境解析不到（LastTaskResult 0x80070002）。
  - 改後 **PASS**（exit 0）：`dry-run process pid=7348 ppid=2720 parent=svchost.exe`、`LastTaskResult=0`。
- `sh scripts/lint-markdown-content.sh` → exit 0。
- **未跑 cargo**（本單無 Rust 變更）。

## 接線表（自報）

| 面 | writer & shape | reader | failure signal |
|---|---|---|---|
| 新腳本 `lane-stop.ps1` | `scripts/fleet/lane-stop.ps1:41` `param(-Name <lane>, -LogDir)`；樹收集 `scripts/fleet/lane-stop.ps1:81` `Find-LaneProcessIds`（seed＝CommandLine 含 wrapper/brief 路徑，BFS 子孫）；驗證 `scripts/fleet/lane-stop.ps1:130` | 控制者／交還決策；#674 管理者的回收動作；`docs/fleet/rules.md` R3「三證合一」 | 殺後仍有殘留 → `Fail` exit 1（`scripts/fleet/lane-stop.ps1:135`）；無此任務／wrapper 遺失 → exit 1 |
| 新參數／行為：wrapper 結束記錄 | `scripts/fleet/lane-launch.ps1:96` `finally { Add-Content … "=== EXIT code=$code ==="; Set-Content __DONE__ $code }`（模板佔位 `__LOG__` 於 `scripts/fleet/lane-launch.ps1:150/196` 填入） | `lane-status.ps1` 的 `done=` 欄；任何看「START 有、EXIT 無」的偵測；lane-stop 以「done 不存在」決定是否補寫（`scripts/fleet/lane-stop.ps1:146`） | 正常結束、出錯、被 lane-stop 停，三種 endings 都有 EXIT 行＋done-file；被硬殺時由 lane-stop 補寫哨兵 `stopped` |
| runbook | `docs/guides/operator-runbook.md:45` START HERE 第 5 步；`docs/guides/operator-runbook.md:154` §六硬規則列 | 操作者／控制者 | 明文：`Stop-`／`Unregister-ScheduledTask` 不殺子程序樹，停 lane 一律 `lane-stop.ps1`（決策 `fleet.lane-stop-4090`） |

## 範圍外（未動）

- dispatch 的訊號分類（#669）、lane 心跳（#569）、`crates/**`、`.github/**`。
- 未碰任何真實 lane（gh669／gh678／gh690 此刻在跑）；所有實驗只用自註冊、名帶 `-test` 的 `edda-lane-gh672-test`，做完自行 unregister 並清測試檔。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>



Issue: #672
