### PR TITLE
feat(coord): process object claims and merge gate protection (GH-581)

### DIFF
--- a/crates/edda-bridge-claude/src/dispatch/session.rs
+++ b/crates/edda-bridge-claude/src/dispatch/session.rs
@@ -241,6 +241,9 @@ pub(super) fn dispatch_subagent_context(
         let suffix =
             crate::peers::format_peer_suffix(p.branch.as_deref(), p.current_phase.as_deref());
         lines.push(format!("- {} {suffix}", p.label));
+        if let Some(sub) = &p.claimed_subject {
+            lines.push(format!("  claimed subject: {sub}"));
+        }
         if !p.claimed_paths.is_empty() {
             lines.push(format!("  claimed: {}", p.claimed_paths.join(", ")));
         }

--- a/crates/edda-bridge-claude/src/dispatch/tests.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tests.rs
@@ -2183,6 +2183,33 @@ fn subagent_start_creates_heartbeat() {
 }
 
 #[test]
+fn subagent_start_renders_claimed_subject_in_injected_context() {
+    let _env = env_guard();
+    let pid = "test_subagent_start_claimed_subject";
+    let _ = edda_store::ensure_dirs(pid);
+
+    crate::peers::write_heartbeat_minimal(pid, "peer-sess", "peer-worker", ".");
+    crate::peers::write_claim_with_subject(
+        pid,
+        "peer-sess",
+        "peer-worker",
+        &["src/*".into()],
+        Some("pr:570"),
+    );
+
+    let res = crate::dispatch::session::dispatch_subagent_context(pid, "my-subagent")
+        .expect("render active peers");
+    let stdout = res.stdout.expect("has stdout");
+    assert!(
+        stdout.contains("claimed subject: pr:570"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("claimed: src/*"), "stdout: {stdout}");
+
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
 fn subagent_stop_removes_heartbeat() {
     let _env = env_guard();
     let pid = "test_subagent_stop";

--- a/crates/edda-bridge-claude/src/peers/board.rs
+++ b/crates/edda-bridge-claude/src/peers/board.rs
@@ -41,6 +41,11 @@ pub fn compute_board_state(project_id: &str) -> BoardState {
                             .collect()
                     })
                     .unwrap_or_default();
+                let subject = event
+                    .payload
+                    .get("subject")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
                 claims.insert(
                     event.session_id.clone(),
                     ClaimEntry {
@@ -48,6 +53,7 @@ pub fn compute_board_state(project_id: &str) -> BoardState {
                         label,
                         paths,
                         ts: event.ts,
+                        subject,
                     },
                 );
             }

--- a/crates/edda-bridge-claude/src/peers/discovery.rs
+++ b/crates/edda-bridge-claude/src/peers/discovery.rs
@@ -54,12 +54,9 @@ pub fn discover_active_peers(project_id: &str, current_session_id: &str) -> Vec<
             _ => continue,
         };
 
-        let claimed_paths = board
-            .claims
-            .iter()
-            .find(|c| c.session_id == hb.session_id)
-            .map(|c| c.paths.clone())
-            .unwrap_or_default();
+        let matching_claim = board.claims.iter().find(|c| c.session_id == hb.session_id);
+        let claimed_paths = matching_claim.map(|c| c.paths.clone()).unwrap_or_default();
+        let claimed_subject = matching_claim.and_then(|c| c.subject.clone());
 
         let task_subjects: Vec<String> = hb
             .active_tasks
@@ -79,6 +76,7 @@ pub fn discover_active_peers(project_id: &str, current_session_id: &str) -> Vec<
             files_modified_count: hb.files_modified_count,
             recent_commits: hb.recent_commits,
             claimed_paths,
+            claimed_subject,
             branch: hb.branch,
             current_phase: hb.current_phase,
         });
@@ -120,12 +118,9 @@ pub fn discover_all_sessions(project_id: &str) -> Vec<PeerSummary> {
         let hb_epoch = parse_rfc3339_to_epoch(&hb.last_heartbeat).unwrap_or(0);
         let age = now.saturating_sub(hb_epoch);
 
-        let claimed_paths = board
-            .claims
-            .iter()
-            .find(|c| c.session_id == hb.session_id)
-            .map(|c| c.paths.clone())
-            .unwrap_or_default();
+        let matching_claim = board.claims.iter().find(|c| c.session_id == hb.session_id);
+        let claimed_paths = matching_claim.map(|c| c.paths.clone()).unwrap_or_default();
+        let claimed_subject = matching_claim.and_then(|c| c.subject.clone());
 
         let task_subjects: Vec<String> = hb
             .active_tasks
@@ -145,6 +140,7 @@ pub fn discover_all_sessions(project_id: &str) -> Vec<PeerSummary> {
             files_modified_count: hb.files_modified_count,
             recent_commits: hb.recent_commits,
             claimed_paths,
+            claimed_subject,
             branch: hb.branch,
             current_phase: hb.current_phase,
         });

--- a/crates/edda-bridge-claude/src/peers/heartbeat.rs
+++ b/crates/edda-bridge-claude/src/peers/heartbeat.rs
@@ -221,18 +221,33 @@ pub(crate) fn append_coord_event(project_id: &str, event: &CoordEvent) {
     let _ = writeln!(file, "{line}");
 }
 
-/// Write a claim event.
-pub fn write_claim(project_id: &str, session_id: &str, label: &str, paths: &[String]) {
+/// Write a claim event with optional process subject.
+pub fn write_claim_with_subject(
+    project_id: &str,
+    session_id: &str,
+    label: &str,
+    paths: &[String],
+    subject: Option<&str>,
+) {
+    let mut payload = serde_json::json!({
+        "label": label,
+        "paths": paths,
+    });
+    if let Some(sub) = subject {
+        payload["subject"] = serde_json::Value::String(sub.to_string());
+    }
     let event = CoordEvent {
         ts: now_rfc3339(),
         session_id: session_id.to_string(),
         event_type: CoordEventType::Claim,
-        payload: serde_json::json!({
-            "label": label,
-            "paths": paths,
-        }),
+        payload,
     };
     append_coord_event(project_id, &event);
+}
+
+/// Write a claim event.
+pub fn write_claim(project_id: &str, session_id: &str, label: &str, paths: &[String]) {
+    write_claim_with_subject(project_id, session_id, label, paths, None);
 }
 
 /// Write an unclaim event (on session end).

--- a/crates/edda-bridge-claude/src/peers/mod.rs
+++ b/crates/edda-bridge-claude/src/peers/mod.rs
@@ -99,6 +99,8 @@ pub struct ClaimEntry {
     pub label: String,
     pub paths: Vec<String>,
     pub ts: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
 }
 
 /// A binding entry in the coordination log.
@@ -173,6 +175,8 @@ pub struct PeerSummary {
     pub files_modified_count: usize,
     pub recent_commits: Vec<String>,
     pub claimed_paths: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claimed_subject: Option<String>,
     pub branch: Option<String>,
     pub current_phase: Option<String>,
 }
@@ -244,8 +248,8 @@ pub(crate) use heartbeat::{
 };
 pub use heartbeat::{
     find_binding_conflict, remove_heartbeat, resolve_request_targets, touch_heartbeat,
-    write_binding, write_claim, write_heartbeat_minimal, write_request, write_request_ack,
-    write_unclaim,
+    write_binding, write_claim, write_claim_with_subject, write_heartbeat_minimal, write_request,
+    write_request_ack, write_unclaim,
 };
 pub use helpers::format_age;
 pub(crate) use helpers::{format_peer_suffix, pending_requests_for_session};

--- a/crates/edda-bridge-claude/src/peers/render_coord.rs
+++ b/crates/edda-bridge-claude/src/peers/render_coord.rs
@@ -228,7 +228,9 @@ pub fn render_coordination_protocol_with(
                 (Some(sub), false) => format!("{sub}, {}", p.claimed_paths.join(", ")),
                 (Some(sub), true) => sub.clone(),
                 (None, false) => p.claimed_paths.join(", "),
-                (None, true) => String::new(),
+                (None, true) => {
+                    unreachable!("peers without paths or subject are filtered out above")
+                }
             };
             lines.push(format!("- {} → Agent {} ({age})", target, p.label));
         }

--- a/crates/edda-bridge-claude/src/peers/render_coord.rs
+++ b/crates/edda-bridge-claude/src/peers/render_coord.rs
@@ -218,17 +218,19 @@ pub fn render_coordination_protocol_with(
     // Off-limits
     let peer_claims: Vec<&PeerSummary> = peers
         .iter()
-        .filter(|p| !p.claimed_paths.is_empty())
+        .filter(|p| !p.claimed_paths.is_empty() || p.claimed_subject.is_some())
         .collect();
     if !peer_claims.is_empty() {
         lines.push("### Off-limits (other agents active)".to_string());
         for p in peer_claims.iter().take(5) {
             let age = format_age(p.age_secs);
-            lines.push(format!(
-                "- {} → Agent {} ({age})",
-                p.claimed_paths.join(", "),
-                p.label
-            ));
+            let target = match (&p.claimed_subject, p.claimed_paths.is_empty()) {
+                (Some(sub), false) => format!("{sub}, {}", p.claimed_paths.join(", ")),
+                (Some(sub), true) => sub.clone(),
+                (None, false) => p.claimed_paths.join(", "),
+                (None, true) => String::new(),
+            };
+            lines.push(format!("- {} → Agent {} ({age})", target, p.label));
         }
     }
 

--- a/crates/edda-bridge-claude/src/peers/tests.rs
+++ b/crates/edda-bridge-claude/src/peers/tests.rs
@@ -3511,5 +3511,22 @@ fn claim_with_process_subject_roundtrips_to_board_and_peer_summary() {
     assert_eq!(peers[0].claimed_subject.as_deref(), Some("pr:570"));
     assert_eq!(peers[0].claimed_paths, vec!["docs/spec.md".to_string()]);
 
+    // GH-581 / Round 1 P1-4: Verify Off-limits rendering contains the claimed subject
+    let rendered = render_coordination_protocol(pid, "other-agent", "/path/to/repo")
+        .expect("renders protocol");
+    assert!(
+        rendered.contains("- pr:570, docs/spec.md → Agent review-pr570"),
+        "rendered: {rendered}"
+    );
+
+    // Also verify subject-only rendering without paths
+    write_claim_with_subject(pid, sid, "review-pr570", &[], Some("pr:570"));
+    let rendered_sub_only = render_coordination_protocol(pid, "other-agent", "/path/to/repo")
+        .expect("renders protocol");
+    assert!(
+        rendered_sub_only.contains("- pr:570 → Agent review-pr570"),
+        "rendered_sub_only: {rendered_sub_only}"
+    );
+
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }

--- a/crates/edda-bridge-claude/src/peers/tests.rs
+++ b/crates/edda-bridge-claude/src/peers/tests.rs
@@ -222,6 +222,7 @@ fn per_turn_peer_block_hash_stable_across_small_age_delta() {
                 files_modified_count: 1,
                 recent_commits: vec![],
                 claimed_paths: vec!["src/a/*".into()],
+                claimed_subject: None,
                 branch: Some("main".into()),
                 current_phase: None,
             },
@@ -235,6 +236,7 @@ fn per_turn_peer_block_hash_stable_across_small_age_delta() {
                 files_modified_count: 2,
                 recent_commits: vec![],
                 claimed_paths: vec![],
+                claimed_subject: None,
                 branch: Some("main".into()),
                 current_phase: None,
             },
@@ -289,6 +291,7 @@ fn per_turn_peer_block_changes_on_real_staleness_transition() {
             files_modified_count: 1,
             recent_commits: vec![],
             claimed_paths: vec![],
+            claimed_subject: None,
             branch: Some("main".into()),
             current_phase: None,
         }]
@@ -3475,5 +3478,38 @@ fn lane_heartbeat_written_without_bridge_is_discovered_then_goes_stale() {
     );
 
     remove_heartbeat(pid, sid);
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn claim_with_process_subject_roundtrips_to_board_and_peer_summary() {
+    let pid = "test_gh581_subject_roundtrip";
+    let sid = "sess-pr-review";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    write_claim_with_subject(
+        pid,
+        sid,
+        "review-pr570",
+        &["docs/spec.md".into()],
+        Some("pr:570"),
+    );
+
+    let board = compute_board_state(pid);
+    assert_eq!(board.claims.len(), 1);
+    let claim = &board.claims[0];
+    assert_eq!(claim.session_id, sid);
+    assert_eq!(claim.label, "review-pr570");
+    assert_eq!(claim.paths, vec!["docs/spec.md".to_string()]);
+    assert_eq!(claim.subject.as_deref(), Some("pr:570"));
+
+    // Write heartbeat so discover_all_sessions finds the session
+    write_heartbeat_minimal(pid, sid, "review-pr570", "/path/to/repo");
+    let peers = discover_all_sessions(pid);
+    assert_eq!(peers.len(), 1);
+    assert_eq!(peers[0].claimed_subject.as_deref(), Some("pr:570"));
+    assert_eq!(peers[0].claimed_paths, vec!["docs/spec.md".to_string()]);
+
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }

--- a/crates/edda-cli/src/cmd_bridge.rs
+++ b/crates/edda-cli/src/cmd_bridge.rs
@@ -114,6 +114,9 @@ pub enum BridgeClaudeCmd {
         /// File path patterns this scope covers (e.g. "src/auth/*")
         #[arg(long)]
         paths: Vec<String>,
+        /// Process object or subject this scope covers (e.g. "pr:570", "release:v0.4.1")
+        #[arg(long)]
+        subject: Option<String>,
         /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
@@ -309,8 +312,15 @@ pub fn run_bridge(cmd: BridgeCmd, repo_root: &Path) -> anyhow::Result<()> {
             BridgeClaudeCmd::Claim {
                 label,
                 paths,
+                subject,
                 session,
-            } => claim(repo_root, &label, &paths, session.as_deref()),
+            } => claim(
+                repo_root,
+                &label,
+                &paths,
+                subject.as_deref(),
+                session.as_deref(),
+            ),
             BridgeClaudeCmd::Unclaim {
                 session,
                 if_claimed,
@@ -635,10 +645,11 @@ pub fn peers(repo_root: &Path, json: bool) -> anyhow::Result<()> {
     println!("Active sessions ({}):\n", active.len());
     for p in &active {
         let age = edda_bridge_claude::peers::format_age(p.age_secs);
-        let scope = if p.claimed_paths.is_empty() {
-            String::new()
-        } else {
-            format!(" [{}]", p.claimed_paths.join(", "))
+        let scope = match (&p.claimed_subject, p.claimed_paths.is_empty()) {
+            (Some(sub), false) => format!(" [{sub}; {}]", p.claimed_paths.join(", ")),
+            (Some(sub), true) => format!(" [{sub}]"),
+            (None, false) => format!(" [{}]", p.claimed_paths.join(", ")),
+            (None, true) => String::new(),
         };
         let label = if p.label.is_empty() {
             "(no label)".to_string()
@@ -744,6 +755,7 @@ pub fn claim(
     repo_root: &Path,
     label: &str,
     paths: &[String],
+    subject: Option<&str>,
     cli_session: Option<&str>,
 ) -> anyhow::Result<()> {
     let project_id = edda_store::project_id(repo_root);
@@ -754,9 +766,18 @@ pub fn claim(
         .into_iter()
         .find(|c| c.session_id == session_id);
 
-    edda_bridge_claude::peers::write_claim(&project_id, &session_id, label, paths);
+    edda_bridge_claude::peers::write_claim_with_subject(
+        &project_id,
+        &session_id,
+        label,
+        paths,
+        subject,
+    );
     for line in claim_disclosure(replaced.as_ref(), label, paths) {
         println!("{line}");
+    }
+    if let Some(sub) = subject {
+        println!("  subject: {sub}");
     }
     if !paths.is_empty() {
         println!("  paths: {}", paths.join(", "));
@@ -2463,6 +2484,7 @@ mod tests {
             label: label.into(),
             paths: paths.iter().map(|p| (*p).to_string()).collect(),
             ts: "2026-08-20T00:00:00Z".into(),
+            subject: None,
         }
     }
 
@@ -2554,8 +2576,15 @@ mod tests {
         let pid = edda_store::project_id(repo.path());
         let _ = edda_store::ensure_dirs(&pid);
 
-        claim(repo.path(), "auth", &["src/auth/*".into()], Some("s1")).expect("first claim");
-        claim(repo.path(), "api", &["src/api/*".into()], Some("s1")).expect("second claim");
+        claim(
+            repo.path(),
+            "auth",
+            &["src/auth/*".into()],
+            None,
+            Some("s1"),
+        )
+        .expect("first claim");
+        claim(repo.path(), "api", &["src/api/*".into()], None, Some("s1")).expect("second claim");
 
         // The board folds to one claim per session, so the first scope is gone.
         // The disclosure tests above separately pin what the command prints.
@@ -2587,7 +2616,7 @@ mod tests {
             &["src/worker.rs".into()],
         );
 
-        let err = claim(repo.path(), "intruder", &["docs/*".into()], None)
+        let err = claim(repo.path(), "intruder", &["docs/*".into()], None, None)
             .expect_err("an adjacent shell must not adopt the live worker");
         assert!(err.to_string().contains("--session"), "{err}");
 
@@ -2615,10 +2644,18 @@ mod tests {
             repo.path(),
             "auth",
             &["src/auth/*".into(), "src/token/*".into()],
+            None,
             Some("s1"),
         )
         .expect("first claim");
-        claim(repo.path(), "auth", &["src/auth/*".into()], Some("s1")).expect("narrowed claim");
+        claim(
+            repo.path(),
+            "auth",
+            &["src/auth/*".into()],
+            None,
+            Some("s1"),
+        )
+        .expect("narrowed claim");
 
         let claims = edda_bridge_claude::peers::compute_board_state(&pid).claims;
         assert_eq!(claims.len(), 1);
@@ -2635,8 +2672,15 @@ mod tests {
         let pid = edda_store::project_id(repo.path());
         let _ = edda_store::ensure_dirs(&pid);
 
-        claim(repo.path(), "auth", &["src/auth/*".into()], Some("s1")).expect("s1 claim");
-        claim(repo.path(), "api", &["src/api/*".into()], Some("s2")).expect("s2 claim");
+        claim(
+            repo.path(),
+            "auth",
+            &["src/auth/*".into()],
+            None,
+            Some("s1"),
+        )
+        .expect("s1 claim");
+        claim(repo.path(), "api", &["src/api/*".into()], None, Some("s2")).expect("s2 claim");
 
         let mut claims = edda_bridge_claude::peers::compute_board_state(&pid).claims;
         claims.sort_by(|a, b| a.session_id.cmp(&b.session_id));

--- a/crates/edda-cli/src/cmd_claim.rs
+++ b/crates/edda-cli/src/cmd_claim.rs
@@ -362,6 +362,16 @@ pub fn check(
             globset::Glob::new(&token).map_err(|e| format!("invalid glob {token:?}: {e}"))?;
         }
     }
+    for c in claims {
+        if let Some(sub) = &c.subject {
+            if has_wildcard(sub) {
+                globset::GlobBuilder::new(sub)
+                    .case_insensitive(true)
+                    .build()
+                    .map_err(|e| format!("invalid claim subject glob {sub:?}: {e}"))?;
+            }
+        }
+    }
 
     let mut conflicts = Vec::new();
     for c in claims {
@@ -371,7 +381,7 @@ pub fn check(
         let mut intersections = Vec::new();
         for q in query {
             if let Some(sub) = &c.subject {
-                if subjects_intersect(q, sub) {
+                if subjects_intersect(q, sub)? {
                     intersections.push(PathIntersection {
                         query: q.to_string(),
                         claim_path: sub.clone(),
@@ -404,27 +414,32 @@ pub fn check(
 /// Whether a query token and a claim subject token name the same process object.
 ///
 /// Compares case-insensitively and allows glob matching if either side has wildcards.
-fn subjects_intersect(query: &str, subject: &str) -> bool {
+/// Fails closed with an error if a wildcard pattern cannot be parsed.
+pub fn subjects_intersect(query: &str, subject: &str) -> Result<bool, String> {
     let q = query.trim();
     let s = subject.trim();
     if q.eq_ignore_ascii_case(s) {
-        return true;
+        return Ok(true);
     }
     if has_wildcard(q) {
-        if let Ok(glob) = globset::GlobBuilder::new(q).case_insensitive(true).build() {
-            if glob.compile_matcher().is_match(s) {
-                return true;
-            }
+        let glob = globset::GlobBuilder::new(q)
+            .case_insensitive(true)
+            .build()
+            .map_err(|e| format!("invalid query glob {q:?}: {e}"))?;
+        if glob.compile_matcher().is_match(s) {
+            return Ok(true);
         }
     }
     if has_wildcard(s) {
-        if let Ok(glob) = globset::GlobBuilder::new(s).case_insensitive(true).build() {
-            if glob.compile_matcher().is_match(q) {
-                return true;
-            }
+        let glob = globset::GlobBuilder::new(s)
+            .case_insensitive(true)
+            .build()
+            .map_err(|e| format!("invalid claim subject glob {s:?}: {e}"))?;
+        if glob.compile_matcher().is_match(q) {
+            return Ok(true);
         }
     }
-    false
+    Ok(false)
 }
 
 /// Whether a query token and a claim token can name the same file.
@@ -1661,6 +1676,21 @@ mod tests {
         assert!(surfaces_intersect("src/[oops", "src/fine.rs").is_err());
         let claims = vec![claim("g", "s", &["src/[oops"])];
         assert!(check(&claims, &["src/fine.rs"]).is_err());
+    }
+
+    #[test]
+    fn invalid_subject_glob_is_an_error_not_a_clear() {
+        // GH-581 / Round 1 P1-3: unparseable subject glob must fail closed (exit 2),
+        // never fall through to false ("surface is clear").
+        assert!(subjects_intersect("pr:570", "pr:57[0-").is_err());
+        let mut bad_claim = claim("g", "s", &[]);
+        bad_claim.subject = Some("pr:57[0-".to_string());
+        assert!(check(&[bad_claim], &["pr:570"]).is_err());
+
+        // Valid globs match as expected
+        assert!(subjects_intersect("pr:570", "pr:57*").unwrap());
+        assert!(!subjects_intersect("pr:570", "pr:58*").unwrap());
+        assert!(subjects_intersect("pr:57*", "pr:570").unwrap());
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_claim.rs
+++ b/crates/edda-cli/src/cmd_claim.rs
@@ -298,6 +298,10 @@ fn read_active_claims(project_id: &str) -> anyhow::Result<Vec<ClaimEntry>> {
                         .collect::<Result<Vec<_>, _>>()?,
                     None => anyhow::bail!("{ctx}: claim event has no paths field"),
                 };
+                let subject = payload
+                    .get("subject")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string);
                 claims.insert(
                     session_id.to_string(),
                     ClaimEntry {
@@ -305,6 +309,7 @@ fn read_active_claims(project_id: &str) -> anyhow::Result<Vec<ClaimEntry>> {
                         label: label.to_string(),
                         paths,
                         ts: ts.to_string(),
+                        subject,
                     },
                 );
             }
@@ -360,11 +365,19 @@ pub fn check(
 
     let mut conflicts = Vec::new();
     for c in claims {
-        if c.paths.is_empty() {
+        if c.paths.is_empty() && c.subject.is_none() {
             continue;
         }
         let mut intersections = Vec::new();
         for q in query {
+            if let Some(sub) = &c.subject {
+                if subjects_intersect(q, sub) {
+                    intersections.push(PathIntersection {
+                        query: q.to_string(),
+                        claim_path: sub.clone(),
+                    });
+                }
+            }
             for claimed in &c.paths {
                 if surfaces_intersect(q, claimed)? {
                     intersections.push(PathIntersection {
@@ -386,6 +399,32 @@ pub fn check(
         conflicts,
         stale_claims: Vec::new(),
     })
+}
+
+/// Whether a query token and a claim subject token name the same process object.
+///
+/// Compares case-insensitively and allows glob matching if either side has wildcards.
+fn subjects_intersect(query: &str, subject: &str) -> bool {
+    let q = query.trim();
+    let s = subject.trim();
+    if q.eq_ignore_ascii_case(s) {
+        return true;
+    }
+    if has_wildcard(q) {
+        if let Ok(glob) = globset::GlobBuilder::new(q).case_insensitive(true).build() {
+            if glob.compile_matcher().is_match(s) {
+                return true;
+            }
+        }
+    }
+    if has_wildcard(s) {
+        if let Ok(glob) = globset::GlobBuilder::new(s).case_insensitive(true).build() {
+            if glob.compile_matcher().is_match(q) {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 /// Whether a query token and a claim token can name the same file.
@@ -1127,6 +1166,7 @@ mod tests {
             label: label.to_string(),
             paths: paths.iter().map(|p| p.to_string()).collect(),
             ts: "2026-01-01T00:00:00Z".to_string(),
+            subject: None,
         }
     }
 
@@ -1386,6 +1426,7 @@ mod tests {
         // the same NTFS file. The check must refuse (exit 2) instead.
         let repo = tempfile::tempdir().expect("repo tempdir");
         std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
+        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
         let project_id = edda_store::project_id(repo.path());
         let store = tempfile::tempdir().expect("store tempdir");
         write_board(
@@ -1485,6 +1526,7 @@ mod tests {
     fn e2e_unreadable_board_is_error_not_clear() {
         let repo = tempfile::tempdir().expect("repo tempdir");
         std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
+        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
         let project_id = edda_store::project_id(repo.path());
         let store = tempfile::tempdir().expect("store tempdir");
         // A directory at the board path makes every read fail.
@@ -1504,6 +1546,7 @@ mod tests {
     fn e2e_malformed_board_line_is_error_not_clear() {
         let repo = tempfile::tempdir().expect("repo tempdir");
         std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
+        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
         let project_id = edda_store::project_id(repo.path());
         let store = tempfile::tempdir().expect("store tempdir");
         write_board(
@@ -1527,6 +1570,7 @@ mod tests {
         // A missing board file legitimately means an empty board: exit 0.
         let repo = tempfile::tempdir().expect("repo tempdir");
         std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
+        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
         let store = tempfile::tempdir().expect("store tempdir");
         let (code, stdout, stderr) = run_edda(
             &["claim", "check", "src/main.rs", "--json"],
@@ -1545,6 +1589,7 @@ mod tests {
         // not silently record a pathless claim from a typo.
         let repo = tempfile::tempdir().expect("repo tempdir");
         std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
+        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
         let project_id = edda_store::project_id(repo.path());
         let store = tempfile::tempdir().expect("store tempdir");
         let (code, stdout, stderr) = run_edda(
@@ -1566,6 +1611,7 @@ mod tests {
     fn e2e_non_check_label_rejects_json_flag() {
         let repo = tempfile::tempdir().expect("repo tempdir");
         std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
+        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
         let store = tempfile::tempdir().expect("store tempdir");
         let (code, stdout, stderr) =
             run_edda(&["claim", "auth", "--json"], repo.path(), store.path());
@@ -1580,6 +1626,7 @@ mod tests {
         // The plain claim path must keep working byte-identically.
         let repo = tempfile::tempdir().expect("repo tempdir");
         std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
+        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
         let project_id = edda_store::project_id(repo.path());
         let store = tempfile::tempdir().expect("store tempdir");
         let (code, stdout, stderr) = run_edda(
@@ -1796,6 +1843,7 @@ mod tests {
         // nor flip the exit code.
         let repo = tempfile::tempdir().expect("repo tempdir");
         std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
+        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
         let project_id = edda_store::project_id(repo.path());
         let store = tempfile::tempdir().expect("store tempdir");
         write_board(
@@ -1838,6 +1886,7 @@ mod tests {
         // stays distinguishable from "the liveness judgement broke".
         let repo = tempfile::tempdir().expect("repo tempdir");
         std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
+        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
         let project_id = edda_store::project_id(repo.path());
         let store = tempfile::tempdir().expect("store tempdir");
         write_board(
@@ -1867,6 +1916,7 @@ mod tests {
         // same verdict `edda peers` reaches — so its claim must not conflict.
         let repo = tempfile::tempdir().expect("repo tempdir");
         std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
+        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
         let project_id = edda_store::project_id(repo.path());
         let store = tempfile::tempdir().expect("store tempdir");
         write_board(
@@ -1895,6 +1945,7 @@ mod tests {
         // filtered stale claims alongside the (live-only) conflict list.
         let repo = tempfile::tempdir().expect("repo tempdir");
         std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
+        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
         let project_id = edda_store::project_id(repo.path());
         let store = tempfile::tempdir().expect("store tempdir");
         write_board(
@@ -1943,6 +1994,7 @@ mod tests {
         }
         let repo = tempfile::tempdir().expect("repo tempdir");
         std::fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
+        std::fs::create_dir_all(repo.path().join(".edda")).expect("fake .edda");
         let project_id = edda_store::project_id(repo.path());
 
         // Conflict case: an active claim overlaps the query surface.

--- a/crates/edda-cli/src/cmd_claim.rs
+++ b/crates/edda-cli/src/cmd_claim.rs
@@ -595,7 +595,7 @@ fn normalize_token(token: &str) -> String {
     s
 }
 
-fn has_wildcard(pattern: &str) -> bool {
+pub(crate) fn has_wildcard(pattern: &str) -> bool {
     pattern.contains('*') || pattern.contains('?') || pattern.contains('[') || pattern.contains('{')
 }
 

--- a/crates/edda-cli/src/cmd_prs/merge_gate.rs
+++ b/crates/edda-cli/src/cmd_prs/merge_gate.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::process::Command;
 
 /// Command line arguments for `edda prs check-merge`
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Default)]
 pub struct CheckMergeArgs {
     /// PR number to evaluate (queries GitHub via `gh` CLI)
     #[arg(value_name = "PR", conflicts_with = "input")]
@@ -56,10 +56,14 @@ pub struct CheckMergeArgs {
     /// Output evaluation report as JSON
     #[arg(long)]
     pub json: bool,
+
+    /// Override process claim held by another session (GH-581)
+    #[arg(long)]
+    pub force: bool,
 }
 
 /// Host-agnostic input for evaluating merge preconditions.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct MergeGateInput {
     pub head_sha: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -76,10 +80,14 @@ pub struct MergeGateInput {
     pub required_ci_green: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub failed_checks: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claimed_by: Option<String>,
+    #[serde(default)]
+    pub force: bool,
 }
 
 /// Evaluation outcome for merge preconditions.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct MergeGateResult {
     pub can_merge: bool,
     pub head_sha: String,
@@ -93,6 +101,10 @@ pub struct MergeGateResult {
     pub p1_count: usize,
     pub required_ci_green: bool,
     pub reasons: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claimed_by: Option<String>,
+    #[serde(default)]
+    pub force: bool,
 }
 
 /// Check if string is a valid 40-character hex commit SHA.
@@ -164,6 +176,15 @@ pub fn evaluate_merge_preconditions(input: &MergeGateInput) -> MergeGateResult {
         }
     }
 
+    // 6. Process object claim protection (GH-581)
+    if let Some(holder) = &input.claimed_by {
+        if !input.force {
+            reasons.push(format!(
+                "PR is claimed by active session '{holder}' — use --force to override"
+            ));
+        }
+    }
+
     MergeGateResult {
         can_merge: reasons.is_empty(),
         head_sha: input.head_sha.clone(),
@@ -175,6 +196,8 @@ pub fn evaluate_merge_preconditions(input: &MergeGateInput) -> MergeGateResult {
         p1_count: input.p1_count,
         required_ci_green: input.required_ci_green,
         reasons,
+        claimed_by: input.claimed_by.clone(),
+        force: input.force,
     }
 }
 
@@ -574,6 +597,8 @@ fn fetch_pr_from_gh(
         p1_count: p1,
         required_ci_green,
         failed_checks,
+        claimed_by: None,
+        force: false,
     })
 }
 
@@ -607,6 +632,12 @@ pub fn format_merge_report(result: &MergeGateResult) -> (String, String) {
             result.p0_count, result.p1_count
         );
         let _ = writeln!(stdout_buf, "  Required CI: green");
+        if let Some(holder) = &result.claimed_by {
+            let _ = writeln!(
+                stdout_buf,
+                "  Claim Notice: Overriding process claim held by '{holder}' (--force specified)"
+            );
+        }
     } else {
         use std::fmt::Write;
         let _ = writeln!(
@@ -631,7 +662,7 @@ pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result
         anyhow::bail!("--merge requires a live PR number and cannot be used with '--input'");
     }
 
-    let input = if let Some(input_source) = &args.input {
+    let mut input = if let Some(input_source) = &args.input {
         let raw = if input_source == "-" {
             let mut buf = String::new();
             std::io::stdin().read_to_string(&mut buf)?;
@@ -654,12 +685,49 @@ pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result
             p1_count: args.p1,
             required_ci_green: args.ci_green,
             failed_checks: Vec::new(),
+            claimed_by: None,
+            force: args.force,
         }
     } else {
         anyhow::bail!(
             "Specify either a PR number (e.g. 'edda prs check-merge 580') or '--input <FILE>'"
         );
     };
+
+    if args.force {
+        input.force = true;
+    }
+
+    if let Some(pr_number) = args.pr {
+        if input.claimed_by.is_none() {
+            let project_id = edda_store::project_id(repo_root);
+            let target_subject = format!("pr:{pr_number}");
+            let board = edda_bridge_claude::peers::compute_board_state(&project_id);
+            if let Some(c) = board.claims.iter().find(|c| {
+                c.subject
+                    .as_deref()
+                    .map(|s| s.eq_ignore_ascii_case(&target_subject))
+                    .unwrap_or(false)
+            }) {
+                let is_live = matches!(
+                    edda_bridge_claude::peers::classify_session_liveness(
+                        &project_id,
+                        &c.session_id,
+                    ),
+                    edda_bridge_claude::peers::SessionLiveness::Live { .. }
+                );
+                if is_live {
+                    let my_sid = std::env::var("EDDA_SESSION_ID").ok();
+                    if my_sid.as_deref() != Some(&c.session_id) {
+                        input.claimed_by = Some(format!(
+                            "{} (label: '{}', subject: '{target_subject}')",
+                            c.session_id, c.label
+                        ));
+                    }
+                }
+            }
+        }
+    }
 
     let result = evaluate_merge_preconditions(&input);
 
@@ -723,6 +791,7 @@ mod tests {
             p1_count: 0,
             required_ci_green: true,
             failed_checks: vec![],
+            ..Default::default()
         };
         let result = evaluate_merge_preconditions(&input);
         assert!(!result.can_merge);
@@ -744,6 +813,7 @@ mod tests {
             p1_count: 0,
             required_ci_green: true,
             failed_checks: vec![],
+            ..Default::default()
         };
         let result = evaluate_merge_preconditions(&input);
         assert!(!result.can_merge);
@@ -765,6 +835,7 @@ mod tests {
             p1_count: 0,
             required_ci_green: true,
             failed_checks: vec![],
+            ..Default::default()
         };
         let result = evaluate_merge_preconditions(&input);
         assert!(!result.can_merge);
@@ -786,6 +857,7 @@ mod tests {
             p1_count: 0,
             required_ci_green: false,
             failed_checks: vec!["CI Gate (fail)".into()],
+            ..Default::default()
         };
         let result = evaluate_merge_preconditions(&input);
         assert!(!result.can_merge);
@@ -805,6 +877,7 @@ mod tests {
             p1_count: 0,
             required_ci_green: true,
             failed_checks: vec![],
+            ..Default::default()
         };
         let res_cr = evaluate_merge_preconditions(&input_cr);
         assert!(!res_cr.can_merge);
@@ -821,6 +894,7 @@ mod tests {
             p1_count: 0,
             required_ci_green: true,
             failed_checks: vec![],
+            ..Default::default()
         };
         let res_p0 = evaluate_merge_preconditions(&input_p0);
         assert!(!res_p0.can_merge);
@@ -837,6 +911,7 @@ mod tests {
             p1_count: 2,
             required_ci_green: true,
             failed_checks: vec![],
+            ..Default::default()
         };
         let res_p1 = evaluate_merge_preconditions(&input_p1);
         assert!(!res_p1.can_merge);
@@ -858,6 +933,7 @@ mod tests {
             p1_count: 0,
             required_ci_green: true,
             failed_checks: vec![],
+            ..Default::default()
         };
         let result = evaluate_merge_preconditions(&input);
         assert!(result.can_merge);
@@ -1056,6 +1132,7 @@ Commit: 1234567890abcdef1234567890abcdef12345678
             p1_count: 0,
             required_ci_green: true,
             failed_checks: vec![],
+            ..Default::default()
         };
         fs::write(&input_file, serde_json::to_string(&valid_input).unwrap()).unwrap();
 
@@ -1072,6 +1149,7 @@ Commit: 1234567890abcdef1234567890abcdef12345678
             input: Some(input_file.to_str().unwrap().into()),
             merge: false,
             json: true,
+            ..Default::default()
         };
 
         let res = run_check_merge(args, temp_dir.path());
@@ -1097,6 +1175,7 @@ Commit: 1234567890abcdef1234567890abcdef12345678
             input: Some(input_file.to_str().unwrap().into()),
             merge: true,
             json: false,
+            ..Default::default()
         };
 
         let res = run_check_merge(args, temp_dir.path());
@@ -1120,6 +1199,7 @@ Commit: 1234567890abcdef1234567890abcdef12345678
             p1_count: 0,
             required_ci_green: true,
             reasons: vec![],
+            ..Default::default()
         };
 
         let (stdout, stderr) = format_merge_report(&result);
@@ -1148,6 +1228,7 @@ Commit: 1234567890abcdef1234567890abcdef12345678
                 "blocking findings present: 1 P0, 1 P1 (both must be 0)".into(),
                 "required CI check(s) are not green".into(),
             ],
+            ..Default::default()
         };
 
         let (stdout, stderr) = format_merge_report(&result);

--- a/crates/edda-cli/src/cmd_prs/merge_gate.rs
+++ b/crates/edda-cli/src/cmd_prs/merge_gate.rs
@@ -10,7 +10,7 @@ use std::process::Command;
 #[derive(Debug, Clone, Args, Default)]
 pub struct CheckMergeArgs {
     /// PR number to evaluate (queries GitHub via `gh` CLI)
-    #[arg(value_name = "PR", conflicts_with = "input")]
+    #[arg(value_name = "PR")]
     pub pr: Option<u64>,
 
     /// Explicit head commit SHA
@@ -63,9 +63,11 @@ pub struct CheckMergeArgs {
 }
 
 /// Host-agnostic input for evaluating merge preconditions.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MergeGateInput {
     pub head_sha: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pr_author: Option<String>,
     pub verdict: Option<String>,
@@ -589,6 +591,7 @@ fn fetch_pr_from_gh(
 
     Ok(MergeGateInput {
         head_sha,
+        pr: Some(pr),
         pr_author: gh_view.author.as_ref().map(|a| a.login.clone()),
         verdict,
         verdict_sha,
@@ -656,6 +659,41 @@ pub fn format_merge_report(result: &MergeGateResult) -> (String, String) {
     (stdout_buf, stderr_buf)
 }
 
+/// Query the coordination board for an active process claim on `pr:<pr_number>`.
+///
+/// Filters for live sessions and excludes `current_session_id`.
+/// Matches using `subjects_intersect` so glob subjects (e.g. `pr:57*`) are honoured.
+pub fn check_active_pr_claim(
+    repo_root: &Path,
+    pr_number: u64,
+    current_session_id: Option<&str>,
+) -> Option<String> {
+    let project_id = edda_store::project_id(repo_root);
+    let target_subject = format!("pr:{pr_number}");
+    let board = edda_bridge_claude::peers::compute_board_state(&project_id);
+
+    board.claims.into_iter().find_map(|c| {
+        let sub = c.subject.as_deref()?;
+        if !crate::cmd_claim::subjects_intersect(&target_subject, sub).unwrap_or(false) {
+            return None;
+        }
+        let is_live = matches!(
+            edda_bridge_claude::peers::classify_session_liveness(&project_id, &c.session_id),
+            edda_bridge_claude::peers::SessionLiveness::Live { .. }
+        );
+        if !is_live {
+            return None;
+        }
+        if current_session_id.is_some() && current_session_id == Some(&c.session_id) {
+            return None;
+        }
+        Some(format!(
+            "{} (label: '{}', subject: '{}')",
+            c.session_id, c.label, sub
+        ))
+    })
+}
+
 /// Execute the merge precondition check CLI entrypoint.
 pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result<()> {
     if args.merge && (args.pr.is_none() || args.input.is_some()) {
@@ -677,6 +715,7 @@ pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result
     } else if let Some(head_sha) = args.head_sha {
         MergeGateInput {
             head_sha,
+            pr: args.pr,
             pr_author: None,
             verdict: args.verdict,
             verdict_sha: args.verdict_sha,
@@ -686,7 +725,7 @@ pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result
             required_ci_green: args.ci_green,
             failed_checks: Vec::new(),
             claimed_by: None,
-            force: args.force,
+            force: false,
         }
     } else {
         anyhow::bail!(
@@ -698,34 +737,11 @@ pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result
         input.force = true;
     }
 
-    if let Some(pr_number) = args.pr {
+    let target_pr = args.pr.or(input.pr);
+    if let Some(pr_number) = target_pr {
         if input.claimed_by.is_none() {
-            let project_id = edda_store::project_id(repo_root);
-            let target_subject = format!("pr:{pr_number}");
-            let board = edda_bridge_claude::peers::compute_board_state(&project_id);
-            if let Some(c) = board.claims.iter().find(|c| {
-                c.subject
-                    .as_deref()
-                    .map(|s| s.eq_ignore_ascii_case(&target_subject))
-                    .unwrap_or(false)
-            }) {
-                let is_live = matches!(
-                    edda_bridge_claude::peers::classify_session_liveness(
-                        &project_id,
-                        &c.session_id,
-                    ),
-                    edda_bridge_claude::peers::SessionLiveness::Live { .. }
-                );
-                if is_live {
-                    let my_sid = std::env::var("EDDA_SESSION_ID").ok();
-                    if my_sid.as_deref() != Some(&c.session_id) {
-                        input.claimed_by = Some(format!(
-                            "{} (label: '{}', subject: '{target_subject}')",
-                            c.session_id, c.label
-                        ));
-                    }
-                }
-            }
+            let my_sid = std::env::var("EDDA_SESSION_ID").ok();
+            input.claimed_by = check_active_pr_claim(repo_root, pr_number, my_sid.as_deref());
         }
     }
 
@@ -779,19 +795,29 @@ mod tests {
     const VALID_SHA_A: &str = "1234567890abcdef1234567890abcdef12345678";
     const VALID_SHA_B: &str = "abcdef1234567890abcdef1234567890abcdef12";
 
-    #[test]
-    fn test_refuse_when_no_verdict() {
-        let input = MergeGateInput {
+    fn base_input() -> MergeGateInput {
+        MergeGateInput {
             head_sha: VALID_SHA_A.into(),
+            pr: None,
             pr_author: None,
-            verdict: None,
-            verdict_sha: None,
+            verdict: Some("LGTM".into()),
+            verdict_sha: Some(VALID_SHA_A.into()),
             verdict_author: None,
             p0_count: 0,
             p1_count: 0,
             required_ci_green: true,
             failed_checks: vec![],
-            ..Default::default()
+            claimed_by: None,
+            force: false,
+        }
+    }
+
+    #[test]
+    fn test_refuse_when_no_verdict() {
+        let input = MergeGateInput {
+            verdict: None,
+            verdict_sha: None,
+            ..base_input()
         };
         let result = evaluate_merge_preconditions(&input);
         assert!(!result.can_merge);
@@ -805,15 +831,8 @@ mod tests {
     fn test_refuse_when_verdict_stale_new_push() {
         let input = MergeGateInput {
             head_sha: VALID_SHA_B.into(),
-            pr_author: None,
-            verdict: Some("LGTM".into()),
             verdict_sha: Some(VALID_SHA_A.into()),
-            verdict_author: None,
-            p0_count: 0,
-            p1_count: 0,
-            required_ci_green: true,
-            failed_checks: vec![],
-            ..Default::default()
+            ..base_input()
         };
         let result = evaluate_merge_preconditions(&input);
         assert!(!result.can_merge);
@@ -827,15 +846,8 @@ mod tests {
     fn test_refuse_when_sha_is_invalid() {
         let input = MergeGateInput {
             head_sha: "short".into(),
-            pr_author: None,
-            verdict: Some("LGTM".into()),
             verdict_sha: Some("short".into()),
-            verdict_author: None,
-            p0_count: 0,
-            p1_count: 0,
-            required_ci_green: true,
-            failed_checks: vec![],
-            ..Default::default()
+            ..base_input()
         };
         let result = evaluate_merge_preconditions(&input);
         assert!(!result.can_merge);
@@ -848,16 +860,9 @@ mod tests {
     #[test]
     fn test_refuse_when_ci_not_green() {
         let input = MergeGateInput {
-            head_sha: VALID_SHA_A.into(),
-            pr_author: None,
-            verdict: Some("LGTM".into()),
-            verdict_sha: Some(VALID_SHA_A.into()),
-            verdict_author: None,
-            p0_count: 0,
-            p1_count: 0,
             required_ci_green: false,
             failed_checks: vec!["CI Gate (fail)".into()],
-            ..Default::default()
+            ..base_input()
         };
         let result = evaluate_merge_preconditions(&input);
         assert!(!result.can_merge);
@@ -868,16 +873,8 @@ mod tests {
     fn test_refuse_when_blocking_findings_or_changes_requested() {
         // Case A: Changes Requested
         let input_cr = MergeGateInput {
-            head_sha: VALID_SHA_A.into(),
-            pr_author: None,
             verdict: Some("Changes Requested".into()),
-            verdict_sha: Some(VALID_SHA_A.into()),
-            verdict_author: None,
-            p0_count: 0,
-            p1_count: 0,
-            required_ci_green: true,
-            failed_checks: vec![],
-            ..Default::default()
+            ..base_input()
         };
         let res_cr = evaluate_merge_preconditions(&input_cr);
         assert!(!res_cr.can_merge);
@@ -885,16 +882,8 @@ mod tests {
 
         // Case B: P0 > 0 (e.g. 12)
         let input_p0 = MergeGateInput {
-            head_sha: VALID_SHA_A.into(),
-            pr_author: None,
-            verdict: Some("LGTM".into()),
-            verdict_sha: Some(VALID_SHA_A.into()),
-            verdict_author: None,
             p0_count: 12,
-            p1_count: 0,
-            required_ci_green: true,
-            failed_checks: vec![],
-            ..Default::default()
+            ..base_input()
         };
         let res_p0 = evaluate_merge_preconditions(&input_p0);
         assert!(!res_p0.can_merge);
@@ -902,16 +891,8 @@ mod tests {
 
         // Case C: P1 > 0
         let input_p1 = MergeGateInput {
-            head_sha: VALID_SHA_A.into(),
-            pr_author: None,
-            verdict: Some("LGTM".into()),
-            verdict_sha: Some(VALID_SHA_A.into()),
-            verdict_author: None,
-            p0_count: 0,
             p1_count: 2,
-            required_ci_green: true,
-            failed_checks: vec![],
-            ..Default::default()
+            ..base_input()
         };
         let res_p1 = evaluate_merge_preconditions(&input_p1);
         assert!(!res_p1.can_merge);
@@ -924,16 +905,9 @@ mod tests {
     #[test]
     fn test_approve_when_all_preconditions_met() {
         let input = MergeGateInput {
-            head_sha: VALID_SHA_A.into(),
-            pr_author: None,
-            verdict: Some("LGTM".into()),
             verdict_sha: Some(VALID_SHA_A.to_uppercase()), // case-insensitive equality
             verdict_author: Some("opus-reviewer".into()),
-            p0_count: 0,
-            p1_count: 0,
-            required_ci_green: true,
-            failed_checks: vec![],
-            ..Default::default()
+            ..base_input()
         };
         let result = evaluate_merge_preconditions(&input);
         assert!(result.can_merge);
@@ -1122,18 +1096,7 @@ Commit: 1234567890abcdef1234567890abcdef12345678
     fn test_run_check_merge_input_file_report_only() {
         let temp_dir = tempfile::tempdir().unwrap();
         let input_file = temp_dir.path().join("input.json");
-        let valid_input = MergeGateInput {
-            head_sha: VALID_SHA_A.into(),
-            pr_author: None,
-            verdict: Some("LGTM".into()),
-            verdict_sha: Some(VALID_SHA_A.into()),
-            verdict_author: Some("reviewer".into()),
-            p0_count: 0,
-            p1_count: 0,
-            required_ci_green: true,
-            failed_checks: vec![],
-            ..Default::default()
-        };
+        let valid_input = base_input();
         fs::write(&input_file, serde_json::to_string(&valid_input).unwrap()).unwrap();
 
         let args = CheckMergeArgs {
@@ -1240,5 +1203,57 @@ Commit: 1234567890abcdef1234567890abcdef12345678
         assert!(stderr.contains("  - review verdict is not LGTM"));
         assert!(stderr.contains("  - blocking findings present: 1 P0, 1 P1"));
         assert!(stderr.contains("  - required CI check(s) are not green"));
+    }
+
+    #[test]
+    fn test_check_active_pr_claim_semantics() {
+        let repo = tempfile::tempdir().expect("repo");
+        std::fs::create_dir_all(repo.path().join(".edda")).expect("edda");
+        std::fs::create_dir_all(repo.path().join(".git")).expect("git");
+        let project_id = edda_store::project_id(repo.path());
+        let _store = crate::test_support::isolated_store();
+
+        // Initially no claims
+        assert_eq!(check_active_pr_claim(repo.path(), 570, None), None);
+
+        // Claim with subject pr:570 by session s1 (live)
+        edda_bridge_claude::peers::write_heartbeat_minimal(&project_id, "s1", "reviewer", "/tmp");
+        edda_bridge_claude::peers::write_claim_with_subject(
+            &project_id,
+            "s1",
+            "rev-570",
+            &[],
+            Some("pr:570"),
+        );
+
+        // Live claim by s1 is detected for another session
+        let res = check_active_pr_claim(repo.path(), 570, Some("s2"));
+        assert!(res.is_some());
+        assert!(res.as_ref().unwrap().contains("s1"));
+        assert!(res.as_ref().unwrap().contains("pr:570"));
+
+        // Same session (s1) is permitted
+        assert_eq!(check_active_pr_claim(repo.path(), 570, Some("s1")), None);
+
+        // Different PR (571) is clear
+        assert_eq!(check_active_pr_claim(repo.path(), 571, Some("s2")), None);
+
+        // Glob matching: a claim on pr:57* matches PR 570 (Round 1 P1-2)
+        edda_bridge_claude::peers::write_heartbeat_minimal(
+            &project_id,
+            "s_glob",
+            "glob_rev",
+            "/tmp",
+        );
+        edda_bridge_claude::peers::write_claim_with_subject(
+            &project_id,
+            "s_glob",
+            "rev-glob",
+            &[],
+            Some("pr:57*"),
+        );
+        let res_glob = check_active_pr_claim(repo.path(), 570, Some("s1")); // s1 is allowed for s1's claim, but s_glob also claims it!
+        assert!(res_glob.is_some());
+        assert!(res_glob.as_ref().unwrap().contains("s_glob"));
     }
 }

--- a/crates/edda-cli/src/cmd_prs/merge_gate.rs
+++ b/crates/edda-cli/src/cmd_prs/merge_gate.rs
@@ -663,35 +663,53 @@ pub fn format_merge_report(result: &MergeGateResult) -> (String, String) {
 ///
 /// Filters for live sessions and excludes `current_session_id`.
 /// Matches using `subjects_intersect` so glob subjects (e.g. `pr:57*`) are honoured.
-pub fn check_active_pr_claim(
+/// Fails closed (returns `Err`) if a claim subject glob cannot be parsed soundly.
+pub(crate) fn check_active_pr_claim(
     repo_root: &Path,
     pr_number: u64,
     current_session_id: Option<&str>,
-) -> Option<String> {
+) -> anyhow::Result<Option<String>> {
     let project_id = edda_store::project_id(repo_root);
     let target_subject = format!("pr:{pr_number}");
     let board = edda_bridge_claude::peers::compute_board_state(&project_id);
 
-    board.claims.into_iter().find_map(|c| {
-        let sub = c.subject.as_deref()?;
-        if !crate::cmd_claim::subjects_intersect(&target_subject, sub).unwrap_or(false) {
-            return None;
+    // Validate all claim subject globs up front so a corrupted/unparseable glob fails closed
+    for c in &board.claims {
+        if let Some(sub) = c.subject.as_deref() {
+            if crate::cmd_claim::has_wildcard(sub) {
+                globset::GlobBuilder::new(sub)
+                    .case_insensitive(true)
+                    .build()
+                    .map_err(|e| anyhow::anyhow!("invalid claim subject glob '{sub}': {e}"))?;
+            }
+        }
+    }
+
+    for c in board.claims {
+        let Some(sub) = c.subject.as_deref() else {
+            continue;
+        };
+        let matches = crate::cmd_claim::subjects_intersect(&target_subject, sub)
+            .map_err(|e| anyhow::anyhow!("failed to parse claim subject: {e}"))?;
+        if !matches {
+            continue;
         }
         let is_live = matches!(
             edda_bridge_claude::peers::classify_session_liveness(&project_id, &c.session_id),
             edda_bridge_claude::peers::SessionLiveness::Live { .. }
         );
         if !is_live {
-            return None;
+            continue;
         }
-        if current_session_id.is_some() && current_session_id == Some(&c.session_id) {
-            return None;
+        if current_session_id == Some(&c.session_id) {
+            continue;
         }
-        Some(format!(
+        return Ok(Some(format!(
             "{} (label: '{}', subject: '{}')",
             c.session_id, c.label, sub
-        ))
-    })
+        )));
+    }
+    Ok(None)
 }
 
 /// Execute the merge precondition check CLI entrypoint.
@@ -715,7 +733,7 @@ pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result
     } else if let Some(head_sha) = args.head_sha {
         MergeGateInput {
             head_sha,
-            pr: args.pr,
+            pr: None,
             pr_author: None,
             verdict: args.verdict,
             verdict_sha: args.verdict_sha,
@@ -741,7 +759,7 @@ pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result
     if let Some(pr_number) = target_pr {
         if input.claimed_by.is_none() {
             let my_sid = std::env::var("EDDA_SESSION_ID").ok();
-            input.claimed_by = check_active_pr_claim(repo_root, pr_number, my_sid.as_deref());
+            input.claimed_by = check_active_pr_claim(repo_root, pr_number, my_sid.as_deref())?;
         }
     }
 
@@ -1214,7 +1232,7 @@ Commit: 1234567890abcdef1234567890abcdef12345678
         let _store = crate::test_support::isolated_store();
 
         // Initially no claims
-        assert_eq!(check_active_pr_claim(repo.path(), 570, None), None);
+        assert_eq!(check_active_pr_claim(repo.path(), 570, None).unwrap(), None);
 
         // Claim with subject pr:570 by session s1 (live)
         edda_bridge_claude::peers::write_heartbeat_minimal(&project_id, "s1", "reviewer", "/tmp");
@@ -1227,16 +1245,22 @@ Commit: 1234567890abcdef1234567890abcdef12345678
         );
 
         // Live claim by s1 is detected for another session
-        let res = check_active_pr_claim(repo.path(), 570, Some("s2"));
+        let res = check_active_pr_claim(repo.path(), 570, Some("s2")).unwrap();
         assert!(res.is_some());
         assert!(res.as_ref().unwrap().contains("s1"));
         assert!(res.as_ref().unwrap().contains("pr:570"));
 
         // Same session (s1) is permitted
-        assert_eq!(check_active_pr_claim(repo.path(), 570, Some("s1")), None);
+        assert_eq!(
+            check_active_pr_claim(repo.path(), 570, Some("s1")).unwrap(),
+            None
+        );
 
         // Different PR (571) is clear
-        assert_eq!(check_active_pr_claim(repo.path(), 571, Some("s2")), None);
+        assert_eq!(
+            check_active_pr_claim(repo.path(), 571, Some("s2")).unwrap(),
+            None
+        );
 
         // Glob matching: a claim on pr:57* matches PR 570 (Round 1 P1-2)
         edda_bridge_claude::peers::write_heartbeat_minimal(
@@ -1252,8 +1276,20 @@ Commit: 1234567890abcdef1234567890abcdef12345678
             &[],
             Some("pr:57*"),
         );
-        let res_glob = check_active_pr_claim(repo.path(), 570, Some("s1")); // s1 is allowed for s1's claim, but s_glob also claims it!
+        let res_glob = check_active_pr_claim(repo.path(), 570, Some("s1")).unwrap(); // s1 is allowed for s1's claim, but s_glob also claims it!
         assert!(res_glob.is_some());
         assert!(res_glob.as_ref().unwrap().contains("s_glob"));
+
+        // Unparseable glob (Round 2 P1): fails closed with Err
+        edda_bridge_claude::peers::write_heartbeat_minimal(&project_id, "s_bad", "bad_rev", "/tmp");
+        edda_bridge_claude::peers::write_claim_with_subject(
+            &project_id,
+            "s_bad",
+            "rev-bad",
+            &[],
+            Some("pr:57[0-"),
+        );
+        let res_bad = check_active_pr_claim(repo.path(), 570, Some("s2"));
+        assert!(res_bad.is_err(), "unparseable claim glob must fail closed");
     }
 }

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -179,6 +179,9 @@ enum Command {
         /// File path patterns this scope covers (e.g. "src/auth/*")
         #[arg(long)]
         paths: Vec<String>,
+        /// Process object or subject this scope covers (e.g. "pr:570", "release:v0.4.1")
+        #[arg(long)]
+        subject: Option<String>,
         /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
@@ -781,6 +784,9 @@ enum BridgeClaudeCmd {
         /// File path patterns this scope covers (e.g. "src/auth/*")
         #[arg(long)]
         paths: Vec<String>,
+        /// Process object or subject this scope covers (e.g. "pr:570", "release:v0.4.1")
+        #[arg(long)]
+        subject: Option<String>,
         /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
         #[arg(long)]
         session: Option<String>,
@@ -1127,6 +1133,7 @@ fn main() -> anyhow::Result<()> {
         Command::Claim {
             label,
             paths,
+            subject,
             session,
             cmd,
         } => match cmd {
@@ -1134,7 +1141,13 @@ fn main() -> anyhow::Result<()> {
                 cmd_claim::claim_check(&repo_root, &query, json)
             }
             None => match label {
-                Some(label) => cmd_bridge::claim(&repo_root, &label, &paths, session.as_deref()),
+                Some(label) => cmd_bridge::claim(
+                    &repo_root,
+                    &label,
+                    &paths,
+                    subject.as_deref(),
+                    session.as_deref(),
+                ),
                 // No label and no `check` subcommand: invalid usage.
                 // Declared contract for GH-589 (cli.claim-diagnostics-contract=explicit-mode-dispatch):
                 // require an explicit scope label or the `check` subcommand, exiting with code 2.

--- a/crates/edda-cli/src/tui/app.rs
+++ b/crates/edda-cli/src/tui/app.rs
@@ -251,6 +251,7 @@ mod tests {
             files_modified_count: 0,
             recent_commits: vec![],
             claimed_paths: vec![],
+            claimed_subject: None,
             branch: None,
             current_phase: None,
         }

--- a/crates/edda-cli/tests/process_claim_contract.rs
+++ b/crates/edda-cli/tests/process_claim_contract.rs
@@ -126,6 +126,15 @@ fn claim_with_subject_records_on_board() {
         board.contains("\"label\":\"review-pr570\""),
         "board: {board}"
     );
+
+    // GH-581 / Round 1 & Round 2 P1: Verify edda peers formats the claimed subject
+    env.write_heartbeat("reviewer-1", 0);
+    let (p_code, p_stdout, p_stderr) = env.run_edda(&["peers"]);
+    assert_eq!(p_code, 0, "peers failed: {p_stderr}");
+    assert!(
+        p_stdout.contains("[pr:570]"),
+        "edda peers output should contain [pr:570], got: {p_stdout}"
+    );
 }
 
 #[test]
@@ -341,4 +350,33 @@ fn check_merge_refuses_claimed_pr_unless_force() {
     );
     assert_eq!(code_mask, 1, "live claim must not be masked by stale claim");
     assert!(stderr_mask.contains("z-live-sess"), "stderr: {stderr_mask}");
+
+    // Case 7: Unparseable claim glob on board fails closed (refuses merge with error)
+    let env_bad = TestEnv::new();
+    env_bad.write_heartbeat("bad-reviewer", 0);
+    env_bad.run_edda(&[
+        "claim",
+        "review-bad",
+        "--subject",
+        "pr:57[0-",
+        "--session",
+        "bad-reviewer",
+    ]);
+    let input_path_bad = env_bad.repo.join("input.json");
+    std::fs::write(&input_path_bad, input_json.to_string()).expect("write input.json");
+    let (code_bad, _, stderr_bad) = env_bad.run_edda_with_env(
+        &[
+            "prs",
+            "check-merge",
+            "570",
+            "--input",
+            input_path_bad.to_str().unwrap(),
+        ],
+        &[("EDDA_SESSION_ID", "other-worker")],
+    );
+    assert_ne!(code_bad, 0, "unparseable glob must fail closed");
+    assert!(
+        stderr_bad.contains("failed to parse claim subject") || stderr_bad.contains("error"),
+        "stderr: {stderr_bad}"
+    );
 }

--- a/crates/edda-cli/tests/process_claim_contract.rs
+++ b/crates/edda-cli/tests/process_claim_contract.rs
@@ -1,0 +1,293 @@
+//! Contract tests for process object claims and merge gate claim protection (GH-581).
+//!
+//! Verifies:
+//! 1. `edda claim review-pr570 --subject pr:570` records the subject on the board.
+//! 2. `edda claim check pr:570` detects the conflict (exit 1) when session is live.
+//! 3. `edda claim check pr:571` reports clear (exit 0).
+//! 4. `edda prs check-merge` refuses when PR subject is claimed by an active session (exit 1).
+//! 5. `edda prs check-merge --force` overrides the active claim and proceeds with a Claim Notice.
+//! 6. Stale session claims or unrelated subjects do not block merge gate.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+struct TestEnv {
+    _dir: tempfile::TempDir,
+    repo: PathBuf,
+    store: PathBuf,
+    project_id: String,
+}
+
+impl TestEnv {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let repo = dir.path().join("repo");
+        let store = dir.path().join("store");
+        // Hermetic isolation (GH-646)
+        std::fs::create_dir_all(repo.join(".edda")).expect("create .edda");
+        std::fs::create_dir_all(repo.join(".git")).expect("create .git");
+        std::fs::create_dir_all(&store).expect("create store");
+        let project_id = edda_store::project_id(&repo);
+        Self {
+            _dir: dir,
+            repo,
+            store,
+            project_id,
+        }
+    }
+
+    fn board_path(&self) -> PathBuf {
+        self.store
+            .join("projects")
+            .join(&self.project_id)
+            .join("state")
+            .join("coordination.jsonl")
+    }
+
+    fn write_heartbeat(&self, session_id: &str, age_secs: u64) {
+        let ts = chrono::Utc::now() - chrono::Duration::seconds(age_secs as i64);
+        let hb = serde_json::json!({
+            "session_id": session_id,
+            "started_at": ts.to_rfc3339(),
+            "last_heartbeat": ts.to_rfc3339(),
+            "label": "worker",
+            "focus_files": [],
+            "active_tasks": [],
+            "files_modified_count": 0,
+            "total_edits": 0,
+            "recent_commits": []
+        });
+        let state_dir = self
+            .store
+            .join("projects")
+            .join(&self.project_id)
+            .join("state");
+        std::fs::create_dir_all(&state_dir).expect("state dir");
+        std::fs::write(
+            state_dir.join(format!("session.{session_id}.json")),
+            serde_json::to_string_pretty(&hb).unwrap(),
+        )
+        .expect("write heartbeat");
+    }
+
+    fn run_edda(&self, args: &[&str]) -> (i32, String, String) {
+        let bin = PathBuf::from(env!("CARGO_BIN_EXE_edda"));
+        let out = Command::new(&bin)
+            .args(args)
+            .current_dir(&self.repo)
+            .env("EDDA_STORE_ROOT", &self.store)
+            .output()
+            .expect("spawn edda");
+        (
+            out.status.code().expect("exit code"),
+            String::from_utf8_lossy(&out.stdout).into_owned(),
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        )
+    }
+
+    fn run_edda_with_env(&self, args: &[&str], env_vars: &[(&str, &str)]) -> (i32, String, String) {
+        let bin = PathBuf::from(env!("CARGO_BIN_EXE_edda"));
+        let mut cmd = Command::new(&bin);
+        cmd.args(args)
+            .current_dir(&self.repo)
+            .env("EDDA_STORE_ROOT", &self.store);
+        for (k, v) in env_vars {
+            cmd.env(k, v);
+        }
+        let out = cmd.output().expect("spawn edda");
+        (
+            out.status.code().expect("exit code"),
+            String::from_utf8_lossy(&out.stdout).into_owned(),
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        )
+    }
+}
+
+#[test]
+fn claim_with_subject_records_on_board() {
+    let env = TestEnv::new();
+    let (code, stdout, stderr) = env.run_edda(&[
+        "claim",
+        "review-pr570",
+        "--subject",
+        "pr:570",
+        "--session",
+        "reviewer-1",
+    ]);
+
+    assert_eq!(code, 0, "stdout={stdout:?} stderr={stderr:?}");
+    assert!(stdout.contains("Claimed scope: review-pr570"));
+    assert!(stdout.contains("subject: pr:570"));
+    assert!(stdout.contains("session: reviewer-1"));
+
+    let board = std::fs::read_to_string(env.board_path()).expect("read board");
+    assert!(board.contains("\"subject\":\"pr:570\""), "board: {board}");
+    assert!(
+        board.contains("\"label\":\"review-pr570\""),
+        "board: {board}"
+    );
+}
+
+#[test]
+fn claim_check_detects_matching_process_subject() {
+    let env = TestEnv::new();
+    env.write_heartbeat("reviewer-1", 0); // live session
+    let (code, stdout, stderr) = env.run_edda(&[
+        "claim",
+        "review-pr570",
+        "--subject",
+        "pr:570",
+        "--session",
+        "reviewer-1",
+    ]);
+    assert_eq!(code, 0, "stdout={stdout:?} stderr={stderr:?}");
+
+    // Conflict check on pr:570 -> exit 1
+    let (code_conflict, stdout_conflict, stderr_conflict) =
+        env.run_edda(&["claim", "check", "pr:570"]);
+    assert_eq!(
+        code_conflict, 1,
+        "stdout={stdout_conflict:?} stderr={stderr_conflict:?}"
+    );
+    assert!(
+        stdout_conflict.contains("CONFLICT with claim \"review-pr570\""),
+        "stdout: {stdout_conflict}"
+    );
+    assert!(stdout_conflict.contains("session reviewer-1"));
+
+    // Disjoint check on pr:571 -> exit 0
+    let (code_clear, stdout_clear, stderr_clear) = env.run_edda(&["claim", "check", "pr:571"]);
+    assert_eq!(
+        code_clear, 0,
+        "stdout={stdout_clear:?} stderr={stderr_clear:?}"
+    );
+    assert!(
+        stdout_clear.contains("No conflicts") || stdout_clear.contains("surface is clear"),
+        "stdout: {stdout_clear}"
+    );
+}
+
+#[test]
+fn claim_check_on_stale_session_subject_reports_clear() {
+    let env = TestEnv::new();
+    // Stale session (e.g. 500s ago, heartbeat expired)
+    env.write_heartbeat("reviewer-old", 500);
+    let (code, _, _) = env.run_edda(&[
+        "claim",
+        "review-pr570",
+        "--subject",
+        "pr:570",
+        "--session",
+        "reviewer-old",
+    ]);
+    assert_eq!(code, 0);
+
+    // Stale session claim must not conflict (exit 0)
+    let (code_check, stdout_check, _) = env.run_edda(&["claim", "check", "pr:570"]);
+    assert_eq!(code_check, 0);
+    assert!(
+        stdout_check.contains("surface is clear") || stdout_check.contains("No conflicts"),
+        "stdout: {stdout_check}"
+    );
+}
+
+#[test]
+fn check_merge_refuses_claimed_pr_unless_force() {
+    let env = TestEnv::new();
+    env.write_heartbeat("active-reviewer", 0); // live session
+    let (code, _, _) = env.run_edda(&[
+        "claim",
+        "review-pr570",
+        "--subject",
+        "pr:570",
+        "--session",
+        "active-reviewer",
+    ]);
+    assert_eq!(code, 0);
+
+    // Prepare a valid MergeGateInput json file
+    let input_json = serde_json::json!({
+        "head_sha": "1234567890abcdef1234567890abcdef12345678",
+        "pr_author": "worker-1",
+        "verdict": "LGTM",
+        "verdict_sha": "1234567890abcdef1234567890abcdef12345678",
+        "verdict_author": "authorized-reviewer",
+        "p0_count": 0,
+        "p1_count": 0,
+        "required_ci_green": true,
+        "failed_checks": []
+    });
+    let input_path = env.repo.join("input.json");
+    std::fs::write(&input_path, input_json.to_string()).expect("write input.json");
+
+    // Case 1: Same session holding claim is allowed to merge
+    let (code_same, stdout_same, _) = env.run_edda_with_env(
+        &[
+            "prs",
+            "check-merge",
+            "--input",
+            input_path.to_str().unwrap(),
+            "--head-sha",
+            "1234567890abcdef1234567890abcdef12345678",
+        ],
+        &[("EDDA_SESSION_ID", "active-reviewer")],
+    );
+    assert_eq!(
+        code_same, 0,
+        "same session holding claim should pass: stdout={stdout_same}"
+    );
+    assert!(stdout_same.contains("PASS: Merge preconditions satisfied"));
+
+    // Now test with PR argument in run_check_merge
+    // We can simulate input with claimed_by set to verify evaluate_merge_preconditions and formatting
+    let claimed_input_json = serde_json::json!({
+        "head_sha": "1234567890abcdef1234567890abcdef12345678",
+        "pr_author": "worker-1",
+        "verdict": "LGTM",
+        "verdict_sha": "1234567890abcdef1234567890abcdef12345678",
+        "verdict_author": "authorized-reviewer",
+        "p0_count": 0,
+        "p1_count": 0,
+        "required_ci_green": true,
+        "failed_checks": [],
+        "claimed_by": "active-reviewer (label: 'review-pr570', subject: 'pr:570')"
+    });
+    let claimed_input_path = env.repo.join("claimed_input.json");
+    std::fs::write(&claimed_input_path, claimed_input_json.to_string())
+        .expect("write claimed_input.json");
+
+    // Case 2: Claimed by other session -> REFUSED (exit 1)
+    let (code_refused, _stdout_refused, stderr_refused) = env.run_edda_with_env(
+        &[
+            "prs",
+            "check-merge",
+            "--input",
+            claimed_input_path.to_str().unwrap(),
+        ],
+        &[("EDDA_SESSION_ID", "other-worker")],
+    );
+    assert_eq!(
+        code_refused, 1,
+        "claimed PR should refuse merge: stderr={stderr_refused}"
+    );
+    assert!(stderr_refused.contains("REFUSED"));
+    assert!(stderr_refused.contains("PR is claimed by active session 'active-reviewer (label: 'review-pr570', subject: 'pr:570')' — use --force to override"));
+
+    // Case 3: Override with --force -> PASS with Claim Notice (exit 0)
+    let (code_force, stdout_force, stderr_force) = env.run_edda_with_env(
+        &[
+            "prs",
+            "check-merge",
+            "--input",
+            claimed_input_path.to_str().unwrap(),
+            "--force",
+        ],
+        &[("EDDA_SESSION_ID", "other-worker")],
+    );
+    assert_eq!(
+        code_force, 0,
+        "force should allow merge: stderr={stderr_force} stdout={stdout_force}"
+    );
+    assert!(stdout_force.contains("PASS: Merge preconditions satisfied"));
+    assert!(stdout_force.contains("Claim Notice: Overriding process claim held by 'active-reviewer (label: 'review-pr570', subject: 'pr:570')' (--force specified)"));
+}

--- a/crates/edda-cli/tests/process_claim_contract.rs
+++ b/crates/edda-cli/tests/process_claim_contract.rs
@@ -143,50 +143,36 @@ fn claim_check_detects_matching_process_subject() {
     assert_eq!(code, 0, "stdout={stdout:?} stderr={stderr:?}");
 
     // Conflict check on pr:570 -> exit 1
-    let (code_conflict, stdout_conflict, stderr_conflict) =
-        env.run_edda(&["claim", "check", "pr:570"]);
-    assert_eq!(
-        code_conflict, 1,
-        "stdout={stdout_conflict:?} stderr={stderr_conflict:?}"
-    );
-    assert!(
-        stdout_conflict.contains("CONFLICT with claim \"review-pr570\""),
-        "stdout: {stdout_conflict}"
-    );
+    let (code_conflict, stdout_conflict, _) = env.run_edda(&["claim", "check", "pr:570"]);
+    assert_eq!(code_conflict, 1);
+    assert!(stdout_conflict.contains("CONFLICT with claim \"review-pr570\""));
     assert!(stdout_conflict.contains("session reviewer-1"));
 
     // Disjoint check on pr:571 -> exit 0
-    let (code_clear, stdout_clear, stderr_clear) = env.run_edda(&["claim", "check", "pr:571"]);
-    assert_eq!(
-        code_clear, 0,
-        "stdout={stdout_clear:?} stderr={stderr_clear:?}"
-    );
-    assert!(
-        stdout_clear.contains("No conflicts") || stdout_clear.contains("surface is clear"),
-        "stdout: {stdout_clear}"
-    );
+    let (code_clear, stdout_clear, _) = env.run_edda(&["claim", "check", "pr:571"]);
+    assert_eq!(code_clear, 0);
+    assert!(stdout_clear.contains("No conflicts"));
 }
 
 #[test]
 fn claim_check_on_stale_session_subject_reports_clear() {
     let env = TestEnv::new();
-    // Stale session (e.g. 500s ago, heartbeat expired)
-    env.write_heartbeat("reviewer-old", 500);
+    env.write_heartbeat("reviewer-1", 600); // 10 minutes ago = stale
     let (code, _, _) = env.run_edda(&[
         "claim",
         "review-pr570",
         "--subject",
         "pr:570",
         "--session",
-        "reviewer-old",
+        "reviewer-1",
     ]);
     assert_eq!(code, 0);
 
-    // Stale session claim must not conflict (exit 0)
+    // Because session is stale, claim check ignores it and reports clear (exit 0)
     let (code_check, stdout_check, _) = env.run_edda(&["claim", "check", "pr:570"]);
     assert_eq!(code_check, 0);
     assert!(
-        stdout_check.contains("surface is clear") || stdout_check.contains("No conflicts"),
+        stdout_check.contains("No conflicts"),
         "stdout: {stdout_check}"
     );
 }
@@ -205,9 +191,11 @@ fn check_merge_refuses_claimed_pr_unless_force() {
     ]);
     assert_eq!(code, 0);
 
-    // Prepare a valid MergeGateInput json file
+    // Prepare a valid MergeGateInput json file WITHOUT claimed_by.
+    // The gate will resolve the claim live from the coordination board for PR 570.
     let input_json = serde_json::json!({
         "head_sha": "1234567890abcdef1234567890abcdef12345678",
+        "pr": 570,
         "pr_author": "worker-1",
         "verdict": "LGTM",
         "verdict_sha": "1234567890abcdef1234567890abcdef12345678",
@@ -220,15 +208,14 @@ fn check_merge_refuses_claimed_pr_unless_force() {
     let input_path = env.repo.join("input.json");
     std::fs::write(&input_path, input_json.to_string()).expect("write input.json");
 
-    // Case 1: Same session holding claim is allowed to merge
+    // Case 1: Same session holding claim is allowed to merge (exit 0)
     let (code_same, stdout_same, _) = env.run_edda_with_env(
         &[
             "prs",
             "check-merge",
+            "570",
             "--input",
             input_path.to_str().unwrap(),
-            "--head-sha",
-            "1234567890abcdef1234567890abcdef12345678",
         ],
         &[("EDDA_SESSION_ID", "active-reviewer")],
     );
@@ -238,31 +225,15 @@ fn check_merge_refuses_claimed_pr_unless_force() {
     );
     assert!(stdout_same.contains("PASS: Merge preconditions satisfied"));
 
-    // Now test with PR argument in run_check_merge
-    // We can simulate input with claimed_by set to verify evaluate_merge_preconditions and formatting
-    let claimed_input_json = serde_json::json!({
-        "head_sha": "1234567890abcdef1234567890abcdef12345678",
-        "pr_author": "worker-1",
-        "verdict": "LGTM",
-        "verdict_sha": "1234567890abcdef1234567890abcdef12345678",
-        "verdict_author": "authorized-reviewer",
-        "p0_count": 0,
-        "p1_count": 0,
-        "required_ci_green": true,
-        "failed_checks": [],
-        "claimed_by": "active-reviewer (label: 'review-pr570', subject: 'pr:570')"
-    });
-    let claimed_input_path = env.repo.join("claimed_input.json");
-    std::fs::write(&claimed_input_path, claimed_input_json.to_string())
-        .expect("write claimed_input.json");
-
-    // Case 2: Claimed by other session -> REFUSED (exit 1)
+    // Case 2: Other session trying to merge without --force -> REFUSED (exit 1)
+    // Board claim is detected directly by check-merge
     let (code_refused, _stdout_refused, stderr_refused) = env.run_edda_with_env(
         &[
             "prs",
             "check-merge",
+            "570",
             "--input",
-            claimed_input_path.to_str().unwrap(),
+            input_path.to_str().unwrap(),
         ],
         &[("EDDA_SESSION_ID", "other-worker")],
     );
@@ -278,8 +249,9 @@ fn check_merge_refuses_claimed_pr_unless_force() {
         &[
             "prs",
             "check-merge",
+            "570",
             "--input",
-            claimed_input_path.to_str().unwrap(),
+            input_path.to_str().unwrap(),
             "--force",
         ],
         &[("EDDA_SESSION_ID", "other-worker")],
@@ -290,4 +262,83 @@ fn check_merge_refuses_claimed_pr_unless_force() {
     );
     assert!(stdout_force.contains("PASS: Merge preconditions satisfied"));
     assert!(stdout_force.contains("Claim Notice: Overriding process claim held by 'active-reviewer (label: 'review-pr570', subject: 'pr:570')' (--force specified)"));
+
+    // Case 4: Another PR (571) is not claimed -> PASS without Claim Notice (exit 0)
+    let (code_571, stdout_571, _) = env.run_edda_with_env(
+        &[
+            "prs",
+            "check-merge",
+            "571",
+            "--input",
+            input_path.to_str().unwrap(),
+        ],
+        &[("EDDA_SESSION_ID", "other-worker")],
+    );
+    assert_eq!(code_571, 0, "unclaimed PR passes");
+    assert!(stdout_571.contains("PASS: Merge preconditions satisfied"));
+    assert!(!stdout_571.contains("Claim Notice"));
+
+    // Case 5: Glob claim (pr:57*) on board also protects PR 570 (Round 1 P1-2)
+    let env_glob = TestEnv::new();
+    env_glob.write_heartbeat("glob-reviewer", 0);
+    let (code_g, _, _) = env_glob.run_edda(&[
+        "claim",
+        "review-glob",
+        "--subject",
+        "pr:57*",
+        "--session",
+        "glob-reviewer",
+    ]);
+    assert_eq!(code_g, 0);
+    let input_path_glob = env_glob.repo.join("input.json");
+    std::fs::write(&input_path_glob, input_json.to_string()).expect("write input.json");
+    let (code_glob_refused, _, stderr_glob) = env_glob.run_edda_with_env(
+        &[
+            "prs",
+            "check-merge",
+            "570",
+            "--input",
+            input_path_glob.to_str().unwrap(),
+        ],
+        &[("EDDA_SESSION_ID", "other-worker")],
+    );
+    assert_eq!(code_glob_refused, 1, "glob claim must protect PR 570");
+    assert!(stderr_glob.contains("PR is claimed by active session 'glob-reviewer (label: 'review-glob', subject: 'pr:57*')' — use --force to override"));
+
+    // Case 6: Live claim is not masked by an earlier stale claim (Round 1 P1-1)
+    let env_mask = TestEnv::new();
+    // Stale session with label sorting before 'z-live'
+    env_mask.write_heartbeat("a-stale-sess", 600); // 600 seconds old = stale
+    env_mask.run_edda(&[
+        "claim",
+        "a-stale-label",
+        "--subject",
+        "pr:570",
+        "--session",
+        "a-stale-sess",
+    ]);
+    // Live session with label sorting after 'a-stale-label'
+    env_mask.write_heartbeat("z-live-sess", 0); // live
+    env_mask.run_edda(&[
+        "claim",
+        "z-live-label",
+        "--subject",
+        "pr:570",
+        "--session",
+        "z-live-sess",
+    ]);
+    let input_path_mask = env_mask.repo.join("input.json");
+    std::fs::write(&input_path_mask, input_json.to_string()).expect("write input.json");
+    let (code_mask, _, stderr_mask) = env_mask.run_edda_with_env(
+        &[
+            "prs",
+            "check-merge",
+            "570",
+            "--input",
+            input_path_mask.to_str().unwrap(),
+        ],
+        &[("EDDA_SESSION_ID", "other-worker")],
+    );
+    assert_eq!(code_mask, 1, "live claim must not be masked by stale claim");
+    assert!(stderr_mask.contains("z-live-sess"), "stderr: {stderr_mask}");
 }


### PR DESCRIPTION
## Summary
Support claims on process objects (e.g. \--subject pr:570\) alongside file paths, and protect in-flight PR review loops from premature merge via \dda prs check-merge\.

Issue: #581

## Proposed Changes
- \crates/edda-bridge-claude\:
  - Extend \ClaimEntry\ and \PeerSummary\ with \subject\ / \claimed_subject\.
  - Add \write_claim_with_subject\ and record \subject\ in \coordination.jsonl\ events.
  - Expose \claimed_subject\ in active peer discovery, session context injection, and coordination rendering.
- \crates/edda-cli\:
  - Support \--subject <URN>\ in \dda claim\ and \dda bridge claude claim\.
  - Extend \dda claim check\ to detect conflicts on matching process subjects with case-insensitive and glob comparison.
  - Extend \dda prs check-merge\ to query the coordination board for active claims on \pr:<N>\, refusing merge unless \--force\ is specified.
  - Add integration tests in \crates/edda-cli/tests/process_claim_contract.rs\.

## Verification
- Local checks run in lane \worker-2\:
  - \cargo fmt --all --check\ (PASSED)
  - \cargo clippy -p edda-bridge-claude -p edda --all-targets -- -D warnings\ (PASSED)
  - \cargo test -p edda --test process_claim_contract\ (4/4 PASSED)
  - \cargo test -p edda --bin edda -- cmd_claim\ (41/41 PASSED)
  - \cargo test -p edda --bin edda -- cmd_prs::merge_gate\ (15/15 PASSED)