### PR TITLE
docs(core): COMPATIBILITY.md — schema_version upgrade policy and enumerated stable --json contracts (GH-651)

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -30,7 +30,8 @@ store version**:
   to v13 (`schema.rs:238-308`): v5 added cross-project sync fields, v6 the
   `task_briefs` view, v7 `device_tokens`, v8 `decide_snapshots`, v9 hot-path
   indexes, v10 decision deepening columns, v11 `village_id`, v12 the
-  suggestions queue, v13 further decision columns.
+  suggestions queue, v13 the `task_leases` table
+  (`schema.rs:216-226`).
 - **Event payload version** — `edda_core::SCHEMA_VERSION`
   (`crates/edda-core/src/types.rs:4`, stamped into every event payload at
   `crates/edda-core/src/event.rs:186` and siblings). This has been `1` for
@@ -136,7 +137,7 @@ One JSON object — the `AskResult` envelope
 `related_notes`, `conversations` (arrays). Keys `tasks` (array, GH-404),
 `dependents` (array) and `override_risk` (object) are present **only when
 non-empty / Some** — they are serialized with `skip_serializing_if`
-(`lib.rs:66-71`) and their absence means "none", not "removed".
+(`lib.rs:62-67`) and their absence means "none", not "removed".
 
 A `DecisionHit` (element of `decisions`/`timeline`;
 `crates/edda-ask/src/lib.rs:84-107`) always carries: `event_id`, `key`,
@@ -170,7 +171,7 @@ Golden fixtures: `crates/edda-mcp/src/lib.rs` →
 Declared stable by the ruling, **not yet implemented**. Today `edda status`
 is text-only and takes no `--json` flag
 (`crates/edda-cli/src/cmd_status.rs:5-10`, dispatched at
-`crates/edda-cli/src/main.rs:669-671,1224`); passing `--json` is rejected at
+`crates/edda-cli/src/main.rs:289,1224`); passing `--json` is rejected at
 argument parsing. There is no key set to pin, so no golden fixture exists for
 it yet: the flag must land together with its fixture in the same commit, and
 this page updates the same day. Tracked as #730.
@@ -178,7 +179,8 @@ this page updates the same day. Tracked as #730.
 ## 3. Layer 2/3 events are unstable
 
 All Layer 2/3 objects — task, claim, receipt, verdict, plan, and phase
-events, plus the `edda review` review-verdict events — are **unstable** until
+events, plus the `edda review` review-verdict events (the verb itself is a
+designed future verb, tracked as #652) — are **unstable** until
 the v1 event spec (#608) lands and declares otherwise.
 
 That is not re-declared here: it is the recorded decision

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -25,9 +25,9 @@ store version**:
 - **Ledger store version** — `schema_meta.version` in the SQLite ledger
   (`schema_meta` defined at
   `crates/edda-ledger/src/sqlite_store/schema.rs:75-79`, read/written at
-  `schema.rs:318-335`). This is the number a binary compares against itself
+  `schema.rs:342-356`). This is the number a binary compares against itself
   when opening a ledger. The recorded history is a migration ladder from v1
-  to v13 (`schema.rs:238-308`): v5 added cross-project sync fields, v6 the
+  to v13 (`schema.rs:249-341`): v5 added cross-project sync fields, v6 the
   `task_briefs` view, v7 `device_tokens`, v8 `decide_snapshots`, v9 hot-path
   indexes, v10 decision deepening columns, v11 `village_id`, v12 the
   suggestions queue, v13 the `task_leases` table
@@ -52,17 +52,18 @@ store version**:
   actually works today — `Ledger::open` → `SqliteStore::open_or_create` →
   `apply_schema` runs every missing migration upward
   (`crates/edda-ledger/src/ledger.rs:32-41`,
-  `crates/edda-ledger/src/sqlite_store/mod.rs:44-52`,
-  `schema.rs:238-308`).
+  `crates/edda-ledger/src/sqlite_store/mod.rs:45-53`,
+  `schema.rs:249-341`).
 - **Refuse newer.** A ledger with a store version **newer** than the binary
   is refused to open (exit 2, with a message naming both version numbers).
   Refusing is deliberate: the alternative is silently misinterpreting a
   ledger we cannot correctly read.
-  **Implementation status (honest note):** this gate is declared policy but
-  not yet enforced — `apply_schema` only walks `current < N` upward
-  (`schema.rs:238-308`) and a newer ledger currently opens without a version
-  check. The gap is tracked as #729; consumers must not rely on
-  the current lenient behavior, and the gate may land in any 0.x release.
+  **Enforced as of #735 (GH-729, closed):** opening a ledger checks the
+  store version against `MAX_KNOWN_SCHEMA_VERSION` (13) and fails with
+  `UnsupportedSchemaVersionError` (`schema.rs:228-247`); the message names
+  both the stored and the maximum supported version, and `edda verify`
+  maps it to exit 2 (`crates/edda-cli/src/cmd_verify.rs:40-43`). The
+  contract is pinned by `crates/edda-cli/tests/schema_refusal_contract.rs`.
 - **Minor bump, announced.** A `schema_version` jump is a **0.x minor bump**
   (e.g. 0.4 → 0.5), not a major-version event. The release that bumps the
   store version ships an updated version of this page documenting the
@@ -71,8 +72,8 @@ store version**:
   the escape hatches: data can always be extracted in the form it was written.
 - **Read-only consumers never migrate.** `edda verify` opens the ledger
   `query_only` and never applies schema or migrations
-  (`crates/edda-ledger/src/sqlite_store/mod.rs:62-82`); an unreadable ledger
-  is reported at exit 2 (`crates/edda-cli/src/cmd_verify.rs:55-59`), never
+  (`crates/edda-ledger/src/sqlite_store/mod.rs:63-83`); an unreadable ledger
+  is reported at exit 2 (`crates/edda-cli/src/cmd_verify.rs:55-63`), never
   repaired by a verification command.
 
 ## 2. Stable `--json` contracts
@@ -82,7 +83,7 @@ Ledger decision: `compat.stable-json-surfaces=dispatch-verify-ask-status-mcp`
 Exactly the surfaces enumerated below are stable. **Everything not listed
 here is unstable by default** — including every other `--json` flag in the
 CLI (e.g. `edda phase --json`, `edda ask --fleet --json`
-(`crates/edda-cli/src/cmd_ask.rs:131-137`)): it may change shape in any
+(`crates/edda-cli/src/cmd_ask.rs:167-173`)): it may change shape in any
 release without notice.
 
 Within 0.x, a stable surface may have keys **added**. Keys are never
@@ -97,7 +98,7 @@ One JSON object with exactly these keys (emitted at
 
 | Key | Type | Notes |
 |---|---|---|
-| `outcome` | string | one of `done`, `crash`, `timeout`, `max_turns`, `budget_exceeded` (`cmd_dispatch.rs:113-123`) |
+| `outcome` | string | one of `done`, `crash`, `timeout`, `max_turns`, `budget_exceeded` (`cmd_dispatch.rs:114-122`) |
 | `result_text` | string \| null | agent summary; null except `done` |
 | `cost_usd` | number \| null | honest cost; null when the backend reported no usage |
 | `session_id` | string | id to reuse for continuity |
@@ -106,7 +107,7 @@ One JSON object with exactly these keys (emitted at
 | `model_observed` | string | what the backend reported in-band, or `unknown` |
 
 Exit-code table (contract, mirrors the long help; mapping at
-`cmd_dispatch.rs:127-135`): `0` done · `1` crash or any other failure ·
+`cmd_dispatch.rs:127-134`): `0` done · `1` crash or any other failure ·
 `2` timeout · `3` budget exceeded · `4` max turns.
 
 Golden fixture: `crates/edda-cli/src/cmd_dispatch.rs` →
@@ -131,16 +132,19 @@ both the intact and the broken side, through the real binary).
 ### `edda ask --json`
 
 One JSON object — the `AskResult` envelope
-(`crates/edda-ask/src/lib.rs:52-74`), printed at
-`crates/edda-cli/src/cmd_ask.rs:51-53`. Keys always present: `query`
+(`crates/edda-ask/src/lib.rs:52-75`), printed at
+`crates/edda-cli/src/cmd_ask.rs:80-82`. Keys always present: `query`
 (string), `input_type` (string), `decisions`, `timeline`, `related_commits`,
 `related_notes`, `conversations` (arrays). Keys `tasks` (array, GH-404),
-`dependents` (array) and `override_risk` (object) are present **only when
-non-empty / Some** — they are serialized with `skip_serializing_if`
-(`lib.rs:62-67`) and their absence means "none", not "removed".
+`dependents` (array), `override_risk` (object), `workspace_event_count`
+(integer, total events in the workspace ledger) and
+`workspace_decision_count` (integer, total decisions) are present **only
+when non-empty / Some** — they are serialized with `skip_serializing_if`
+(`lib.rs:62-73`; the two count keys were added by #728) and their absence
+means "none", not "removed".
 
 A `DecisionHit` (element of `decisions`/`timeline`;
-`crates/edda-ask/src/lib.rs:84-107`) always carries: `event_id`, `key`,
+`crates/edda-ask/src/lib.rs:90-110`) always carries: `event_id`, `key`,
 `value`, `reason`, `domain`, `branch`, `ts` (strings), `is_active` (bool);
 `tags` (array), `village_id` (string), and `staleness` (object) appear only
 when non-empty / Some.
@@ -171,7 +175,7 @@ Golden fixtures: `crates/edda-mcp/src/lib.rs` →
 Declared stable by the ruling, **not yet implemented**. Today `edda status`
 is text-only and takes no `--json` flag
 (`crates/edda-cli/src/cmd_status.rs:5-10`, dispatched at
-`crates/edda-cli/src/main.rs:289,1224`); passing `--json` is rejected at
+`crates/edda-cli/src/main.rs:289,1246`); passing `--json` is rejected at
 argument parsing. There is no key set to pin, so no golden fixture exists for
 it yet: the flag must land together with its fixture in the same commit, and
 this page updates the same day. Tracked as #730.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,186 @@
+# Compatibility Policy
+
+This page is the compatibility contract for edda in 0.x. It transcribes the
+operator ruling of 2026-09-02 on
+[GH-651](https://github.com/fagemx/edda/issues/651) — held in the decision
+ledger as `compat.schema-version-policy=read-older-refuse-newer-minor-bump-announced`
+and `compat.stable-json-surfaces=dispatch-verify-ask-status-mcp` — into policy
+form. The lane does not re-decide; this page records.
+
+It is not prose backed by nothing: every stable `--json` surface declared in
+§2 has a golden-fixture test that pins its key set and types. Renaming or
+retyping a contracted key turns the fixture red, so this page cannot silently
+go stale — if a fixture fails, the contract moved and this page must ship
+updated in the same release.
+
+## 1. `schema_version` upgrade policy
+
+Ledger decision: `compat.schema-version-policy=read-older-refuse-newer-minor-bump-announced`
+
+### 1.1 Which `schema_version` this policy governs
+
+Two version namespaces exist in the tree; the policy governs the **ledger
+store version**:
+
+- **Ledger store version** — `schema_meta.version` in the SQLite ledger
+  (`schema_meta` defined at
+  `crates/edda-ledger/src/sqlite_store/schema.rs:75-79`, read/written at
+  `schema.rs:318-335`). This is the number a binary compares against itself
+  when opening a ledger. The recorded history is a migration ladder from v1
+  to v13 (`schema.rs:238-308`): v5 added cross-project sync fields, v6 the
+  `task_briefs` view, v7 `device_tokens`, v8 `decide_snapshots`, v9 hot-path
+  indexes, v10 decision deepening columns, v11 `village_id`, v12 the
+  suggestions queue, v13 further decision columns.
+- **Event payload version** — `edda_core::SCHEMA_VERSION`
+  (`crates/edda-core/src/types.rs:4`, stamped into every event payload at
+  `crates/edda-core/src/event.rs:186` and siblings). This has been `1` for
+  the project's entire history and is part of the Layer 1 event format, whose
+  stability is governed by the v1 event spec (#608), not by this page.
+- Decide-snapshot rows additionally carry a per-row
+  `"schema_version": "snapshot.v1"` string
+  (`crates/edda-ledger/src/sqlite_store/schema.rs:151`); it identifies the
+  snapshot shape, not the ledger.
+
+### 1.2 The policy
+
+- **Read older.** A binary may open any ledger whose store version is **≤ its
+  own**. Old ledgers are migrated forward on open, never rewritten in place at
+  the event level: the raw events in the ledger are immutable, and changes to
+  derived views go through `edda rebuild`
+  (`crates/edda-cli/src/cmd_rebuild.rs`). This matches the ladder as it
+  actually works today — `Ledger::open` → `SqliteStore::open_or_create` →
+  `apply_schema` runs every missing migration upward
+  (`crates/edda-ledger/src/ledger.rs:32-41`,
+  `crates/edda-ledger/src/sqlite_store/mod.rs:44-52`,
+  `schema.rs:238-308`).
+- **Refuse newer.** A ledger with a store version **newer** than the binary
+  is refused to open (exit 2, with a message naming both version numbers).
+  Refusing is deliberate: the alternative is silently misinterpreting a
+  ledger we cannot correctly read.
+  **Implementation status (honest note):** this gate is declared policy but
+  not yet enforced — `apply_schema` only walks `current < N` upward
+  (`schema.rs:238-308`) and a newer ledger currently opens without a version
+  check. The gap is tracked as #729; consumers must not rely on
+  the current lenient behavior, and the gate may land in any 0.x release.
+- **Minor bump, announced.** A `schema_version` jump is a **0.x minor bump**
+  (e.g. 0.4 → 0.5), not a major-version event. The release that bumps the
+  store version ships an updated version of this page documenting the
+  migration path — the v5–v13 entries in §1.1 are the pattern. The JSONL
+  ledger export and `edda export` (`crates/edda-cli/src/cmd_export.rs`) are
+  the escape hatches: data can always be extracted in the form it was written.
+- **Read-only consumers never migrate.** `edda verify` opens the ledger
+  `query_only` and never applies schema or migrations
+  (`crates/edda-ledger/src/sqlite_store/mod.rs:62-82`); an unreadable ledger
+  is reported at exit 2 (`crates/edda-cli/src/cmd_verify.rs:55-59`), never
+  repaired by a verification command.
+
+## 2. Stable `--json` contracts
+
+Ledger decision: `compat.stable-json-surfaces=dispatch-verify-ask-status-mcp`
+
+Exactly the surfaces enumerated below are stable. **Everything not listed
+here is unstable by default** — including every other `--json` flag in the
+CLI (e.g. `edda phase --json`, `edda ask --fleet --json`
+(`crates/edda-cli/src/cmd_ask.rs:131-137`)): it may change shape in any
+release without notice.
+
+Within 0.x, a stable surface may have keys **added**. Keys are never
+**deleted, renamed, or retyped**. Consumers must tolerate unknown keys (that
+is what "additive" means for them).
+
+### `edda dispatch --json`
+
+One JSON object with exactly these keys (emitted at
+`crates/edda-cli/src/cmd_dispatch.rs:259-268`; mirrored in the long help,
+`crates/edda-cli/src/main.rs:483-489`):
+
+| Key | Type | Notes |
+|---|---|---|
+| `outcome` | string | one of `done`, `crash`, `timeout`, `max_turns`, `budget_exceeded` (`cmd_dispatch.rs:113-123`) |
+| `result_text` | string \| null | agent summary; null except `done` |
+| `cost_usd` | number \| null | honest cost; null when the backend reported no usage |
+| `session_id` | string | id to reuse for continuity |
+| `error` | string \| null | crash detail; null except `crash` |
+| `model_requested` | string | what edda passed to the backend, or `inherited` |
+| `model_observed` | string | what the backend reported in-band, or `unknown` |
+
+Exit-code table (contract, mirrors the long help; mapping at
+`cmd_dispatch.rs:127-135`): `0` done · `1` crash or any other failure ·
+`2` timeout · `3` budget exceeded · `4` max turns.
+
+Golden fixture: `crates/edda-cli/src/cmd_dispatch.rs` →
+`compat_golden_fixture_dispatch_json_keys_types_and_exit_code_table`
+(crate `edda`).
+
+### `edda verify --json`
+
+One JSON object with exactly these keys (emitted at
+`crates/edda-cli/src/cmd_verify.rs:63-69`):
+
+| Key | Type | Notes |
+|---|---|---|
+| `ok` | bool | chain intact |
+| `events` | integer | events scanned |
+| `first_bad_event` | string \| null | first broken event id, null when intact |
+
+Golden fixture: `crates/edda-cli/src/cmd_verify.rs` →
+`compat_golden_fixture_verify_json_keys_and_types` (crate `edda`; covers
+both the intact and the broken side, through the real binary).
+
+### `edda ask --json`
+
+One JSON object — the `AskResult` envelope
+(`crates/edda-ask/src/lib.rs:52-74`), printed at
+`crates/edda-cli/src/cmd_ask.rs:51-53`. Keys always present: `query`
+(string), `input_type` (string), `decisions`, `timeline`, `related_commits`,
+`related_notes`, `conversations` (arrays). Keys `tasks` (array, GH-404),
+`dependents` (array) and `override_risk` (object) are present **only when
+non-empty / Some** — they are serialized with `skip_serializing_if`
+(`lib.rs:66-71`) and their absence means "none", not "removed".
+
+A `DecisionHit` (element of `decisions`/`timeline`;
+`crates/edda-ask/src/lib.rs:84-107`) always carries: `event_id`, `key`,
+`value`, `reason`, `domain`, `branch`, `ts` (strings), `is_active` (bool);
+`tags` (array), `village_id` (string), and `staleness` (object) appear only
+when non-empty / Some.
+
+Golden fixture: `crates/edda-cli/src/cmd_ask.rs` →
+`compat_golden_fixture_ask_json_keys_and_types` (crate `edda`).
+
+### edda-mcp tool responses
+
+Of the MCP tools, two return JSON payloads, and their shapes are stable:
+
+- `edda_ask` (`crates/edda-mcp/src/lib.rs:263-287`) — returns the same
+  `AskResult` envelope as `edda ask --json` (same key set, same optionality
+  rules).
+- `edda_tool_tier` (`crates/edda-mcp/src/lib.rs:407-417`) — one JSON object,
+  the `ToolTierResult` shape (`crates/edda-core/src/tool_tier.rs:103-108`):
+  `tool` (string), `tier` (string, `T0`–`T4`), `approval` (string,
+  `none`/`lazy`/`required`/`blocked`), `description` (string).
+
+Other MCP tools return human-readable text; their output is not a contract.
+
+Golden fixtures: `crates/edda-mcp/src/lib.rs` →
+`compat_golden_fixture_ask_tool_response_keys_and_types` and
+`compat_golden_fixture_tool_tier_response_keys_and_types`.
+
+### `edda status --json`
+
+Declared stable by the ruling, **not yet implemented**. Today `edda status`
+is text-only and takes no `--json` flag
+(`crates/edda-cli/src/cmd_status.rs:5-10`, dispatched at
+`crates/edda-cli/src/main.rs:669-671,1224`); passing `--json` is rejected at
+argument parsing. There is no key set to pin, so no golden fixture exists for
+it yet: the flag must land together with its fixture in the same commit, and
+this page updates the same day. Tracked as #730.
+
+## 3. Layer 2/3 events are unstable
+
+All Layer 2/3 objects — task, claim, receipt, verdict, plan, and phase
+events, plus the `edda review` review-verdict events — are **unstable** until
+the v1 event spec (#608) lands and declares otherwise.
+
+That is not re-declared here: it is the recorded decision
+`spec.v1-scope=layer1-ledger-events-only-review-verdict-unstable`, cited
+rather than restated.

--- a/README.md
+++ b/README.md
@@ -446,6 +446,8 @@ Next — folding the fleet intelligence layer into the product ([#560](https://g
 
 Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup.
 
+**Compatibility contract:** [COMPATIBILITY.md](COMPATIBILITY.md) — the `schema_version` upgrade policy and the enumerated stable `--json` surfaces. If you change a contracted output shape, this is the page (and the golden fixtures) you answer to.
+
 ## Community
 
 - [GitHub Issues](https://github.com/fagemx/edda/issues) — bugs & feature requests

--- a/crates/edda-cli/src/cmd_ask.rs
+++ b/crates/edda-cli/src/cmd_ask.rs
@@ -293,4 +293,136 @@ mod tests {
              branch gated on a blank body is dead code"
         );
     }
+
+    /// Path to the `edda` binary cargo just built for this test run
+    /// (`current_exe` = `target/debug/deps/<test>-<hash>.exe`).
+    fn edda_bin() -> std::path::PathBuf {
+        let exe = std::env::current_exe().expect("current_exe");
+        let dir = exe
+            .parent()
+            .and_then(|d| d.parent())
+            .expect("deps/.. = target/debug")
+            .to_path_buf();
+        dir.join(format!("edda{}", std::env::consts::EXE_SUFFIX))
+    }
+
+    /// Run `edda ask` in `repo` and return (exit code, stdout, stderr).
+    fn run_edda_ask(args: &[&str], repo: &Path) -> (i32, String, String) {
+        assert!(edda_bin().exists(), "edda binary not found");
+        let out = std::process::Command::new(edda_bin())
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .expect("spawn edda");
+        (
+            out.status.code().expect("exit code"),
+            String::from_utf8_lossy(&out.stdout).into_owned(),
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        )
+    }
+
+    /// GH-651 golden fixture for the `edda ask --json` stable contract
+    /// (ledger decision `compat.stable-json-surfaces`; policy page:
+    /// COMPATIBILITY.md § "Stable `--json` contracts"). Within 0.x, keys may
+    /// be added, never deleted, renamed, or retyped. Pins the exact top-level
+    /// key set (as it is emitted today: `tasks`, `dependents`, and
+    /// `override_risk` are `skip_serializing_if` — absent when empty/None)
+    /// and the per-key types of the envelope and of a `DecisionHit`, through
+    /// the real binary.
+    #[test]
+    fn compat_golden_fixture_ask_json_keys_and_types() {
+        use edda_core::event::new_decision_event;
+        use edda_core::types::DecisionPayload;
+
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        let ledger = Ledger::open_or_init(repo.path()).expect("open_or_init");
+        let parent = ledger.last_event_hash().expect("parent hash");
+        let dp = DecisionPayload {
+            key: "db.engine".to_string(),
+            value: "sqlite".to_string(),
+            reason: Some("golden fixture".to_string()),
+            scope: None,
+            authority: None,
+            affected_paths: None,
+            tags: None,
+            review_after: None,
+            reversibility: None,
+            village_id: None,
+        };
+        let event =
+            new_decision_event("main", parent.as_deref(), "system", &dp).expect("decision event");
+        ledger.append_event(&event).expect("append decision");
+        drop(ledger);
+
+        let (code, stdout, stderr) = run_edda_ask(&["ask", "--json", "db"], repo.path());
+        assert_eq!(code, 0, "stdout={stdout:?} stderr={stderr:?}");
+        let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+
+        let mut keys: Vec<&str> = v
+            .as_object()
+            .expect("one JSON object")
+            .keys()
+            .map(|k| k.as_str())
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec![
+                "conversations",
+                "decisions",
+                "input_type",
+                "query",
+                "related_commits",
+                "related_notes",
+                "timeline",
+            ],
+            "ask --json top-level key set changed — this is a stable contract; \
+             see COMPATIBILITY.md (tasks/dependents/override_risk are \
+             absent when empty by the skip_serializing_if contract)"
+        );
+        assert_eq!(v["query"], "db");
+        assert!(v["input_type"].is_string());
+        for section in [
+            "decisions",
+            "timeline",
+            "related_commits",
+            "related_notes",
+            "conversations",
+        ] {
+            assert!(v[section].is_array(), "{section} must be an array: {v}");
+        }
+
+        // DecisionHit shape (the only populated section here).
+        let d = &v["decisions"][0];
+        let mut dkeys: Vec<&str> = d
+            .as_object()
+            .expect("decision object")
+            .keys()
+            .map(|k| k.as_str())
+            .collect();
+        dkeys.sort_unstable();
+        assert_eq!(
+            dkeys,
+            vec![
+                "branch",
+                "domain",
+                "event_id",
+                "is_active",
+                "key",
+                "reason",
+                "ts",
+                "value",
+            ],
+            "DecisionHit key set changed — this is a stable contract; \
+             see COMPATIBILITY.md"
+        );
+        assert!(d["event_id"].is_string());
+        assert_eq!(d["key"], "db.engine");
+        assert_eq!(d["value"], "sqlite");
+        assert!(d["reason"].is_string());
+        assert!(d["domain"].is_string());
+        assert!(d["branch"].is_string());
+        assert!(d["ts"].is_string());
+        assert_eq!(d["is_active"], serde_json::Value::Bool(true));
+    }
 }

--- a/crates/edda-cli/src/cmd_ask.rs
+++ b/crates/edda-cli/src/cmd_ask.rs
@@ -363,8 +363,10 @@ mod tests {
     /// (ledger decision `compat.stable-json-surfaces`; policy page:
     /// COMPATIBILITY.md § "Stable `--json` contracts"). Within 0.x, keys may
     /// be added, never deleted, renamed, or retyped. Pins the exact top-level
-    /// key set (as it is emitted today: `tasks`, `dependents`, and
-    /// `override_risk` are `skip_serializing_if` — absent when empty/None)
+    /// key set (as it is emitted today: `tasks`, `dependents`,
+    /// `override_risk`, `workspace_event_count`, and `workspace_decision_count`
+    /// are `skip_serializing_if` — absent when empty/None; both counts are
+    /// always known here because this fixture opens a real ledger first)
     /// and the per-key types of the envelope and of a `DecisionHit`, through
     /// the real binary.
     #[test]
@@ -413,13 +415,27 @@ mod tests {
                 "related_commits",
                 "related_notes",
                 "timeline",
+                "workspace_decision_count",
+                "workspace_event_count",
             ],
             "ask --json top-level key set changed — this is a stable contract; \
-             see COMPATIBILITY.md (tasks/dependents/override_risk are \
-             absent when empty by the skip_serializing_if contract)"
+             see COMPATIBILITY.md (tasks/dependents/override_risk and the \
+             workspace counts are absent when empty/unknown by the \
+             skip_serializing_if contract)"
         );
         assert_eq!(v["query"], "db");
         assert!(v["input_type"].is_string());
+        // The two workspace counts are integers when the ledger is readable
+        // (always the case here — the fixture wrote one event and one
+        // decision), and absent from the key set above when unknown.
+        assert!(
+            v["workspace_event_count"].is_u64(),
+            "workspace_event_count must be an integer: {v}"
+        );
+        assert!(
+            v["workspace_decision_count"].is_u64(),
+            "workspace_decision_count must be an integer: {v}"
+        );
         for section in [
             "decisions",
             "timeline",

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -595,6 +595,94 @@ mod tests {
         }
     }
 
+    // ── GH-651 compat golden fixture ──
+
+    /// GH-651 golden fixture for the `edda dispatch --json` stable contract
+    /// (ledger decision `compat.stable-json-surfaces=dispatch-verify-ask-
+    /// status-mcp`; policy page: COMPATIBILITY.md § "Stable `--json`
+    /// contracts"). Within 0.x, keys may be added, never deleted, renamed, or
+    /// retyped. This test is the machine-readable reader of the policy: a
+    /// rename or retype must turn it red, and COMPATIBILITY.md must ship
+    /// updated in the same release. Covers the key set, the per-key types
+    /// (including the null sides of the optional keys), the outcome wire
+    /// vocabulary, and the exit-code table from the long help.
+    #[test]
+    fn compat_golden_fixture_dispatch_json_keys_types_and_exit_code_table() {
+        // `done` populates every optional key; `crash` exercises the null
+        // sides. Together they pin the full type of each key.
+        let done = DispatchOutput::from_result(
+            PhaseResult::AgentDone {
+                cost_usd: Some(1.25),
+                result_text: Some("did it".into()),
+            },
+            "sess-1".into(),
+            "inherited".into(),
+            "openai-codex/gpt-5.6-sol".into(),
+        );
+        let value: serde_json::Value = serde_json::from_str(&done.to_json()).expect("json parses");
+
+        let mut keys: Vec<&str> = value
+            .as_object()
+            .expect("one JSON object")
+            .keys()
+            .map(|k| k.as_str())
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec![
+                "cost_usd",
+                "error",
+                "model_observed",
+                "model_requested",
+                "outcome",
+                "result_text",
+                "session_id",
+            ],
+            "dispatch --json key set changed — this is a stable contract; \
+             see COMPATIBILITY.md"
+        );
+        assert_eq!(value["outcome"], "done");
+        assert!(value["result_text"].is_string());
+        assert_eq!(value["cost_usd"].as_f64(), Some(1.25));
+        assert!(value["session_id"].is_string());
+        assert!(value["error"].is_null());
+        assert_eq!(value["model_requested"], "inherited");
+        assert!(value["model_observed"].is_string());
+
+        let crash = DispatchOutput::from_result(
+            PhaseResult::AgentCrash {
+                error: "boom".into(),
+            },
+            "sess-1".into(),
+            "inherited".into(),
+            "unknown".into(),
+        );
+        let value: serde_json::Value = serde_json::from_str(&crash.to_json()).expect("json parses");
+        assert_eq!(value["outcome"], "crash");
+        assert!(value["result_text"].is_null());
+        assert!(value["cost_usd"].is_null());
+        assert_eq!(value["error"], "boom");
+        assert!(value["session_id"].is_string());
+        assert!(value["model_requested"].is_string());
+        assert!(value["model_observed"].is_string());
+
+        // Outcome wire vocabulary — the strings a consumer switches on.
+        assert_eq!(Outcome::Done.as_str(), "done");
+        assert_eq!(Outcome::Crash.as_str(), "crash");
+        assert_eq!(Outcome::Timeout.as_str(), "timeout");
+        assert_eq!(Outcome::MaxTurns.as_str(), "max_turns");
+        assert_eq!(Outcome::BudgetExceeded.as_str(), "budget_exceeded");
+
+        // Exit-code table (long help + COMPATIBILITY.md): 0 done, 1 crash,
+        // 2 timeout, 3 budget exceeded, 4 max turns.
+        assert_eq!(exit_code_for(Outcome::Done), 0);
+        assert_eq!(exit_code_for(Outcome::Crash), 1);
+        assert_eq!(exit_code_for(Outcome::Timeout), 2);
+        assert_eq!(exit_code_for(Outcome::BudgetExceeded), 3);
+        assert_eq!(exit_code_for(Outcome::MaxTurns), 4);
+    }
+
     #[test]
     fn dispatch_accepts_json_flag() {
         let args = parse(&["edda", "--agent", "pi", "--prompt-file", "p.txt", "--json"]);

--- a/crates/edda-cli/src/cmd_verify.rs
+++ b/crates/edda-cli/src/cmd_verify.rs
@@ -157,6 +157,68 @@ mod tests {
             .collect()
     }
 
+    /// GH-651 golden fixture for the `edda verify --json` stable contract
+    /// (ledger decision `compat.stable-json-surfaces`; policy page:
+    /// COMPATIBILITY.md § "Stable `--json` contracts"). Within 0.x, keys may
+    /// be added, never deleted, renamed, or retyped. Pins the exact key set
+    /// and per-key types on both the clean (`first_bad_event: null`) and the
+    /// broken (`first_bad_event: string`) side, through the real binary.
+    #[test]
+    fn compat_golden_fixture_verify_json_keys_and_types() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        seeded_ledger(repo.path());
+
+        let (code, stdout, stderr) = run_edda(&["verify", "--json"], repo.path());
+        assert_eq!(code, 0, "stdout={stdout:?} stderr={stderr:?}");
+        let v: Value = serde_json::from_str(&stdout).expect("valid JSON");
+
+        let mut keys: Vec<&str> = v
+            .as_object()
+            .expect("one JSON object")
+            .keys()
+            .map(|k| k.as_str())
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec!["events", "first_bad_event", "ok"],
+            "verify --json key set changed — this is a stable contract; \
+             see COMPATIBILITY.md"
+        );
+        assert_eq!(v["ok"], Value::Bool(true));
+        assert!(v["events"].is_u64(), "events must be an integer: {v}");
+        assert_eq!(v["events"], Value::from(2));
+        assert_eq!(v["first_bad_event"], Value::Null);
+
+        // Broken side: same key set, `ok` flips to false and
+        // `first_bad_event` names the first broken event as a string.
+        let e2 = &seeded_event_ids(repo.path())[1];
+        tamper(
+            repo.path(),
+            e2,
+            "UPDATE events SET payload = replace(payload, 'second event', 'tampered') \
+             WHERE event_id = ?1",
+        );
+        let (code, stdout, stderr) = run_edda(&["verify", "--json"], repo.path());
+        assert_eq!(code, 1, "stdout={stdout:?} stderr={stderr:?}");
+        let v: Value = serde_json::from_str(&stdout).expect("valid JSON");
+        let mut keys: Vec<&str> = v
+            .as_object()
+            .expect("one JSON object")
+            .keys()
+            .map(|k| k.as_str())
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec!["events", "first_bad_event", "ok"],
+            "broken-side key set must match the clean side"
+        );
+        assert_eq!(v["ok"], Value::Bool(false));
+        assert_eq!(v["first_bad_event"], Value::String(e2.clone()));
+        assert!(v["events"].is_u64(), "events must be an integer: {v}");
+    }
+
     #[test]
     fn verify_clean_ledger_is_ok_and_exits_0() {
         let repo = tempfile::tempdir().expect("repo tempdir");

--- a/crates/edda-mcp/src/lib.rs
+++ b/crates/edda-mcp/src/lib.rs
@@ -608,10 +608,23 @@ mod tests {
                 "related_commits",
                 "related_notes",
                 "timeline",
+                "workspace_decision_count",
+                "workspace_event_count",
             ],
             "edda_ask tool response key set changed — this is a stable contract; \
-             see COMPATIBILITY.md (tasks/dependents/override_risk are absent \
-             when empty by the skip_serializing_if contract)"
+             see COMPATIBILITY.md (tasks/dependents/override_risk and the \
+             workspace counts are absent when empty/unknown by the \
+             skip_serializing_if contract)"
+        );
+        // The two workspace counts are integers when the ledger is readable,
+        // and absent from the key set above when unknown (#728).
+        assert!(
+            v["workspace_event_count"].is_u64(),
+            "workspace_event_count must be an integer: {v}"
+        );
+        assert!(
+            v["workspace_decision_count"].is_u64(),
+            "workspace_decision_count must be an integer: {v}"
         );
         assert!(v["query"].is_string());
         assert!(v["input_type"].is_string());

--- a/crates/edda-mcp/src/lib.rs
+++ b/crates/edda-mcp/src/lib.rs
@@ -557,6 +557,140 @@ mod tests {
         assert!(server.open_ledger().is_err());
     }
 
+    // ── GH-651 compat golden fixtures ──
+
+    /// GH-651 golden fixture for the `edda_ask` MCP tool response (ledger
+    /// decision `compat.stable-json-surfaces`; policy page: COMPATIBILITY.md
+    /// § "Stable `--json` contracts"). Within 0.x, keys may be added, never
+    /// deleted, renamed, or retyped. The tool returns an `AskResult` rendered
+    /// as JSON text, so the pinned shape matches `edda ask --json`.
+    #[tokio::test]
+    async fn compat_golden_fixture_ask_tool_response_keys_and_types() {
+        let (_tmp, root) = setup_workspace();
+        let server = EddaServer::new(root);
+
+        server
+            .edda_decide(Parameters(DecideParams {
+                decision: "db.engine=postgres".to_string(),
+                reason: Some("golden fixture".to_string()),
+            }))
+            .await
+            .unwrap();
+
+        let result = server
+            .edda_ask(Parameters(AskParams {
+                query: Some("db".to_string()),
+                context_summary: None,
+                limit: None,
+                include_superseded: None,
+                branch: None,
+            }))
+            .await
+            .unwrap();
+
+        let text = result.content[0].raw.as_text().unwrap().text.as_str();
+        let v: serde_json::Value = serde_json::from_str(text).expect("tool returns valid JSON");
+
+        let mut keys: Vec<&str> = v
+            .as_object()
+            .expect("one JSON object")
+            .keys()
+            .map(|k| k.as_str())
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec![
+                "conversations",
+                "decisions",
+                "input_type",
+                "query",
+                "related_commits",
+                "related_notes",
+                "timeline",
+            ],
+            "edda_ask tool response key set changed — this is a stable contract; \
+             see COMPATIBILITY.md (tasks/dependents/override_risk are absent \
+             when empty by the skip_serializing_if contract)"
+        );
+        assert!(v["query"].is_string());
+        assert!(v["input_type"].is_string());
+        for section in [
+            "decisions",
+            "timeline",
+            "related_commits",
+            "related_notes",
+            "conversations",
+        ] {
+            assert!(v[section].is_array(), "{section} must be an array: {v}");
+        }
+
+        let d = &v["decisions"][0];
+        let mut dkeys: Vec<&str> = d
+            .as_object()
+            .expect("decision object")
+            .keys()
+            .map(|k| k.as_str())
+            .collect();
+        dkeys.sort_unstable();
+        assert_eq!(
+            dkeys,
+            vec![
+                "branch",
+                "domain",
+                "event_id",
+                "is_active",
+                "key",
+                "reason",
+                "ts",
+                "value",
+            ],
+            "DecisionHit key set changed — this is a stable contract; \
+             see COMPATIBILITY.md"
+        );
+        assert!(d["event_id"].is_string());
+        assert_eq!(d["key"], "db.engine");
+        assert_eq!(d["value"], "postgres");
+        assert_eq!(d["is_active"], serde_json::Value::Bool(true));
+    }
+
+    /// GH-651 golden fixture for the `edda_tool_tier` MCP tool response —
+    /// the other JSON-returning MCP tool. Pins the exact key set and types
+    /// of `ToolTierResult`.
+    #[tokio::test]
+    async fn compat_golden_fixture_tool_tier_response_keys_and_types() {
+        let (_tmp, root) = setup_workspace();
+        let server = EddaServer::new(root);
+
+        let result = server
+            .edda_tool_tier(Parameters(ToolTierParams {
+                tool_name: "bash".to_string(),
+            }))
+            .await
+            .unwrap();
+
+        let text = result.content[0].raw.as_text().unwrap().text.as_str();
+        let v: serde_json::Value = serde_json::from_str(text).expect("tool returns valid JSON");
+
+        let mut keys: Vec<&str> = v
+            .as_object()
+            .expect("one JSON object")
+            .keys()
+            .map(|k| k.as_str())
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec!["approval", "description", "tier", "tool"],
+            "edda_tool_tier response key set changed — this is a stable contract; \
+             see COMPATIBILITY.md"
+        );
+        assert_eq!(v["tool"], "bash");
+        assert!(v["tier"].is_string(), "tier must be a string: {v}");
+        assert!(v["approval"].is_string(), "approval must be a string: {v}");
+        assert!(v["description"].is_string());
+    }
+
     // --- edda_decide tests ---
 
     #[tokio::test]


### PR DESCRIPTION
Issue: #651

Follow-ups filed: #729 (refuse-newer gate — since closed by #735, integrated into this branch), #730 (status --json), #731 (pre-existing Windows-local test failures — no longer reproduced on the integrated tree).

## Placement: repo root (not `docs/reference/`)

Kept at the repo root for three reasons: (1) the issue's suspected surface names `COMPATIBILITY.md（repo 根）＋ README 一行連結`; (2) it sits next to README.md / CONTRIBUTING.md as a top-level contract document — the audience is external consumers deciding whether to depend on edda, who read the root before they read `docs/`; (3) `docs/reference/` currently holds query-performance and CLI reference material, not governance contracts. README links to it from the Contributions section.

## What's in the page

1. **`schema_version` upgrade policy** (`compat.schema-version-policy=read-older-refuse-newer-minor-bump-announced`) — transcribed from the operator ruling, not invented: read-older (migration ladder v1→v13 evidenced at `schema.rs:238-308`), refuse-newer (**enforced** as of #735/GH-729, integrated into this branch — pinned by `schema_refusal_contract.rs`), 0.x minor bump announced with the release, JSONL export/`edda export` as escape hatches, read-only consumers never migrate. Distinguishes the two version namespaces actually in the tree (SQLite store `schema_meta.version` vs `edda_core::SCHEMA_VERSION`, plus the per-row `snapshot.v1`).
2. **Enumerated stable `--json` contracts** (`compat.stable-json-surfaces=dispatch-verify-ask-status-mcp`) — enumerated, not principled: `edda dispatch --json` (full key/type table + exit-code table), `edda verify --json`, `edda ask --json` (envelope + DecisionHit, including the `skip_serializing_if` absence-means-none keys), the two JSON-returning MCP tools (`edda_ask`, `edda_tool_tier`). `edda status --json` declared stable by the ruling but documented as not-yet-implemented (#730). Everything not listed is unstable by default, explicitly.
3. **Layer 2/3 events unstable** — cited to `spec.v1-scope=layer1-ledger-events-only-review-verdict-unstable`, not restated.

Every assertion carries a `file:line` reference. All references were verified at the round-1 tree, **re-verified in full** at `43cb9d5e…` (three inaccuracies corrected: the `edda status` dispatch citation, one `skip_serializing_if` range, and the v13 migration prose), and **re-anchored to the integrated tree** after the base merges at `ee0eae0b9a57ae89c21bb01b90f4ad33a770805f`. No production `--json` behavior changed — if any contracted output is found broken, it routes to a follow-up issue, per the brief.

## Golden fixtures — red/green proof

5 fixtures pin key sets and per-key types through the real binary / real tool handlers:
- `cmd_dispatch.rs → compat_golden_fixture_dispatch_json_keys_types_and_exit_code_table`
- `cmd_verify.rs → compat_golden_fixture_verify_json_keys_and_types` (clean + broken side)
- `cmd_ask.rs → compat_golden_fixture_ask_json_keys_and_types`
- `edda-mcp → compat_golden_fixture_ask_tool_response_keys_and_types`, `compat_golden_fixture_tool_tier_response_keys_and_types`

**Break detection (deliberately renamed `cost_usd` → `cost` in `DispatchOutput::to_json`):**

```
---- cmd_dispatch::tests::compat_golden_fixture_dispatch_json_keys_types_and_exit_code_table stdout ----
assertion `left == right` failed: dispatch --json key set changed — this is a stable contract; see COMPATIBILITY.md
  left: ["cost", "error", "model_observed", "model_requested", "outcome", "result_text", "session_id"]
 right: ["cost_usd", "error", "model_observed", "model_requested", "outcome", "result_text", "session_id"]
test result: FAILED. 0 passed; 1 failed
```

**After reverting:** `test result: ok. 1 passed` — all 5 fixtures green again.

## doneWhen 對照（issue #651 的實際 doneWhen，四條）

| #651 doneWhen | Status |
|---|---|
| `COMPATIBILITY.md` 存在，含三節：`schema_version` 政策、穩定 `--json` 契約清單（逐一列出，其餘預設 unstable）、Layer 2/3 事件 unstable 聲明 | ✅ §1 / §2 / §3；every claim carries a `file:line` reference — all re-anchored and re-verified at `ee0eae0b…` |
| 每個宣告穩定的 `--json` 有 golden-fixture 測試；先驗證改鍵名會 FAIL | ✅ 5 fixtures green; red/green transcript above (both sides in this PR) |
| README 連到它；#608 body 註明引用關係 | ✅ clause A: `README.md:449` links the page; clause B: #608 body annotated (doneWhen 重複項標為已移出，見下) |
| 三項裁定已在帳本（`edda ask compat` 能查到） | ✅ 2-of-3 queryable on this machine — `compat.schema-version-policy` 與 `compat.stable-json-surfaces` resolve `active`; the third (`spec.v1-scope`) is an unreachable ledger on this machine, pre-existing and not caused by this diff; the ruling text is durably carried by #608's 2026-09-02 comment and `fleet.4090-two-controller-split` (D2: unreachable ledger, not a false claim) |

## Round 2 changes (docs + base integration, head `ee0eae0b9a57ae89c21bb01b90f4ad33a770805f`)

Four commits on top of the reviewed `f7a0110c…`:

1. `43cb9d5` — docs fixes from the round-1 verdict: `edda status` dispatch citation (`main.rs:669-671` → `main.rs:289`, `PipelineCmd::Status` was a different verb), `skip_serializing_if` range (`lib.rs:66-71` → `62-67`), v13 prose (it adds the `task_leases` table, not decision columns), §3 now names #652 next to `edda review`. Issue #608 body annotated on GitHub (no code): compat policy noted as delivered by #651 / PR #732, the duplicated 相容性政策 item in #608's doneWhen marked 已移出 — discharging doneWhen bullet 3, clause B.
2. `a5b3574` — merge `origin/main` `d185524`. **Why:** PR CI builds the merge commit, and main's #728 (GH-701) had added two optional `AskResult` keys (`workspace_event_count`, `workspace_decision_count`, `skip_serializing_if`), so the branch's ask fixture pinned the pre-#728 key set and went red on CI (ubuntu: fixture failed with exactly those two extra keys) even though this PR's own diff never touched Rust. #735 also enforced the refuse-newer gate this page documented as not-yet-enforced. Current-base integration is in scope for every handoff, so the base was merged rather than left silently broken.
3. `29cdd98` — sync to the integrated contract: both ask golden fixtures (`edda`, `edda-mcp`) pin the post-#728 key set (two count keys present as integers when the ledger is readable, absent when unknown), COMPATIBILITY.md §2 documents them, §1.2 replaces the honest note with the enforced gate (citing `schema.rs:228-247` and `schema_refusal_contract.rs`), and every `file:line` reference is re-anchored to the merged tree. No `--json` behavior changed on this branch — the key additions are main's #728; the fixtures and page describe the integrated tree (the brief's contract: record reality, don't change it).
4. `ee0eae0` — merge `origin/main` `64720f2` (GH-714 #737, conductor persistence), which landed on main while this round was in flight; it touches no contract surface and no fixture file.

The branch's own delta vs current `origin/main` is 6 files, +639/−0: COMPATIBILITY.md (new), README +2, and test-only Rust (the golden fixtures).

## Gate receipt (L1)

- **Frozen SHA:** `f7a0110c7ee01226dc8d60fe32ddabc91a518a9d` (clean tree, single commit)
- **Toolchain:** stable-x86_64-pc-windows-msvc (rustup default)
- **Build lane:** `worker-2` (`CARGO_TARGET_DIR=%LOCALAPPDATA%\fleet-workstation\lanes\worker-2`), `CARGO_INCREMENTAL=0`
- `cargo fmt --all --check` — **OK**
- `cargo clippy --workspace --all-targets -- -D warnings` — **OK**
- `cargo test --workspace --no-fail-fast` — **11 failures in 3 suites, all pre-existing environmental, filed as #731**:
  - `edda` ×4: reproduced on the **clean base tree** with the diff stashed
  - `edda-bridge-claude` ×6, `edda-ledger` ×1: run code bit-identical to base (the diff compiles into neither crate); same discovery-collision class
  - the 5 new fixtures and both `edda-mcp` fixtures pass; all other suites green
  - `cargo test -p edda -p edda-mcp`: 460+ passed, same 4 pre-existing failures, all 5 new fixtures green
- No gate rerun for this SHA; the L0 clippy/fmt/test results above are from the same frozen SHA.
- **Round 2 (`ee0eae0b…`), lane `worker-2`, all gates RAN at the final tree:** `cargo fmt --all --check` OK; `sh scripts/lint-markdown-content.sh` exit 0; `cargo clippy -p edda --all-targets -- -D warnings` OK; `cargo clippy -p edda-mcp --all-targets -- -D warnings` OK; `cargo test -p edda` **fully green** — 467 passed, 0 failed, plus all integration suites (the 4 Windows-local failures from #731 no longer reproduce on the integrated tree; main's #728 worktree-resolution fix removed them); `cargo test -p edda-mcp` 19 passed / 0 failed; `cargo test -p edda-ask` 49 passed / 0 failed (focused Windows runs: `edda-ask` and `edda-mcp` are outside CI's Windows 7-crate subset and both were touched by the merge). L1 is not rerun: the branch's own Rust delta vs current main remains test-only, and the merged-in main code (d185524, 64720f2) shipped through its own PRs' CI on all three OSes; exact-head CI on the pushed merge commit is the final gate.

## Notes for review

- The old branch `docs/gh651-compatibility` (29222d1) was used as reference only — never merged, cherry-picked, or rebased; this PR is a single clean commit off `origin/main` `c9f6111`.
- Two `compat.*` decisions were re-recorded on this machine's ledger per the handback comment (ledgers do not cross machines); no third decision recorded, per the ruling.
- Docs + test-only diff: exact-head CI is the primary gate; the L1 receipt above covers the Windows-local picture including the 16 crates CI's Windows job does not exercise.

## Gate receipt — round-2 closeout (lane `verifier`)

- **Frozen SHA:** `ee0eae0b9a57ae89c21bb01b90f4ad33a770805f` (clean tree, no new commits in this pass)
- **Toolchain:** rustc 1.93.1 (01f6ddf75 2026-02-11), cargo 1.93.1, stable-x86_64-pc-windows-msvc
- **Build lane:** `verifier` (`CARGO_TARGET_DIR=%LOCALAPPDATA%leet-workstation\laneserifier`), L1 with `CARGO_INCREMENTAL=0`
- **L0:** `sh scripts/lint-markdown-content.sh` exit 0; `cargo fmt --all --check` OK; `cargo clippy -p edda --all-targets -- -D warnings` OK (first attempt died with a clippy-driver `STATUS_ACCESS_VIOLATION` crash — compiler crash, not a lint; retry on the same SHA clean); `cargo test -p edda` 493 passed / 0 failed incl. all 5 compat fixtures; `cargo test -p edda-mcp` 19 passed / 0 failed
- **L1 (once at this frozen SHA):** `cargo fmt --all --check` OK; `cargo clippy --workspace --all-targets -- -D warnings` OK; `cargo test --workspace --no-fail-fast` — every target green except `edda-bridge-claude --lib`, which is **nondeterministically flaky on this workstation**: failure count varied across four runs (23 → 3 → 23 → 1, different tests each time, all env-var/pid-identity tests such as `*_uses_env_var` / `*_env_override` / `idempotency_guard_works`; even `--test-threads=1` failed a different single test). `edda-bridge-claude` is untouched by this diff (PR #736 owns it) and is **inside** CI's Windows 7-crate subset — exact-head CI (run 33706709143, head confirmed `ee0eae0b…`) runs these very tests **green** on Windows, Linux and macOS, so the local red is environmental, not a property of the tree. The two merge commits also invalidate the older receipts above; this is the receipt for the final tree.
- **Base:** `git merge-tree --write-tree origin/main HEAD` (main at `da5996f6…`) → exit 0, clean tree; no integration needed.


