### PR TITLE
docs(specs): align RAN-timeout and lattice prose with combine_gate_status semantics

### DIFF
--- a/docs/superpowers/plans/2026-09-02-edda-review-slice1.md
+++ b/docs/superpowers/plans/2026-09-02-edda-review-slice1.md
@@ -2678,8 +2678,9 @@ fn classify_crash(error: &str) -> &'static str {
     if OVERLOAD_MARKERS.iter().any(|m| e.contains(m)) { "overload" } else { "crash" }
 }
 
-/// The gate evidence lattice (spec §8), used by EVERY source — local receipts,
-/// exact-head CI, and RAN — so the rule exists once instead of being restated
+/// The gate evidence lattice (spec §8). Local READ seeds the accumulator
+/// (`read_gates` returns the starting status directly, not a call); CI and RAN
+/// each call this once, so the rule exists once instead of being restated
 /// per source (Round 5 and Round 6 both broke it by restating it):
 ///
 /// * `undeclared` is absorbing — nothing substitutes for declaring gates;

--- a/docs/superpowers/specs/2026-09-02-edda-review-design.md
+++ b/docs/superpowers/specs/2026-09-02-edda-review-design.md
@@ -86,7 +86,7 @@ edda review [--base <ref>] [--head <ref>] [--pr <n>] [--spec <path|#n>] [--trust
 | `--timeout-sec` | 900 | 引擎回合上限 |
 | `--budget-usd` | 無 | pi 生效；codex 無法生效（沿用 dispatch 的警告） |
 | `--run-gates` | 關 | **RAN 唯一的開關**：跑全部宣告的閘門（§6.4）。不開就只 READ |
-| `--max-ran-sec` | 300 | RAN 總時長上限；超過即停，未跑完的閘門記 `unverified` |
+| `--max-ran-sec` | 300 | RAN 總時長上限；超過即停，未跑完的閘門 RAN 對它沉默（回報 `None`），狀態依 §8 的格合成——既有的 `verified` 不會被降級 |
 | `--keep-worktree` | 關 | 保留臨時 detached worktree 供除錯 |
 | `--json` | 關 | 印 `review_verdict` payload ＋ `event_id`（unstable；見 §7） |
 
@@ -338,8 +338,9 @@ spawn、輪詢 `try_wait`，到期就砍**整棵程序樹**——Unix 用 `Comma
 本身不算兌現期限。被殺的閘門記 exit `-1` 與 `timed_out`，剩下的閘門記「未跑」；RAN 對
 未跑完的閘門沉默（回報 `None`）、對實際失敗回報 `red`，狀態依 §8 的格合成——既有的
 `verified` 不會被降級——`notes` 說明。stdout 尾段寫 blob 失敗是**大聲的**：該 RAN 條目
-`stdout_blob = null`、`notes` 記一行，而且這條 RAN 條目不作為 `verified` 的證據（它對該
-閘門不回報 `green`），最終狀態仍由格合成。
+`stdout_blob = null`、`notes` 記一行，而且這條 RAN 條目不作為 `verified` 的證據——
+`ReviewGateRan` 沒有 per-gate 的結果欄位，任一條目的 blob 存不進去，整個 RAN 就沉默
+（回報 `None`）——最終狀態仍由格合成。
 
 - 白名單裡**沒有** `git *`；edda 自己需要的 git 都是程序內固定子命令。
 - cargo 類閘門（指令以 `cargo ` 開頭）只在環境有 `CARGO_TARGET_DIR` 時執行；沒有就跳過並記
@@ -459,7 +460,7 @@ exit 0 → `green`；非 0 → `red`；沒有 → 該 gate 未涵蓋。全部 gr
 取 required 名單做交集；PR 在解析後被 push 也不會把新 head 的綠記到受審 SHA 上。required
 全部 `completed` + `success`（或 `skipped`）→ verified；任一 `failure` / `cancelled` / `timed_out`
 → red；有 `in_progress` / `queued` → `pending`（`read[].result` 的合法值：`green | red | pending`），
-狀態 unverified。`neutral` **不算綠**——它的語意是「這個 check 放棄判定」。required 名單為空時
+CI 對這件事的回報是 `unverified`——它在格上是中性的，不改變其他來源已建立的結論。`neutral` **不算綠**——它的語意是「這個 check 放棄判定」。required 名單為空時
 CI 對本 head 沒有任何主張，直接不貢獻（**不可**退回「所有 optional check 都算」，否則沒設分支
 保護的 repo 用任何一個碰巧綠的 job 就買到 verified）。
 

--- a/docs/superpowers/specs/2026-09-02-edda-review-design.md
+++ b/docs/superpowers/specs/2026-09-02-edda-review-design.md
@@ -335,9 +335,11 @@ maintainer}` 時）spec 的 `verify` 段逐行。在臨時 worktree **逐字**�
 duration_ms / stdout 尾段 blob`。總時長 `--max-ran-sec` 是**硬期限**：每條閘門以剩餘時間
 spawn、輪詢 `try_wait`，到期就砍**整棵程序樹**——Unix 用 `CommandExt::process_group(0)` 開
 新 process group 並 `kill -9 -- -<pgid>`；Windows 用 `taskkill /PID <pid> /T /F`；只殺 `sh`
-本身不算兌現期限。被殺的閘門記 exit `-1` 與 `timed_out`，剩下的閘門記「未跑」，
-`gates.status = unverified`，`notes` 說明。stdout 尾段寫 blob 失敗是**大聲的**：該 RAN 條目
-`stdout_blob = null`、`notes` 記一行，而且這條 RAN 不能讓 `gates.status` 變 `verified`。
+本身不算兌現期限。被殺的閘門記 exit `-1` 與 `timed_out`，剩下的閘門記「未跑」；RAN 對
+未跑完的閘門沉默（回報 `None`）、對實際失敗回報 `red`，狀態依 §8 的格合成——既有的
+`verified` 不會被降級——`notes` 說明。stdout 尾段寫 blob 失敗是**大聲的**：該 RAN 條目
+`stdout_blob = null`、`notes` 記一行，而且這條 RAN 條目不作為 `verified` 的證據（它對該
+閘門不回報 `green`），最終狀態仍由格合成。
 
 - 白名單裡**沒有** `git *`；edda 自己需要的 git 都是程序內固定子命令。
 - cargo 類閘門（指令以 `cargo ` 開頭）只在環境有 `CARGO_TARGET_DIR` 時執行；沒有就跳過並記
@@ -474,8 +476,9 @@ CI 對本 head 沒有任何主張，直接不貢獻（**不可**退回「所有 
 
 要求兩者同時 verified 會讓「CI 全綠但作者沒在本機留收據」的 PR 讀成 unverified，那是把
 證據當儀式（Round 5 P1）；而讓跳過的 RAN 把 verified 降成 unverified 是同一個錯誤的另一面
-（Round 6 P1）。實作上這條規則寫成**單一函式** `combine_gate_status(current, incoming)`，
-三個來源都呼叫它——這條規則被分別重述兩次，就被破壞了兩次。
+（Round 6 P1）。實作上這條規則寫成**單一函式** `combine_gate_status(current, incoming)`——
+本地 READ 是 accumulator 的**初值**（`read_gates` 直接回傳起始 status），CI 與 RAN 各呼叫
+它一次——這條規則被分別重述兩次，就被破壞了兩次。
 
 PR body 裡的散文 L1 receipt 不解析；fleet 在一個迭代內改用 `edda run -- <gate>` 產收據。
 
@@ -496,8 +499,8 @@ PR body 裡的散文 L1 receipt 不解析；fleet 在一個迭代內改用 `edda
 | `model_observed` 拿不到 | 照審，`unknown`，不合格 |
 | 同模型不同 session | 照審，`same-model`；預設政策合格，`model` 政策不合格 |
 | 模型寫法對照表不認得 | 該來源 `unverified`；絕不記 `verified`；只在 `model` 政策下不合格 |
-| `--run-gates` 但 cargo 閘門而無 `CARGO_TARGET_DIR` | 該閘門跳過並說明，`unverified` |
-| RAN 超時 | 未跑完的閘門 `unverified`，說明哪些沒跑 |
+| `--run-gates` 但 cargo 閘門而無 `CARGO_TARGET_DIR` | 該閘門跳過並說明（RAN 對它沉默，回報 `None`），狀態依 §8 的格合成 |
+| RAN 超時 | RAN 對未跑完的閘門沉默（回報 `None`），狀態依 §8 的格合成，既有的 `verified` 不會被降級；說明哪些沒跑 |
 | spec 來自 `untrusted` issue | 照審；`verify` 欄不執行 |
 | 臨時 worktree 移除失敗 | 警告＋`notes`，判決不受影響 |
 


### PR DESCRIPTION
Issue: #688

Docs lane on `docs/gh688-review-spec-lattice` (from `origin/main`); head `7bf0d31`.

## What changed

Round 6 collapsed gate evidence synthesis into the single lattice `combine_gate_status(current, incoming)` (`undeclared` absorbs; any `red` wins; else any `verified` wins; `incoming: None` is silent). Two prose spots still asserted a global `gates.status` assignment and would reintroduce the Round 6 downgrade bug if implemented literally.

### 1. `docs/superpowers/specs/2026-09-02-edda-review-design.md` — §6.4 (RAN timeout)
- Was: killed gates + not-run gates → "`gates.status = unverified`"; a blob-capture failure "不能讓 `gates.status` 變 `verified`".
- Now: RAN 對未跑完的閘門**沉默（回報 `None`）**、對實際失敗回報 `red`；狀態依 §8 的格合成，**既有的 `verified` 不會被降級**。The blob-failure sentence now says the entry is not `verified` evidence (does not report `green`) and the final status is still lattice-composed.

### 2. `docs/superpowers/specs/2026-09-02-edda-review-design.md` — §9 failure table (RAN rows)
- `RAN 超時` row: was "未跑完的閘門 `unverified`" → now "RAN 對未跑完的閘門沉默（回報 `None`），狀態依 §8 的格合成，既有的 `verified` 不會被降級；說明哪些沒跑".
- `--run-gates 但 cargo 閘門而無 CARGO_TARGET_DIR` row (same shape, found in full scan): was "該閘門跳過並說明，`unverified`" → now "該閘門跳過並說明（RAN 對它沉默，回報 `None`），狀態依 §8 的格合成".

### 3. `docs/superpowers/plans/2026-09-02-edda-review-slice1.md` + spec §8 — "three sources all call"
- Was (both files): 三個來源都「呼叫」`combine_gate_status` / "used by EVERY source".
- Now: **本地 READ 是 accumulator 的初值**（`read_gates` 直接回傳起始 status），**CI 與 RAN 各呼叫一次** `combine_gate_status`.
- Note on the plan edit: the changed lines are the **doc comment** on `combine_gate_status` inside the Task 10 code block — that comment is itself the erroneous prose the issue points at. **No executable code was touched**; Round 7's verified semantics are intact (the `fn` body and all tests are byte-identical).

## Full-text scan result (both files, all `gates.status` / 合成 assertions)

**Changed** (same-shape residuals beyond the two named spots, all in the two target files):
- spec §9 `cargo 閘門無 CARGO_TARGET_DIR` row — asserted per-source global `unverified`.
- spec §8 "三個來源都呼叫它" — same call-topology error as plan Task 10.
- plan Task 10 `combine_gate_status` doc comment "used by EVERY source" — same call-topology error (doc comment only).

**Scanned, judged no change needed:**
- spec §7 qualified formula (`gates.status = verified` ∧ …) — reads the *final combined* status, not a per-source assignment.
- spec §8 / §9 `閘門集合為空 → gates.status = undeclared` — true global statement: no sources exist when the set is empty.
- spec §8 READ/CI report semantics (全部 green → `verified`; 任一 failure → `red`; pending → …) — describes each source's own *report* (the accumulator input), not a global assignment; lattice combines afterward.
- spec §9 `模型寫法對照表不認得 | 該來源 unverified` — about the model-identity source, not `gates.status`.
- plan Task 7 `stdout_blob` doc comment "such a RAN never counts toward `gates.status = verified`" — constrains the *entry's evidentiary value* (cannot serve as verified evidence), which the lattice already encodes; it directs no status assignment and implies no downgrade. Doc comment inside a code fence not named by the issue — left untouched.
- plan Task 10 Step 3 code comments (sections `// 6.` / `// 7.` on CI and RAN) and all test/fn code — semantics already correct per Round 7; untouched.
- `grep -rln "gates.status" docs/` finds **no other file** in the spec stack with this shape.

## doneWhen 對照

| doneWhen | Status |
|---|---|
| §6.4 與 §9 的 RAN 逾時敘述不再直接斷言全域 `unverified` | ✅ both rewritten to "RAN 回報 `None`／`red`，狀態依 §8 格合成，既有 `verified` 不降級" |
| plan 措辭改為「本地 READ 是格的初值，CI 與 RAN 各呼叫一次 `combine_gate_status`」 | ✅ plan doc comment + spec §8 sentence |
| 全文掃描結果在 PR 裡列出 | ✅ table above |
| `sh scripts/lint-markdown-content.sh` exit 0 | ✅ ran locally (exit 0) and again via pre-commit hook on `bfac4c1` |
| 零 `.rs` 變更 | ✅ below |

## Zero `.rs` proof

`git diff --stat origin/main..HEAD`:

```
 docs/superpowers/plans/2026-09-02-edda-review-slice1.md |  5 +++--
 docs/superpowers/specs/2026-09-02-edda-review-design.md | 17 ++++++++++-------
 2 files changed, 13 insertions(+), 9 deletions(-)
```

## Verification budget

Docs-only — no Cargo gates run locally, no build lane used, `CARGO_TARGET_DIR` untouched. Exact-head CI is the gate for this PR.
