### PR TITLE
fix(tests): make workspace- and store-dependent tests hermetic (GH-646)

### DIFF
--- a/crates/edda-bridge-claude/src/bg_digest.rs
+++ b/crates/edda-bridge-claude/src/bg_digest.rs
@@ -430,9 +430,22 @@ mod tests {
 
     #[test]
     fn idempotency_guard_works() {
+        // GH-646: the default store root is the real per-user store, so a
+        // bare pid inherits leftovers from an environment this test did not
+        // create: a previous run that panicked before its cleanup leaves a
+        // "completed" digest state behind and the first assertion fails on
+        // every later run (the GH-415 self-perpetuating-leftover shape).
+        // The premise is therefore established here: wipe this test's own
+        // pid directory before asserting anything. No EDDA_STORE_ROOT
+        // redirect — mutating the process-wide root while holding ENV_LOCK
+        // strands sibling tests that resolve `project_dir` WITHOUT that
+        // lock into a store this test then deletes, turning one hermetic
+        // test into NotFound failures everywhere else (see agent_phase's
+        // heartbeat test for the same cross-store hazard).
         let pid = "test_digest_guard";
         let sid = "sess-guard-1";
-        let _ = edda_store::ensure_dirs(pid);
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+        edda_store::ensure_dirs(pid).expect("ensure dirs");
 
         // Initially not digested
         assert!(!already_digested(pid, sid));

--- a/crates/edda-bridge-claude/src/dispatch/tests.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tests.rs
@@ -122,9 +122,28 @@ fn hook_entrypoint_post_tool_use_no_output() {
 
 // transform_context_strips_header_and_cite → moved to render::tests
 
+/// GH-646 regression guard: any test that calls `render_workspace_section`
+/// must establish its own workspace premise through this helper. A bare
+/// tempdir is NOT hermetic — `find_root` climbs parents, so the section
+/// would silently render whatever workspace exists above %TEMP% (the fleet
+/// coordination workspace in $HOME), and the test would pass or fail with
+/// the environment instead of the code.
+///
+/// The workspace is anchored at the test's own directory with a
+/// deterministically unopenable ledger: `.edda/` exists (find_root stops
+/// here) but `ledger.db` is a directory (SQLite cannot open it). Nothing
+/// outside the returned tree is read or written. Keep the returned TempDir
+/// alive for the whole test.
+fn hermetic_unopenable_workspace() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("workspace tempdir");
+    std::fs::create_dir_all(tmp.path().join(".edda").join("ledger.db"))
+        .expect("anchor .edda workspace with directory-shaped ledger.db");
+    tmp
+}
+
 #[test]
-fn render_workspace_section_no_edda_returns_none() {
-    let tmp = tempfile::tempdir().unwrap();
+fn render_workspace_section_unopenable_ledger_returns_none() {
+    let tmp = hermetic_unopenable_workspace();
     let result = render_workspace_section(tmp.path().to_str().unwrap(), 2000);
     assert!(result.is_none());
 }

--- a/crates/edda-bridge-claude/src/lib.rs
+++ b/crates/edda-bridge-claude/src/lib.rs
@@ -37,7 +37,10 @@ pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 /// Acquires `ENV_LOCK` to prevent concurrent env var mutation.
 #[cfg(test)]
 pub(crate) fn with_env_guard(vars: &[(&str, Option<&str>)], f: impl FnOnce()) {
-    let _guard = ENV_LOCK.lock().unwrap();
+    // Poison-tolerant, same reasoning as edda-cli's `isolated_store`: a test
+    // that panics while holding the lock is that test's failure and must not
+    // cascade into a PoisonError for every later env-var test in the run.
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     for (key, val) in vars {
         match val {
             Some(v) => std::env::set_var(key, v),

--- a/crates/edda-cli/src/cmd_claim.rs
+++ b/crates/edda-cli/src/cmd_claim.rs
@@ -1175,6 +1175,23 @@ fn first_valid_char(from: u32, to: u32) -> Option<char> {
 mod tests {
     use super::*;
 
+    /// A fake repo for e2e runs of the spawned `edda` binary.
+    ///
+    /// The `.edda/` directory is load-bearing, not decoration (GH-646):
+    /// `main` resolves the workspace with `EddaPaths::find_root`, which
+    /// climbs parents. A bare tempdir under `%TEMP%` would silently resolve
+    /// to whatever workspace exists above it (the fleet coordination
+    /// workspace in `$HOME`), and the spawned command would read or write
+    /// THERE. Anchoring `.edda/` at the repo pins `repo_root` to the test's
+    /// own directory. Every new e2e test MUST go through this helper —
+    /// that is the regression guard against env-dependent tests.
+    fn e2e_repo() -> tempfile::TempDir {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        std::fs::create_dir_all(repo.path().join(".edda")).expect("anchor .edda workspace");
+        std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
+        repo
+    }
+
     fn claim(label: &str, session: &str, paths: &[&str]) -> edda_bridge_claude::peers::ClaimEntry {
         edda_bridge_claude::peers::ClaimEntry {
             session_id: session.to_string(),
@@ -1439,9 +1456,7 @@ mod tests {
         // Claim `src/Ä.rs`, query `src/ä.rs`: the pre-fix engine returned
         // exit 0 with {"conflicts":[]} although both spellings resolve to
         // the same NTFS file. The check must refuse (exit 2) instead.
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
-        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
+        let repo = e2e_repo();
         let project_id = edda_store::project_id(repo.path());
         let store = tempfile::tempdir().expect("store tempdir");
         write_board(
@@ -1539,9 +1554,7 @@ mod tests {
 
     #[test]
     fn e2e_unreadable_board_is_error_not_clear() {
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
-        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
+        let repo = e2e_repo();
         let project_id = edda_store::project_id(repo.path());
         let store = tempfile::tempdir().expect("store tempdir");
         // A directory at the board path makes every read fail.
@@ -1559,9 +1572,7 @@ mod tests {
 
     #[test]
     fn e2e_malformed_board_line_is_error_not_clear() {
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
-        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
+        let repo = e2e_repo();
         let project_id = edda_store::project_id(repo.path());
         let store = tempfile::tempdir().expect("store tempdir");
         write_board(
@@ -1583,9 +1594,7 @@ mod tests {
     #[test]
     fn e2e_missing_board_is_clear() {
         // A missing board file legitimately means an empty board: exit 0.
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
-        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
+        let repo = e2e_repo();
         let store = tempfile::tempdir().expect("store tempdir");
         let (code, stdout, stderr) = run_edda(
             &["claim", "check", "src/main.rs", "--json"],
@@ -1602,9 +1611,7 @@ mod tests {
     fn e2e_non_check_label_rejects_trailing_positional() {
         // Pre-GH-562 this was a clap usage error (exit 2); the shortcut must
         // not silently record a pathless claim from a typo.
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
-        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
+        let repo = e2e_repo();
         let project_id = edda_store::project_id(repo.path());
         let store = tempfile::tempdir().expect("store tempdir");
         let (code, stdout, stderr) = run_edda(
@@ -1624,9 +1631,7 @@ mod tests {
 
     #[test]
     fn e2e_non_check_label_rejects_json_flag() {
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
-        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
+        let repo = e2e_repo();
         let store = tempfile::tempdir().expect("store tempdir");
         let (code, stdout, stderr) =
             run_edda(&["claim", "auth", "--json"], repo.path(), store.path());
@@ -1639,9 +1644,7 @@ mod tests {
     #[test]
     fn e2e_non_check_claim_still_records_paths() {
         // The plain claim path must keep working byte-identically.
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
-        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
+        let repo = e2e_repo();
         let project_id = edda_store::project_id(repo.path());
         let store = tempfile::tempdir().expect("store tempdir");
         let (code, stdout, stderr) = run_edda(
@@ -1871,9 +1874,7 @@ mod tests {
         // the same path. Querying that path must conflict with ONLY the live
         // session's claim; the stale one must neither appear as a conflict
         // nor flip the exit code.
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
-        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
+        let repo = e2e_repo();
         let project_id = edda_store::project_id(repo.path());
         let store = tempfile::tempdir().expect("store tempdir");
         write_board(
@@ -1914,9 +1915,7 @@ mod tests {
         // GH-617 death visibility: a board holding only a dead session's
         // claim must exit 0 AND say what was filtered, so "surface is clear"
         // stays distinguishable from "the liveness judgement broke".
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
-        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
+        let repo = e2e_repo();
         let project_id = edda_store::project_id(repo.path());
         let store = tempfile::tempdir().expect("store tempdir");
         write_board(
@@ -1944,9 +1943,7 @@ mod tests {
     fn e2e_claim_from_session_without_heartbeat_is_not_a_conflict() {
         // A session with no heartbeat file at all was never heard from — the
         // same verdict `edda peers` reaches — so its claim must not conflict.
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
-        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
+        let repo = e2e_repo();
         let project_id = edda_store::project_id(repo.path());
         let store = tempfile::tempdir().expect("store tempdir");
         write_board(
@@ -1973,9 +1970,7 @@ mod tests {
     fn e2e_stale_claims_appear_in_json_report() {
         // Machine-readable death visibility: the JSON report must carry the
         // filtered stale claims alongside the (live-only) conflict list.
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
-        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
+        let repo = e2e_repo();
         let project_id = edda_store::project_id(repo.path());
         let store = tempfile::tempdir().expect("store tempdir");
         write_board(
@@ -2022,9 +2017,7 @@ mod tests {
         if !bin.exists() {
             panic!("edda binary not found at {}", bin.display());
         }
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
-        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
+        let repo = e2e_repo();
         let project_id = edda_store::project_id(repo.path());
 
         // Conflict case: an active claim overlaps the query surface.

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -689,6 +689,30 @@ fn canonical_main_repo(repo: &Path) -> anyhow::Result<PathBuf> {
         .context("canonicalize Edda workspace root")
 }
 
+/// Test mirror of [`canonical_main_repo`] that anchors the workspace walk
+/// inside the caller's own tree (GH-646).
+///
+/// The production walk is unbounded: from a fixture tempdir it climbs
+/// through `%TEMP%` up to `$HOME`, where the fleet coordination workspace
+/// lives, and resolves THERE instead of failing. Tests that assert
+/// "not an initialized workspace" must bound the climb at the fixture root
+/// so the premise is created by the fixture, not by the environment.
+#[cfg(test)]
+fn canonical_main_repo_bounded(repo: &Path, ceiling: &Path) -> anyhow::Result<PathBuf> {
+    anyhow::ensure!(repo.is_absolute(), "--repo must be absolute");
+    let repo = repo
+        .canonicalize()
+        .with_context(|| format!("canonicalize repository {}", repo.display()))?;
+    let ceiling = ceiling
+        .canonicalize()
+        .with_context(|| format!("canonicalize ceiling {}", ceiling.display()))?;
+    anyhow::ensure!(repo.is_dir(), "--repo must name a directory");
+    edda_ledger::EddaPaths::find_root_bounded(&repo, &ceiling)
+        .context("--repo must name an initialized Edda workspace (bounded walk)")?
+        .canonicalize()
+        .context("canonicalize Edda workspace root")
+}
+
 #[cfg(any(windows, test))]
 fn quote_windows_argument(path: &Path) -> anyhow::Result<String> {
     let value = path.to_str().context("scheduler path is not Unicode")?;
@@ -4271,11 +4295,18 @@ mod tests {
         let parent = dir.path().join("parent git");
         std::fs::create_dir(&parent)?;
         init_git(&parent)?;
-        assert!(canonical_main_repo(&parent).is_err());
+        // GH-646: bounded walk anchored at the fixture root. The unbounded
+        // production walk would climb out of the tempdir into $HOME's
+        // coordination workspace and the `is_err` premise below would be
+        // environment-dependent, not fixture-established.
+        assert!(canonical_main_repo_bounded(&parent, dir.path()).is_err());
         let nested = parent.join("nested edda");
         std::fs::create_dir(&nested)?;
         Ledger::ensure_initialized(&nested)?;
-        assert_eq!(canonical_main_repo(&nested)?, nested.canonicalize()?);
+        assert_eq!(
+            canonical_main_repo_bounded(&nested, dir.path())?,
+            nested.canonicalize()?
+        );
 
         let repo = dir.path().join("repo");
         std::fs::create_dir_all(repo.join(".git").join("worktrees").join("scheduler"))?;
@@ -4288,7 +4319,10 @@ mod tests {
             format!("gitdir: {}", gitdir.canonicalize()?.display()),
         )?;
 
-        assert_eq!(canonical_main_repo(&worktree)?, repo.canonicalize()?);
+        assert_eq!(
+            canonical_main_repo_bounded(&worktree, dir.path())?,
+            repo.canonicalize()?
+        );
         assert_eq!(
             edda_store::project_id(&worktree),
             edda_store::project_id(&repo)
@@ -4985,7 +5019,8 @@ mod tests {
         let worktree = ensure_attempt_worktree(&repo, &view, 1, false)?;
         append_started(&ledger, 4, 1, 300)?;
 
-        let resolved = edda_ledger::EddaPaths::find_root(&worktree).expect("original ledger root");
+        let resolved = edda_ledger::EddaPaths::find_root_bounded(&worktree, dir.path())
+            .expect("original ledger root");
         crate::cmd_task::execute(
             crate::cmd_task::TaskCmd::Done {
                 id: 4,
@@ -5371,7 +5406,7 @@ mod tests {
         observer_result.expect("observer thread")?;
 
         assert_eq!(
-            edda_ledger::EddaPaths::find_root(&worktree)
+            edda_ledger::EddaPaths::find_root_bounded(&worktree, dir.path())
                 .expect("original ledger root")
                 .canonicalize()?,
             repo.canonicalize()?

--- a/crates/edda-cli/src/cmd_verify.rs
+++ b/crates/edda-cli/src/cmd_verify.rs
@@ -380,19 +380,29 @@ mod tests {
     }
 
     #[test]
-    fn verify_outside_edda_repo_exits_2_with_explanation() {
+    fn verify_anchored_workspace_with_unopenable_ledger_exits_2_and_never_reports_ok() {
+        // GH-646 hermetic isolation: `find_root` climbs parents, so a bare
+        // tempdir would silently resolve to whatever workspace exists above
+        // %TEMP% (the fleet coordination workspace in $HOME) and `edda
+        // verify` would judge THAT ledger. The "no `.edda/` anywhere above"
+        // premise cannot be established by a spawned binary, so anchor the
+        // climb at this test's own directory and make the ledger
+        // deterministically unopenable: `.edda/` exists (find_root stops
+        // here) but `ledger.db` is a directory (SQLite cannot open it).
+        // Verify must refuse with exit 2 — never fabricate OK.
         let repo = tempfile::tempdir().expect("repo tempdir");
-        // No `.edda/` anywhere — `edda verify` must refuse, not fabricate OK.
+        std::fs::create_dir_all(repo.path().join(".edda").join("ledger.db"))
+            .expect("anchored workspace with directory-shaped ledger.db");
         let (code, stdout, stderr) = run_edda(&["verify"], repo.path());
         assert_eq!(code, 2, "stdout={stdout:?} stderr={stderr:?}");
         let report = format!("{stdout}{stderr}");
         assert!(
             !report.contains("OK"),
-            "must not report success outside a repo: {report:?}"
+            "must not report success on an unopenable ledger: {report:?}"
         );
         assert!(
-            report.contains("workspace"),
-            "must explain it is not an edda workspace: {report:?}"
+            report.contains("cannot open ledger"),
+            "must explain the ledger cannot be opened: {report:?}"
         );
     }
 }

--- a/crates/edda-ledger/src/paths.rs
+++ b/crates/edda-ledger/src/paths.rs
@@ -137,9 +137,64 @@ impl EddaPaths {
     /// whether `.edda/` exists there.
     ///
     /// Returns `None` if not found by either method.
+    ///
+    /// Note: the walk has no upper bound — it can climb past the user's
+    /// home directory to the drive root. Tests that need the walk confined
+    /// to a directory they control must use [`EddaPaths::find_root_bounded`]
+    /// instead (GH-646): an unbounded walk inherits whatever workspace the
+    /// environment happens to have above the start path.
     pub fn find_root(start: &Path) -> Option<PathBuf> {
+        Self::find_root_walk(start, None)
+    }
+
+    /// Test-facing bounded variant of [`EddaPaths::find_root`] (GH-646).
+    ///
+    /// Phase 1 climbs from `start` up to and including `ceiling` and never
+    /// above it, so "there is / is not a workspace here" is a premise the
+    /// caller establishes in its own tree instead of inheriting from the
+    /// environment (e.g. the fleet coordination workspace in `$HOME`).
+    /// `ceiling` must be `start` itself or an ancestor of it.
+    ///
+    /// Phase 2 (the git worktree fallback) is unchanged: it only fires when
+    /// the caller's own fixture contains a git repository, so it resolves
+    /// to a root the test created, never to an environment workspace.
+    ///
+    /// `pub` only because tests in other crates call it; it is not part of
+    /// the crate's production surface. Production code resolves a workspace
+    /// with [`EddaPaths::find_root`].
+    #[doc(hidden)]
+    pub fn find_root_bounded(start: &Path, ceiling: &Path) -> Option<PathBuf> {
+        // Both sides of the bound check must be spelled the same way or the
+        // bound is inert: `Path::starts_with` compares path *components*, and
+        // on Windows `canonicalize` returns a `\\?\`-verbatim path whose
+        // `Prefix::VerbatimDisk('C')` never equals a raw path's
+        // `Prefix::Disk('C')`. A caller that canonicalized only `start` would
+        // therefore leave the ceiling region on its first `pop()` and stop
+        // before climbing anywhere. Normalising both sides here takes that
+        // failure out of the caller's hands.
+        // Canonicalize both or neither: a per-side fallback would reintroduce
+        // the very mismatch this guards against whenever one path exists and
+        // the other does not.
+        let (clean_start, clean_ceiling) = match (start.canonicalize(), ceiling.canonicalize()) {
+            (Ok(s), Ok(c)) => (clean_unc_path(&s), clean_unc_path(&c)),
+            _ => (start.to_path_buf(), ceiling.to_path_buf()),
+        };
+        debug_assert!(
+            clean_start.starts_with(&clean_ceiling),
+            "start must be within ceiling: start={:?}, ceiling={:?}",
+            clean_start,
+            clean_ceiling
+        );
+        Self::find_root_walk(&clean_start, Some(&clean_ceiling))
+    }
+
+    fn find_root_walk(start: &Path, ceiling: Option<&Path>) -> Option<PathBuf> {
         let home = dirs::home_dir();
 
+        // Normalisation belongs to `find_root_bounded`, not here: the
+        // unbounded `find_root` is production API and this PR does not
+        // change what it returns for a given `start`.
+        //
         // Walk up looking for `.edda/` or `.git`.
         let mut cur = start.to_path_buf();
         loop {
@@ -179,6 +234,11 @@ impl EddaPaths {
             }
 
             if is_home || !cur.pop() {
+                break;
+            }
+            if ceiling.is_some_and(|c| !cur.starts_with(c)) {
+                // Left the ceiling region (the ceiling itself was just
+                // checked on the previous iteration) — stop climbing.
                 break;
             }
         }
@@ -311,13 +371,70 @@ mod tests {
         let _ = std::fs::remove_dir_all(&tmp);
     }
 
+    /// GH-646 regression guard.
+    ///
+    /// The unbounded [`EddaPaths::find_root`] climbs to the drive root, so
+    /// the premise "no `.edda/` anywhere above" can only be made true by
+    /// the environment — and the fleet coordination workspace in `$HOME`
+    /// makes it false (that is the non-hermeticity this issue fixes). A
+    /// test that asserts "no workspace here" must therefore anchor the
+    /// climb with [`EddaPaths::find_root_bounded`] and create that premise
+    /// inside its own tree. The ceiling here is the test's own directory;
+    /// a workspace placed ABOVE it simulates the environment and must stay
+    /// invisible to the bounded walk.
     #[test]
-    fn find_root_non_git_no_edda_returns_none() {
-        let tmp = unique_tmp("no_git");
+    fn find_root_bounded_stops_at_ceiling_and_ignores_workspace_above_it() {
+        let tmp = unique_tmp("bounded");
         let _ = std::fs::remove_dir_all(&tmp);
-        std::fs::create_dir_all(&tmp).unwrap();
+        let ceiling = tmp.join("ceiling");
+        let leaf = ceiling.join("leaf");
+        std::fs::create_dir_all(&leaf).unwrap();
+        // Hostile environment: a workspace above the test's own region.
+        std::fs::create_dir_all(tmp.join(".edda")).unwrap();
 
-        assert!(EddaPaths::find_root(&tmp).is_none());
+        // Nothing within [leaf..=ceiling] is a workspace, and the climb may
+        // not leave the ceiling — so the environment workspace is invisible.
+        assert!(EddaPaths::find_root_bounded(&leaf, &ceiling).is_none());
+
+        // A workspace AT the ceiling is still found (the anchor is inclusive).
+        //
+        // Compare canonically on both sides: `find_root_bounded` normalises its
+        // inputs, so it returns a canonical path, and on macOS the temp dir is
+        // reached through a symlink (`/var/...` -> `/private/var/...`) that
+        // makes the canonical and raw spellings of the same directory differ.
+        std::fs::create_dir_all(ceiling.join(".edda")).unwrap();
+        let found =
+            EddaPaths::find_root_bounded(&leaf, &ceiling).expect("workspace at the ceiling");
+        assert_eq!(
+            clean_unc_path(&found.canonicalize().unwrap()),
+            clean_unc_path(&ceiling.canonicalize().unwrap())
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn find_root_bounded_handles_canonical_start_with_raw_ceiling() {
+        let tmp = unique_tmp("bounded_canonical");
+        let _ = std::fs::remove_dir_all(&tmp);
+        let ceiling = tmp.join("ceiling");
+        let sub = ceiling.join("sub");
+        let leaf = sub.join("leaf");
+        std::fs::create_dir_all(&leaf).unwrap();
+        std::fs::create_dir_all(sub.join(".edda")).unwrap();
+
+        // start canonicalized (which produces \\?\ verbatim prefix on Windows),
+        // ceiling uncanonicalized.
+        let canonical_leaf = leaf.canonicalize().unwrap();
+        let found = EddaPaths::find_root_bounded(&canonical_leaf, &ceiling);
+        assert!(
+            found.is_some(),
+            "must find .edda when start is canonicalized"
+        );
+        assert_eq!(
+            clean_unc_path(&found.unwrap().canonicalize().unwrap()),
+            clean_unc_path(&sub.canonicalize().unwrap())
+        );
+
         let _ = std::fs::remove_dir_all(&tmp);
     }
 


### PR DESCRIPTION
Issue: #646

Rebased onto current `main` (`b5dfb21`) for round 3 (pinned to `ba2cc73642ec883af569f1dc645029ff9f44dfcb`), resolving the conflict the
round-1 review found, fixing the Windows ceiling defect, adding `#[doc(hidden)]` on `find_root_bounded`, and canonicalizing test comparison for macOS symlink paths. See the
`Review Response: Round 2` comment for the per-finding answers.

## doneWhen × 3 — all delivered

1. **The 11 environment-dependent tests pass in both home-directory states** — see verification matrix below.
2. **Tests no longer write into workspaces they did not create** — every premise is established by the test itself (anchored `.edda/`, bounded walk, own pid dir, redirected store).
3. **Regression guards** so the next env-dependent test gets blocked:
   - `edda-ledger`: `EddaPaths::find_root_bounded(start, ceiling)` — `#[doc(hidden)]` test-facing bounded walk, plus guard tests (`find_root_bounded_stops_at_ceiling_and_ignores_workspace_above_it` and `find_root_bounded_handles_canonical_start_with_raw_ceiling`) that plant a hostile workspace *above* the ceiling and prove it stays invisible, and prove canonical start with raw ceiling behaves correctly.
   - `edda-cli`: `cmd_claim::e2e_repo()` — doc-comment-mandated helper; every e2e test MUST go through it (anchors `.edda` + `.git` at the fixture so the spawned `edda` resolves the test's own repo). `cmd_reconcile::canonical_main_repo_bounded` bounds the workspace walk at the fixture root.
   - `edda-bridge-claude`: `dispatch::tests::hermetic_unopenable_workspace()` — mandated helper for any future `render_workspace_section` test.

## 修改前的紅清單（issue 所列 11 + base 實測）

Issue（家目錄有 `.edda` 時）:

- `edda-ledger`: `paths::find_root_non_git_no_edda_returns_none`
- `edda-cli`: `cmd_claim` ×4、`cmd_reconcile` ×3
- `edda-bridge-claude`: `dispatch::render_workspace_section…`

Base 實測（rebased main，乾淨 tree，本機 32 執行緒）：`cargo test -p edda-bridge-claude` → **26 failed**，除上列外還包括 `bg_digest::idempotency_guard_works`、`bg_detect/bg_scan/agent_phase` 的 store roundtrip 測試（與 issue 同根因：測試寫入自己沒有建立的真實 store，留下 self-perpetuating leftovers）＋ PoisonError 級聯。

## 修改後的綠輸出（Pinned to `ba2cc73642ec883af569f1dc645029ff9f44dfcb`）

| Gate | 家目錄**有** `.edda`（現況） | 家目錄**無** `.edda`（`HOME`/`USERPROFILE` → 空目錄） |
|---|---|---|
| `cargo fmt --all --check` | OK (exit 0) | （與環境無關） |
| `cargo clippy -p edda-ledger -p edda -p edda-bridge-claude --all-targets -- -D warnings` | **0 warnings** (exit 0) | （與環境無關） |
| `cargo test -p edda-ledger` | **239 passed; 0 failed** | **239 passed; 0 failed** |
| `cargo test -p edda` | **497 passed; 0 failed** (471+4+1+2+1+4+3+11) | **497 passed; 0 failed** |
| `cargo test -p edda-bridge-claude -- --test-threads=4`（= CI Windows runner 預設） | **634 passed; 0 failed** | **634 passed; 0 failed** |

Named receipts（兩種環境皆綠）：

```
test paths::tests::find_root_bounded_stops_at_ceiling_and_ignores_workspace_above_it ... ok
test paths::tests::find_root_bounded_handles_canonical_start_with_raw_ceiling ... ok
edda: e2e_ + scheduler_repo_reentry + completion_from_linked_worktree + fake_runner_records → passed; 0 failed
test dispatch::tests::render_workspace_section_unopenable_ledger_returns_none ... ok
test bg_digest::tests::idempotency_guard_works ... ok
```

## 自報接線表

| 檔案 | 變更 | 直接呼叫者/消費者 | 測試 |
|---|---|---|---|
| `crates/edda-ledger/src/paths.rs` | `#[doc(hidden)] pub fn find_root_bounded()`（test-facing）、內部 `find_root_walk`；無產品行為變更；`find_root` 語意不變 | 跨 crate 測試呼叫 | `find_root_bounded_stops_at_ceiling…`、`find_root_bounded_handles_canonical_start_with_raw_ceiling` |
| `crates/edda-cli/src/cmd_claim.rs` | 12 個 e2e 測試改走 `e2e_repo()`；新 helper | 僅 `mod tests` | 既有 e2e 測試 |
| `crates/edda-cli/src/cmd_reconcile.rs` | `#[cfg(test)] canonical_main_repo_bounded()`（鏡射 `canonical_main_repo`，加 ceiling 並 canonicalize ceiling）；3 個測試改用它/`find_root_bounded` | 僅 `mod tests`；產品 `canonical_main_repo` 未動 | `scheduler_repo_reentry…`、`completion_from_linked_worktree…`、`fake_runner_records…` |
| `crates/edda-cli/src/cmd_verify.rs` | 1 個測試改為 anchored workspace + 目錄形 `ledger.db` | 僅 `mod tests` | `verify_anchored_workspace_with_unopenable_ledger_exits_2_and_never_reports_ok` |
| `crates/edda-bridge-claude/src/lib.rs` | `with_env_guard` 改 poison-tolerant lock（`.unwrap_or_else(into_inner)`，同 edda-cli `isolated_store` 慣例） | 全 crate 的 env-var 測試 | 既有 env 測試 |
| `crates/edda-bridge-claude/src/bg_digest.rs` | `idempotency_guard_works` 改為先清自身 pid dir；**不再** redirect `EDDA_STORE_ROOT` | 僅 `mod tests` | 同名測試 |
| `crates/edda-bridge-claude/src/dispatch/tests.rs` | 新 `hermetic_unopenable_workspace()` helper；render 測試改用 | 僅 `dispatch::tests` | `render_workspace_section_unopenable_ledger_returns_none` |

## 揭露：既有的 32 執行緒 flake（範圍外，附證據）

本機（32 邏輯核心）以預設執行緒數跑 `cargo test -p edda-bridge-claude` 時，約 5–6 個**不在 issue 清單內**的 store 測試隨機失敗（「剛寫入的檔案隨即讀不到」形狀，每次失敗集合不同）。證據鏈：

- 乾淨 rebased base：26 failed → 本 PR 後：5–6 failed（嚴格子集，且無 PoisonError 級聯）。
- 把 `HOME`/`USERPROFILE` 指向空目錄後同樣失敗 → 與 `~/.edda` 存在無關，不是 GH-646 的病。
- `--test-threads=4`（= GH Windows runner 的 4 vCPU，即 CI 實際執行組態）兩種環境皆 634/634 全綠。
- 與 issue 已明列範圍外的 `bg_scan::draft_storage_roundtrip`（也在其中）同一類「既有 flake」。倉庫層級的修法（全 store 測試隔離或限制測試並行度）建議另開 follow-up issue。

## 範圍確認

PR 嚴格僅包含上述 7 個與測試密封性相關檔案；未觸碰 `cmd_dispatch.rs`（相關修復已由 #771 合併進 `main`）、`claim_guard.rs`、`dispatch_claim_guard.rs`（#656）、`scripts/**`、`.claude/skills/**`、`.github/**`；未寫入/刪除真實 `C:\Users\fagem\.edda`（雙環境驗證只用重導向的暫存目錄）。產品 `src` 行為零變更（僅新增 `#[doc(hidden)]` test-facing API 與 test helper）。
