### PR TITLE
docs(edda-conductor): verdict gate documentation debt (GH-542)

### DIFF
--- a/crates/edda-cli/src/cmd_verdict.rs
+++ b/crates/edda-cli/src/cmd_verdict.rs
@@ -9,7 +9,7 @@
 
 //! Freshness (GH-519 D6): a verdict only satisfies a gate if it postdates
 //! the gate's `gate_entered_at`. Approving a subject BEFORE its gate opens
-//! (a pre-recorded verdict) therefore does not work â the gate ignores any
+//! (a pre-recorded verdict) therefore does not work — the gate ignores any
 //! verdict recorded before it entered `AWAITING_VERDICT`, even for the
 //! matching SHA. Record the verdict after the gate opens; the conductor
 //! prints the exact `edda verdict` command to run.

--- a/crates/edda-cli/src/cmd_verdict.rs
+++ b/crates/edda-cli/src/cmd_verdict.rs
@@ -7,6 +7,13 @@
 //! SHA. `<subject>` is a free-form string; for conductor gates it is
 //! `<plan-name>/<phase-id>`.
 
+//! Freshness (GH-519 D6): a verdict only satisfies a gate if it postdates
+//! the gate's `gate_entered_at`. Approving a subject BEFORE its gate opens
+//! (a pre-recorded verdict) therefore does not work â the gate ignores any
+//! verdict recorded before it entered `AWAITING_VERDICT`, even for the
+//! matching SHA. Record the verdict after the gate opens; the conductor
+//! prints the exact `edda verdict` command to run.
+
 use clap::Subcommand;
 use edda_core::event::new_verdict_event;
 use edda_core::secret_guard::redact;

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -716,6 +716,14 @@ const GATE_POLL_SEC: u64 = 2;
 /// wait on the same `(subject, gate_sha)` forever while `max_attempts`
 /// never trips — this counter is the real loop bound. Exhausting it fails
 /// the phase like `on_reject: halt`, with a distinct error naming the bound.
+///
+/// Fixed at 3 rather than plan-configurable, on purpose: this bound exists
+/// to kill loop-shaped defects (the D6 loop measured 176 cycles before the
+/// fix), and a plan-author-tunable ceiling would let the same optimism that
+/// wrote an unbounded gate re-open the loop from inside the plan file. Three
+/// covers the multi-round review cycles this repo actually ships (e.g. the
+/// three-round review of GH-534); a phase that genuinely needs more review
+/// rounds should be split into smaller phases instead of raising the bound.
 const MAX_GATE_REDISPATCHES: u32 = 3;
 
 /// `<plan-name>/<phase-id>` — the subject an `edda verdict` targets (D1/D3).
@@ -1092,6 +1100,19 @@ async fn process_phase_result(
                                 Some(PhaseUpdate {
                                     checks: Some(check_result.results),
                                     gate_sha: Some(gate_sha.clone()),
+                                    // D6 LOAD-BEARING: `gate_entered_at` is
+                                    // REWRITTEN on every gate entry, including
+                                    // redispatch re-entry. Verdict freshness
+                                    // compares the verdict timestamp against
+                                    // this bound, so re-entry stales every
+                                    // earlier verdict for the same
+                                    // (subject, gate_sha) — including the
+                                    // rejection that triggered this
+                                    // redispatch — and that is what kills the
+                                    // re-approval loop. Hoisting, caching, or
+                                    // reusing the original bound here silently
+                                    // reintroduces the 176-cycle D6 loop
+                                    // while the happy path still passes.
                                     gate_entered_at: Some(now_rfc3339()),
                                     ..Default::default()
                                 }),
@@ -3851,7 +3872,13 @@ phases:
             Some("fix the flaky test"),
         );
 
-        // Redispatch re-enters the gate with a fresh gate_sha; approve it.
+        // Redispatch re-enters the gate with the SAME gate_sha, NOT a fresh
+        // one: the redispatch turn here produces no new commit, so HEAD (and
+        // therefore the sha a verdict must match) is unchanged. The D6
+        // freshness rule still blocks the first rejection from re-satisfying
+        // the re-entered gate, because re-entry rewrote gate_entered_at and
+        // the rejection now predates it. Approving that same sha works
+        // because it is recorded after the second gate_entered_at.
         let shas = wait_for_gate_events(&root, "gated", 2).await;
         record_verdict(
             &root,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -743,6 +743,13 @@ Verdict recorded: approved demo/phase-1 @ 00000000000000000000000000000000000000
   comment: sanity
 ```
 
+> **Freshness (GH-519 D6):** a verdict only satisfies a waiting gate if it
+> postdates the gate's `gate_entered_at`. Pre-recording a verdict — approving
+> a known SHA *before* the gate opens — does not work: the gate ignores any
+> verdict recorded before it entered `AWAITING_VERDICT`, even for the
+> matching SHA. Wait for the gate to open, then run the `edda verdict`
+> command the conductor prints.
+
 ### `edda phase`
 
 Agent phase map, plus approve/reject sugar over `edda verdict` (GH-547).


### PR DESCRIPTION
## Summary

Resolves #542 — the four documentation/rationale items from the #539 round-1 verifier P3 cluster. Comments and docs only; no behavior change.

## Changes

1. **Fixed the inverted redispatch test comment** (`sequential.rs` test `reject_then_redispatch...`): it claimed "Redispatch re-enters the gate with a fresh gate_sha" — the exact false assumption behind the original 176-cycle loop. The sha is NOT fresh across redispatch (the redispatch turn produces no new commit, so HEAD is unchanged); it is D6 freshness (re-entry rewrote `gate_entered_at`) that blocks the earlier rejection, not a new sha.

2. **Marked the `gate_entered_at` rewrite as load-bearing** where it happens (gate entry `PhaseUpdate`): re-entry stales every earlier verdict for the same `(subject, gate_sha)`, including the rejection that triggered the redispatch — hoisting or caching this write silently reintroduces the loop while the happy path still passes.

3. **Documented that pre-recorded verdicts are unsupported under freshness**: `cmd_verdict.rs` module doc and the `edda verdict` section of `docs/reference/cli.md` now state that a verdict recorded before the gate opens does not satisfy the gate, even for the matching SHA.

4. **Stated the rationale for the fixed `MAX_GATE_REDISPATCHES` ceiling** (option 3 of the issue's doneWhen): a plan-author-tunable bound would re-open the loop D6 was created to kill; three covers the multi-round review cycles this repo actually ships; split phases instead of raising it.

## IN SCOPE

- Changed paths: `crates/edda-conductor/src/runner/sequential.rs` (comments), `crates/edda-cli/src/cmd_verdict.rs` (module doc), `docs/reference/cli.md` (verdict section)
- Issue acceptance: the four doneWhen items of #542 (item 4 delivered as stated rationale)
- No behavior change; no callers or consumers affected

## Gate receipt (L1, frozen SHA `4badeb75a995ce9da8420b659cc4c29c75dcc593`)

- `cargo fmt --all --check`: OK
- `cargo clippy --workspace --all-targets -- -D warnings`: OK (Windows, stable)
- `cargo test --workspace`: all crates green except `edda` crate — 430 passed, 13 e2e failures (`cmd_claim`/`cmd_reconcile`/`cmd_verify`). Failure set verified **identical on `main` @ `1375687`** (430/13, same test names): non-hermetic coordination-board resolution in the operator home directory (#646 class), machine-environmental, not introduced by this change.
- `cargo test -p edda-conductor`: 336 passed, 0 failed
- `cargo test -p edda cmd_verdict`: 8 passed, 0 failed
- `CARGO_INCREMENTAL=0` throughout; default `target/` lane

Closes #542