### PR TITLE
feat(edda-conductor): honest gate-timeout state, waiver semantics, and on_gate_timeout policy (GH-552)

### DIFF
--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -380,7 +380,10 @@ pub fn retry(repo_root: &Path, phase_id: &str, plan_name: Option<&str>) -> Resul
 
     let current_status = {
         let ps = state.get_phase_mut(phase_id)?;
-        if ps.status != PhaseStatus::Failed && ps.status != PhaseStatus::Stale {
+        if ps.status != PhaseStatus::Failed
+            && ps.status != PhaseStatus::Stale
+            && ps.status != PhaseStatus::GateTimedOut
+        {
             bail!(
                 "Phase \"{}\" is {:?}, not Failed or Stale. Cannot retry.",
                 phase_id,
@@ -420,6 +423,22 @@ pub fn skip(
         .ok_or_else(|| anyhow::anyhow!("no state for plan \"{name}\""))?;
 
     let ps = state.get_phase_mut(phase_id)?;
+    if ps.status == PhaseStatus::GateTimedOut {
+        // GH-552: skipping a timed-out gate is a WAIVER — the phase ran and
+        // its checks passed, so recording `Skipped` would understate what
+        // was verified. Keep the honest status, record the waiver.
+        ps.skip_reason = Some(
+            reason
+                .unwrap_or("gate waived by operator (edda conduct skip)")
+                .to_string(),
+        );
+        if state.plan_status == PlanStatus::Blocked {
+            state.plan_status = PlanStatus::Running;
+        }
+        save_state(repo_root, &state)?;
+        println!("Phase \"{phase_id}\" gate waived (status kept as GateTimedOut).");
+        return Ok(());
+    }
     if ps.status != PhaseStatus::Failed
         && ps.status != PhaseStatus::Stale
         && ps.status != PhaseStatus::Pending
@@ -585,6 +604,7 @@ fn print_status(state: &PlanState) {
             PhaseStatus::Skipped => "\u{2298}",                         // ⊘
             PhaseStatus::Stale => "\u{23F0}",                           // ⏰
             PhaseStatus::AwaitingVerdict => "\u{23F8}",                 // ⏸
+            PhaseStatus::GateTimedOut => "\u{29D7}",                    // ⧗
             PhaseStatus::Pending => "\u{25CB}",                         // ○
         };
         let detail = match ps.status {
@@ -600,6 +620,14 @@ fn print_status(state: &PlanState) {
             PhaseStatus::Skipped => {
                 let reason = ps.skip_reason.as_deref().unwrap_or("");
                 format!("({})", reason)
+            }
+            PhaseStatus::GateTimedOut => {
+                // GH-552: honest audit line — timed-out gate, and whether
+                // it was waived (the status itself is never Skipped).
+                match ps.skip_reason.as_deref() {
+                    Some(reason) => format!("(waived: {})", reason),
+                    None => "(awaiting operator: retry or waive)".to_string(),
+                }
             }
             _ => String::new(),
         };

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -323,6 +323,7 @@ pub fn build_phase(
         gate: None,
         gate_timeout_sec: None,
         on_reject: Default::default(),
+        on_gate_timeout: Default::default(),
         // A dispatched single turn declares no owned write surface.
         owns: Vec::new(),
     }

--- a/crates/edda-conductor/src/plan/schema.rs
+++ b/crates/edda-conductor/src/plan/schema.rs
@@ -92,6 +92,10 @@ pub struct Phase {
     /// Policy when the gate verdict rejects. Default: redispatch.
     #[serde(default)]
     pub on_reject: OnReject,
+    /// Policy when the gate times out with no verdict (GH-552). Default:
+    /// halt (block for a human).
+    #[serde(default)]
+    pub on_gate_timeout: OnGateTimeout,
     /// Path globs this phase owns as its write surface. Published in the
     /// phase's auto-claim event so peer lanes can see the scope (GH-561).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -116,6 +120,24 @@ pub enum OnReject {
     Redispatch,
     /// Fail the phase with the rejection comment as the error.
     Halt,
+}
+
+/// What happens when a verdict gate times out with no verdict (GH-552).
+/// Lets an unattended run declare the decision in advance instead of
+/// exiting with instructions it cannot follow.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OnGateTimeout {
+    /// Move the phase to `GateTimedOut` and block for a human (the
+    /// pre-GH-552 behavior, minus the dishonest `Failed` label). The
+    /// interactive prompt offers retry/waive; headless runs stop and wait
+    /// for the operator.
+    #[default]
+    Halt,
+    /// Auto-waive the gate: the phase keeps its honest `GateTimedOut`
+    /// status with a waiver reason recorded, and the plan proceeds. For
+    /// scheduled sweeps whose gates are reviewed after the fact.
+    Skip,
 }
 
 /// Failure policy for a phase.

--- a/crates/edda-conductor/src/runner/edda.rs
+++ b/crates/edda-conductor/src/runner/edda.rs
@@ -261,6 +261,41 @@ pub fn record_phase_failed_with_plan(
     );
 }
 
+/// Record a gate timeout in the workspace ledger with the honest
+/// classification (GH-552): the phase's work completed and its checks
+/// passed — nothing failed — so the note carries `status:
+/// "gate_timed_out"`, never "failed".
+pub fn record_phase_gate_timed_out(
+    cwd: &Path,
+    plan_id: Option<&str>,
+    phase_id: &str,
+    cost_usd: Option<f64>,
+    error: &str,
+) {
+    let error_str = if error.len() > 200 {
+        format!("{}...", truncate_str(error, 200))
+    } else {
+        error.to_string()
+    };
+    let cost_str = cost_usd.map(|c| format!(" [${c:.3}]")).unwrap_or_default();
+    let text = format!("Phase \"{phase_id}\" gate timed out{cost_str}: {error_str}");
+    let mut tags = vec!["conductor".to_string(), format!("phase:{phase_id}")];
+    tags.push("gate_timeout".to_string());
+    let payload = serde_json::json!({
+        "plan_id": plan_id,
+        "phase_id": phase_id,
+        "status": "gate_timed_out",
+        "cost_usd": cost_usd,
+    });
+    append_ledger_note_best_effort(
+        &format!("phase \"{phase_id}\" gate timed out"),
+        cwd,
+        &text,
+        &tags,
+        Some(("conductor_phase", payload)),
+    );
+}
+
 /// Record plan completion in the workspace ledger with the honest total
 /// cost: `total_cost_usd: None` (unmeasured — no phase ever recorded a
 /// measured cost) serializes as JSON null, never 0.0 (#533 discipline).

--- a/crates/edda-conductor/src/runner/event_log.rs
+++ b/crates/edda-conductor/src/runner/event_log.rs
@@ -60,6 +60,27 @@ pub enum Event {
         phase_id: String,
         reason: String,
     },
+    /// The verdict gate expired with no verdict (GH-552). Distinct from
+    /// `PhaseFailed` so the audit log can tell "the agent could not do the
+    /// work" from "the work is done, checked, and waiting on a human who
+    /// did not show up". `elapsed_ms` is the real wall time spent in
+    /// AWAITING_VERDICT, not the zero a failure shape produced.
+    GateTimedOut {
+        phase_id: String,
+        gate_sha: String,
+        elapsed_ms: u64,
+    },
+    /// A timed-out gate was waived — by the operator (interactive prompt or
+    /// `edda conduct skip`) or automatically (`on_gate_timeout: skip`). The
+    /// phase keeps its honest `GateTimedOut` status; this records who moved
+    /// the plan past the gate and why (GH-552).
+    GateWaived {
+        phase_id: String,
+        reason: String,
+        /// True when `on_gate_timeout: skip` waived it without a human.
+        #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+        auto: bool,
+    },
     /// A gated phase passed its checks and entered AWAITING_VERDICT (D4).
     GateEntered {
         phase_id: String,

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -1,7 +1,7 @@
 use crate::agent::budget::BudgetTracker;
 use crate::agent::launcher::{phase_session_id_attempt, AgentLauncher, PhaseResult};
 use crate::check::engine::{CheckEngine, CheckRunResult};
-use crate::plan::schema::{CheckSpec, OnFail, OnReject, Plan};
+use crate::plan::schema::{CheckSpec, OnFail, OnGateTimeout, OnReject, Plan};
 use crate::plan::topo::topo_sort;
 use crate::runner::edda;
 use crate::runner::event_log::{self, Event, EventLogger};
@@ -114,14 +114,17 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
         }
 
         if is_plan_blocked(state) {
-            let failed = state
-                .phases
-                .iter()
-                .find(|p| p.status == PhaseStatus::Failed || p.status == PhaseStatus::Stale);
+            let failed = state.phases.iter().find(|p| {
+                p.status == PhaseStatus::Failed
+                    || p.status == PhaseStatus::Stale
+                    // GH-552: an unwaived gate timeout blocks like a failure.
+                    || (p.status == PhaseStatus::GateTimedOut && p.skip_reason.is_none())
+            });
             let failed_id = failed.map(|f| f.id.clone()).unwrap_or_default();
+            let failed_status = failed.map(|f| f.status).unwrap_or(PhaseStatus::Failed);
 
             if interactive {
-                match prompt_blocked_action(&failed_id) {
+                match prompt_blocked_action(&failed_id, failed_status) {
                     BlockedAction::Retry => {
                         let current = state
                             .get_phase(&failed_id)
@@ -155,6 +158,50 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                             ))
                             .await;
                         println!("  ⊘ Skipped \"{failed_id}\"");
+                        continue;
+                    }
+                    BlockedAction::Waive => {
+                        // GH-552: the phase ran, its checks passed, and its
+                        // gate timed out — record a waiver on the honest
+                        // GateTimedOut status, never a false Skipped.
+                        let (gate_sha, entered_at) = {
+                            let ps = state.get_phase(&failed_id)?;
+                            (
+                                ps.gate_sha.clone().unwrap_or_default(),
+                                ps.gate_entered_at.clone(),
+                            )
+                        };
+                        let waited = entered_at
+                            .and_then(|t| {
+                                time::OffsetDateTime::parse(
+                                    &t,
+                                    &time::format_description::well_known::Rfc3339,
+                                )
+                                .ok()
+                            })
+                            .map(|t| {
+                                std::time::Duration::from_secs(
+                                    (time::OffsetDateTime::now_utc() - t).whole_seconds().max(0)
+                                        as u64,
+                                )
+                            })
+                            .map(format_elapsed)
+                            .unwrap_or_else(|| "unknown".into());
+                        let reason = format!(
+                            "gate waived after timeout: work completed and checks passed (commit {gate_sha}); waited {waited}"
+                        );
+                        let ps = state.get_phase_mut(&failed_id)?;
+                        ps.skip_reason = Some(reason.clone());
+                        state.plan_status = PlanStatus::Running;
+                        save_state_reconciled(cwd, state)?;
+                        event_log.record(Event::GateWaived {
+                            phase_id: failed_id.clone(),
+                            reason: reason.clone(),
+                            auto: false,
+                        });
+                        println!(
+                            "  ⧗ Waived gate on \"{failed_id}\" (status kept as GateTimedOut)"
+                        );
                         continue;
                     }
                     BlockedAction::Abort => {
@@ -500,8 +547,25 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                     }
                 }
                 GateVerdict::TimedOut => {
-                    // D3: distinct "gate timed out" failure — NOT silent,
-                    // NOT auto-approve.
+                    // D3: NOT silent, NOT auto-approve. GH-552: also not a
+                    // phase failure — the work completed and its checks
+                    // passed, so the honest terminal state is GateTimedOut
+                    // with the real elapsed gate time, and the plan's
+                    // on_gate_timeout policy decides what happens next.
+                    let elapsed_ms = time::OffsetDateTime::parse(
+                        &entered_at,
+                        &time::format_description::well_known::Rfc3339,
+                    )
+                    .ok()
+                    .and_then(|t| {
+                        let elapsed = time::OffsetDateTime::now_utc() - t;
+                        if elapsed.whole_seconds() < 0 {
+                            None
+                        } else {
+                            Some(elapsed.whole_seconds() as u64 * 1000)
+                        }
+                    })
+                    .unwrap_or(0);
                     let msg = format!(
                         "gate timed out: no verdict for \"{subject}\" (sha {gate_sha}) within {}s",
                         phase.gate_timeout_sec.unwrap_or(0)
@@ -510,10 +574,10 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                         state,
                         &gated_id,
                         PhaseStatus::AwaitingVerdict,
-                        PhaseStatus::Failed,
+                        PhaseStatus::GateTimedOut,
                         Some(PhaseUpdate {
                             error: Some(ErrorInfo {
-                                error_type: ErrorType::Timeout,
+                                error_type: ErrorType::GateTimeout,
                                 message: msg.clone(),
                                 retryable: false,
                                 check_index: None,
@@ -524,7 +588,7 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                     )?;
                     println!("  ⏰ Phase \"{gated_id}\" {msg}");
                     if let Some(tmux) = tmux_session {
-                        let _ = tmux.update_phase_status(&gated_id, "Failed");
+                        let _ = tmux.update_phase_status(&gated_id, "GateTimedOut");
                     }
                     let gate_cost = state.get_phase(&gated_id).ok().and_then(|p| p.cost_usd);
                     edda::record_phase_failed_with_plan(
@@ -534,29 +598,46 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                         gate_cost,
                         &msg,
                     );
-                    let gate_ps = state.get_phase(&gated_id)?;
-                    event_log.record(Event::PhaseFailed {
+                    event_log.record(Event::GateTimedOut {
                         phase_id: gated_id.clone(),
-                        attempt: gate_ps.attempts,
-                        duration_ms: 0,
-                        error: msg,
-                        error_type: Some(ErrorType::Timeout.tag().to_string()),
-                        env_retries: gate_ps.env_retries,
-                        attempt_charged: true,
+                        gate_sha: gate_sha.clone(),
+                        elapsed_ms,
                     });
                     // GH-564 P1-3: same parked output as the approved branch.
                     // Consume the sidecar with the verdict (GH-564 Round-2 P1).
                     let final_output = load_gate_output(cwd, &plan.name, &gated_id);
                     clear_gate_output(cwd, &plan.name, &gated_id);
+                    let gate_ps = state.get_phase(&gated_id)?;
                     notifier
                         .notify_phase_terminal(phase_terminal_event(
                             &plan.name,
                             &gated_id,
-                            "Failed",
+                            "GateTimedOut",
                             gate_ps.attempts,
                             final_output.as_deref(),
                         ))
                         .await;
+
+                    // GH-552 policy: let an unattended run declare the
+                    // decision in advance instead of exiting with
+                    // instructions it cannot follow.
+                    if phase.on_gate_timeout == OnGateTimeout::Skip {
+                        let reason = format!(
+                            "gate waived after timeout ({} waited, {}s configured): work completed and checks passed; auto-waived by on_gate_timeout: skip",
+                            format_elapsed(std::time::Duration::from_millis(elapsed_ms)),
+                            phase.gate_timeout_sec.unwrap_or(0)
+                        );
+                        let ps = state.get_phase_mut(&gated_id)?;
+                        ps.skip_reason = Some(reason.clone());
+                        event_log.record(Event::GateWaived {
+                            phase_id: gated_id.clone(),
+                            reason: reason.clone(),
+                            auto: true,
+                        });
+                        println!(
+                            "  ⧗ Gate auto-waived for \"{gated_id}\" (on_gate_timeout: skip) — plan proceeds"
+                        );
+                    }
                 }
                 GateVerdict::LedgerUnreadable(err) => {
                     // GH-541: the gate could not read the ledger persistently
@@ -1923,6 +2004,7 @@ fn build_plan_context(plan: &Plan, state: &PlanState, current_phase: &str) -> St
             PhaseStatus::AwaitingVerdict => "⏸",
             PhaseStatus::Skipped => "⊘",
             PhaseStatus::Stale => "⏰",
+            PhaseStatus::GateTimedOut => "⧗",
             PhaseStatus::Pending => {
                 if ps.id == current_phase {
                     "▶"
@@ -1939,12 +2021,40 @@ fn build_plan_context(plan: &Plan, state: &PlanState, current_phase: &str) -> St
 enum BlockedAction {
     Retry,
     Skip,
+    /// GH-552: move the plan past a timed-out gate WITHOUT recording the
+    /// phase as Skipped — the phase keeps its honest `GateTimedOut` status
+    /// with a waiver reason.
+    Waive,
     Abort,
     Quit,
 }
 
-fn prompt_blocked_action(phase_id: &str) -> BlockedAction {
+fn prompt_blocked_action(phase_id: &str, status: PhaseStatus) -> BlockedAction {
     use std::io::{BufRead, Write};
+    if status == PhaseStatus::GateTimedOut {
+        // GH-552: the work completed and checks passed — "skip" would lie.
+        // Offer waive instead, and record it as such.
+        println!("\n  Phase \"{phase_id}\" gate timed out (work completed, checks passed).\n");
+        println!(
+            "  [R] Retry (re-run the phase)   [W] Waive the gate (proceed)   [A] Abort   [Q] Quit (resume later)"
+        );
+        loop {
+            print!("  > ");
+            let _ = std::io::stdout().flush();
+            let mut input = String::new();
+            match std::io::stdin().lock().read_line(&mut input) {
+                Ok(0) | Err(_) => return BlockedAction::Quit, // EOF or error
+                _ => {}
+            }
+            match input.trim().to_lowercase().as_str() {
+                "r" | "retry" => return BlockedAction::Retry,
+                "w" | "waive" => return BlockedAction::Waive,
+                "a" | "abort" => return BlockedAction::Abort,
+                "q" | "quit" => return BlockedAction::Quit,
+                _ => println!("  Invalid choice. Enter R, W, A, or Q."),
+            }
+        }
+    }
     println!("\n  Phase \"{phase_id}\" is blocked.\n");
     println!("  [R] Retry   [S] Skip   [A] Abort   [Q] Quit (resume later)");
     loop {
@@ -4413,7 +4523,7 @@ phases:
     }
 
     #[tokio::test]
-    async fn gate_timeout_fails_distinctly() {
+    async fn gate_timeout_records_honest_gate_timed_out_state() {
         let root = fresh_root("timeout");
         init_git_repo(&root);
         // No verdict will ever arrive.
@@ -4438,26 +4548,109 @@ phases:
         .unwrap()
         .unwrap();
 
+        // GH-552: the work completed and its checks passed — the timeout is
+        // NOT a phase failure and NOT a skip. The persisted status and the
+        // event log both carry the honest classification.
         let phase = &state.phases[0];
-        assert_eq!(phase.status, PhaseStatus::Failed);
+        assert_eq!(phase.status, PhaseStatus::GateTimedOut);
         let err = phase
             .error
             .as_ref()
             .expect("gate timeout must set an error");
-        assert_eq!(err.error_type, ErrorType::Timeout);
+        assert_eq!(err.error_type, ErrorType::GateTimeout);
         assert!(
             err.message.contains("gate timed out"),
             "distinct gate timeout error, got: {}",
             err.message
         );
         assert_eq!(state.plan_status, PlanStatus::Blocked);
-        // GH-564: the gate timeout failure emits exactly one terminal
-        // notification.
+        // The event log records GateTimedOut with the real elapsed time.
+        let events =
+            std::fs::read_to_string(root.join(".edda/conductor/gated/events.jsonl")).unwrap();
+        assert!(
+            events.contains("gate_timed_out"),
+            "event log must classify the gate timeout: {events}"
+        );
+        let gate_event = events
+            .lines()
+            .find(|l| l.contains("gate_timed_out"))
+            .unwrap();
+        let elapsed = serde_json::from_str::<serde_json::Value>(gate_event).unwrap()["elapsed_ms"]
+            .as_u64()
+            .expect("elapsed_ms must be a number");
+        assert!(
+            elapsed >= 1000,
+            "elapsed_ms must reflect the real gate wait, got {elapsed}"
+        );
+        // GH-564: the gate timeout emits exactly one terminal notification,
+        // now carrying the honest status name.
         let tv = terminal_view(&notifier.terminal_events());
         assert_eq!(tv.len(), 1, "exactly one terminal notification: {tv:?}");
         assert_eq!(
             (tv[0].1.as_str(), tv[0].2.as_str(), tv[0].3),
-            ("a", "Failed", 1)
+            ("a", "GateTimedOut", 1)
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// GH-552: `on_gate_timeout: skip` lets an unattended run declare the
+    /// decision in advance — the gate is auto-waived (honest status kept,
+    /// waiver reason recorded) and the plan proceeds to dependents.
+    #[tokio::test]
+    async fn on_gate_timeout_skip_auto_waives_and_plan_proceeds() {
+        let root = fresh_root("autoskip");
+        init_git_repo(&root);
+        let launcher = MockLauncher::new();
+        launcher.set_results(
+            "b",
+            vec![PhaseResult::AgentDone {
+                cost_usd: None,
+                result_text: Some("done".into()),
+            }],
+        );
+        let yaml = r#"
+name: autoskip
+timeout_sec: 600
+phases:
+  - id: a
+    prompt: "do it"
+    gate: verdict
+    gate_timeout_sec: 1
+    on_gate_timeout: skip
+  - id: b
+    prompt: "next"
+    depends_on: [a]
+"#;
+        let plan = parse_plan(yaml).unwrap();
+        let state = PlanState::from_plan(&plan, "test.yaml");
+        let (state, _notifier, launcher) = tokio::time::timeout(
+            GATE_TEST_DEADLINE,
+            spawn_runner(yaml, root.clone(), launcher, state),
+        )
+        .await
+        .expect("gate test exceeded 30s")
+        .unwrap()
+        .unwrap();
+
+        let phase_a = &state.phases[0];
+        assert_eq!(phase_a.status, PhaseStatus::GateTimedOut);
+        let reason = phase_a
+            .skip_reason
+            .as_ref()
+            .expect("auto-waive must record the waiver reason");
+        assert!(reason.contains("auto-waived"), "{reason}");
+        assert!(reason.contains("checks passed"), "{reason}");
+        // The plan proceeded past the waived gate.
+        assert_eq!(state.plan_status, PlanStatus::Completed);
+        assert_eq!(state.phases[1].status, PhaseStatus::Passed);
+        assert_eq!(launcher.call_count("b"), 1, "dependent phase dispatched");
+        // The event log records the automatic waiver.
+        let events =
+            std::fs::read_to_string(root.join(".edda/conductor/autoskip/events.jsonl")).unwrap();
+        assert!(events.contains("gate_waived"), "{events}");
+        assert!(
+            events.contains("\"auto\":true"),
+            "the auto waiver must be marked automatic: {events}"
         );
         let _ = std::fs::remove_dir_all(&root);
     }
@@ -4700,12 +4893,12 @@ phases:
             2,
             "exactly ONE redispatch — the stale rejection must not re-satisfy the re-entered gate"
         );
-        assert_eq!(state.phases[0].status, PhaseStatus::Failed);
+        assert_eq!(state.phases[0].status, PhaseStatus::GateTimedOut);
         let err = state.phases[0]
             .error
             .as_ref()
             .expect("gate timeout must set an error");
-        assert_eq!(err.error_type, ErrorType::Timeout);
+        assert_eq!(err.error_type, ErrorType::GateTimeout);
         assert!(
             err.message.contains("gate timed out"),
             "distinct gate timeout error, got: {}",

--- a/crates/edda-conductor/src/state/derive.rs
+++ b/crates/edda-conductor/src/state/derive.rs
@@ -10,16 +10,20 @@ pub fn derive_plan_status(phases: &[crate::state::machine::PhaseState]) -> PlanS
     }) {
         return PlanStatus::Running;
     }
-    if phases
-        .iter()
-        .any(|p| p.status == PhaseStatus::Failed || p.status == PhaseStatus::Stale)
-    {
+    if phases.iter().any(|p| {
+        p.status == PhaseStatus::Failed
+                || p.status == PhaseStatus::Stale
+                // GH-552: an unwaived gate timeout blocks like a failure —
+                // a waived one (skip_reason set) is a resolved dependency.
+                || (p.status == PhaseStatus::GateTimedOut && p.skip_reason.is_none())
+    }) {
         return PlanStatus::Blocked;
     }
-    if phases
-        .iter()
-        .all(|p| p.status == PhaseStatus::Passed || p.status == PhaseStatus::Skipped)
-    {
+    if phases.iter().all(|p| {
+        p.status == PhaseStatus::Passed
+            || p.status == PhaseStatus::Skipped
+            || (p.status == PhaseStatus::GateTimedOut && p.skip_reason.is_some())
+    }) {
         return PlanStatus::Completed;
     }
     PlanStatus::Pending
@@ -109,7 +113,13 @@ pub fn find_next_phase(plan: &Plan, state: &PlanState, order: &[String]) -> Opti
                 .phases
                 .iter()
                 .find(|p| p.id == *dep)
-                .map(|p| p.status == PhaseStatus::Passed || p.status == PhaseStatus::Skipped)
+                .map(|p| {
+                    p.status == PhaseStatus::Passed
+                        || p.status == PhaseStatus::Skipped
+                        // GH-552: a waived gate timeout shipped its commit;
+                        // dependents may run.
+                        || (p.status == PhaseStatus::GateTimedOut && p.skip_reason.is_some())
+                })
                 .unwrap_or(false)
         });
         if deps_ok {
@@ -180,6 +190,46 @@ mod tests {
     fn derive_completed_mixed_passed_skipped() {
         let phases = make_state(&[("a", PhaseStatus::Passed), ("b", PhaseStatus::Skipped)]);
         assert_eq!(derive_plan_status(&phases), PlanStatus::Completed);
+    }
+
+    /// GH-552: an unwaived gate timeout blocks the plan; a waived one
+    /// (skip_reason set) counts as a resolved dependency toward completion.
+    #[test]
+    fn derive_gate_timed_out_waived_vs_unwaived() {
+        let mut unwaived = make_state(&[("a", PhaseStatus::GateTimedOut)]);
+        assert_eq!(derive_plan_status(&unwaived), PlanStatus::Blocked);
+
+        unwaived[0].skip_reason = Some("gate waived".into());
+        assert_eq!(derive_plan_status(&unwaived), PlanStatus::Completed);
+    }
+
+    /// GH-552: a waived gate timeout satisfies dependencies for later
+    /// phases; an unwaived one does not.
+    #[test]
+    fn find_next_phase_treats_waived_gate_timeout_as_satisfied_dep() {
+        let yaml = r#"
+name: test
+phases:
+  - id: a
+    prompt: "x"
+  - id: b
+    prompt: "y"
+    depends_on: [a]
+"#;
+        let plan = parse_plan(yaml).unwrap();
+        let mut state = PlanState::from_plan(&plan, "test.yaml");
+        state.phases[0].status = PhaseStatus::GateTimedOut;
+        let order = vec!["a".to_string(), "b".to_string()];
+        assert!(
+            find_next_phase(&plan, &state, &order).is_none(),
+            "unwaived gate timeout must not unblock dependents"
+        );
+        state.phases[0].skip_reason = Some("gate waived".into());
+        assert_eq!(
+            find_next_phase(&plan, &state, &order).as_deref(),
+            Some("b"),
+            "waived gate timeout satisfies the dependency"
+        );
     }
 
     #[test]

--- a/crates/edda-conductor/src/state/machine.rs
+++ b/crates/edda-conductor/src/state/machine.rs
@@ -17,6 +17,17 @@ pub enum PhaseStatus {
     Stale,
     /// Checks passed but an external verdict gate is holding the phase (D3).
     AwaitingVerdict,
+    /// GH-552: the verdict gate expired with no verdict — the phase's work
+    /// completed and its checks passed, so nothing failed and calling it
+    /// `Failed` erases the audit distinction between "the agent could not do
+    /// the work" and "the work is done, checked, and waiting on a human who
+    /// did not show up". It is also never `Skipped`: the phase ran.
+    ///
+    /// Resolution: with `skip_reason` set the gate was **waived** — the plan
+    /// treats it like a satisfied dependency and the record keeps the honest
+    /// status; without it the plan is blocked and the phase offers
+    /// retry/waive (interactive) or honors `on_gate_timeout` (headless).
+    GateTimedOut,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -146,6 +157,11 @@ pub enum ErrorType {
     /// work — the gate cannot observe verdicts written to a ledger it
     /// cannot read.
     LedgerUnreadable,
+    /// The verdict gate expired with no verdict (GH-552): the phase's work
+    /// completed and its checks passed — the review, not the work, ran out
+    /// of time. Distinct from `Timeout` (an agent/check timeout, where the
+    /// work itself did not finish).
+    GateTimeout,
 }
 
 impl ErrorType {
@@ -163,6 +179,7 @@ impl ErrorType {
             ErrorType::GateRejected => "gate_rejected",
             ErrorType::Environmental => "environmental",
             ErrorType::LedgerUnreadable => "ledger_unreadable",
+            ErrorType::GateTimeout => "gate_timeout",
         }
     }
 }
@@ -216,11 +233,19 @@ const VALID_TRANSITIONS: &[(PhaseStatus, &[PhaseStatus])] = &[
             // Rejected verdict with on_reject: redispatch runs one more agent
             // turn in the SAME session (D3), so the phase goes back to Running.
             PhaseStatus::Running,
+            // GH-552: the gate expired with no verdict — work completed,
+            // checks passed, nothing failed.
+            PhaseStatus::GateTimedOut,
         ],
     ),
     (PhaseStatus::Failed, &[PhaseStatus::Pending]), // retry
     (PhaseStatus::Stale, &[PhaseStatus::Pending]),  // retry
-                                                    // Passed and Skipped are terminal
+    (
+        PhaseStatus::GateTimedOut,
+        &[PhaseStatus::Pending], // retry (GH-552)
+    ),
+    // Passed and Skipped are terminal; GateTimedOut is resolved in place
+    // (waive = skip_reason set on the same status), never through Skipped.
 ];
 
 fn is_valid_transition(from: PhaseStatus, to: PhaseStatus) -> bool {


### PR DESCRIPTION
## Summary

Resolves #552. A gate timeout used to be recorded as `phase_failed` with `duration_ms: 0` — even though the phase's work had completed and every check had passed (machine-enforced: a phase cannot reach `AWAITING_VERDICT` otherwise). The durable record understated what was verified, the only exit was `Skipped`, and an unattended run had no way to declare the decision in advance.

## Changes

1. **`PhaseStatus::GateTimedOut`** — a distinct terminal state: work done, checks green, the review ran out of time. Never `Failed` (nothing failed) and never `Skipped` (the phase ran). Serde tag `gate_timed_out` (additive).
2. **`ErrorType::GateTimeout`** (tag `gate_timeout`, additive per the GH-540 stable-tag surface) — distinguishable in the persisted phase state and in the event log.
3. **`Event::GateTimedOut { phase_id, gate_sha, elapsed_ms }`** — the real elapsed gate wait replaces `duration_ms: 0`.
4. **Waiver semantics** — moving past a timed-out gate records a **waiver** on the honest `GateTimedOut` status (`skip_reason` set), never a `Skipped`: the interactive prompt offers Retry/**Waive**/Abort/Quit (Skip is unreachable for a phase that ran), `edda conduct skip` waives, and `Event::GateWaived { reason, auto }` records who moved the plan and why. A waived gate satisfies dependencies and counts toward plan completion (`derive_plan_status` + `find_next_phase` updated); an unwaived one blocks like a failure.
5. **`Phase.on_gate_timeout: skip | halt`** (default `halt` = pre-GH-552 blocking behavior) — a headless run declares the decision in advance instead of exiting with instructions it cannot follow.

## IN SCOPE

- Changed paths: `crates/edda-conductor/src/state/{machine,derive}.rs`, `crates/edda-conductor/src/plan/schema.rs`, `crates/edda-conductor/src/runner/{sequential,event_log}.rs`, `crates/edda-cli/src/cmd_conduct.rs`, `crates/edda-cli/src/cmd_dispatch.rs` (new `Phase` field initializer)
- Direct consumers: the gate wait match site, the blocked-phase loop, the plan-status derivation, `conduct skip/retry/status`, JSONL consumers of the event log (additive events/tags)
- Acceptance: the five #552 doneWhen items
- Security/data-loss: no new writers; the audit record becomes strictly more truthful

## doneWhen audit

- ✅ Gate timeout distinguishable from agent/check failure: persisted status `GateTimedOut` + `ErrorType::GateTimeout` + `gate_timed_out` event (asserted in `gate_timeout_records_honest_gate_timed_out_state`)
- ✅ A completed, checks-green phase is not recorded as `Skipped`: waiver keeps `GateTimedOut`; Skip is unreachable from the timed-out gate prompt
- ✅ Elapsed gate time recorded: `elapsed_ms` asserted ≥ the configured timeout in the test
- ✅ Non-interactive runs can declare the policy: `on_gate_timeout: skip` auto-waives and proceeds (`on_gate_timeout_skip_auto_waives_and_plan_proceeds`)
- ✅ Covered by tests: 4 new/updated runner tests + 2 derive-level matrix tests; the old gate-timeout tests failed under the new behavior first, pinning the change

## Gate receipt (L1, frozen SHA `df34108ffc464ee428eae4cef440ec26b3fa0866`, clean tree, worktree `edda-wt-gh552`)

- `cargo fmt --all --check`: OK
- `cargo clippy --workspace --all-targets -- -D warnings`: OK (Windows, stable)
- `cargo test --workspace`: only the 13 pre-existing `edda` e2e failures — names diffed **identical to the main baseline** (#646 non-hermetic class); `edda` crate 446 passed
- `cargo test -p edda-conductor`: 352 passed, 0 failed
- `CARGO_INCREMENTAL=0` throughout

Closes #552