### PR TITLE
fix(edda-cli): classify backend auth failure as a crash, not a done turn (#669)

### DIFF
--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -228,10 +228,20 @@ impl DispatchOutput {
             .unwrap_or_else(|| NO_USAGE_COST_TEXT.to_owned())
     }
 
-    /// Text-mode stdout: result text, then `Cost:`, then the model story
+    /// Text-mode stdout: an `Outcome:` line whenever the turn did not
+    /// finish, then result text, then `Cost:`, then the model story
     /// (GH-574), then `Session:`.
+    ///
+    /// A failed turn used to render exactly like a successful one — same
+    /// `Cost:`/`Session:` summary, nothing naming the failure (GH-669) — so
+    /// a reader of stdout alone could not tell the two apart. The marker
+    /// leads the output and is emitted only for non-`done` outcomes, so a
+    /// successful turn's shape is unchanged.
     pub fn render_text(&self) -> String {
         let mut out = String::new();
+        if self.outcome != Outcome::Done {
+            out.push_str(&format!("Outcome: {}\n", self.outcome.as_str()));
+        }
         if let Some(text) = &self.result_text {
             out.push_str(text);
             if !text.ends_with('\n') {
@@ -845,6 +855,53 @@ mod tests {
         let args = parse(&["edda", "--agent", "pi", "--list-models", "--json"]);
         let error = run_inner(args).expect_err("--json + --list-models must be refused");
         assert!(error.to_string().contains("--json"), "{error}");
+    }
+
+    // ── GH-669: a backend authentication failure is not a done turn ──
+
+    #[test]
+    fn backend_auth_failure_reports_crash_exit_1_and_non_null_error() {
+        // The whole caller-facing contract for the observed failure: claude
+        // answers a revoked/invalid OAuth token with a result message whose
+        // `subtype` is "success" and whose `is_error` is true. Dispatch must
+        // read that as a failed turn — exit 1, `outcome` not "done", `error`
+        // a non-null string — instead of exit 0 with the reason parked in
+        // `result_text`.
+        use edda_conductor::agent::stream::{classify_result, MonitorResult, ResultInfo};
+        let reason = "Failed to authenticate. API Error: 401 OAuth access token is invalid.";
+        let monitor = MonitorResult {
+            total_cost_usd: 0.0,
+            result: Some(ResultInfo {
+                subtype: "success".into(),
+                total_cost_usd: Some(0.0),
+                error: None,
+                is_error: true,
+                result_text: Some(reason.into()),
+            }),
+            result_text: Some(reason.into()),
+            model: Some("claude-opus-5[1m]".into()),
+        };
+        let out = DispatchOutput::from_result(
+            classify_result(&monitor, Some(1)),
+            "0e92629d-1f2e-597e-90ec-662e206efcde".into(),
+            "inherited".into(),
+            "claude-opus-5[1m]".into(),
+        );
+
+        assert_eq!(out.exit_code(), 1, "{out:?}");
+        let value: serde_json::Value = serde_json::from_str(&out.to_json()).unwrap();
+        assert_ne!(value["outcome"].as_str(), Some("done"));
+        assert_eq!(value["outcome"].as_str(), Some("crash"));
+        assert!(
+            value["error"].as_str().is_some_and(|e| e.contains("401")),
+            "error must describe the failure, got {}",
+            value["error"]
+        );
+
+        // And the human-readable turn must not read like a successful one.
+        let text = out.render_text();
+        assert!(text.contains("Outcome: crash"), "{text}");
+        assert!(!text.contains("Cost: $0.00"), "{text}");
     }
 
     // ── Outcome → exit-code mapping (all five PhaseResult variants) ──

--- a/crates/edda-conductor/src/agent/pi_rpc.rs
+++ b/crates/edda-conductor/src/agent/pi_rpc.rs
@@ -463,6 +463,17 @@ impl PiRpcSession {
 
                     match msg.get("type").and_then(Value::as_str) {
                         Some("agent_settled") => settled = true,
+                        // pi reports a failed turn in band and settles
+                        // normally afterwards (GH-669): `turn_end` carries
+                        // `stopReason: "error"` with the reason in
+                        // `errorMessage`, and an authentication failure
+                        // reaches `agent_settled` with no text and zero
+                        // cost. Reading settlement alone reported that turn
+                        // as done — `edda dispatch` exit 0. Only `turn_end`
+                        // is read, never the per-message `message_end`: it
+                        // is the turn's last word, so a recovered
+                        // mid-turn error does not fail the phase.
+                        Some("turn_end") => state.error = turn_error(&msg),
                         Some("message_update") => {
                             state.observe_message_update(&msg);
                             if over_budget(state.cost, budget_usd) {
@@ -492,6 +503,10 @@ impl PiRpcSession {
                     });
                 }
             }
+        }
+
+        if let Some(error) = state.error.take() {
+            return Ok(PhaseResult::AgentCrash { error });
         }
 
         // After settlement, `get_session_stats` gives the authoritative
@@ -714,11 +729,29 @@ fn extension_ui_cancellation(msg: &Value) -> Option<Value> {
     Some(json!({ "type": "extension_ui_response", "id": id, "cancelled": true }))
 }
 
-/// Accumulates result text and cost from `message_update` events.
+/// The reason a `turn_end` event reports, when pi ended the turn on an
+/// error rather than an answer (GH-669). `None` for a turn that ended
+/// normally, so a settled turn stays a completed one.
+fn turn_error(msg: &Value) -> Option<String> {
+    if msg.pointer("/message/stopReason").and_then(Value::as_str) != Some("error") {
+        return None;
+    }
+    let detail = msg
+        .pointer("/message/errorMessage")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|detail| !detail.is_empty())
+        .unwrap_or("pi ended the turn on an error without a reason");
+    Some(detail.to_owned())
+}
+
+/// Accumulates result text and cost from `message_update` events, plus the
+/// reason a `turn_end` gave for a failed turn.
 #[derive(Default)]
 struct TurnState {
     result_text: String,
     cost: Option<f64>,
+    error: Option<String>,
 }
 
 impl TurnState {
@@ -753,6 +786,11 @@ mod tests {
     const STATE_GPT56: &str = r#"{"id":"req-3","type":"response","command":"get_state","success":true,"data":{"model":{"provider":"openai-codex","id":"gpt-5.6-sol"},"thinkingLevel":"high"}}"#;
     const STATE_NULL: &str = r#"{"id":"req-3","type":"response","command":"get_state","success":true,"data":{"model":null}}"#;
     const STARTUP_DIAGNOSTIC: &str = "pi: no API key configured for provider openrouter";
+    /// The `turn_end` pi emits when the provider rejects its credentials,
+    /// captured 2026-09-02 from `pi --mode rpc --model openai/gpt-4o-mini`
+    /// with an invalid `OPENAI_API_KEY` (`content`, `usage` and the nested
+    /// provider JSON elided). pi follows it with `agent_settled`.
+    const TURN_END_AUTH_ERROR: &str = r#"{"type":"turn_end","message":{"role":"assistant","content":[],"provider":"openai","model":"gpt-4o-mini","stopReason":"error","errorMessage":"OpenAI API error (401): Incorrect API key provided"}}"#;
 
     fn delta_line(usage_cost: &str, text: &str) -> String {
         format!(
@@ -775,6 +813,9 @@ mod tests {
         Utf8Framing,
         /// Writes a startup diagnostic to stderr and dies before settling.
         StderrThenDie,
+        /// Answers the prompt, then ends the turn on a provider
+        /// authentication error and settles normally (GH-669).
+        TurnEndAuthError,
         /// Closes stdout while staying alive: stdout EOF with a live child.
         #[cfg(unix)]
         CloseStdoutAndLive,
@@ -797,6 +838,13 @@ mod tests {
             FakeScenario::BudgetMidRun => format!(
                 "read_cmd\nwrite_line '{PROMPT_OK}'\nwrite_line '{}'\nsleep 60",
                 delta_line("5.0", "x")
+            ),
+            FakeScenario::TurnEndAuthError => format!(
+                "read_cmd
+write_line '{PROMPT_OK}'
+write_line '{TURN_END_AUTH_ERROR}'
+write_line '{SETTLED}'
+sleep 60"
             ),
             FakeScenario::PromptRejected => {
                 format!("read_cmd\nwrite_line '{PROMPT_REJECTED}'\nsleep 60")
@@ -930,6 +978,48 @@ mod tests {
         assert!(matches!(result, PhaseResult::AgentDone { .. }));
         assert!(observed.is_none(), "null model must render as unknown");
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn turn_ended_on_provider_auth_error_is_a_crash_not_done() -> Result<()> {
+        // GH-669: pi settles normally after a failed turn, so reading
+        // `agent_settled` alone reported an authentication failure as a
+        // completed turn — `edda dispatch` exit 0 with a null error.
+        let phase = phase_from_yaml(
+            "  - id: a
+    prompt: x
+",
+        );
+        let (result, _observed) = run_fake(FakeScenario::TurnEndAuthError, &phase).await?;
+        match result {
+            PhaseResult::AgentCrash { error } => {
+                assert!(error.contains("401"), "{error}");
+                assert!(error.contains("Incorrect API key"), "{error}");
+            }
+            other => panic!("expected AgentCrash, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn turn_error_reads_only_a_failed_turn_end() {
+        let settled_ok: Value = serde_json::from_str(
+            r#"{"type":"turn_end","message":{"role":"assistant","stopReason":"stop"}}"#,
+        )
+        .unwrap();
+        assert_eq!(turn_error(&settled_ok), None);
+
+        let failed: Value = serde_json::from_str(TURN_END_AUTH_ERROR).unwrap();
+        assert_eq!(
+            turn_error(&failed).as_deref(),
+            Some("OpenAI API error (401): Incorrect API key provided")
+        );
+
+        // A failed turn with no reason still fails, with a stated one.
+        let bare: Value =
+            serde_json::from_str(r#"{"type":"turn_end","message":{"stopReason":"error"}}"#)
+                .unwrap();
+        assert!(turn_error(&bare).is_some_and(|e| !e.is_empty()));
     }
 
     #[tokio::test]

--- a/crates/edda-conductor/src/agent/stream.rs
+++ b/crates/edda-conductor/src/agent/stream.rs
@@ -36,6 +36,13 @@ pub enum StreamMessage {
         total_cost_usd: Option<f64>,
         #[serde(default)]
         error: Option<String>,
+        /// claude's own verdict on the turn, independent of `subtype`: a
+        /// turn that failed on an API error is still labelled
+        /// `subtype: "success"` and marked here (GH-669). Absent means
+        /// false — an older backend that never sends the field reports no
+        /// failure, which is the pre-GH-669 reading.
+        #[serde(default)]
+        is_error: bool,
         #[serde(default, rename = "result")]
         result_text: Option<String>,
     },
@@ -50,6 +57,8 @@ pub struct ResultInfo {
     pub subtype: String,
     pub total_cost_usd: Option<f64>,
     pub error: Option<String>,
+    /// claude's `is_error` flag for the turn — see [`StreamMessage::Result`].
+    pub is_error: bool,
     pub result_text: Option<String>,
 }
 
@@ -152,11 +161,13 @@ impl StreamMonitor {
                 subtype,
                 total_cost_usd,
                 error,
+                is_error,
                 result_text,
             } => Some(ResultInfo {
                 subtype: subtype.clone(),
                 total_cost_usd: *total_cost_usd,
                 error: error.clone(),
+                is_error: *is_error,
                 result_text: result_text.clone(),
             }),
             _ => None,
@@ -278,6 +289,22 @@ fn truncate(s: &str, max_len: usize) -> String {
 pub fn classify_result(monitor: &MonitorResult, exit_code: Option<i32>) -> PhaseResult {
     match &monitor.result {
         Some(info) => match info.subtype.as_str() {
+            // A turn claude itself marked failed is a crash however its
+            // subtype reads (GH-669): an authentication failure arrives as
+            // `subtype: "success"` with `is_error: true` and the reason in
+            // `result`, and reading only the subtype reported a turn that
+            // did nothing as done — `edda dispatch` exit 0. The override is
+            // scoped to "success" on purpose: `error_max_turns` and
+            // `error_max_budget_usd` carry `is_error` too and keep their own
+            // outcome classes below.
+            "success" if info.is_error => PhaseResult::AgentCrash {
+                error: info
+                    .error
+                    .clone()
+                    .or_else(|| info.result_text.clone())
+                    .filter(|detail| !detail.trim().is_empty())
+                    .unwrap_or_else(|| "agent reported a failed turn without a reason".to_owned()),
+            },
             "success" => PhaseResult::AgentDone {
                 cost_usd: info.total_cost_usd,
                 result_text: monitor.result_text.clone(),
@@ -381,6 +408,7 @@ mod tests {
                 subtype: "success".into(),
                 total_cost_usd: Some(0.5),
                 error: None,
+                is_error: false,
                 result_text: None,
             }),
             result_text: None,
@@ -400,6 +428,7 @@ mod tests {
                 subtype: "error_max_turns".into(),
                 total_cost_usd: Some(1.0),
                 error: None,
+                is_error: false,
                 result_text: None,
             }),
             result_text: None,
@@ -417,6 +446,7 @@ mod tests {
                 subtype: "error_max_budget_usd".into(),
                 total_cost_usd: Some(2.0),
                 error: None,
+                is_error: false,
                 result_text: None,
             }),
             result_text: None,
@@ -434,6 +464,7 @@ mod tests {
                 subtype: "error_during_execution".into(),
                 total_cost_usd: Some(0.1),
                 error: Some("tool crashed".into()),
+                is_error: false,
                 result_text: None,
             }),
             result_text: None,
@@ -446,6 +477,125 @@ mod tests {
         }
     }
 
+    // ── GH-669: a failed turn claude still labels `subtype: "success"` ──
+
+    /// The verbatim result line claude emits when its OAuth token is
+    /// rejected (captured 2026-09-02 from `claude -p --verbose
+    /// --output-format stream-json` with an invalid
+    /// `CLAUDE_CODE_OAUTH_TOKEN`; `usage`, `modelUsage` and the uuid/session
+    /// fields elided, every field below is byte-for-byte as claude printed
+    /// it). The subtype says "success" and `is_error` says otherwise.
+    const AUTH_FAILURE_RESULT_LINE: &str = r#"{"duration_api_ms":0,"stop_reason":"stop_sequence","total_cost_usd":0,"permission_denials":[],"terminal_reason":"api_error","is_error":true,"num_turns":1,"subtype":"success","api_error_status":401,"result":"Failed to authenticate. API Error: 401 OAuth access token is invalid.","type":"result","duration_ms":2266}"#;
+
+    /// Rebuild a [`ResultInfo`] from one raw stream line exactly the way
+    /// [`StreamMonitor::run`] does, so these tests exercise the same fields
+    /// the monitor actually carries out of the stream.
+    fn result_info_from_line(line: &str) -> ResultInfo {
+        match serde_json::from_str::<StreamMessage>(line).expect("parse result line") {
+            StreamMessage::Result {
+                subtype,
+                total_cost_usd,
+                error,
+                is_error,
+                result_text,
+            } => ResultInfo {
+                subtype,
+                total_cost_usd,
+                error,
+                is_error,
+                result_text,
+            },
+            other => panic!("expected Result, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_result_carries_is_error() {
+        let info = result_info_from_line(AUTH_FAILURE_RESULT_LINE);
+        assert_eq!(info.subtype, "success");
+        assert!(info.is_error, "claude reported is_error: true");
+        // The reason travels in `result`, not `error`, on this shape.
+        assert!(info.error.is_none());
+        assert_eq!(
+            info.result_text.as_deref(),
+            Some("Failed to authenticate. API Error: 401 OAuth access token is invalid.")
+        );
+    }
+
+    #[test]
+    fn classify_errored_success_is_crash_not_done() {
+        // GH-669: classifying on `subtype` alone reported an authentication
+        // failure as a completed turn, which `edda dispatch` turned into
+        // exit 0 — a turn that did nothing, indistinguishable from success.
+        let info = result_info_from_line(AUTH_FAILURE_RESULT_LINE);
+        let monitor = MonitorResult {
+            total_cost_usd: 0.0,
+            result_text: info.result_text.clone(),
+            result: Some(info),
+            model: Some("claude-opus-5[1m]".into()),
+        };
+        match classify_result(&monitor, Some(1)) {
+            PhaseResult::AgentCrash { error } => {
+                assert!(error.contains("401"), "{error}");
+                assert!(error.contains("Failed to authenticate"), "{error}");
+            }
+            other => panic!("expected AgentCrash, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn classify_errored_success_without_detail_still_crashes() {
+        // No `result` text and no `error` field: the outcome must still be a
+        // crash, with a stated reason rather than an empty one.
+        let monitor = MonitorResult {
+            total_cost_usd: 0.0,
+            result: Some(ResultInfo {
+                subtype: "success".into(),
+                total_cost_usd: Some(0.0),
+                error: None,
+                is_error: true,
+                result_text: None,
+            }),
+            result_text: None,
+            model: None,
+        };
+        match classify_result(&monitor, Some(1)) {
+            PhaseResult::AgentCrash { error } => assert!(!error.is_empty()),
+            other => panic!("expected AgentCrash, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn is_error_does_not_swallow_the_other_terminal_classes() {
+        // The `is_error` override is scoped to "success": the budget and
+        // max-turns subtypes carry it too, and each keeps its own exit
+        // class (3 and 4) instead of collapsing into crash.
+        for (subtype, expected) in [
+            ("error_max_turns", "max_turns"),
+            ("error_max_budget_usd", "budget_exceeded"),
+        ] {
+            let monitor = MonitorResult {
+                total_cost_usd: 1.0,
+                result: Some(ResultInfo {
+                    subtype: subtype.into(),
+                    total_cost_usd: Some(1.0),
+                    error: None,
+                    is_error: true,
+                    result_text: None,
+                }),
+                result_text: None,
+                model: None,
+            };
+            let classified = classify_result(&monitor, Some(1));
+            let ok = matches!(
+                (expected, &classified),
+                ("max_turns", PhaseResult::MaxTurns { .. })
+                    | ("budget_exceeded", PhaseResult::BudgetExceeded { .. })
+            );
+            assert!(ok, "{subtype} classified as {classified:?}");
+        }
+    }
+
     #[test]
     fn classify_unknown_subtype() {
         let monitor = MonitorResult {
@@ -454,6 +604,7 @@ mod tests {
                 subtype: "new_error_type".into(),
                 total_cost_usd: None,
                 error: None,
+                is_error: false,
                 result_text: None,
             }),
             result_text: None,


### PR DESCRIPTION
closes #669

`edda dispatch` returned **exit 0 with `outcome=done`** for a turn that never ran, because two of the three backends report a failed turn *in band* and then finish exactly the way a successful one does. Frozen SHA `32ce1e30fcf05a2c4b02fb677e2f3612aea258ec`, base `030b36b2048431a443407d8c0ba3d035351c8a0f`.

## Root cause — measured, not guessed

Captured 2026-09-02 from the real backends on this workstation.

**claude** (`claude -p --verbose --output-format stream-json`, invalid `CLAUDE_CODE_OAUTH_TOKEN`) ends the stream with a result message whose `subtype` says success and whose `is_error` says otherwise:

```json
{"total_cost_usd":0,"terminal_reason":"api_error","is_error":true,"num_turns":1,"subtype":"success","api_error_status":401,"result":"Failed to authenticate. API Error: 401 OAuth access token is invalid.","type":"result"}
```

`classify_result` matched on `subtype` alone (`crates/edda-conductor/src/agent/stream.rs:279-297` at base) and `is_error` was never even deserialized, so this became `AgentDone { cost_usd: Some(0.0) }` → `Outcome::Done` → exit 0.

**pi** (`pi --mode rpc`, invalid `OPENAI_API_KEY`) emits `turn_end` with `stopReason: "error"` and `errorMessage`, then `agent_settled` — the same settlement a good turn produces:

```json
{"type":"turn_end","message":{"role":"assistant","content":[],"provider":"openai","model":"gpt-4o-mini","stopReason":"error","errorMessage":"OpenAI API error (401): ..."}}
{"type":"agent_settled"}
```

`run_phase` watched only `agent_settled`, so it returned `AgentDone` → exit 0. **The issue's suspected surface named only claude; pi had the same defect and is fixed here too.**

**codex** was already correct — see the per-backend table below.

## Red receipts (before the fix, base SHA `030b36b`)

End-to-end, the exact contract the issue is about:

```
$ CLAUDE_CODE_OAUTH_TOKEN=<invalid> edda dispatch --agent claude --prompt-file prompt.txt --cwd . --timeout-sec 120 --json
=== exit code: 0 ===
{"cost_usd":0.0,"error":null,"model_observed":"claude-opus-5[1m]","model_requested":"inherited","outcome":"done","result_text":"Failed to authenticate. API Error: 401 OAuth access token is invalid.","session_id":"0e92629d-1f2e-597e-90ec-662e206efcde"}
```

```
$ OPENAI_API_KEY=<invalid> edda dispatch --agent pi --model openai/gpt-4o-mini --prompt-file prompt.txt --cwd . --timeout-sec 90 --json
exit=0
{"cost_usd":0.0,"error":null,"model_observed":"openai/gpt-4o-mini","model_requested":"openai/gpt-4o-mini","outcome":"done","result_text":null,"session_id":"af7232d8-2f80-5f71-ae7f-d2a39644b45e"}
```

Unit level, written first and run against the unfixed classifier:

```
test agent::stream::tests::classify_errored_success_is_crash_not_done ... FAILED
test agent::stream::tests::classify_errored_success_without_detail_still_crashes ... FAILED

---- agent::stream::tests::classify_errored_success_is_crash_not_done stdout ----
thread '...' panicked at crates\edda-conductor\src\agent\stream.rs:526:22:
expected AgentCrash, got AgentDone { cost_usd: Some(0.0), result_text: Some("Failed to authenticate. API Error: 401 OAuth access token is invalid.") }

test result: FAILED. 15 passed; 2 failed; 0 ignored; 0 measured; 324 filtered out; finished in 0.04s
```

```
test cmd_dispatch::tests::backend_auth_failure_reports_crash_exit_1_and_non_null_error ... FAILED

---- cmd_dispatch::tests::backend_auth_failure_reports_crash_exit_1_and_non_null_error stdout ----
thread '...' panicked at crates\edda-cli\src\cmd_dispatch.rs:881:9:
assertion `left == right` failed: DispatchOutput { outcome: Done, result_text: Some("Failed to authenticate. API Error: 401 OAuth access token is invalid."), cost_usd: Some(0.0), session_id: "...", error: None, ... }
  left: 0
 right: 1

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 439 filtered out; finished in 0.00s
```

## Green receipts (after the fix, `32ce1e3`)

```
$ CLAUDE_CODE_OAUTH_TOKEN=<invalid> edda dispatch --agent claude ... --json
=== exit code: 1 ===
{"cost_usd":null,"error":"Failed to authenticate. API Error: 401 OAuth access token is invalid.","model_observed":"claude-opus-5[1m]","model_requested":"inherited","outcome":"crash","result_text":null,"session_id":"3ab6e623-9340-56fd-acc2-63f2dc4cf3a7"}
```

Text mode — the human-readable turn no longer reads like a successful one:

```
$ CLAUDE_CODE_OAUTH_TOKEN=<invalid> edda dispatch --agent claude ...
exit=1
--- stdout ---
Outcome: crash
Cost: n/a (no usage data reported)
Model requested: inherited
Model observed: claude-opus-5[1m]
Session: 4d0f120f-b92c-544c-b906-4bd64b592b49
--- stderr ---
Error: Failed to authenticate. API Error: 401 OAuth access token is invalid.
```

```
$ OPENAI_API_KEY=<invalid> edda dispatch --agent pi --model openai/gpt-4o-mini ... --json
exit=1
{"cost_usd":null,"error":"OpenAI API error (401): {\"message\":\"Incorrect API key provided: sk-inval****h669 ...\",\"code\":\"invalid_api_key\"}","model_observed":"unknown","model_requested":"openai/gpt-4o-mini","outcome":"crash","result_text":null,"session_id":"ec0ece76-6f12-5ee2-a62f-a2641ec265b8"}
```

Unit level:

```
test agent::stream::tests::parse_result_carries_is_error ... ok
test agent::stream::tests::classify_errored_success_is_crash_not_done ... ok
test agent::stream::tests::classify_errored_success_without_detail_still_crashes ... ok
test agent::stream::tests::is_error_does_not_swallow_the_other_terminal_classes ... ok
test agent::pi_rpc::tests::turn_ended_on_provider_auth_error_is_a_crash_not_done ... ok
test agent::pi_rpc::tests::turn_error_reads_only_a_failed_turn_end ... ok
test cmd_dispatch::tests::backend_auth_failure_reports_crash_exit_1_and_non_null_error ... ok
```

## All three backends checked — none assumed

| Backend | Auth-failure shape | Before | After | Evidence |
|---|---|---|---|---|
| claude | result `subtype:"success"` + `is_error:true`, reason in `result` | **exit 0, `outcome=done`** | exit 1, `outcome=crash`, `error` non-null | `stream.rs:281-300`; e2e receipts above |
| pi | `turn_end` `stopReason:"error"` + `errorMessage`, then `agent_settled` | **exit 0, `outcome=done`** | exit 1, `outcome=crash`, `error` non-null | `pi_rpc.rs` `turn_error` + `turn_end` arm; e2e receipts above |
| codex | app-server answers `turn/completed` with a non-`completed` status, which `TurnAccumulator::observe` turns into an error (`codex_app_server.rs:375-388`), reaching `drive_turn` as `AgentCrash` (`codex_rpc.rs:521-530`) | already exit 1 | unchanged | ran with an empty `CODEX_HOME`: `exit=1`, `{"outcome":"crash","error":"Codex turn failed: unexpected status 401 Unauthorized: Missing bearer or basic authentication in header, url: https://api.openai.com/v1/responses ..."}` |

Scope held to classification and reporting: no retry, no fallback (`fleet.review-provider-overload` territory).

## doneWhen

- [x] backend auth failure → **exit 1**, not 0 (claude and pi; codex already did)
- [x] `--json` gives `outcome` != `done` and a non-null `error` string
- [x] human-readable output marks the failed turn (`Outcome: crash` leads stdout; success shape unchanged)
- [x] verified FAIL first, with the pre-fix exit-0 receipt recorded above
- [x] all three backend classification paths checked with evidence, not assumption

## Wiring audit

| New surface | Writer & shape | Reader | Failure signal | Layer reach |
|---|---|---|---|---|
| `StreamMessage::Result.is_error: bool` (serde `#[serde(default)]`) | claude's stream-json result line, deserialized at `crates/edda-conductor/src/agent/stream.rs:39` | `StreamMonitor::run` copies it into `ResultInfo` at `crates/edda-conductor/src/agent/stream.rs:168` | absent field defaults to `false` = "no failure reported", the pre-GH-669 reading; pinned by `parse_result_carries_is_error` (`crates/edda-conductor/src/agent/stream.rs:497`) | conductor-internal parse layer |
| `ResultInfo.is_error: bool` (pub field) | `StreamMonitor::run`, `crates/edda-conductor/src/agent/stream.rs:168` | `classify_result`, `crates/edda-conductor/src/agent/stream.rs:290` | a `true` that no arm reads would silently restore exit 0; pinned by `classify_errored_success_is_crash_not_done` (`crates/edda-conductor/src/agent/stream.rs:506`) and by the CLI-level `backend_auth_failure_reports_crash_exit_1_and_non_null_error` (`crates/edda-cli/src/cmd_dispatch.rs:849`) | Layer 2 dispatch contract — every exit-code reader (Task Scheduler lane wrapper, controller watcher, future `edda wave`, CI) |
| `turn_error(&Value) -> Option<String>` (private fn) | pi's `turn_end` event, `crates/edda-conductor/src/agent/pi_rpc.rs:719` | the `Some("turn_end")` arm of `run_phase`'s stream loop, `crates/edda-conductor/src/agent/pi_rpc.rs:475` | returning `None` for a failed turn restores exit 0; pinned by `turn_error_reads_only_a_failed_turn_end` (`crates/edda-conductor/src/agent/pi_rpc.rs:1000`) and end-to-end by `turn_ended_on_provider_auth_error_is_a_crash_not_done` (`crates/edda-conductor/src/agent/pi_rpc.rs:983`) | same Layer 2 dispatch contract, pi backend |
| `TurnState.error: Option<String>` (private field) | the `turn_end` arm above | post-settlement check in `run_phase`, `crates/edda-conductor/src/agent/pi_rpc.rs:523` | a recorded error never drained would let a failed turn settle as done | conductor-internal turn state |
| `Outcome: <class>` line on dispatch text stdout (non-`done` outcomes only) | `DispatchOutput::render_text`, `crates/edda-cli/src/cmd_dispatch.rs:243` | humans and any text-mode stdout reader | its absence is exactly the GH-669 symptom — a failed turn rendering identically to a good one | `edda dispatch` text output; `--json` shape unchanged, success text shape unchanged |

No new CLI flags and no new `--json` fields.

## Gates (L0, touched crates)

Lane `worker-1`. Toolchain: stable-x86_64-pc-windows-msvc (rustc/clippy 1.93.0). SHA `32ce1e30fcf05a2c4b02fb677e2f3612aea258ec`.

```
cargo fmt --all --check                                             -> FMT OK
cargo clippy -p edda-conductor -p edda --all-targets -- -D warnings -> Finished, 0 warnings
cargo test -p edda-conductor  -> ok. 342 passed; 0 failed; 1 ignored
cargo test -p edda            -> 431 passed; 9 failed  (see below)
```

**Pre-existing baseline, not caused by this change.** The 9 `edda` failures reproduce on a clean tree at base `030b36b` — I reverted the patch, re-ran, got `430 passed; 9 failed` with the identical set, then reapplied:

```
cmd_claim::tests::e2e_exit_codes_conflict_and_disjoint
cmd_claim::tests::e2e_malformed_board_line_is_error_not_clear
cmd_claim::tests::e2e_non_check_claim_still_records_paths
cmd_claim::tests::e2e_unicode_case_pair_is_error_not_clear
cmd_claim::tests::e2e_unreadable_board_is_error_not_clear
cmd_reconcile::tests::completion_from_linked_worktree_uses_the_original_ledger
cmd_reconcile::tests::fake_runner_records_session_in_main_ledger_before_turn_and_fails_without_receipt
cmd_reconcile::tests::scheduler_repo_reentry_requires_absolute_existing_path_and_resolves_main_worktree
cmd_verify::tests::verify_outside_edda_repo_exits_2_with_explanation
```

They look environment-sensitive (running inside a worktree that is itself an edda repo with a live ledger: `verify` finds a real chain where the test expects none, `claim` finds the real coordination board). **FOLLOW-UP ISSUE candidate**, out of scope here — flagged, not filed, since this lane is scoped to #669.

One transient, non-reproducing infrastructure failure worth recording rather than hiding: a `clippy-driver` run on the untouched `edda-serve` crate died with `STATUS_HEAP_CORRUPTION`, and one `link.exe` invocation hit `LNK1104` on a locked output. Both passed on an immediate re-run with no source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Issue: #669
