### PR TITLE
fix(ledger): enforce the refuse-newer schema_version gate on ledger open (GH-729)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,6 +982,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror",
  "time",
  "tracing",

--- a/crates/edda-cli/src/cmd_verify.rs
+++ b/crates/edda-cli/src/cmd_verify.rs
@@ -37,6 +37,10 @@ pub fn execute(repo_root: &Path, json: bool) -> Result<()> {
     let ledger = match Ledger::open_existing(repo_root) {
         Ok(ledger) => ledger,
         Err(err) => {
+            if let Some(e) = err.downcast_ref::<edda_ledger::UnsupportedSchemaVersionError>() {
+                eprintln!("error: {e}");
+                std::process::exit(2);
+            }
             eprintln!(
                 "error: cannot open ledger at {}: {:#}",
                 repo_root.display(),

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -1075,7 +1075,7 @@ enum McpCommand {
     Serve,
 }
 
-fn main() -> anyhow::Result<()> {
+fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "warn".into()),
@@ -1084,6 +1084,28 @@ fn main() -> anyhow::Result<()> {
         .init();
 
     let cli = parse_cli();
+    if let Err(err) = run(cli) {
+        if let Some(e) = find_unsupported_schema_version_error(&err) {
+            eprintln!("error: {e}");
+            std::process::exit(2);
+        }
+        eprintln!("Error: {err:?}");
+        std::process::exit(1);
+    }
+}
+
+fn find_unsupported_schema_version_error(
+    err: &anyhow::Error,
+) -> Option<&edda_ledger::UnsupportedSchemaVersionError> {
+    for cause in err.chain() {
+        if let Some(e) = cause.downcast_ref::<edda_ledger::UnsupportedSchemaVersionError>() {
+            return Some(e);
+        }
+    }
+    None
+}
+
+fn run(cli: Cli) -> anyhow::Result<()> {
     let cwd = std::env::current_dir()?;
     let repo_root = edda_ledger::EddaPaths::find_root(&cwd).unwrap_or(cwd);
 

--- a/crates/edda-cli/tests/schema_refusal_contract.rs
+++ b/crates/edda-cli/tests/schema_refusal_contract.rs
@@ -1,0 +1,86 @@
+//! Golden contract tests for refusing newer schema versions on ledger open (GH-729).
+//!
+//! Operator ruling (compat.schema-version-policy=read-older-refuse-newer-minor-bump-announced):
+//! A ledger whose store version is newer than the binary must be refused to open
+//! with exit code 2 and an error message naming both the stored version and the
+//! binary's maximum supported version.
+
+use rusqlite::Connection;
+use std::path::PathBuf;
+use std::process::Command;
+
+struct TestEnv {
+    _dir: tempfile::TempDir,
+    repo: PathBuf,
+}
+
+impl TestEnv {
+    fn new(future_version: u32) -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let repo = dir.path().join("repo");
+        let edda_dir = repo.join(".edda");
+        std::fs::create_dir_all(&edda_dir).expect("create .edda");
+        std::fs::create_dir_all(repo.join(".git")).expect("create .git");
+
+        // Create a ledger.db with future schema version in schema_meta
+        let db_path = edda_dir.join("ledger.db");
+        let conn = Connection::open(&db_path).expect("open sqlite db");
+        conn.execute_batch(&format!(
+            "CREATE TABLE schema_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO schema_meta (key, value) VALUES ('version', '{future_version}');"
+        ))
+        .expect("write schema_meta");
+
+        Self { _dir: dir, repo }
+    }
+
+    fn run_edda(&self, args: &[&str]) -> (i32, String, String) {
+        let bin = PathBuf::from(env!("CARGO_BIN_EXE_edda"));
+        let out = Command::new(&bin)
+            .args(args)
+            .current_dir(&self.repo)
+            .output()
+            .expect("spawn edda");
+        (
+            out.status.code().expect("exit code"),
+            String::from_utf8_lossy(&out.stdout).into_owned(),
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        )
+    }
+}
+
+#[test]
+fn status_refuses_newer_schema_with_exit_2_and_both_versions() {
+    let env = TestEnv::new(99);
+    let (code, stdout, stderr) = env.run_edda(&["status"]);
+
+    assert_eq!(code, 2, "stdout={stdout:?} stderr={stderr:?}");
+    assert!(
+        stderr.contains("refusing to open ledger: stored schema version 99 is newer than maximum supported version 13"),
+        "stderr should name both version numbers (stored 99, max 13), got: {stderr:?}"
+    );
+}
+
+#[test]
+fn verify_refuses_newer_schema_with_exit_2_and_both_versions() {
+    let env = TestEnv::new(99);
+    let (code, stdout, stderr) = env.run_edda(&["verify"]);
+
+    assert_eq!(code, 2, "stdout={stdout:?} stderr={stderr:?}");
+    assert!(
+        stderr.contains("refusing to open ledger: stored schema version 99 is newer than maximum supported version 13"),
+        "stderr should name both version numbers (stored 99, max 13), got: {stderr:?}"
+    );
+}
+
+#[test]
+fn ask_refuses_newer_schema_with_exit_2_and_both_versions() {
+    let env = TestEnv::new(99);
+    let (code, stdout, stderr) = env.run_edda(&["ask", "test query"]);
+
+    assert_eq!(code, 2, "stdout={stdout:?} stderr={stderr:?}");
+    assert!(
+        stderr.contains("refusing to open ledger: stored schema version 99 is newer than maximum supported version 13"),
+        "stderr should name both version numbers (stored 99, max 13), got: {stderr:?}"
+    );
+}

--- a/crates/edda-ledger/Cargo.toml
+++ b/crates/edda-ledger/Cargo.toml
@@ -25,3 +25,7 @@ hex.workspace = true
 tracing.workspace = true
 globset.workspace = true
 dirs.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+

--- a/crates/edda-ledger/src/lib.rs
+++ b/crates/edda-ledger/src/lib.rs
@@ -27,6 +27,7 @@ pub use domain::{
 pub use ledger::Ledger;
 pub use lock::WorkspaceLock;
 pub use paths::{validate_branch_name, EddaPaths};
+pub use sqlite_store::{UnsupportedSchemaVersionError, MAX_KNOWN_SCHEMA_VERSION};
 pub use tasks::{TaskStatus, TaskView};
 pub use tombstone::{append_tombstone, list_tombstones, make_tombstone, DeleteReason, Tombstone};
 pub use verdict::{latest_verdict, parse_verdict_event, VerdictRecord};

--- a/crates/edda-ledger/src/sqlite_store/mod.rs
+++ b/crates/edda-ledger/src/sqlite_store/mod.rs
@@ -13,6 +13,7 @@ mod task_leases;
 pub mod types;
 mod village;
 
+pub use schema::{UnsupportedSchemaVersionError, MAX_KNOWN_SCHEMA_VERSION};
 pub use types::*;
 
 use rusqlite::Connection;
@@ -73,6 +74,7 @@ impl SqliteStore {
         store
             .conn
             .execute_batch("PRAGMA busy_timeout = 5000; PRAGMA query_only = ON;")?;
+        store.check_schema_version_supported()?;
         Ok(store)
     }
 

--- a/crates/edda-ledger/src/sqlite_store/schema.rs
+++ b/crates/edda-ledger/src/sqlite_store/schema.rs
@@ -224,8 +224,32 @@ CREATE TABLE IF NOT EXISTS task_leases (
 CREATE INDEX IF NOT EXISTS idx_task_leases_expires_at ON task_leases(expires_at);
 ";
 
+/// The maximum schema version known and supported by this binary.
+pub const MAX_KNOWN_SCHEMA_VERSION: u32 = 13;
+
+#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
+#[error("refusing to open ledger: stored schema version {stored} is newer than maximum supported version {max} (upgrade edda to open this workspace)")]
+pub struct UnsupportedSchemaVersionError {
+    pub stored: u32,
+    pub max: u32,
+}
+
 impl SqliteStore {
+    pub(super) fn check_schema_version_supported(&self) -> anyhow::Result<()> {
+        let current = self.schema_version()?;
+        if current > MAX_KNOWN_SCHEMA_VERSION {
+            anyhow::bail!(UnsupportedSchemaVersionError {
+                stored: current,
+                max: MAX_KNOWN_SCHEMA_VERSION,
+            });
+        }
+        Ok(())
+    }
+
     pub(super) fn apply_schema(&self) -> anyhow::Result<()> {
+        // Enforce that the ledger version is not newer than our max supported version.
+        self.check_schema_version_supported()?;
+
         // Always apply v1 base schema (idempotent via IF NOT EXISTS)
         self.conn.execute_batch(SCHEMA_SQL)?;
 
@@ -986,5 +1010,71 @@ impl SqliteStore {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    #[test]
+    fn test_refuse_newer_schema_version_on_open_or_create() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("ledger.db");
+
+        // Manually create a database with a future schema version (e.g. 99)
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE schema_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                 INSERT INTO schema_meta (key, value) VALUES ('version', '99');",
+            )
+            .unwrap();
+        }
+
+        // Attempting to open_or_create must fail with UnsupportedSchemaVersionError
+        let err = match SqliteStore::open_or_create(&db_path) {
+            Ok(_) => panic!("open_or_create should have failed on newer schema"),
+            Err(e) => e,
+        };
+        let version_err = err
+            .downcast_ref::<UnsupportedSchemaVersionError>()
+            .expect("should fail with UnsupportedSchemaVersionError");
+        assert_eq!(version_err.stored, 99);
+        assert_eq!(version_err.max, MAX_KNOWN_SCHEMA_VERSION);
+        assert!(err
+            .to_string()
+            .contains("stored schema version 99 is newer than maximum supported version 13"));
+    }
+
+    #[test]
+    fn test_refuse_newer_schema_version_on_open_existing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("ledger.db");
+
+        // Manually create a database with a future schema version (e.g. 99)
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE schema_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                 INSERT INTO schema_meta (key, value) VALUES ('version', '99');",
+            )
+            .unwrap();
+        }
+
+        // Attempting to open_existing must fail with UnsupportedSchemaVersionError
+        let err = match SqliteStore::open_existing(&db_path) {
+            Ok(_) => panic!("open_existing should have failed on newer schema"),
+            Err(e) => e,
+        };
+        let version_err = err
+            .downcast_ref::<UnsupportedSchemaVersionError>()
+            .expect("should fail with UnsupportedSchemaVersionError");
+        assert_eq!(version_err.stored, 99);
+        assert_eq!(version_err.max, MAX_KNOWN_SCHEMA_VERSION);
+        assert!(err
+            .to_string()
+            .contains("stored schema version 99 is newer than maximum supported version 13"));
     }
 }


### PR DESCRIPTION
## Summary

Issue: #729

Enforce the refuse-newer schema_version gate on ledger open per COMPATIBILITY.md policy (`compat.schema-version-policy=read-older-refuse-newer-minor-bump-announced`).

### Changes
1. **`MAX_KNOWN_SCHEMA_VERSION` & `UnsupportedSchemaVersionError`**:
   - Defined `MAX_KNOWN_SCHEMA_VERSION = 13` next to the migration ladder in `crates/edda-ledger/src/sqlite_store/schema.rs`.
   - Defined `UnsupportedSchemaVersionError { stored, max }` with error message naming both versions: `refusing to open ledger: stored schema version {stored} is newer than maximum supported version {max} (upgrade edda to open this workspace)`.
2. **Refuse on Open**:
   - Enforced in `SqliteStore::open_or_create` before schema bootstrap or migrations run.
   - Enforced in `SqliteStore::open_existing` (used by `edda verify` and read-only queries) immediately after read-only connection initialization.
3. **CLI Exit Code 2 & Diagnostic**:
   - Updated `main.rs` and `cmd_verify.rs` to detect `UnsupportedSchemaVersionError` across the error cause chain, emit the diagnostic on stderr, and exit with code 2.
4. **Tests**:
   - Added unit tests in `crates/edda-ledger/src/sqlite_store/schema.rs` testing `open_or_create` and `open_existing` refusal on future schema version.
   - Added golden contract integration test `crates/edda-cli/tests/schema_refusal_contract.rs` testing exit code 2 and both versions named across `status`, `verify`, and `ask`.

## Evidence

- **Unit tests**:
  `cargo test -p edda-ledger -- schema::tests::` passed (2/2).
- **Integration golden contract**:
  `cargo test -p edda --test schema_refusal_contract` passed (3/3):
  ```
  test ask_refuses_newer_schema_with_exit_2_and_both_versions ... ok
  test status_refuses_newer_schema_with_exit_2_and_both_versions ... ok
  test verify_refuses_newer_schema_with_exit_2_and_both_versions ... ok
  ```
- **Diagnostics verification**:
  When `stored = 99`, CLI exits 2 with:
  `error: refusing to open ledger: stored schema version 99 is newer than maximum supported version 13 (upgrade edda to open this workspace)`