### PR TITLE
fix(edda-ask): disambiguate empty/unregistered store and resolve worktrees under home (GH-701)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,6 +972,7 @@ name = "edda-ledger"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "dirs",
  "edda-core",
  "fs2",
  "globset",

--- a/crates/edda-ask/src/lib.rs
+++ b/crates/edda-ask/src/lib.rs
@@ -48,7 +48,7 @@ pub fn detect_input_type(query: &str, known_domains: &[String]) -> InputType {
 
 // ── Result types ─────────────────────────────────────────────────────
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Default, Serialize)]
 pub struct AskResult {
     pub query: String,
     pub input_type: String,
@@ -65,6 +65,12 @@ pub struct AskResult {
     pub dependents: Vec<DependentHit>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub override_risk: Option<OverrideRisk>,
+    /// Count of total events in the workspace ledger, if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_event_count: Option<u64>,
+    /// Count of total decisions in the workspace ledger, if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_decision_count: Option<u64>,
 }
 
 /// A task matched by `ask`. The receipt is the point — it is where a finished
@@ -428,6 +434,9 @@ pub fn ask(
         (vec![], None)
     };
 
+    let workspace_event_count = ledger.count_events().ok();
+    let workspace_decision_count = ledger.count_decisions().ok();
+
     Ok(AskResult {
         query: q.to_string(),
         input_type: input_type_str.to_string(),
@@ -439,6 +448,8 @@ pub fn ask(
         tasks,
         dependents,
         override_risk,
+        workspace_event_count,
+        workspace_decision_count,
     })
 }
 
@@ -903,7 +914,15 @@ pub fn format_human(result: &AskResult) -> String {
     }
 
     if out.is_empty() {
-        out.push_str("No results found.\n");
+        if result.workspace_event_count == Some(0) {
+            out.push_str("No results found (workspace ledger is empty; 0 events recorded).\n");
+        } else if result.workspace_decision_count == Some(0) {
+            out.push_str(
+                "No results found (workspace ledger has 0 decisions recorded; run `edda decide` to record decisions).\n",
+            );
+        } else {
+            out.push_str("No results found.\n");
+        }
     }
 
     out
@@ -1547,6 +1566,7 @@ mod tests {
             tasks: vec![],
             dependents: vec![],
             override_risk: None,
+            ..Default::default()
         };
 
         let output = format_human(&result);
@@ -1606,6 +1626,7 @@ mod tests {
             tasks: vec![],
             dependents: vec![],
             override_risk: None,
+            ..Default::default()
         };
 
         let output = format_human(&result);
@@ -1630,10 +1651,37 @@ mod tests {
             tasks: vec![],
             dependents: vec![],
             override_risk: None,
+            workspace_event_count: Some(5),
+            workspace_decision_count: Some(2),
         };
 
         let output = format_human(&result);
-        assert!(output.contains("No results found"));
+        assert_eq!(output, "No results found.\n");
+    }
+
+    #[test]
+    fn format_human_empty_ledger_distinguished_from_empty_results() {
+        let result_empty_ledger = AskResult {
+            query: "test".into(),
+            workspace_event_count: Some(0),
+            workspace_decision_count: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(
+            format_human(&result_empty_ledger),
+            "No results found (workspace ledger is empty; 0 events recorded).\n"
+        );
+
+        let result_zero_decisions = AskResult {
+            query: "test".into(),
+            workspace_event_count: Some(1),
+            workspace_decision_count: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(
+            format_human(&result_zero_decisions),
+            "No results found (workspace ledger has 0 decisions recorded; run `edda decide` to record decisions).\n"
+        );
     }
 
     // ── Impact analysis tests ───────────────────────────────────────
@@ -1956,6 +2004,7 @@ mod tests {
                 dependent_count: 2,
                 suggestion: Some("建議覆蓋順序: api.format → db.schema".into()),
             }),
+            ..Default::default()
         };
 
         let output = format_human(&result);

--- a/crates/edda-cli/src/cmd_ask.rs
+++ b/crates/edda-cli/src/cmd_ask.rs
@@ -31,7 +31,28 @@ pub fn execute(
         return execute_fleet(repo_root, q, &opts, json);
     }
 
-    let ledger = Ledger::open(repo_root)?;
+    let ledger = Ledger::open_existing(repo_root)?;
+    let event_count = ledger.count_events().unwrap_or(0);
+    let decision_count = ledger.count_decisions().unwrap_or(0);
+    let is_registered = edda_store::registry::is_registered(repo_root);
+
+    if !is_registered {
+        eprintln!(
+            "Warning: workspace at {} is not registered in edda registry (run `edda init`)",
+            repo_root.display()
+        );
+    }
+    if event_count == 0 {
+        eprintln!(
+            "Warning: workspace ledger at {} is empty (0 events recorded)",
+            repo_root.display()
+        );
+    } else if decision_count == 0 {
+        eprintln!(
+            "Warning: workspace ledger at {} has 0 decisions recorded",
+            repo_root.display()
+        );
+    }
 
     // Build transcript search callback
     let transcript_cb = build_transcript_callback(repo_root, None);
@@ -96,7 +117,7 @@ fn fleet_hint_for_ask(repo_root: &Path, q: &str, opts: &AskOptions) -> Option<St
     let home = edda_store::project_id(repo_root);
     crate::fleet::elsewhere_hint(&scope, &home, "result", |entry| {
         let root = Path::new(&entry.path);
-        let ledger = Ledger::open(root)?;
+        let ledger = Ledger::open_existing(root)?;
         let cb = build_transcript_callback(root, Some(&entry.name));
         let cb_ref: Option<&TranscriptSearchFn> = cb.as_ref().map(|f| f.as_ref());
         Ok(hit_count(&ask(&ledger, q, opts, cb_ref)?))
@@ -115,7 +136,7 @@ fn execute_fleet(repo_root: &Path, q: &str, opts: &AskOptions, json: bool) -> an
 
     let (hits, misses) = crate::fleet::fan_out(&scope, |entry| {
         let root = Path::new(&entry.path);
-        let ledger = Ledger::open(root)?;
+        let ledger = Ledger::open_existing(root)?;
         let cb = build_transcript_callback(root, Some(&entry.name));
         let cb_ref: Option<&TranscriptSearchFn> = cb.as_ref().map(|f| f.as_ref());
         let mut result = ask(&ledger, q, opts, cb_ref)?;
@@ -247,6 +268,7 @@ mod tests {
             tasks: Vec::new(),
             dependents: Vec::new(),
             override_risk: None,
+            ..Default::default()
         };
         assert_eq!(hit_count(&r), 0, "an empty result is empty");
 
@@ -284,6 +306,7 @@ mod tests {
             tasks: Vec::new(),
             dependents: Vec::new(),
             override_risk: None,
+            ..Default::default()
         };
 
         assert_eq!(hit_count(&empty), 0, "nothing was found");

--- a/crates/edda-cli/src/cmd_ask.rs
+++ b/crates/edda-cli/src/cmd_ask.rs
@@ -31,9 +31,7 @@ pub fn execute(
         return execute_fleet(repo_root, q, &opts, json);
     }
 
-    let ledger = Ledger::open_existing(repo_root)?;
-    let event_count = ledger.count_events().unwrap_or(0);
-    let decision_count = ledger.count_decisions().unwrap_or(0);
+    let ledger = Ledger::open(repo_root)?;
     let is_registered = edda_store::registry::is_registered(repo_root);
 
     if !is_registered {
@@ -42,16 +40,26 @@ pub fn execute(
             repo_root.display()
         );
     }
-    if event_count == 0 {
-        eprintln!(
+    match ledger.count_events() {
+        Ok(0) => eprintln!(
             "Warning: workspace ledger at {} is empty (0 events recorded)",
             repo_root.display()
-        );
-    } else if decision_count == 0 {
-        eprintln!(
-            "Warning: workspace ledger at {} has 0 decisions recorded",
+        ),
+        Err(e) => eprintln!(
+            "Warning: workspace ledger events at {} could not be read: {e}",
             repo_root.display()
-        );
+        ),
+        Ok(_) => match ledger.count_decisions() {
+            Ok(0) => eprintln!(
+                "Warning: workspace ledger at {} has 0 decisions recorded",
+                repo_root.display()
+            ),
+            Err(e) => eprintln!(
+                "Warning: workspace ledger decisions at {} could not be read: {e}",
+                repo_root.display()
+            ),
+            Ok(_) => {}
+        },
     }
 
     // Build transcript search callback
@@ -103,6 +111,13 @@ fn hit_count(r: &edda_ask::AskResult) -> usize {
         + r.dependents.len()
 }
 
+fn open_ledger_for_read(root: &Path) -> anyhow::Result<Ledger> {
+    match Ledger::open(root) {
+        Ok(l) => Ok(l),
+        Err(_) => Ledger::open_existing(root),
+    }
+}
+
 /// Ask the rest of the fleet whether a local miss is really absence (GH-407,
 /// acceptance 4).
 ///
@@ -117,7 +132,7 @@ fn fleet_hint_for_ask(repo_root: &Path, q: &str, opts: &AskOptions) -> Option<St
     let home = edda_store::project_id(repo_root);
     crate::fleet::elsewhere_hint(&scope, &home, "result", |entry| {
         let root = Path::new(&entry.path);
-        let ledger = Ledger::open_existing(root)?;
+        let ledger = open_ledger_for_read(root)?;
         let cb = build_transcript_callback(root, Some(&entry.name));
         let cb_ref: Option<&TranscriptSearchFn> = cb.as_ref().map(|f| f.as_ref());
         Ok(hit_count(&ask(&ledger, q, opts, cb_ref)?))
@@ -136,7 +151,7 @@ fn execute_fleet(repo_root: &Path, q: &str, opts: &AskOptions, json: bool) -> an
 
     let (hits, misses) = crate::fleet::fan_out(&scope, |entry| {
         let root = Path::new(&entry.path);
-        let ledger = Ledger::open_existing(root)?;
+        let ledger = open_ledger_for_read(root)?;
         let cb = build_transcript_callback(root, Some(&entry.name));
         let cb_ref: Option<&TranscriptSearchFn> = cb.as_ref().map(|f| f.as_ref());
         let mut result = ask(&ledger, q, opts, cb_ref)?;

--- a/crates/edda-cli/src/fleet.rs
+++ b/crates/edda-cli/src/fleet.rs
@@ -13,6 +13,23 @@ pub use edda_store::fleet::{fan_out, group_by_project, FleetHit, FleetMiss};
 use edda_store::registry::ProjectEntry;
 use std::path::Path;
 
+/// Helper to identify whether a miss is an ephemeral test fixture (e.g. from temp directories).
+pub fn is_temp_miss(miss: &FleetMiss) -> bool {
+    if !miss.reason.starts_with("repo not on this machine") {
+        return false;
+    }
+    let r = &miss.reason;
+    r.contains("/Temp/")
+        || r.contains("\\Temp\\")
+        || r.starts_with("repo not on this machine (/tmp/")
+        || r.starts_with("repo not on this machine (/var/tmp/")
+        || miss.project.starts_with(".tmp")
+        || miss.project.starts_with("edda_init_test_")
+        || miss.project.starts_with("edda_ask_test_")
+        || miss.project.starts_with("edda_test_")
+        || miss.project.starts_with("edda-pr")
+}
+
 /// Report the projects that did not answer, in the one form every fleet verb
 /// uses.
 ///
@@ -20,8 +37,16 @@ use std::path::Path;
 /// prefix would contradict half of them — the most common miss is "repo not on
 /// this machine", which is absent, not unreadable.
 pub fn print_misses(misses: &[FleetMiss]) {
+    let mut temp_count = 0;
     for miss in misses {
-        println!("  [{}] {}", miss.project, miss.reason);
+        if is_temp_miss(miss) {
+            temp_count += 1;
+        } else {
+            println!("  [{}] {}", miss.project, miss.reason);
+        }
+    }
+    if temp_count > 0 {
+        println!("  ({temp_count} ephemeral test fixture(s) omitted; not on this machine)");
     }
 }
 
@@ -42,12 +67,22 @@ pub fn print_misses(misses: &[FleetMiss]) {
 /// shortfall clause so the sentence still reads in order.
 pub fn empty_summary(what: &str, tail: &str, scope_len: usize, misses: &[FleetMiss]) -> String {
     let answered = scope_len.saturating_sub(misses.len());
+    let temp_count = misses.iter().filter(|m| is_temp_miss(m)).count();
+    let real_misses = misses.len() - temp_count;
+
+    let omitted_clause = if temp_count > 0 {
+        format!(" ({temp_count} ephemeral test fixture(s) omitted)")
+    } else {
+        String::new()
+    };
+
     if misses.is_empty() {
         format!("No {what} across {answered} project(s){tail}")
+    } else if real_misses == 0 {
+        format!("No {what} in the {answered} project(s) that answered{tail}{omitted_clause}")
     } else {
         format!(
-            "No {what} in the {answered} project(s) that answered{tail}; {} could not be read (above)",
-            misses.len()
+            "No {what} in the {answered} project(s) that answered{tail}; {real_misses} could not be read (above){omitted_clause}"
         )
     }
 }
@@ -316,5 +351,35 @@ mod tests {
             env.get("unreadable").is_none() && env.get("fleet").is_none(),
             "the retired spellings must not come back: {env}"
         );
+    }
+
+    #[test]
+    fn ephemeral_test_fixture_misses_are_omitted_from_flooding() {
+        let temp_miss = FleetMiss {
+            project: ".tmpABC123".to_string(),
+            reason: "repo not on this machine (C:\\Users\\fagem\\AppData\\Local\\Temp\\.tmpABC123)"
+                .to_string(),
+        };
+        assert!(is_temp_miss(&temp_miss));
+
+        let real_miss = FleetMiss {
+            project: "dazun".to_string(),
+            reason: "repo not on this machine (D:\\work\\dazun)".to_string(),
+        };
+        assert!(!is_temp_miss(&real_miss));
+
+        let summary = empty_summary(
+            "results",
+            " for: q",
+            5,
+            &[temp_miss.clone(), real_miss.clone()],
+        );
+        assert!(summary.contains("3 project(s) that answered"));
+        assert!(summary.contains("1 could not be read (above)"));
+        assert!(summary.contains("1 ephemeral test fixture(s) omitted"));
+
+        let only_temp_summary = empty_summary("results", " for: q", 5, &[temp_miss]);
+        assert!(only_temp_summary.contains("4 project(s) that answered for: q"));
+        assert!(only_temp_summary.contains("1 ephemeral test fixture(s) omitted"));
     }
 }

--- a/crates/edda-cli/src/fleet.rs
+++ b/crates/edda-cli/src/fleet.rs
@@ -13,21 +13,25 @@ pub use edda_store::fleet::{fan_out, group_by_project, FleetHit, FleetMiss};
 use edda_store::registry::ProjectEntry;
 use std::path::Path;
 
-/// Helper to identify whether a miss is an ephemeral test fixture (e.g. from temp directories).
+/// Helper to identify whether a miss is an ephemeral test fixture based on path provenance.
 pub fn is_temp_miss(miss: &FleetMiss) -> bool {
-    if !miss.reason.starts_with("repo not on this machine") {
+    if !miss.reason.starts_with("repo not on this machine (") {
         return false;
     }
-    let r = &miss.reason;
-    r.contains("/Temp/")
-        || r.contains("\\Temp\\")
-        || r.starts_with("repo not on this machine (/tmp/")
-        || r.starts_with("repo not on this machine (/var/tmp/")
-        || miss.project.starts_with(".tmp")
-        || miss.project.starts_with("edda_init_test_")
-        || miss.project.starts_with("edda_ask_test_")
-        || miss.project.starts_with("edda_test_")
-        || miss.project.starts_with("edda-pr")
+    let Some(path_str) = miss
+        .reason
+        .strip_prefix("repo not on this machine (")
+        .and_then(|s| s.strip_suffix(')'))
+    else {
+        return false;
+    };
+    let p = Path::new(path_str);
+    let temp = std::env::temp_dir();
+    p.starts_with(&temp)
+        || path_str.starts_with("/tmp/")
+        || path_str.starts_with("/var/tmp/")
+        || path_str.contains(r"\AppData\Local\Temp\")
+        || path_str.contains("/AppData/Local/Temp/")
 }
 
 /// Report the projects that did not answer, in the one form every fleet verb
@@ -70,19 +74,13 @@ pub fn empty_summary(what: &str, tail: &str, scope_len: usize, misses: &[FleetMi
     let temp_count = misses.iter().filter(|m| is_temp_miss(m)).count();
     let real_misses = misses.len() - temp_count;
 
-    let omitted_clause = if temp_count > 0 {
-        format!(" ({temp_count} ephemeral test fixture(s) omitted)")
-    } else {
-        String::new()
-    };
-
     if misses.is_empty() {
         format!("No {what} across {answered} project(s){tail}")
     } else if real_misses == 0 {
-        format!("No {what} in the {answered} project(s) that answered{tail}{omitted_clause}")
+        format!("No {what} in the {answered} project(s) that answered{tail}")
     } else {
         format!(
-            "No {what} in the {answered} project(s) that answered{tail}; {real_misses} could not be read (above){omitted_clause}"
+            "No {what} in the {answered} project(s) that answered{tail}; {real_misses} could not be read (above)"
         )
     }
 }
@@ -376,10 +374,11 @@ mod tests {
         );
         assert!(summary.contains("3 project(s) that answered"));
         assert!(summary.contains("1 could not be read (above)"));
-        assert!(summary.contains("1 ephemeral test fixture(s) omitted"));
 
         let only_temp_summary = empty_summary("results", " for: q", 5, &[temp_miss]);
-        assert!(only_temp_summary.contains("4 project(s) that answered for: q"));
-        assert!(only_temp_summary.contains("1 ephemeral test fixture(s) omitted"));
+        assert_eq!(
+            only_temp_summary,
+            "No results in the 4 project(s) that answered for: q"
+        );
     }
 }

--- a/crates/edda-ledger/Cargo.toml
+++ b/crates/edda-ledger/Cargo.toml
@@ -24,3 +24,4 @@ sha2.workspace = true
 hex.workspace = true
 tracing.workspace = true
 globset.workspace = true
+dirs.workspace = true

--- a/crates/edda-ledger/src/ledger.rs
+++ b/crates/edda-ledger/src/ledger.rs
@@ -101,6 +101,23 @@ impl Ledger {
         Self::open(repo_root.to_path_buf())
     }
 
+    /// Return the total count of events in the ledger.
+    pub fn count_events(&self) -> anyhow::Result<u64> {
+        self.sqlite.count_events().context("Ledger::count_events")
+    }
+
+    /// Return the total count of decisions in the ledger.
+    pub fn count_decisions(&self) -> anyhow::Result<u64> {
+        self.sqlite
+            .count_decisions()
+            .context("Ledger::count_decisions")
+    }
+
+    /// Check whether the ledger contains any events.
+    pub fn is_empty(&self) -> anyhow::Result<bool> {
+        Ok(self.count_events()? == 0)
+    }
+
     // ── HEAD branch ─────────────────────────────────────────────────
 
     /// Read the current HEAD branch name.

--- a/crates/edda-ledger/src/ledger.rs
+++ b/crates/edda-ledger/src/ledger.rs
@@ -113,11 +113,6 @@ impl Ledger {
             .context("Ledger::count_decisions")
     }
 
-    /// Check whether the ledger contains any events.
-    pub fn is_empty(&self) -> anyhow::Result<bool> {
-        Ok(self.count_events()? == 0)
-    }
-
     // ── HEAD branch ─────────────────────────────────────────────────
 
     /// Read the current HEAD branch name.

--- a/crates/edda-ledger/src/paths.rs
+++ b/crates/edda-ledger/src/paths.rs
@@ -120,6 +120,15 @@ pub fn validate_branch_name(name: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn clean_unc_path(p: &Path) -> PathBuf {
+    let s = p.to_string_lossy();
+    if let Some(stripped) = s.strip_prefix(r"\\?\") {
+        PathBuf::from(stripped)
+    } else {
+        p.to_path_buf()
+    }
+}
+
 impl EddaPaths {
     /// Walk up from `start` looking for a directory containing `.edda/`.
     ///
@@ -129,33 +138,51 @@ impl EddaPaths {
     ///
     /// Returns `None` if not found by either method.
     pub fn find_root(start: &Path) -> Option<PathBuf> {
-        // Phase 1: Git-aware resolution.
-        // If start is inside a git worktree or repository, resolve to the git root.
-        // If that root contains .edda/, that is our authoritative workspace.
-        // This MUST precede walking up parent directories because detached worktrees
-        // may be placed inside scratch directories whose ancestors contain an unrelated
-        // .edda/ (e.g. ~/.edda/fleet/wt-review-pr<PR>).
-        if let Some(git_root) = edda_core::git::resolve_git_root(start) {
-            if git_root.join(".edda").is_dir() {
-                return Some(git_root);
-            }
-            // If inside a git repo without .edda, do NOT escape above git root into
-            // parent directories (such as ~/.edda) which are not part of this repository.
-            return None;
-        }
-
-        // Phase 2: Walk up looking for .edda/ (for non-git workspaces)
         let home = dirs::home_dir();
+
+        // Walk up looking for `.edda/` or `.git`.
         let mut cur = start.to_path_buf();
         loop {
-            let is_home = home.as_deref().is_some_and(|h| h == cur.as_path());
+            // Case 1: Check for .edda/ directory (nested or direct workspace).
+            // Do NOT treat the user's home directory as a workspace root (its ~/.edda
+            // is the global user state directory or fleet scratch space).
+            let is_home = home.as_deref().is_some_and(|h| {
+                h == cur.as_path()
+                    || h.canonicalize().ok().as_deref() == cur.canonicalize().ok().as_deref()
+            });
+
             if !is_home && cur.join(".edda").is_dir() {
                 return Some(cur);
             }
+
+            // Case 2: Git boundary.
+            // If we encounter a `.git` file or directory, we have reached the root of
+            // this git worktree or repository.
+            let git_marker = cur.join(".git");
+            if git_marker.is_file() {
+                // This is a git worktree root (its .git is a file pointing to gitdir).
+                // If the worktree root itself does not have .edda/, resolve to the main
+                // repository and check if .edda/ exists there.
+                // Do NOT continue walking up above this worktree (which could escape into ~/.edda).
+                return edda_core::git::resolve_git_root(&cur).and_then(|main_repo| {
+                    let cleaned = clean_unc_path(&main_repo);
+                    if cleaned.join(".edda").is_dir() {
+                        Some(cleaned)
+                    } else {
+                        None
+                    }
+                });
+            } else if git_marker.is_dir() {
+                // This is a main git repository root. Since it has no .edda/ (checked above),
+                // do NOT escape above this git repository into parent directories (e.g. ~/.edda).
+                return None;
+            }
+
             if is_home || !cur.pop() {
                 break;
             }
         }
+
         None
     }
 }
@@ -332,6 +359,30 @@ mod tests {
             resolved.canonicalize().unwrap(),
             repo.canonicalize().unwrap(),
             "must resolve to main_repo, NOT fake_home!"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn find_root_nested_workspace_inside_git_repo() {
+        // P0-1: An edda workspace nested inside a larger git repo must be discovered
+        let tmp = unique_tmp("nested_git");
+        let _ = std::fs::remove_dir_all(&tmp);
+        let repo = tmp.join("outer_git");
+        let nested = repo.join("sub").join("nested_workspace");
+        let deep = nested.join("deep").join("dir");
+
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+        std::fs::create_dir_all(nested.join(".edda")).unwrap();
+        std::fs::create_dir_all(&deep).unwrap();
+
+        let found = EddaPaths::find_root(&deep);
+        assert!(found.is_some(), "must discover nested edda workspace");
+        assert_eq!(
+            found.unwrap().canonicalize().unwrap(),
+            nested.canonicalize().unwrap(),
+            "must resolve to nested workspace, not outer git repo"
         );
 
         let _ = std::fs::remove_dir_all(&tmp);

--- a/crates/edda-ledger/src/paths.rs
+++ b/crates/edda-ledger/src/paths.rs
@@ -129,19 +129,34 @@ impl EddaPaths {
     ///
     /// Returns `None` if not found by either method.
     pub fn find_root(start: &Path) -> Option<PathBuf> {
-        // Phase 1: Walk up looking for .edda/ (fast path)
+        // Phase 1: Git-aware resolution.
+        // If start is inside a git worktree or repository, resolve to the git root.
+        // If that root contains .edda/, that is our authoritative workspace.
+        // This MUST precede walking up parent directories because detached worktrees
+        // may be placed inside scratch directories whose ancestors contain an unrelated
+        // .edda/ (e.g. ~/.edda/fleet/wt-review-pr<PR>).
+        if let Some(git_root) = edda_core::git::resolve_git_root(start) {
+            if git_root.join(".edda").is_dir() {
+                return Some(git_root);
+            }
+            // If inside a git repo without .edda, do NOT escape above git root into
+            // parent directories (such as ~/.edda) which are not part of this repository.
+            return None;
+        }
+
+        // Phase 2: Walk up looking for .edda/ (for non-git workspaces)
+        let home = dirs::home_dir();
         let mut cur = start.to_path_buf();
         loop {
-            if cur.join(".edda").is_dir() {
+            let is_home = home.as_deref().is_some_and(|h| h == cur.as_path());
+            if !is_home && cur.join(".edda").is_dir() {
                 return Some(cur);
             }
-            if !cur.pop() {
+            if is_home || !cur.pop() {
                 break;
             }
         }
-
-        // Phase 2: Git worktree fallback — resolve to main repo, check .edda/ there
-        edda_core::git::resolve_git_root(start).filter(|root| root.join(".edda").is_dir())
+        None
     }
 }
 
@@ -276,6 +291,49 @@ mod tests {
         std::fs::create_dir_all(&tmp).unwrap();
 
         assert!(EddaPaths::find_root(&tmp).is_none());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn find_root_worktree_inside_parent_with_dot_edda() {
+        // GH-701: A detached review worktree is created at ~/.edda/fleet/wt-review-pr<N>.
+        // Its parent hierarchy has ~/.edda (the global user state directory).
+        // find_root must resolve to the main repo, NOT ~/.edda!
+        let tmp = unique_tmp("wt_in_fake_home");
+        let _ = std::fs::remove_dir_all(&tmp);
+        let repo = tmp.join("main_repo");
+        let fake_home = tmp.join("fake_home");
+        let wt = fake_home
+            .join(".edda")
+            .join("fleet")
+            .join("wt-review-pr100");
+
+        // Main repo with .edda
+        std::fs::create_dir_all(repo.join(".git").join("worktrees").join("pr100")).unwrap();
+        std::fs::create_dir_all(repo.join(".edda")).unwrap();
+
+        // Fake home containing an unrelated .edda directory (user store root)
+        std::fs::create_dir_all(fake_home.join(".edda")).unwrap();
+
+        // Worktree under fake_home/.edda/fleet
+        std::fs::create_dir_all(&wt).unwrap();
+        let gitdir = repo.join(".git").join("worktrees").join("pr100");
+        let gitdir_str = gitdir
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .replace('\\', "/");
+        std::fs::write(wt.join(".git"), format!("gitdir: {gitdir_str}")).unwrap();
+
+        let found = EddaPaths::find_root(&wt);
+        assert!(found.is_some(), "must resolve worktree to main repo");
+        let resolved = found.unwrap();
+        assert_eq!(
+            resolved.canonicalize().unwrap(),
+            repo.canonicalize().unwrap(),
+            "must resolve to main_repo, NOT fake_home!"
+        );
+
         let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/crates/edda-ledger/src/sqlite_store/decisions.rs
+++ b/crates/edda-ledger/src/sqlite_store/decisions.rs
@@ -325,6 +325,14 @@ impl SqliteStore {
         Ok(count > 0)
     }
 
+    /// Return the total count of decisions in the decisions table.
+    pub fn count_decisions(&self) -> anyhow::Result<u64> {
+        let count: i64 = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM decisions", [], |row| row.get(0))?;
+        Ok(count as u64)
+    }
+
     /// Insert an imported decision from another project.
     /// This writes both the event and the decisions table entry.
     pub fn insert_imported_decision(&self, p: ImportParams<'_>) -> anyhow::Result<()> {

--- a/crates/edda-ledger/src/sqlite_store/events.rs
+++ b/crates/edda-ledger/src/sqlite_store/events.rs
@@ -303,6 +303,14 @@ impl SqliteStore {
         Ok(true)
     }
 
+    /// Return the total count of events in the events table.
+    pub fn count_events(&self) -> anyhow::Result<u64> {
+        let count: i64 = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))?;
+        Ok(count as u64)
+    }
+
     /// Read all events in insertion order.
     pub fn iter_events(&self) -> anyhow::Result<Vec<Event>> {
         let mut stmt = self.conn.prepare(

--- a/crates/edda-store/src/registry.rs
+++ b/crates/edda-store/src/registry.rs
@@ -116,6 +116,12 @@ pub fn get_project(pid: &str) -> Option<ProjectEntry> {
     reg.projects.get(pid).cloned()
 }
 
+/// Check whether a project is registered in the user-level registry.
+pub fn is_registered(repo_root: &Path) -> bool {
+    let pid = project_id(repo_root);
+    get_project(&pid).is_some()
+}
+
 /// Update last_seen timestamp for a project.
 pub fn touch_project(repo_root: &Path) -> anyhow::Result<()> {
     let _lock = lock_file(&registry_lock_path())?;


### PR DESCRIPTION
## Summary

Issue: #701

This PR resolves three visibility and store resolution gaps affecting `edda ask` and `edda ask --fleet`:
1. **The Worktree Escape Bug**: When standing in a detached review worktree placed inside the home/store hierarchy (e.g. `~/.edda/fleet/wt-review-pr<PR>`), `EddaPaths::find_root` previously walked up parent directories and hit `~/.edda/` first, incorrectly treating `$HOME` as an edda workspace with a brand new empty database. We now walk up within the git boundary, check for nested edda workspaces, stop at the `.git` marker, and resolve detached worktrees to the main repository without escaping into `~/.edda`.
2. **Disambiguating Empty/Unregistered Stores from Missing Keys**: When `edda ask` finds no matches, it previously emitted `No results found.` with exit 0 regardless of whether the workspace was unregistered, completely empty, or had zero decisions. We now:
   - Check if the workspace is registered in the global registry and warn on stderr if unregistered.
   - Check `count_events()` and `count_decisions()`, distinguishing an empty ledger (`(workspace ledger is empty; 0 events recorded)`) or zero-decision ledger (`(workspace ledger has 0 decisions recorded; run 'edda decide' to record decisions)`) in both human text and stderr, while surfacing errors as unreadable rather than false zeros.
   - Surface `workspace_event_count` and `workspace_decision_count` in `AskResult` JSON.
   - Local `edda ask` runs migrations via `Ledger::open`, while peer fleet queries gracefully fall back to read-only `open_existing`.
3. **Collapsing Ephemeral Test Fixture Spam**: In `edda ask --fleet` (and other fleet verbs), missing ephemeral test fixtures (`.tmp*`, `/Temp/`, `/tmp/`) are collapsed into a clean single-line summary `(N ephemeral test fixture(s) omitted; not on this machine)` keyed on path provenance instead of spewing thousands of lines of terminal spam.

## Evidence

- **Pre-fix FAIL Receipt**: In detached worktree `C:\Users\fagem\.edda\fleet\wt-test-fail-701`, `edda ask "bridge.pi"` returned `No results found. Exit code: 0`, failing to resolve to the parent repo's ledger.
- **Post-fix PASS Receipt**: In detached worktree `C:\Users\fagem\.edda\fleet\wt-test-fixed-701`, `edda ask "bridge.pi"` properly resolved to `C:/ai_agent/edda` and returned the `bridge.pi` decision.
- **Fleet Verb Receipts**: `edda ask --fleet "bridge.pi"` reduced 2576 lines of `.tmp*` spam to:
  ```
  (2576 ephemeral test fixture(s) omitted; not on this machine)
  No results in the 5 project(s) that answered for: bridge.pi
  ```
- **Tests**:
  - `paths::tests::find_root_worktree_inside_parent_with_dot_edda` passed.
  - `paths::tests::find_root_nested_workspace_inside_git_repo` passed.
  - `fleet::tests::ephemeral_test_fixture_misses_are_omitted_from_flooding` passed.
  - `tests::format_human_empty_ledger_distinguished_from_empty_results` passed.
  - All CI gates passed (9/9 green).