### PR TITLE
fix(edda-ledger,conductor): verdict gate fails closed on a bad freshness bound and surfaces unreadable-ledger errors (GH-541)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,6 +898,7 @@ dependencies = [
  "edda-notify",
  "edda-store",
  "regex",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yml",

--- a/crates/edda-conductor/Cargo.toml
+++ b/crates/edda-conductor/Cargo.toml
@@ -29,3 +29,8 @@ uuid.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+# GH-541: gate read-error tests use tokio::time::start_paused.
+tokio = { version = "1", features = ["process", "time", "rt-multi-thread", "io-util", "macros", "test-util"] }
+# GH-541: the gate's read-error tracker classifies SQLite busy/lock errors
+# as transient; tests construct those errors directly.
+rusqlite = { version = "0.32", features = ["bundled"] }

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -546,6 +546,65 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                         ))
                         .await;
                 }
+                GateVerdict::LedgerUnreadable(err) => {
+                    // GH-541: the gate could not read the ledger persistently
+                    // (not lock contention). Failing with the diagnostic is
+                    // the only honest outcome — the printed `edda verdict`
+                    // command writes to a ledger this gate cannot read, so
+                    // the wait was unrescuable from the start.
+                    let msg = format!(
+                        "gate aborted: ledger unreadable for \"{subject}\" (sha {gate_sha}): {err}"
+                    );
+                    transition(
+                        state,
+                        &gated_id,
+                        PhaseStatus::AwaitingVerdict,
+                        PhaseStatus::Failed,
+                        Some(PhaseUpdate {
+                            error: Some(ErrorInfo {
+                                error_type: ErrorType::LedgerUnreadable,
+                                message: msg.clone(),
+                                retryable: false,
+                                check_index: None,
+                                timestamp: now_rfc3339(),
+                            }),
+                            ..Default::default()
+                        }),
+                    )?;
+                    println!("  ⚠ Phase \"{gated_id}\" {msg}");
+                    if let Some(tmux) = tmux_session {
+                        let _ = tmux.update_phase_status(&gated_id, "Failed");
+                    }
+                    let gate_cost = state.get_phase(&gated_id).ok().and_then(|p| p.cost_usd);
+                    edda::record_phase_failed_with_plan(
+                        cwd,
+                        Some(&plan.name),
+                        &gated_id,
+                        gate_cost,
+                        &msg,
+                    );
+                    let gate_ps = state.get_phase(&gated_id)?;
+                    event_log.record(Event::PhaseFailed {
+                        phase_id: gated_id.clone(),
+                        attempt: gate_ps.attempts,
+                        duration_ms: 0,
+                        error: msg,
+                        error_type: Some(ErrorType::LedgerUnreadable.tag().to_string()),
+                        env_retries: gate_ps.env_retries,
+                        attempt_charged: true,
+                    });
+                    let final_output = load_gate_output(cwd, &plan.name, &gated_id);
+                    clear_gate_output(cwd, &plan.name, &gated_id);
+                    notifier
+                        .notify_phase_terminal(phase_terminal_event(
+                            &plan.name,
+                            &gated_id,
+                            "Failed",
+                            gate_ps.attempts,
+                            final_output.as_deref(),
+                        ))
+                        .await;
+                }
                 GateVerdict::Cancelled => {
                     // The loop top sees the cancelled token and shuts down;
                     // the phase stays AWAITING_VERDICT so a later
@@ -710,6 +769,73 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
 /// Ledger poll interval while a gate waits for a verdict.
 const GATE_POLL_SEC: u64 = 2;
 
+/// GH-541: first report of a persistent ledger read failure goes out
+/// immediately; repeats follow this interval, doubling up to the cap.
+const GATE_READ_ERROR_REPORT_SECS: u64 = 30;
+const GATE_READ_ERROR_REPORT_CAP_SECS: u64 = 300;
+/// GH-541: consecutive persistent (non-lock) ledger read failures after
+/// which the gate fails with the diagnostic instead of waiting silently.
+/// At the 2s poll this is ~30s of a persistently broken ledger — an
+/// operator-fixable fault (corrupt db, permissions, wrong workspace root)
+/// must not consume the whole gate budget unnoticed.
+const GATE_MAX_PERSISTENT_READ_ERRORS: u32 = 15;
+
+/// GH-541: tracks persistent (non-lock) ledger read failures while a gate
+/// waits. Busy/lock contention is transient and never counts. A healthy
+/// poll resets the budget. Reports the error on the first failure and then
+/// on a decaying interval; returns `LedgerUnreadable` when the budget
+/// expires.
+struct ReadErrorTracker {
+    consecutive: u32,
+    report_backoff_secs: u64,
+    next_report: Option<Instant>,
+}
+
+impl Default for ReadErrorTracker {
+    fn default() -> Self {
+        Self {
+            consecutive: 0,
+            report_backoff_secs: GATE_READ_ERROR_REPORT_SECS,
+            next_report: None,
+        }
+    }
+}
+
+impl ReadErrorTracker {
+    /// Observe a poll error. Returns `Some(GateVerdict::LedgerUnreadable)`
+    /// when the persistent-failure budget is exhausted.
+    fn observe(&mut self, err: &anyhow::Error) -> Option<GateVerdict> {
+        if edda_ledger::lock::is_busy_error(err) {
+            // Transient lock contention: degrade quietly, as before.
+            return None;
+        }
+        self.consecutive += 1;
+        if self.consecutive == 1 || self.next_report.is_some_and(|t| Instant::now() >= t) {
+            eprintln!(
+                "  ⚠ verdict gate: ledger read failed (attempt {}): {err:#}",
+                self.consecutive
+            );
+            self.next_report = Some(Instant::now() + Duration::from_secs(self.report_backoff_secs));
+            self.report_backoff_secs =
+                (self.report_backoff_secs * 2).min(GATE_READ_ERROR_REPORT_CAP_SECS);
+        }
+        if self.consecutive >= GATE_MAX_PERSISTENT_READ_ERRORS {
+            return Some(GateVerdict::LedgerUnreadable(format!(
+                "{} consecutive failed ledger reads: {err:#}",
+                self.consecutive
+            )));
+        }
+        None
+    }
+
+    /// A healthy poll (the ledger opened and the query answered) resets the
+    /// persistent-failure budget.
+    fn reset(&mut self) {
+        self.consecutive = 0;
+        self.next_report = None;
+    }
+}
+
 /// D6: bound gate redispatch cycles with their own persisted counter, NOT
 /// `attempt` (which D3 forbids incrementing on redispatch). A redispatch
 /// turn is not guaranteed to produce a commit, so a re-entered gate can
@@ -760,6 +886,12 @@ enum GateVerdict {
     /// `gate_timeout_sec` elapsed with no matching verdict — NOT silent,
     /// NOT auto-approve (D3).
     TimedOut,
+    /// The ledger stayed unreadable (NOT SQLite busy/lock contention) for
+    /// the whole error budget (GH-541): fail the gate with the diagnostic
+    /// instead of polling in silence forever. In this state the printed
+    /// `edda verdict` command could never satisfy the gate anyway — it
+    /// writes to a ledger this gate cannot read.
+    LedgerUnreadable(String),
     /// The CancellationToken fired while waiting. The phase stays
     /// AWAITING_VERDICT so a later resume re-enters the wait (D3 restart).
     Cancelled,
@@ -800,19 +932,39 @@ async fn wait_for_verdict(
     }
     let mut last_heartbeat = Instant::now();
 
+    // GH-541: a failed ledger read is not the same event as "no verdict yet".
+    // SQLite busy/lock contention degrades quietly (transient); every other
+    // error (corrupt database, permission, missing workspace) is persistent,
+    // is reported at least once and then on a decaying interval, and fails
+    // the gate after the error budget — the one response that cannot be
+    // right here is silence (the operator runs the printed approve command
+    // and nothing happens, with no diagnostic anywhere).
+    let mut read_errors = ReadErrorTracker::default();
+
     loop {
         // Poll BEFORE the deadline check: a verdict recorded during this
         // wait (e.g. right after the gate_entered event) must be observed
         // at the last poll, not skipped by a deadline that fires first.
-        // Poll the ledger. Best-effort: an unreadable or locked ledger simply
-        // means "no verdict observed yet" this round.
-        if let Ok(ledger) = edda_ledger::Ledger::open(cwd) {
-            if let Ok(Some(record)) = ledger.latest_verdict_fresh(subject, gate_sha, entered_at) {
-                return match record.payload.decision {
-                    edda_core::VerdictDecision::Approved => GateVerdict::Approved(record),
-                    edda_core::VerdictDecision::Rejected => GateVerdict::Rejected(record),
-                };
+        match edda_ledger::Ledger::open(cwd) {
+            Err(e) => {
+                if let Some(v) = read_errors.observe(&e) {
+                    return v;
+                }
             }
+            Ok(ledger) => match ledger.latest_verdict_fresh(subject, gate_sha, entered_at) {
+                Ok(Some(record)) => {
+                    return match record.payload.decision {
+                        edda_core::VerdictDecision::Approved => GateVerdict::Approved(record),
+                        edda_core::VerdictDecision::Rejected => GateVerdict::Rejected(record),
+                    };
+                }
+                Ok(None) => read_errors.reset(),
+                Err(e) => {
+                    if let Some(v) = read_errors.observe(&e) {
+                        return v;
+                    }
+                }
+            },
         }
         if let Some(deadline) = deadline {
             if time::OffsetDateTime::now_utc() >= deadline {
@@ -4321,6 +4473,88 @@ phases:
         )
         .await;
         assert!(matches!(verdict, GateVerdict::TimedOut));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// GH-541 §2: a healthy poll resets the persistent-error budget — tested
+    /// directly on the tracker: 14 persistent errors, a reset, then more
+    /// errors must NOT fail the gate.
+    #[test]
+    fn read_error_tracker_budget_resets_on_healthy_poll() {
+        let mut t = ReadErrorTracker::default();
+        let err = anyhow::anyhow!("corrupt database");
+        for _ in 0..(GATE_MAX_PERSISTENT_READ_ERRORS - 1) {
+            assert!(t.observe(&err).is_none());
+        }
+        t.reset();
+        for _ in 0..(GATE_MAX_PERSISTENT_READ_ERRORS - 1) {
+            assert!(t.observe(&err).is_none(), "reset must clear the budget");
+        }
+    }
+
+    /// GH-541 §2: SQLite busy/lock contention is transient — it never
+    /// counts toward the persistent-error budget and never fails the gate.
+    #[test]
+    fn read_error_tracker_ignores_busy_errors() {
+        let busy = anyhow::Error::new(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+            Some("database is locked".into()),
+        ));
+        let mut t = ReadErrorTracker::default();
+        for _ in 0..(GATE_MAX_PERSISTENT_READ_ERRORS * 3) {
+            assert!(t.observe(&busy).is_none(), "busy errors are transient");
+        }
+    }
+
+    /// GH-541 §2: persistent errors exhaust the budget exactly at the limit
+    /// and the diagnostic names the failure mode and the count.
+    #[test]
+    fn read_error_tracker_fails_at_budget() {
+        let mut t = ReadErrorTracker::default();
+        let err = anyhow::anyhow!("disk I/O error");
+        for _ in 0..(GATE_MAX_PERSISTENT_READ_ERRORS - 1) {
+            assert!(t.observe(&err).is_none());
+        }
+        match t.observe(&err) {
+            Some(GateVerdict::LedgerUnreadable(msg)) => {
+                assert!(msg.contains("consecutive failed ledger reads"), "{msg}");
+                assert!(msg.contains("disk I/O error"), "{msg}");
+            }
+            other => panic!("expected LedgerUnreadable, got {other:?}"),
+        }
+    }
+
+    /// GH-541 §2: a persistently unreadable ledger must fail the gate with
+    /// a diagnostic after the error budget — not poll in silence forever.
+    /// A bare directory has no `.edda` workspace, so every `Ledger::open`
+    /// fails with a persistent (non-lock) error.
+    #[tokio::test(start_paused = true)]
+    async fn wait_for_verdict_fails_after_persistent_read_errors() {
+        let root =
+            std::env::temp_dir().join(format!("edda_gate_unreadable_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+
+        let cancel = CancellationToken::new();
+        let verdict = wait_for_verdict(
+            &root,
+            "plan/phase",
+            &"d".repeat(40),
+            None, // no timeout: without the error budget this would hang forever
+            Some(&now_rfc3339()),
+            &cancel,
+            None,
+        )
+        .await;
+        match verdict {
+            GateVerdict::LedgerUnreadable(msg) => {
+                assert!(
+                    msg.contains("consecutive failed ledger reads"),
+                    "diagnostic must name the failure mode: {msg}"
+                );
+            }
+            other => panic!("expected LedgerUnreadable, got {other:?}"),
+        }
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -242,7 +242,19 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                 let sha = ps.gate_sha.clone().with_context(|| {
                     format!("AWAITING_VERDICT state for \"{gated_id}\" is missing gate_sha")
                 })?;
-                let at = ps.gate_entered_at.clone().unwrap_or_else(now_rfc3339);
+                // GH-541: fail CLOSED on a missing freshness bound. Substituting
+                // `now` (the previous behavior) admitted every verdict recorded
+                // after the resume instant — including the stale rejection from
+                // the previous gate entry that D6 blocks — with no diagnostic.
+                // An AWAITING_VERDICT phase must carry the persisted entry time:
+                // it is the D6 bound and the timeout anchor across restarts.
+                let at = ps.gate_entered_at.clone().with_context(|| {
+                    format!(
+                        "AWAITING_VERDICT state for \"{gated_id}\" is missing gate_entered_at — \
+                         the D6 freshness bound cannot be established, so refusing to wait; \
+                         a stale verdict could otherwise be admitted"
+                    )
+                })?;
                 (sha, at)
             };
             let phase_num = order.iter().position(|id| id == &gated_id).unwrap_or(0) + 1;
@@ -3680,6 +3692,50 @@ phases:
             (tv[1].1.as_str(), tv[1].2.as_str(), tv[1].3),
             ("b", "Passed", 1)
         );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// GH-541 Round-1 P1-1: an AWAITING_VERDICT phase whose persisted state
+    /// is missing `gate_entered_at` must fail closed at resume — no
+    /// substitution with `now` (which would admit the stale rejection from
+    /// the previous gate entry), and a matching verdict already in the
+    /// ledger must NOT satisfy the gate. The run errors with a diagnostic.
+    #[tokio::test]
+    async fn resume_without_gate_entered_at_fails_closed() {
+        let root = fresh_root("missingentered");
+        let head = init_git_repo(&root);
+        let launcher = MockLauncher::new();
+        let plan = parse_plan(GATED_YAML).unwrap();
+        let mut state = PlanState::from_plan(&plan, "test.yaml");
+        state.phases[0].status = PhaseStatus::AwaitingVerdict;
+        state.phases[0].gate_sha = Some(head.clone());
+        state.phases[0].gate_entered_at = None; // the corruption under test
+
+        // A matching approval is already in the ledger — it must NOT be
+        // admitted without a freshness bound.
+        record_verdict(&root, "gated/a", &head, VerdictDecision::Approved, None);
+
+        let handle = spawn_runner(GATED_YAML, root.clone(), launcher, state);
+        let result = tokio::time::timeout(GATE_TEST_DEADLINE, handle)
+            .await
+            .expect("gate test exceeded 30s")
+            .unwrap();
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("expected run_plan to error on the missing gate_entered_at"),
+        };
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("missing gate_entered_at"),
+            "diagnostic must name the missing invariant: {msg}"
+        );
+
+        // The stale-verdict approval was not consumed: the phase is still
+        // awaiting on disk.
+        let persisted = crate::state::persist::load_state(&root, "gated")
+            .unwrap()
+            .expect("state persists");
+        assert_eq!(persisted.phases[0].status, PhaseStatus::AwaitingVerdict);
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/crates/edda-conductor/src/state/machine.rs
+++ b/crates/edda-conductor/src/state/machine.rs
@@ -141,6 +141,11 @@ pub enum ErrorType {
     /// Windows LNK1104): not the agent's work, so retrying is worthwhile —
     /// but the retry is never charged to `max_attempts`.
     Environmental,
+    /// The verdict gate aborted because the ledger stayed unreadable for
+    /// the whole error budget (GH-541): infrastructure, not the agent's
+    /// work — the gate cannot observe verdicts written to a ledger it
+    /// cannot read.
+    LedgerUnreadable,
 }
 
 impl ErrorType {
@@ -157,6 +162,7 @@ impl ErrorType {
             ErrorType::UserAbort => "user_abort",
             ErrorType::GateRejected => "gate_rejected",
             ErrorType::Environmental => "environmental",
+            ErrorType::LedgerUnreadable => "ledger_unreadable",
         }
     }
 }

--- a/crates/edda-ledger/src/lock.rs
+++ b/crates/edda-ledger/src/lock.rs
@@ -2,6 +2,25 @@ use crate::paths::EddaPaths;
 use fs2::FileExt;
 use std::fs::{File, OpenOptions};
 
+/// True when the error is SQLite busy/locked contention — a transient
+/// condition where retrying the same read later succeeds (GH-541). Any other
+/// ledger error (corrupt database, permission failure, missing workspace) is
+/// persistent and must surface to the operator instead of being swallowed as
+/// "no verdict yet" forever.
+pub fn is_busy_error(err: &anyhow::Error) -> bool {
+    use rusqlite::ffi::ErrorCode;
+    err.chain().any(|cause| {
+        cause.downcast_ref::<rusqlite::Error>().is_some_and(|e| {
+            matches!(
+                e,
+                rusqlite::Error::SqliteFailure(ffi, _)
+                    if ffi.code == ErrorCode::DatabaseBusy
+                        || ffi.code == ErrorCode::DatabaseLocked
+            )
+        })
+    })
+}
+
 /// Exclusive workspace lock backed by `.edda/LOCK`.
 /// Automatically released when dropped.
 pub struct WorkspaceLock {
@@ -36,6 +55,28 @@ impl WorkspaceLock {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn busy_errors_are_transient_others_are_not() {
+        let busy = anyhow::Error::new(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+            Some("database is locked".into()),
+        ));
+        assert!(is_busy_error(&busy));
+        let wrapped = anyhow::Error::new(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+            Some("database is locked".into()),
+        ))
+        .context("verdict query failed");
+        assert!(
+            is_busy_error(&wrapped),
+            "classification must walk the chain"
+        );
+        let corrupt = anyhow::anyhow!("file is not a database");
+        assert!(!is_busy_error(&corrupt));
+        let missing = anyhow::anyhow!("not an edda workspace");
+        assert!(!is_busy_error(&missing));
+    }
 
     #[test]
     fn acquire_and_drop() {

--- a/crates/edda-ledger/src/verdict.rs
+++ b/crates/edda-ledger/src/verdict.rs
@@ -64,25 +64,30 @@ fn parse_rfc3339(s: &str) -> Option<time::OffsetDateTime> {
 /// parsed instants, not string order (mixed-precision RFC3339 does not sort
 /// chronologically).
 ///
-/// An unparsable `not_before` imposes no bound (the caller always writes it
-/// via the same well-formed formatter). A verdict whose own `ts` cannot be
-/// parsed never satisfies a bounded query — it must not resurrect itself
-/// through a formatting defect.
+/// `None` for `not_before` is an unbounded query (freshness not in force) —
+/// the latest matching verdict wins. A **present but unparsable** bound
+/// fails CLOSED (GH-541): no verdict satisfies, because admitting every
+/// verdict regardless of age is the loop-prone direction D6 exists to kill
+/// — the opposite of the sibling rule below, where an unparsable verdict
+/// timestamp never satisfies a bounded query. The bound reaches this
+/// predicate from a JSON state file on disk; a corrupt or hand-edited value
+/// must degrade to "gate stays shut", not "gate admits anything".
 pub fn latest_verdict_fresh<'a>(
     verdicts: &'a [VerdictRecord],
     subject: &str,
     sha: &str,
     not_before: Option<&str>,
 ) -> Option<&'a VerdictRecord> {
-    let bound = not_before.and_then(parse_rfc3339);
+    let Some(raw_bound) = not_before else {
+        // Unbounded query: same semantics as [`latest_verdict`].
+        return latest_verdict(verdicts, subject, sha);
+    };
+    // Fail closed on an unparsable bound (GH-541): no verdict satisfies.
+    let bound = parse_rfc3339(raw_bound)?;
     verdicts.iter().rev().find(|v| {
-        if v.payload.subject != subject || v.payload.sha != sha {
-            return false;
-        }
-        match bound {
-            None => true,
-            Some(bound) => parse_rfc3339(&v.ts).is_some_and(|ts| ts > bound),
-        }
+        v.payload.subject == subject
+            && v.payload.sha == sha
+            && parse_rfc3339(&v.ts).is_some_and(|ts| ts > bound)
     })
 }
 
@@ -263,8 +268,11 @@ mod tests {
         assert!(latest_verdict_fresh(&verdicts, "s", &sha, Some("2026-01-01T12:00:01Z")).is_none());
     }
 
+    /// GH-541: a present-but-unparsable bound fails CLOSED — no verdict
+    /// satisfies, even one that matches (subject, sha). Admitting every
+    /// verdict regardless of age is the loop-prone direction D6 kills.
     #[test]
-    fn fresh_query_unparsable_not_before_imposes_no_bound() {
+    fn fresh_query_unparsable_not_before_fails_closed() {
         let sha = "2".repeat(40);
         let verdicts = vec![VerdictRecord {
             event_id: "ev".into(),
@@ -277,6 +285,27 @@ mod tests {
                 actor: "tester".into(),
             },
         }];
-        assert!(latest_verdict_fresh(&verdicts, "s", &sha, Some("not-a-timestamp")).is_some());
+        assert!(latest_verdict_fresh(&verdicts, "s", &sha, Some("not-a-timestamp")).is_none());
+    }
+
+    /// GH-541: `None` remains the unbounded query — freshness not in force,
+    /// the latest matching verdict wins (no regression in the no-bound case).
+    #[test]
+    fn fresh_query_none_bound_stays_unbounded() {
+        let sha = "3".repeat(40);
+        let verdicts = vec![VerdictRecord {
+            event_id: "ev".into(),
+            ts: "not-a-timestamp-either".into(),
+            payload: VerdictPayload {
+                subject: "s".into(),
+                decision: VerdictDecision::Approved,
+                sha: sha.clone(),
+                comment: None,
+                actor: "tester".into(),
+            },
+        }];
+        let found = latest_verdict_fresh(&verdicts, "s", &sha, None)
+            .expect("unbounded query must find the matching verdict");
+        assert_eq!(found.payload.decision, VerdictDecision::Approved);
     }
 }


### PR DESCRIPTION
## Summary

Resolves #541 — both ways the #519 verdict gate's safety **turns itself off silently**.

## §1 — `latest_verdict_fresh` fails OPEN on an unparsable `not_before` (`edda-ledger`)

Previously a present-but-unparsable bound degraded to `None` = unbounded → **every stale verdict satisfied the gate**: the loop-prone direction D6 was created to kill, and the opposite of the sibling rule two lines later (unparsable verdict `ts` never satisfies). The bound arrives from a JSON state file on disk; a corrupt or hand-edited value must degrade to "gate stays shut".

**Fix:** `None` remains the legitimate unbounded query (unchanged semantics); a **present but unparsable** bound now fails closed — no verdict satisfies. The old test asserting the fail-open behavior was inverted and two new tests pin the boundary (fail-closed; `None` stays unbounded).

## §2 — `wait_for_verdict` swallows ledger read errors (`edda-conductor`)

Previously `if let Ok(ledger)` + `if let Ok(Some(..))` made a corrupt database / permission failure / missing workspace **indistinguishable from "no verdict yet"** — the gate polled every 2s printing nothing, and with `gate_timeout_sec: None` forever.

**Fix:** poll errors are classified by the new `edda_ledger::lock::is_busy_error`:
- **SQLite busy/locked** → transient, degrades quietly (unchanged behavior)
- **persistent** → reported on stderr immediately, then on a decaying interval (30s → doubling → 300s cap); after **15 consecutive** persistent failures (≈30s at the 2s poll) the gate fails via new `GateVerdict::LedgerUnreadable` → new `ErrorType::LedgerUnreadable` (tag `ledger_unreadable`, additive per the GH-540 stable-tag surface) → full phase-failure path (state, event log, tmux, notify, ledger record)
- a **healthy poll resets** the budget

In the unreadable state the printed `edda verdict approve ...` command could never satisfy the gate anyway — it writes to a ledger the gate cannot read. This also de-silences the **#543 worktree symptom** (gate pointed at a workspace without `.edda`): it now aborts with a diagnostic after ~30s instead of polling silently forever. #543's root cause (three coexisting workspace resolutions) remains its own issue.

## IN SCOPE

- Changed paths: `crates/edda-ledger/src/verdict.rs`, `crates/edda-ledger/src/lock.rs` (`is_busy_error` + test), `crates/edda-conductor/src/runner/sequential.rs`, `crates/edda-conductor/src/state/machine.rs` (new ErrorType variant + tag), `crates/edda-conductor/Cargo.toml` + `Cargo.lock` (dev-deps: rusqlite for error construction, tokio test-util for paused time)
- Direct consumers: `Ledger::latest_verdict_fresh` (one caller: the gate poll); the gate's match site; any JSONL consumer of `error_type` tags (additive)
- Acceptance: the four #541 doneWhen items
- Security/data-loss: strictly tightens the gate (fail-closed, no silent waits); no new writers

## doneWhen audit

- ✅ An unparsable/absent freshness bound cannot admit a stale verdict: `fresh_query_unparsable_not_before_fails_closed`
- ✅ A persistently unreadable ledger surfaces a diagnostic rather than polling silently: `wait_for_verdict_fails_after_persistent_read_errors` (paused time, bare dir) + `read_error_tracker_fails_at_budget`
- ✅ Transient lock contention still degrades quietly: `read_error_tracker_ignores_busy_errors` + `busy_errors_are_transient_others_are_not` (chain-walking classifier)
- ✅ Both paths covered by tests; error budget reset covered by `read_error_tracker_budget_resets_on_healthy_poll`

## Gate receipt (L1, frozen SHA `0eaed1dfbef91baa67471aadffb959c2287694a4`, clean tree, worktree `edda-wt-gh541`)

- `cargo fmt --all --check`: OK
- `cargo clippy --workspace --all-targets -- -D warnings`: OK (Windows, stable)
- `cargo test --workspace`: only the 13 pre-existing `edda` e2e failures — failure names diffed **identical to the main baseline** (#646 non-hermetic class); `edda` crate 431 passed
- `cargo test -p edda-ledger`: 233 passed (one environmental flake, `find_root_non_git_no_edda_returns_none` — walks up from temp into the operator home's `.edda`; verified failing on the **main checkout at main** too, and passing in this workspace run)
- `cargo test -p edda-conductor`: 348 passed, 0 failed
- `CARGO_INCREMENTAL=0` throughout

Closes #541