### PR TITLE
feat(cli): merge-precondition gate (GH-580)

### DIFF
--- a/crates/edda-cli/src/cmd_prs.rs
+++ b/crates/edda-cli/src/cmd_prs.rs
@@ -7,6 +7,8 @@ use std::process::Command;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
+pub mod merge_gate;
+
 #[derive(Subcommand)]
 pub enum PrsCmd {
     /// Scan recent PRs and record them as events
@@ -18,11 +20,14 @@ pub enum PrsCmd {
         #[arg(long, default_value = "all")]
         state: String,
     },
+    /// Evaluate merge preconditions for a PR (current-head LGTM, green CI, SHA window)
+    CheckMerge(merge_gate::CheckMergeArgs),
 }
 
 pub fn run_prs(cmd: PrsCmd, repo_root: &Path) -> anyhow::Result<()> {
     match cmd {
         PrsCmd::Scan { limit, state } => scan_prs(repo_root, limit, &state),
+        PrsCmd::CheckMerge(args) => merge_gate::run_check_merge(args, repo_root),
     }
 }
 

--- a/crates/edda-cli/src/cmd_prs/merge_gate.rs
+++ b/crates/edda-cli/src/cmd_prs/merge_gate.rs
@@ -577,6 +577,54 @@ fn fetch_pr_from_gh(
     })
 }
 
+/// Format standard CLI output reports for merge precondition results.
+pub fn format_merge_report(result: &MergeGateResult) -> (String, String) {
+    let mut stdout_buf = String::new();
+    let mut stderr_buf = String::new();
+
+    if result.can_merge {
+        use std::fmt::Write;
+        let _ = writeln!(stdout_buf, "PASS: Merge preconditions satisfied.");
+        let _ = writeln!(stdout_buf, "  PR Head:     {}", result.head_sha);
+        if let Some(author) = &result.pr_author {
+            let _ = writeln!(stdout_buf, "  PR Author:   {author}");
+        }
+        let author_str = result
+            .verdict_author
+            .as_deref()
+            .map(|a| format!(" by {a}"))
+            .unwrap_or_default();
+        let _ = writeln!(
+            stdout_buf,
+            "  Verdict:     {}{} (pinned at {})",
+            result.verdict.as_deref().unwrap_or("none"),
+            author_str,
+            result.verdict_sha.as_deref().unwrap_or("none")
+        );
+        let _ = writeln!(
+            stdout_buf,
+            "  Findings:    P0={}, P1={}",
+            result.p0_count, result.p1_count
+        );
+        let _ = writeln!(stdout_buf, "  Required CI: green");
+    } else {
+        use std::fmt::Write;
+        let _ = writeln!(
+            stderr_buf,
+            "REFUSED: Merge preconditions not satisfied for head {}:",
+            result.head_sha
+        );
+        if let Some(author) = &result.pr_author {
+            let _ = writeln!(stderr_buf, "  PR Author:   {author}");
+        }
+        for reason in &result.reasons {
+            let _ = writeln!(stderr_buf, "  - {reason}");
+        }
+    }
+
+    (stdout_buf, stderr_buf)
+}
+
 /// Execute the merge precondition check CLI entrypoint.
 pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result<()> {
     if args.merge && (args.pr.is_none() || args.input.is_some()) {
@@ -618,37 +666,13 @@ pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result
     if args.json {
         let json_out = serde_json::to_string_pretty(&result)?;
         println!("{json_out}");
-    } else if result.can_merge {
-        println!("PASS: Merge preconditions satisfied.");
-        println!("  PR Head:     {}", result.head_sha);
-        if let Some(author) = &result.pr_author {
-            println!("  PR Author:   {author}");
+    } else {
+        let (out, err) = format_merge_report(&result);
+        if !out.is_empty() {
+            print!("{out}");
         }
-        let author_str = result
-            .verdict_author
-            .as_deref()
-            .map(|a| format!(" by {a}"))
-            .unwrap_or_default();
-        println!(
-            "  Verdict:     {}{} (pinned at {})",
-            result.verdict.as_deref().unwrap_or("none"),
-            author_str,
-            result.verdict_sha.as_deref().unwrap_or("none")
-        );
-        println!(
-            "  Findings:    P0={}, P1={}",
-            result.p0_count, result.p1_count
-        );
-        println!("  Required CI: green");
-        eprintln!(
-            "REFUSED: Merge preconditions not satisfied for head {}:",
-            result.head_sha
-        );
-        if let Some(author) = &result.pr_author {
-            eprintln!("  PR Author:   {author}");
-        }
-        for reason in &result.reasons {
-            eprintln!("  - {reason}");
+        if !err.is_empty() {
+            eprint!("{err}");
         }
     }
 
@@ -1081,5 +1105,59 @@ Commit: 1234567890abcdef1234567890abcdef12345678
             .unwrap_err()
             .to_string()
             .contains("cannot be used with '--input'"));
+    }
+
+    #[test]
+    fn test_format_merge_report_pass() {
+        let result = MergeGateResult {
+            can_merge: true,
+            head_sha: VALID_SHA_A.into(),
+            pr_author: Some("alice".into()),
+            verdict: Some("LGTM".into()),
+            verdict_sha: Some(VALID_SHA_A.into()),
+            verdict_author: Some("bob".into()),
+            p0_count: 0,
+            p1_count: 0,
+            required_ci_green: true,
+            reasons: vec![],
+        };
+
+        let (stdout, stderr) = format_merge_report(&result);
+        assert!(stderr.is_empty(), "PASS report must not write to stderr");
+        assert!(stdout.contains("PASS: Merge preconditions satisfied."));
+        assert!(stdout.contains("PR Head:     1234567890abcdef1234567890abcdef12345678"));
+        assert!(stdout.contains("PR Author:   alice"));
+        assert!(stdout.contains("Verdict:     LGTM by bob"));
+        assert!(stdout.contains("Required CI: green"));
+    }
+
+    #[test]
+    fn test_format_merge_report_refused() {
+        let result = MergeGateResult {
+            can_merge: false,
+            head_sha: VALID_SHA_A.into(),
+            pr_author: Some("alice".into()),
+            verdict: Some("Changes Requested".into()),
+            verdict_sha: Some(VALID_SHA_A.into()),
+            verdict_author: Some("bob".into()),
+            p0_count: 1,
+            p1_count: 1,
+            required_ci_green: false,
+            reasons: vec![
+                "review verdict is not LGTM (found 'Changes Requested')".into(),
+                "blocking findings present: 1 P0, 1 P1 (both must be 0)".into(),
+                "required CI check(s) are not green".into(),
+            ],
+        };
+
+        let (stdout, stderr) = format_merge_report(&result);
+        assert!(stdout.is_empty(), "REFUSED report must not write to stdout");
+        assert!(stderr.contains(
+            "REFUSED: Merge preconditions not satisfied for head 1234567890abcdef1234567890abcdef12345678:"
+        ));
+        assert!(stderr.contains("PR Author:   alice"));
+        assert!(stderr.contains("  - review verdict is not LGTM"));
+        assert!(stderr.contains("  - blocking findings present: 1 P0, 1 P1"));
+        assert!(stderr.contains("  - required CI check(s) are not green"));
     }
 }

--- a/crates/edda-cli/src/cmd_prs/merge_gate.rs
+++ b/crates/edda-cli/src/cmd_prs/merge_gate.rs
@@ -376,13 +376,13 @@ pub fn parse_verdict_text(text: &str) -> (Option<String>, Option<String>, usize,
 }
 
 #[derive(Debug, Clone)]
-pub struct ReviewTimelineEvent {
-    pub timestamp: String,
-    pub author: Option<String>,
-    pub verdict: String,
-    pub verdict_sha: Option<String>,
-    pub p0_count: usize,
-    pub p1_count: usize,
+struct ReviewTimelineEvent {
+    timestamp: String,
+    author: Option<String>,
+    verdict: String,
+    verdict_sha: Option<String>,
+    p0_count: usize,
+    p1_count: usize,
 }
 
 /// Pure timeline extractor: processes reviews and structured comments into the final verdict.
@@ -395,13 +395,12 @@ pub fn extract_timeline_verdict(
     // 1. Process GitHub formal reviews (APPROVED / CHANGES_REQUESTED)
     for r in &gh_view.reviews {
         if let Some(allowed) = allowed_reviewers {
-            if let Some(author) = &r.author {
-                if !allowed
-                    .iter()
-                    .any(|u| u.eq_ignore_ascii_case(&author.login))
-                {
-                    continue;
-                }
+            match &r.author {
+                Some(author)
+                    if allowed
+                        .iter()
+                        .any(|u| u.eq_ignore_ascii_case(&author.login)) => {}
+                _ => continue, // Fail closed: unauthenticated/unattributable events are rejected
             }
         }
 
@@ -435,13 +434,12 @@ pub fn extract_timeline_verdict(
     // 2. Process structured review comments
     for comment in &gh_view.comments {
         if let Some(allowed) = allowed_reviewers {
-            if let Some(author) = &comment.author {
-                if !allowed
-                    .iter()
-                    .any(|u| u.eq_ignore_ascii_case(&author.login))
-                {
-                    continue;
-                }
+            match &comment.author {
+                Some(author)
+                    if allowed
+                        .iter()
+                        .any(|u| u.eq_ignore_ascii_case(&author.login)) => {}
+                _ => continue, // Fail closed: unauthenticated/unattributable events are rejected
             }
         }
 
@@ -642,11 +640,13 @@ pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result
             result.p0_count, result.p1_count
         );
         println!("  Required CI: green");
-    } else {
         eprintln!(
             "REFUSED: Merge preconditions not satisfied for head {}:",
             result.head_sha
         );
+        if let Some(author) = &result.pr_author {
+            eprintln!("  PR Author:   {author}");
+        }
         for reason in &result.reasons {
             eprintln!("  - {reason}");
         }
@@ -951,7 +951,10 @@ Commit: 1234567890abcdef1234567890abcdef12345678
 
     #[test]
     fn test_allowed_reviewers_filter() {
-        let gh_view = GhViewPr {
+        let allowed = vec!["authorized-reviewer".to_string()];
+
+        // Case 1: Unauthorized user comment is rejected
+        let gh_view_unauth = GhViewPr {
             head_ref_oid: VALID_SHA_A.into(),
             author: Some(GhAuthor {
                 login: "fagemx".into(),
@@ -967,10 +970,52 @@ Commit: 1234567890abcdef1234567890abcdef12345678
             }],
             reviews: vec![],
         };
-
-        let allowed = vec!["authorized-reviewer".to_string()];
-        let (verdict, _, _, _, _) = extract_timeline_verdict(&gh_view, Some(&allowed));
+        let (verdict, _, _, _, _) = extract_timeline_verdict(&gh_view_unauth, Some(&allowed));
         assert!(verdict.is_none());
+
+        // Case 2: Unattributable (author: None) comment/review is rejected (fail closed)
+        let gh_view_none = GhViewPr {
+            head_ref_oid: VALID_SHA_A.into(),
+            author: Some(GhAuthor {
+                login: "fagemx".into(),
+            }),
+            comments: vec![GhComment {
+                body: format!(
+                    "## Code Review: Round 1\n\n### Verdict\nLGTM (P0=0, P1=0) at `{VALID_SHA_A}`"
+                ),
+                author: None,
+                created_at: Some("2026-09-02T08:00:00Z".into()),
+            }],
+            reviews: vec![GhReviewItem {
+                state: "APPROVED".into(),
+                author: None,
+                body: Some(format!("LGTM @ {VALID_SHA_A}")),
+                submitted_at: Some("2026-09-02T08:30:00Z".into()),
+            }],
+        };
+        let (verdict, _, _, _, _) = extract_timeline_verdict(&gh_view_none, Some(&allowed));
+        assert!(verdict.is_none());
+
+        // Case 3: Authorized reviewer is accepted
+        let gh_view_auth = GhViewPr {
+            head_ref_oid: VALID_SHA_A.into(),
+            author: Some(GhAuthor {
+                login: "fagemx".into(),
+            }),
+            comments: vec![GhComment {
+                body: format!(
+                    "## Code Review: Round 1\n\n### Verdict\nLGTM (P0=0, P1=0) at `{VALID_SHA_A}`"
+                ),
+                author: Some(GhAuthor {
+                    login: "authorized-reviewer".into(),
+                }),
+                created_at: Some("2026-09-02T08:00:00Z".into()),
+            }],
+            reviews: vec![],
+        };
+        let (verdict, _, author, _, _) = extract_timeline_verdict(&gh_view_auth, Some(&allowed));
+        assert_eq!(verdict.as_deref(), Some("LGTM"));
+        assert_eq!(author.as_deref(), Some("authorized-reviewer"));
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_prs/merge_gate.rs
+++ b/crates/edda-cli/src/cmd_prs/merge_gate.rs
@@ -25,6 +25,10 @@ pub struct CheckMergeArgs {
     #[arg(long)]
     pub verdict: Option<String>,
 
+    /// Optional author of the review verdict
+    #[arg(long)]
+    pub verdict_author: Option<String>,
+
     /// Count of P0 blocking findings
     #[arg(long, default_value_t = 0)]
     pub p0: usize,
@@ -36,6 +40,10 @@ pub struct CheckMergeArgs {
     /// Mark required CI checks as green
     #[arg(long)]
     pub ci_green: bool,
+
+    /// Optional list of allowed reviewer usernames
+    #[arg(long, value_delimiter = ',')]
+    pub allowed_reviewers: Option<Vec<String>>,
 
     /// Path to JSON file containing MergeGateInput (or '-' for stdin)
     #[arg(long, value_name = "FILE")]
@@ -54,8 +62,12 @@ pub struct CheckMergeArgs {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MergeGateInput {
     pub head_sha: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr_author: Option<String>,
     pub verdict: Option<String>,
     pub verdict_sha: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verdict_author: Option<String>,
     #[serde(default)]
     pub p0_count: usize,
     #[serde(default)]
@@ -71,8 +83,12 @@ pub struct MergeGateInput {
 pub struct MergeGateResult {
     pub can_merge: bool,
     pub head_sha: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr_author: Option<String>,
     pub verdict: Option<String>,
     pub verdict_sha: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verdict_author: Option<String>,
     pub p0_count: usize,
     pub p1_count: usize,
     pub required_ci_green: bool,
@@ -151,8 +167,10 @@ pub fn evaluate_merge_preconditions(input: &MergeGateInput) -> MergeGateResult {
     MergeGateResult {
         can_merge: reasons.is_empty(),
         head_sha: input.head_sha.clone(),
+        pr_author: input.pr_author.clone(),
         verdict: input.verdict.clone(),
         verdict_sha: input.verdict_sha.clone(),
+        verdict_author: input.verdict_author.clone(),
         p0_count: input.p0_count,
         p1_count: input.p1_count,
         required_ci_green: input.required_ci_green,
@@ -161,12 +179,10 @@ pub fn evaluate_merge_preconditions(input: &MergeGateInput) -> MergeGateResult {
 }
 
 // GitHub API / `gh` structures
-#[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
 pub struct GhViewPr {
     #[serde(rename = "headRefOid")]
     pub head_ref_oid: String,
-    #[serde(default)]
     pub author: Option<GhAuthor>,
     #[serde(default)]
     pub comments: Vec<GhComment>,
@@ -174,27 +190,22 @@ pub struct GhViewPr {
     pub reviews: Vec<GhReviewItem>,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
 pub struct GhAuthor {
     pub login: String,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
 pub struct GhComment {
     pub body: String,
-    #[serde(default)]
     pub author: Option<GhAuthor>,
     #[serde(rename = "createdAt")]
     pub created_at: Option<String>,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
 pub struct GhReviewItem {
     pub state: String,
-    #[serde(default)]
     pub author: Option<GhAuthor>,
     pub body: Option<String>,
     #[serde(rename = "submittedAt")]
@@ -208,13 +219,46 @@ struct GhCheckItem {
     bucket: Option<String>,
 }
 
-/// Determines if a comment is a structured review verdict, preventing casual comments from triggering a verdict.
+/// Determines if a comment is a structured review verdict, preventing casual comments and
+/// implementer responses from triggering a verdict.
 pub fn is_structured_review_comment(body: &str) -> bool {
-    body.contains("## Code Review:")
-        || body.contains("### Verdict")
-        || body.contains("<<<VERDICT")
-        || body.contains("Verdict as of the ruling:")
-        || body.contains("**Verdict as of the ruling:")
+    // 1. Explicitly reject implementer review responses
+    if body.lines().any(|line| {
+        let trimmed = line.trim();
+        trimmed.starts_with("## Review Response") || trimmed.starts_with("# Review Response")
+    }) {
+        return false;
+    }
+
+    // 2. Must contain an anchored review header line
+    let has_review_header = body.lines().any(|line| {
+        let trimmed = line.trim();
+        trimmed.starts_with("## Code Review:")
+            || trimmed.starts_with("### Verdict")
+            || trimmed.starts_with("<<<VERDICT")
+            || trimmed.starts_with("## Operator ruling")
+            || trimmed.starts_with("Verdict as of the ruling:")
+            || trimmed.starts_with("**Verdict as of the ruling:")
+    });
+
+    if !has_review_header {
+        return false;
+    }
+
+    // 3. Must contain an explicit verdict indicator line
+    body.lines().any(|line| {
+        let trimmed = line.trim();
+        trimmed.starts_with("### Verdict")
+            || trimmed.starts_with("Verdict as of the ruling:")
+            || trimmed.starts_with("**Verdict as of the ruling:")
+            || trimmed.starts_with("- verdict:")
+            || trimmed.starts_with("**Verdict:")
+            || trimmed.starts_with("Verdict:")
+            || trimmed.starts_with("LGTM (")
+            || trimmed.starts_with("**LGTM")
+            || trimmed.starts_with("Changes Requested,")
+            || trimmed.starts_with("**Changes Requested")
+    })
 }
 
 fn parse_count(line: &str, prefix: &str) -> Option<usize> {
@@ -231,25 +275,80 @@ pub fn parse_verdict_text(text: &str) -> (Option<String>, Option<String>, usize,
     let mut p0 = 0;
     let mut p1 = 0;
 
-    let has_changes_requested =
-        text.contains("Changes Requested") || text.contains("changes_requested");
-    let has_lgtm = text.contains("LGTM") || text.contains("lgtm");
-
-    if has_lgtm && !has_changes_requested {
-        verdict = Some("LGTM".to_string());
-    } else if has_changes_requested && !has_lgtm {
-        verdict = Some("Changes Requested".to_string());
-    } else if has_lgtm && has_changes_requested {
-        let pos_cr = text.rfind("Changes Requested").unwrap_or(0);
-        let pos_lgtm = text.rfind("LGTM").unwrap_or(0);
-        if pos_lgtm > pos_cr {
-            verdict = Some("LGTM".to_string());
-        } else {
-            verdict = Some("Changes Requested".to_string());
+    // Look for SHA in header line first: "## Code Review: ... @ <SHA>"
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("## Code Review:") || trimmed.starts_with("## Review:") {
+            if let Some(at_idx) = trimmed.rfind('@') {
+                let after = trimmed[at_idx + 1..].trim();
+                let clean =
+                    after.trim_matches(['*', '`', '(', ')', '.', ',', ':', '"', '\'', '[', ']']);
+                let sha_candidate: String = clean
+                    .chars()
+                    .take_while(|c| c.is_ascii_hexdigit())
+                    .collect();
+                if sha_candidate.len() == 40 {
+                    verdict_sha = Some(sha_candidate);
+                    break;
+                }
+            }
         }
     }
 
-    for line in text.lines() {
+    // Focus parsing on the final verdict section if present (using rfind to avoid matching earlier quotes)
+    let target_section = if let Some(idx) = text.rfind("\n### Verdict") {
+        &text[idx..]
+    } else if let Some(idx) = text.rfind("\n<<<VERDICT") {
+        &text[idx..]
+    } else if let Some(idx) = text.rfind("Verdict as of the ruling:") {
+        &text[idx..]
+    } else if let Some(idx) = text.rfind("### Verdict") {
+        &text[idx..]
+    } else {
+        text
+    };
+
+    for line in target_section.lines() {
+        let trimmed = line.trim().trim_matches('*').trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with("<<<") {
+            continue;
+        }
+        let clean = if let Some(idx) = trimmed.find("Verdict as of the ruling:") {
+            trimmed[idx + "Verdict as of the ruling:".len()..]
+                .trim()
+                .trim_matches('*')
+                .trim()
+        } else if let Some(idx) = trimmed.find("Verdict:") {
+            trimmed[idx + "Verdict:".len()..]
+                .trim()
+                .trim_matches('*')
+                .trim()
+        } else {
+            trimmed
+        };
+
+        if clean.starts_with("LGTM") || clean.starts_with("Approved") {
+            verdict = Some("LGTM".to_string());
+            break;
+        } else if clean.starts_with("Changes Requested") || clean.starts_with("changes_requested") {
+            verdict = Some("Changes Requested".to_string());
+            break;
+        }
+    }
+
+    if verdict.is_none() {
+        let has_changes_requested = target_section.contains("Changes Requested")
+            || target_section.contains("changes_requested");
+        let has_lgtm = target_section.contains("LGTM") || target_section.contains("lgtm");
+
+        if has_changes_requested {
+            verdict = Some("Changes Requested".to_string());
+        } else if has_lgtm {
+            verdict = Some("LGTM".to_string());
+        }
+    }
+
+    for line in target_section.lines() {
         if let Some(val) = parse_count(line, "P0") {
             p0 = p0.max(val);
         } else if let Some(val) = parse_count(line, "p0") {
@@ -263,35 +362,49 @@ pub fn parse_verdict_text(text: &str) -> (Option<String>, Option<String>, usize,
         }
     }
 
-    for word in text.split_whitespace() {
-        let clean = word.trim_matches(['*', '`', '(', ')', '.', ',', ':', '"', '\'', '[', ']']);
-        if clean.len() == 40 && clean.chars().all(|c| c.is_ascii_hexdigit()) {
-            verdict_sha = Some(clean.to_string());
-            break;
+    if verdict_sha.is_none() {
+        for word in target_section.split_whitespace() {
+            let clean = word.trim_matches(['*', '`', '(', ')', '.', ',', ':', '"', '\'', '[', ']']);
+            if clean.len() == 40 && clean.chars().all(|c| c.is_ascii_hexdigit()) {
+                verdict_sha = Some(clean.to_string());
+                break;
+            }
         }
     }
 
     (verdict, verdict_sha, p0, p1)
 }
 
-#[derive(Debug)]
-struct ReviewTimelineEvent {
-    timestamp: String,
-    verdict: String,
-    verdict_sha: Option<String>,
-    p0_count: usize,
-    p1_count: usize,
+#[derive(Debug, Clone)]
+pub struct ReviewTimelineEvent {
+    pub timestamp: String,
+    pub author: Option<String>,
+    pub verdict: String,
+    pub verdict_sha: Option<String>,
+    pub p0_count: usize,
+    pub p1_count: usize,
 }
 
 /// Pure timeline extractor: processes reviews and structured comments into the final verdict.
 pub fn extract_timeline_verdict(
     gh_view: &GhViewPr,
-) -> (Option<String>, Option<String>, usize, usize) {
+    allowed_reviewers: Option<&[String]>,
+) -> (Option<String>, Option<String>, Option<String>, usize, usize) {
     let mut timeline: Vec<ReviewTimelineEvent> = Vec::new();
 
     // 1. Process GitHub formal reviews (APPROVED / CHANGES_REQUESTED)
-    // The formal review state is strictly authoritative for the verdict (cannot be overridden by prose)
     for r in &gh_view.reviews {
+        if let Some(allowed) = allowed_reviewers {
+            if let Some(author) = &r.author {
+                if !allowed
+                    .iter()
+                    .any(|u| u.eq_ignore_ascii_case(&author.login))
+                {
+                    continue;
+                }
+            }
+        }
+
         let verdict_opt = match r.state.as_str() {
             "APPROVED" => Some("LGTM".to_string()),
             "CHANGES_REQUESTED" => Some("Changes Requested".to_string()),
@@ -299,7 +412,6 @@ pub fn extract_timeline_verdict(
         };
 
         if let Some(formal_verdict) = verdict_opt {
-            // Parse body only for SHA, p0, p1 (formal review state is NOT overridden by prose)
             let (_, sha, parsed_p0, parsed_p1) = if let Some(body) = &r.body {
                 parse_verdict_text(body)
             } else {
@@ -307,8 +419,11 @@ pub fn extract_timeline_verdict(
             };
 
             let ts = r.submitted_at.clone().unwrap_or_default();
+            let author = r.author.as_ref().map(|a| a.login.clone());
+
             timeline.push(ReviewTimelineEvent {
                 timestamp: ts,
+                author,
                 verdict: formal_verdict,
                 verdict_sha: sha,
                 p0_count: parsed_p0,
@@ -318,8 +433,18 @@ pub fn extract_timeline_verdict(
     }
 
     // 2. Process structured review comments
-    // Comments must meet is_structured_review_comment to ensure casual comments are ignored
     for comment in &gh_view.comments {
+        if let Some(allowed) = allowed_reviewers {
+            if let Some(author) = &comment.author {
+                if !allowed
+                    .iter()
+                    .any(|u| u.eq_ignore_ascii_case(&author.login))
+                {
+                    continue;
+                }
+            }
+        }
+
         if !is_structured_review_comment(&comment.body) {
             continue;
         }
@@ -327,8 +452,11 @@ pub fn extract_timeline_verdict(
         let (v, sha, parsed_p0, parsed_p1) = parse_verdict_text(&comment.body);
         if let Some(found_v) = v {
             let ts = comment.created_at.clone().unwrap_or_default();
+            let author = comment.author.as_ref().map(|a| a.login.clone());
+
             timeline.push(ReviewTimelineEvent {
                 timestamp: ts,
+                author,
                 verdict: found_v,
                 verdict_sha: sha,
                 p0_count: parsed_p0,
@@ -344,15 +472,20 @@ pub fn extract_timeline_verdict(
         (
             Some(latest.verdict),
             latest.verdict_sha,
+            latest.author,
             latest.p0_count,
             latest.p1_count,
         )
     } else {
-        (None, None, 0, 0)
+        (None, None, None, 0, 0)
     }
 }
 
-fn fetch_pr_from_gh(pr: u64, repo_root: &Path) -> anyhow::Result<MergeGateInput> {
+fn fetch_pr_from_gh(
+    pr: u64,
+    allowed_reviewers: Option<&[String]>,
+    repo_root: &Path,
+) -> anyhow::Result<MergeGateInput> {
     let view_output = Command::new("gh")
         .args([
             "pr",
@@ -374,7 +507,8 @@ fn fetch_pr_from_gh(pr: u64, repo_root: &Path) -> anyhow::Result<MergeGateInput>
         serde_json::from_slice(&view_output.stdout).context("parse gh pr view json output")?;
 
     let head_sha = gh_view.head_ref_oid.clone();
-    let (verdict, verdict_sha, p0, p1) = extract_timeline_verdict(&gh_view);
+    let (verdict, verdict_sha, verdict_author, p0, p1) =
+        extract_timeline_verdict(&gh_view, allowed_reviewers);
 
     // Fetch PR checks
     let checks_output = Command::new("gh")
@@ -434,8 +568,10 @@ fn fetch_pr_from_gh(pr: u64, repo_root: &Path) -> anyhow::Result<MergeGateInput>
 
     Ok(MergeGateInput {
         head_sha,
+        pr_author: gh_view.author.as_ref().map(|a| a.login.clone()),
         verdict,
         verdict_sha,
+        verdict_author,
         p0_count: p0,
         p1_count: p1,
         required_ci_green,
@@ -460,12 +596,14 @@ pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result
         };
         serde_json::from_str::<MergeGateInput>(&raw).context("parse MergeGateInput JSON")?
     } else if let Some(pr_number) = args.pr {
-        fetch_pr_from_gh(pr_number, repo_root)?
+        fetch_pr_from_gh(pr_number, args.allowed_reviewers.as_deref(), repo_root)?
     } else if let Some(head_sha) = args.head_sha {
         MergeGateInput {
             head_sha,
+            pr_author: None,
             verdict: args.verdict,
             verdict_sha: args.verdict_sha,
+            verdict_author: args.verdict_author,
             p0_count: args.p0,
             p1_count: args.p1,
             required_ci_green: args.ci_green,
@@ -485,9 +623,18 @@ pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result
     } else if result.can_merge {
         println!("PASS: Merge preconditions satisfied.");
         println!("  PR Head:     {}", result.head_sha);
+        if let Some(author) = &result.pr_author {
+            println!("  PR Author:   {author}");
+        }
+        let author_str = result
+            .verdict_author
+            .as_deref()
+            .map(|a| format!(" by {a}"))
+            .unwrap_or_default();
         println!(
-            "  Verdict:     {} (pinned at {})",
+            "  Verdict:     {}{} (pinned at {})",
             result.verdict.as_deref().unwrap_or("none"),
+            author_str,
             result.verdict_sha.as_deref().unwrap_or("none")
         );
         println!(
@@ -544,8 +691,10 @@ mod tests {
     fn test_refuse_when_no_verdict() {
         let input = MergeGateInput {
             head_sha: VALID_SHA_A.into(),
+            pr_author: None,
             verdict: None,
             verdict_sha: None,
+            verdict_author: None,
             p0_count: 0,
             p1_count: 0,
             required_ci_green: true,
@@ -563,8 +712,10 @@ mod tests {
     fn test_refuse_when_verdict_stale_new_push() {
         let input = MergeGateInput {
             head_sha: VALID_SHA_B.into(),
+            pr_author: None,
             verdict: Some("LGTM".into()),
             verdict_sha: Some(VALID_SHA_A.into()),
+            verdict_author: None,
             p0_count: 0,
             p1_count: 0,
             required_ci_green: true,
@@ -582,8 +733,10 @@ mod tests {
     fn test_refuse_when_sha_is_invalid() {
         let input = MergeGateInput {
             head_sha: "short".into(),
+            pr_author: None,
             verdict: Some("LGTM".into()),
             verdict_sha: Some("short".into()),
+            verdict_author: None,
             p0_count: 0,
             p1_count: 0,
             required_ci_green: true,
@@ -601,8 +754,10 @@ mod tests {
     fn test_refuse_when_ci_not_green() {
         let input = MergeGateInput {
             head_sha: VALID_SHA_A.into(),
+            pr_author: None,
             verdict: Some("LGTM".into()),
             verdict_sha: Some(VALID_SHA_A.into()),
+            verdict_author: None,
             p0_count: 0,
             p1_count: 0,
             required_ci_green: false,
@@ -618,8 +773,10 @@ mod tests {
         // Case A: Changes Requested
         let input_cr = MergeGateInput {
             head_sha: VALID_SHA_A.into(),
+            pr_author: None,
             verdict: Some("Changes Requested".into()),
             verdict_sha: Some(VALID_SHA_A.into()),
+            verdict_author: None,
             p0_count: 0,
             p1_count: 0,
             required_ci_green: true,
@@ -632,8 +789,10 @@ mod tests {
         // Case B: P0 > 0 (e.g. 12)
         let input_p0 = MergeGateInput {
             head_sha: VALID_SHA_A.into(),
+            pr_author: None,
             verdict: Some("LGTM".into()),
             verdict_sha: Some(VALID_SHA_A.into()),
+            verdict_author: None,
             p0_count: 12,
             p1_count: 0,
             required_ci_green: true,
@@ -646,8 +805,10 @@ mod tests {
         // Case C: P1 > 0
         let input_p1 = MergeGateInput {
             head_sha: VALID_SHA_A.into(),
+            pr_author: None,
             verdict: Some("LGTM".into()),
             verdict_sha: Some(VALID_SHA_A.into()),
+            verdict_author: None,
             p0_count: 0,
             p1_count: 2,
             required_ci_green: true,
@@ -665,8 +826,10 @@ mod tests {
     fn test_approve_when_all_preconditions_met() {
         let input = MergeGateInput {
             head_sha: VALID_SHA_A.into(),
+            pr_author: None,
             verdict: Some("LGTM".into()),
             verdict_sha: Some(VALID_SHA_A.to_uppercase()), // case-insensitive equality
+            verdict_author: Some("opus-reviewer".into()),
             p0_count: 0,
             p1_count: 0,
             required_ci_green: true,
@@ -675,6 +838,7 @@ mod tests {
         let result = evaluate_merge_preconditions(&input);
         assert!(result.can_merge);
         assert!(result.reasons.is_empty());
+        assert_eq!(result.verdict_author.as_deref(), Some("opus-reviewer"));
     }
 
     #[test]
@@ -697,18 +861,26 @@ Commit: 1234567890abcdef1234567890abcdef12345678
     #[test]
     fn test_is_structured_review_comment() {
         assert!(is_structured_review_comment(
-            "## Code Review: Round 1\nLGTM"
+            "## Code Review: Round 1\n\n### Verdict\nLGTM (P0=0, P1=0) at `1234567890abcdef1234567890abcdef12345678`"
         ));
         assert!(is_structured_review_comment(
             "### Verdict\nChanges Requested"
         ));
-        assert!(is_structured_review_comment("<<<VERDICT\nLGTM\nVERDICT>>>"));
         assert!(is_structured_review_comment(
-            "Verdict as of the ruling: LGTM"
+            "<<<VERDICT\n**Verdict:** LGTM\nVERDICT>>>"
         ));
         assert!(is_structured_review_comment(
-            "**Verdict as of the ruling: LGTM**"
+            "## Operator ruling on #699\n\nVerdict as of the ruling: LGTM"
         ));
+
+        // Implementer review responses must NEVER match
+        assert!(!is_structured_review_comment(
+            "## Review Response: Round 1 — PR #711\n\n- Requires comments to be structured review verdicts via is_structured_review_comment (e.g. ## Code Review:)"
+        ));
+        assert!(!is_structured_review_comment(
+            "# Review Response: Round 2\n\nLGTM is mentioned here"
+        ));
+
         // Casual comments must NOT match
         assert!(!is_structured_review_comment("ready for LGTM review"));
         assert!(!is_structured_review_comment(
@@ -737,9 +909,10 @@ Commit: 1234567890abcdef1234567890abcdef12345678
             }],
         };
 
-        let (verdict, sha, p0, p1) = extract_timeline_verdict(&gh_view);
+        let (verdict, sha, author, p0, p1) = extract_timeline_verdict(&gh_view, None);
         assert_eq!(verdict.as_deref(), Some("Changes Requested"));
         assert_eq!(sha.as_deref(), Some(VALID_SHA_A));
+        assert_eq!(author.as_deref(), Some("reviewer"));
         assert_eq!(p0, 0);
         assert_eq!(p1, 0);
     }
@@ -756,14 +929,14 @@ Commit: 1234567890abcdef1234567890abcdef12345678
                     "## Code Review: Round 1\n\n### Verdict\nLGTM (P0=0, P1=0) at `{VALID_SHA_A}`"
                 ),
                 author: Some(GhAuthor {
-                    login: "fagemx".into(),
+                    login: "reviewer-a".into(),
                 }),
                 created_at: Some("2026-09-02T08:00:00Z".into()),
             }],
             reviews: vec![GhReviewItem {
                 state: "CHANGES_REQUESTED".into(),
                 author: Some(GhAuthor {
-                    login: "fagemx".into(),
+                    login: "reviewer-b".into(),
                 }),
                 body: Some(format!("blocking findings @ {VALID_SHA_A}")),
                 submitted_at: Some("2026-09-02T09:00:00Z".into()),
@@ -771,8 +944,33 @@ Commit: 1234567890abcdef1234567890abcdef12345678
         };
 
         // Newer CHANGES_REQUESTED review (09:00) wins over older LGTM comment (08:00)
-        let (verdict, _, _, _) = extract_timeline_verdict(&gh_view);
+        let (verdict, _, author, _, _) = extract_timeline_verdict(&gh_view, None);
         assert_eq!(verdict.as_deref(), Some("Changes Requested"));
+        assert_eq!(author.as_deref(), Some("reviewer-b"));
+    }
+
+    #[test]
+    fn test_allowed_reviewers_filter() {
+        let gh_view = GhViewPr {
+            head_ref_oid: VALID_SHA_A.into(),
+            author: Some(GhAuthor {
+                login: "fagemx".into(),
+            }),
+            comments: vec![GhComment {
+                body: format!(
+                    "## Code Review: Round 1\n\n### Verdict\nLGTM (P0=0, P1=0) at `{VALID_SHA_A}`"
+                ),
+                author: Some(GhAuthor {
+                    login: "unauthorized-user".into(),
+                }),
+                created_at: Some("2026-09-02T08:00:00Z".into()),
+            }],
+            reviews: vec![],
+        };
+
+        let allowed = vec!["authorized-reviewer".to_string()];
+        let (verdict, _, _, _, _) = extract_timeline_verdict(&gh_view, Some(&allowed));
+        assert!(verdict.is_none());
     }
 
     #[test]
@@ -781,8 +979,10 @@ Commit: 1234567890abcdef1234567890abcdef12345678
         let input_file = temp_dir.path().join("input.json");
         let valid_input = MergeGateInput {
             head_sha: VALID_SHA_A.into(),
+            pr_author: None,
             verdict: Some("LGTM".into()),
             verdict_sha: Some(VALID_SHA_A.into()),
+            verdict_author: Some("reviewer".into()),
             p0_count: 0,
             p1_count: 0,
             required_ci_green: true,
@@ -795,9 +995,11 @@ Commit: 1234567890abcdef1234567890abcdef12345678
             head_sha: None,
             verdict_sha: None,
             verdict: None,
+            verdict_author: None,
             p0: 0,
             p1: 0,
             ci_green: false,
+            allowed_reviewers: None,
             input: Some(input_file.to_str().unwrap().into()),
             merge: false,
             json: true,
@@ -818,9 +1020,11 @@ Commit: 1234567890abcdef1234567890abcdef12345678
             head_sha: None,
             verdict_sha: None,
             verdict: None,
+            verdict_author: None,
             p0: 0,
             p1: 0,
             ci_green: false,
+            allowed_reviewers: None,
             input: Some(input_file.to_str().unwrap().into()),
             merge: true,
             json: false,

--- a/crates/edda-cli/src/cmd_prs/merge_gate.rs
+++ b/crates/edda-cli/src/cmd_prs/merge_gate.rs
@@ -1,0 +1,620 @@
+use anyhow::Context;
+use clap::Args;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::Read;
+use std::path::Path;
+use std::process::Command;
+
+/// Command line arguments for `edda prs check-merge`
+#[derive(Debug, Clone, Args)]
+pub struct CheckMergeArgs {
+    /// PR number to evaluate (queries GitHub via `gh` CLI)
+    #[arg(value_name = "PR")]
+    pub pr: Option<u64>,
+
+    /// Explicit head commit SHA
+    #[arg(long)]
+    pub head_sha: Option<String>,
+
+    /// Explicit verdict commit SHA
+    #[arg(long)]
+    pub verdict_sha: Option<String>,
+
+    /// Explicit verdict (e.g. "lgtm", "changes-requested")
+    #[arg(long)]
+    pub verdict: Option<String>,
+
+    /// Count of P0 blocking findings
+    #[arg(long, default_value_t = 0)]
+    pub p0: usize,
+
+    /// Count of P1 blocking findings
+    #[arg(long, default_value_t = 0)]
+    pub p1: usize,
+
+    /// Mark required CI checks as green
+    #[arg(long)]
+    pub ci_green: bool,
+
+    /// Path to JSON file containing MergeGateInput (or '-' for stdin)
+    #[arg(long, value_name = "FILE")]
+    pub input: Option<String>,
+
+    /// Execute `gh pr merge <PR> --squash` if preconditions pass
+    #[arg(long)]
+    pub merge: bool,
+
+    /// Output evaluation report as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// Host-agnostic input for evaluating merge preconditions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MergeGateInput {
+    pub head_sha: String,
+    pub verdict: Option<String>,
+    pub verdict_sha: Option<String>,
+    #[serde(default)]
+    pub p0_count: usize,
+    #[serde(default)]
+    pub p1_count: usize,
+    #[serde(default)]
+    pub required_ci_green: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failed_checks: Vec<String>,
+}
+
+/// Evaluation outcome for merge preconditions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MergeGateResult {
+    pub can_merge: bool,
+    pub head_sha: String,
+    pub verdict: Option<String>,
+    pub verdict_sha: Option<String>,
+    pub p0_count: usize,
+    pub p1_count: usize,
+    pub required_ci_green: bool,
+    pub reasons: Vec<String>,
+}
+
+/// Pure evaluation function without host or network dependencies.
+pub fn evaluate_merge_preconditions(input: &MergeGateInput) -> MergeGateResult {
+    let mut reasons = Vec::new();
+
+    // 1. Verdict presence & state
+    match &input.verdict {
+        None => {
+            reasons.push("no review verdict found on PR".to_string());
+        }
+        Some(v) => {
+            let v_clean = v.trim().to_lowercase();
+            if v_clean.is_empty() || v_clean == "none" || v_clean == "unreviewed" {
+                reasons.push("no review verdict found on PR".to_string());
+            } else if v_clean != "lgtm" && !v_clean.contains("lgtm") && v_clean != "approved" {
+                reasons.push(format!("review verdict is not LGTM (found '{v}')"));
+            }
+        }
+    }
+
+    // 2. Blocking findings (P0=0 and P1=0)
+    if input.p0_count > 0 || input.p1_count > 0 {
+        reasons.push(format!(
+            "blocking findings present: {} P0, {} P1 (both must be 0)",
+            input.p0_count, input.p1_count
+        ));
+    }
+
+    // 3. SHA window check (verdict SHA must match current PR head)
+    if let Some(v_sha) = &input.verdict_sha {
+        let v_clean = v_sha.trim();
+        let h_clean = input.head_sha.trim();
+        let matches = if v_clean.len() >= 7 && h_clean.len() >= 7 {
+            v_clean == h_clean || v_clean.starts_with(h_clean) || h_clean.starts_with(v_clean)
+        } else {
+            v_clean == h_clean
+        };
+
+        if !matches {
+            reasons.push(format!(
+                "SHA window mismatch: verdict pinned to '{v_clean}' but current head is '{h_clean}' (new commits pushed after review)"
+            ));
+        }
+    } else if input.verdict.is_some() {
+        reasons.push("review verdict is not pinned to any commit SHA".to_string());
+    }
+
+    // 4. Required CI checks
+    if !input.required_ci_green {
+        if input.failed_checks.is_empty() {
+            reasons.push("required CI check(s) are not green".to_string());
+        } else {
+            reasons.push(format!(
+                "required CI check(s) failed or pending: {}",
+                input.failed_checks.join(", ")
+            ));
+        }
+    }
+
+    MergeGateResult {
+        can_merge: reasons.is_empty(),
+        head_sha: input.head_sha.clone(),
+        verdict: input.verdict.clone(),
+        verdict_sha: input.verdict_sha.clone(),
+        p0_count: input.p0_count,
+        p1_count: input.p1_count,
+        required_ci_green: input.required_ci_green,
+        reasons,
+    }
+}
+
+// GitHub API / `gh` structures
+#[derive(Debug, Deserialize)]
+struct GhViewPr {
+    #[serde(rename = "headRefOid")]
+    head_ref_oid: String,
+    #[serde(default)]
+    comments: Vec<GhComment>,
+    #[serde(default)]
+    reviews: Vec<GhReviewItem>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhComment {
+    body: String,
+    #[serde(rename = "createdAt")]
+    _created_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhReviewItem {
+    state: String,
+    body: Option<String>,
+    #[serde(rename = "submittedAt")]
+    _submitted_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhCheckItem {
+    name: String,
+    state: Option<String>,
+    bucket: Option<String>,
+}
+
+/// Extract verdict info (verdict, verdict_sha, p0, p1) from comment or review body text
+pub fn parse_verdict_text(text: &str) -> (Option<String>, Option<String>, usize, usize) {
+    let mut verdict = None;
+    let mut verdict_sha = None;
+    let mut p0 = 0;
+    let mut p1 = 0;
+
+    let has_changes_requested =
+        text.contains("Changes Requested") || text.contains("changes_requested");
+    let has_lgtm = text.contains("LGTM") || text.contains("lgtm");
+
+    if has_lgtm && !has_changes_requested {
+        verdict = Some("LGTM".to_string());
+    } else if has_changes_requested && !has_lgtm {
+        verdict = Some("Changes Requested".to_string());
+    } else if has_lgtm && has_changes_requested {
+        let pos_cr = text.rfind("Changes Requested").unwrap_or(0);
+        let pos_lgtm = text.rfind("LGTM").unwrap_or(0);
+        if pos_lgtm > pos_cr {
+            verdict = Some("LGTM".to_string());
+        } else {
+            verdict = Some("Changes Requested".to_string());
+        }
+    }
+
+    for line in text.lines() {
+        if let Some(idx) = line.find("P0=") {
+            let rest = &line[idx + 3..];
+            if let Some(digit) = rest.chars().next().and_then(|c| c.to_digit(10)) {
+                p0 = digit as usize;
+            }
+        } else if let Some(idx) = line.find("P0:") {
+            let rest = line[idx + 3..].trim();
+            if let Some(digit) = rest.chars().next().and_then(|c| c.to_digit(10)) {
+                p0 = digit as usize;
+            }
+        }
+
+        if let Some(idx) = line.find("P1=") {
+            let rest = &line[idx + 3..];
+            if let Some(digit) = rest.chars().next().and_then(|c| c.to_digit(10)) {
+                p1 = digit as usize;
+            }
+        } else if let Some(idx) = line.find("P1:") {
+            let rest = line[idx + 3..].trim();
+            if let Some(digit) = rest.chars().next().and_then(|c| c.to_digit(10)) {
+                p1 = digit as usize;
+            }
+        }
+    }
+
+    for word in text.split_whitespace() {
+        let clean = word.trim_matches(|c: char| {
+            c == '*'
+                || c == '`'
+                || c == '('
+                || c == ')'
+                || c == '.'
+                || c == ','
+                || c == ':'
+                || c == '"'
+                || c == '\''
+                || c == '['
+                || c == ']'
+        });
+        if clean.len() == 40 && clean.chars().all(|c| c.is_ascii_hexdigit()) {
+            verdict_sha = Some(clean.to_string());
+            break;
+        }
+    }
+
+    (verdict, verdict_sha, p0, p1)
+}
+
+fn fetch_pr_from_gh(pr: u64, repo_root: &Path) -> anyhow::Result<MergeGateInput> {
+    let view_output = Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            &pr.to_string(),
+            "--json",
+            "headRefOid,comments,reviews",
+        ])
+        .current_dir(repo_root)
+        .output()
+        .context("execute gh pr view")?;
+
+    if !view_output.status.success() {
+        let stderr = String::from_utf8_lossy(&view_output.stderr);
+        anyhow::bail!("gh pr view {} failed: {}", pr, stderr.trim());
+    }
+
+    let gh_view: GhViewPr =
+        serde_json::from_slice(&view_output.stdout).context("parse gh pr view json output")?;
+
+    let head_sha = gh_view.head_ref_oid;
+
+    let mut verdict = None;
+    let mut verdict_sha = None;
+    let mut p0 = 0;
+    let mut p1 = 0;
+
+    for r in gh_view.reviews.iter().rev() {
+        if r.state == "APPROVED" {
+            verdict = Some("LGTM".to_string());
+            if let Some(body) = &r.body {
+                let (_, sha, parsed_p0, parsed_p1) = parse_verdict_text(body);
+                if sha.is_some() {
+                    verdict_sha = sha;
+                }
+                p0 = parsed_p0;
+                p1 = parsed_p1;
+            }
+            break;
+        } else if r.state == "CHANGES_REQUESTED" {
+            verdict = Some("Changes Requested".to_string());
+            if let Some(body) = &r.body {
+                let (_, sha, parsed_p0, parsed_p1) = parse_verdict_text(body);
+                if sha.is_some() {
+                    verdict_sha = sha;
+                }
+                p0 = parsed_p0;
+                p1 = parsed_p1;
+            }
+            break;
+        }
+    }
+
+    for comment in gh_view.comments.iter().rev() {
+        let (v, sha, parsed_p0, parsed_p1) = parse_verdict_text(&comment.body);
+        if let Some(found_v) = v {
+            verdict = Some(found_v);
+            if sha.is_some() {
+                verdict_sha = sha;
+            }
+            p0 = parsed_p0;
+            p1 = parsed_p1;
+            break;
+        }
+    }
+
+    let checks_output = Command::new("gh")
+        .args([
+            "pr",
+            "checks",
+            &pr.to_string(),
+            "--json",
+            "name,state,bucket",
+        ])
+        .current_dir(repo_root)
+        .output()
+        .context("execute gh pr checks")?;
+
+    let mut required_ci_green = true;
+    let mut failed_checks = Vec::new();
+
+    if checks_output.status.success() {
+        let checks: Vec<GhCheckItem> =
+            serde_json::from_slice(&checks_output.stdout).unwrap_or_default();
+
+        let ci_gate_item = checks.iter().find(|c| c.name == "CI Gate");
+
+        if let Some(ci_gate) = ci_gate_item {
+            let pass = ci_gate.bucket.as_deref() == Some("pass")
+                || ci_gate.state.as_deref() == Some("SUCCESS");
+            if !pass {
+                required_ci_green = false;
+                failed_checks.push(format!(
+                    "CI Gate ({})",
+                    ci_gate.bucket.as_deref().unwrap_or("unknown")
+                ));
+            }
+        } else if !checks.is_empty() {
+            for c in &checks {
+                let pass =
+                    c.bucket.as_deref() == Some("pass") || c.state.as_deref() == Some("SUCCESS");
+                if !pass {
+                    required_ci_green = false;
+                    failed_checks.push(format!(
+                        "{} ({})",
+                        c.name,
+                        c.bucket.as_deref().unwrap_or("unknown")
+                    ));
+                }
+            }
+        } else {
+            required_ci_green = false;
+            failed_checks.push("no checks reported".to_string());
+        }
+    } else {
+        required_ci_green = false;
+        failed_checks.push("failed to fetch CI checks via gh".to_string());
+    }
+
+    Ok(MergeGateInput {
+        head_sha,
+        verdict,
+        verdict_sha,
+        p0_count: p0,
+        p1_count: p1,
+        required_ci_green,
+        failed_checks,
+    })
+}
+
+/// Execute the merge precondition check CLI entrypoint.
+pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result<()> {
+    let input = if let Some(input_source) = &args.input {
+        let raw = if input_source == "-" {
+            let mut buf = String::new();
+            std::io::stdin().read_to_string(&mut buf)?;
+            buf
+        } else {
+            fs::read_to_string(input_source)
+                .with_context(|| format!("read input file: {input_source}"))?
+        };
+        serde_json::from_str::<MergeGateInput>(&raw).context("parse MergeGateInput JSON")?
+    } else if let Some(pr_number) = args.pr {
+        fetch_pr_from_gh(pr_number, repo_root)?
+    } else if let Some(head_sha) = args.head_sha {
+        MergeGateInput {
+            head_sha,
+            verdict: args.verdict,
+            verdict_sha: args.verdict_sha,
+            p0_count: args.p0,
+            p1_count: args.p1,
+            required_ci_green: args.ci_green,
+            failed_checks: Vec::new(),
+        }
+    } else {
+        anyhow::bail!(
+            "Specify either a PR number (e.g. 'edda prs check-merge 580') or '--input <FILE>'"
+        );
+    };
+
+    let result = evaluate_merge_preconditions(&input);
+
+    if args.json {
+        let json_out = serde_json::to_string_pretty(&result)?;
+        println!("{json_out}");
+    } else if result.can_merge {
+        println!("PASS: Merge preconditions satisfied.");
+        println!("  PR Head:     {}", result.head_sha);
+        println!(
+            "  Verdict:     {} (pinned at {})",
+            result.verdict.as_deref().unwrap_or("none"),
+            result.verdict_sha.as_deref().unwrap_or("none")
+        );
+        println!(
+            "  Findings:    P0={}, P1={}",
+            result.p0_count, result.p1_count
+        );
+        println!("  Required CI: green");
+    } else {
+        eprintln!(
+            "REFUSED: Merge preconditions not satisfied for head {}:",
+            result.head_sha
+        );
+        for reason in &result.reasons {
+            eprintln!("  - {reason}");
+        }
+    }
+
+    if args.merge {
+        if result.can_merge {
+            if let Some(pr_number) = args.pr {
+                println!("Executing merge: gh pr merge {pr_number} --squash");
+                let status = Command::new("gh")
+                    .args(["pr", "merge", &pr_number.to_string(), "--squash"])
+                    .current_dir(repo_root)
+                    .status()
+                    .context("execute gh pr merge")?;
+                if !status.success() {
+                    anyhow::bail!("gh pr merge failed with status {}", status);
+                }
+            } else {
+                anyhow::bail!("--merge requires a PR number positional argument");
+            }
+        } else {
+            eprintln!("Error: Cannot merge because preconditions failed.");
+            std::process::exit(1);
+        }
+    }
+
+    if !result.can_merge {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_refuse_when_no_verdict() {
+        let input = MergeGateInput {
+            head_sha: "abc1234567890123456789012345678901234567".into(),
+            verdict: None,
+            verdict_sha: None,
+            p0_count: 0,
+            p1_count: 0,
+            required_ci_green: true,
+            failed_checks: vec![],
+        };
+        let result = evaluate_merge_preconditions(&input);
+        assert!(!result.can_merge);
+        assert!(result
+            .reasons
+            .iter()
+            .any(|r| r.contains("no review verdict")));
+    }
+
+    #[test]
+    fn test_refuse_when_verdict_stale_new_push() {
+        let input = MergeGateInput {
+            head_sha: "new1234567890123456789012345678901234567".into(),
+            verdict: Some("LGTM".into()),
+            verdict_sha: Some("old1234567890123456789012345678901234567".into()),
+            p0_count: 0,
+            p1_count: 0,
+            required_ci_green: true,
+            failed_checks: vec![],
+        };
+        let result = evaluate_merge_preconditions(&input);
+        assert!(!result.can_merge);
+        assert!(result
+            .reasons
+            .iter()
+            .any(|r| r.contains("SHA window mismatch")));
+    }
+
+    #[test]
+    fn test_refuse_when_ci_not_green() {
+        let sha = "1234567890123456789012345678901234567890";
+        let input = MergeGateInput {
+            head_sha: sha.into(),
+            verdict: Some("LGTM".into()),
+            verdict_sha: Some(sha.into()),
+            p0_count: 0,
+            p1_count: 0,
+            required_ci_green: false,
+            failed_checks: vec!["CI Gate (fail)".into()],
+        };
+        let result = evaluate_merge_preconditions(&input);
+        assert!(!result.can_merge);
+        assert!(result.reasons.iter().any(|r| r.contains("CI Gate (fail)")));
+    }
+
+    #[test]
+    fn test_refuse_when_blocking_findings_or_changes_requested() {
+        let sha = "1234567890123456789012345678901234567890";
+        // Case A: Changes Requested
+        let input_cr = MergeGateInput {
+            head_sha: sha.into(),
+            verdict: Some("Changes Requested".into()),
+            verdict_sha: Some(sha.into()),
+            p0_count: 0,
+            p1_count: 0,
+            required_ci_green: true,
+            failed_checks: vec![],
+        };
+        let res_cr = evaluate_merge_preconditions(&input_cr);
+        assert!(!res_cr.can_merge);
+        assert!(res_cr.reasons.iter().any(|r| r.contains("not LGTM")));
+
+        // Case B: P0 > 0
+        let input_p0 = MergeGateInput {
+            head_sha: sha.into(),
+            verdict: Some("LGTM".into()),
+            verdict_sha: Some(sha.into()),
+            p0_count: 1,
+            p1_count: 0,
+            required_ci_green: true,
+            failed_checks: vec![],
+        };
+        let res_p0 = evaluate_merge_preconditions(&input_p0);
+        assert!(!res_p0.can_merge);
+        assert!(res_p0
+            .reasons
+            .iter()
+            .any(|r| r.contains("blocking findings present")));
+
+        // Case C: P1 > 0
+        let input_p1 = MergeGateInput {
+            head_sha: sha.into(),
+            verdict: Some("LGTM".into()),
+            verdict_sha: Some(sha.into()),
+            p0_count: 0,
+            p1_count: 2,
+            required_ci_green: true,
+            failed_checks: vec![],
+        };
+        let res_p1 = evaluate_merge_preconditions(&input_p1);
+        assert!(!res_p1.can_merge);
+        assert!(res_p1
+            .reasons
+            .iter()
+            .any(|r| r.contains("blocking findings present")));
+    }
+
+    #[test]
+    fn test_approve_when_all_preconditions_met() {
+        let sha = "fa208a3ab4911d3fa9f2dcd60fb332a8575f5b69";
+        let input = MergeGateInput {
+            head_sha: sha.into(),
+            verdict: Some("LGTM".into()),
+            verdict_sha: Some(sha.into()),
+            p0_count: 0,
+            p1_count: 0,
+            required_ci_green: true,
+            failed_checks: vec![],
+        };
+        let result = evaluate_merge_preconditions(&input);
+        assert!(result.can_merge);
+        assert!(result.reasons.is_empty());
+    }
+
+    #[test]
+    fn test_parse_verdict_text_extraction() {
+        let comment = r#"
+### Verdict
+LGTM (P0=0, P1=0) at `fa208a3ab4911d3fa9f2dcd60fb332a8575f5b69`
+CI is all green.
+"#;
+        let (verdict, sha, p0, p1) = parse_verdict_text(comment);
+        assert_eq!(verdict.as_deref(), Some("LGTM"));
+        assert_eq!(
+            sha.as_deref(),
+            Some("fa208a3ab4911d3fa9f2dcd60fb332a8575f5b69")
+        );
+        assert_eq!(p0, 0);
+        assert_eq!(p1, 0);
+    }
+}

--- a/crates/edda-cli/src/cmd_prs/merge_gate.rs
+++ b/crates/edda-cli/src/cmd_prs/merge_gate.rs
@@ -161,37 +161,44 @@ pub fn evaluate_merge_preconditions(input: &MergeGateInput) -> MergeGateResult {
 }
 
 // GitHub API / `gh` structures
-#[derive(Debug, Deserialize)]
-struct GhViewPr {
+#[allow(dead_code)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct GhViewPr {
     #[serde(rename = "headRefOid")]
-    head_ref_oid: String,
-    author: GhAuthor,
+    pub head_ref_oid: String,
     #[serde(default)]
-    comments: Vec<GhComment>,
+    pub author: Option<GhAuthor>,
     #[serde(default)]
-    reviews: Vec<GhReviewItem>,
+    pub comments: Vec<GhComment>,
+    #[serde(default)]
+    pub reviews: Vec<GhReviewItem>,
 }
 
-#[derive(Debug, Deserialize)]
-struct GhAuthor {
-    login: String,
+#[allow(dead_code)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct GhAuthor {
+    pub login: String,
 }
 
-#[derive(Debug, Deserialize)]
-struct GhComment {
-    body: String,
-    author: Option<GhAuthor>,
+#[allow(dead_code)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct GhComment {
+    pub body: String,
+    #[serde(default)]
+    pub author: Option<GhAuthor>,
     #[serde(rename = "createdAt")]
-    created_at: Option<String>,
+    pub created_at: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
-struct GhReviewItem {
-    state: String,
-    author: Option<GhAuthor>,
-    body: Option<String>,
+#[allow(dead_code)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct GhReviewItem {
+    pub state: String,
+    #[serde(default)]
+    pub author: Option<GhAuthor>,
+    pub body: Option<String>,
     #[serde(rename = "submittedAt")]
-    submitted_at: Option<String>,
+    pub submitted_at: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -207,8 +214,7 @@ pub fn is_structured_review_comment(body: &str) -> bool {
         || body.contains("### Verdict")
         || body.contains("<<<VERDICT")
         || body.contains("Verdict as of the ruling:")
-        || (body.contains("Verdict")
-            && (body.contains("LGTM") || body.contains("Changes Requested")))
+        || body.contains("**Verdict as of the ruling:")
 }
 
 fn parse_count(line: &str, prefix: &str) -> Option<usize> {
@@ -277,6 +283,75 @@ struct ReviewTimelineEvent {
     p1_count: usize,
 }
 
+/// Pure timeline extractor: processes reviews and structured comments into the final verdict.
+pub fn extract_timeline_verdict(
+    gh_view: &GhViewPr,
+) -> (Option<String>, Option<String>, usize, usize) {
+    let mut timeline: Vec<ReviewTimelineEvent> = Vec::new();
+
+    // 1. Process GitHub formal reviews (APPROVED / CHANGES_REQUESTED)
+    // The formal review state is strictly authoritative for the verdict (cannot be overridden by prose)
+    for r in &gh_view.reviews {
+        let verdict_opt = match r.state.as_str() {
+            "APPROVED" => Some("LGTM".to_string()),
+            "CHANGES_REQUESTED" => Some("Changes Requested".to_string()),
+            _ => None,
+        };
+
+        if let Some(formal_verdict) = verdict_opt {
+            // Parse body only for SHA, p0, p1 (formal review state is NOT overridden by prose)
+            let (_, sha, parsed_p0, parsed_p1) = if let Some(body) = &r.body {
+                parse_verdict_text(body)
+            } else {
+                (None, None, 0, 0)
+            };
+
+            let ts = r.submitted_at.clone().unwrap_or_default();
+            timeline.push(ReviewTimelineEvent {
+                timestamp: ts,
+                verdict: formal_verdict,
+                verdict_sha: sha,
+                p0_count: parsed_p0,
+                p1_count: parsed_p1,
+            });
+        }
+    }
+
+    // 2. Process structured review comments
+    // Comments must meet is_structured_review_comment to ensure casual comments are ignored
+    for comment in &gh_view.comments {
+        if !is_structured_review_comment(&comment.body) {
+            continue;
+        }
+
+        let (v, sha, parsed_p0, parsed_p1) = parse_verdict_text(&comment.body);
+        if let Some(found_v) = v {
+            let ts = comment.created_at.clone().unwrap_or_default();
+            timeline.push(ReviewTimelineEvent {
+                timestamp: ts,
+                verdict: found_v,
+                verdict_sha: sha,
+                p0_count: parsed_p0,
+                p1_count: parsed_p1,
+            });
+        }
+    }
+
+    // Sort timeline chronologically (oldest to newest) so the newest review event wins
+    timeline.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+
+    if let Some(latest) = timeline.pop() {
+        (
+            Some(latest.verdict),
+            latest.verdict_sha,
+            latest.p0_count,
+            latest.p1_count,
+        )
+    } else {
+        (None, None, 0, 0)
+    }
+}
+
 fn fetch_pr_from_gh(pr: u64, repo_root: &Path) -> anyhow::Result<MergeGateInput> {
     let view_output = Command::new("gh")
         .args([
@@ -298,85 +373,10 @@ fn fetch_pr_from_gh(pr: u64, repo_root: &Path) -> anyhow::Result<MergeGateInput>
     let gh_view: GhViewPr =
         serde_json::from_slice(&view_output.stdout).context("parse gh pr view json output")?;
 
-    let head_sha = gh_view.head_ref_oid;
-    let pr_author = gh_view.author.login.as_str();
+    let head_sha = gh_view.head_ref_oid.clone();
+    let (verdict, verdict_sha, p0, p1) = extract_timeline_verdict(&gh_view);
 
-    let mut timeline: Vec<ReviewTimelineEvent> = Vec::new();
-
-    // 1. Process GitHub review approvals / changes_requested
-    for r in &gh_view.reviews {
-        if let Some(reviewer) = &r.author {
-            if reviewer.login == pr_author {
-                continue; // Author cannot review their own PR
-            }
-        }
-
-        let verdict_opt = match r.state.as_str() {
-            "APPROVED" => Some("LGTM".to_string()),
-            "CHANGES_REQUESTED" => Some("Changes Requested".to_string()),
-            _ => None,
-        };
-
-        if let Some(v) = verdict_opt {
-            let (body_v, sha, parsed_p0, parsed_p1) = if let Some(body) = &r.body {
-                parse_verdict_text(body)
-            } else {
-                (None, None, 0, 0)
-            };
-
-            let final_v = body_v.unwrap_or(v);
-            let ts = r.submitted_at.clone().unwrap_or_default();
-
-            timeline.push(ReviewTimelineEvent {
-                timestamp: ts,
-                verdict: final_v,
-                verdict_sha: sha,
-                p0_count: parsed_p0,
-                p1_count: parsed_p1,
-            });
-        }
-    }
-
-    // 2. Process structured review comments from non-authors
-    for comment in &gh_view.comments {
-        if let Some(author) = &comment.author {
-            if author.login == pr_author {
-                continue; // Ignore comments from PR author (e.g. implementer review response)
-            }
-        }
-
-        if !is_structured_review_comment(&comment.body) {
-            continue;
-        }
-
-        let (v, sha, parsed_p0, parsed_p1) = parse_verdict_text(&comment.body);
-        if let Some(found_v) = v {
-            let ts = comment.created_at.clone().unwrap_or_default();
-            timeline.push(ReviewTimelineEvent {
-                timestamp: ts,
-                verdict: found_v,
-                verdict_sha: sha,
-                p0_count: parsed_p0,
-                p1_count: parsed_p1,
-            });
-        }
-    }
-
-    // Sort timeline chronologically (oldest to newest) so the newest review event wins
-    timeline.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
-
-    let (verdict, verdict_sha, p0, p1) = if let Some(latest) = timeline.pop() {
-        (
-            Some(latest.verdict),
-            latest.verdict_sha,
-            latest.p0_count,
-            latest.p1_count,
-        )
-    } else {
-        (None, None, 0, 0)
-    };
-
-    // 3. Fetch PR checks
+    // Fetch PR checks
     let checks_output = Command::new("gh")
         .args([
             "pr",
@@ -507,7 +507,10 @@ pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result
 
     if args.merge {
         if result.can_merge {
-            let pr_number = args.pr.expect("checked above");
+            let pr_number = match args.pr {
+                Some(num) => num,
+                None => anyhow::bail!("--merge requires a PR number positional argument"),
+            };
             println!("Executing merge: gh pr merge {pr_number} --squash");
             let status = Command::new("gh")
                 .args(["pr", "merge", &pr_number.to_string(), "--squash"])
@@ -700,11 +703,76 @@ Commit: 1234567890abcdef1234567890abcdef12345678
             "### Verdict\nChanges Requested"
         ));
         assert!(is_structured_review_comment("<<<VERDICT\nLGTM\nVERDICT>>>"));
+        assert!(is_structured_review_comment(
+            "Verdict as of the ruling: LGTM"
+        ));
+        assert!(is_structured_review_comment(
+            "**Verdict as of the ruling: LGTM**"
+        ));
         // Casual comments must NOT match
         assert!(!is_structured_review_comment("ready for LGTM review"));
         assert!(!is_structured_review_comment(
             "I fixed the bug, please LGTM"
         ));
+        assert!(!is_structured_review_comment("Not an LGTM yet"));
+    }
+
+    #[test]
+    fn test_formal_review_state_not_overridden_by_prose() {
+        let gh_view = GhViewPr {
+            head_ref_oid: VALID_SHA_A.into(),
+            author: Some(GhAuthor {
+                login: "fagemx".into(),
+            }),
+            comments: vec![],
+            reviews: vec![GhReviewItem {
+                state: "CHANGES_REQUESTED".into(),
+                author: Some(GhAuthor {
+                    login: "reviewer".into(),
+                }),
+                body: Some(format!(
+                    "Not an LGTM yet - see inline notes. @ {VALID_SHA_A}"
+                )),
+                submitted_at: Some("2026-09-02T10:00:00Z".into()),
+            }],
+        };
+
+        let (verdict, sha, p0, p1) = extract_timeline_verdict(&gh_view);
+        assert_eq!(verdict.as_deref(), Some("Changes Requested"));
+        assert_eq!(sha.as_deref(), Some(VALID_SHA_A));
+        assert_eq!(p0, 0);
+        assert_eq!(p1, 0);
+    }
+
+    #[test]
+    fn test_timeline_chronological_order() {
+        let gh_view = GhViewPr {
+            head_ref_oid: VALID_SHA_A.into(),
+            author: Some(GhAuthor {
+                login: "fagemx".into(),
+            }),
+            comments: vec![GhComment {
+                body: format!(
+                    "## Code Review: Round 1\n\n### Verdict\nLGTM (P0=0, P1=0) at `{VALID_SHA_A}`"
+                ),
+                author: Some(GhAuthor {
+                    login: "fagemx".into(),
+                }),
+                created_at: Some("2026-09-02T08:00:00Z".into()),
+            }],
+            reviews: vec![GhReviewItem {
+                state: "CHANGES_REQUESTED".into(),
+                author: Some(GhAuthor {
+                    login: "fagemx".into(),
+                }),
+                body: Some(format!("blocking findings @ {VALID_SHA_A}")),
+                submitted_at: Some("2026-09-02T09:00:00Z".into()),
+            }],
+        };
+
+        // Newer CHANGES_REQUESTED review (09:00) wins over older LGTM comment (08:00)
+        let (verdict, _, _, _) = extract_timeline_verdict(&gh_view);
+        assert_eq!(verdict.as_deref(), Some("Changes Requested"));
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_prs/merge_gate.rs
+++ b/crates/edda-cli/src/cmd_prs/merge_gate.rs
@@ -10,7 +10,7 @@ use std::process::Command;
 #[derive(Debug, Clone, Args)]
 pub struct CheckMergeArgs {
     /// PR number to evaluate (queries GitHub via `gh` CLI)
-    #[arg(value_name = "PR")]
+    #[arg(value_name = "PR", conflicts_with = "input")]
     pub pr: Option<u64>,
 
     /// Explicit head commit SHA
@@ -79,11 +79,25 @@ pub struct MergeGateResult {
     pub reasons: Vec<String>,
 }
 
+/// Check if string is a valid 40-character hex commit SHA.
+pub fn is_valid_40_hex_sha(sha: &str) -> bool {
+    let s = sha.trim();
+    s.len() == 40 && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
 /// Pure evaluation function without host or network dependencies.
 pub fn evaluate_merge_preconditions(input: &MergeGateInput) -> MergeGateResult {
     let mut reasons = Vec::new();
 
-    // 1. Verdict presence & state
+    // 1. Validate head SHA shape
+    let h_clean = input.head_sha.trim();
+    if !is_valid_40_hex_sha(h_clean) {
+        reasons.push(format!(
+            "head_sha '{h_clean}' is not a valid 40-character hex commit SHA"
+        ));
+    }
+
+    // 2. Verdict presence & state
     match &input.verdict {
         None => {
             reasons.push("no review verdict found on PR".to_string());
@@ -98,7 +112,7 @@ pub fn evaluate_merge_preconditions(input: &MergeGateInput) -> MergeGateResult {
         }
     }
 
-    // 2. Blocking findings (P0=0 and P1=0)
+    // 3. Blocking findings (P0=0 and P1=0)
     if input.p0_count > 0 || input.p1_count > 0 {
         reasons.push(format!(
             "blocking findings present: {} P0, {} P1 (both must be 0)",
@@ -106,17 +120,14 @@ pub fn evaluate_merge_preconditions(input: &MergeGateInput) -> MergeGateResult {
         ));
     }
 
-    // 3. SHA window check (verdict SHA must match current PR head)
+    // 4. SHA window check (verdict SHA must match current PR head exactly)
     if let Some(v_sha) = &input.verdict_sha {
         let v_clean = v_sha.trim();
-        let h_clean = input.head_sha.trim();
-        let matches = if v_clean.len() >= 7 && h_clean.len() >= 7 {
-            v_clean == h_clean || v_clean.starts_with(h_clean) || h_clean.starts_with(v_clean)
-        } else {
-            v_clean == h_clean
-        };
-
-        if !matches {
+        if !is_valid_40_hex_sha(v_clean) {
+            reasons.push(format!(
+                "verdict_sha '{v_clean}' is not a valid 40-character hex commit SHA"
+            ));
+        } else if !v_clean.eq_ignore_ascii_case(h_clean) {
             reasons.push(format!(
                 "SHA window mismatch: verdict pinned to '{v_clean}' but current head is '{h_clean}' (new commits pushed after review)"
             ));
@@ -125,7 +136,7 @@ pub fn evaluate_merge_preconditions(input: &MergeGateInput) -> MergeGateResult {
         reasons.push("review verdict is not pinned to any commit SHA".to_string());
     }
 
-    // 4. Required CI checks
+    // 5. Required CI checks
     if !input.required_ci_green {
         if input.failed_checks.is_empty() {
             reasons.push("required CI check(s) are not green".to_string());
@@ -154,6 +165,7 @@ pub fn evaluate_merge_preconditions(input: &MergeGateInput) -> MergeGateResult {
 struct GhViewPr {
     #[serde(rename = "headRefOid")]
     head_ref_oid: String,
+    author: GhAuthor,
     #[serde(default)]
     comments: Vec<GhComment>,
     #[serde(default)]
@@ -161,18 +173,25 @@ struct GhViewPr {
 }
 
 #[derive(Debug, Deserialize)]
+struct GhAuthor {
+    login: String,
+}
+
+#[derive(Debug, Deserialize)]
 struct GhComment {
     body: String,
+    author: Option<GhAuthor>,
     #[serde(rename = "createdAt")]
-    _created_at: Option<String>,
+    created_at: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 struct GhReviewItem {
     state: String,
+    author: Option<GhAuthor>,
     body: Option<String>,
     #[serde(rename = "submittedAt")]
-    _submitted_at: Option<String>,
+    submitted_at: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -180,6 +199,23 @@ struct GhCheckItem {
     name: String,
     state: Option<String>,
     bucket: Option<String>,
+}
+
+/// Determines if a comment is a structured review verdict, preventing casual comments from triggering a verdict.
+pub fn is_structured_review_comment(body: &str) -> bool {
+    body.contains("## Code Review:")
+        || body.contains("### Verdict")
+        || body.contains("<<<VERDICT")
+        || body.contains("Verdict as of the ruling:")
+        || (body.contains("Verdict")
+            && (body.contains("LGTM") || body.contains("Changes Requested")))
+}
+
+fn parse_count(line: &str, prefix: &str) -> Option<usize> {
+    let idx = line.find(prefix)?;
+    let rest = line[idx + prefix.len()..].trim_start_matches([':', '=', ' ']);
+    let num_str: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    num_str.parse::<usize>().ok()
 }
 
 /// Extract verdict info (verdict, verdict_sha, p0, p1) from comment or review body text
@@ -208,45 +244,21 @@ pub fn parse_verdict_text(text: &str) -> (Option<String>, Option<String>, usize,
     }
 
     for line in text.lines() {
-        if let Some(idx) = line.find("P0=") {
-            let rest = &line[idx + 3..];
-            if let Some(digit) = rest.chars().next().and_then(|c| c.to_digit(10)) {
-                p0 = digit as usize;
-            }
-        } else if let Some(idx) = line.find("P0:") {
-            let rest = line[idx + 3..].trim();
-            if let Some(digit) = rest.chars().next().and_then(|c| c.to_digit(10)) {
-                p0 = digit as usize;
-            }
+        if let Some(val) = parse_count(line, "P0") {
+            p0 = p0.max(val);
+        } else if let Some(val) = parse_count(line, "p0") {
+            p0 = p0.max(val);
         }
 
-        if let Some(idx) = line.find("P1=") {
-            let rest = &line[idx + 3..];
-            if let Some(digit) = rest.chars().next().and_then(|c| c.to_digit(10)) {
-                p1 = digit as usize;
-            }
-        } else if let Some(idx) = line.find("P1:") {
-            let rest = line[idx + 3..].trim();
-            if let Some(digit) = rest.chars().next().and_then(|c| c.to_digit(10)) {
-                p1 = digit as usize;
-            }
+        if let Some(val) = parse_count(line, "P1") {
+            p1 = p1.max(val);
+        } else if let Some(val) = parse_count(line, "p1") {
+            p1 = p1.max(val);
         }
     }
 
     for word in text.split_whitespace() {
-        let clean = word.trim_matches(|c: char| {
-            c == '*'
-                || c == '`'
-                || c == '('
-                || c == ')'
-                || c == '.'
-                || c == ','
-                || c == ':'
-                || c == '"'
-                || c == '\''
-                || c == '['
-                || c == ']'
-        });
+        let clean = word.trim_matches(['*', '`', '(', ')', '.', ',', ':', '"', '\'', '[', ']']);
         if clean.len() == 40 && clean.chars().all(|c| c.is_ascii_hexdigit()) {
             verdict_sha = Some(clean.to_string());
             break;
@@ -256,6 +268,15 @@ pub fn parse_verdict_text(text: &str) -> (Option<String>, Option<String>, usize,
     (verdict, verdict_sha, p0, p1)
 }
 
+#[derive(Debug)]
+struct ReviewTimelineEvent {
+    timestamp: String,
+    verdict: String,
+    verdict_sha: Option<String>,
+    p0_count: usize,
+    p1_count: usize,
+}
+
 fn fetch_pr_from_gh(pr: u64, repo_root: &Path) -> anyhow::Result<MergeGateInput> {
     let view_output = Command::new("gh")
         .args([
@@ -263,7 +284,7 @@ fn fetch_pr_from_gh(pr: u64, repo_root: &Path) -> anyhow::Result<MergeGateInput>
             "view",
             &pr.to_string(),
             "--json",
-            "headRefOid,comments,reviews",
+            "headRefOid,author,comments,reviews",
         ])
         .current_dir(repo_root)
         .output()
@@ -278,51 +299,84 @@ fn fetch_pr_from_gh(pr: u64, repo_root: &Path) -> anyhow::Result<MergeGateInput>
         serde_json::from_slice(&view_output.stdout).context("parse gh pr view json output")?;
 
     let head_sha = gh_view.head_ref_oid;
+    let pr_author = gh_view.author.login.as_str();
 
-    let mut verdict = None;
-    let mut verdict_sha = None;
-    let mut p0 = 0;
-    let mut p1 = 0;
+    let mut timeline: Vec<ReviewTimelineEvent> = Vec::new();
 
-    for r in gh_view.reviews.iter().rev() {
-        if r.state == "APPROVED" {
-            verdict = Some("LGTM".to_string());
-            if let Some(body) = &r.body {
-                let (_, sha, parsed_p0, parsed_p1) = parse_verdict_text(body);
-                if sha.is_some() {
-                    verdict_sha = sha;
-                }
-                p0 = parsed_p0;
-                p1 = parsed_p1;
+    // 1. Process GitHub review approvals / changes_requested
+    for r in &gh_view.reviews {
+        if let Some(reviewer) = &r.author {
+            if reviewer.login == pr_author {
+                continue; // Author cannot review their own PR
             }
-            break;
-        } else if r.state == "CHANGES_REQUESTED" {
-            verdict = Some("Changes Requested".to_string());
-            if let Some(body) = &r.body {
-                let (_, sha, parsed_p0, parsed_p1) = parse_verdict_text(body);
-                if sha.is_some() {
-                    verdict_sha = sha;
-                }
-                p0 = parsed_p0;
-                p1 = parsed_p1;
-            }
-            break;
+        }
+
+        let verdict_opt = match r.state.as_str() {
+            "APPROVED" => Some("LGTM".to_string()),
+            "CHANGES_REQUESTED" => Some("Changes Requested".to_string()),
+            _ => None,
+        };
+
+        if let Some(v) = verdict_opt {
+            let (body_v, sha, parsed_p0, parsed_p1) = if let Some(body) = &r.body {
+                parse_verdict_text(body)
+            } else {
+                (None, None, 0, 0)
+            };
+
+            let final_v = body_v.unwrap_or(v);
+            let ts = r.submitted_at.clone().unwrap_or_default();
+
+            timeline.push(ReviewTimelineEvent {
+                timestamp: ts,
+                verdict: final_v,
+                verdict_sha: sha,
+                p0_count: parsed_p0,
+                p1_count: parsed_p1,
+            });
         }
     }
 
-    for comment in gh_view.comments.iter().rev() {
+    // 2. Process structured review comments from non-authors
+    for comment in &gh_view.comments {
+        if let Some(author) = &comment.author {
+            if author.login == pr_author {
+                continue; // Ignore comments from PR author (e.g. implementer review response)
+            }
+        }
+
+        if !is_structured_review_comment(&comment.body) {
+            continue;
+        }
+
         let (v, sha, parsed_p0, parsed_p1) = parse_verdict_text(&comment.body);
         if let Some(found_v) = v {
-            verdict = Some(found_v);
-            if sha.is_some() {
-                verdict_sha = sha;
-            }
-            p0 = parsed_p0;
-            p1 = parsed_p1;
-            break;
+            let ts = comment.created_at.clone().unwrap_or_default();
+            timeline.push(ReviewTimelineEvent {
+                timestamp: ts,
+                verdict: found_v,
+                verdict_sha: sha,
+                p0_count: parsed_p0,
+                p1_count: parsed_p1,
+            });
         }
     }
 
+    // Sort timeline chronologically (oldest to newest) so the newest review event wins
+    timeline.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+
+    let (verdict, verdict_sha, p0, p1) = if let Some(latest) = timeline.pop() {
+        (
+            Some(latest.verdict),
+            latest.verdict_sha,
+            latest.p0_count,
+            latest.p1_count,
+        )
+    } else {
+        (None, None, 0, 0)
+    };
+
+    // 3. Fetch PR checks
     let checks_output = Command::new("gh")
         .args([
             "pr",
@@ -346,6 +400,7 @@ fn fetch_pr_from_gh(pr: u64, repo_root: &Path) -> anyhow::Result<MergeGateInput>
 
         if let Some(ci_gate) = ci_gate_item {
             let pass = ci_gate.bucket.as_deref() == Some("pass")
+                || ci_gate.bucket.as_deref() == Some("skipping")
                 || ci_gate.state.as_deref() == Some("SUCCESS");
             if !pass {
                 required_ci_green = false;
@@ -356,8 +411,9 @@ fn fetch_pr_from_gh(pr: u64, repo_root: &Path) -> anyhow::Result<MergeGateInput>
             }
         } else if !checks.is_empty() {
             for c in &checks {
-                let pass =
-                    c.bucket.as_deref() == Some("pass") || c.state.as_deref() == Some("SUCCESS");
+                let pass = c.bucket.as_deref() == Some("pass")
+                    || c.bucket.as_deref() == Some("skipping")
+                    || c.state.as_deref() == Some("SUCCESS");
                 if !pass {
                     required_ci_green = false;
                     failed_checks.push(format!(
@@ -389,6 +445,10 @@ fn fetch_pr_from_gh(pr: u64, repo_root: &Path) -> anyhow::Result<MergeGateInput>
 
 /// Execute the merge precondition check CLI entrypoint.
 pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result<()> {
+    if args.merge && (args.pr.is_none() || args.input.is_some()) {
+        anyhow::bail!("--merge requires a live PR number and cannot be used with '--input'");
+    }
+
     let input = if let Some(input_source) = &args.input {
         let raw = if input_source == "-" {
             let mut buf = String::new();
@@ -447,18 +507,15 @@ pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result
 
     if args.merge {
         if result.can_merge {
-            if let Some(pr_number) = args.pr {
-                println!("Executing merge: gh pr merge {pr_number} --squash");
-                let status = Command::new("gh")
-                    .args(["pr", "merge", &pr_number.to_string(), "--squash"])
-                    .current_dir(repo_root)
-                    .status()
-                    .context("execute gh pr merge")?;
-                if !status.success() {
-                    anyhow::bail!("gh pr merge failed with status {}", status);
-                }
-            } else {
-                anyhow::bail!("--merge requires a PR number positional argument");
+            let pr_number = args.pr.expect("checked above");
+            println!("Executing merge: gh pr merge {pr_number} --squash");
+            let status = Command::new("gh")
+                .args(["pr", "merge", &pr_number.to_string(), "--squash"])
+                .current_dir(repo_root)
+                .status()
+                .context("execute gh pr merge")?;
+            if !status.success() {
+                anyhow::bail!("gh pr merge failed with status {}", status);
             }
         } else {
             eprintln!("Error: Cannot merge because preconditions failed.");
@@ -477,10 +534,13 @@ pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result
 mod tests {
     use super::*;
 
+    const VALID_SHA_A: &str = "1234567890abcdef1234567890abcdef12345678";
+    const VALID_SHA_B: &str = "abcdef1234567890abcdef1234567890abcdef12";
+
     #[test]
     fn test_refuse_when_no_verdict() {
         let input = MergeGateInput {
-            head_sha: "abc1234567890123456789012345678901234567".into(),
+            head_sha: VALID_SHA_A.into(),
             verdict: None,
             verdict_sha: None,
             p0_count: 0,
@@ -499,9 +559,9 @@ mod tests {
     #[test]
     fn test_refuse_when_verdict_stale_new_push() {
         let input = MergeGateInput {
-            head_sha: "new1234567890123456789012345678901234567".into(),
+            head_sha: VALID_SHA_B.into(),
             verdict: Some("LGTM".into()),
-            verdict_sha: Some("old1234567890123456789012345678901234567".into()),
+            verdict_sha: Some(VALID_SHA_A.into()),
             p0_count: 0,
             p1_count: 0,
             required_ci_green: true,
@@ -516,12 +576,30 @@ mod tests {
     }
 
     #[test]
-    fn test_refuse_when_ci_not_green() {
-        let sha = "1234567890123456789012345678901234567890";
+    fn test_refuse_when_sha_is_invalid() {
         let input = MergeGateInput {
-            head_sha: sha.into(),
+            head_sha: "short".into(),
             verdict: Some("LGTM".into()),
-            verdict_sha: Some(sha.into()),
+            verdict_sha: Some("short".into()),
+            p0_count: 0,
+            p1_count: 0,
+            required_ci_green: true,
+            failed_checks: vec![],
+        };
+        let result = evaluate_merge_preconditions(&input);
+        assert!(!result.can_merge);
+        assert!(result
+            .reasons
+            .iter()
+            .any(|r| r.contains("not a valid 40-character hex commit SHA")));
+    }
+
+    #[test]
+    fn test_refuse_when_ci_not_green() {
+        let input = MergeGateInput {
+            head_sha: VALID_SHA_A.into(),
+            verdict: Some("LGTM".into()),
+            verdict_sha: Some(VALID_SHA_A.into()),
             p0_count: 0,
             p1_count: 0,
             required_ci_green: false,
@@ -534,12 +612,11 @@ mod tests {
 
     #[test]
     fn test_refuse_when_blocking_findings_or_changes_requested() {
-        let sha = "1234567890123456789012345678901234567890";
         // Case A: Changes Requested
         let input_cr = MergeGateInput {
-            head_sha: sha.into(),
+            head_sha: VALID_SHA_A.into(),
             verdict: Some("Changes Requested".into()),
-            verdict_sha: Some(sha.into()),
+            verdict_sha: Some(VALID_SHA_A.into()),
             p0_count: 0,
             p1_count: 0,
             required_ci_green: true,
@@ -549,28 +626,25 @@ mod tests {
         assert!(!res_cr.can_merge);
         assert!(res_cr.reasons.iter().any(|r| r.contains("not LGTM")));
 
-        // Case B: P0 > 0
+        // Case B: P0 > 0 (e.g. 12)
         let input_p0 = MergeGateInput {
-            head_sha: sha.into(),
+            head_sha: VALID_SHA_A.into(),
             verdict: Some("LGTM".into()),
-            verdict_sha: Some(sha.into()),
-            p0_count: 1,
+            verdict_sha: Some(VALID_SHA_A.into()),
+            p0_count: 12,
             p1_count: 0,
             required_ci_green: true,
             failed_checks: vec![],
         };
         let res_p0 = evaluate_merge_preconditions(&input_p0);
         assert!(!res_p0.can_merge);
-        assert!(res_p0
-            .reasons
-            .iter()
-            .any(|r| r.contains("blocking findings present")));
+        assert!(res_p0.reasons.iter().any(|r| r.contains("12 P0")));
 
         // Case C: P1 > 0
         let input_p1 = MergeGateInput {
-            head_sha: sha.into(),
+            head_sha: VALID_SHA_A.into(),
             verdict: Some("LGTM".into()),
-            verdict_sha: Some(sha.into()),
+            verdict_sha: Some(VALID_SHA_A.into()),
             p0_count: 0,
             p1_count: 2,
             required_ci_green: true,
@@ -586,11 +660,10 @@ mod tests {
 
     #[test]
     fn test_approve_when_all_preconditions_met() {
-        let sha = "fa208a3ab4911d3fa9f2dcd60fb332a8575f5b69";
         let input = MergeGateInput {
-            head_sha: sha.into(),
+            head_sha: VALID_SHA_A.into(),
             verdict: Some("LGTM".into()),
-            verdict_sha: Some(sha.into()),
+            verdict_sha: Some(VALID_SHA_A.to_uppercase()), // case-insensitive equality
             p0_count: 0,
             p1_count: 0,
             required_ci_green: true,
@@ -602,19 +675,94 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_verdict_text_extraction() {
+    fn test_parse_verdict_text_multi_digits() {
         let comment = r#"
 ### Verdict
-LGTM (P0=0, P1=0) at `fa208a3ab4911d3fa9f2dcd60fb332a8575f5b69`
-CI is all green.
+Changes Requested, P0=12, P1=3
+Commit: 1234567890abcdef1234567890abcdef12345678
 "#;
         let (verdict, sha, p0, p1) = parse_verdict_text(comment);
-        assert_eq!(verdict.as_deref(), Some("LGTM"));
+        assert_eq!(verdict.as_deref(), Some("Changes Requested"));
         assert_eq!(
             sha.as_deref(),
-            Some("fa208a3ab4911d3fa9f2dcd60fb332a8575f5b69")
+            Some("1234567890abcdef1234567890abcdef12345678")
         );
-        assert_eq!(p0, 0);
-        assert_eq!(p1, 0);
+        assert_eq!(p0, 12);
+        assert_eq!(p1, 3);
+    }
+
+    #[test]
+    fn test_is_structured_review_comment() {
+        assert!(is_structured_review_comment(
+            "## Code Review: Round 1\nLGTM"
+        ));
+        assert!(is_structured_review_comment(
+            "### Verdict\nChanges Requested"
+        ));
+        assert!(is_structured_review_comment("<<<VERDICT\nLGTM\nVERDICT>>>"));
+        // Casual comments must NOT match
+        assert!(!is_structured_review_comment("ready for LGTM review"));
+        assert!(!is_structured_review_comment(
+            "I fixed the bug, please LGTM"
+        ));
+    }
+
+    #[test]
+    fn test_run_check_merge_input_file_report_only() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let input_file = temp_dir.path().join("input.json");
+        let valid_input = MergeGateInput {
+            head_sha: VALID_SHA_A.into(),
+            verdict: Some("LGTM".into()),
+            verdict_sha: Some(VALID_SHA_A.into()),
+            p0_count: 0,
+            p1_count: 0,
+            required_ci_green: true,
+            failed_checks: vec![],
+        };
+        fs::write(&input_file, serde_json::to_string(&valid_input).unwrap()).unwrap();
+
+        let args = CheckMergeArgs {
+            pr: None,
+            head_sha: None,
+            verdict_sha: None,
+            verdict: None,
+            p0: 0,
+            p1: 0,
+            ci_green: false,
+            input: Some(input_file.to_str().unwrap().into()),
+            merge: false,
+            json: true,
+        };
+
+        let res = run_check_merge(args, temp_dir.path());
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_run_check_merge_rejects_merge_with_input_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let input_file = temp_dir.path().join("input.json");
+        fs::write(&input_file, "{}").unwrap();
+
+        let args = CheckMergeArgs {
+            pr: None,
+            head_sha: None,
+            verdict_sha: None,
+            verdict: None,
+            p0: 0,
+            p1: 0,
+            ci_green: false,
+            input: Some(input_file.to_str().unwrap().into()),
+            merge: true,
+            json: false,
+        };
+
+        let res = run_check_merge(args, temp_dir.path());
+        assert!(res.is_err());
+        assert!(res
+            .unwrap_err()
+            .to_string()
+            .contains("cannot be used with '--input'"));
     }
 }


### PR DESCRIPTION
Issue: #580

## Summary

Implements \dda prs check-merge\ as an automated gate to evaluate PR merge preconditions per \pr.merge-policy\ and \ci.merge-gate\.

## Changes

- Pure evaluator \valuate_merge_preconditions\:
  - Enforces review verdict presence and requires \LGTM\ (or \Approved\).
  - Enforces zero blocking findings (\p0 == 0 && p1 == 0\).
  - Enforces SHA window (\erdict_sha == head_sha\), refusing any PR where new commits were pushed after review.
  - Enforces required CI checks (such as \CI Gate\).
  - Outputs detailed diagnostic reasons for refusal.
- CLI subcommand \dda prs check-merge\:
  - Positionally takes \<PR>\ and queries GitHub via \gh pr view\ and \gh pr checks\.
  - Supports \--input <FILE>\ (or stdin \-\) for pure host-agnostic / offline evaluation.
  - Supports \--head-sha\, \--verdict-sha\, \--verdict\, \--ci-green\ flag overrides.
  - Report-only by default (exit 0 on pass, exit 1 on refusal).
  - Merges via \gh pr merge <PR> --squash\ only when \--merge\ flag is explicitly provided.
  - Supports \--json\ for machine-readable evaluation reports.

## Verification

- L0/L1 gates on crate \dda\:
  - \cargo fmt --check\: pass
  - \cargo clippy -p edda --all-targets -- -D warnings\: pass
  - \cargo test -p edda --bin edda cmd_prs\: pass
- Tested on live PRs:
  - PR #687 (valid merged LGTM): PASS (\can_merge: true\)
  - PR #673 (open PR with Changes Requested and moved head): REFUSED (\can_merge: false\, correctly cites non-LGTM, 2 P0s, and SHA window mismatch)