### PR TITLE
fix(bridge): surface swallowed hook-path writes and add pre-commit ratchet (GH-692)

### DIFF
--- a/crates/edda-bridge-claude/src/bg_detect.rs
+++ b/crates/edda-bridge-claude/src/bg_detect.rs
@@ -109,7 +109,7 @@ struct AuditEntry {
 /// combine the increment + threshold check into a single file-locked
 /// read-modify-write, but the current design is acceptable for the
 /// single-user CLI use case.
-pub fn increment_session_count(project_id: &str) {
+pub fn increment_session_count(project_id: &str, session_id: &str) {
     let state = load_detect_state(project_id).unwrap_or(DetectState {
         last_detect_at: String::new(),
         sessions_since_last: 0,
@@ -121,7 +121,17 @@ pub fn increment_session_count(project_id: &str) {
         ..state
     };
 
-    let _ = save_detect_state_raw(project_id, &updated);
+    if let Err(e) = save_detect_state_raw(project_id, &updated) {
+        // GH-692: the detect-state write failed — count it, don't pretend the
+        // counter advanced. Without this, the next threshold crossing is
+        // silently misjudged.
+        crate::state::record_dropped_write(
+            project_id,
+            session_id,
+            "detect state",
+            &format!("{e:#}"),
+        );
+    }
 }
 
 /// Check whether background pattern detection should run for this project.
@@ -948,11 +958,11 @@ mod tests {
         // Start fresh
         let _ = fs::remove_file(detect_state_path(pid));
 
-        increment_session_count(pid);
+        increment_session_count(pid, "sess-test");
         let state = load_detect_state(pid).unwrap();
         assert_eq!(state.sessions_since_last, 1);
 
-        increment_session_count(pid);
+        increment_session_count(pid, "sess-test");
         let state = load_detect_state(pid).unwrap();
         assert_eq!(state.sessions_since_last, 2);
 

--- a/crates/edda-bridge-claude/src/bg_digest.rs
+++ b/crates/edda-bridge-claude/src/bg_digest.rs
@@ -271,6 +271,12 @@ fn build_stats_context(project_id: &str) -> String {
     if !digest.notes.is_empty() {
         parts.push(format!("Notes: {}", digest.notes.join("; ")));
     }
+    if digest.dropped_writes > 0 {
+        parts.push(format!(
+            "Dropped writes: {} — some hook-path writes FAILED and were not persisted (GH-692)",
+            digest.dropped_writes
+        ));
+    }
 
     parts.join("\n")
 }

--- a/crates/edda-bridge-claude/src/digest/orchestrate.rs
+++ b/crates/edda-bridge-claude/src/digest/orchestrate.rs
@@ -1089,7 +1089,16 @@ fn record_failure(project_id: &str, session_id: &str, state: &mut DigestState, e
         state.retry_count = 1;
     }
     state.last_error = error.to_string();
-    let _ = save_digest_state(project_id, state);
+    if let Err(e) = save_digest_state(project_id, state) {
+        // GH-692: failing to persist the failure record is itself a dropped
+        // write — count it so the session digest can show the loss.
+        crate::state::record_dropped_write(
+            project_id,
+            session_id,
+            "digest state",
+            &format!("{e:#}"),
+        );
+    }
 }
 
 /// Build a warning message if there are pending digest failures.

--- a/crates/edda-bridge-claude/src/digest/prev.rs
+++ b/crates/edda-bridge-claude/src/digest/prev.rs
@@ -123,6 +123,11 @@ pub struct PrevDigest {
     /// Activity classification for this session.
     #[serde(default)]
     pub activity: String,
+    /// Hook-path writes that failed and were dropped during this session
+    /// (GH-692). Zero means every write landed; a nonzero count is printed by
+    /// the session digest so a lost write never looks like "nothing happened".
+    #[serde(default)]
+    pub dropped_writes: u64,
 }
 
 /// Write prev_digest.json from SessionStats + optional ledger extras.
@@ -178,6 +183,7 @@ pub fn write_prev_digest(
         cache_creation_tokens: stats.cache_creation_tokens,
         estimated_cost_usd: stats.estimated_cost_usd,
         activity: stats.activity.to_string(),
+        dropped_writes: crate::state::read_dropped_writes(project_id, session_id),
     };
 
     let path = edda_store::project_dir(project_id)

--- a/crates/edda-bridge-claude/src/dispatch/events.rs
+++ b/crates/edda-bridge-claude/src/dispatch/events.rs
@@ -3,27 +3,30 @@ use std::path::Path;
 use crate::parse::*;
 use crate::signals::SubagentSummary;
 
-/// Best-effort write of a `commit` event to the workspace ledger.
+/// Write a `commit` event to the workspace ledger.
 /// Uses try-lock: silently skips if workspace is locked by another process.
-pub(super) fn try_write_commit_event(raw: &serde_json::Value, msg: &str) {
+///
+/// GH-692: a failed ledger open or append is returned as an error (and counted
+/// by the caller via `record_dropped_write`) instead of being swallowed —
+/// only a *missing workspace* and a *contended lock* are legitimate silent
+/// skips.
+pub(super) fn try_write_commit_event(raw: &serde_json::Value, msg: &str) -> anyhow::Result<()> {
     let cwd = get_str(raw, "cwd");
     if cwd.is_empty() {
-        return;
+        return Ok(());
     }
     let Some(root) = edda_ledger::EddaPaths::find_root(Path::new(&cwd)) else {
-        return;
+        return Ok(()); // no edda workspace — hooks fire in arbitrary dirs
     };
-    let Ok(ledger) = edda_ledger::Ledger::open(&root) else {
-        return;
-    };
+    let ledger = edda_ledger::Ledger::open(&root)?;
     let Ok(_lock) = edda_ledger::WorkspaceLock::acquire(&ledger.paths) else {
-        return; // locked by another process — skip
+        return Ok(()); // locked by another process — skip
     };
     let Ok(branch) = ledger.head_branch() else {
-        return;
+        return Ok(());
     };
     let Ok(parent_hash) = ledger.last_event_hash() else {
-        return;
+        return Ok(());
     };
     let mut params = edda_core::event::CommitEventParams {
         branch: &branch,
@@ -36,31 +39,36 @@ pub(super) fn try_write_commit_event(raw: &serde_json::Value, msg: &str) {
         labels: vec!["auto_detect".to_string()],
     };
     if let Ok(event) = edda_core::event::new_commit_event(&mut params) {
-        let _ = ledger.append_event(&event);
+        ledger.append_event(&event)?;
     }
+    Ok(())
 }
 
-/// Best-effort write of a `merge` event to the workspace ledger.
+/// Write a `merge` event to the workspace ledger.
 /// Uses try-lock: silently skips if workspace is locked by another process.
-pub(super) fn try_write_merge_event(raw: &serde_json::Value, src: &str, strategy: &str) {
+///
+/// GH-692: failed ledger open/append propagate — see `try_write_commit_event`.
+pub(super) fn try_write_merge_event(
+    raw: &serde_json::Value,
+    src: &str,
+    strategy: &str,
+) -> anyhow::Result<()> {
     let cwd = get_str(raw, "cwd");
     if cwd.is_empty() {
-        return;
+        return Ok(());
     }
     let Some(root) = edda_ledger::EddaPaths::find_root(Path::new(&cwd)) else {
-        return;
+        return Ok(()); // no edda workspace — hooks fire in arbitrary dirs
     };
-    let Ok(ledger) = edda_ledger::Ledger::open(&root) else {
-        return;
-    };
+    let ledger = edda_ledger::Ledger::open(&root)?;
     let Ok(_lock) = edda_ledger::WorkspaceLock::acquire(&ledger.paths) else {
-        return;
+        return Ok(()); // locked by another process — skip
     };
     let Ok(branch) = ledger.head_branch() else {
-        return;
+        return Ok(());
     };
     let Ok(parent_hash) = ledger.last_event_hash() else {
-        return;
+        return Ok(());
     };
     if let Ok(event) = edda_core::event::new_merge_event(
         &branch,
@@ -70,8 +78,9 @@ pub(super) fn try_write_merge_event(raw: &serde_json::Value, src: &str, strategy
         strategy,
         &[],
     ) {
-        let _ = ledger.append_event(&event);
+        ledger.append_event(&event)?;
     }
+    Ok(())
 }
 
 /// Check if current directory is a karvi project (has server/board.json).
@@ -154,27 +163,31 @@ pub(super) fn try_post_karvi_signal(
     }
 }
 
-/// Best-effort write of a task-completed `note` event to workspace ledger.
+/// Write a task-completed `note` event to workspace ledger.
 /// Uses try-lock: silently skips if workspace is locked by another process.
-pub(super) fn try_write_task_completed_note_event(cwd: &str, task_id: &str, task_subject: &str) {
+///
+/// GH-692: failed ledger open/append propagate — see `try_write_commit_event`.
+pub(super) fn try_write_task_completed_note_event(
+    cwd: &str,
+    task_id: &str,
+    task_subject: &str,
+) -> anyhow::Result<()> {
     if cwd.is_empty() || task_id.is_empty() {
-        return;
+        return Ok(());
     }
 
     let Some(root) = edda_ledger::EddaPaths::find_root(Path::new(cwd)) else {
-        return;
+        return Ok(()); // no edda workspace — hooks fire in arbitrary dirs
     };
-    let Ok(ledger) = edda_ledger::Ledger::open(&root) else {
-        return;
-    };
+    let ledger = edda_ledger::Ledger::open(&root)?;
     let Ok(_lock) = edda_ledger::WorkspaceLock::acquire(&ledger.paths) else {
-        return;
+        return Ok(()); // locked by another process — skip
     };
     let Ok(branch) = ledger.head_branch() else {
-        return;
+        return Ok(());
     };
     let Ok(parent_hash) = ledger.last_event_hash() else {
-        return;
+        return Ok(());
     };
 
     let text = if task_subject.is_empty() {
@@ -187,36 +200,37 @@ pub(super) fn try_write_task_completed_note_event(cwd: &str, task_id: &str, task
     if let Ok(event) =
         edda_core::event::new_note_event(&branch, parent_hash.as_deref(), "agent", &text, &tags)
     {
-        let _ = ledger.append_event(&event);
+        ledger.append_event(&event)?;
     }
+    Ok(())
 }
 
-/// Best-effort write of a sub-agent completion `note` event to workspace ledger.
+/// Write a sub-agent completion `note` event to workspace ledger.
 /// Uses try-lock: silently skips if workspace is locked by another process.
+///
+/// GH-692: failed ledger open/append propagate — see `try_write_commit_event`.
 pub(super) fn try_write_subagent_completed_note_event(
     cwd: &str,
     agent_id: &str,
     agent_type: &str,
     summary: &SubagentSummary,
-) {
+) -> anyhow::Result<()> {
     if cwd.is_empty() || agent_id.is_empty() {
-        return;
+        return Ok(());
     }
 
     let Some(root) = edda_ledger::EddaPaths::find_root(Path::new(cwd)) else {
-        return;
+        return Ok(()); // no edda workspace — hooks fire in arbitrary dirs
     };
-    let Ok(ledger) = edda_ledger::Ledger::open(&root) else {
-        return;
-    };
+    let ledger = edda_ledger::Ledger::open(&root)?;
     let Ok(_lock) = edda_ledger::WorkspaceLock::acquire(&ledger.paths) else {
-        return;
+        return Ok(()); // locked by another process — skip
     };
     let Ok(branch) = ledger.head_branch() else {
-        return;
+        return Ok(());
     };
     let Ok(parent_hash) = ledger.last_event_hash() else {
-        return;
+        return Ok(());
     };
 
     let mut details = Vec::new();
@@ -251,6 +265,7 @@ pub(super) fn try_write_subagent_completed_note_event(
     if let Ok(event) =
         edda_core::event::new_note_event(&branch, parent_hash.as_deref(), "agent", &text, &tags)
     {
-        let _ = ledger.append_event(&event);
+        ledger.append_event(&event)?;
     }
+    Ok(())
 }

--- a/crates/edda-bridge-claude/src/dispatch/mod.rs
+++ b/crates/edda-bridge-claude/src/dispatch/mod.rs
@@ -55,6 +55,19 @@ impl HookResult {
     pub fn empty() -> Self {
         Self::default()
     }
+
+    /// Attach a stderr warning while keeping any stdout output.
+    ///
+    /// Per the hook contract, stderr is shown to the user and exits 1 —
+    /// non-blocking. Used to surface failed hook-path writes (GH-692) so a
+    /// dropped ledger/session write is visible to both agent and human.
+    pub fn with_warning(mut self, msg: String) -> Self {
+        self.stderr = Some(match self.stderr.take() {
+            Some(existing) => format!("{existing}\n{msg}"),
+            None => msg,
+        });
+        self
+    }
 }
 
 impl From<Option<String>> for HookResult {
@@ -134,8 +147,18 @@ pub fn hook_entrypoint_from_stdin(stdin: &str) -> anyhow::Result<HookResult> {
         raw: sanitized_raw,
     };
 
-    // Append to session ledger
-    let _ = append_to_session_ledger(&envelope);
+    // Append to session ledger.
+    // GH-692: a failed append is counted and warned — the count surfaces in
+    // the SessionEnd warning and the next session's digest. It must never
+    // look like the event was recorded when it was not.
+    if let Err(e) = append_to_session_ledger(&envelope) {
+        crate::state::record_dropped_write(
+            &project_id,
+            &session_id,
+            "session ledger",
+            &format!("{e:#}"),
+        );
+    }
 
     // Update peer heartbeat timestamp (lightweight touch for liveness)
     if !session_id.is_empty() {
@@ -222,6 +245,7 @@ pub fn hook_entrypoint_from_stdin(stdin: &str) -> anyhow::Result<HookResult> {
             let agent_type = get_str(&raw, "agent_type");
             let agent_transcript_path = get_str(&raw, "agent_transcript_path");
             let last_assistant_message = get_str(&raw, "last_assistant_message");
+            let mut result = HookResult::empty();
             if !agent_id.is_empty() {
                 let summary = extract_subagent_summary(
                     &agent_transcript_path,
@@ -242,15 +266,28 @@ pub fn hook_entrypoint_from_stdin(stdin: &str) -> anyhow::Result<HookResult> {
                     },
                 );
 
-                try_write_subagent_completed_note_event(&cwd, &agent_id, &agent_type, &summary);
+                if let Err(e) =
+                    try_write_subagent_completed_note_event(&cwd, &agent_id, &agent_type, &summary)
+                {
+                    // GH-692: the note event was NOT written — surface it.
+                    crate::state::record_dropped_write(
+                        &project_id,
+                        &session_id,
+                        "ledger note event (subagent completed)",
+                        &format!("{e:#}"),
+                    );
+                    result = result.with_warning(format!("edda: ledger write failed: {e:#}"));
+                }
                 crate::peers::remove_heartbeat(&project_id, &agent_id);
             }
-            Ok(HookResult::empty())
+            Ok(result)
         }
         "TaskCompleted" => {
             let task_id = get_str(&raw, "task_id");
             let task_subject = get_str(&raw, "task_subject");
             let task_description = get_str(&raw, "task_description");
+
+            let mut result = HookResult::empty();
 
             if !task_id.is_empty() {
                 crate::peers::write_task_completed(
@@ -261,10 +298,19 @@ pub fn hook_entrypoint_from_stdin(stdin: &str) -> anyhow::Result<HookResult> {
                     &task_description,
                 );
 
-                try_write_task_completed_note_event(&cwd, &task_id, &task_subject);
+                if let Err(e) = try_write_task_completed_note_event(&cwd, &task_id, &task_subject) {
+                    // GH-692: the note event was NOT written — surface it.
+                    crate::state::record_dropped_write(
+                        &project_id,
+                        &session_id,
+                        "ledger note event (task completed)",
+                        &format!("{e:#}"),
+                    );
+                    result = result.with_warning(format!("edda: ledger write failed: {e:#}"));
+                }
             }
 
-            Ok(HookResult::empty())
+            Ok(result)
         }
         "TeammateIdle" => {
             let teammate_name = get_str(&raw, "teammate_name");

--- a/crates/edda-bridge-claude/src/dispatch/session.rs
+++ b/crates/edda-bridge-claude/src/dispatch/session.rs
@@ -278,7 +278,13 @@ pub(super) fn dispatch_session_end(
     let decide_count = read_counter(project_id, session_id, "decide_count");
     let signal_count = read_counter(project_id, session_id, "signal_count");
 
-    // 2c. Snapshot session digest for next session's "## Previous Session"
+    // 2c. Snapshot session digest for next session's "## Previous Session".
+    // Known undercount: hook-path writes that fail LATER in SessionEnd (the
+    // postmortem L3 stores and detect state below) are counted but not
+    // reflected in this digest, so it can disagree with the SessionEnd
+    // stderr warning by up to that phase's failure count. Nothing is
+    // invisible — the warning (and the counter it reads) is the complete
+    // record; this snapshot is an approximation for the next-session context.
     crate::digest::write_prev_digest_from_store(
         project_id,
         session_id,

--- a/crates/edda-bridge-claude/src/dispatch/session.rs
+++ b/crates/edda-bridge-claude/src/dispatch/session.rs
@@ -346,7 +346,7 @@ pub(super) fn dispatch_session_end(
     }
 
     // 2i. Background pattern detection (interval-gated)
-    crate::bg_detect::increment_session_count(project_id);
+    crate::bg_detect::increment_session_count(project_id, session_id);
     if crate::bg_detect::should_run(project_id) {
         let tx = bg_tx.clone();
         let pid = project_id.to_string();
@@ -416,14 +416,26 @@ pub(super) fn dispatch_session_end(
     // 2d. Push notification (best-effort, fire-and-forget)
     notify_session_end(project_id, cwd, session_id);
 
-    // 3. Clean up session-scoped state files
+    // 3. Collect the dropped-write count before cleanup deletes the counter
+    //    (GH-692: a failed hook-path write must surface at session end).
+    let dropped_writes = crate::state::read_dropped_writes(project_id, session_id);
+
+    // 4. Clean up session-scoped state files
     cleanup_session_state(project_id, session_id);
 
-    // 4. Collect warnings (pending tasks)
-    if let Some(warning) = collect_session_end_warnings(project_id) {
-        Ok(HookResult::warning(warning))
-    } else {
+    // 5. Collect warnings (pending tasks, dropped writes — GH-692)
+    let mut warnings = collect_session_end_warnings(project_id)
+        .into_iter()
+        .collect::<Vec<_>>();
+    if dropped_writes > 0 {
+        warnings.push(format!(
+            "edda: {dropped_writes} hook write(s) failed this session and were NOT persisted (ledger/session-ledger/coordination/state) — see debug log"
+        ));
+    }
+    if warnings.is_empty() {
         Ok(HookResult::empty())
+    } else {
+        Ok(HookResult::warning(warnings.join("\n")))
     }
 }
 
@@ -566,11 +578,27 @@ pub(super) fn run_postmortem(project_id: &str, session_id: &str, cwd: &str) {
         rules_store.run_decay_cycle();
     }
 
-    let _ = rules_store.save_project(project_id);
+    if let Err(e) = rules_store.save_project(project_id) {
+        // GH-692: the L3 rules write failed — count it, don't pretend it landed.
+        crate::state::record_dropped_write(
+            project_id,
+            session_id,
+            "L3 rules store",
+            &format!("{e:#}"),
+        );
+    }
 
     let mut lessons_store = edda_postmortem::lessons::LessonsStore::load_project(project_id);
     lessons_store.add_lessons(&result.lessons, session_id);
-    let _ = lessons_store.save_project(project_id);
+    if let Err(e) = lessons_store.save_project(project_id) {
+        // GH-692: the L3 lessons write failed — count it, don't pretend it landed.
+        crate::state::record_dropped_write(
+            project_id,
+            session_id,
+            "L3 lessons store",
+            &format!("{e:#}"),
+        );
+    }
 
     // Sync top lessons to CLAUDE.md (best-effort)
     let claude_md_path = Path::new(cwd).join("CLAUDE.md");
@@ -639,6 +667,8 @@ pub(super) fn cleanup_session_state(project_id: &str, session_id: &str) {
     let _ = fs::remove_file(state_dir.join(format!("nudge_ts.{session_id}")));
     // Recall rate counters
     let _ = fs::remove_file(state_dir.join(format!("nudge_count.{session_id}")));
+    // Dropped-write counter (GH-692)
+    let _ = fs::remove_file(state_dir.join(format!("dropped_writes.{session_id}")));
     let _ = fs::remove_file(state_dir.join(format!("decide_count.{session_id}")));
     let _ = fs::remove_file(state_dir.join(format!("signal_count.{session_id}")));
     // Late peer detection counter (#11)

--- a/crates/edda-bridge-claude/src/dispatch/tests.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tests.rs
@@ -17,6 +17,7 @@ use super::{
 // Imports from sub-modules
 use super::events::{
     extract_task_id, is_karvi_project, try_write_commit_event, try_write_merge_event,
+    try_write_task_completed_note_event,
 };
 use super::helpers::{inject_karvi_brief, read_project_state, render_active_plan_from_dir};
 use super::session::{
@@ -1756,7 +1757,7 @@ fn try_write_commit_event_creates_event() {
         "cwd": workspace.to_str().unwrap()
     });
 
-    try_write_commit_event(&raw, "feat: add auth");
+    try_write_commit_event(&raw, "feat: add auth").unwrap();
 
     // Verify event was written
     let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
@@ -1789,7 +1790,7 @@ fn try_write_merge_event_creates_event() {
         "cwd": workspace.to_str().unwrap()
     });
 
-    try_write_merge_event(&raw, "PR#42", "squash");
+    try_write_merge_event(&raw, "PR#42", "squash").unwrap();
 
     // Verify event was written
     let ledger = edda_ledger::Ledger::open(&workspace).unwrap();
@@ -1813,7 +1814,7 @@ fn try_write_commit_event_skips_when_no_workspace() {
         "cwd": tmp.path().to_str().unwrap()
     });
     // Should not panic or error
-    try_write_commit_event(&raw, "test");
+    try_write_commit_event(&raw, "test").unwrap();
 }
 
 #[test]
@@ -1823,7 +1824,64 @@ fn try_write_commit_event_skips_when_empty_cwd() {
         "tool_input": { "command": "git commit -m \"test\"" }
     });
     // No cwd field — should silently skip
-    try_write_commit_event(&raw, "test");
+    try_write_commit_event(&raw, "test").unwrap();
+}
+
+// ── GH-692: failed hook-path writes must be visible ──
+
+/// Make the ledger DB read-only so ledger opens/appends fail at write time.
+fn set_ledger_readonly(paths: &edda_ledger::EddaPaths, ro: bool) {
+    let mut perms = std::fs::metadata(&paths.ledger_db).unwrap().permissions();
+    perms.set_readonly(ro);
+    std::fs::set_permissions(&paths.ledger_db, perms).unwrap();
+}
+
+#[test]
+fn try_write_commit_event_reports_readonly_ledger() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace = tmp.path().to_path_buf();
+    let paths = edda_ledger::EddaPaths::discover(&workspace);
+    edda_ledger::ledger::init_workspace(&paths).unwrap();
+    edda_ledger::ledger::init_head(&paths, "main").unwrap();
+    edda_ledger::ledger::init_branches_json(&paths, "main").unwrap();
+
+    set_ledger_readonly(&paths, true);
+    let raw = serde_json::json!({
+        "tool_name": "Bash",
+        "tool_input": { "command": "git commit -m \"feat: ro\"" },
+        "cwd": workspace.to_str().unwrap()
+    });
+
+    // GH-692: a failed write must NOT look like success.
+    let result = try_write_commit_event(&raw, "feat: ro");
+    assert!(
+        result.is_err(),
+        "read-only ledger must surface the failed write"
+    );
+
+    // Restore so tempdir cleanup can delete the file (Windows).
+    set_ledger_readonly(&paths, false);
+}
+
+#[test]
+fn try_write_task_completed_note_event_reports_readonly_ledger() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace = tmp.path().to_path_buf();
+    let paths = edda_ledger::EddaPaths::discover(&workspace);
+    edda_ledger::ledger::init_workspace(&paths).unwrap();
+    edda_ledger::ledger::init_head(&paths, "main").unwrap();
+    edda_ledger::ledger::init_branches_json(&paths, "main").unwrap();
+
+    set_ledger_readonly(&paths, true);
+
+    let result =
+        try_write_task_completed_note_event(workspace.to_str().unwrap(), "T1", "demo task");
+    assert!(
+        result.is_err(),
+        "read-only ledger must surface the failed write"
+    );
+
+    set_ledger_readonly(&paths, false);
 }
 
 // ── Auto-claim in PostToolUse (#56) ──

--- a/crates/edda-bridge-claude/src/dispatch/tools.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tools.rs
@@ -357,13 +357,26 @@ pub(super) fn dispatch_post_tool_use(
     // Count every detected signal (including SelfRecord and cooldown-suppressed ones).
     increment_counter(project_id, session_id, "signal_count");
 
-    // Auto-write events to workspace ledger (best-effort, try-lock).
-    match &signal {
+    // Auto-write events to workspace ledger (try-lock).
+    // GH-692: a failed open/append is surfaced to the agent instead of being
+    // silently dropped, and counted for the session digest.
+    let write_result = match &signal {
         crate::nudge::NudgeSignal::Commit(msg) => try_write_commit_event(raw, msg),
         crate::nudge::NudgeSignal::Merge(src, strategy) => {
             try_write_merge_event(raw, src, strategy)
         }
-        _ => {}
+        _ => Ok(()),
+    };
+    if let Err(e) = write_result {
+        crate::state::record_dropped_write(
+            project_id,
+            session_id,
+            "ledger event (post-tool-use)",
+            &format!("{e:#}"),
+        );
+        return Ok(HookResult::warning(format!(
+            "edda: ledger write failed: {e:#}"
+        )));
     }
 
     // Write-back to karvi API if this is a karvi project (fire-and-forget).

--- a/crates/edda-bridge-claude/src/dispatch/tools.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tools.rs
@@ -374,6 +374,12 @@ pub(super) fn dispatch_post_tool_use(
             "ledger event (post-tool-use)",
             &format!("{e:#}"),
         );
+        // Fail fast, documented trade-off: this early return also skips the
+        // karvi write-back, the SelfRecord decide-count, the cooldown check
+        // and this turn's nudge additionalContext — a read-only ledger
+        // therefore costs the agent its nudge for this PostToolUse.
+        // `mark_nudge_sent` is skipped too, so the nudge is not permanently
+        // lost; the failure warning stays unburied in the hook output.
         return Ok(HookResult::warning(format!(
             "edda: ledger write failed: {e:#}"
         )));

--- a/crates/edda-bridge-claude/src/peers/heartbeat.rs
+++ b/crates/edda-bridge-claude/src/peers/heartbeat.rs
@@ -46,7 +46,7 @@ pub(crate) fn write_heartbeat(
             }
         });
 
-    let _ = edda_store::update_heartbeat(project_id, session_id, |hb| {
+    let result = edda_store::update_heartbeat(project_id, session_id, |hb| {
         if hb.started_at.is_empty() {
             hb.started_at = now.clone();
         }
@@ -74,31 +74,56 @@ pub(crate) fn write_heartbeat(
         // parent_session_id and the conductor lane fields (plan, phase,
         // attempt, stage, pid) belong to other producers — preserved.
     });
+    if let Err(e) = result {
+        // GH-692: the heartbeat write failed — count it, don't pretend it landed.
+        crate::state::record_dropped_write(
+            project_id,
+            session_id,
+            "peer heartbeat",
+            &format!("{e:#}"),
+        );
+    }
 }
 
 /// Lightweight heartbeat touch: only update last_heartbeat timestamp.
 /// Rides the shared locked update; a still-virgin record is not persisted.
 pub fn touch_heartbeat(project_id: &str, session_id: &str) {
     let now = now_rfc3339();
-    let _ = edda_store::update_heartbeat(project_id, session_id, |hb| {
+    let result = edda_store::update_heartbeat(project_id, session_id, |hb| {
         if hb.started_at.is_empty() && hb.last_heartbeat.is_empty() {
             // No existing heartbeat: skip touch (write_heartbeat creates it).
             return;
         }
         hb.last_heartbeat = now.clone();
     });
+    if let Err(e) = result {
+        crate::state::record_dropped_write(
+            project_id,
+            session_id,
+            "peer heartbeat touch",
+            &format!("{e:#}"),
+        );
+    }
 }
 
 /// Update the branch field in an existing heartbeat.
 /// Called when the agent intentionally switches branch (git checkout / git switch).
 pub(crate) fn update_heartbeat_branch(project_id: &str, session_id: &str, branch: &str) {
-    let _ = edda_store::update_heartbeat(project_id, session_id, |hb| {
+    let result = edda_store::update_heartbeat(project_id, session_id, |hb| {
         if hb.started_at.is_empty() && hb.last_heartbeat.is_empty() {
             // No existing heartbeat: nothing to update.
             return;
         }
         hb.branch = Some(branch.to_string());
     });
+    if let Err(e) = result {
+        crate::state::record_dropped_write(
+            project_id,
+            session_id,
+            "peer heartbeat branch update",
+            &format!("{e:#}"),
+        );
+    }
 }
 
 /// Ensure a heartbeat file exists for this session.
@@ -134,7 +159,7 @@ pub fn remove_heartbeat(project_id: &str, session_id: &str) {
 pub fn write_heartbeat_minimal(project_id: &str, session_id: &str, label: &str, cwd: &str) {
     let now = now_rfc3339();
     let branch = detect_git_branch_in(cwd);
-    let _ = edda_store::update_heartbeat(project_id, session_id, |hb| {
+    let result = edda_store::update_heartbeat(project_id, session_id, |hb| {
         if hb.started_at.is_empty() {
             hb.started_at = now.clone();
         }
@@ -146,6 +171,14 @@ pub fn write_heartbeat_minimal(project_id: &str, session_id: &str, label: &str, 
         // Signal fields and the conductor lane fields belong to other
         // producers on the shared surface — preserved.
     });
+    if let Err(e) = result {
+        crate::state::record_dropped_write(
+            project_id,
+            session_id,
+            "peer heartbeat (minimal)",
+            &format!("{e:#}"),
+        );
+    }
 }
 
 /// Write a heartbeat for a sub-agent spawned via Claude Code's Task tool.
@@ -163,7 +196,7 @@ pub(crate) fn write_subagent_heartbeat(
 ) {
     let now = now_rfc3339();
     let branch = detect_git_branch_in(cwd);
-    let _ = edda_store::update_heartbeat(project_id, agent_id, |hb| {
+    let result = edda_store::update_heartbeat(project_id, agent_id, |hb| {
         if hb.started_at.is_empty() {
             hb.started_at = now.clone();
         }
@@ -175,6 +208,14 @@ pub(crate) fn write_subagent_heartbeat(
         }
         // Signal fields and lane fields belong to other producers — preserved.
     });
+    if let Err(e) = result {
+        crate::state::record_dropped_write(
+            project_id,
+            agent_id,
+            "sub-agent heartbeat",
+            &format!("{e:#}"),
+        );
+    }
 }
 
 /// Remove all sub-agent heartbeats belonging to a parent session.
@@ -194,6 +235,16 @@ pub(crate) fn cleanup_subagent_heartbeats(project_id: &str, parent_session_id: &
             if let Ok(hb) = serde_json::from_str::<SessionHeartbeat>(&content) {
                 if hb.parent_session_id.as_deref() == Some(parent_session_id) {
                     let _ = fs::remove_file(entry.path());
+                    // Also drop this sub-agent's dropped-write counter (GH-692),
+                    // keyed by the same id as the heartbeat file.
+                    let name = entry.file_name().to_string_lossy().to_string();
+                    let sid = name
+                        .strip_prefix("session.")
+                        .and_then(|s| s.strip_suffix(".json"))
+                        .unwrap_or("");
+                    if !sid.is_empty() {
+                        let _ = fs::remove_file(state_dir.join(format!("dropped_writes.{sid}")));
+                    }
                 }
             }
         }
@@ -205,20 +256,33 @@ pub(crate) fn cleanup_subagent_heartbeats(project_id: &str, parent_session_id: &
 // ── Coordination Events (append-only log) ──
 
 /// Append a coordination event to coordination.jsonl.
+///
+/// GH-692: any failure creating the directory, serializing, opening or
+/// writing the append-only log is counted (per session) and warned — a lost
+/// coordination event must not look like a quiet channel.
 pub(crate) fn append_coord_event(project_id: &str, event: &CoordEvent) {
+    if let Err(e) = append_coord_event_inner(project_id, event) {
+        crate::state::record_dropped_write(
+            project_id,
+            &event.session_id,
+            "coordination event",
+            &format!("{e:#}"),
+        );
+    }
+}
+
+fn append_coord_event_inner(project_id: &str, event: &CoordEvent) -> anyhow::Result<()> {
     let path = coordination_path(project_id);
     if let Some(parent) = path.parent() {
-        let _ = fs::create_dir_all(parent);
+        fs::create_dir_all(parent)?;
     }
-    let line = match serde_json::to_string(event) {
-        Ok(l) => l,
-        Err(_) => return,
-    };
-    let mut file = match fs::OpenOptions::new().create(true).append(true).open(&path) {
-        Ok(f) => f,
-        Err(_) => return,
-    };
-    let _ = writeln!(file, "{line}");
+    let line = serde_json::to_string(event)?;
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)?;
+    writeln!(file, "{line}")?;
+    Ok(())
 }
 
 /// Write a claim event with optional process subject.
@@ -502,7 +566,7 @@ pub(crate) fn resolve_teammate_session(project_id: &str, teammate_name: &str) ->
 /// pre-lane record, then atomically restored it after the runner wrote
 /// lane fields, erasing them).
 pub(crate) fn update_teammate_phase(project_id: &str, session_id: &str, phase: &str) {
-    let _ = edda_store::update_heartbeat(project_id, session_id, |hb| {
+    let result = edda_store::update_heartbeat(project_id, session_id, |hb| {
         // `update_heartbeat` seeds a blank record when no file exists; a
         // TeammateIdle event must not create a heartbeat for a session that
         // never had one, so leave the still-blank record unwritten.
@@ -512,6 +576,14 @@ pub(crate) fn update_teammate_phase(project_id: &str, session_id: &str, phase: &
         hb.current_phase = Some(phase.to_string());
         hb.last_heartbeat = now_rfc3339();
     });
+    if let Err(e) = result {
+        crate::state::record_dropped_write(
+            project_id,
+            session_id,
+            "teammate phase heartbeat update",
+            &format!("{e:#}"),
+        );
+    }
 }
 
 /// Write a teammate idle event to coordination.jsonl.

--- a/crates/edda-bridge-claude/src/state.rs
+++ b/crates/edda-bridge-claude/src/state.rs
@@ -32,6 +32,51 @@ pub fn read_counter(project_id: &str, session_id: &str, name: &str) -> u64 {
         .unwrap_or(0)
 }
 
+// ── Dropped-Write Visibility (GH-692) ──
+
+/// Record a failed hook-path write so the loss stays observable.
+///
+/// Death visibility for ledger, session-ledger, coordination, heartbeat,
+/// L3-store and digest-state writes on the hook path: every dropped write is
+/// `tracing::warn!`-ed and counted in a per-session counter. The count is
+/// printed by the SessionEnd hook warning and carried into the session digest
+/// (`prev_digest.json` → "Dropped writes"), so a failed write can never look
+/// like "nothing happened".
+pub fn record_dropped_write(project_id: &str, session_id: &str, what: &str, err: &str) {
+    tracing::warn!(
+        error = %err,
+        what = %what,
+        "edda hook write dropped — data was not persisted"
+    );
+    if session_id.is_empty() {
+        return;
+    }
+    let path = edda_store::project_dir(project_id)
+        .join("state")
+        .join(format!("dropped_writes.{session_id}"));
+    let current: u64 = fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(0);
+    if let Err(counter_err) = fs::write(&path, (current + 1).to_string()) {
+        tracing::warn!(
+            error = %counter_err,
+            "edda: failed to persist dropped_writes counter — this loss is reported via tracing only"
+        );
+    }
+}
+
+/// Read the per-session dropped-write count (0 if missing).
+pub fn read_dropped_writes(project_id: &str, session_id: &str) -> u64 {
+    let path = edda_store::project_dir(project_id)
+        .join("state")
+        .join(format!("dropped_writes.{session_id}"));
+    fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(0)
+}
+
 // ── Injection Dedup ──
 
 /// Path to the inject hash state file for a given session.
@@ -184,6 +229,24 @@ fn now_rfc3339() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn dropped_writes_round_trip() {
+        let pid = "test_state_dropped_writes";
+        let sid = "s-dw";
+        let _ = edda_store::ensure_dirs(pid);
+
+        assert_eq!(read_dropped_writes(pid, sid), 0);
+        record_dropped_write(pid, sid, "session ledger", "test failure");
+        record_dropped_write(pid, sid, "coordination event", "test failure");
+        assert_eq!(read_dropped_writes(pid, sid), 2);
+
+        // Empty session id: warn only, no counter write, no panic.
+        record_dropped_write(pid, "", "session ledger", "test failure");
+        assert_eq!(read_dropped_writes(pid, ""), 0);
+
+        let _ = std::fs::remove_dir_all(edda_store::project_dir(pid));
+    }
 
     #[test]
     fn counter_round_trip() {

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -144,7 +144,12 @@ while IFS= read -r -d '' meta; do
             next
         }
         /^---/ || /^\+\+\+/ { next }
-        /^[ -]/ {            # context line: advance, remember text
+        /^-/ { next }        # deleted line: absent from the NEW file, so it
+                             # must not advance line (wrong file:line) and
+                             # must not set prev - a removed swallow-ok
+                             # comment would otherwise still suppress the
+                             # added line beneath it
+        /^[ ]/ {             # context line: advance, remember text
             line++
             prev = substr($0, 2)
             next

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -18,6 +18,17 @@
 #                                     that directory's Cargo.toml, not the
 #                                     directory name)
 #   - staged *.md                  -> sh scripts/lint-markdown-content.sh
+#   - staged crates/*/src/**/*.rs  -> GH-692 ratchet: ADDED lines (excluding
+#                                     tests.rs and tests/) must not swallow
+#                                     hook-path write errors
+#                                     ('let _ = <write-call>',
+#                                     '<write-call>(...).ok();'). Hit without
+#                                     '// swallow-ok: <reason>' on the same or
+#                                     previous line -> reject. Existing code is
+#                                     never re-flagged: only added lines are
+#                                     examined. Same swallow-pattern family as
+#                                     scripts/wiring-scan.sh section 2 (#594),
+#                                     narrowed to hook-path write calls.
 #
 # Bypass everything with `git commit --no-verify`. CI runs on pull requests
 # and on pushes to main (.github/workflows/ci.yml), so a feature branch is
@@ -46,7 +57,8 @@ rm -f "$skip_marker"
 # source: no environment variable or other override can hide staged paths
 # from the gates.
 staged_z=$(mktemp)
-trap 'rm -f "$staged_z"' EXIT
+ratchet_violations=$(mktemp)
+trap 'rm -f "$staged_z" "$ratchet_violations"' EXIT
 git diff --cached --raw -z --no-renames --diff-filter=ACMR >"$staged_z"
 [ -s "$staged_z" ] || exit 0
 
@@ -99,7 +111,63 @@ while IFS= read -r -d '' meta; do
     esac
 done <"$staged_z"
 
-# --- cargo fmt ------------------------------------------------------------
+# --- GH-692 ratchet: swallowed hook-path writes on ADDED lines --------------
+
+# The issue's style family (same shapes wiring-scan.sh section 2 greps for,
+# narrowed to hook-path write calls):
+#   1. let _ = .*(append_event|append_to_session_ledger|save_project|
+#                  save_digest_state|save_detect_state|update_heartbeat|
+#                  write_heartbeat|fs::write|writeln!)
+#   2. the same write calls ending in .ok();
+# An added line matching either is rejected unless that line — or the line
+# directly above it — carries '// swallow-ok: <reason>'.
+
+while IFS= read -r -d '' meta; do
+    IFS= read -r -d '' f || break
+    [ -n "$f" ] || continue
+    case "$f" in
+        crates/*/src/*.rs) ;;
+        *) continue ;;
+    esac
+    # Exclude tests.rs files and anything under a tests/ directory.
+    base=${f#crates/*/src/}
+    case "$base" in
+        *tests.rs | tests/* | */tests/*) continue ;;
+    esac
+    # -U1 keeps one context line above each addition so a swallow-ok comment
+    # on the previous (unchanged) line is still visible to the check.
+    git diff --cached -U1 -- "$f" | awk -v file="$f" '
+        /^@@/ {
+            split(substr($3, 2), a, ",")
+            line = a[1] - 1
+            prev = ""
+            next
+        }
+        /^---/ || /^\+\+\+/ { next }
+        /^[ -]/ {            # context line: advance, remember text
+            line++
+            prev = substr($0, 2)
+            next
+        }
+        /^\+/ {
+            line++
+            text = substr($0, 2)
+            if (text ~ /let _ = .*(append_event|append_to_session_ledger|save_project|save_digest_state|save_detect_state|update_heartbeat|write_heartbeat|fs::write|writeln!)/ ||
+                text ~ /(append_event|append_to_session_ledger|save_project|save_digest_state|save_detect_state|update_heartbeat|write_heartbeat|fs::write|writeln!).*\.ok\(\);/) {
+                if (text !~ /swallow-ok/ && prev !~ /swallow-ok/) {
+                    print file ":" line ": " text
+                }
+            }
+            prev = text
+        }
+    ' >>"$ratchet_violations"
+done <"$staged_z"
+
+if [ -s "$ratchet_violations" ]; then
+    echo "pre-commit: GH-692 ratchet — swallowed hook-path write on ADDED line(s):" >&2
+    cat "$ratchet_violations" >&2
+    fail "style: 'let _ = <write-call>(...)' or '<write-call>(...).ok();' on added lines under crates/*/src (tests.rs / tests/ excluded), where <write-call> is one of append_event, append_to_session_ledger, save_project, save_digest_state, save_detect_state, update_heartbeat, write_heartbeat, fs::write, writeln! — propagate the error, or justify with '// swallow-ok: <reason>' on the same or previous line"
+fi
 
 if [ "$fmt_needed" -eq 1 ]; then
     echo "pre-commit: cargo fmt --all --check"

--- a/scripts/githooks/test.sh
+++ b/scripts/githooks/test.sh
@@ -302,6 +302,30 @@ fi
 git reset -q --hard "$prev"
 rm -rf crates/litname
 
+# --- GH-692: swallowed hook-path write on an added line is rejected ---------
+# Added line under crates/*/src (not a tests file) matching the issue's style
+# ('let _ = ledger.append_event(&e);') with no swallow-ok justification must
+# block the commit and print the style and line number. Adding
+# '// swallow-ok: cleanup only' on the same line lets it through. Stub cargo
+# keeps the fmt/clippy gates green so only the ratchet decides.
+prev=$(git rev-parse HEAD)
+: > "$stub_log"
+printf '\nfn gh692_swallow() {
+    let _ = ledger.append_event(&e);
+}
+' >> crates/hooktest/src/main.rs
+git add crates/hooktest/src/main.rs
+expect_reject "reject: added 'let _ = ledger.append_event(&e);' without swallow-ok (GH-692)" \
+    "let _ = ledger.append_event" \
+    env PATH="$stub_dir:$PATH" CARGO_STUB_LOG="$stub_log" \
+    git commit -m "feat(test): swallowed hook write"
+sed -i 's|let _ = ledger.append_event(&e);|let _ = ledger.append_event(&e); // swallow-ok: cleanup only|' crates/hooktest/src/main.rs
+git add crates/hooktest/src/main.rs
+expect_accept "accept: same write line with '// swallow-ok: cleanup only' passes (GH-692)" \
+    env PATH="$stub_dir:$PATH" CARGO_STUB_LOG="$stub_log" \
+    git commit -m "feat(test): swallowed hook write justified"
+git reset -q --hard "$prev"
+
 echo
 if [ "$failed" -eq 0 ]; then
     echo "ALL SCENARIOS PASSED"

--- a/scripts/githooks/test.sh
+++ b/scripts/githooks/test.sh
@@ -326,6 +326,83 @@ expect_accept "accept: same write line with '// swallow-ok: cleanup only' passes
     git commit -m "feat(test): swallowed hook write justified"
 git reset -q --hard "$prev"
 
+# --- GH-692 round 1: a hunk with deletions must report the true new-file line
+# Deletion ('-') lines do not exist in the new file: they must not advance the
+# line counter (previously each deletion inflated the reported line number).
+prev=$(git rev-parse HEAD)
+cat > crates/hooktest/src/main.rs <<'EOF'
+fn f() -> i32 {
+    1
+}
+
+fn main() {
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    println!("{}", a + b + c);
+}
+EOF
+git add crates/hooktest/src/main.rs
+expect_accept "accept: base for the deletions scenario passes the ratchet (GH-692)" \
+    env PATH="$stub_dir:$PATH" CARGO_STUB_LOG="$stub_log" \
+    git commit -m "feat(test): deletions scenario base"
+# Rewrite: delete the 4 statements, add the violating write. The hunk has 4
+# deletions before the addition; the write lands on new-file line 6.
+cat > crates/hooktest/src/main.rs <<'EOF'
+fn f() -> i32 {
+    1
+}
+
+fn main() {
+    let _ = ledger.append_event(&e);
+}
+EOF
+git add crates/hooktest/src/main.rs
+expect_reject "reject: hunk with 4 deletions reports the true new-file line 6 (GH-692)" \
+    "crates/hooktest/src/main.rs:6:" \
+    env PATH="$stub_dir:$PATH" CARGO_STUB_LOG="$stub_log" \
+    git commit -m "feat(test): swallowed hook write after deletions"
+git reset -q --hard "$prev"
+
+# --- GH-692 round 1: REMOVING a swallow-ok comment must un-suppress ---------
+# The diff shows the deleted swallow-ok comment directly above the newly added
+# violating line (one deletion, one addition), but that comment no longer
+# exists in the new file, so it must not suppress the violation (previously
+# prev was set from '-' lines and the commit was accepted).
+prev=$(git rev-parse HEAD)
+cat > crates/hooktest/src/main.rs <<'EOF'
+fn f() -> i32 {
+    1
+}
+
+fn gh692_stale() {
+    // swallow-ok: cleanup only
+    let a = 1;
+}
+EOF
+git add crates/hooktest/src/main.rs
+expect_accept "accept: base for the stale-ok scenario passes the ratchet (GH-692)" \
+    env PATH="$stub_dir:$PATH" CARGO_STUB_LOG="$stub_log" \
+    git commit -m "feat(test): stale-ok base"
+# Replace the (removed) swallow-ok comment with a violating write: the added
+# line must be flagged even though the diff shows the old swallow-ok above it.
+cat > crates/hooktest/src/main.rs <<'EOF'
+fn f() -> i32 {
+    1
+}
+
+fn gh692_stale() {
+    let _ = ledger.append_event(&e);
+    let a = 1;
+}
+EOF
+git add crates/hooktest/src/main.rs
+expect_reject "reject: removed swallow-ok comment no longer suppresses (GH-692)" \
+    "crates/hooktest/src/main.rs:6:" \
+    env PATH="$stub_dir:$PATH" CARGO_STUB_LOG="$stub_log" \
+    git commit -m "feat(test): stale swallow-ok removed"
+git reset -q --hard "$prev"
+
 echo
 if [ "$failed" -eq 0 ]; then
     echo "ALL SCENARIOS PASSED"


### PR DESCRIPTION
Issue: #692

Every hook-path write to the ledger / session ledger / coordination log / heartbeats / L3 stores / digest state swallowed its error with `let _ =` — a failed write looked exactly like a quiet session. This PR makes every such failure observable, and adds a pre-commit ratchet so new swallowed writes cannot land without an explicit justification.

## DoneWhen, item by item

### 1. Issue table — every row now fails loudly

| issue row | change | surface |
|---|---|---|
| `dispatch/events.rs:39,73,190,254` (`ledger.append_event`) | `try_write_commit_event` / `try_write_merge_event` / `try_write_task_completed_note_event` / `try_write_subagent_completed_note_event` now return `anyhow::Result<()>`; ledger open/append errors propagate (`crates/edda-bridge-claude/src/dispatch/events.rs:13,55,168,216`). Legitimate skips (no workspace, contended try-lock, empty cwd) stay silent `Ok(())` by design, documented in the fns | PostToolUse returns `HookResult::warning("edda: ledger write failed: …")` (`dispatch/tools.rs:373-380`); SubagentCompleted / TaskCompleted attach the same line via `with_warning` while keeping stdout (`dispatch/mod.rs:270-280,303-311`) |
| `dispatch/mod.rs:138` (`append_to_session_ledger`) | failure → `record_dropped_write` + tracing warn (`dispatch/mod.rs:150-158`) | counted; surfaced at SessionEnd (below) |
| `dispatch/session.rs:566,570` (`rules_store`/`lessons_store.save_project`) | both L3 writes checked; failure → `record_dropped_write` (`dispatch/session.rs:581-601`) | counted |
| `peers/heartbeat.rs:49,83,95,137,208-223` | every `update_heartbeat` call site (`write_heartbeat:49`, `touch_heartbeat:83`, `update_heartbeat_branch:95`, `write_heartbeat_minimal:137`, `write_subagent_heartbeat:196`, `update_teammate_phase:565`) and `append_coord_event` (`:261-288`, inner fn returns `Result`) checked → `record_dropped_write` | counted |
| `digest/orchestrate.rs:1092` (`save_digest_state`) | `record_failure` counts its own dropped persistence (`digest/orchestrate.rs:1092-1101`) — losing the failure record is itself a dropped write | counted |
| `bg_detect.rs:124` (`save_detect_state_raw`) | **confirmed present, different line**: the issue's grep missed it because the swallow sits inside `increment_session_count` (`let _ = save_detect_state_raw(project_id, &updated)`). Now checked; `increment_session_count` takes `session_id` for attribution (`bg_detect.rs:112-136`) | counted |

### 2. Death visibility — NOT best-effort

- Per-session counter: `state::record_dropped_write` / `state::read_dropped_writes` (`state.rs:45,70`) — every dropped write is `tracing::warn!`-ed AND persisted to `state/dropped_writes.<session_id>`.
- SessionEnd warning: `dispatch/session.rs:421-436` — `edda: N hook write(s) failed this session and were NOT persisted (ledger/session-ledger/coordination/state) — see debug log`.
- Session digest: `prev_digest.json` carries `dropped_writes` (`digest/prev.rs:130,186`); `bg_digest` prints `Dropped writes: N — some hook-path writes FAILED and were not persisted` (`bg_digest.rs:274-278`). The counter is read **before** `cleanup_session_state` deletes it (`session.rs:419-424`; digest written at `:282`).

### 3. Red / green evidence (same machine, same procedure)

Setup: scratch workspace `C:/gh692-demo/ws` (`edda init`), isolated store via `EDDA_STORE_ROOT`, `chmod 444 .edda/ledger.db`, then `edda hook claude` fed a PostToolUse commit signal.

**RED — base (`c9f6111`, fix stashed):** write fails silently, hook reports success, zero failure signal:

```
{"hookSpecificOutput":{"additionalContext":"<!-- edda:start -->\n⚠️ You haven't recorded any decisions this session yet. You just committed \"feat: demo\". …"},"hookEventName":"PostToolUse"}
EXIT=0
```

**GREEN — this PR (`4567b7d`):** same readonly ledger, same input:

```
WARN edda_bridge_claude::state: edda hook write dropped — data was not persisted error=attempt to write a readonly database: Error code 8 what=ledger event (post-tool-use)
edda: ledger write failed: attempt to write a readonly database: Error code 8: Attempt to write a readonly database
EXIT=1
```

and downstream:

```
$ cat store/projects/*/state/dropped_writes.s-gh692
1
$ edda hook claude   # SessionEnd, same session
edda: 1 hook write(s) failed this session and were NOT persisted (ledger/session-ledger/coordination/state) — see debug log
EXIT=1
$ grep dropped_writes store/projects/*/state/prev_digest.json
  "dropped_writes": 1
```

### 4. Pre-commit ratchet (added lines only; existing code untouched)

- `scripts/githooks/pre-commit:114-172`: for staged added lines under `crates/*/src/**/*.rs` (excluding `tests.rs` and `tests/`), rejects `let _ = <write-call>` and `<write-call>(…).ok();` where `<write-call>` ∈ {append_event, append_to_session_ledger, save_project, save_digest_state, save_detect_state, update_heartbeat, write_heartbeat, fs::write, writeln!} unless the same or previous line carries `// swallow-ok: <reason>`. Rejection prints the style and `file:line`. Deletion (`-`) diff lines are skipped entirely — they do not exist in the new file, so they neither advance the reported line number nor feed `prev`; a `// swallow-ok:` comment that the commit removes therefore cannot suppress the added line beneath it (round-1 review fix, P1). Style family follows the issue table / `wiring-scan.sh` section 2 (#594) narrowed to hook-path write calls — not a new taxonomy.
- `scripts/githooks/test.sh:305-404`: four GH-692 scenarios (stub cargo so only the ratchet decides) — the original reject/accept pair plus two round-1 scenarios:

```
PASS: reject: added 'let _ = ledger.append_event(&e);' without swallow-ok (GH-692)
PASS: accept: same write line with '// swallow-ok: cleanup only' passes (GH-692)
PASS: accept: base for the deletions scenario accepts (base must stay green) (GH-692)
PASS: reject: hunk with 4 deletions reports the true new-file line 6 (GH-692)
PASS: accept: base for the stale-ok scenario accepts (base must stay green) (GH-692)
PASS: reject: removed swallow-ok comment no longer suppresses (GH-692)
```

Both round-1 scenarios are red on the pre-fix hook (suite run against the head-`4567b7d` hook): the 4-deletion hunk reported `main.rs:10` instead of the true new-file line 6, and the commit that removes a `// swallow-ok:` comment was accepted — the deleted comment still suppressed the added violating line beneath it.

This PR's own diff passes the ratchet (real commit `30692e3` through the fixed hook).

## Gates

- `sh scripts/lint-markdown-content.sh` — exit 0
- `cargo test -p edda-bridge-claude` — 628 passed / 6 failed (parallel, env races); at head `4567b7d` (fix stashed) the same run red-flagged 24 tests — a superset of the same #734 environmental class, so no failure is attributable to this diff. CI runners are isolated and are the authoritative green for this suite.
- `sh scripts/githooks/test.sh` — ALL SCENARIOS PASSED (including the 4 GH-692 scenarios), output above; the 2 round-1 scenarios verified red on the pre-fix hook.

### L1 gate receipt (frozen SHA, round-1 fixes)

- **Full SHA:** `30692e3dcc3eda03a85a34e3194456ffbd207c2e`, clean tree
- **Toolchain:** rustc 1.93.1 (01f6ddf75 2026-02-11), Windows, `CARGO_INCREMENTAL=0`
- **Build lane:** `worker-2` (`%LOCALAPPDATA%\fleet-workstation\lanes\worker-2`), no ad-hoc target dirs
- `cargo fmt --all --check` — **PASS**
- `cargo clippy --workspace --all-targets -- -D warnings` — **PASS**
- `cargo test --workspace --no-fail-fast` — **47 suites ok; 3 red suites, all environmental, none introduced by this diff**: `edda_ledger` (1: `find_root_non_git_no_edda_returns_none` — discovers the real `~/.edda`), `edda` bin (4: `cmd_reconcile` ×3 / `cmd_verify` ×1 — same discovery), `edda-bridge-claude` (6, parallel env-race subset of the 24-failure set reproduced at head `4567b7d` with this diff stashed). Same class as the prior receipt, cause filed as #734. Two transient `link.exe` 1104 (file-in-use) locks during the run cleared on retry without any change — environmental, recorded for cost.
- Exact-head CI (pushed at this SHA) is the isolation-clean confirmation of the workspace test.

### Prior round receipt (superseded, kept for the record)

- **Full SHA:** `4567b7db139ce2211a37e863cbb23558fa3a9533`, clean tree, single commit
- **Toolchain:** rustc 1.93.1 (01f6ddf75 2026-02-11), Windows, `CARGO_INCREMENTAL=0`
- **Build lane:** `worker-1` (`%LOCALAPPDATA%\fleet-workstation\lanes\worker-1`), no ad-hoc target dirs
- `cargo fmt --all --check` — **PASS**
- `cargo clippy --workspace --all-targets -- -D warnings` — **PASS**
- `cargo test --workspace --no-fail-fast` — **3 suites red, all environmental, none introduced by this diff**: `edda_ledger` (1: `find_root_non_git_no_edda_returns_none` — discovers the real `~/.edda`), `edda` bin (4: `cmd_reconcile`/`cmd_verify` — same discovery), `edda-bridge-claude` (25 parallel incl. env races / 3 single-threaded, base-identical — reproduced with fix stashed earlier in this session). All failing code paths are byte-identical to base (diff touches only `edda-bridge-claude` + `scripts/githooks`); cause filed as #734. All other suites: `test result: ok`.
- Exact-head CI is the isolation-clean confirmation of the workspace test.

## Wiring table (self-reported)

| New surface | 1. Writer & shape | 2. Reader | 3. Failure signal | 4. Layer reach |
|---|---|---|---|---|
| Failure line on propagatable ledger writes | `events.rs:13,55,168,216` return `Result`; `tools.rs:373-380` + `mod.rs:270-280,303-311` attach `edda: ledger write failed: <err>` via `HookResult::with_warning` (`mod.rs:64`) | Claude Code shows stderr to the **user** in-turn (exit 1) but does not feed it to the model (`cmd_bridge.rs:503-505`); the **agent** sees the failure next session via the digest arm (`dropped_writes >= 1` -> `bg_digest.rs:274`) - that arm is what satisfies doneWhen item 1 | stderr line + tracing warn + counter | hook stdout/stderr contract; per hook invocation |
| `dropped_writes` per-session counter | `state.rs:45-67` writes `state/dropped_writes.<sid>` (+1), warn on counter-write failure itself; called from 15 sites (`mod.rs:151`, `tools.rs:370`, `session.rs:581,596`, `heartbeat.rs:79,100,120,175,212,265,580`, `orchestrate.rs:1095`, `bg_detect.rs:128`) | `session.rs:421` (SessionEnd warning), `prev.rs:186` (digest), `bg_digest.rs:274` (next-session context) | nonzero count ⇒ explicit "FAILED / NOT persisted" warning in hook output and digest | `%EDDA_STORE_ROOT%\projects\<pid>\state\`; per session, printed at session end |
| Pre-commit ratchet | `scripts/githooks/pre-commit:114-176`, diff-added-line scan over staged `crates/*/src` | developer committing; `test.sh:316-333` | reject + style + `file:line`; `// swallow-ok: <reason>` explicit escape | local commits via `core.hooksPath`; CI unchanged; `--no-verify` bypass documented in the hook header |

## Deliberately NOT in this PR

- `scripts/review-pr.sh` wiring lens (issue Predicted surface) — **split to #733**; PR #720 is rewriting that file and a parallel edit would conflict.
- `.github/**` — worker forbidden zone; untouched.
- Any crate outside the issue table — untouched.

## Follow-up issues

- #745 — `agent_phase::write_phase_state` / `try_write_phase_change_event` still swallow hook-path write errors on the same PostToolUse path, outside #692's table and the ratchet's call list (round-1 review FOLLOW-UP)
- #733 — `review-pr.sh` wiring lens (deferred, conflict avoidance)
- #734 — workspace test suites red on machines with a real `~/.edda` (pre-existing test isolation, found during the L1 run)

