### PR TITLE
fix(edda-cli): recovery verbs find plan state living in a worktree (GH-557)

### DIFF
--- a/.claude/skills/parallel-wave/SKILL.md
+++ b/.claude/skills/parallel-wave/SKILL.md
@@ -53,9 +53,10 @@ be decided mechanically and boldly.
 
 ## Splitting a running serial plan
 
-Order is mandatory: `edda conduct skip <phase> --reason "parallelized: <new plan>"`
+Order is mandatory: `edda conduct skip <phase> --plan <serial-plan> --reason "parallelized: <new plan>"`
 for every phase being split out, **then** launch the parallel plans. Launch-first
-duplicates the work when the serial runner advances.
+duplicates the work when the serial runner advances. `--plan` is required once any
+other store on the machine holds a plan (parallel worktree lanes are that state).
 
 ## Review + merge
 

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -70,8 +70,9 @@ pub enum ConductCmd {
     },
     /// Abort a running plan
     Abort {
-        /// Plan name (auto-detects if only one)
-        plan_name: Option<String>,
+        /// Plan name (auto-detects if only one store holds plans)
+        #[arg(long)]
+        plan: Option<String>,
     },
 }
 
@@ -103,7 +104,7 @@ pub fn run_cmd(cmd: ConductCmd, repo_root: &Path) -> Result<()> {
             reason,
             plan,
         } => skip(repo_root, &phase_id, reason.as_deref(), plan.as_deref()),
-        ConductCmd::Abort { plan_name } => abort(repo_root, plan_name.as_deref()),
+        ConductCmd::Abort { plan } => abort(repo_root, plan.as_deref()),
     }
 }
 
@@ -345,55 +346,16 @@ fn status_impl(repo_root: &Path, plan_name: Option<&str>, json: bool) -> Result<
             None => vec![(name.to_string(), repo_root.to_path_buf())],
         }
     } else {
-        // Round-2 P2, adjusted by round-3 P1-1, adjusted by round-4 P1-1/P1-3:
-        // the unnamed listing is a READ-ONLY overview — it scans the direct
-        // worktree union AND every store registry (a scratchpad-launched plan
-        // is invisible otherwise, which is the literally-reported symptom of
-        // #557), and a corrupt state file degrades to a stderr warning + a
-        // marked entry instead of killing the overview of every healthy lane.
-        // Mutating verbs still propagate corrupt files (retarget risk).
-        let mut found: Vec<(String, PathBuf)> = Vec::new();
-        let mark = |name: &str, store: &Path, found: &mut Vec<(String, PathBuf)>| {
-            if !found.iter().any(|(n, _)| n == name) {
-                found.push((name.to_string(), store.to_path_buf()));
-            }
-        };
-        for store in plan_stores(repo_root) {
-            let conductor_dir = store.join(".edda").join("conductor");
-            if !conductor_dir.exists() {
-                continue;
-            }
-            // Registry-referenced stores first (round-4 P1-1).
-            match registry_read(&store) {
-                Ok(registry) => {
-                    for (name, referenced) in &registry {
-                        match load_state(referenced, name) {
-                            Ok(Some(_)) => mark(name, referenced, &mut found),
-                            Ok(None) => continue,
-                            Err(e) => eprintln!(
-                                "⚠ plan \"{name}\" (registry → {}) unreadable, omitted from the listing: {e}",
-                                referenced.display()
-                            ),
-                        }
-                    }
-                }
-                Err(e) => eprintln!("⚠ store registry unreadable ({}): {e}", store.display()),
-            }
-            for entry in std::fs::read_dir(&conductor_dir)? {
-                let entry = entry?;
-                if entry.file_type()?.is_dir() {
-                    if let Some(name) = entry.file_name().to_str() {
-                        match load_state(&store, name) {
-                            Ok(Some(_)) => mark(name, &store, &mut found),
-                            Ok(None) => continue,
-                            Err(e) => eprintln!(
-                                "⚠ plan \"{name}\" state in {} unreadable, omitted from listing: {e}",
-                                store.display()
-                            ),
-                        }
-                    }
-                }
-            }
+        // Round-6: ONE discovery pass shared with the recovery verbs — the
+        // listing and the verbs can no longer disagree. A corrupt state
+        // file degrades to a stderr warning + omission on this read-only
+        // overview (mutating verbs propagate it instead).
+        let (mut found, corrupt) = discover_plans(repo_root)?;
+        for (name, store, e) in &corrupt {
+            eprintln!(
+                "⚠ plan \"{name}\" state in {} unreadable, omitted from the listing: {e:#}",
+                store.display()
+            );
         }
         found.sort_by(|a, b| a.0.cmp(&b.0));
         found
@@ -733,12 +695,14 @@ fn normalize_store_path(p: &Path) -> String {
         .map(|c| c.to_string_lossy().trim_start_matches(r"\\?\").to_string())
         .unwrap_or_else(|_| p.to_string_lossy().to_string());
     let unified = canonical.replace('/', "\\");
-    // Windows paths are case-insensitive; POSIX paths are not —
-    // lowercasing on Linux would collapse distinct lanes (round-5 P3).
+    // Windows paths are case-insensitive and separator-ambiguous (8.3
+    // short names, / vs \\); POSIX paths are neither — folding either on
+    // Linux would collapse distinct lanes and mangle the display
+    // (round-5/6 P3).
     if cfg!(windows) {
         unified.to_lowercase()
     } else {
-        unified
+        canonical
     }
 }
 
@@ -870,6 +834,82 @@ fn registry_record(root: &Path, plan: &str, store: &Path) {
     drop(lock);
 }
 
+/// Plans found, as (name, store) — the shared discovery output type.
+pub type DiscoveredPlans = Vec<(String, PathBuf)>;
+/// Corrupt-state diagnostics from a discovery pass (name, store, error).
+pub type DiscoveryCorruption = Vec<(String, PathBuf, anyhow::Error)>;
+
+/// One discovery pass shared by `status` and the recovery verbs (GH-557
+/// round-6: the two surfaces must never disagree about which store holds a
+/// plan). Scans every store's conductor directory plus every store
+/// registry, deduped by (plan, normalized store). Returns the plan→store
+/// map and the corrupt-state diagnostics — callers decide: warn on the
+/// read-only overview, error on a mutating verb.
+fn discover_plans(repo_root: &Path) -> Result<(DiscoveredPlans, DiscoveryCorruption)> {
+    let mut found: Vec<(String, PathBuf)> = Vec::new();
+    let mut corrupt: Vec<(String, PathBuf, anyhow::Error)> = Vec::new();
+    let mark = |name: &str, store: &Path, found: &mut Vec<(String, PathBuf)>| {
+        if !found
+            .iter()
+            .any(|(n, s)| n == name && normalize_store_path(s) == normalize_store_path(store))
+        {
+            found.push((name.to_string(), store.to_path_buf()));
+        }
+    };
+    for store in plan_stores(repo_root) {
+        let conductor_dir = store.join(".edda").join("conductor");
+        // Registry-referenced stores FIRST (round-5 P1-2: the registry is
+        // the store `conduct run` actually used — the authoritative record;
+        // a stale same-name state.json in the repo root or a worktree must
+        // not outrank it).
+        match registry_read(&store) {
+            Ok(registry) => {
+                for (name, referenced) in &registry {
+                    match load_state(referenced, name) {
+                        Ok(Some(_)) => mark(name, referenced, &mut found),
+                        Ok(None) => continue,
+                        Err(e) => corrupt.push((
+                            name.clone(),
+                            referenced.clone(),
+                            e.context(format!(
+                                "plan \"{name}\" registry points to {}",
+                                referenced.display()
+                            )),
+                        )),
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("⚠ store registry unreadable ({}): {e}", store.display());
+            }
+        }
+        if !conductor_dir.exists() {
+            continue;
+        }
+        for entry in std::fs::read_dir(&conductor_dir)? {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                if let Some(name) = entry.file_name().to_str() {
+                    match load_state(&store, name) {
+                        Ok(Some(_)) => mark(name, &store, &mut found),
+                        Ok(None) => continue,
+                        Err(e) => corrupt.push((
+                            name.to_string(),
+                            store.clone(),
+                            e.context(format!(
+                                "plan \"{name}\" state in {} is unreadable",
+                                store.display()
+                            )),
+                        )),
+                    }
+                }
+            }
+        }
+    }
+    found.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok((found, corrupt))
+}
+
 /// Every store currently holding `<plan>`'s state.json (GH-557), in
 /// deterministic order (repo root first, then `git worktree list` order).
 /// A corrupt state file is an error, NOT "absent" — swallowing it would
@@ -877,59 +917,28 @@ fn registry_record(root: &Path, plan: &str, store: &Path) {
 /// stale same-name state.
 fn stores_holding(repo_root: &Path, plan: &str) -> Result<Vec<PathBuf>> {
     edda_conductor::state::persist::validate_plan_name(plan)?;
-    let mut holding: Vec<PathBuf> = Vec::new();
-    let mut seen: Vec<String> = Vec::new();
-    // push: normalized identity (round-5 P1-1 — raw PathBuf equality is
-    // case- and short-name-sensitive on Windows and cried wolf on a single
-    // store), first writer wins.
-    let push = |store: PathBuf, holding: &mut Vec<PathBuf>, seen: &mut Vec<String>| {
-        let key = normalize_store_path(&store);
-        if !seen.contains(&key) {
-            seen.push(key);
-            holding.push(store);
-        }
-    };
-    // Registry FIRST (round-5 P1-2): it is the store `conduct run` actually
-    // used — the authoritative record. Any stale same-name state.json in
-    // the repo root or a worktree must not outrank it.
-    for store in plan_stores(repo_root) {
-        // A corrupt REGISTRY is read-path noise (warn, keep scanning) —
-        // mutating verbs still propagate corrupt state files.
-        let registry = match registry_read(&store) {
-            Ok(m) => m,
-            Err(e) => {
-                eprintln!("⚠ store registry unreadable ({}): {e}", store.display());
-                continue;
-            }
-        };
-        if let Some(referenced) = registry.get(plan) {
-            if load_state(referenced, plan)
-                .with_context(|| {
-                    format!(
-                        "plan \"{plan}\" registry points to {}",
-                        referenced.display()
-                    )
-                })?
-                .is_some()
-            {
-                push(referenced.clone(), &mut holding, &mut seen);
-            }
+    let (found, corrupt) = discover_plans(repo_root)?;
+    // A corrupt state file for THIS plan is an error, never "absent" —
+    // swallowing it could retarget the mutation onto a different store
+    // holding a same-name state. Corrupt files of OTHER plans are that
+    // lane's problem and do not block this verb.
+    for (name, store, e) in &corrupt {
+        if name == plan {
+            return Err(anyhow::anyhow!(
+                "plan \"{plan}\" state in {} is unreadable: {e:#}",
+                store.display()
+            ));
         }
     }
-    // Direct scan second.
-    for store in plan_stores(repo_root) {
-        match load_state(&store, plan) {
-            Ok(Some(_)) => push(store, &mut holding, &mut seen),
-            Ok(None) => continue,
-            Err(e) => {
-                return Err(e.context(format!(
-                    "plan \"{plan}\" state in {} is unreadable",
-                    store.display()
-                )))
-            }
-        }
-    }
-    Ok(holding)
+    // discover_plans orders registry-referenced stores FIRST (round-5
+    // P1-2: the registry is the authoritative `conduct run` record; a
+    // stale same-name state.json anywhere else must not outrank it) and
+    // dedups by normalized store identity (round-5 P1-1).
+    Ok(found
+        .into_iter()
+        .filter(|(name, _)| name == plan)
+        .map(|(_, store)| store.clone())
+        .collect())
 }
 
 /// The store a verb should act on: the first store holding the plan. When
@@ -1506,6 +1515,38 @@ mod tests {
             text.contains("plan-x") && text.contains("scratchpad"),
             "registry-referenced plans must be listed with provenance: {text}"
         );
+    }
+
+    /// GH-557 (independent-review round 6, P0-1): every recovery invocation
+    /// the docs and the shipped skill teach must PARSE — `abort --plan`
+    /// was a positional arg, so the documented command errored out.
+    #[test]
+    fn documented_recovery_invocations_parse() {
+        match parse(&["edda", "abort", "--plan", "plan-x"]) {
+            ConductCmd::Abort { plan } => {
+                assert_eq!(plan.as_deref(), Some("plan-x"))
+            }
+            _other => panic!("expected Abort"),
+        }
+        match parse(&["edda", "retry", "a", "--plan", "plan-x"]) {
+            ConductCmd::Retry { phase_id, plan } => {
+                assert_eq!(phase_id, "a");
+                assert_eq!(plan.as_deref(), Some("plan-x"));
+            }
+            _other => panic!("expected Retry"),
+        }
+        match parse(&["edda", "skip", "a", "--plan", "plan-x", "--reason", "why"]) {
+            ConductCmd::Skip {
+                phase_id,
+                reason,
+                plan,
+            } => {
+                assert_eq!(phase_id, "a");
+                assert_eq!(plan.as_deref(), Some("plan-x"));
+                assert_eq!(reason.as_deref(), Some("why"));
+            }
+            _other => panic!("expected Skip"),
+        }
     }
 
     /// GH-557: with no matching state anywhere, the error names the searched

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -186,20 +186,21 @@ pub fn run(
         }
     };
 
-    // GH-557 round-3 P0-2: record the store this run actually uses, so the
-    // recovery verbs can find a plan launched from a plain directory (the
-    // plan YAML's own folder — the reported incident's shape) that no
-    // worktree scan can enumerate. Best-effort at the nearest repo root:
-    // the run cwd's, then the invoking shell's.
-    {
-        let registry_root = edda_ledger::EddaPaths::find_root(&cwd)
-            .or_else(|| {
-                std::env::current_dir()
-                    .ok()
-                    .and_then(|d| edda_ledger::EddaPaths::find_root(&d))
-            })
-            .unwrap_or_else(|| cwd.clone());
-        registry_record(&registry_root, &plan.name, &cwd);
+    // GH-557 round-3 P0-2 / round-4 P0-3: record the store this run actually
+    // uses, so the recovery verbs can find a plan launched from a plain
+    // directory (the plan YAML's own folder — the reported incident's shape)
+    // that no worktree scan can enumerate. find_root(run_cwd) returns the
+    // run cwd ITSELF once its .edda exists, so a single-root choice files
+    // every plan after the first where nothing reads it. Record into EVERY
+    // candidate root — the invoking shell's root first (the lane the
+    // operator/agent stands in), then the run cwd's — reads scan all of
+    // them, so at least one lands inside plan_stores scope.
+    // Round-4 P1-4: the chain is a pure function so tests can drive it.
+    for root in registry_roots_for(
+        &cwd,
+        &std::env::current_dir().unwrap_or_else(|_| cwd.clone()),
+    ) {
+        registry_record(&root, &plan.name, &cwd);
     }
 
     let order = edda_conductor::plan::topo::topo_sort(&plan)?;
@@ -340,34 +341,51 @@ fn status_impl(repo_root: &Path, plan_name: Option<&str>, json: bool) -> Result<
             None => vec![(name.to_string(), repo_root.to_path_buf())],
         }
     } else {
-        // Round-2 P2, adjusted by round-3 P1-1: the listing scans the same
-        // union resolve_plan_name auto-detects over, filtered to directories
-        // that hold a parseable state.json. A CORRUPT state file propagates
-        // (an error, never "absent"); the named-missing fallback below
-        // restores status --json's "null" contract.
+        // Round-2 P2, adjusted by round-3 P1-1, adjusted by round-4 P1-1/P1-3:
+        // the unnamed listing is a READ-ONLY overview — it scans the direct
+        // worktree union AND every store registry (a scratchpad-launched plan
+        // is invisible otherwise, which is the literally-reported symptom of
+        // #557), and a corrupt state file degrades to a stderr warning + a
+        // marked entry instead of killing the overview of every healthy lane.
+        // Mutating verbs still propagate corrupt files (retarget risk).
         let mut found: Vec<(String, PathBuf)> = Vec::new();
+        let mark = |name: &str, store: &Path, found: &mut Vec<(String, PathBuf)>| {
+            if !found.iter().any(|(n, _)| n == name) {
+                found.push((name.to_string(), store.to_path_buf()));
+            }
+        };
         for store in plan_stores(repo_root) {
             let conductor_dir = store.join(".edda").join("conductor");
             if !conductor_dir.exists() {
                 continue;
+            }
+            // Registry-referenced stores first (round-4 P1-1).
+            match registry_read(&store) {
+                Ok(registry) => {
+                    for (name, referenced) in &registry {
+                        match load_state(referenced, name) {
+                            Ok(Some(_)) => mark(name, referenced, &mut found),
+                            Ok(None) => continue,
+                            Err(e) => eprintln!(
+                                "⚠ plan \"{name}\" (registry → {}) unreadable, listed as broken: {e}",
+                                referenced.display()
+                            ),
+                        }
+                    }
+                }
+                Err(e) => eprintln!("⚠ store registry unreadable ({}): {e}", store.display()),
             }
             for entry in std::fs::read_dir(&conductor_dir)? {
                 let entry = entry?;
                 if entry.file_type()?.is_dir() {
                     if let Some(name) = entry.file_name().to_str() {
                         match load_state(&store, name) {
-                            Ok(Some(_)) => {
-                                if !found.iter().any(|(n, _)| n == name) {
-                                    found.push((name.to_string(), store.clone()));
-                                }
-                            }
+                            Ok(Some(_)) => mark(name, &store, &mut found),
                             Ok(None) => continue,
-                            Err(e) => {
-                                return Err(e.context(format!(
-                                    "plan \"{name}\" state in {} is unreadable",
-                                    store.display()
-                                )))
-                            }
+                            Err(e) => eprintln!(
+                                "⚠ plan \"{name}\" state in {} unreadable, omitted from listing: {e}",
+                                store.display()
+                            ),
                         }
                     }
                 }
@@ -700,8 +718,29 @@ pub(crate) fn cost_line(total_cost_usd: f64, cost_measured: bool) -> String {
 /// <worktree>` stores its state in that worktree's `.edda/conductor/`,
 /// and the recovery verbs must be able to find it no matter which cwd
 /// the operator invokes from.
+/// Normalized identity of a store path: canonicalized where possible
+/// (resolving 8.3 short names, symlinks, and case) with the `\\?\` UNC
+/// prefix stripped, lowercased — Windows path forms diverge wildly
+/// (`RUNNER~1` vs the long name, forward vs back slashes) and the same
+/// physical store MUST NOT enter the list twice (GH-557 round-4 P0-2).
+fn normalize_store_path(p: &Path) -> String {
+    let canonical = std::fs::canonicalize(p)
+        .map(|c| c.to_string_lossy().trim_start_matches(r"\\?\").to_string())
+        .unwrap_or_else(|_| p.to_string_lossy().to_string());
+    canonical.replace('/', "\\").to_lowercase()
+}
+
 fn plan_stores(repo_root: &Path) -> Vec<PathBuf> {
-    let mut stores = vec![repo_root.to_path_buf()];
+    let mut stores: Vec<PathBuf> = Vec::new();
+    let mut seen: Vec<String> = Vec::new();
+    let push = |p: PathBuf, stores: &mut Vec<PathBuf>, seen: &mut Vec<String>| {
+        let key = normalize_store_path(&p);
+        if !seen.contains(&key) {
+            seen.push(key);
+            stores.push(p);
+        }
+    };
+    push(repo_root.to_path_buf(), &mut stores, &mut seen);
     let out = std::process::Command::new("git")
         .args(["worktree", "list", "--porcelain"])
         .current_dir(repo_root)
@@ -710,10 +749,7 @@ fn plan_stores(repo_root: &Path) -> Vec<PathBuf> {
         if out.status.success() {
             for line in String::from_utf8_lossy(&out.stdout).lines() {
                 if let Some(path) = line.strip_prefix("worktree ") {
-                    let p = PathBuf::from(path);
-                    if !stores.contains(&p) {
-                        stores.push(p);
-                    }
+                    push(PathBuf::from(path), &mut stores, &mut seen);
                 }
             }
         } else {
@@ -740,28 +776,76 @@ fn registry_path(root: &Path) -> PathBuf {
 
 /// Read a store registry. Best-effort: missing or corrupt file reads as an
 /// empty map — the direct worktree scan remains the fallback.
-fn registry_read(root: &Path) -> std::collections::BTreeMap<String, PathBuf> {
-    let mut map = std::collections::BTreeMap::new();
-    if let Ok(content) = std::fs::read_to_string(registry_path(root)) {
-        if let Ok(parsed) =
-            serde_json::from_str::<std::collections::BTreeMap<String, String>>(&content)
-        {
-            for (plan, store) in parsed {
-                map.insert(plan, PathBuf::from(store));
-            }
+/// Candidate registry roots for a run launched with `run_cwd`, invoked
+/// from `shell_cwd` (GH-557 round-4 P0-3): the invoking shell's root
+/// first — the lane the operator/agent stands in — then the run cwd's.
+/// `find_root(run_cwd)` returns the run cwd ITSELF once its `.edda`
+/// exists (created by the first run there), so a single-root choice
+/// files every plan after the first where nothing reads it; recording
+/// into every candidate and reading from every scanned store makes the
+/// write side and the read side meet.
+fn registry_roots_for(run_cwd: &Path, shell_cwd: &Path) -> Vec<PathBuf> {
+    let mut roots: Vec<PathBuf> = Vec::new();
+    for r in [
+        edda_ledger::EddaPaths::find_root(shell_cwd),
+        edda_ledger::EddaPaths::find_root(run_cwd),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if !roots.contains(&r) {
+            roots.push(r);
         }
     }
-    map
+    if roots.is_empty() {
+        roots.push(run_cwd.to_path_buf());
+    }
+    roots
 }
 
-/// Record plan → store in the registry under `root`. Best-effort: a failed
-/// write prints a warning; discovery falls back to the worktree scan.
+/// Read a store registry. Missing file reads as an empty map; a CORRUPT
+/// file is an error — round-4 P1-2: silently reading it as empty makes the
+/// next record persist an empty map plus one key, destroying every other
+/// plan's entry.
+fn registry_read(root: &Path) -> Result<std::collections::BTreeMap<String, PathBuf>> {
+    let path = registry_path(root);
+    if !path.exists() {
+        return Ok(std::collections::BTreeMap::new());
+    }
+    let content = std::fs::read_to_string(&path)
+        .with_context(|| format!("reading store registry {}", path.display()))?;
+    let parsed: std::collections::BTreeMap<String, String> = serde_json::from_str(&content)
+        .with_context(|| format!("parsing store registry {}", path.display()))?;
+    Ok(parsed
+        .into_iter()
+        .map(|(plan, store)| (plan, PathBuf::from(store)))
+        .collect())
+}
+
+/// Record plan → store in the registry under `root`, under the registry's
+/// exclusive lock (round-4 P1-2: two concurrent `conduct run` processes
+/// are the parallel-wave norm; unlocked read-modify-write loses entries).
+/// Best-effort: lock contention or a corrupt existing registry prints a
+/// warning and skips the write — discovery still has the direct scan.
 fn registry_record(root: &Path, plan: &str, store: &Path) {
     let path = registry_path(root);
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    let mut map = registry_read(root);
+    let lock = match edda_store::lock_file(&PathBuf::from(format!("{}.lock", path.display()))) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("⚠ store registry lock failed ({}): {e}", path.display());
+            return;
+        }
+    };
+    let mut map = match registry_read(root) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("⚠ store registry unreadable, skipping record: {e}");
+            return;
+        }
+    };
     map.insert(plan.to_string(), store.to_path_buf());
     match serde_json::to_string_pretty(&map) {
         Ok(data) => {
@@ -771,6 +855,7 @@ fn registry_record(root: &Path, plan: &str, store: &Path) {
         }
         Err(e) => eprintln!("⚠ store registry serialize failed: {e}"),
     }
+    drop(lock);
 }
 
 /// Every store currently holding `<plan>`'s state.json (GH-557), in
@@ -798,7 +883,16 @@ fn stores_holding(repo_root: &Path, plan: &str) -> Result<Vec<PathBuf>> {
     // (round-3 P0-2: the reported incident's store was the plan YAML's own
     // directory).
     for store in plan_stores(repo_root) {
-        if let Some(referenced) = registry_read(&store).get(plan) {
+        // Round-4 P1-2: a corrupt REGISTRY is read-path noise (warn, keep
+        // scanning) — mutating verbs still propagate corrupt state files.
+        let registry = match registry_read(&store) {
+            Ok(m) => m,
+            Err(e) => {
+                eprintln!("⚠ store registry unreadable ({}): {e}", store.display());
+                continue;
+            }
+        };
+        if let Some(referenced) = registry.get(plan) {
             if !holding.contains(referenced)
                 && load_state(referenced, plan)
                     .with_context(|| {
@@ -1229,6 +1323,138 @@ mod tests {
         let root = _dir.path().join("repo");
         let out = status_impl(&root, Some("plan-y"), true).unwrap();
         assert_eq!(out.trim(), "null", "{out}");
+    }
+
+    /// GH-557 (independent-review round 4, P0-3): the registry-root chain
+    /// must include the invoking shell's store even after the run cwd has
+    /// grown its own `.edda` — find_root(run_cwd) returns the run cwd
+    /// itself at that point, and entries filed only there are unreadable.
+    #[test]
+    fn registry_roots_cover_the_invoking_store_after_edda_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let shell = dir.path().join("repo");
+        let run_cwd = dir.path().join("scratchpad");
+        std::fs::create_dir_all(shell.join(".edda")).unwrap();
+        std::fs::create_dir_all(run_cwd.join(".edda")).unwrap();
+
+        let roots = registry_roots_for(&run_cwd, &shell);
+        assert!(
+            roots.contains(&shell),
+            "invoking shell's store must be a registry root: {roots:?}"
+        );
+    }
+
+    /// GH-557 (independent-review round 4, P0-3): two plans launched from
+    /// the same external plan-YAML directory — the parallel-wave shape the
+    /// issue reports (wave-b-par-b4 AND wave-b-par-b5) — must BOTH be
+    /// recoverable after the first run created `.edda` there.
+    #[test]
+    fn second_plan_in_same_external_store_is_recoverable() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("repo");
+        let plans_dir = dir.path().join("scratchpad");
+        std::fs::create_dir_all(root.join(".edda").join("conductor")).unwrap();
+        std::fs::create_dir_all(&plans_dir).unwrap();
+
+        for name in ["plan-x", "plan-y"] {
+            let yaml = format!("name: {name}\nphases:\n  - id: a\n    prompt: x\n");
+            let plan = parse_plan(&yaml).unwrap();
+            let mut state = edda_conductor::state::machine::PlanState::from_plan(
+                &plan,
+                &format!("{name}.yaml"),
+            );
+            state.phases[0].status = PhaseStatus::Failed;
+            state.plan_status = PlanStatus::Blocked;
+            let state_dir = plans_dir.join(".edda").join("conductor").join(name);
+            std::fs::create_dir_all(&state_dir).unwrap();
+            std::fs::write(
+                state_dir.join("state.json"),
+                serde_json::to_string_pretty(&state).unwrap(),
+            )
+            .unwrap();
+        }
+
+        // Two runs from the same plans_dir: after the first, scratchpad has
+        // .edda, so find_root(run_cwd) == scratchpad. The chain records into
+        // every candidate root, so both entries land somewhere the verbs read.
+        for name in ["plan-x", "plan-y"] {
+            for root in registry_roots_for(&plans_dir, &root) {
+                registry_record(&root, name, &plans_dir);
+            }
+        }
+
+        // The repo-root registry (the one verbs scan) knows both plans.
+        let registry = registry_read(&root).unwrap();
+        assert!(registry.contains_key("plan-x"), "{registry:?}");
+        assert!(registry.contains_key("plan-y"), "{registry:?}");
+
+        retry(&root, "a", Some("plan-y")).unwrap();
+        let reloaded = load_state(&plans_dir, "plan-y").unwrap().unwrap();
+        assert_eq!(reloaded.phases[0].status, PhaseStatus::Pending);
+    }
+
+    /// GH-557 (independent-review round 4, P1-3): one corrupt state file
+    /// must not take down the overview of every healthy lane — the
+    /// read-only listing warns and skips; mutating verbs still error.
+    #[test]
+    fn status_listing_survives_a_corrupt_state_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("repo");
+        let conductor = root.join(".edda").join("conductor");
+        std::fs::create_dir_all(conductor.join("plan-healthy")).unwrap();
+        std::fs::create_dir_all(conductor.join("plan-corrupt")).unwrap();
+
+        let plan = parse_plan("name: plan-healthy\nphases:\n  - id: a\n    prompt: x\n").unwrap();
+        let state = edda_conductor::state::machine::PlanState::from_plan(&plan, "h.yaml");
+        std::fs::write(
+            conductor.join("plan-healthy").join("state.json"),
+            serde_json::to_string_pretty(&state).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            conductor.join("plan-corrupt").join("state.json"),
+            b"{corrupt",
+        )
+        .unwrap();
+
+        let text = status_impl(&root, None, false).unwrap();
+        assert!(
+            text.contains("plan-healthy"),
+            "healthy lanes must still be listed: {text}"
+        );
+        assert!(
+            !text.contains("plan-corrupt"),
+            "the corrupt entry is omitted (warned on stderr), not listed as healthy: {text}"
+        );
+    }
+
+    /// GH-557 (independent-review round 4, P1-1): the unnamed listing must
+    /// include registry-referenced plans — the literally-reported symptom
+    /// ("status never lists wave-b-par-b4/b5").
+    #[test]
+    fn status_listing_includes_registry_referenced_plans() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("repo");
+        let plans_dir = dir.path().join("scratchpad");
+        std::fs::create_dir_all(root.join(".edda").join("conductor")).unwrap();
+        std::fs::create_dir_all(&plans_dir).unwrap();
+
+        let plan = parse_plan("name: plan-x\nphases:\n  - id: a\n    prompt: x\n").unwrap();
+        let state = edda_conductor::state::machine::PlanState::from_plan(&plan, "x.yaml");
+        let state_dir = plans_dir.join(".edda").join("conductor").join("plan-x");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        std::fs::write(
+            state_dir.join("state.json"),
+            serde_json::to_string_pretty(&state).unwrap(),
+        )
+        .unwrap();
+        registry_record(&root, "plan-x", &plans_dir);
+
+        let text = status_impl(&root, None, false).unwrap();
+        assert!(
+            text.contains("plan-x") && text.contains("scratchpad"),
+            "registry-referenced plans must be listed with provenance: {text}"
+        );
     }
 
     /// GH-557: with no matching state anywhere, the error names the searched

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -998,67 +998,33 @@ fn resolve_plan_name(repo_root: &Path, explicit: Option<&str>) -> Result<String>
         return Ok(name.to_string());
     }
 
-    // GH-557 review rounds 2–3: the auto-detection scope is the INVOKING
+    // GH-557 review rounds 2–7: the auto-detection scope is the INVOKING
     // store (repo_root), falling back to another store only when exactly
     // one store on the machine holds any plan. Once more than one store
     // contributes, a destructive verb requires an explicit --plan — bare
     // auto-detection across lanes is how `abort` hits the wrong plan.
-    // Corrupt state files propagate (they are errors, never "absent").
-    let mut contributing: Vec<(PathBuf, Vec<String>)> = Vec::new();
-    for store in plan_stores(repo_root) {
-        let conductor_dir = store.join(".edda").join("conductor");
-        if !conductor_dir.exists() {
-            continue;
-        }
-        let mut store_names = Vec::new();
-        for entry in std::fs::read_dir(&conductor_dir)? {
-            let entry = entry?;
-            if entry.file_type()?.is_dir() {
-                if let Some(n) = entry.file_name().to_str() {
-                    match load_state(&store, n) {
-                        Ok(Some(_)) => store_names.push(n.to_string()),
-                        Ok(None) => continue,
-                        Err(e) => {
-                            return Err(e.context(format!(
-                                "plan \"{n}\" state in {} is unreadable",
-                                store.display()
-                            )))
-                        }
-                    }
-                }
-            }
-        }
-        if !store_names.is_empty() {
-            contributing.push((store, store_names));
-        }
+    // Round-7 P0: discovery is the SAME pass `status` and `stores_holding`
+    // use — one rule, per-store name merging, no plan name discarded.
+    // Corrupt state files do not block auto-detection (the corrupt plan is
+    // not actionable anyway); targeting one errors in stores_holding.
+    let (found, corrupt) = discover_plans(repo_root)?;
+    for (name, store, e) in &corrupt {
+        eprintln!(
+            "⚠ plan \"{name}\" state in {} unreadable, excluded from auto-detection: {e:#}",
+            store.display()
+        );
     }
-
-    // Round-5: registry-referenced plans are contributors too — a plan
-    // launched from an external YAML directory is listed by `status`, so
-    // bare recovery verbs must see it (or refuse), never ignore it.
-    for store in plan_stores(repo_root) {
-        let registry = match registry_read(&store) {
-            Ok(m) => m,
-            Err(e) => {
-                eprintln!("⚠ store registry unreadable ({}): {e}", store.display());
-                continue;
+    let mut contributing: Vec<(PathBuf, Vec<String>)> = Vec::new();
+    for (name, store) in &found {
+        if let Some(entry) = contributing
+            .iter_mut()
+            .find(|(s, _)| normalize_store_path(s) == normalize_store_path(store))
+        {
+            if !entry.1.contains(name) {
+                entry.1.push(name.clone());
             }
-        };
-        for (name, referenced) in &registry {
-            if load_state(referenced, name)
-                .with_context(|| {
-                    format!(
-                        "plan \"{name}\" registry points to {}",
-                        referenced.display()
-                    )
-                })?
-                .is_some()
-                && !contributing
-                    .iter()
-                    .any(|(s, _)| normalize_store_path(s) == normalize_store_path(referenced))
-            {
-                contributing.push((referenced.clone(), vec![name.clone()]));
-            }
+        } else {
+            contributing.push((store.clone(), vec![name.clone()]));
         }
     }
 
@@ -1341,6 +1307,52 @@ mod tests {
 
         let reloaded = load_state(&store, "plan-x").unwrap().unwrap();
         assert_eq!(reloaded.phases[0].status, PhaseStatus::Pending);
+    }
+
+    /// GH-557 (independent-review round 7, P0-1): TWO registry plans in the
+    /// SAME external store — the exact wave-b-par-b4/b5 shape — must make a
+    /// bare destructive verb REFUSE ("Multiple plans found"), never act on
+    /// an arbitrary one. Regression for the per-store dedup that dropped
+    /// every plan name after the first.
+    #[test]
+    fn auto_detect_refuses_when_two_registry_plans_share_one_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("repo");
+        let plans_dir = dir.path().join("scratchpad");
+        std::fs::create_dir_all(root.join(".edda").join("conductor")).unwrap();
+        std::fs::create_dir_all(&plans_dir).unwrap();
+
+        for name in ["plan-x", "plan-y"] {
+            let yaml = format!("name: {name}\nphases:\n  - id: a\n    prompt: x\n");
+            let plan = parse_plan(&yaml).unwrap();
+            let mut state = edda_conductor::state::machine::PlanState::from_plan(
+                &plan,
+                &format!("{name}.yaml"),
+            );
+            state.phases[0].status = PhaseStatus::Failed;
+            state.plan_status = PlanStatus::Blocked;
+            let state_dir = plans_dir.join(".edda").join("conductor").join(name);
+            std::fs::create_dir_all(&state_dir).unwrap();
+            std::fs::write(
+                state_dir.join("state.json"),
+                serde_json::to_string_pretty(&state).unwrap(),
+            )
+            .unwrap();
+            registry_record(&root, name, &plans_dir);
+        }
+
+        // status sees both (through discover_plans).
+        let text = status_impl(&root, None, false).unwrap();
+        assert!(text.contains("plan-x") && text.contains("plan-y"), "{text}");
+
+        // A bare destructive verb refuses instead of picking one.
+        let err = resolve_plan_name(&root, None).unwrap_err();
+        assert!(
+            err.to_string().contains("Multiple plans found"),
+            "bare verb must refuse with both names: {err}"
+        );
+        // Explicit --plan still resolves through the registry.
+        assert_eq!(resolve_plan_name(&root, Some("plan-y")).unwrap(), "plan-y");
     }
 
     /// GH-557 (independent-review round 3, P0-3): bare destructive verbs

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -73,6 +73,10 @@ pub enum ConductCmd {
         /// Plan name (auto-detects if only one store holds plans)
         #[arg(long)]
         plan: Option<String>,
+        /// Positional plan name — kept for the karvi→edda integration
+        /// contract (`edda conduct abort {plan}` in brief-schema.md).
+        /// `--plan` wins when both are given.
+        plan_name: Option<String>,
     },
 }
 
@@ -104,7 +108,9 @@ pub fn run_cmd(cmd: ConductCmd, repo_root: &Path) -> Result<()> {
             reason,
             plan,
         } => skip(repo_root, &phase_id, reason.as_deref(), plan.as_deref()),
-        ConductCmd::Abort { plan } => abort(repo_root, plan.as_deref()),
+        ConductCmd::Abort { plan, plan_name } => {
+            abort(repo_root, plan.as_deref().or(plan_name.as_deref()))
+        }
     }
 }
 
@@ -856,33 +862,38 @@ fn discover_plans(repo_root: &Path) -> Result<(DiscoveredPlans, DiscoveryCorrupt
             found.push((name.to_string(), store.to_path_buf()));
         }
     };
+    // PASS 1 — every store's registry, before any directory scan
+    // (round-8 P0: an interleaved per-store loop let repo_root's own
+    // directory entry insert before a worktree's registry-referenced
+    // store, so a stale same-name state.json outranked the live lane).
     for store in plan_stores(repo_root) {
-        let conductor_dir = store.join(".edda").join("conductor");
-        // Registry-referenced stores FIRST (round-5 P1-2: the registry is
-        // the store `conduct run` actually used — the authoritative record;
-        // a stale same-name state.json in the repo root or a worktree must
-        // not outrank it).
-        match registry_read(&store) {
-            Ok(registry) => {
-                for (name, referenced) in &registry {
-                    match load_state(referenced, name) {
-                        Ok(Some(_)) => mark(name, referenced, &mut found),
-                        Ok(None) => continue,
-                        Err(e) => corrupt.push((
-                            name.clone(),
-                            referenced.clone(),
-                            e.context(format!(
-                                "plan \"{name}\" registry points to {}",
-                                referenced.display()
-                            )),
-                        )),
-                    }
-                }
-            }
+        let registry = match registry_read(&store) {
+            Ok(m) => m,
             Err(e) => {
                 eprintln!("⚠ store registry unreadable ({}): {e}", store.display());
+                continue;
+            }
+        };
+        for (name, referenced) in &registry {
+            match load_state(referenced, name) {
+                Ok(Some(_)) => mark(name, referenced, &mut found),
+                Ok(None) => continue,
+                Err(e) => corrupt.push((
+                    name.clone(),
+                    referenced.clone(),
+                    e.context(format!(
+                        "plan \"{name}\" registry points to {}",
+                        referenced.display()
+                    )),
+                )),
             }
         }
+    }
+    // PASS 2 — directory scan. Skip names the registry already resolved
+    // (found OR corrupt): a stale/truncated copy in the repo root must
+    // neither outrank the live store nor deny recovery for it.
+    for store in plan_stores(repo_root) {
+        let conductor_dir = store.join(".edda").join("conductor");
         if !conductor_dir.exists() {
             continue;
         }
@@ -890,6 +901,11 @@ fn discover_plans(repo_root: &Path) -> Result<(DiscoveredPlans, DiscoveryCorrupt
             let entry = entry?;
             if entry.file_type()?.is_dir() {
                 if let Some(name) = entry.file_name().to_str() {
+                    if found.iter().any(|(n, _)| n == name)
+                        || corrupt.iter().any(|(n, _, _)| n == name)
+                    {
+                        continue;
+                    }
                     match load_state(&store, name) {
                         Ok(Some(_)) => mark(name, &store, &mut found),
                         Ok(None) => continue,
@@ -918,27 +934,29 @@ fn discover_plans(repo_root: &Path) -> Result<(DiscoveredPlans, DiscoveryCorrupt
 fn stores_holding(repo_root: &Path, plan: &str) -> Result<Vec<PathBuf>> {
     edda_conductor::state::persist::validate_plan_name(plan)?;
     let (found, corrupt) = discover_plans(repo_root)?;
-    // A corrupt state file for THIS plan is an error, never "absent" —
-    // swallowing it could retarget the mutation onto a different store
-    // holding a same-name state. Corrupt files of OTHER plans are that
-    // lane's problem and do not block this verb.
-    for (name, store, e) in &corrupt {
-        if name == plan {
-            return Err(anyhow::anyhow!(
-                "plan \"{plan}\" state in {} is unreadable: {e:#}",
-                store.display()
-            ));
-        }
-    }
-    // discover_plans orders registry-referenced stores FIRST (round-5
-    // P1-2: the registry is the authoritative `conduct run` record; a
-    // stale same-name state.json anywhere else must not outrank it) and
-    // dedups by normalized store identity (round-5 P1-1).
-    Ok(found
+    // Registry-referenced stores land first (discover_plans pass 1) and
+    // a stale same-name directory copy is not even collected (pass 2
+    // skips names the registry already resolved). Dedup is by
+    // normalized store identity (round-5 P1-1).
+    let holding: Vec<PathBuf> = found
         .into_iter()
         .filter(|(name, _)| name == plan)
-        .map(|(_, store)| store.clone())
-        .collect())
+        .map(|(_, store)| store)
+        .collect();
+    // A corrupt file denies recovery only when it is the ONLY copy of
+    // this plan (round-8: a truncated leftover in the repo root must
+    // not block a healthy registry-referenced store).
+    if holding.is_empty() {
+        for (name, store, e) in &corrupt {
+            if name == plan {
+                return Err(anyhow::anyhow!(
+                    "plan \"{plan}\" state in {} is unreadable: {e:#}",
+                    store.display()
+                ));
+            }
+        }
+    }
+    Ok(holding)
 }
 
 /// The store a verb should act on: the first store holding the plan. When
@@ -1242,6 +1260,83 @@ mod tests {
         assert!(!root.join(".edda").join("conductor").join("plan-x").exists());
     }
 
+    /// GH-557 (independent-review round 8, P0): a same-name plan that was
+    /// first run at the repo root (leaving a stale state.json) then moved
+    /// into a lane — registry recorded only on the worktree, the shape of
+    /// `conduct run --cwd <wt>` from inside the worktree — must have
+    /// recovery verbs act on the LIVE store, never the stale root copy.
+    #[test]
+    fn registry_store_outranks_stale_same_name_in_repo_root() {
+        let (_dir, wt) = repo_with_worktree_state();
+        let root = _dir.path().join("repo");
+
+        let plan = parse_plan(
+            "name: plan-x
+phases:
+  - id: a
+    prompt: x
+",
+        )
+        .unwrap();
+        let mut stale = edda_conductor::state::machine::PlanState::from_plan(&plan, "plan-x.yaml");
+        stale.phases[0].status = PhaseStatus::Failed;
+        stale.plan_status = PlanStatus::Blocked;
+        stale.phases[0].skip_reason = Some("stale-root".into());
+        let stale_dir = root.join(".edda").join("conductor").join("plan-x");
+        std::fs::create_dir_all(&stale_dir).unwrap();
+        std::fs::write(
+            stale_dir.join("state.json"),
+            serde_json::to_string_pretty(&stale).unwrap(),
+        )
+        .unwrap();
+
+        let mut live = load_state(&wt, "plan-x").unwrap().unwrap();
+        live.phases[0].status = PhaseStatus::Failed;
+        live.plan_status = PlanStatus::Blocked;
+        save_state(&wt, &live).unwrap();
+
+        // Run-from-inside-the-worktree: registry lands only on the wt.
+        registry_record(&wt, "plan-x", &wt);
+
+        retry(&root, "a", Some("plan-x")).unwrap();
+
+        let live = load_state(&wt, "plan-x").unwrap().unwrap();
+        assert_eq!(live.phases[0].status, PhaseStatus::Pending);
+        let stale = load_state(&root, "plan-x").unwrap().unwrap();
+        assert_eq!(
+            stale.phases[0].status,
+            PhaseStatus::Failed,
+            "must not mutate the stale repo-root copy"
+        );
+        assert_eq!(stale.phases[0].skip_reason.as_deref(), Some("stale-root"));
+    }
+
+    /// GH-557 (independent-review round 8): a truncated leftover
+    /// state.json at the repo root must not deny recovery of a healthy
+    /// registry-referenced copy of the same plan.
+    #[test]
+    fn stale_corrupt_copy_does_not_deny_healthy_registry_store() {
+        let (_dir, wt) = repo_with_worktree_state();
+        let root = _dir.path().join("repo");
+
+        let corrupt_dir = root.join(".edda").join("conductor").join("plan-x");
+        std::fs::create_dir_all(&corrupt_dir).unwrap();
+        std::fs::write(corrupt_dir.join("state.json"), b"{corrupt").unwrap();
+
+        let mut live = load_state(&wt, "plan-x").unwrap().unwrap();
+        live.phases[0].status = PhaseStatus::Failed;
+        live.plan_status = PlanStatus::Blocked;
+        save_state(&wt, &live).unwrap();
+        registry_record(&wt, "plan-x", &wt);
+
+        retry(&root, "a", Some("plan-x")).unwrap();
+
+        let live = load_state(&wt, "plan-x").unwrap().unwrap();
+        assert_eq!(live.phases[0].status, PhaseStatus::Pending);
+        let leftover = std::fs::read(corrupt_dir.join("state.json")).unwrap();
+        assert_eq!(leftover, b"{corrupt");
+    }
+
     /// GH-557: a corrupt state file is an ERROR, not "no state" — swallowing
     /// it could retarget a mutating verb onto a stale same-name state in
     /// another store (independent-review P1-1).
@@ -1535,8 +1630,17 @@ mod tests {
     #[test]
     fn documented_recovery_invocations_parse() {
         match parse(&["edda", "abort", "--plan", "plan-x"]) {
-            ConductCmd::Abort { plan } => {
-                assert_eq!(plan.as_deref(), Some("plan-x"))
+            ConductCmd::Abort { plan, plan_name } => {
+                assert_eq!(plan.as_deref(), Some("plan-x"));
+                assert_eq!(plan_name.as_deref(), None);
+            }
+            _other => panic!("expected Abort"),
+        }
+        // Positional form kept for the karvi→edda contract.
+        match parse(&["edda", "abort", "plan-x"]) {
+            ConductCmd::Abort { plan, plan_name } => {
+                assert_eq!(plan.as_deref(), None);
+                assert_eq!(plan_name.as_deref(), Some("plan-x"));
             }
             _other => panic!("expected Abort"),
         }

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -11,7 +11,7 @@ use edda_conductor::runner::sequential::{run_plan, RunContext};
 use edda_conductor::state::machine::{PhaseStatus, PlanState, PlanStatus};
 use edda_conductor::state::persist::{load_state, update_state};
 use edda_conductor::tmux::TmuxSession;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tokio_util::sync::CancellationToken;
 
 // ── CLI Schema ──
@@ -308,74 +308,154 @@ pub fn run(
 
 /// Execute `edda conduct status [plan-name]`
 pub fn status(repo_root: &Path, plan_name: Option<&str>, json: bool) -> Result<()> {
-    let conductor_dir = repo_root.join(".edda").join("conductor");
-    if !conductor_dir.exists() {
-        if json {
-            println!("[]");
-        } else {
-            println!("No conductor state found.");
-        }
-        return Ok(());
-    }
+    let out = status_impl(repo_root, plan_name, json)?;
+    print!("{out}");
+    Ok(())
+}
 
-    let plans: Vec<String> = if let Some(name) = plan_name {
-        vec![name.to_string()]
+/// GH-557: plan state lives in the store that launched it (repo root or a
+/// git worktree) — scan all of them. Split from [`status`] so the text is
+/// testable without stdout capture.
+fn status_impl(repo_root: &Path, plan_name: Option<&str>, json: bool) -> Result<String> {
+    let mut out = String::new();
+    let stores = plan_stores(repo_root);
+    let plans: Vec<(String, PathBuf)> = if let Some(name) = plan_name {
+        match resolve_plan_store(repo_root, name)? {
+            Some(store) => vec![(name.to_string(), store)],
+            None => vec![(name.to_string(), repo_root.to_path_buf())],
+        }
     } else {
-        // List all plan directories
-        let mut names = Vec::new();
-        for entry in std::fs::read_dir(&conductor_dir)? {
-            let entry = entry?;
-            if entry.file_type()?.is_dir() {
-                if let Some(name) = entry.file_name().to_str() {
-                    names.push(name.to_string());
+        let mut found: Vec<(String, PathBuf)> = Vec::new();
+        for store in &stores {
+            let conductor_dir = store.join(".edda").join("conductor");
+            if !conductor_dir.exists() {
+                continue;
+            }
+            for entry in std::fs::read_dir(&conductor_dir)? {
+                let entry = entry?;
+                if entry.file_type()?.is_dir() {
+                    if let Some(name) = entry.file_name().to_str() {
+                        if !found.iter().any(|(n, _)| n == name) {
+                            found.push((name.to_string(), store.clone()));
+                        }
+                    }
                 }
             }
         }
-        names.sort();
-        names
+        found.sort_by(|a, b| a.0.cmp(&b.0));
+        found
     };
 
     if plans.is_empty() {
         if json {
-            println!("[]");
+            out.push_str("[]\n");
         } else {
-            println!("No plans found.");
+            out.push_str("No plans found.\n");
         }
-        return Ok(());
+        return Ok(out);
     }
 
     if json {
         let states: Vec<PlanState> = plans
             .iter()
-            .filter_map(|name| load_state(repo_root, name).ok().flatten())
+            .filter_map(|(name, store)| load_state(store, name).ok().flatten())
             .collect();
         // Single plan name specified: output object directly; otherwise array
         if plan_name.is_some() {
             if let Some(s) = states.into_iter().next() {
-                println!("{}", serde_json::to_string_pretty(&s)?);
+                out.push_str(&serde_json::to_string_pretty(&s)?);
+                out.push('\n');
             } else {
-                println!("null");
+                out.push_str("null\n");
             }
         } else {
-            println!("{}", serde_json::to_string_pretty(&states)?);
+            out.push_str(&serde_json::to_string_pretty(&states)?);
+            out.push('\n');
         }
     } else {
-        for name in &plans {
-            let state = load_state(repo_root, name)?;
+        for (name, store) in &plans {
+            let state = load_state(store, name)?;
             match state {
-                Some(s) => print_status(&s),
-                None => println!("Plan \"{name}\": no state file found"),
+                Some(s) => {
+                    out.push_str(&format!(
+                        "  Store: {}\n",
+                        if *store == repo_root {
+                            "(repo root)".to_string()
+                        } else {
+                            store.display().to_string()
+                        }
+                    ));
+                    out.push_str(&print_status_to_string(&s));
+                }
+                None => out.push_str(&format!("Plan \"{name}\": no state file found\n")),
             }
         }
     }
 
-    Ok(())
+    Ok(out)
+}
+
+/// Render one plan's status block (the body `print_status` writes).
+fn print_status_to_string(state: &PlanState) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "Plan: {} ({:?})\n",
+        state.plan_name, state.plan_status
+    ));
+    if !state.plan_file.is_empty() {
+        out.push_str(&format!("  File: {}\n", state.plan_file));
+    }
+    out.push_str(&format!(
+        "  Cost: {}\n",
+        cost_line(state.total_cost_usd, state.cost_measured)
+    ));
+    out.push('\n');
+    for ps in &state.phases {
+        let icon = match ps.status {
+            PhaseStatus::Passed => "\u{2713}",
+            PhaseStatus::Failed => "\u{2717}",
+            PhaseStatus::Running | PhaseStatus::Checking => "\u{25B6}",
+            PhaseStatus::Skipped => "\u{2298}",
+            PhaseStatus::Stale => "\u{23F0}",
+            PhaseStatus::GateTimedOut => "\u{29D7}",
+            PhaseStatus::AwaitingVerdict => "\u{23F8}",
+            PhaseStatus::Pending => "\u{25CB}",
+        };
+        let detail = match ps.status {
+            PhaseStatus::Passed => format!("(attempt {})", ps.attempts),
+            PhaseStatus::Failed => {
+                let err = ps
+                    .error
+                    .as_ref()
+                    .map(|e| e.message.as_str())
+                    .unwrap_or("unknown");
+                format!("(attempt {}, {})", ps.attempts, err)
+            }
+            PhaseStatus::Skipped => {
+                let reason = ps.skip_reason.as_deref().unwrap_or("");
+                format!("({})", reason)
+            }
+            PhaseStatus::GateTimedOut => match ps.skip_reason.as_deref() {
+                Some(reason) => format!("(waived: {})", reason),
+                None => "(awaiting operator: retry or waive)".to_string(),
+            },
+            _ => String::new(),
+        };
+        out.push_str(&format!(
+            "  {icon} {:<24} {:?} {detail}\n",
+            ps.id, ps.status
+        ));
+    }
+    out.push('\n');
+    out
 }
 
 /// Execute `edda conduct retry <phase-id>`
 pub fn retry(repo_root: &Path, phase_id: &str, plan_name: Option<&str>) -> Result<()> {
     let name = resolve_plan_name(repo_root, plan_name)?;
-    update_state(repo_root, &name, |state| {
+    let store =
+        resolve_plan_store(repo_root, &name)?.ok_or_else(|| no_state_error(repo_root, &name))?;
+    update_state(&store, &name, |state| {
         let current_status = {
             let ps = state.get_phase_mut(phase_id)?;
             if ps.status != PhaseStatus::Failed
@@ -419,7 +499,9 @@ pub fn skip(
     plan_name: Option<&str>,
 ) -> Result<()> {
     let name = resolve_plan_name(repo_root, plan_name)?;
-    let is_waived = update_state(repo_root, &name, |state| {
+    let store =
+        resolve_plan_store(repo_root, &name)?.ok_or_else(|| no_state_error(repo_root, &name))?;
+    let is_waived = update_state(&store, &name, |state| {
         let ps = state.get_phase_mut(phase_id)?;
         if ps.status == PhaseStatus::GateTimedOut {
             // GH-552: skipping a timed-out gate is a WAIVER — the phase ran and
@@ -468,7 +550,9 @@ pub fn skip(
 /// Execute `edda conduct abort [plan-name]`
 pub fn abort(repo_root: &Path, plan_name: Option<&str>) -> Result<()> {
     let name = resolve_plan_name(repo_root, plan_name)?;
-    update_state(repo_root, &name, |state| {
+    let store =
+        resolve_plan_store(repo_root, &name)?.ok_or_else(|| no_state_error(repo_root, &name))?;
+    update_state(&store, &name, |state| {
         if state.plan_status == PlanStatus::Completed || state.plan_status == PlanStatus::Aborted {
             bail!("Plan \"{}\" is already {:?}.", name, state.plan_status);
         }
@@ -554,6 +638,74 @@ pub(crate) fn cost_line(total_cost_usd: f64, cost_measured: bool) -> String {
     }
 }
 
+/// Directories that can hold conductor state for this repo (GH-557):
+/// the repo root itself plus every git worktree reported by
+/// `git worktree list --porcelain`. A plan launched with `--cwd
+/// <worktree>` stores its state in that worktree's `.edda/conductor/`,
+/// and the recovery verbs must be able to find it no matter which cwd
+/// the operator invokes from.
+fn plan_stores(repo_root: &Path) -> Vec<PathBuf> {
+    let mut stores = vec![repo_root.to_path_buf()];
+    let out = std::process::Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(repo_root)
+        .output();
+    if let Ok(out) = out {
+        if out.status.success() {
+            for line in String::from_utf8_lossy(&out.stdout).lines() {
+                if let Some(path) = line.strip_prefix("worktree ") {
+                    let p = PathBuf::from(path);
+                    if !stores.contains(&p) {
+                        stores.push(p);
+                    }
+                }
+            }
+        }
+    }
+    stores
+}
+
+/// Find the store directory that actually holds `<plan>`'s state.json
+/// (GH-557): the repo root first, then each git worktree. A corrupt state
+/// file is an error, NOT "absent" — swallowing it would retarget a
+/// mutating verb onto a different store that happens to hold a stale
+/// same-name state.
+fn resolve_plan_store(repo_root: &Path, plan: &str) -> Result<Option<PathBuf>> {
+    for store in plan_stores(repo_root) {
+        match load_state(&store, plan) {
+            Ok(Some(_)) => return Ok(Some(store)),
+            Ok(None) => continue,
+            Err(e) => {
+                return Err(e.context(format!(
+                    "plan \"{plan}\" state in {} is unreadable",
+                    store.display()
+                )))
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Refuse to act when the plan's state is nowhere on the repo (GH-557):
+/// the runner's own blocked-phase message names retry/skip/abort — those
+/// commands must never answer "no state for plan" without pointing at the
+/// actual resolution surface.
+fn no_state_error(repo_root: &Path, plan: &str) -> anyhow::Error {
+    let searched: Vec<String> = plan_stores(repo_root)
+        .iter()
+        .filter(|p| p.join(".edda").join("conductor").is_dir())
+        .map(|p| p.display().to_string())
+        .collect();
+    let shown = if searched.len() > 5 {
+        format!("{} … ({} stores)", searched[..5].join(", "), searched.len())
+    } else {
+        searched.join(", ")
+    };
+    anyhow::anyhow!(
+        "no state for plan \"{plan}\" (searched: {shown}); a plan launched with a --cwd outside this repo's worktrees stores its state there and is not auto-discoverable"
+    )
+}
+
 fn resolve_plan_name(repo_root: &Path, explicit: Option<&str>) -> Result<String> {
     if let Some(name) = explicit {
         return Ok(name.to_string());
@@ -587,57 +739,6 @@ fn resolve_plan_name(repo_root: &Path, explicit: Option<&str>) -> Result<String>
     }
 }
 
-fn print_status(state: &PlanState) {
-    println!("\nPlan: {} ({:?})", state.plan_name, state.plan_status);
-    if !state.plan_file.is_empty() {
-        println!("  File: {}", state.plan_file);
-    }
-    println!(
-        "  Cost: {}",
-        cost_line(state.total_cost_usd, state.cost_measured)
-    );
-
-    println!();
-    for ps in &state.phases {
-        let icon = match ps.status {
-            PhaseStatus::Passed => "\u{2713}",                          // ✓
-            PhaseStatus::Failed => "\u{2717}",                          // ✗
-            PhaseStatus::Running | PhaseStatus::Checking => "\u{25B6}", // ▶
-            PhaseStatus::Skipped => "\u{2298}",                         // ⊘
-            PhaseStatus::Stale => "\u{23F0}",                           // ⏰
-            PhaseStatus::AwaitingVerdict => "\u{23F8}",                 // ⏸
-            PhaseStatus::GateTimedOut => "\u{29D7}",                    // ⧗
-            PhaseStatus::Pending => "\u{25CB}",                         // ○
-        };
-        let detail = match ps.status {
-            PhaseStatus::Passed => format!("(attempt {})", ps.attempts),
-            PhaseStatus::Failed => {
-                let err = ps
-                    .error
-                    .as_ref()
-                    .map(|e| e.message.as_str())
-                    .unwrap_or("unknown");
-                format!("(attempt {}, {})", ps.attempts, err)
-            }
-            PhaseStatus::Skipped => {
-                let reason = ps.skip_reason.as_deref().unwrap_or("");
-                format!("({})", reason)
-            }
-            PhaseStatus::GateTimedOut => {
-                // GH-552: honest audit line — timed-out gate, and whether
-                // it was waived (the status itself is never Skipped).
-                match ps.skip_reason.as_deref() {
-                    Some(reason) => format!("(waived: {})", reason),
-                    None => "(awaiting operator: retry or waive)".to_string(),
-                }
-            }
-            _ => String::new(),
-        };
-        println!("  {icon} {:<24} {:?} {detail}", ps.id, ps.status);
-    }
-    println!();
-}
-
 fn now_rfc3339() -> String {
     time::OffsetDateTime::now_utc()
         .format(&time::format_description::well_known::Rfc3339)
@@ -655,6 +756,7 @@ mod tests {
     use super::*;
     use clap::Parser;
     use edda_conductor::plan::parser::parse_plan;
+    use edda_conductor::state::persist::save_state;
 
     /// Minimal parser harness: `ConductCmd` is a `Subcommand`, so it needs a
     /// root command to be parsed standalone.
@@ -675,6 +777,192 @@ mod tests {
             ConductCmd::Run { agent, .. } => agent,
             _ => panic!("expected the Run subcommand"),
         }
+    }
+
+    /// GH-557 harness: a real git repo plus one worktree, with a conductor
+    /// state for `plan-x` fabricated inside the worktree's `.edda` — the
+    /// exact shape of a plan launched with `--cwd <worktree>`.
+    fn repo_with_worktree_state() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("repo");
+        let wt = dir.path().join("wt");
+        std::fs::create_dir_all(&root).unwrap();
+        let git = |args: &[&str], cwd: &std::path::Path| {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(cwd)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        git(&["init", "-q"], &root);
+        std::fs::write(root.join("f.txt"), "x").unwrap();
+        git(&["add", "."], &root);
+        git(
+            &[
+                "-c",
+                "user.email=t@t",
+                "-c",
+                "user.name=t",
+                "commit",
+                "-qm",
+                "init",
+            ],
+            &root,
+        );
+        git(
+            &[
+                "worktree",
+                "add",
+                "-q",
+                "-b",
+                "wt-branch",
+                wt.to_str().unwrap(),
+            ],
+            &root,
+        );
+
+        let plan_yaml = "name: plan-x\nphases:\n  - id: a\n    prompt: x\n";
+        let plan = parse_plan(plan_yaml).unwrap();
+        let state = edda_conductor::state::machine::PlanState::from_plan(&plan, "plan-x.yaml");
+        let state_dir = wt.join(".edda").join("conductor").join("plan-x");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        std::fs::write(
+            state_dir.join("state.json"),
+            serde_json::to_string_pretty(&state).unwrap(),
+        )
+        .unwrap();
+        (dir, wt)
+    }
+
+    /// GH-557 regression: a plan state that lives in a worktree is acted on
+    /// by the recovery verbs from the MAIN repo cwd — the exact dead end
+    /// from the issue (`conduct run` resumes it, its own message names
+    /// retry/skip/abort, and those answered "no state for plan").
+    ///
+    /// Verified to FAIL before the fix: with store resolution reduced to the
+    /// repo root, `retry` errors with "no state for plan \"plan-x\"".
+    #[test]
+    fn retry_resolves_state_living_in_a_worktree() {
+        let (_dir, wt) = repo_with_worktree_state();
+        let root = _dir.path().join("repo");
+
+        // The old failure mode, asserted directly.
+        assert!(
+            load_state(&root, "plan-x").unwrap().is_none(),
+            "precondition: the state is NOT in the repo root store"
+        );
+
+        // A failed phase, as the blocked runner leaves it.
+        let mut state = load_state(&wt, "plan-x").unwrap().unwrap();
+        state.phases[0].status = PhaseStatus::Failed;
+        state.plan_status = PlanStatus::Blocked;
+        save_state(&wt, &state).unwrap();
+
+        retry(&root, "a", Some("plan-x")).unwrap();
+
+        let reloaded = load_state(&wt, "plan-x").unwrap().unwrap();
+        assert_eq!(reloaded.phases[0].status, PhaseStatus::Pending);
+        assert_eq!(reloaded.plan_status, PlanStatus::Running);
+        // The fix never writes a duplicate store in the repo root.
+        assert!(
+            !root.join(".edda").join("conductor").join("plan-x").exists(),
+            "the fix must act in place, not fork the state into the repo root"
+        );
+    }
+
+    /// GH-557 (independent-review P1-4): `status` itself must list and
+    /// resolve worktree-launched plans — tested through the same code path
+    /// the verb runs, not a helper that did not exist before the fix.
+    #[test]
+    fn status_lists_and_resolves_worktree_launch_plans() {
+        let (_dir, _wt) = repo_with_worktree_state();
+        let root = _dir.path().join("repo");
+
+        // Unnamed listing: the worktree plan must appear, with provenance.
+        let text = status_impl(&root, None, false).unwrap();
+        assert!(text.contains("plan-x"), "{text}");
+        assert!(
+            text.contains("wt"),
+            "listing must show store provenance: {text}"
+        );
+
+        // Named: resolves into the worktree store and renders the state.
+        let named = status_impl(&root, Some("plan-x"), false).unwrap();
+        assert!(named.contains("plan-x"), "{named}");
+        assert!(named.contains("Pending"), "{named}");
+
+        // Unknown plan: honest emptiness, not another store's data.
+        let missing = status_impl(&root, Some("plan-y"), false).unwrap();
+        assert!(missing.contains("no state file found"), "{missing}");
+    }
+
+    /// GH-557 (independent-review P1-4): skip and abort act on the
+    /// worktree store in place.
+    #[test]
+    fn skip_and_abort_act_on_worktree_store_from_repo_root() {
+        let (_dir, wt) = repo_with_worktree_state();
+        let root = _dir.path().join("repo");
+
+        let mut state = load_state(&wt, "plan-x").unwrap().unwrap();
+        state.phases[0].status = PhaseStatus::Failed;
+        state.plan_status = PlanStatus::Blocked;
+        save_state(&wt, &state).unwrap();
+
+        skip(&root, "a", Some("lane handed off"), Some("plan-x")).unwrap();
+        let reloaded = load_state(&wt, "plan-x").unwrap().unwrap();
+        assert_eq!(reloaded.phases[0].status, PhaseStatus::Skipped);
+        assert_eq!(
+            reloaded.phases[0].skip_reason.as_deref(),
+            Some("lane handed off")
+        );
+
+        abort(&root, Some("plan-x")).unwrap();
+        let reloaded = load_state(&wt, "plan-x").unwrap().unwrap();
+        assert_eq!(reloaded.plan_status, PlanStatus::Aborted);
+        assert!(!root.join(".edda").join("conductor").join("plan-x").exists());
+    }
+
+    /// GH-557: a corrupt state file is an ERROR, not "no state" — swallowing
+    /// it could retarget a mutating verb onto a stale same-name state in
+    /// another store (independent-review P1-1).
+    #[test]
+    fn resolve_plan_store_propagates_corrupt_state_as_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(root.join(".edda").join("conductor").join("plan-x")).unwrap();
+        std::fs::write(
+            root.join(".edda")
+                .join("conductor")
+                .join("plan-x")
+                .join("state.json"),
+            b"{corrupt",
+        )
+        .unwrap();
+
+        let err = resolve_plan_store(&root, "plan-x").unwrap_err();
+        assert!(
+            err.to_string().contains("unreadable"),
+            "corrupt state must surface as unreadable: {err}"
+        );
+    }
+
+    /// GH-557: with no matching state anywhere, the error names the searched
+    /// stores (capped) instead of the bare "no state for plan".
+    #[test]
+    fn no_state_error_names_the_searched_stores() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("repo");
+        std::fs::create_dir_all(&root).unwrap();
+        let err = no_state_error(&root, "plan-x");
+        let text = err.to_string();
+        assert!(text.contains("searched:"), "{text}");
+        assert!(text.contains("plan-x"), "{text}");
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -912,9 +912,12 @@ fn discover_plans(repo_root: &Path) -> Result<(DiscoveredPlans, DiscoveryCorrupt
             }
         }
     }
-    // PASS 2 — directory scan. Skip names the registry already resolved
-    // (found OR corrupt): a stale/truncated copy in the repo root must
-    // neither outrank the live store nor deny recovery for it.
+    // PASS 2 — directory scan. Skip only the *same* (name, store) the
+    // registry already resolved (round-11 P1: a name-global skip silently
+    // erased a live same-name plan in another store, and a corrupt
+    // registry target denied a healthy copy elsewhere). Registry-first
+    // insertion + stable sort still ranks the live lane first; duplicates
+    // surface via resolve_plan_store's shadow warning.
     for store in plan_stores(repo_root) {
         let conductor_dir = store.join(".edda").join("conductor");
         if !conductor_dir.exists() {
@@ -957,8 +960,9 @@ fn discover_plans(repo_root: &Path) -> Result<(DiscoveredPlans, DiscoveryCorrupt
             };
             if is_dir {
                 if let Some(name) = entry.file_name().to_str() {
-                    if found.iter().any(|(n, _)| n == name)
-                        || corrupt.iter().any(|(n, _, _)| n == name)
+                    let same = |s: &Path| normalize_store_path(s) == normalize_store_path(&store);
+                    if found.iter().any(|(n, s)| n == name && same(s))
+                        || corrupt.iter().any(|(n, s, _)| n == name && same(s))
                     {
                         continue;
                     }
@@ -1388,6 +1392,90 @@ phases:
         retry(&root, "a", Some("plan-x")).unwrap();
 
         let live = load_state(&wt, "plan-x").unwrap().unwrap();
+        assert_eq!(live.phases[0].status, PhaseStatus::Pending);
+        let leftover = std::fs::read(corrupt_dir.join("state.json")).unwrap();
+        assert_eq!(leftover, b"{corrupt");
+    }
+
+    /// GH-557 (independent-review round 11, P1-1): two LIVE same-name copies
+    /// — registry points at the worktree, repo root still has its own state
+    /// — must BOTH appear in `status`, and a verb must shadow-warn rather
+    /// than erase the root copy.
+    #[test]
+    fn same_name_live_copy_is_listed_and_not_erased() {
+        let (_dir, wt) = repo_with_worktree_state();
+        let root = _dir.path().join("repo");
+
+        let plan = parse_plan("name: plan-x\nphases:\n  - id: a\n    prompt: x\n").unwrap();
+        let mut root_state =
+            edda_conductor::state::machine::PlanState::from_plan(&plan, "plan-x.yaml");
+        root_state.phases[0].status = PhaseStatus::Failed;
+        root_state.plan_status = PlanStatus::Blocked;
+        let root_dir = root.join(".edda").join("conductor").join("plan-x");
+        std::fs::create_dir_all(&root_dir).unwrap();
+        std::fs::write(
+            root_dir.join("state.json"),
+            serde_json::to_string_pretty(&root_state).unwrap(),
+        )
+        .unwrap();
+
+        let mut live = load_state(&wt, "plan-x").unwrap().unwrap();
+        live.phases[0].status = PhaseStatus::Failed;
+        live.plan_status = PlanStatus::Blocked;
+        save_state(&wt, &live).unwrap();
+        registry_record(&root, "plan-x", &wt);
+
+        let text = status_impl(&root, None, false).unwrap();
+        assert!(
+            text.contains(&normalize_store_path(&wt)),
+            "live registry store must be listed: {text}"
+        );
+        assert!(
+            text.contains("(repo root)"),
+            "live repo-root copy must not be erased from status: {text}"
+        );
+
+        let holding = stores_holding(&root, "plan-x").unwrap();
+        assert!(
+            holding.len() >= 2,
+            "both stores must be visible to verbs: {holding:?}"
+        );
+        assert_eq!(
+            normalize_store_path(&holding[0]),
+            normalize_store_path(&wt),
+            "registry-referenced store ranks first"
+        );
+    }
+
+    /// GH-557 (independent-review round 11, P1-2): a truncated registry
+    /// target must not deny recovery of a healthy same-name copy in the
+    /// repo root (the inverse of `stale_corrupt_copy_does_not_deny_…`).
+    #[test]
+    fn corrupt_registry_target_does_not_deny_healthy_same_name_elsewhere() {
+        let (_dir, wt) = repo_with_worktree_state();
+        let root = _dir.path().join("repo");
+
+        let plan = parse_plan("name: plan-x\nphases:\n  - id: a\n    prompt: x\n").unwrap();
+        let mut root_state =
+            edda_conductor::state::machine::PlanState::from_plan(&plan, "plan-x.yaml");
+        root_state.phases[0].status = PhaseStatus::Failed;
+        root_state.plan_status = PlanStatus::Blocked;
+        let root_dir = root.join(".edda").join("conductor").join("plan-x");
+        std::fs::create_dir_all(&root_dir).unwrap();
+        std::fs::write(
+            root_dir.join("state.json"),
+            serde_json::to_string_pretty(&root_state).unwrap(),
+        )
+        .unwrap();
+
+        let corrupt_dir = wt.join(".edda").join("conductor").join("plan-x");
+        std::fs::create_dir_all(&corrupt_dir).unwrap();
+        std::fs::write(corrupt_dir.join("state.json"), b"{corrupt").unwrap();
+        registry_record(&root, "plan-x", &wt);
+
+        retry(&root, "a", Some("plan-x")).unwrap();
+
+        let live = load_state(&root, "plan-x").unwrap().unwrap();
         assert_eq!(live.phases[0].status, PhaseStatus::Pending);
         let leftover = std::fs::read(corrupt_dir.join("state.json")).unwrap();
         assert_eq!(leftover, b"{corrupt");

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -318,15 +318,17 @@ pub fn status(repo_root: &Path, plan_name: Option<&str>, json: bool) -> Result<(
 /// testable without stdout capture.
 fn status_impl(repo_root: &Path, plan_name: Option<&str>, json: bool) -> Result<String> {
     let mut out = String::new();
-    let stores = plan_stores(repo_root);
     let plans: Vec<(String, PathBuf)> = if let Some(name) = plan_name {
         match resolve_plan_store(repo_root, name)? {
             Some(store) => vec![(name.to_string(), store)],
             None => vec![(name.to_string(), repo_root.to_path_buf())],
         }
     } else {
+        // Round-2 P2: same union resolve_plan_name auto-detects over,
+        // filtered to directories that actually hold a state.json — the
+        // directory-name rule and the state.json rule used to disagree.
         let mut found: Vec<(String, PathBuf)> = Vec::new();
-        for store in &stores {
+        for store in plan_stores(repo_root) {
             let conductor_dir = store.join(".edda").join("conductor");
             if !conductor_dir.exists() {
                 continue;
@@ -335,7 +337,9 @@ fn status_impl(repo_root: &Path, plan_name: Option<&str>, json: bool) -> Result<
                 let entry = entry?;
                 if entry.file_type()?.is_dir() {
                     if let Some(name) = entry.file_name().to_str() {
-                        if !found.iter().any(|(n, _)| n == name) {
+                        if load_state(&store, name).ok().flatten().is_some()
+                            && !found.iter().any(|(n, _)| n == name)
+                        {
                             found.push((name.to_string(), store.clone()));
                         }
                     }
@@ -356,10 +360,18 @@ fn status_impl(repo_root: &Path, plan_name: Option<&str>, json: bool) -> Result<
     }
 
     if json {
-        let states: Vec<PlanState> = plans
-            .iter()
-            .filter_map(|(name, store)| load_state(store, name).ok().flatten())
-            .collect();
+        // Round-2 P2: propagate, don't silently drop — a corrupt state file
+        // is an error, never an absent entry (same rule as the text mode).
+        let mut states = Vec::new();
+        for (name, store) in &plans {
+            states.push(
+                load_state(store, name)
+                    .with_context(|| format!("plan \"{name}\" in {}", store.display()))?
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("plan \"{name}\": no state file in {}", store.display())
+                    })?,
+            );
+        }
         // Single plan name specified: output object directly; otherwise array
         if plan_name.is_some() {
             if let Some(s) = states.into_iter().next() {
@@ -398,6 +410,7 @@ fn status_impl(repo_root: &Path, plan_name: Option<&str>, json: bool) -> Result<
 /// Render one plan's status block (the body `print_status` writes).
 fn print_status_to_string(state: &PlanState) -> String {
     let mut out = String::new();
+    out.push('\n');
     out.push_str(&format!(
         "Plan: {} ({:?})\n",
         state.plan_name, state.plan_status
@@ -435,6 +448,8 @@ fn print_status_to_string(state: &PlanState) -> String {
                 let reason = ps.skip_reason.as_deref().unwrap_or("");
                 format!("({})", reason)
             }
+            // GH-552: a waived gate keeps the honest status — "skip" would
+            // understate what was verified (the phase ran and passed).
             PhaseStatus::GateTimedOut => match ps.skip_reason.as_deref() {
                 Some(reason) => format!("(waived: {})", reason),
                 None => "(awaiting operator: retry or waive)".to_string(),
@@ -455,7 +470,7 @@ pub fn retry(repo_root: &Path, phase_id: &str, plan_name: Option<&str>) -> Resul
     let name = resolve_plan_name(repo_root, plan_name)?;
     let store =
         resolve_plan_store(repo_root, &name)?.ok_or_else(|| no_state_error(repo_root, &name))?;
-    update_state(&store, &name, |state| {
+    let plan_file = update_state(&store, &name, |state| {
         let current_status = {
             let ps = state.get_phase_mut(phase_id)?;
             if ps.status != PhaseStatus::Failed
@@ -484,10 +499,24 @@ pub fn retry(repo_root: &Path, phase_id: &str, plan_name: Option<&str>) -> Resul
             state.plan_status = PlanStatus::Running;
         }
 
-        Ok(())
+        Ok(state.plan_file.clone())
     })?;
 
-    println!("Phase \"{phase_id}\" reset to Pending. Run `edda conduct run` to resume.");
+    // GH-557 review round 2, P1-1: a destructive verb must name the store
+    // it wrote, and the resume hint must resolve the SAME store.
+    println!("Phase \"{phase_id}\" reset to Pending.");
+    println!("  store: {}", store.display());
+    if plan_file.is_empty() {
+        println!(
+            "  resume: `edda conduct run <plan.yaml> --cwd {}`",
+            store.display()
+        );
+    } else {
+        println!(
+            "  resume: `edda conduct run {plan_file} --cwd {}`",
+            store.display()
+        );
+    }
     Ok(())
 }
 
@@ -539,6 +568,7 @@ pub fn skip(
         Ok(false)
     })?;
 
+    println!("  store: {}", store.display());
     if is_waived {
         println!("Phase \"{phase_id}\" gate waived (status kept as GateTimedOut).");
     } else {
@@ -562,7 +592,7 @@ pub fn abort(repo_root: &Path, plan_name: Option<&str>) -> Result<()> {
         Ok(())
     })?;
 
-    println!("Plan \"{name}\" aborted.");
+    println!("Plan \"{name}\" aborted. (store: {})", store.display());
     Ok(())
 }
 
@@ -665,15 +695,17 @@ fn plan_stores(repo_root: &Path) -> Vec<PathBuf> {
     stores
 }
 
-/// Find the store directory that actually holds `<plan>`'s state.json
-/// (GH-557): the repo root first, then each git worktree. A corrupt state
-/// file is an error, NOT "absent" — swallowing it would retarget a
-/// mutating verb onto a different store that happens to hold a stale
-/// same-name state.
-fn resolve_plan_store(repo_root: &Path, plan: &str) -> Result<Option<PathBuf>> {
+/// Every store currently holding `<plan>`'s state.json (GH-557), in
+/// deterministic order (repo root first, then `git worktree list` order).
+/// A corrupt state file is an error, NOT "absent" — swallowing it would
+/// retarget a mutating verb onto a different store that happens to hold a
+/// stale same-name state.
+fn stores_holding(repo_root: &Path, plan: &str) -> Result<Vec<PathBuf>> {
+    edda_conductor::state::persist::validate_plan_name(plan)?;
+    let mut holding = Vec::new();
     for store in plan_stores(repo_root) {
         match load_state(&store, plan) {
-            Ok(Some(_)) => return Ok(Some(store)),
+            Ok(Some(_)) => holding.push(store),
             Ok(None) => continue,
             Err(e) => {
                 return Err(e.context(format!(
@@ -683,7 +715,32 @@ fn resolve_plan_store(repo_root: &Path, plan: &str) -> Result<Option<PathBuf>> {
             }
         }
     }
-    Ok(None)
+    Ok(holding)
+}
+
+/// The store a verb should act on: the first store holding the plan. When
+/// more than one store holds the same plan name, the others are shadowed —
+/// warn on stderr so a destructive verb is never mute about that (GH-557
+/// independent review round 2, P1-1).
+fn resolve_plan_store(repo_root: &Path, plan: &str) -> Result<Option<PathBuf>> {
+    let holding = stores_holding(repo_root, plan)?;
+    match holding.len() {
+        0 => Ok(None),
+        1 => Ok(Some(holding[0].clone())),
+        _ => {
+            eprintln!(
+                "⚠ plan \"{plan}\" exists in {} stores; acting on {} (shadowed: {})",
+                holding.len(),
+                holding[0].display(),
+                holding[1..]
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            Ok(Some(holding[0].clone()))
+        }
+    }
 }
 
 /// Refuse to act when the plan's state is nowhere on the repo (GH-557):
@@ -696,13 +753,20 @@ fn no_state_error(repo_root: &Path, plan: &str) -> anyhow::Error {
         .filter(|p| p.join(".edda").join("conductor").is_dir())
         .map(|p| p.display().to_string())
         .collect();
-    let shown = if searched.len() > 5 {
+    let shown = if searched.is_empty() {
+        "no store with a .edda/conductor directory".to_string()
+    } else if searched.len() > 5 {
         format!("{} … ({} stores)", searched[..5].join(", "), searched.len())
     } else {
         searched.join(", ")
     };
+    // GH-557 review round 2, P1-2: name the REAL store rule — a plan's
+    // state lives in the --cwd it was launched with, the plan's own `cwd:`
+    // key, or the plan file's directory. The old text blamed a --cwd the
+    // operator may never have passed.
     anyhow::anyhow!(
-        "no state for plan \"{plan}\" (searched: {shown}); a plan launched with a --cwd outside this repo's worktrees stores its state there and is not auto-discoverable"
+        "no state for plan \"{plan}\" (searched: {shown}); a plan's state lives in the store it was launched from — \
+         the --cwd passed to conduct run, the plan's cwd: key, or the plan file's own directory"
     )
 }
 
@@ -711,23 +775,35 @@ fn resolve_plan_name(repo_root: &Path, explicit: Option<&str>) -> Result<String>
         return Ok(name.to_string());
     }
 
-    let conductor_dir = repo_root.join(".edda").join("conductor");
-    if !conductor_dir.exists() {
-        bail!("No conductor state found. Specify --plan <name>.");
-    }
-
-    let mut names = Vec::new();
-    for entry in std::fs::read_dir(&conductor_dir)? {
-        let entry = entry?;
-        if entry.file_type()?.is_dir() {
-            if let Some(n) = entry.file_name().to_str() {
-                names.push(n.to_string());
+    // GH-557 review round 2, P1-3: auto-detection spans the same stores
+    // `status` lists — the shipped agent recovery loop reads `status --json`
+    // and then runs retry/skip/abort WITHOUT --plan, so a split resolution
+    // let `abort` hit the wrong plan or dead-end. Scanning the same union
+    // makes the read and write verbs agree; more than one plan still
+    // requires an explicit --plan, so a destructive verb can never silently
+    // resolve across lanes.
+    let mut names: Vec<String> = Vec::new();
+    for store in plan_stores(repo_root) {
+        let conductor_dir = store.join(".edda").join("conductor");
+        if !conductor_dir.exists() {
+            continue;
+        }
+        for entry in std::fs::read_dir(&conductor_dir)? {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                if let Some(n) = entry.file_name().to_str() {
+                    if load_state(&store, n).ok().flatten().is_some()
+                        && !names.iter().any(|existing| existing == n)
+                    {
+                        names.push(n.to_string());
+                    }
+                }
             }
         }
     }
 
     match names.len() {
-        0 => bail!("No plans found."),
+        0 => bail!("No plans found. Specify --plan <name>."),
         1 => Ok(names
             .into_iter()
             .next()

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -186,6 +186,22 @@ pub fn run(
         }
     };
 
+    // GH-557 round-3 P0-2: record the store this run actually uses, so the
+    // recovery verbs can find a plan launched from a plain directory (the
+    // plan YAML's own folder — the reported incident's shape) that no
+    // worktree scan can enumerate. Best-effort at the nearest repo root:
+    // the run cwd's, then the invoking shell's.
+    {
+        let registry_root = edda_ledger::EddaPaths::find_root(&cwd)
+            .or_else(|| {
+                std::env::current_dir()
+                    .ok()
+                    .and_then(|d| edda_ledger::EddaPaths::find_root(&d))
+            })
+            .unwrap_or_else(|| cwd.clone());
+        registry_record(&registry_root, &plan.name, &cwd);
+    }
+
     let order = edda_conductor::plan::topo::topo_sort(&plan)?;
 
     if dry_run {
@@ -324,9 +340,11 @@ fn status_impl(repo_root: &Path, plan_name: Option<&str>, json: bool) -> Result<
             None => vec![(name.to_string(), repo_root.to_path_buf())],
         }
     } else {
-        // Round-2 P2: same union resolve_plan_name auto-detects over,
-        // filtered to directories that actually hold a state.json — the
-        // directory-name rule and the state.json rule used to disagree.
+        // Round-2 P2, adjusted by round-3 P1-1: the listing scans the same
+        // union resolve_plan_name auto-detects over, filtered to directories
+        // that hold a parseable state.json. A CORRUPT state file propagates
+        // (an error, never "absent"); the named-missing fallback below
+        // restores status --json's "null" contract.
         let mut found: Vec<(String, PathBuf)> = Vec::new();
         for store in plan_stores(repo_root) {
             let conductor_dir = store.join(".edda").join("conductor");
@@ -337,10 +355,19 @@ fn status_impl(repo_root: &Path, plan_name: Option<&str>, json: bool) -> Result<
                 let entry = entry?;
                 if entry.file_type()?.is_dir() {
                     if let Some(name) = entry.file_name().to_str() {
-                        if load_state(&store, name).ok().flatten().is_some()
-                            && !found.iter().any(|(n, _)| n == name)
-                        {
-                            found.push((name.to_string(), store.clone()));
+                        match load_state(&store, name) {
+                            Ok(Some(_)) => {
+                                if !found.iter().any(|(n, _)| n == name) {
+                                    found.push((name.to_string(), store.clone()));
+                                }
+                            }
+                            Ok(None) => continue,
+                            Err(e) => {
+                                return Err(e.context(format!(
+                                    "plan \"{name}\" state in {} is unreadable",
+                                    store.display()
+                                )))
+                            }
                         }
                     }
                 }
@@ -360,27 +387,26 @@ fn status_impl(repo_root: &Path, plan_name: Option<&str>, json: bool) -> Result<
     }
 
     if json {
-        // Round-2 P2: propagate, don't silently drop — a corrupt state file
-        // is an error, never an absent entry (same rule as the text mode).
-        let mut states = Vec::new();
-        for (name, store) in &plans {
-            states.push(
-                load_state(store, name)
-                    .with_context(|| format!("plan \"{name}\" in {}", store.display()))?
-                    .ok_or_else(|| {
-                        anyhow::anyhow!("plan \"{name}\": no state file in {}", store.display())
-                    })?,
-            );
-        }
-        // Single plan name specified: output object directly; otherwise array
+        // Named-missing keeps the pre-GH-557 "null" contract (round-3 P1-1);
+        // a CORRUPT state file still propagates as an error. The unnamed
+        // listing builds only from parseable states, so its array is clean.
         if plan_name.is_some() {
-            if let Some(s) = states.into_iter().next() {
-                out.push_str(&serde_json::to_string_pretty(&s)?);
-                out.push('\n');
-            } else {
-                out.push_str("null\n");
+            let (name, store) = &plans[0];
+            let state = load_state(store, name)?;
+            match state {
+                Some(s) => {
+                    out.push_str(&serde_json::to_string_pretty(&s)?);
+                    out.push('\n');
+                }
+                None => out.push_str("null\n"),
             }
         } else {
+            let mut states = Vec::new();
+            for (name, store) in &plans {
+                states.push(load_state(store, name)?.ok_or_else(|| {
+                    anyhow::anyhow!("plan \"{name}\": no state file in {}", store.display())
+                })?);
+            }
             out.push_str(&serde_json::to_string_pretty(&states)?);
             out.push('\n');
         }
@@ -690,9 +716,61 @@ fn plan_stores(repo_root: &Path) -> Vec<PathBuf> {
                     }
                 }
             }
+        } else {
+            // GH-557 round-3 P1-2: silent degradation turns the no-state
+            // error into a false diagnosis ("searched: <repo root>").
+            eprintln!(
+                "⚠ could not enumerate git worktrees ({}); searching the repo root only",
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
         }
     }
     stores
+}
+
+/// Store registry: `<root>/.edda/conductor/.stores.json` maps plan name →
+/// the store directory `conduct run` actually used (GH-557 round 3, P0-2).
+/// The reported incident's store was the plan YAML's own directory — a
+/// plain path that is neither the repo root nor a registered worktree —
+/// so search-order heuristics can never cover it; `run` records the store
+/// it chose and the recovery verbs look it up.
+fn registry_path(root: &Path) -> PathBuf {
+    root.join(".edda").join("conductor").join(".stores.json")
+}
+
+/// Read a store registry. Best-effort: missing or corrupt file reads as an
+/// empty map — the direct worktree scan remains the fallback.
+fn registry_read(root: &Path) -> std::collections::BTreeMap<String, PathBuf> {
+    let mut map = std::collections::BTreeMap::new();
+    if let Ok(content) = std::fs::read_to_string(registry_path(root)) {
+        if let Ok(parsed) =
+            serde_json::from_str::<std::collections::BTreeMap<String, String>>(&content)
+        {
+            for (plan, store) in parsed {
+                map.insert(plan, PathBuf::from(store));
+            }
+        }
+    }
+    map
+}
+
+/// Record plan → store in the registry under `root`. Best-effort: a failed
+/// write prints a warning; discovery falls back to the worktree scan.
+fn registry_record(root: &Path, plan: &str, store: &Path) {
+    let path = registry_path(root);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let mut map = registry_read(root);
+    map.insert(plan.to_string(), store.to_path_buf());
+    match serde_json::to_string_pretty(&map) {
+        Ok(data) => {
+            if let Err(e) = edda_store::write_atomic(&path, data.as_bytes()) {
+                eprintln!("⚠ store registry write failed ({}): {e}", path.display());
+            }
+        }
+        Err(e) => eprintln!("⚠ store registry serialize failed: {e}"),
+    }
 }
 
 /// Every store currently holding `<plan>`'s state.json (GH-557), in
@@ -712,6 +790,26 @@ fn stores_holding(repo_root: &Path, plan: &str) -> Result<Vec<PathBuf>> {
                     "plan \"{plan}\" state in {} is unreadable",
                     store.display()
                 )))
+            }
+        }
+    }
+    // Registry-referenced stores (recorded by conduct run) — covers plan
+    // YAMLs living outside the repo, which no worktree scan can reach
+    // (round-3 P0-2: the reported incident's store was the plan YAML's own
+    // directory).
+    for store in plan_stores(repo_root) {
+        if let Some(referenced) = registry_read(&store).get(plan) {
+            if !holding.contains(referenced)
+                && load_state(referenced, plan)
+                    .with_context(|| {
+                        format!(
+                            "plan \"{plan}\" registry points to {}",
+                            referenced.display()
+                        )
+                    })?
+                    .is_some()
+            {
+                holding.push(referenced.clone());
             }
         }
     }
@@ -775,39 +873,57 @@ fn resolve_plan_name(repo_root: &Path, explicit: Option<&str>) -> Result<String>
         return Ok(name.to_string());
     }
 
-    // GH-557 review round 2, P1-3: auto-detection spans the same stores
-    // `status` lists — the shipped agent recovery loop reads `status --json`
-    // and then runs retry/skip/abort WITHOUT --plan, so a split resolution
-    // let `abort` hit the wrong plan or dead-end. Scanning the same union
-    // makes the read and write verbs agree; more than one plan still
-    // requires an explicit --plan, so a destructive verb can never silently
-    // resolve across lanes.
-    let mut names: Vec<String> = Vec::new();
+    // GH-557 review rounds 2–3: the auto-detection scope is the INVOKING
+    // store (repo_root), falling back to another store only when exactly
+    // one store on the machine holds any plan. Once more than one store
+    // contributes, a destructive verb requires an explicit --plan — bare
+    // auto-detection across lanes is how `abort` hits the wrong plan.
+    // Corrupt state files propagate (they are errors, never "absent").
+    let mut contributing: Vec<(PathBuf, Vec<String>)> = Vec::new();
     for store in plan_stores(repo_root) {
         let conductor_dir = store.join(".edda").join("conductor");
         if !conductor_dir.exists() {
             continue;
         }
+        let mut store_names = Vec::new();
         for entry in std::fs::read_dir(&conductor_dir)? {
             let entry = entry?;
             if entry.file_type()?.is_dir() {
                 if let Some(n) = entry.file_name().to_str() {
-                    if load_state(&store, n).ok().flatten().is_some()
-                        && !names.iter().any(|existing| existing == n)
-                    {
-                        names.push(n.to_string());
+                    match load_state(&store, n) {
+                        Ok(Some(_)) => store_names.push(n.to_string()),
+                        Ok(None) => continue,
+                        Err(e) => {
+                            return Err(e.context(format!(
+                                "plan \"{n}\" state in {} is unreadable",
+                                store.display()
+                            )))
+                        }
                     }
                 }
             }
         }
+        if !store_names.is_empty() {
+            contributing.push((store, store_names));
+        }
     }
+
+    if contributing.is_empty() {
+        bail!("No plans found. Specify --plan <name>.");
+    }
+    if contributing.len() > 1 {
+        let shown = contributing
+            .iter()
+            .map(|(s, ns)| format!("{} ({})", s.display(), ns.join("/")))
+            .collect::<Vec<_>>()
+            .join(", ");
+        bail!("Plans found in multiple stores: {shown}. Specify --plan <name>.");
+    }
+    let names = &contributing[0].1;
 
     match names.len() {
         0 => bail!("No plans found. Specify --plan <name>."),
-        1 => Ok(names
-            .into_iter()
-            .next()
-            .context("expected exactly one plan")?),
+        1 => Ok(names[0].clone()),
         _ => bail!(
             "Multiple plans found: {}. Use --plan to specify.",
             names.join(", ")
@@ -957,15 +1073,17 @@ mod tests {
     /// the verb runs, not a helper that did not exist before the fix.
     #[test]
     fn status_lists_and_resolves_worktree_launch_plans() {
-        let (_dir, _wt) = repo_with_worktree_state();
+        let (_dir, wt) = repo_with_worktree_state();
         let root = _dir.path().join("repo");
 
-        // Unnamed listing: the worktree plan must appear, with provenance.
+        // Unnamed listing: the worktree plan must appear, with provenance
+        // naming the exact worktree path (not a substring accident).
         let text = status_impl(&root, None, false).unwrap();
         assert!(text.contains("plan-x"), "{text}");
+        let wt_normalized = wt.to_string_lossy().replace('\\', "/");
         assert!(
-            text.contains("wt"),
-            "listing must show store provenance: {text}"
+            text.contains(&wt_normalized),
+            "listing must show the worktree store path: {text}"
         );
 
         // Named: resolves into the worktree store and renders the state.
@@ -1026,6 +1144,91 @@ mod tests {
             err.to_string().contains("unreadable"),
             "corrupt state must surface as unreadable: {err}"
         );
+    }
+
+    /// GH-557 (independent-review round 3, P0-2): `conduct run` records the
+    /// store it used in the registry, and a plan launched from a plain
+    /// directory — the plan YAML's own folder, neither the repo root nor a
+    /// worktree — is then recoverable from the repo root. This is the
+    /// reported incident's actual shape (parallel-wave launches with no
+    /// --cwd, plan YAMLs live outside the repo).
+    #[test]
+    fn registry_recorded_store_is_recoverable() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("repo");
+        let plans_dir = dir.path().join("scratchpad");
+        std::fs::create_dir_all(root.join(".edda").join("conductor")).unwrap();
+        std::fs::create_dir_all(&plans_dir).unwrap();
+
+        let plan = parse_plan("name: plan-x\nphases:\n  - id: a\n    prompt: x\n").unwrap();
+        let mut state = edda_conductor::state::machine::PlanState::from_plan(&plan, "plan-x.yaml");
+        state.phases[0].status = PhaseStatus::Failed;
+        state.plan_status = PlanStatus::Blocked;
+        let store = plans_dir.clone();
+        let state_dir = store.join(".edda").join("conductor").join("plan-x");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        std::fs::write(
+            state_dir.join("state.json"),
+            serde_json::to_string_pretty(&state).unwrap(),
+        )
+        .unwrap();
+
+        // What conduct run writes at start (best-effort registry record).
+        registry_record(&root, "plan-x", &store);
+
+        // The store is not in any scannable location — only the registry
+        // knows it.
+        assert!(
+            load_state(&root, "plan-x").unwrap().is_none(),
+            "precondition: the store is outside the repo and its worktrees"
+        );
+
+        retry(&root, "a", Some("plan-x")).unwrap();
+
+        let reloaded = load_state(&store, "plan-x").unwrap().unwrap();
+        assert_eq!(reloaded.phases[0].status, PhaseStatus::Pending);
+    }
+
+    /// GH-557 (independent-review round 3, P0-3): bare destructive verbs
+    /// refuse once more than one store contributes plans — auto-detection
+    /// must never silently resolve across lanes.
+    #[test]
+    fn auto_detect_refuses_when_multiple_stores_contribute() {
+        let (_dir, _wt) = repo_with_worktree_state();
+        let root = _dir.path().join("repo");
+
+        // A second plan in the repo-root store: now two stores contribute
+        // (root holds plan-y, the worktree holds plan-x) and bare
+        // destructive verbs must refuse rather than pick a lane.
+        let plan_y = parse_plan("name: plan-y\nphases:\n  - id: a\n    prompt: x\n").unwrap();
+        let state_y = edda_conductor::state::machine::PlanState::from_plan(&plan_y, "y.yaml");
+        let y_dir = root.join(".edda").join("conductor").join("plan-y");
+        std::fs::create_dir_all(&y_dir).unwrap();
+        std::fs::write(
+            y_dir.join("state.json"),
+            serde_json::to_string_pretty(&state_y).unwrap(),
+        )
+        .unwrap();
+
+        let err = resolve_plan_name(&root, None).unwrap_err();
+        let text = err.to_string();
+        assert!(
+            text.contains("multiple stores"),
+            "auto-detection must refuse across stores: {text}"
+        );
+        // An explicit --plan still works across stores.
+        assert_eq!(resolve_plan_name(&root, Some("plan-x")).unwrap(), "plan-x");
+    }
+
+    /// GH-557 (independent-review round 3, P1-1): `status <plan> --json`
+    /// keeps the pre-GH-557 "null" contract for a named-but-missing plan
+    /// (exit 0, body "null"), while text mode stays forgiving.
+    #[test]
+    fn status_json_named_missing_prints_null() {
+        let (_dir, _wt) = repo_with_worktree_state();
+        let root = _dir.path().join("repo");
+        let out = status_impl(&root, Some("plan-y"), true).unwrap();
+        assert_eq!(out.trim(), "null", "{out}");
     }
 
     /// GH-557: with no matching state anywhere, the error names the searched

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -377,15 +377,30 @@ fn status_impl(repo_root: &Path, plan_name: Option<&str>, json: bool) -> Result<
     }
 
     if json {
+        // Round-10 P1-2: every machine-readable object carries `store` so
+        // same-named plans across lanes are distinguishable. Flattened onto
+        // PlanState so existing field paths (`plan_name`, `phases`, …) stay.
+        #[derive(serde::Serialize)]
+        struct StatusJson {
+            store: String,
+            #[serde(flatten)]
+            state: PlanState,
+        }
+        let row = |store: &Path, state: PlanState| StatusJson {
+            store: normalize_store_path(store),
+            state,
+        };
         // Named-missing keeps the pre-GH-557 "null" contract (round-3 P1-1);
         // a CORRUPT state file still propagates as an error. The unnamed
-        // listing builds only from parseable states, so its array is clean.
+        // listing skip-and-warns a plan whose file vanished between
+        // discovery and load (round-10 P1-1: the old filter_map could not
+        // fail; a hard error here would drop every healthy lane's status).
         if plan_name.is_some() {
             let (name, store) = &plans[0];
             let state = load_state(store, name)?;
             match state {
                 Some(s) => {
-                    out.push_str(&serde_json::to_string_pretty(&s)?);
+                    out.push_str(&serde_json::to_string_pretty(&row(store, s))?);
                     out.push('\n');
                 }
                 None => out.push_str("null\n"),
@@ -393,9 +408,17 @@ fn status_impl(repo_root: &Path, plan_name: Option<&str>, json: bool) -> Result<
         } else {
             let mut states = Vec::new();
             for (name, store) in &plans {
-                states.push(load_state(store, name)?.ok_or_else(|| {
-                    anyhow::anyhow!("plan \"{name}\": no state file in {}", store.display())
-                })?);
+                match load_state(store, name) {
+                    Ok(Some(s)) => states.push(row(store, s)),
+                    Ok(None) => eprintln!(
+                        "⚠ plan \"{name}\" state in {} disappeared before load, omitted",
+                        store.display()
+                    ),
+                    Err(e) => eprintln!(
+                        "⚠ plan \"{name}\" state in {} unreadable at load, omitted: {e:#}",
+                        store.display()
+                    ),
+                }
             }
             out.push_str(&serde_json::to_string_pretty(&states)?);
             out.push('\n');
@@ -1512,6 +1535,22 @@ phases:
         );
         // An explicit --plan still works across stores.
         assert_eq!(resolve_plan_name(&root, Some("plan-x")).unwrap(), "plan-x");
+    }
+
+    /// GH-557 (independent-review round 10, P1-2): unnamed `--json` carries
+    /// `store` so same-named plans across lanes are distinguishable, and
+    /// existing PlanState field paths (`plan_name`, …) stay at the top level.
+    #[test]
+    fn status_json_unnamed_includes_store_provenance() {
+        let (_dir, wt) = repo_with_worktree_state();
+        let root = _dir.path().join("repo");
+        let out = status_impl(&root, None, true).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let arr = v.as_array().expect("unnamed json is an array");
+        assert_eq!(arr.len(), 1, "{out}");
+        assert_eq!(arr[0]["plan_name"], "plan-x");
+        let store = arr[0]["store"].as_str().expect("store field");
+        assert_eq!(store, normalize_store_path(&wt));
     }
 
     /// GH-557 (independent-review round 3, P1-1): `status <plan> --json`

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -196,11 +196,15 @@ pub fn run(
     // operator/agent stands in), then the run cwd's — reads scan all of
     // them, so at least one lands inside plan_stores scope.
     // Round-4 P1-4: the chain is a pure function so tests can drive it.
-    for root in registry_roots_for(
-        &cwd,
-        &std::env::current_dir().unwrap_or_else(|_| cwd.clone()),
-    ) {
-        registry_record(&root, &plan.name, &cwd);
+    // Round-5 P2: a dry run writes nothing — no registry entries for a plan
+    // that never ran.
+    if !dry_run {
+        for root in registry_roots_for(
+            &cwd,
+            &std::env::current_dir().unwrap_or_else(|_| cwd.clone()),
+        ) {
+            registry_record(&root, &plan.name, &cwd);
+        }
     }
 
     let order = edda_conductor::plan::topo::topo_sort(&plan)?;
@@ -367,7 +371,7 @@ fn status_impl(repo_root: &Path, plan_name: Option<&str>, json: bool) -> Result<
                             Ok(Some(_)) => mark(name, referenced, &mut found),
                             Ok(None) => continue,
                             Err(e) => eprintln!(
-                                "⚠ plan \"{name}\" (registry → {}) unreadable, listed as broken: {e}",
+                                "⚠ plan \"{name}\" (registry → {}) unreadable, omitted from the listing: {e}",
                                 referenced.display()
                             ),
                         }
@@ -433,14 +437,15 @@ fn status_impl(repo_root: &Path, plan_name: Option<&str>, json: bool) -> Result<
             let state = load_state(store, name)?;
             match state {
                 Some(s) => {
-                    out.push_str(&format!(
-                        "  Store: {}\n",
-                        if *store == repo_root {
-                            "(repo root)".to_string()
-                        } else {
-                            store.display().to_string()
-                        }
-                    ));
+                    // Round-5 P0: print the normalized identity — the test
+                    // compares it against normalize_store_path(wt), robust
+                    // to 8.3 short names, slash direction, and case.
+                    let label = if normalize_store_path(store) == normalize_store_path(repo_root) {
+                        "(repo root)".to_string()
+                    } else {
+                        normalize_store_path(store)
+                    };
+                    out.push_str(&format!("  Store: {label}\n"));
                     out.push_str(&print_status_to_string(&s));
                 }
                 None => out.push_str(&format!("Plan \"{name}\": no state file found\n")),
@@ -612,12 +617,12 @@ pub fn skip(
         Ok(false)
     })?;
 
-    println!("  store: {}", store.display());
     if is_waived {
         println!("Phase \"{phase_id}\" gate waived (status kept as GateTimedOut).");
     } else {
         println!("Phase \"{phase_id}\" skipped.");
     }
+    println!("  store: {}", store.display());
     Ok(())
 }
 
@@ -727,7 +732,14 @@ fn normalize_store_path(p: &Path) -> String {
     let canonical = std::fs::canonicalize(p)
         .map(|c| c.to_string_lossy().trim_start_matches(r"\\?\").to_string())
         .unwrap_or_else(|_| p.to_string_lossy().to_string());
-    canonical.replace('/', "\\").to_lowercase()
+    let unified = canonical.replace('/', "\\");
+    // Windows paths are case-insensitive; POSIX paths are not —
+    // lowercasing on Linux would collapse distinct lanes (round-5 P3).
+    if cfg!(windows) {
+        unified.to_lowercase()
+    } else {
+        unified
+    }
 }
 
 fn plan_stores(repo_root: &Path) -> Vec<PathBuf> {
@@ -752,9 +764,10 @@ fn plan_stores(repo_root: &Path) -> Vec<PathBuf> {
                     push(PathBuf::from(path), &mut stores, &mut seen);
                 }
             }
-        } else {
+        } else if repo_root.join(".git").exists() {
             // GH-557 round-3 P1-2: silent degradation turns the no-state
             // error into a false diagnosis ("searched: <repo root>").
+            // Round-5 P3: a non-git cwd (demo projects) is not a fault.
             eprintln!(
                 "⚠ could not enumerate git worktrees ({}); searching the repo root only",
                 String::from_utf8_lossy(&out.stderr).trim()
@@ -774,8 +787,6 @@ fn registry_path(root: &Path) -> PathBuf {
     root.join(".edda").join("conductor").join(".stores.json")
 }
 
-/// Read a store registry. Best-effort: missing or corrupt file reads as an
-/// empty map — the direct worktree scan remains the fallback.
 /// Candidate registry roots for a run launched with `run_cwd`, invoked
 /// from `shell_cwd` (GH-557 round-4 P0-3): the invoking shell's root
 /// first — the lane the operator/agent stands in — then the run cwd's.
@@ -825,8 +836,9 @@ fn registry_read(root: &Path) -> Result<std::collections::BTreeMap<String, PathB
 /// Record plan → store in the registry under `root`, under the registry's
 /// exclusive lock (round-4 P1-2: two concurrent `conduct run` processes
 /// are the parallel-wave norm; unlocked read-modify-write loses entries).
-/// Best-effort: lock contention or a corrupt existing registry prints a
-/// warning and skips the write — discovery still has the direct scan.
+/// Best-effort: the lock is blocking (a concurrent `conduct run` finishes
+/// its write and releases); a corrupt existing registry prints a warning
+/// and skips the write rather than destroying the other entries.
 fn registry_record(root: &Path, plan: &str, store: &Path) {
     let path = registry_path(root);
     if let Some(parent) = path.parent() {
@@ -865,26 +877,24 @@ fn registry_record(root: &Path, plan: &str, store: &Path) {
 /// stale same-name state.
 fn stores_holding(repo_root: &Path, plan: &str) -> Result<Vec<PathBuf>> {
     edda_conductor::state::persist::validate_plan_name(plan)?;
-    let mut holding = Vec::new();
-    for store in plan_stores(repo_root) {
-        match load_state(&store, plan) {
-            Ok(Some(_)) => holding.push(store),
-            Ok(None) => continue,
-            Err(e) => {
-                return Err(e.context(format!(
-                    "plan \"{plan}\" state in {} is unreadable",
-                    store.display()
-                )))
-            }
+    let mut holding: Vec<PathBuf> = Vec::new();
+    let mut seen: Vec<String> = Vec::new();
+    // push: normalized identity (round-5 P1-1 — raw PathBuf equality is
+    // case- and short-name-sensitive on Windows and cried wolf on a single
+    // store), first writer wins.
+    let push = |store: PathBuf, holding: &mut Vec<PathBuf>, seen: &mut Vec<String>| {
+        let key = normalize_store_path(&store);
+        if !seen.contains(&key) {
+            seen.push(key);
+            holding.push(store);
         }
-    }
-    // Registry-referenced stores (recorded by conduct run) — covers plan
-    // YAMLs living outside the repo, which no worktree scan can reach
-    // (round-3 P0-2: the reported incident's store was the plan YAML's own
-    // directory).
+    };
+    // Registry FIRST (round-5 P1-2): it is the store `conduct run` actually
+    // used — the authoritative record. Any stale same-name state.json in
+    // the repo root or a worktree must not outrank it.
     for store in plan_stores(repo_root) {
-        // Round-4 P1-2: a corrupt REGISTRY is read-path noise (warn, keep
-        // scanning) — mutating verbs still propagate corrupt state files.
+        // A corrupt REGISTRY is read-path noise (warn, keep scanning) —
+        // mutating verbs still propagate corrupt state files.
         let registry = match registry_read(&store) {
             Ok(m) => m,
             Err(e) => {
@@ -893,17 +903,29 @@ fn stores_holding(repo_root: &Path, plan: &str) -> Result<Vec<PathBuf>> {
             }
         };
         if let Some(referenced) = registry.get(plan) {
-            if !holding.contains(referenced)
-                && load_state(referenced, plan)
-                    .with_context(|| {
-                        format!(
-                            "plan \"{plan}\" registry points to {}",
-                            referenced.display()
-                        )
-                    })?
-                    .is_some()
+            if load_state(referenced, plan)
+                .with_context(|| {
+                    format!(
+                        "plan \"{plan}\" registry points to {}",
+                        referenced.display()
+                    )
+                })?
+                .is_some()
             {
-                holding.push(referenced.clone());
+                push(referenced.clone(), &mut holding, &mut seen);
+            }
+        }
+    }
+    // Direct scan second.
+    for store in plan_stores(repo_root) {
+        match load_state(&store, plan) {
+            Ok(Some(_)) => push(store, &mut holding, &mut seen),
+            Ok(None) => continue,
+            Err(e) => {
+                return Err(e.context(format!(
+                    "plan \"{plan}\" state in {} is unreadable",
+                    store.display()
+                )))
             }
         }
     }
@@ -1002,13 +1024,42 @@ fn resolve_plan_name(repo_root: &Path, explicit: Option<&str>) -> Result<String>
         }
     }
 
+    // Round-5: registry-referenced plans are contributors too — a plan
+    // launched from an external YAML directory is listed by `status`, so
+    // bare recovery verbs must see it (or refuse), never ignore it.
+    for store in plan_stores(repo_root) {
+        let registry = match registry_read(&store) {
+            Ok(m) => m,
+            Err(e) => {
+                eprintln!("⚠ store registry unreadable ({}): {e}", store.display());
+                continue;
+            }
+        };
+        for (name, referenced) in &registry {
+            if load_state(referenced, name)
+                .with_context(|| {
+                    format!(
+                        "plan \"{name}\" registry points to {}",
+                        referenced.display()
+                    )
+                })?
+                .is_some()
+                && !contributing
+                    .iter()
+                    .any(|(s, _)| normalize_store_path(s) == normalize_store_path(referenced))
+            {
+                contributing.push((referenced.clone(), vec![name.clone()]));
+            }
+        }
+    }
+
     if contributing.is_empty() {
         bail!("No plans found. Specify --plan <name>.");
     }
     if contributing.len() > 1 {
         let shown = contributing
             .iter()
-            .map(|(s, ns)| format!("{} ({})", s.display(), ns.join("/")))
+            .map(|(s, ns)| format!("{} ({})", normalize_store_path(s), ns.join("/")))
             .collect::<Vec<_>>()
             .join(", ");
         bail!("Plans found in multiple stores: {shown}. Specify --plan <name>.");
@@ -1174,10 +1225,10 @@ mod tests {
         // naming the exact worktree path (not a substring accident).
         let text = status_impl(&root, None, false).unwrap();
         assert!(text.contains("plan-x"), "{text}");
-        let wt_normalized = wt.to_string_lossy().replace('\\', "/");
+        let wt_identity = normalize_store_path(&wt);
         assert!(
-            text.contains(&wt_normalized),
-            "listing must show the worktree store path: {text}"
+            text.contains(&wt_identity),
+            "listing must show the normalized worktree store identity: {text}"
         );
 
         // Named: resolves into the worktree store and renders the state.

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -897,9 +897,42 @@ fn discover_plans(repo_root: &Path) -> Result<(DiscoveredPlans, DiscoveryCorrupt
         if !conductor_dir.exists() {
             continue;
         }
-        for entry in std::fs::read_dir(&conductor_dir)? {
-            let entry = entry?;
-            if entry.file_type()?.is_dir() {
+        // Round-9 P1: directory I/O must not kill discovery. A concurrently
+        // removed worktree (`git worktree remove`, fleet cleanup) can race
+        // `exists()` → `read_dir`; warn and skip that store, same as an
+        // unreadable registry / failed `git worktree list`.
+        let entries = match std::fs::read_dir(&conductor_dir) {
+            Ok(rd) => rd,
+            Err(e) => {
+                eprintln!(
+                    "⚠ could not read conductor dir {}: {e}",
+                    conductor_dir.display()
+                );
+                continue;
+            }
+        };
+        for entry in entries {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(e) => {
+                    eprintln!(
+                        "⚠ skipping unreadable entry in {}: {e}",
+                        conductor_dir.display()
+                    );
+                    continue;
+                }
+            };
+            let is_dir = match entry.file_type() {
+                Ok(t) => t.is_dir(),
+                Err(e) => {
+                    eprintln!(
+                        "⚠ skipping unreadable entry in {}: {e}",
+                        conductor_dir.display()
+                    );
+                    continue;
+                }
+            };
+            if is_dir {
                 if let Some(name) = entry.file_name().to_str() {
                     if found.iter().any(|(n, _)| n == name)
                         || corrupt.iter().any(|(n, _, _)| n == name)

--- a/demo/openclaw-skill/edda-conductor/SKILL.md
+++ b/demo/openclaw-skill/edda-conductor/SKILL.md
@@ -73,10 +73,14 @@ edda conduct status --json
 
 ### Interpret the JSON output
 
-The output is a `PlanState` object (or array if multiple plans):
+The output is a `PlanState` object (or array if multiple plans). Each object
+includes `store` — the directory holding that plan's `state.json` — so two
+lanes with the same `plan_name` are distinguishable. Use `--plan` on retry/
+skip/abort.
 
 ```json
 {
+  "store": "/path/to/worktree",
   "plan_name": "api-decisions",
   "plan_status": "running",
   "total_cost_usd": 0.42,
@@ -252,7 +256,7 @@ If there's only one active plan, assume the user means that one. If multiple, as
 
 - **edda not found**: Tell the user `edda` is not installed or not in PATH.
 - **No active plans**: "No active conductor plans."
-- **Multiple plans**: List them by name, ask user which one.
+- **Multiple plans**: List them by name **and store**, ask user which one.
 - **Stale status**: If `updated_at` in runner-status.json is older than `timeout_sec`, the conductor process likely crashed. Report: "Plan status is stale (last update: [time]). The conductor may have crashed. Re-run to resume."
 - **Conductor not built**: If `edda conduct` fails, suggest `cargo build -p edda-cli`.
 

--- a/demo/openclaw-skill/edda-conductor/SKILL.md
+++ b/demo/openclaw-skill/edda-conductor/SKILL.md
@@ -215,19 +215,19 @@ Options:
 
 **Retry:**
 ```bash
-edda conduct retry [phase-id]
+edda conduct retry [phase-id] --plan [plan-name]
 edda conduct run plan.yaml --quiet
 ```
 
 **Skip:**
 ```bash
-edda conduct skip [phase-id] --reason "user: [reason if given]"
+edda conduct skip [phase-id] --plan [plan-name] --reason "user: [reason if given]"
 edda conduct run plan.yaml --quiet
 ```
 
 **Abort:**
 ```bash
-edda conduct abort
+edda conduct abort --plan [plan-name]
 ```
 
 After retry or skip, you must re-run `edda conduct run` to resume execution.

--- a/docs/reference/brief-schema.md
+++ b/docs/reference/brief-schema.md
@@ -310,7 +310,7 @@ Maps 1:1 from edda `PhaseStatus` enum:
 | Karvi Action | Edda Effect |
 |---|---|
 | Redispatch task | New `edda conduct run` (fresh plan) |
-| Manual block | `edda conduct abort {plan}` |
+| Manual block | `edda conduct abort --plan {plan}` |
 | No action needed | Edda retries are internal — no karvi intervention |
 
 ---

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -796,11 +796,15 @@ edda plan scan     # scan codebase and suggest a plan
 Multi-phase AI plan conductor.
 
 ```bash
-edda conduct run <PLAN.yaml>     # run a plan
-edda conduct status              # show running/completed plans
-edda conduct retry <PLAN>        # reset a failed phase
-edda conduct skip <PLAN>         # skip a phase
-edda conduct abort <PLAN>        # abort a running plan
+edda conduct run <PLAN.yaml>     # run a plan (state lands in --cwd, the plan's cwd:, or the plan file's directory; recorded in the store registry)
+edda conduct status              # list plans across the repo root and its git worktrees, with store provenance
+edda conduct retry <PHASE> --plan <PLAN>   # reset a failed phase (state found via the registry and worktrees)
+edda conduct skip <PHASE> --plan <PLAN>    # skip a phase
+edda conduct abort --plan <PLAN>           # abort a running plan
+
+> Plans are recovered by name from the store `conduct run` recorded, wherever
+> it lives; bare retry/skip/abort auto-detect only when exactly one store on
+> the machine holds plans. `status` also reads worktrees outside the repo.
 ```
 
 ---

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -801,11 +801,13 @@ edda conduct status              # list plans across the repo root and its git w
 edda conduct retry <PHASE> --plan <PLAN>   # reset a failed phase (state found via the registry and worktrees)
 edda conduct skip <PHASE> --plan <PLAN>    # skip a phase
 edda conduct abort --plan <PLAN>           # abort a running plan
+```
 
 > Plans are recovered by name from the store `conduct run` recorded, wherever
 > it lives; bare retry/skip/abort auto-detect only when exactly one store on
 > the machine holds plans. `status` also reads worktrees outside the repo.
-```
+
+---
 
 ---
 


### PR DESCRIPTION
## Summary

Resolves #557. A plan launched with `conduct run` from a directory `plan_stores` cannot enumerate (the plan YAML's own folder — the parallel-wave launch shape — or a worktree) dead-ended every recovery verb.

## History (independent Opus review, 5 rounds — each round's findings fixed)

- R1: stale base reverting GH-714 (P0) → rebuilt on current main
- R2: provenance on destructive verbs, registry wiring, runner-status bucket (P1s)
- R3: **root-cause overturned with evidence** — the incident's store is the plan YAML's own directory; worktree scans can never cover it → store registry implemented
- R4: Windows 8.3-path normalization (P0), registry candidate chain (P0), lock + corrupt-registry error (P1s)
- R5: normalized identity everywhere, registry-first precedence, status --json contract, dry-run purity

## Current design

- `conduct run` records plan → store in a registry (`.edda/conductor/.stores.json`) at every candidate root (invoking shell's root first, then the run cwd's), under an exclusive lock; corrupt registries refuse writes
- `resolve_plan_store` = registries first (authoritative), then the direct repo-root + git-worktree scan, deduped by normalized path identity (canonicalized, UNC-stripped, Windows-only case folding)
- destructive verbs print the resolved store; same-name shadowing warns; >1 contributing store makes bare verbs refuse and require --plan
- `status` lists across stores with provenance; corrupt state files: error on mutation, warn+omit on the read-only overview

## Gate receipt (L1, frozen SHA `677a3cb07d50f7a2c6650c4cec05f17a03dfeda7`, clean tree, worktree `edda-wt-gh557`)

- `cargo fmt --all --check`: OK
- `cargo clippy --workspace --all-targets -- -D warnings`: OK (Windows, stable)
- `cargo test --workspace`: 21 failures, all `edda-bridge-claude` env-var parallel-race (#757, verified pre-existing on main @ df3bd4d, set varies per run); `edda`/`edda-conductor`/`edda-cli` green; `edda` crate 477 passed (11 tests new across rounds)
- `CARGO_INCREMENTAL=0` throughout

Closes #557