### PR TITLE
fix(edda-bridge-claude): per-turn peer dedup defeated by wall-clock age in hashed block (GH-678)

### DIFF
--- a/crates/edda-bridge-claude/src/peers/helpers.rs
+++ b/crates/edda-bridge-claude/src/peers/helpers.rs
@@ -139,6 +139,27 @@ pub fn format_age(secs: u64) -> String {
     }
 }
 
+/// Coarse age for the per-turn peer block (GH-678).
+///
+/// The per-turn injection is deduped by hashing its rendered bytes
+/// (`state::is_same_as_last_inject`). `format_age` emits wall-clock distance
+/// ("11s ago"), which differs on essentially every turn while any peer is
+/// heartbeating, so the hash never matches and the block is re-injected
+/// every turn. This variant quantizes to minute/hour boundaries: a live
+/// peer's age hovers inside the same bucket across turns (identical bytes,
+/// dedup fires), while crossing a real staleness boundary still changes the
+/// block. The first-contact protocol render keeps `format_age` — it fires
+/// once per 0→N transition, so a varying age there costs nothing.
+pub fn format_age_coarse(secs: u64) -> String {
+    if secs < 60 {
+        "<1m ago".to_string()
+    } else if secs < 3600 {
+        format!("{}m ago", secs / 60)
+    } else {
+        format!("{}h ago", secs / 3600)
+    }
+}
+
 /// Compare RFC3339 timestamps without discarding fractional seconds.
 pub fn timestamp_at_or_after(lhs: &str, rhs: &str) -> bool {
     let format = &time::format_description::well_known::Rfc3339;

--- a/crates/edda-bridge-claude/src/peers/render_coord.rs
+++ b/crates/edda-bridge-claude/src/peers/render_coord.rs
@@ -4,7 +4,8 @@ use super::autoclaim::derive_scope_from_files;
 use super::board::{compute_board_state, partition_requests_for_session};
 use super::discovery::discover_active_peers;
 use super::helpers::{
-    self, format_age, format_peer_suffix, session_label_from_board, truncate_to_budget,
+    self, format_age, format_age_coarse, format_peer_suffix, session_label_from_board,
+    truncate_to_budget,
 };
 use super::read_heartbeat;
 use super::{
@@ -341,7 +342,11 @@ pub(crate) fn render_peer_updates_with(
 
     // Peer activity (tasks → focus files → bare label)
     for p in peers.iter().take(3) {
-        let age = format_age(p.age_secs);
+        // GH-678: coarse age, not format_age. This block is deduped by hashing
+        // its rendered bytes; a wall-clock age differs every turn and defeats
+        // the dedup. format_age_coarse renders identical bytes for the same
+        // peer state while real staleness transitions still change the block.
+        let age = format_age_coarse(p.age_secs);
         let branch_suffix = format_peer_suffix(p.branch.as_deref(), p.current_phase.as_deref());
         if !p.task_subjects.is_empty() {
             for t in p.task_subjects.iter().take(1) {

--- a/crates/edda-bridge-claude/src/peers/tests.rs
+++ b/crates/edda-bridge-claude/src/peers/tests.rs
@@ -197,6 +197,115 @@ fn format_age_display() {
     assert_eq!(format_age(3700), "1h ago");
 }
 
+/// GH-678: the per-turn peer block is deduped by hashing its rendered bytes.
+/// The hashed string must not carry a wall-clock-relative age ("11s ago"),
+/// which differs on essentially every turn while any peer is active.
+/// Same peer set, small age delta → the render → wrap → hash path must
+/// produce the same hash, so `is_same_as_last_inject` fires and the
+/// UserPromptSubmit hook returns an empty result.
+#[test]
+fn per_turn_peer_block_hash_stable_across_small_age_delta() {
+    let pid = "test_gh678_hash_stable";
+    let sid = "me";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    let make_peers = |age: u64| -> Vec<PeerSummary> {
+        vec![
+            PeerSummary {
+                session_id: "p1".into(),
+                label: "worker-1".into(),
+                age_secs: age,
+                last_heartbeat: now_rfc3339(),
+                focus_files: vec![],
+                task_subjects: vec!["fix bug".into()],
+                files_modified_count: 1,
+                recent_commits: vec![],
+                claimed_paths: vec!["src/a/*".into()],
+                branch: Some("main".into()),
+                current_phase: None,
+            },
+            PeerSummary {
+                session_id: "p2".into(),
+                label: "worker-2".into(),
+                age_secs: age + 7,
+                last_heartbeat: now_rfc3339(),
+                focus_files: vec!["src/b/mod.rs".into()],
+                task_subjects: vec![],
+                files_modified_count: 2,
+                recent_commits: vec![],
+                claimed_paths: vec![],
+                branch: Some("main".into()),
+                current_phase: None,
+            },
+        ]
+    };
+    let board = BoardState::default();
+
+    // Turn 1: peers at 11s / 18s.
+    let first = render_peer_updates_with(&make_peers(11), &board, pid, sid).unwrap();
+    let wrapped_first = crate::render::wrap_boundary(&first);
+    assert!(!crate::state::is_same_as_last_inject(
+        pid,
+        sid,
+        &wrapped_first
+    ));
+    crate::state::write_inject_hash(pid, sid, &wrapped_first);
+
+    // Turn 2: same peers, ages drifted to 5s / 12s — no semantic change.
+    let second = render_peer_updates_with(&make_peers(5), &board, pid, sid).unwrap();
+    let wrapped_second = crate::render::wrap_boundary(&second);
+
+    assert_eq!(
+        first, second,
+        "per-turn peer block must render identical bytes for the same peer state\n--- turn 1 ---\n{first}\n--- turn 2 ---\n{second}"
+    );
+    assert!(
+        crate::state::is_same_as_last_inject(pid, sid, &wrapped_second),
+        "dedup must fire: identical peer state must hash identically\n--- turn 1 ---\n{first}\n--- turn 2 ---\n{second}"
+    );
+
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+/// GH-678 companion: the coarse rendering must not suppress a real
+/// transition. A peer crossing a staleness boundary (fresh → genuinely
+/// aging out) must still change the block.
+#[test]
+fn per_turn_peer_block_changes_on_real_staleness_transition() {
+    let pid = "test_gh678_stale_transition";
+    let sid = "me";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    let make_peers = |age: u64| -> Vec<PeerSummary> {
+        vec![PeerSummary {
+            session_id: "p1".into(),
+            label: "worker-1".into(),
+            age_secs: age,
+            last_heartbeat: now_rfc3339(),
+            focus_files: vec![],
+            task_subjects: vec!["fix bug".into()],
+            files_modified_count: 1,
+            recent_commits: vec![],
+            claimed_paths: vec![],
+            branch: Some("main".into()),
+            current_phase: None,
+        }]
+    };
+    let board = BoardState::default();
+
+    let fresh = render_peer_updates_with(&make_peers(30), &board, pid, sid).unwrap();
+    let aged = render_peer_updates_with(&make_peers(90), &board, pid, sid).unwrap();
+
+    assert_ne!(
+        fresh, aged,
+        "a peer crossing a staleness boundary must change the block\n--- fresh ---\n{fresh}\n--- aged ---\n{aged}"
+    );
+
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
 #[test]
 fn parse_rfc3339_basic() {
     let epoch = parse_rfc3339_to_epoch("2026-02-16T10:05:23Z").unwrap();


### PR DESCRIPTION
Closes #678

## Summary

The `UserPromptSubmit` per-turn injection is deduped by hashing the rendered
context (`state::is_same_as_last_inject`, `dispatch/session.rs:184-190`) and
skipping when it equals the last injection. But the per-turn peer block stamped
every peer line with `format_age(age_secs)` — `render_coord.rs:344` — a
wall-clock distance (`"11s ago"`) that differs on essentially every turn while
any peer is heartbeating. The hash never matched, so the block was re-injected
every turn and stayed in the conversation permanently, churning the prompt-cache
prefix.

**Fix:** a new `format_age_coarse` helper (`peers/helpers.rs:153`) quantizes age
to minute/hour buckets (`"<1m ago"` / `"{n}m ago"` / `"{n}h ago"`). The per-turn
path (`render_coord.rs:349`) now uses it. A live peer's age hovers inside the
same bucket across turns, so identical peer state renders identical bytes and
the dedup fires; crossing a real staleness boundary (e.g. 30s → 90s) still
changes the block.

The first-contact coordination protocol render (`render_coord.rs:195,225,476`)
keeps `format_age` **unchanged and deliberately** — it fires once per 0→N
transition, so a varying age there costs nothing.

**Other bridges:** no change needed. Codex / Hermes / OpenClaw / Cursor call the
same `edda_bridge_claude::peers` renderer (e.g. `edda-bridge-codex/src/dispatch.rs:200`)
and inherit the fix. Verified: `git diff --stat` touches only
`crates/edda-bridge-claude/src/peers/{helpers,render_coord,tests}.rs`.

## TDD: red before, green after (verbatim)

### Red — `cargo test -p edda-bridge-claude per_turn_peer_block` on the pre-fix tree

```
running 2 tests
test peers::tests::per_turn_peer_block_hash_stable_across_small_age_delta ... FAILED
test peers::tests::per_turn_peer_block_changes_on_real_staleness_transition ... ok

failures:

---- peers::tests::per_turn_peer_block_hash_stable_across_small_age_delta stdout ----

thread 'peers::tests::per_turn_peer_block_hash_stable_across_small_age_delta' (30516) panicked at crates\edda-bridge-claude\src\peers\tests.rs:255:5:
assertion `left == right` failed: per-turn peer block must render identical bytes for the same peer state
--- turn 1 ---
## Peers (2 active)
Claim: `edda claim "label" --paths "path"` | Message: `edda request "peer" "msg"`
- worker-1 (11s ago) [branch: main]: fix bug
- worker-2 (18s ago) [branch: main]: editing mod.rs
--- turn 2 ---
## Peers (2 active)
Claim: `edda claim "label" --paths "path"` | Message: `edda request "peer" "msg"`
- worker-1 (5s ago) [branch: main]: fix bug
- worker-2 (12s ago) [branch: main]: editing mod.rs
  left: "## Peers (2 active)\nClaim: `edda claim \"label\" --paths \"path\"` | Message: `edda request \"peer\" \"msg\"`\n- worker-1 (11s ago) [branch: main]: fix bug\n- worker-2 (18s ago) [branch: main]: editing mod.rs"
 right: "## Peers (2 active)\nClaim: `edda claim \"label\" --paths \"path\"` | Message: `edda request \"peer\" \"msg\"`\n- worker-1 (5s ago) [branch: main]: fix bug\n- worker-2 (12s ago) [branch: main]: editing mod.rs"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

failures:
    peers::tests::per_turn_peer_block_hash_stable_across_small_age_delta

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 614 filtered out; finished in 0.01s

error: test failed, to rerun pass `-p edda-bridge-claude --lib`
```

(The staleness-transition test already passed pre-fix — it is the guard that the
fix must not suppress real transitions.)

### Green — same command after the fix

```
running 2 tests
test peers::tests::per_turn_peer_block_changes_on_real_staleness_transition ... ok
test peers::tests::per_turn_peer_block_hash_stable_across_small_age_delta ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 614 filtered out; finished in 0.01s
```

The stability test walks the real consumption path end to end:
`render_peer_updates_with` → `render::wrap_boundary` → `state::write_inject_hash`
→ `state::is_same_as_last_inject` (returns true on turn 2).

## doneWhen #4 — real multi-peer session, empty hook result observed

**Obtained.** Real dispatch through the built `edda hook claude` binary (this PR's
HEAD build) in a scratch git repo at `%TEMP%\gh678-evidence\repo` with two live
peer sessions (`sess-a`, `sess-b`, each with a real transcript file):

| call | event | result |
|---|---|---|
| 1 | `SessionStart` sess-a | injected memory pack (no peers yet) |
| 2 | `SessionStart` sess-b | injected `## Coordination Protocol` (0→N first contact) |
| 3 | `UserPromptSubmit` sess-a | injected full first-contact protocol (peer count 0→1 for sess-a) |
| 4 | `UserPromptSubmit` sess-a | injected lightweight block: `## Peers (1 active)` / `-  (<1m ago)` (hash baseline) |
| 5 | `UserPromptSubmit` sess-a | **empty — 0 bytes stdout** (dedup fired) |
| 6 | `UserPromptSubmit` sess-a | **empty — 0 bytes stdout** (dedup fired again) |

Diff between call 4 and call 5 pre-fix would have been the age string
(`-  (11s ago)` vs `-  (4s ago)`); post-fix the rendered bytes are identical, so
calls 5 and 6 return `HookResult::empty()` — the exact evidence doneWhen #4
asks for (`UserPromptSubmit` returning an empty hook result).

## Gates (L0 — touched crate only, lane `worker-2`)

- `cargo fmt --all --check` — **PASS**
- `cargo clippy -p edda-bridge-claude --all-targets -- -D warnings` — **PASS**
- `cargo test -p edda-bridge-claude` — single-threaded: **615 passed, 1 failed**
  (`dispatch::tests::render_workspace_section_no_edda_returns_none` — fails
  identically on base `030b36b`; environmental: this worktree itself carries
  `.edda` state, so the "no edda" assertion can't hold locally).
  Parallel runs show a pre-existing Windows env-race flaky set
  (`dispatch::tests::session_start_*`, `context_budget_*`, `bg_*`,
  `state::tests::nudge_cooldown_env_var_override`): the failing sets overlap
  almost fully between base (sampled: 3, 4, 18 failures) and this branch
  (sampled: 20, 22, 23 failures) and are absent from CI's Linux test job. None
  of the flaky sets ever include the new `peers::tests::per_turn_peer_block_*`
  tests, which pass in every run.

## Self-reported wiring audit

| Component | 1. Writer & shape | 2. Reader | 3. Failure signal | 4. Layer reach |
|---|---|---|---|---|
| `format_age_coarse` (`peers/helpers.rs:153`) | `peers`, returns a prose `String` — same shape as `format_age`, bucket-quantized | `render_coord.rs:349` (per-turn path only); regression tests `peers/tests.rs:207,275` | Stale-bucket drift: a peer sitting exactly at a bucket edge toggles the block at most once per boundary — observable in the `per_turn_peer_block_changes_on_real_staleness_transition` test, which pins the transition as *required* behavior | Reaches the injected context on all five bridges (shared renderer) |
| `render_coord.rs:349` consumption point | per-turn peer line text | `dispatch_with_workspace_only` (`session.rs:167`) → `is_same_as_last_inject` (`session.rs:186`) | If the bucket were too coarse (peers rendered identical after going stale), the transition test fails; if too fine, the stability test fails | Same as before the change — `additionalContext` on all bridges, now dedupable |

No new state files, no new write-ends, no new surfaces beyond the helper above.

## Follow-ups observed (not in scope, not opened here)

- `is_same_as_last_inject` has no hit-rate counter — a never-matching hash is
  indistinguishable from legitimately-new context (noted in the issue's wiring
  audit; remains true).
- The `dispatch::tests` env-race flake set on Windows predates this PR (see
  Gates); a `with_env_guard`-read-side fix or test-serialization would be its
  own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Issue: #678
