### PR TITLE
feat(bridge): ingest pi session transcripts post-dispatch (GH-577)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,12 +1120,14 @@ name = "edda-transcript"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "dirs",
  "edda-store",
  "fs2",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
+ "time",
 ]
 
 [[package]]

--- a/crates/edda-bridge-claude/src/digest/helpers.rs
+++ b/crates/edda-bridge-claude/src/digest/helpers.rs
@@ -199,6 +199,7 @@ mod tests {
             output_tokens: 0,
             cache_read_tokens: 0,
             cache_creation_tokens: 0,
+            ..Default::default()
         };
         assert_eq!(
             measured_cost(&usage),
@@ -216,6 +217,7 @@ mod tests {
             output_tokens: 0,
             cache_read_tokens: 0,
             cache_creation_tokens: 0,
+            ..Default::default()
         };
         assert_eq!(
             measured_cost(&usage),
@@ -233,6 +235,7 @@ mod tests {
             output_tokens: 100_000,
             cache_read_tokens: 500_000,
             cache_creation_tokens: 0,
+            ..Default::default()
         };
         let cost = measured_cost(&usage).expect("fable should be priceable");
         // full price in: (1M - 500k) = 500k * $10/M = $5.00

--- a/crates/edda-bridge-claude/src/digest/orchestrate.rs
+++ b/crates/edda-bridge-claude/src/digest/orchestrate.rs
@@ -971,6 +971,20 @@ pub fn digest_session_manual(
     let parent_hash = ledger.last_event_hash()?;
 
     stats.tasks_snapshot = load_tasks_for_digest(project_id);
+
+    // Enrich with usage data (model, tokens, cost) from transcript signals
+    {
+        let usage = crate::signals::read_usage_state(project_id);
+        if !usage.model.is_empty() {
+            stats.model = usage.model.clone();
+        }
+        stats.input_tokens = usage.input_tokens;
+        stats.output_tokens = usage.output_tokens;
+        stats.cache_read_tokens = usage.cache_read_tokens;
+        stats.cache_creation_tokens = usage.cache_creation_tokens;
+        stats.estimated_cost_usd = super::helpers::measured_cost(&usage);
+    }
+
     let (_decisions, notes) = collect_session_ledger_extras(cwd, stats.first_ts.as_deref());
 
     // Identity proof of the consumed prefix, stamped into the note so the

--- a/crates/edda-bridge-claude/src/digest/orchestrate.rs
+++ b/crates/edda-bridge-claude/src/digest/orchestrate.rs
@@ -724,7 +724,9 @@ fn digest_one_session(
         stats.output_tokens = usage.output_tokens;
         stats.cache_read_tokens = usage.cache_read_tokens;
         stats.cache_creation_tokens = usage.cache_creation_tokens;
-        stats.estimated_cost_usd = super::helpers::measured_cost(&usage);
+        stats.estimated_cost_usd = usage
+            .cost_usd
+            .or_else(|| super::helpers::measured_cost(&usage));
     }
 
     // Collect session notes and decisions from workspace ledger
@@ -982,7 +984,9 @@ pub fn digest_session_manual(
         stats.output_tokens = usage.output_tokens;
         stats.cache_read_tokens = usage.cache_read_tokens;
         stats.cache_creation_tokens = usage.cache_creation_tokens;
-        stats.estimated_cost_usd = super::helpers::measured_cost(&usage);
+        stats.estimated_cost_usd = usage
+            .cost_usd
+            .or_else(|| super::helpers::measured_cost(&usage));
     }
 
     let (_decisions, notes) = collect_session_ledger_extras(cwd, stats.first_ts.as_deref());

--- a/crates/edda-bridge-claude/src/signals.rs
+++ b/crates/edda-bridge-claude/src/signals.rs
@@ -43,6 +43,9 @@ pub struct UsageSnapshot {
     pub cache_read_tokens: u64,
     #[serde(default)]
     pub cache_creation_tokens: u64,
+    /// Measured cost in USD if carried directly by the agent transcript (e.g. Pi).
+    #[serde(default)]
+    pub cost_usd: Option<f64>,
     /// Whether at least one `message.usage` record was observed in the
     /// transcript (GH-585 round 2). Presence is recorded independently of
     /// the token counters so a measured all-zero usage (e.g. zero pricing)
@@ -2095,6 +2098,7 @@ mod tests {
                 cache_read_tokens: 100,
                 cache_creation_tokens: 50,
                 usage_observed: true,
+                ..Default::default()
             },
             ..Default::default()
         };

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -1447,11 +1447,9 @@ mod tests {
 
     #[test]
     fn ingest_pi_session_post_dispatch_wired_produces_digest() {
+        let _store = crate::test_support::isolated_store();
         let tmp_ws = tempfile::tempdir().unwrap();
-        let tmp_store = tempfile::tempdir().unwrap();
         let tmp_sessions = tempfile::tempdir().unwrap();
-
-        std::env::set_var("EDDA_STORE_ROOT", tmp_store.path());
 
         let ws_path = tmp_ws.path();
         let ledger = edda_ledger::Ledger::open_or_init(ws_path).unwrap();

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -502,26 +502,28 @@ fn run_inner(args: DispatchArgs) -> Result<i32> {
 }
 
 /// Ingest Pi session transcripts after a dispatch turn and emit `#session_digest`.
-pub fn ingest_pi_session_post_dispatch(
+pub(crate) fn ingest_pi_session_post_dispatch(
     cwd: &std::path::Path,
     session_id: &str,
     session_dir: Option<&std::path::Path>,
 ) -> Result<()> {
     let project_id = edda_store::project_id(cwd);
     let project_dir = edda_store::project_dir(&project_id);
-    let _ = edda_store::ensure_dirs(&project_id);
+    edda_store::ensure_dirs(&project_id)?;
 
     let session_file = match edda_transcript::find_pi_session_file(cwd, session_id, session_dir) {
         Some(f) => f,
-        None => return Ok(()),
+        None => {
+            eprintln!("Warning: pi session file not found for session {session_id}");
+            return Ok(());
+        }
     };
 
     let _stats =
         edda_transcript::ingest_pi_transcript_delta(&project_dir, session_id, cwd, &session_file)?;
 
     let cwd_str = cwd.to_string_lossy();
-    let _ =
-        edda_bridge_claude::digest::digest_session_manual(&project_id, session_id, &cwd_str, true);
+    edda_bridge_claude::digest::digest_session_manual(&project_id, session_id, &cwd_str, true)?;
 
     Ok(())
 }
@@ -1441,5 +1443,123 @@ mod tests {
             res.is_ok(),
             "missing pi session file returns Ok(()) gracefully"
         );
+    }
+
+    #[test]
+    fn ingest_pi_session_post_dispatch_wired_produces_digest() {
+        let tmp_ws = tempfile::tempdir().unwrap();
+        let tmp_store = tempfile::tempdir().unwrap();
+        let tmp_sessions = tempfile::tempdir().unwrap();
+
+        std::env::set_var("EDDA_STORE_ROOT", tmp_store.path());
+
+        let ws_path = tmp_ws.path();
+        let ledger = edda_ledger::Ledger::open_or_init(ws_path).unwrap();
+
+        let session_id = "test-wired-pi-577";
+        let session_file = tmp_sessions
+            .path()
+            .join(format!("2026-09-02T12-00-00-000Z_{session_id}.jsonl"));
+        let lines = vec![
+            serde_json::json!({
+                "type": "session",
+                "version": 3,
+                "id": session_id,
+                "timestamp": "2026-09-02T12:00:00.000Z",
+                "cwd": ws_path.to_string_lossy(),
+            }),
+            serde_json::json!({
+                "type": "message",
+                "id": "m1",
+                "timestamp": "2026-09-02T12:00:05.000Z",
+                "message": {
+                    "role": "user",
+                    "content": [{ "type": "text", "text": "Run tests" }]
+                }
+            }),
+            serde_json::json!({
+                "type": "message",
+                "id": "m2",
+                "timestamp": "2026-09-02T12:01:30.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "toolCall",
+                            "id": "c1",
+                            "name": "bash",
+                            "arguments": { "command": "cargo check" }
+                        }
+                    ],
+                    "model": "gpt-5.6-sol",
+                    "usage": {
+                        "input": 500,
+                        "output": 100,
+                        "cacheRead": 0,
+                        "cacheWrite": 0,
+                        "totalTokens": 600,
+                        "cost": { "total": 0.02 }
+                    }
+                }
+            }),
+            serde_json::json!({
+                "type": "message",
+                "id": "m3",
+                "timestamp": "2026-09-02T12:01:35.000Z",
+                "message": {
+                    "role": "toolResult",
+                    "toolCallId": "c1",
+                    "toolName": "bash",
+                    "content": [{ "type": "text", "text": "ok" }],
+                    "isError": false
+                }
+            }),
+        ];
+
+        let mut content = String::new();
+        for l in lines {
+            content.push_str(&serde_json::to_string(&l).unwrap());
+            content.push('\n');
+        }
+        std::fs::write(&session_file, content).unwrap();
+
+        // Exercise the wired entry point directly
+        let res = ingest_pi_session_post_dispatch(ws_path, session_id, Some(tmp_sessions.path()));
+        assert!(
+            res.is_ok(),
+            "wired post-dispatch ingest should succeed: {:?}",
+            res.err()
+        );
+
+        // Verify that #session_digest note was appended to ledger
+        let events = ledger.iter_events().unwrap();
+        let digests: Vec<_> = events
+            .iter()
+            .filter(|e| {
+                e.payload
+                    .get("tags")
+                    .and_then(|t| t.as_array())
+                    .is_some_and(|arr| arr.iter().any(|tag| tag == "session_digest"))
+            })
+            .collect();
+        assert_eq!(digests.len(), 1, "exactly one session_digest note emitted");
+        let text = digests[0]
+            .payload
+            .get("text")
+            .and_then(|t| t.as_str())
+            .unwrap_or("");
+        assert!(
+            text.contains("1 tool calls"),
+            "text should contain '1 tool calls': {text}"
+        );
+        assert!(
+            text.contains("Bash:1"),
+            "text should contain 'Bash:1': {text}"
+        );
+        assert!(
+            text.contains("gpt-5.6-sol"),
+            "text should contain model: {text}"
+        );
+        assert!(text.contains("$0.02"), "text should contain cost: {text}");
     }
 }

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -450,7 +450,7 @@ fn run_inner(args: DispatchArgs) -> Result<i32> {
             // --session-id must resume the conversation a previous dispatch
             // recorded.
             persistent_codex_threads: true,
-            session_dir: args.session_dir.map(std::path::PathBuf::from),
+            session_dir: args.session_dir.as_ref().map(std::path::PathBuf::from),
         },
     )?;
     let phase = build_phase(
@@ -485,8 +485,45 @@ fn run_inner(args: DispatchArgs) -> Result<i32> {
         }
     }
 
+    // GH-577: Ingest Pi session transcripts after the turn completes.
+    // Observation surface cannot kill work surface (GH-566/GH-577): errors degrade to warnings.
+    if args.agent == AgentKind::Pi {
+        if let Err(e) = ingest_pi_session_post_dispatch(
+            &cwd,
+            &session_id,
+            args.session_dir.as_deref().map(std::path::Path::new),
+        ) {
+            eprintln!("Warning: failed to ingest pi session: {e}");
+        }
+    }
+
     let code = output.exit_code();
     Ok(code)
+}
+
+/// Ingest Pi session transcripts after a dispatch turn and emit `#session_digest`.
+pub fn ingest_pi_session_post_dispatch(
+    cwd: &std::path::Path,
+    session_id: &str,
+    session_dir: Option<&std::path::Path>,
+) -> Result<()> {
+    let project_id = edda_store::project_id(cwd);
+    let project_dir = edda_store::project_dir(&project_id);
+    let _ = edda_store::ensure_dirs(&project_id);
+
+    let session_file = match edda_transcript::find_pi_session_file(cwd, session_id, session_dir) {
+        Some(f) => f,
+        None => return Ok(()),
+    };
+
+    let _stats =
+        edda_transcript::ingest_pi_transcript_delta(&project_dir, session_id, cwd, &session_file)?;
+
+    let cwd_str = cwd.to_string_lossy();
+    let _ =
+        edda_bridge_claude::digest::digest_session_manual(&project_id, session_id, &cwd_str, true);
+
+    Ok(())
 }
 
 /// One turn through the launcher with an empty plan context. Split out from
@@ -1394,5 +1431,15 @@ mod tests {
         assert_eq!(out.outcome, Outcome::Timeout);
         assert_eq!(out.exit_code(), 2);
         assert!(out.render_text().contains("Session: sess-y"));
+    }
+
+    #[test]
+    fn ingest_pi_session_post_dispatch_missing_file_returns_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        let res = ingest_pi_session_post_dispatch(tmp.path(), "nonexistent-sess", None);
+        assert!(
+            res.is_ok(),
+            "missing pi session file returns Ok(()) gracefully"
+        );
     }
 }

--- a/crates/edda-cli/tests/dispatch_pi_transcript.rs
+++ b/crates/edda-cli/tests/dispatch_pi_transcript.rs
@@ -137,6 +137,7 @@ fn test_pi_transcript_ingested_and_idempotent() {
     assert_eq!(stats.model, "gpt-5.6-sol");
     assert_eq!(stats.input_tokens, 1000);
     assert_eq!(stats.output_tokens, 200);
+    assert_eq!(stats.cost_usd, Some(0.05));
 
     // Trigger digest manual
     let cwd_str = ws_path.to_string_lossy();
@@ -174,6 +175,10 @@ fn test_pi_transcript_ingested_and_idempotent() {
         "digest text should contain '2 tool calls': {text}"
     );
     assert!(
+        text.contains("1 min"),
+        "digest text should contain duration '1 min': {text}"
+    );
+    assert!(
         text.contains("Bash:1"),
         "digest text should contain 'Bash:1': {text}"
     );
@@ -184,6 +189,10 @@ fn test_pi_transcript_ingested_and_idempotent() {
     assert!(
         text.contains("gpt-5.6-sol"),
         "digest text should contain model: {text}"
+    );
+    assert!(
+        text.contains("$0.05"),
+        "digest text should contain measured cost '$0.05': {text}"
     );
 
     // Second ingestion should be idempotent (0 new bytes read, no duplicate note)

--- a/crates/edda-cli/tests/dispatch_pi_transcript.rs
+++ b/crates/edda-cli/tests/dispatch_pi_transcript.rs
@@ -1,0 +1,222 @@
+//! Regression test for GH-577: Ingest pi session transcripts from `edda dispatch --agent pi`.
+//!
+//! DoneWhen requirements:
+//! 1. Turns run by `edda dispatch --agent pi` have their session transcripts ingested,
+//!    producing a #session_digest note (calls, duration, tool breakdown, model, usage).
+//! 2. Explicit `--session-id` maps to the same session identity in the ledger.
+//! 3. Incremental ingest is idempotent across multiple calls (no duplicate notes or double counting).
+//! 4. Ingest failure does not fail the dispatch turn.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn write_sample_pi_transcript(dir: &Path, session_id: &str, cwd: &Path) -> PathBuf {
+    let session_file = dir.join(format!("2026-09-02T12-00-00-000Z_{session_id}.jsonl"));
+    let lines = vec![
+        serde_json::json!({
+            "type": "session",
+            "version": 3,
+            "id": session_id,
+            "timestamp": "2026-09-02T12:00:00.000Z",
+            "cwd": cwd.to_string_lossy(),
+        }),
+        serde_json::json!({
+            "type": "message",
+            "id": "msg-u1",
+            "timestamp": "2026-09-02T12:00:05.000Z",
+            "message": {
+                "role": "user",
+                "content": [{ "type": "text", "text": "Run tests" }]
+            }
+        }),
+        serde_json::json!({
+            "type": "message",
+            "id": "msg-a1",
+            "timestamp": "2026-09-02T12:01:30.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "toolCall",
+                        "id": "call-1",
+                        "name": "bash",
+                        "arguments": { "command": "cargo test" }
+                    },
+                    {
+                        "type": "toolCall",
+                        "id": "call-2",
+                        "name": "read",
+                        "arguments": { "path": "src/lib.rs" }
+                    }
+                ],
+                "model": "gpt-5.6-sol",
+                "usage": {
+                    "input": 1000,
+                    "output": 200,
+                    "cacheRead": 500,
+                    "cacheWrite": 0,
+                    "totalTokens": 1700,
+                    "cost": { "total": 0.05 }
+                }
+            }
+        }),
+        serde_json::json!({
+            "type": "message",
+            "id": "msg-r1",
+            "timestamp": "2026-09-02T12:01:35.000Z",
+            "message": {
+                "role": "toolResult",
+                "toolCallId": "call-1",
+                "toolName": "bash",
+                "content": [{ "type": "text", "text": "ok" }],
+                "isError": false
+            }
+        }),
+        serde_json::json!({
+            "type": "message",
+            "id": "msg-r2",
+            "timestamp": "2026-09-02T12:01:40.000Z",
+            "message": {
+                "role": "toolResult",
+                "toolCallId": "call-2",
+                "toolName": "read",
+                "content": [{ "type": "text", "text": "code" }],
+                "isError": false
+            }
+        }),
+    ];
+
+    let mut content = String::new();
+    for l in lines {
+        content.push_str(&serde_json::to_string(&l).unwrap());
+        content.push('\n');
+    }
+    fs::write(&session_file, content).unwrap();
+    session_file
+}
+
+#[test]
+fn test_pi_transcript_ingested_and_idempotent() {
+    let tmp_ws = tempfile::tempdir().unwrap();
+    let tmp_store = tempfile::tempdir().unwrap();
+    let tmp_sessions = tempfile::tempdir().unwrap();
+
+    std::env::set_var("EDDA_STORE_ROOT", tmp_store.path());
+
+    let ws_path = tmp_ws.path();
+    let ledger = edda_ledger::Ledger::open_or_init(ws_path).unwrap();
+
+    let session_id = "test-pi-ingest-577";
+    write_sample_pi_transcript(tmp_sessions.path(), session_id, ws_path);
+
+    let project_id = edda_store::project_id(ws_path);
+    let project_dir = tmp_store.path().join("projects").join(&project_id);
+    fs::create_dir_all(project_dir.join("ledger")).unwrap();
+    fs::create_dir_all(project_dir.join("state")).unwrap();
+    fs::create_dir_all(project_dir.join("transcripts")).unwrap();
+
+    // Verify: find_pi_session_file finds the file
+    let found =
+        edda_transcript::find_pi_session_file(ws_path, session_id, Some(tmp_sessions.path()));
+    assert!(
+        found.is_some(),
+        "find_pi_session_file should locate the session file"
+    );
+    let transcript_path = found.unwrap();
+
+    // Perform ingestion
+    let stats = edda_transcript::ingest_pi_transcript_delta(
+        &project_dir,
+        session_id,
+        ws_path,
+        &transcript_path,
+    )
+    .expect("ingest_pi_transcript_delta should succeed");
+
+    assert_eq!(stats.tool_calls, 2, "should have found 2 tool calls");
+    assert_eq!(stats.model, "gpt-5.6-sol");
+    assert_eq!(stats.input_tokens, 1000);
+    assert_eq!(stats.output_tokens, 200);
+
+    // Trigger digest manual
+    let cwd_str = ws_path.to_string_lossy();
+    let event_id =
+        edda_bridge_claude::digest::digest_session_manual(&project_id, session_id, &cwd_str, true)
+            .expect("digest_session_manual should succeed");
+    assert!(!event_id.is_empty());
+
+    // Query ledger for #session_digest note
+    let events = ledger.iter_events().unwrap();
+    let digests: Vec<_> = events
+        .iter()
+        .filter(|e| {
+            e.payload
+                .get("tags")
+                .and_then(|t: &serde_json::Value| t.as_array())
+                .is_some_and(|arr: &Vec<serde_json::Value>| {
+                    arr.iter().any(|tag| tag == "session_digest")
+                })
+        })
+        .collect();
+
+    assert_eq!(
+        digests.len(),
+        1,
+        "exactly one session_digest note should be produced"
+    );
+    let text = digests[0]
+        .payload
+        .get("text")
+        .and_then(|t: &serde_json::Value| t.as_str())
+        .unwrap_or("");
+    assert!(
+        text.contains("2 tool calls"),
+        "digest text should contain '2 tool calls': {text}"
+    );
+    assert!(
+        text.contains("Bash:1"),
+        "digest text should contain 'Bash:1': {text}"
+    );
+    assert!(
+        text.contains("read:1"),
+        "digest text should contain 'read:1': {text}"
+    );
+    assert!(
+        text.contains("gpt-5.6-sol"),
+        "digest text should contain model: {text}"
+    );
+
+    // Second ingestion should be idempotent (0 new bytes read, no duplicate note)
+    let stats2 = edda_transcript::ingest_pi_transcript_delta(
+        &project_dir,
+        session_id,
+        ws_path,
+        &transcript_path,
+    )
+    .expect("second ingest should succeed");
+    assert_eq!(
+        stats2.bytes_read, 0,
+        "idempotent: 0 bytes read on re-ingest"
+    );
+
+    // Digest again should not produce a duplicate note
+    let _ =
+        edda_bridge_claude::digest::digest_session_manual(&project_id, session_id, &cwd_str, true);
+    let events2 = ledger.iter_events().unwrap();
+    let digests2: Vec<_> = events2
+        .iter()
+        .filter(|e| {
+            e.payload
+                .get("tags")
+                .and_then(|t: &serde_json::Value| t.as_array())
+                .is_some_and(|arr: &Vec<serde_json::Value>| {
+                    arr.iter().any(|tag| tag == "session_digest")
+                })
+        })
+        .collect();
+    assert_eq!(
+        digests2.len(),
+        1,
+        "no duplicate session_digest note emitted"
+    );
+}

--- a/crates/edda-transcript/Cargo.toml
+++ b/crates/edda-transcript/Cargo.toml
@@ -16,6 +16,8 @@ thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 fs2.workspace = true
+dirs.workspace = true
+time.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/edda-transcript/src/lib.rs
+++ b/crates/edda-transcript/src/lib.rs
@@ -2,8 +2,12 @@ mod cursor;
 mod extract;
 mod filter;
 mod ingest;
+pub mod pi;
 
 pub use cursor::TranscriptCursor;
 pub use extract::extract_last_assistant_text;
 pub use filter::{classify_record, FilterAction};
 pub use ingest::{ingest_transcript_delta, IngestStats};
+pub use pi::{
+    find_pi_session_file, ingest_pi_transcript_delta, pi_session_dir_for_cwd, PiIngestStats,
+};

--- a/crates/edda-transcript/src/pi.rs
+++ b/crates/edda-transcript/src/pi.rs
@@ -1,0 +1,510 @@
+//! Pi session transcript discovery, delta ingestion, and ledger normalization (GH-577).
+//!
+//! Pi persists its transcripts to:
+//! `~/.pi/agent/sessions/<encoded-cwd>/<timestamp>_<session-id>.jsonl`
+//! (or to a custom directory when `--session-dir` is provided).
+//!
+//! This module provides:
+//! 1. `find_pi_session_file`: locates the session file by matching session ID in filename or header.
+//! 2. `ingest_pi_transcript_delta`: cursor-based incremental ingestion into `transcripts/{session_id}.jsonl`
+//!    and `ledger/{session_id}.jsonl` (normalizing tool calls and failures so `digest` can summarize it),
+//!    plus updating `state/usage.json`.
+
+use crate::cursor::TranscriptCursor;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+/// Ingestion statistics for a Pi session delta.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct PiIngestStats {
+    pub records_read: usize,
+    pub records_kept: usize,
+    pub tool_calls: usize,
+    pub tool_failures: usize,
+    pub user_prompts: usize,
+    pub bytes_read: u64,
+    pub from_offset: u64,
+    pub to_offset: u64,
+    pub model: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cost_usd: Option<f64>,
+}
+
+/// Compute the default Pi session directory for a given working directory.
+/// Encodes `cwd` into `--<escaped_path>--` under `~/.pi/agent/sessions/`,
+/// strictly matching `@earendil-works/pi-coding-agent`'s `getDefaultSessionDirPath`.
+pub fn pi_session_dir_for_cwd(cwd: &Path) -> Option<PathBuf> {
+    let resolved = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+    let s = resolved.to_string_lossy();
+    let s = s.strip_prefix(r"\\?\").unwrap_or(&s);
+    let trimmed = s.trim_start_matches(['/', '\\']);
+    let mut safe = String::with_capacity(trimmed.len() + 4);
+    safe.push_str("--");
+    for c in trimmed.chars() {
+        if c == '/' || c == '\\' || c == ':' {
+            safe.push('-');
+        } else {
+            safe.push(c);
+        }
+    }
+    safe.push_str("--");
+    let home = dirs::home_dir()?;
+    Some(home.join(".pi").join("agent").join("sessions").join(safe))
+}
+
+/// Find the Pi session JSONL file for a given session ID.
+///
+/// If `session_dir` is provided, searches there.
+/// Otherwise, resolves the default directory via [`pi_session_dir_for_cwd`].
+pub fn find_pi_session_file(
+    cwd: &Path,
+    session_id: &str,
+    session_dir: Option<&Path>,
+) -> Option<PathBuf> {
+    let dir = match session_dir {
+        Some(d) => d.to_path_buf(),
+        None => pi_session_dir_for_cwd(cwd)?,
+    };
+
+    if !dir.exists() {
+        return None;
+    }
+
+    let entries = fs::read_dir(&dir).ok()?;
+    let suffix = format!("_{session_id}.jsonl");
+    let exact = format!("{session_id}.jsonl");
+
+    let mut matches = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let fname = entry.file_name().to_string_lossy().to_string();
+        if !fname.ends_with(".jsonl") {
+            continue;
+        }
+
+        if fname == exact || fname.ends_with(&suffix) {
+            matches.push(path);
+            continue;
+        }
+
+        // Header check: if filename doesn't match suffix, inspect the first line
+        if let Ok(file) = fs::File::open(&path) {
+            use std::io::BufRead;
+            let mut reader = std::io::BufReader::new(file);
+            let mut first_line = String::new();
+            if reader.read_line(&mut first_line).is_ok() {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&first_line) {
+                    if v.get("type").and_then(|t| t.as_str()) == Some("session")
+                        && v.get("id").and_then(|id| id.as_str()) == Some(session_id)
+                    {
+                        matches.push(path);
+                    }
+                }
+            }
+        }
+    }
+
+    // If multiple matches exist, pick the most recently modified
+    matches.sort_by_key(|p| {
+        fs::metadata(p)
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+    });
+    matches.pop()
+}
+
+fn now_rfc3339() -> String {
+    let now = time::OffsetDateTime::now_utc();
+    now.format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
+}
+
+fn normalize_tool_name(name: &str) -> &str {
+    match name {
+        "bash" | "terminal" | "shell" => "Bash",
+        "edit" | "edit_file" | "file_edit" => "Edit",
+        "write" | "write_file" | "file_write" => "Write",
+        other => other,
+    }
+}
+
+const DEFAULT_MAX_BYTES: u64 = 8 * 1024 * 1024; // 8MB
+
+/// Ingest a Pi session transcript file incrementally into `project_dir`.
+///
+/// 1. Reads new lines using a session-specific cursor (`pi_transcript_cursor.{session_id}.json`).
+/// 2. Appends raw transcript lines to `transcripts/{session_id}.jsonl`.
+/// 3. Normalizes tool calls, tool results, and user prompts into `ledger/{session_id}.jsonl`.
+/// 4. Updates `state/usage.json` with observed model and token totals.
+pub fn ingest_pi_transcript_delta(
+    project_dir: &Path,
+    session_id: &str,
+    cwd: &Path,
+    transcript_path: &Path,
+) -> anyhow::Result<PiIngestStats> {
+    let state_dir = project_dir.join("state");
+    let ledger_dir = project_dir.join("ledger");
+    let transcripts_dir = project_dir.join("transcripts");
+
+    fs::create_dir_all(&state_dir)?;
+    fs::create_dir_all(&ledger_dir)?;
+    fs::create_dir_all(&transcripts_dir)?;
+
+    // Session-level lock to guard concurrent ingestion
+    let lock_path = state_dir.join(format!("ingest_pi.{session_id}.lock"));
+    let _lock = edda_store::lock_file(&lock_path)?;
+
+    // Cursor path
+    let cursor_path = state_dir.join(format!("pi_transcript_cursor.{session_id}.json"));
+    let mut cursor = if cursor_path.exists() {
+        let content = fs::read_to_string(&cursor_path)?;
+        serde_json::from_str(&content).unwrap_or(TranscriptCursor {
+            offset: 0,
+            file_size: 0,
+            mtime_unix: 0,
+            updated_at_unix: 0,
+        })
+    } else {
+        TranscriptCursor {
+            offset: 0,
+            file_size: 0,
+            mtime_unix: 0,
+            updated_at_unix: 0,
+        }
+    };
+
+    let meta = fs::metadata(transcript_path)?;
+    let file_size = meta.len();
+    cursor.detect_truncation(file_size);
+
+    if cursor.offset >= file_size {
+        return Ok(PiIngestStats {
+            from_offset: cursor.offset,
+            to_offset: cursor.offset,
+            ..Default::default()
+        });
+    }
+
+    let max_bytes: u64 = std::env::var("EDDA_TRANSCRIPT_MAX_BYTES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_MAX_BYTES);
+
+    let mut file = fs::File::open(transcript_path)?;
+    file.seek(SeekFrom::Start(cursor.offset))?;
+
+    let bytes_to_read = (file_size - cursor.offset).min(max_bytes);
+    let mut buf = vec![0u8; bytes_to_read as usize];
+    let actually_read = file.read(&mut buf)?;
+    buf.truncate(actually_read);
+
+    // Partial line protection: only consume up to the last newline
+    let consumable_len = match buf.iter().rposition(|&b| b == b'\n') {
+        Some(pos) => pos + 1,
+        None => 0,
+    };
+
+    if consumable_len == 0 {
+        return Ok(PiIngestStats {
+            from_offset: cursor.offset,
+            to_offset: cursor.offset,
+            ..Default::default()
+        });
+    }
+
+    let from_offset = cursor.offset;
+    let to_offset = from_offset + consumable_len as u64;
+    let data = &buf[..consumable_len];
+
+    // Transcripts raw store path
+    let raw_store_path = transcripts_dir.join(format!("{session_id}.jsonl"));
+    let mut raw_store_file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&raw_store_path)?;
+
+    // Session ledger path
+    let ledger_path = ledger_dir.join(format!("{session_id}.jsonl"));
+    let mut ledger_file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&ledger_path)?;
+
+    let project_id = project_dir
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or_default()
+        .to_string();
+    let cwd_str = cwd.to_string_lossy().to_string();
+
+    let mut stats = PiIngestStats {
+        bytes_read: consumable_len as u64,
+        from_offset,
+        to_offset,
+        ..Default::default()
+    };
+
+    // Load existing usage state if present
+    let usage_path = state_dir.join("usage.json");
+    let current_usage = if usage_path.exists() {
+        fs::read_to_string(&usage_path)
+            .ok()
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+            .unwrap_or_default()
+    } else {
+        serde_json::Value::Null
+    };
+
+    let mut model_seen = String::new();
+    let mut total_input = 0u64;
+    let mut total_output = 0u64;
+    let mut total_cache_read = 0u64;
+    let mut total_cache_write = 0u64;
+    let mut total_cost = 0.0f64;
+    let mut usage_observed = false;
+
+    let default_ts = now_rfc3339();
+
+    for raw_line in data.split(|&b| b == b'\n') {
+        if raw_line.is_empty() {
+            continue;
+        }
+        stats.records_read += 1;
+
+        // Write raw line verbatim to transcripts/
+        raw_store_file.write_all(raw_line)?;
+        raw_store_file.write_all(b"\n")?;
+        stats.records_kept += 1;
+
+        let parsed: serde_json::Value = match serde_json::from_slice(raw_line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        let ts = parsed
+            .get("timestamp")
+            .and_then(|t| t.as_str())
+            .unwrap_or(&default_ts)
+            .to_string();
+
+        let line_type = parsed.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+        if line_type == "message" {
+            if let Some(msg) = parsed.get("message") {
+                let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
+                match role {
+                    "assistant" => {
+                        // Extract model & usage if present
+                        if let Some(m) = msg
+                            .get("model")
+                            .or_else(|| parsed.get("model"))
+                            .and_then(|v| v.as_str())
+                        {
+                            if !m.is_empty() {
+                                model_seen = m.to_string();
+                            }
+                        }
+
+                        if let Some(u) = msg.get("usage") {
+                            usage_observed = true;
+                            if let Some(inp) = u.get("input").and_then(|v| v.as_u64()) {
+                                total_input += inp;
+                            }
+                            if let Some(out) = u.get("output").and_then(|v| v.as_u64()) {
+                                total_output += out;
+                            }
+                            if let Some(cr) = u.get("cacheRead").and_then(|v| v.as_u64()) {
+                                total_cache_read += cr;
+                            }
+                            if let Some(cw) = u.get("cacheWrite").and_then(|v| v.as_u64()) {
+                                total_cache_write += cw;
+                            }
+                            if let Some(cost) = u
+                                .get("cost")
+                                .and_then(|c| c.get("total"))
+                                .and_then(|v| v.as_f64())
+                            {
+                                total_cost += cost;
+                            }
+                        }
+
+                        // Extract tool calls from content array
+                        if let Some(content_arr) = msg.get("content").and_then(|c| c.as_array()) {
+                            for item in content_arr {
+                                if item.get("type").and_then(|t| t.as_str()) == Some("toolCall") {
+                                    stats.tool_calls += 1;
+                                    let tool_name =
+                                        item.get("name").and_then(|n| n.as_str()).unwrap_or("");
+                                    let tool_id =
+                                        item.get("id").and_then(|i| i.as_str()).unwrap_or("");
+                                    let tool_input = item
+                                        .get("arguments")
+                                        .cloned()
+                                        .unwrap_or(serde_json::Value::Null);
+
+                                    let record = serde_json::json!({
+                                        "ts": ts,
+                                        "project_id": project_id,
+                                        "session_id": session_id,
+                                        "hook_event_name": "PostToolUse",
+                                        "tool_name": normalize_tool_name(tool_name),
+                                        "tool_use_id": tool_id,
+                                        "cwd": cwd_str,
+                                        "model": model_seen,
+                                        "bridge": "pi",
+                                        "tool_input": tool_input,
+                                    });
+                                    writeln!(ledger_file, "{}", serde_json::to_string(&record)?)?;
+                                }
+                            }
+                        }
+                    }
+                    "toolResult" => {
+                        let is_error = msg
+                            .get("isError")
+                            .and_then(|e| e.as_bool())
+                            .unwrap_or(false);
+                        if is_error {
+                            stats.tool_failures += 1;
+                            let tool_name =
+                                msg.get("toolName").and_then(|n| n.as_str()).unwrap_or("");
+                            let tool_id =
+                                msg.get("toolCallId").and_then(|i| i.as_str()).unwrap_or("");
+                            let tool_content = msg
+                                .get("content")
+                                .cloned()
+                                .unwrap_or(serde_json::Value::Null);
+
+                            let record = serde_json::json!({
+                                "ts": ts,
+                                "project_id": project_id,
+                                "session_id": session_id,
+                                "hook_event_name": "PostToolUseFailure",
+                                "tool_name": normalize_tool_name(tool_name),
+                                "tool_use_id": tool_id,
+                                "cwd": cwd_str,
+                                "bridge": "pi",
+                                "tool_response": tool_content,
+                            });
+                            writeln!(ledger_file, "{}", serde_json::to_string(&record)?)?;
+                        }
+                    }
+                    "user" => {
+                        stats.user_prompts += 1;
+                        let record = serde_json::json!({
+                            "ts": ts,
+                            "project_id": project_id,
+                            "session_id": session_id,
+                            "hook_event_name": "UserPromptSubmit",
+                            "cwd": cwd_str,
+                            "bridge": "pi",
+                        });
+                        writeln!(ledger_file, "{}", serde_json::to_string(&record)?)?;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    stats.model = model_seen.clone();
+    stats.input_tokens = total_input;
+    stats.output_tokens = total_output;
+    stats.cache_read_tokens = total_cache_read;
+    stats.cache_creation_tokens = total_cache_write;
+    stats.cost_usd = if usage_observed {
+        Some(total_cost)
+    } else {
+        None
+    };
+
+    // Update usage state file for the digest reader
+    if usage_observed || !model_seen.is_empty() {
+        let prev_u = current_usage.get("usage").cloned().unwrap_or_default();
+        let prev_in = prev_u
+            .get("input_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let prev_out = prev_u
+            .get("output_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let prev_cr = prev_u
+            .get("cache_read_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let prev_cw = prev_u
+            .get("cache_creation_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+
+        let usage_obj = serde_json::json!({
+            "session_id": session_id,
+            "updated_at": now_rfc3339(),
+            "usage": {
+                "model": if model_seen.is_empty() {
+                    prev_u.get("model").and_then(|v| v.as_str()).unwrap_or("").to_string()
+                } else {
+                    model_seen
+                },
+                "input_tokens": prev_in + total_input,
+                "output_tokens": prev_out + total_output,
+                "cache_read_tokens": prev_cr + total_cache_read,
+                "cache_creation_tokens": prev_cw + total_cache_write,
+                "usage_observed": true,
+            }
+        });
+        let _ = fs::write(&usage_path, serde_json::to_string_pretty(&usage_obj)?);
+    }
+
+    // Save updated cursor
+    cursor.offset = to_offset;
+    cursor.file_size = file_size;
+    let data = serde_json::to_string_pretty(&cursor)?;
+    edda_store::write_atomic(&cursor_path, data.as_bytes())?;
+
+    Ok(stats)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pi_session_dir_for_cwd() {
+        let p = Path::new("C:\\ai_agent\\edda");
+        let dir = pi_session_dir_for_cwd(p).expect("should compute dir");
+        let dir_str = dir.to_string_lossy();
+        assert!(
+            dir_str.contains("--C--ai_agent-edda--") || dir_str.contains(".pi"),
+            "got {dir_str}"
+        );
+    }
+
+    #[test]
+    fn test_find_pi_session_file_by_name_and_header() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_id = "test-sess-uuid-1234";
+
+        let sess_file = tmp
+            .path()
+            .join(format!("2026-09-02T12-00-00-000Z_{session_id}.jsonl"));
+        fs::write(
+            &sess_file,
+            format!(r#"{{"type":"session","id":"{session_id}"}}"#),
+        )
+        .unwrap();
+
+        let cwd = Path::new("C:\\test\\dir");
+        let found = find_pi_session_file(cwd, session_id, Some(tmp.path()));
+        assert_eq!(found, Some(sess_file));
+    }
+}

--- a/crates/edda-transcript/src/pi.rs
+++ b/crates/edda-transcript/src/pi.rs
@@ -270,6 +270,7 @@ pub fn ingest_pi_transcript_delta(
     let mut total_cache_write = 0u64;
     let mut total_cost = 0.0f64;
     let mut usage_observed = false;
+    let mut cost_observed = false;
 
     let default_ts = now_rfc3339();
 
@@ -333,6 +334,7 @@ pub fn ingest_pi_transcript_delta(
                                 .and_then(|v| v.as_f64())
                             {
                                 total_cost += cost;
+                                cost_observed = true;
                             }
                         }
 
@@ -420,7 +422,7 @@ pub fn ingest_pi_transcript_delta(
     stats.output_tokens = total_output;
     stats.cache_read_tokens = total_cache_read;
     stats.cache_creation_tokens = total_cache_write;
-    stats.cost_usd = if usage_observed {
+    stats.cost_usd = if cost_observed {
         Some(total_cost)
     } else {
         None
@@ -457,6 +459,13 @@ pub fn ingest_pi_transcript_delta(
             .get("cache_creation_tokens")
             .and_then(|v| v.as_u64())
             .unwrap_or(0);
+        let prev_cost = prev_u.get("cost_usd").and_then(|v| v.as_f64());
+        let final_cost = match (prev_cost, cost_observed) {
+            (Some(prev), true) => Some(prev + total_cost),
+            (Some(prev), false) => Some(prev),
+            (None, true) => Some(total_cost),
+            (None, false) => None,
+        };
 
         let usage_obj = serde_json::json!({
             "session_id": session_id,
@@ -471,7 +480,7 @@ pub fn ingest_pi_transcript_delta(
                 "output_tokens": prev_out + total_output,
                 "cache_read_tokens": prev_cr + total_cache_read,
                 "cache_creation_tokens": prev_cw + total_cache_write,
-                "cost_usd": if usage_observed { Some(total_cost) } else { None },
+                "cost_usd": final_cost,
                 "usage_observed": true,
             }
         });

--- a/crates/edda-transcript/src/pi.rs
+++ b/crates/edda-transcript/src/pi.rs
@@ -428,7 +428,19 @@ pub fn ingest_pi_transcript_delta(
 
     // Update usage state file for the digest reader
     if usage_observed || !model_seen.is_empty() {
-        let prev_u = current_usage.get("usage").cloned().unwrap_or_default();
+        // GH-577 round 2 (P1-3): usage.json is project-scoped. If it records
+        // a DIFFERENT session_id, do NOT accumulate into it — reset to zero
+        // so one session's digest never reports another session's tokens.
+        // Only accumulate if resuming the same session.
+        let is_same_session =
+            current_usage.get("session_id").and_then(|s| s.as_str()) == Some(session_id);
+
+        let prev_u = if is_same_session {
+            current_usage.get("usage").cloned().unwrap_or_default()
+        } else {
+            serde_json::Value::Null
+        };
+
         let prev_in = prev_u
             .get("input_tokens")
             .and_then(|v| v.as_u64())
@@ -459,15 +471,26 @@ pub fn ingest_pi_transcript_delta(
                 "output_tokens": prev_out + total_output,
                 "cache_read_tokens": prev_cr + total_cache_read,
                 "cache_creation_tokens": prev_cw + total_cache_write,
+                "cost_usd": if usage_observed { Some(total_cost) } else { None },
                 "usage_observed": true,
             }
         });
-        let _ = fs::write(&usage_path, serde_json::to_string_pretty(&usage_obj)?);
+        fs::write(&usage_path, serde_json::to_string_pretty(&usage_obj)?)?;
     }
 
     // Save updated cursor
     cursor.offset = to_offset;
     cursor.file_size = file_size;
+    cursor.mtime_unix = meta
+        .modified()
+        .ok()
+        .and_then(|m| m.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    cursor.updated_at_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
     let data = serde_json::to_string_pretty(&cursor)?;
     edda_store::write_atomic(&cursor_path, data.as_bytes())?;
 


### PR DESCRIPTION
## Summary

Ingests Pi session transcripts after `edda dispatch --agent pi` turns finish, closing the observability gap where Pi was the only execution agent without bridge or transcript ingestion.

- Added `edda-transcript::pi` module for discovering Pi session JSONL files (`~/.pi/agent/sessions/--<escaped_cwd>--/<ts>_<sid>.jsonl` or custom `--session-dir`) and performing cursor-based delta ingestion.
- Normalizes tool calls, tool failures, user prompts, and token usage into `transcripts/{session_id}.jsonl`, `ledger/{session_id}.jsonl`, and `state/usage.json`.
- Enriches manual session digest (`digest_session_manual`) with usage state so `#session_digest` notes capture model, token counts, and cost.
- Triggers `#session_digest` generation after Pi dispatch turns in `cmd_dispatch.rs`.
- Degrades ingestion failures to warnings without failing the dispatch turn (observation surface cannot kill work surface).
- Added comprehensive integration tests verifying transcript ingestion, session digest attributes (tool count, breakdown, duration, model), and incremental idempotency.
- Recorded decision `bridge.pi=file-polling-post-dispatch` in ledger via `edda decide`.

Issue: #577
