### PR TITLE
fix(cli): re-declare non-check edda claim usage diagnostics contract (GH-589)

### DIFF
--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -1135,8 +1135,9 @@ fn main() -> anyhow::Result<()> {
             }
             None => match label {
                 Some(label) => cmd_bridge::claim(&repo_root, &label, &paths, session.as_deref()),
-                // No label and no `check` subcommand: invalid usage, exactly
-                // like the pre-GH-562 "missing <LABEL>" clap error.
+                // No label and no `check` subcommand: invalid usage.
+                // Declared contract for GH-589 (cli.claim-diagnostics-contract=explicit-mode-dispatch):
+                // require an explicit scope label or the `check` subcommand, exiting with code 2.
                 None => {
                     eprintln!(
                         "error: 'edda claim' requires a label (e.g. 'edda claim auth --paths src/auth/*') or the 'check' subcommand"

--- a/crates/edda-cli/tests/claim_usage_contract.rs
+++ b/crates/edda-cli/tests/claim_usage_contract.rs
@@ -1,25 +1,25 @@
-//! Regression tests for the non-check dda claim usage diagnostics contract (GH-589).
+//! Regression tests for the non-check `edda claim` usage diagnostics contract (GH-589).
 //!
-//! GH-562 introduced dda claim check as a subcommand while preserving
-//! dda claim <LABEL> for scope claims. The diagnostics contract for
-//! non-check usage errors is:
+//! GH-562 introduced `edda claim check` as a subcommand while preserving
+//! `edda claim <LABEL>` for scope claims. The diagnostics contract for
+//! non-`check` usage errors is:
 //!
-//! 1. Missing label and no subcommand (dda claim):
+//! 1. Missing label and no subcommand (`edda claim`):
 //!    - Exit code 2.
-//!    - Stderr specifies that dda claim requires a label or the check subcommand.
+//!    - Stderr specifies that `edda claim` requires a label or the `check` subcommand.
 //!    - No claim is written to the coordination board.
 //!
-//! 2. Extra positional arguments on plain claim (dda claim auth extra --session probe):
+//! 2. Extra positional arguments on plain claim (`edda claim auth extra --session probe`):
 //!    - Exit code 2.
-//!    - Stderr reports subcommand conflict (cannot be used with).
+//!    - Stderr reports subcommand conflict (`cannot be used with`).
 //!    - No claim is written to the coordination board.
 //!
-//! 3. Check-only flag on plain claim (dda claim auth --json):
+//! 3. Check-only flag on plain claim (`edda claim auth --json`):
 //!    - Exit code 2.
-//!    - Stderr reports unexpected argument --json.
+//!    - Stderr reports unexpected argument `--json`.
 //!    - No claim is written to the coordination board.
 //!
-//! 4. Valid plain claim (dda claim auth --paths src/auth/* --session probe):
+//! 4. Valid plain claim (`edda claim auth --paths src/auth/* --session probe`):
 //!    - Exit code 0.
 //!    - Claim is written to the coordination board with paths and session.
 
@@ -100,7 +100,7 @@ fn plain_claim_rejects_extra_positional_arguments() {
 
     assert_eq!(code, 2, "stdout={stdout:?} stderr={stderr:?}");
     assert!(
-        stderr.contains("cannot be used with") || stderr.contains("unexpected argument"),
+        stderr.contains("cannot be used with"),
         "stderr should report argument conflict, got: {stderr:?}"
     );
     assert!(

--- a/crates/edda-cli/tests/claim_usage_contract.rs
+++ b/crates/edda-cli/tests/claim_usage_contract.rs
@@ -1,0 +1,158 @@
+//! Regression tests for the non-check dda claim usage diagnostics contract (GH-589).
+//!
+//! GH-562 introduced dda claim check as a subcommand while preserving
+//! dda claim <LABEL> for scope claims. The diagnostics contract for
+//! non-check usage errors is:
+//!
+//! 1. Missing label and no subcommand (dda claim):
+//!    - Exit code 2.
+//!    - Stderr specifies that dda claim requires a label or the check subcommand.
+//!    - No claim is written to the coordination board.
+//!
+//! 2. Extra positional arguments on plain claim (dda claim auth extra --session probe):
+//!    - Exit code 2.
+//!    - Stderr reports subcommand conflict (cannot be used with).
+//!    - No claim is written to the coordination board.
+//!
+//! 3. Check-only flag on plain claim (dda claim auth --json):
+//!    - Exit code 2.
+//!    - Stderr reports unexpected argument --json.
+//!    - No claim is written to the coordination board.
+//!
+//! 4. Valid plain claim (dda claim auth --paths src/auth/* --session probe):
+//!    - Exit code 0.
+//!    - Claim is written to the coordination board with paths and session.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+struct TestEnv {
+    _dir: tempfile::TempDir,
+    repo: PathBuf,
+    store: PathBuf,
+    project_id: String,
+}
+
+impl TestEnv {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let repo = dir.path().join("repo");
+        let store = dir.path().join("store");
+        // Hermetic isolation (GH-646): create .edda so EddaPaths::find_root
+        // stops here rather than climbing to the home directory.
+        std::fs::create_dir_all(repo.join(".edda")).expect("create .edda");
+        std::fs::create_dir_all(repo.join(".git")).expect("create .git");
+        std::fs::create_dir_all(&store).expect("create store");
+        let project_id = edda_store::project_id(&repo);
+        Self {
+            _dir: dir,
+            repo,
+            store,
+            project_id,
+        }
+    }
+
+    fn board_path(&self) -> PathBuf {
+        self.store
+            .join("projects")
+            .join(&self.project_id)
+            .join("state")
+            .join("coordination.jsonl")
+    }
+
+    fn run_edda(&self, args: &[&str]) -> (i32, String, String) {
+        let bin = PathBuf::from(env!("CARGO_BIN_EXE_edda"));
+        let out = Command::new(&bin)
+            .args(args)
+            .current_dir(&self.repo)
+            .env("EDDA_STORE_ROOT", &self.store)
+            .output()
+            .expect("spawn edda");
+        (
+            out.status.code().expect("exit code"),
+            String::from_utf8_lossy(&out.stdout).into_owned(),
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        )
+    }
+}
+
+#[test]
+fn missing_label_and_no_subcommand_exits_2_with_contract_diagnostics() {
+    let env = TestEnv::new();
+    let (code, stdout, stderr) = env.run_edda(&["claim"]);
+
+    assert_eq!(code, 2, "stdout={stdout:?} stderr={stderr:?}");
+    assert!(stdout.is_empty(), "stdout should be empty, got: {stdout:?}");
+    assert!(
+        stderr.contains("error: 'edda claim' requires a label (e.g. 'edda claim auth --paths src/auth/*') or the 'check' subcommand"),
+        "stderr should contain contract diagnostics, got: {stderr:?}"
+    );
+    assert!(
+        !env.board_path().exists(),
+        "coordination board must not be created on missing label"
+    );
+}
+
+#[test]
+fn plain_claim_rejects_extra_positional_arguments() {
+    let env = TestEnv::new();
+    let (code, stdout, stderr) = env.run_edda(&["claim", "auth", "extra", "--session", "probe"]);
+
+    assert_eq!(code, 2, "stdout={stdout:?} stderr={stderr:?}");
+    assert!(
+        stderr.contains("cannot be used with") || stderr.contains("unexpected argument"),
+        "stderr should report argument conflict, got: {stderr:?}"
+    );
+    assert!(
+        !env.board_path().exists(),
+        "coordination board must not be created on invalid usage"
+    );
+}
+
+#[test]
+fn plain_claim_rejects_check_only_json_flag() {
+    let env = TestEnv::new();
+    let (code, stdout, stderr) = env.run_edda(&["claim", "auth", "--json"]);
+
+    assert_eq!(code, 2, "stdout={stdout:?} stderr={stderr:?}");
+    assert!(
+        stderr.contains("unexpected argument '--json'"),
+        "stderr should report unexpected argument, got: {stderr:?}"
+    );
+    assert!(
+        !env.board_path().exists(),
+        "coordination board must not be created on invalid usage"
+    );
+}
+
+#[test]
+fn valid_plain_claim_succeeds_and_records_to_board() {
+    let env = TestEnv::new();
+    let (code, stdout, stderr) = env.run_edda(&[
+        "claim",
+        "auth",
+        "--paths",
+        "src/auth/*",
+        "--session",
+        "probe",
+    ]);
+
+    assert_eq!(code, 0, "stdout={stdout:?} stderr={stderr:?}");
+    assert!(
+        stdout.contains("Claimed scope: auth"),
+        "stdout should confirm claim, got: {stdout:?}"
+    );
+    assert!(
+        env.board_path().exists(),
+        "coordination board must be created on valid claim"
+    );
+    let content = std::fs::read_to_string(env.board_path()).expect("read board");
+    assert!(
+        content.contains("\"paths\":[\"src/auth/*\"]"),
+        "board content should carry claimed paths, got: {content:?}"
+    );
+    assert!(
+        content.contains("\"session_id\":\"probe\""),
+        "board content should carry session_id, got: {content:?}"
+    );
+}


### PR DESCRIPTION
Deliberately re-declares and pins the diagnostics contract for non-`check` usage errors of `edda claim` following GH-562.

Issue: #589

## Contract & Rationale

With GH-562 introducing the `check` subcommand alongside plain scope claim `<LABEL>`, a missing argument invocation `edda claim` cannot emit clap's generic "the following required arguments were not provided: <LABEL>" without concealing the subcommand alternative.

The contract is explicitly declared:
1. Missing label and no subcommand (`edda claim`):
   - Exits with code 2.
   - Outputs: `error: 'edda claim' requires a label (e.g. 'edda claim auth --paths src/auth/*') or the 'check' subcommand`
   - Does NOT write to the coordination board.
2. Trailing arguments on plain claim (`edda claim auth extra --session probe`):
   - Exits with code 2.
   - Outputs subcommand conflict diagnostic (`cannot be used with`).
   - Does NOT write to the coordination board.
3. Check-only flag on plain claim (`edda claim auth --json`):
   - Exits with code 2.
   - Outputs unexpected argument diagnostic (`unexpected argument '--json'`).
   - Does NOT write to the coordination board.
4. Valid plain claim (`edda claim auth --paths src/auth/* --session probe`):
   - Exits with code 0.
   - Records scope and paths to the coordination board.

## Changes
- `crates/edda-cli/src/main.rs`: Clarified the contract comment on `Command::Claim`'s `None` arm referencing `cli.claim-diagnostics-contract=explicit-mode-dispatch` and GH-589.
- `crates/edda-cli/tests/claim_usage_contract.rs`: Added 4 hermetic end-to-end integration tests pinning all four branches of the contract.
