### PR TITLE
fix(edda-conductor): manual skip on a pending phase survives concurrent runner saves (GH-556)

### DIFF
--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -17,7 +17,7 @@ use crate::state::machine::{
     transition, CheckResult, CheckStatus, ErrorInfo, ErrorType, PhaseStatus, PhaseUpdate,
     PlanState, PlanStatus,
 };
-use crate::state::persist::save_state;
+use crate::state::persist::save_state_reconciled;
 use crate::tmux::TmuxSession;
 use anyhow::Context;
 use anyhow::Result;
@@ -75,7 +75,7 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
     // exactly-once across repeated `edda conduct run` invocations.
     let stale_transitions = detect_stale_phases(state, plan);
     if !stale_transitions.is_empty() {
-        save_state(cwd, state)?;
+        save_state_reconciled(cwd, state)?;
         event_log::write_runner_status(cwd, state, None);
         write_brief(cwd, state, None);
     }
@@ -91,7 +91,7 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
     if state.started_at.is_none() {
         state.started_at = Some(now_rfc3339());
         state.plan_status = PlanStatus::Running;
-        save_state(cwd, state)?;
+        save_state_reconciled(cwd, state)?;
         event_log::write_runner_status(cwd, state, None);
         write_brief(cwd, state, None);
         event_log.record(Event::PlanStart {
@@ -129,7 +129,7 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                             .unwrap_or(PhaseStatus::Failed);
                         let _ = transition(state, &failed_id, current, PhaseStatus::Pending, None);
                         state.plan_status = PlanStatus::Running;
-                        save_state(cwd, state)?;
+                        save_state_reconciled(cwd, state)?;
                         println!("  ↻ Retrying \"{failed_id}\"");
                         continue;
                     }
@@ -138,7 +138,7 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                         ps.status = PhaseStatus::Skipped;
                         ps.skip_reason = Some("manually skipped (interactive)".into());
                         state.plan_status = PlanStatus::Running;
-                        save_state(cwd, state)?;
+                        save_state_reconciled(cwd, state)?;
                         event_log.record(Event::PhaseSkipped {
                             phase_id: failed_id.clone(),
                             reason: "manually skipped (interactive)".into(),
@@ -160,7 +160,7 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                     BlockedAction::Abort => {
                         state.plan_status = PlanStatus::Aborted;
                         state.aborted_at = Some(now_rfc3339());
-                        save_state(cwd, state)?;
+                        save_state_reconciled(cwd, state)?;
                         // GH-584 round-2 P1-1: the plan abort reaches the
                         // workspace ledger as a structured conductor_plan
                         // event, not only the plan-local event log.
@@ -445,7 +445,7 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                             PhaseStatus::Running,
                             None,
                         )?;
-                        save_state(cwd, state)?;
+                        save_state_reconciled(cwd, state)?;
                         println!(
                             "  ↻ Redispatching one more turn in the same session ({session_id})"
                         );
@@ -553,7 +553,7 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                 }
             }
 
-            save_state(cwd, state)?;
+            save_state_reconciled(cwd, state)?;
             event_log::write_runner_status(cwd, state, Some(&gated_id));
             write_brief(cwd, state, None);
             continue;
@@ -600,7 +600,7 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                 ..Default::default()
             }),
         )?;
-        save_state(cwd, state)?;
+        save_state_reconciled(cwd, state)?;
 
         println!("\n▶ [{phase_num}/{total_phases}] Phase \"{phase_id}\" (attempt {attempt})");
         if let Some(tmux) = tmux_session {
@@ -665,7 +665,7 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
         )
         .await?;
 
-        save_state(cwd, state)?;
+        save_state_reconciled(cwd, state)?;
     }
 
     // Plan completion check
@@ -673,7 +673,7 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
     if is_plan_complete(state) {
         state.plan_status = PlanStatus::Completed;
         state.completed_at = Some(now_rfc3339());
-        save_state(cwd, state)?;
+        save_state_reconciled(cwd, state)?;
         let passed = state
             .phases
             .iter()
@@ -1032,7 +1032,7 @@ async fn process_phase_result(
                 PhaseStatus::Checking,
                 None,
             )?;
-            save_state(cwd, state)?;
+            save_state_reconciled(cwd, state)?;
 
             // GH-566: the lane heartbeat must cover the whole phase
             // lifetime — keep it beating (stage "checking") while the
@@ -3615,7 +3615,7 @@ phases:
                 .format(&time::format_description::well_known::Rfc3339)
                 .unwrap_or_default(),
         );
-        save_state(dir.path(), &persisted).unwrap();
+        crate::state::persist::save_state(dir.path(), &persisted).unwrap();
 
         // Run 1: a fresh conductor process loads the persisted state.
         let mut state = crate::state::persist::load_state(dir.path(), &plan.name)

--- a/crates/edda-conductor/src/state/persist.rs
+++ b/crates/edda-conductor/src/state/persist.rs
@@ -1,4 +1,4 @@
-use crate::state::machine::PlanState;
+use crate::state::machine::{PhaseStatus, PlanState};
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 
@@ -31,6 +31,40 @@ pub fn save_state(cwd: &Path, state: &PlanState) -> Result<()> {
     edda_store::write_atomic(&path, data.as_bytes())
         .with_context(|| format!("saving state: {}", path.display()))?;
     Ok(())
+}
+
+/// Save state from a long-lived writer (the runner) after reconciling with
+/// the state currently on disk (GH-556).
+///
+/// The runner holds `PlanState` in memory for the whole run while other
+/// processes (`edda conduct skip`, `retry`, ...) mutate the same file. A
+/// plain `save_state` then clobbers those external writes with the stale
+/// in-memory copy — observed as a manual skip on a Pending phase reverting
+/// to Pending when a sibling phase transitioned to Stale in the runner.
+///
+/// Reconciliation rule: a phase that is Skipped on disk but still Pending in
+/// memory is a manual skip recorded by another writer while this runner had
+/// not started the phase — operator intent wins, and the disk phase
+/// (including its skip reason) is folded into the in-memory state before
+/// saving. Every other divergence keeps the in-memory value: the runner is
+/// the authority for phases it has started (Running/Checking/terminal
+/// transitions it observed itself).
+pub fn save_state_reconciled(cwd: &Path, state: &mut PlanState) -> Result<()> {
+    if let Ok(Some(disk)) = load_state(cwd, &state.plan_name) {
+        for disk_phase in &disk.phases {
+            if disk_phase.status != PhaseStatus::Skipped {
+                continue;
+            }
+            if let Some(mem) = state
+                .phases
+                .iter_mut()
+                .find(|p| p.id == disk_phase.id && p.status == PhaseStatus::Pending)
+            {
+                *mem = disk_phase.clone();
+            }
+        }
+    }
+    save_state(cwd, state)
 }
 
 #[cfg(test)]
@@ -130,6 +164,106 @@ mod tests {
     }
 
     // ── Corrupted state recovery tests ─────────────────────────────
+
+    /// GH-556 regression: a manual skip written to disk by a second process
+    /// (`edda conduct skip`) while the runner held a stale in-memory copy
+    /// must survive the runner's next save. Before the fix the runner's
+    /// plain save_state clobbered the skip back to Pending.
+    ///
+    /// Reproduction verified to FAIL before the fix: with
+    /// `save_state_reconciled` reduced to plain `save_state`, this test
+    /// fails at the first assertion (phase reverts to Pending, reason gone).
+    #[test]
+    fn manual_skip_survives_concurrent_runner_save() {
+        use crate::state::machine::{transition, PhaseStatus};
+
+        let dir = tempfile::tempdir().unwrap();
+        let plan = parse_plan(
+            "name: wave\nphases:\n  - id: a\n    prompt: x\n  - id: b\n    prompt: y\n    depends_on:\n      - a\n",
+        )
+        .unwrap();
+
+        // The runner starts phase "a" and holds this in-memory copy.
+        let mut runner_state = PlanState::from_plan(&plan, "wave.yaml");
+        transition(
+            &mut runner_state,
+            "a",
+            PhaseStatus::Pending,
+            PhaseStatus::Running,
+            None,
+        )
+        .unwrap();
+        save_state(dir.path(), &runner_state).unwrap();
+
+        // While "a" runs, another process manually skips pending phase "b".
+        let mut cli_state = load_state(dir.path(), "wave").unwrap().unwrap();
+        let b = cli_state.get_phase_mut("b").unwrap();
+        b.status = PhaseStatus::Skipped;
+        b.skip_reason = Some("parallelized: handed to another lane".into());
+        save_state(dir.path(), &cli_state).unwrap();
+
+        // The runner later saves its stale in-memory copy (e.g. after "a"
+        // transitions to Stale). The skip must survive.
+        runner_state.get_phase_mut("a").unwrap().status = PhaseStatus::Stale;
+        save_state_reconciled(dir.path(), &mut runner_state).unwrap();
+
+        let reloaded = load_state(dir.path(), "wave").unwrap().unwrap();
+        let b = reloaded.get_phase("b").unwrap();
+        assert_eq!(b.status, PhaseStatus::Skipped, "skip marker was lost");
+        assert_eq!(
+            b.skip_reason.as_deref(),
+            Some("parallelized: handed to another lane"),
+            "skip reason was lost"
+        );
+        // The runner's own transition is still persisted.
+        assert_eq!(reloaded.get_phase("a").unwrap().status, PhaseStatus::Stale);
+    }
+
+    /// The runner remains the authority for phases it has started: a disk
+    /// Skipped marker must NOT revert a Running phase in memory (the runner
+    /// observed the dispatch itself), while a phase that is Pending in
+    /// memory and Skipped on disk keeps the operator's skip.
+    #[test]
+    fn reconciled_save_keeps_runner_observed_transitions() {
+        use crate::state::machine::{transition, PhaseStatus};
+
+        let dir = tempfile::tempdir().unwrap();
+        let plan =
+            parse_plan("name: wave\nphases:\n  - id: a\n    prompt: x\n  - id: b\n    prompt: y\n")
+                .unwrap();
+
+        // Disk: "a" was skipped by hand after a previous session.
+        let mut disk_state = PlanState::from_plan(&plan, "wave.yaml");
+        let a = disk_state.get_phase_mut("a").unwrap();
+        a.status = PhaseStatus::Skipped;
+        a.skip_reason = Some("manual".into());
+        save_state(dir.path(), &disk_state).unwrap();
+
+        // Runner memory: it already dispatched "b" (Running) and has "a"
+        // as Pending (it has not synced since the skip was written).
+        let mut runner_state = load_state(dir.path(), "wave").unwrap().unwrap();
+        runner_state.get_phase_mut("a").unwrap().status = PhaseStatus::Pending;
+        transition(
+            &mut runner_state,
+            "b",
+            PhaseStatus::Pending,
+            PhaseStatus::Running,
+            None,
+        )
+        .unwrap();
+        save_state_reconciled(dir.path(), &mut runner_state).unwrap();
+
+        let reloaded = load_state(dir.path(), "wave").unwrap().unwrap();
+        // The runner started "b" — its Running status wins.
+        assert_eq!(
+            reloaded.get_phase("b").unwrap().status,
+            PhaseStatus::Running
+        );
+        // "a" was Pending in memory and Skipped on disk → skip wins.
+        let a = reloaded.get_phase("a").unwrap();
+        assert_eq!(a.status, PhaseStatus::Skipped);
+        assert_eq!(a.skip_reason.as_deref(), Some("manual"));
+    }
 
     /// Helper: create the state.json directory structure and write content.
     fn write_corrupt_state(dir: &Path, plan_name: &str, content: &[u8]) {


### PR DESCRIPTION
## Summary

Resolves #556. Root cause is **not** state re-derivation (the issue's suspected surface) — it is a **concurrent-writer clobber**: the runner holds `PlanState` in memory for the whole `run_plan` lifetime while `edda conduct skip` mutates the same `state.json` in another process. When the runner next saves (in the observed run: sibling `b3` timing out to Stale at 08:20Z), its stale in-memory copy overwrites the file and the 07:45Z manual skips on the pending siblings revert to `Pending`.

## Fix

`save_state_reconciled` (`crates/edda-conductor/src/state/persist.rs`): the runner's save reloads the on-disk state first and folds in any phase that is **Skipped on disk while still Pending in memory** — a manual skip recorded by another writer for a phase this runner never started. Operator intent wins. Every other divergence keeps the in-memory value: the runner stays the authority for phases it dispatched itself (Running/Checking/terminal transitions it observed). All 11 runner save sites now use the reconciled save; the CLI's own `load → mutate → save_state` verbs are unchanged (single-shot writers already read current disk state).

## IN SCOPE

- Changed paths: `crates/edda-conductor/src/state/persist.rs` (new fn + 2 tests), `crates/edda-conductor/src/runner/sequential.rs` (save-site swap + import)
- Direct consumers: the run loop's persistence points (resume detection, dispatch, gate redispatch, completion); CLI `conduct skip/retry/abort` behavior unchanged
- Issue acceptance: the three #556 doneWhen items
- Security/data-loss: this change **reduces** data loss (external operator writes no longer clobbered); no new writers introduced

## doneWhen audit

- ✅ Skip marker survives sibling Stale + runner exit + resume: `manual_skip_survives_concurrent_runner_save` (repro of the clobber; **verified FAILING before the fix** — `skip marker was lost` panic at the first assertion — and passing with the fix)
- ✅ Skip reason text survives: asserted in the same test
- ✅ Resumed runner must not dispatch a skipped phase: disk Skipped survives → `find_next_phase` only dispatches Pending; `reconciled_save_keeps_runner_observed_transitions` additionally pins that the runner's own Running transitions are not reverted

## Gate receipt (L1, frozen SHA `e325851b3bb050b5ff0991d16140e5f9a9a6cb95`)

- `cargo fmt --all --check`: OK
- `cargo clippy --workspace --all-targets -- -D warnings`: OK (Windows, stable)
- `cargo test --workspace`: all crates green except the `edda` crate's 13 pre-existing e2e failures — failure set diffed **identical to `main` baseline** (non-hermetic coordination-board resolution, #646 class); `edda` crate passed 431 (was 430: +1 from this PR's new tests)
- `cargo test -p edda-conductor`: 344 passed, 0 failed (incl. the 2 new tests)
- `CARGO_INCREMENTAL=0` throughout; default `target/` lane

Closes #556