### PR TITLE
fix(fleet): one resumable reviewer conversation per PR (GH-708)

### DIFF
--- a/crates/edda-cli/src/agent_kind.rs
+++ b/crates/edda-cli/src/agent_kind.rs
@@ -82,6 +82,17 @@ impl AgentKind {
     pub fn supports_model_listing(self) -> bool {
         matches!(self, AgentKind::Pi)
     }
+
+    /// Whether the backend needs a distinct "continue this conversation"
+    /// spelling (`claude --resume <id>`). Only claude does: it refuses a
+    /// `--session-id` that already exists ("Session ID <id> is already in
+    /// use", exit 1), so repeating the id is a hard failure rather than a
+    /// resume. pi and codex resume by repeating `--session-id` — codex
+    /// through the persisted session→thread map (GH-535) — so `--resume`
+    /// there would claim a switch that does not exist (GH-708).
+    pub fn supports_resume(self) -> bool {
+        matches!(self, AgentKind::Claude)
+    }
 }
 
 // ── Backend × option support matrix (GH-574) ──
@@ -99,6 +110,9 @@ pub(crate) struct DispatchOptions<'a> {
     /// absent — there is no clap default masking explicitness, so nothing
     /// is claimed or dropped for backends that ignore the concept.
     pub permission_mode: Option<&'a str>,
+    /// `--resume`: continue the conversation the session id already names
+    /// (claude only; GH-708).
+    pub resume: bool,
 }
 
 /// Reject unsupported backend/option combinations with an explicit error.
@@ -139,6 +153,11 @@ pub(crate) fn validate_dispatch_options(
             options.permission_mode.map(|m| format!("{m:?}")),
             agent.supports_permission_mode(),
         ),
+        (
+            "--resume",
+            options.resume.then(|| "true".to_owned()),
+            agent.supports_resume(),
+        ),
     ];
     let refused: Vec<String> = unsupported
         .into_iter()
@@ -178,6 +197,10 @@ pub(crate) struct LauncherOptions {
     /// pi `--session-dir` (GH-574). Other backends manage their own session
     /// storage; dispatch rejects the flag for them before reaching here.
     pub session_dir: Option<PathBuf>,
+    /// Continue the conversation the session id already names, instead of
+    /// starting a new one (claude `--resume`; GH-708). Refused for the
+    /// other backends before reaching here.
+    pub resume: bool,
 }
 
 /// Construct and probe (`verify_available`) the launcher for `agent`.
@@ -194,7 +217,9 @@ pub(crate) fn build_launcher(
 ) -> Result<Box<dyn AgentLauncher>> {
     Ok(match agent {
         AgentKind::Claude => {
-            let mut launcher = ClaudeCodeLauncher::new().with_verbose(options.verbose);
+            let mut launcher = ClaudeCodeLauncher::new()
+                .with_verbose(options.verbose)
+                .with_resume(options.resume);
             launcher.transcript_dir = options.transcript_dir;
             launcher.verify_available()?;
             Box::new(launcher)
@@ -251,6 +276,7 @@ mod tests {
             exclude_tools,
             session_dir,
             permission_mode,
+            resume: false,
         }
     }
 

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -241,6 +241,10 @@ pub fn run(
             // Conduct has no session-dir surface (GH-574); pi uses its own
             // default session storage under conduct.
             session_dir: None,
+            // Conduct's session ids are deterministic per plan/phase/attempt
+            // and each attempt is a fresh conversation, so it never resumes
+            // (GH-708). Retries change the attempt, and therefore the id.
+            resume: false,
         },
     )?;
     let engine = CheckEngine::new(cwd.clone());

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -163,6 +163,13 @@ pub struct DispatchOutput {
     /// when it reported nothing. Observed, never inferred from config or
     /// session files (GH-574 honesty rule).
     pub model_observed: String,
+    /// The session id the backend reported in-band, or "unknown" when it
+    /// reported nothing. `session_id` above is what edda ASKED for; this is
+    /// what the backend says it ran. Keeping them apart is the whole point:
+    /// `claude --resume <id>` "starts a copy and says so when the session is
+    /// already running", so echoing the requested id back would report every
+    /// fork as a clean resume (GH-708).
+    pub session_observed: String,
 }
 
 impl DispatchOutput {
@@ -171,6 +178,7 @@ impl DispatchOutput {
         session_id: String,
         model_requested: String,
         model_observed: String,
+        session_observed: String,
     ) -> Self {
         match result {
             PhaseResult::AgentDone {
@@ -184,6 +192,7 @@ impl DispatchOutput {
                 error: None,
                 model_requested,
                 model_observed,
+                session_observed,
             },
             PhaseResult::AgentCrash { error } => Self {
                 outcome: Outcome::Crash,
@@ -193,6 +202,7 @@ impl DispatchOutput {
                 error: Some(error),
                 model_requested,
                 model_observed,
+                session_observed,
             },
             PhaseResult::Timeout => Self {
                 outcome: Outcome::Timeout,
@@ -202,6 +212,7 @@ impl DispatchOutput {
                 error: None,
                 model_requested,
                 model_observed,
+                session_observed,
             },
             PhaseResult::MaxTurns { cost_usd } => Self {
                 outcome: Outcome::MaxTurns,
@@ -211,6 +222,7 @@ impl DispatchOutput {
                 error: None,
                 model_requested,
                 model_observed,
+                session_observed,
             },
             PhaseResult::BudgetExceeded { cost_usd } => Self {
                 outcome: Outcome::BudgetExceeded,
@@ -220,6 +232,7 @@ impl DispatchOutput {
                 error: None,
                 model_requested,
                 model_observed,
+                session_observed,
             },
         }
     }
@@ -240,7 +253,8 @@ impl DispatchOutput {
 
     /// Text-mode stdout: an `Outcome:` line whenever the turn did not
     /// finish, then result text, then `Cost:`, then the model story
-    /// (GH-574), then `Session:`.
+    /// (GH-574), then the session story — `Session:` (asked for) and
+    /// `Session observed:` (what the backend reported, GH-708).
     ///
     /// A failed turn used to render exactly like a successful one — same
     /// `Cost:`/`Session:` summary, nothing naming the failure (GH-669) — so
@@ -262,6 +276,7 @@ impl DispatchOutput {
         out.push_str(&format!("Model requested: {}\n", self.model_requested));
         out.push_str(&format!("Model observed: {}\n", self.model_observed));
         out.push_str(&format!("Session: {}\n", self.session_id));
+        out.push_str(&format!("Session observed: {}\n", self.session_observed));
         out
     }
 
@@ -275,6 +290,7 @@ impl DispatchOutput {
             "error": self.error,
             "model_requested": self.model_requested,
             "model_observed": self.model_observed,
+            "session_observed": self.session_observed,
         })
         .to_string()
     }
@@ -585,11 +601,15 @@ pub async fn run_with_launcher(
     let model_observed = launcher
         .last_observed_model()
         .unwrap_or_else(|| "unknown".to_owned());
+    let session_observed = launcher
+        .last_observed_session()
+        .unwrap_or_else(|| "unknown".to_owned());
     Ok(DispatchOutput::from_result(
         result,
         session_id.to_owned(),
         model_requested,
         model_observed,
+        session_observed,
     ))
 }
 
@@ -739,6 +759,7 @@ mod tests {
             "s".into(),
             "inherited".into(),
             "unknown".into(),
+            "unknown".into(),
         );
         let text = out.render_text();
         assert!(text.contains("Model requested: inherited"), "{text}");
@@ -758,6 +779,7 @@ mod tests {
             "s".into(),
             "openai-codex/gpt-5.6-sol".into(),
             "openai-codex/gpt-5.6-sol".into(),
+            "unknown".into(),
         );
         let text = out.render_text();
         assert!(
@@ -787,9 +809,15 @@ mod tests {
             "s".into(),
             "openai-codex/gpt-5.6-sol".into(),
             "unknown".into(),
+            "unknown".into(),
         );
-        let without_model =
-            DispatchOutput::from_result(result, "s".into(), "inherited".into(), "unknown".into());
+        let without_model = DispatchOutput::from_result(
+            result,
+            "s".into(),
+            "inherited".into(),
+            "unknown".into(),
+            "unknown".into(),
+        );
         assert_ne!(
             with_model.render_text(),
             without_model.render_text(),
@@ -932,12 +960,14 @@ mod tests {
             }),
             result_text: Some(reason.into()),
             model: Some("claude-opus-5[1m]".into()),
+            session_id: None,
         };
         let out = DispatchOutput::from_result(
             classify_result(&monitor, Some(1)),
             "0e92629d-1f2e-597e-90ec-662e206efcde".into(),
             "inherited".into(),
             "claude-opus-5[1m]".into(),
+            "unknown".into(),
         );
 
         assert_eq!(out.exit_code(), 1, "{out:?}");
@@ -986,6 +1016,7 @@ mod tests {
                 "s".into(),
                 "inherited".into(),
                 "unknown".into(),
+                "unknown".into(),
             );
             assert_eq!(
                 exit_code_for(out.outcome),
@@ -1006,6 +1037,7 @@ mod tests {
             },
             "s".into(),
             "inherited".into(),
+            "unknown".into(),
             "unknown".into(),
         );
         assert_eq!(out.exit_code(), 0);
@@ -1043,6 +1075,7 @@ mod tests {
                 "sess-1".into(),
                 "inherited".into(),
                 "unknown".into(),
+                "unknown".into(),
             );
             let value: serde_json::Value =
                 serde_json::from_str(&out.to_json()).expect("json parses");
@@ -1067,7 +1100,8 @@ mod tests {
                     "model_requested",
                     "outcome",
                     "result_text",
-                    "session_id"
+                    "session_id",
+                    "session_observed"
                 ]
             );
         }
@@ -1081,6 +1115,7 @@ mod tests {
             },
             "s".into(),
             "inherited".into(),
+            "unknown".into(),
             "unknown".into(),
         );
         let value: serde_json::Value = serde_json::from_str(&crash.to_json()).unwrap();
@@ -1096,6 +1131,7 @@ mod tests {
             },
             "s".into(),
             "inherited".into(),
+            "unknown".into(),
             "unknown".into(),
         );
         let value: serde_json::Value = serde_json::from_str(&done.to_json()).expect("json parses");
@@ -1117,6 +1153,7 @@ mod tests {
             "abc-123".into(),
             "inherited".into(),
             "unknown".into(),
+            "unknown".into(),
         );
         let text = out.render_text();
         assert!(text.contains("done deal\n"), "{text}");
@@ -1135,6 +1172,7 @@ mod tests {
             PhaseResult::MaxTurns { cost_usd: None },
             "s".into(),
             "inherited".into(),
+            "unknown".into(),
             "unknown".into(),
         );
         let text = out.render_text();
@@ -1165,9 +1203,62 @@ mod tests {
             "my-session-42".into(),
             "inherited".into(),
             "unknown".into(),
+            "unknown".into(),
         );
         assert!(out.render_text().contains("Session: my-session-42"));
         assert!(out.to_json().contains("my-session-42"));
+    }
+
+    /// GH-708: the requested id and the observed one are separate fields
+    /// with separate sources, so a `--resume` that forked instead of
+    /// continuing is visible. Echoing the request into `session_observed`
+    /// would report every fork as a clean resume.
+    #[test]
+    fn requested_and_observed_session_ids_are_reported_separately() {
+        let forked = DispatchOutput::from_result(
+            PhaseResult::AgentDone {
+                cost_usd: None,
+                result_text: None,
+            },
+            "asked-for-42".into(),
+            "inherited".into(),
+            "unknown".into(),
+            "actually-ran-99".into(),
+        );
+        let text = forked.render_text();
+        assert!(text.contains("Session: asked-for-42"), "{text}");
+        assert!(text.contains("Session observed: actually-ran-99"), "{text}");
+        assert!(forked
+            .to_json()
+            .contains("\"session_observed\":\"actually-ran-99\""));
+    }
+
+    /// A backend that reports no session id renders "unknown", never the
+    /// requested id — the same honesty rule `model_observed` follows.
+    #[tokio::test]
+    async fn a_silent_backend_reports_an_unknown_observed_session() {
+        let launcher = MockLauncher::new();
+        let phase = build_phase(
+            "prompt",
+            None,
+            None,
+            "bypassPermissions",
+            CapabilityOptions::default(),
+        );
+        let out = run_with_launcher(
+            &launcher,
+            &phase,
+            "asked-for-42",
+            Path::new("."),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("mock run");
+        assert_eq!(out.session_id, "asked-for-42");
+        assert_eq!(
+            out.session_observed, "unknown",
+            "a launcher that observed nothing must not echo the requested id"
+        );
     }
 
     /// Records the session ids it receives. This proves verbatim delivery

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -35,12 +35,22 @@ pub struct DispatchArgs {
     pub prompt_file: Option<String>,
     /// Session id passed to the backend verbatim. Continuity semantics are
     /// per-backend, and all three persist conversations across invocations:
-    /// claude and pi delegate to their backends, and codex's session→thread
-    /// map is persisted in the per-user edda store (GH-535), so the same id
-    /// resumes the prior codex conversation. Generated and printed when
-    /// omitted so the caller can reuse it on the next call.
+    /// pi delegates to its backend, and codex's session→thread map is
+    /// persisted in the per-user edda store (GH-535), so for both the same
+    /// id resumes the prior conversation. claude is the exception — a
+    /// `--session-id` that already exists is refused ("Session ID <id> is
+    /// already in use"), so a second turn on the same conversation adds
+    /// `--resume` (GH-708). Generated and printed when omitted so the
+    /// caller can reuse it on the next call.
     #[arg(long)]
     pub session_id: Option<String>,
+    /// Continue the conversation `--session-id` names instead of starting a
+    /// new one (claude only, `claude --resume <id>`; GH-708). pi and codex
+    /// resume by repeating `--session-id` alone and refuse this flag rather
+    /// than accept a switch that does nothing. Requires --session-id: there
+    /// is nothing to resume without one.
+    #[arg(long, requires = "session_id")]
+    pub resume: bool,
     /// Working directory for the agent (default: current directory)
     #[arg(long)]
     pub cwd: Option<String>,
@@ -381,6 +391,7 @@ fn run_inner(args: DispatchArgs) -> Result<i32> {
             exclude_tools: args.exclude_tools.as_deref(),
             session_dir: args.session_dir.as_deref(),
             permission_mode: args.permission_mode.as_deref(),
+            resume: args.resume,
         },
     )?;
 
@@ -451,6 +462,7 @@ fn run_inner(args: DispatchArgs) -> Result<i32> {
             // recorded.
             persistent_codex_threads: true,
             session_dir: args.session_dir.as_ref().map(std::path::PathBuf::from),
+            resume: args.resume,
         },
     )?;
     let phase = build_phase(
@@ -1373,6 +1385,68 @@ mod tests {
             .expect_err("codex has no permission-mode concept; the value must be refused");
         assert!(error.to_string().contains("--permission-mode"), "{error}");
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ── GH-708: --resume ──
+
+    #[test]
+    fn resume_requires_a_session_id_to_resume() {
+        // Without an id there is nothing to continue, and claude would pick
+        // "the most recent conversation in this directory" — which for a
+        // review lane is whatever ran there last, not this PR's reviewer.
+        assert!(
+            TestCli::try_parse_from([
+                "edda",
+                "--agent",
+                "claude",
+                "--prompt-file",
+                "p.txt",
+                "--resume"
+            ])
+            .is_err(),
+            "--resume without --session-id must not parse"
+        );
+        let args = parse(&[
+            "edda",
+            "--agent",
+            "claude",
+            "--prompt-file",
+            "p.txt",
+            "--session-id",
+            "7a9c6b1e-0000-4708-8000-000000000001",
+            "--resume",
+        ]);
+        assert!(args.resume);
+        assert_eq!(
+            args.session_id.as_deref(),
+            Some("7a9c6b1e-0000-4708-8000-000000000001")
+        );
+    }
+
+    #[test]
+    fn resume_is_refused_on_backends_that_resume_by_session_id_alone() {
+        for agent in ["pi", "codex"] {
+            let error = validate_dispatch_options(
+                match agent {
+                    "pi" => AgentKind::Pi,
+                    _ => AgentKind::Codex,
+                },
+                &DispatchOptions {
+                    resume: true,
+                    ..Default::default()
+                },
+            )
+            .expect_err("only claude needs a distinct resume spelling");
+            assert!(error.to_string().contains("--resume"), "{error}");
+        }
+        validate_dispatch_options(
+            AgentKind::Claude,
+            &DispatchOptions {
+                resume: true,
+                ..Default::default()
+            },
+        )
+        .expect("claude supports --resume");
     }
 
     // ── End-to-end-ish run through MockLauncher ──

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -484,10 +484,14 @@ enum Command {
     ///   {"outcome":"done|crash|timeout|max_turns|budget_exceeded",
     ///    "result_text":string|null,"cost_usd":number|null,
     ///    "session_id":string,"error":string|null,
-    ///    "model_requested":string,"model_observed":string}
+    ///    "model_requested":string,"model_observed":string,
+    ///    "session_observed":string}
     /// model_requested is the --model value or "inherited"; model_observed
-    /// is what the backend reported in-band or "unknown". --json cannot be
-    /// combined with --list-models (the listing is text) and is refused.
+    /// is what the backend reported in-band or "unknown". session_id is the
+    /// id edda asked for; session_observed is the one the backend reported
+    /// in-band, or "unknown" — they differ when a --resume forked instead of
+    /// continuing. --json cannot be combined with --list-models (the listing
+    /// is text) and is refused.
     Dispatch {
         #[command(flatten)]
         args: cmd_dispatch::DispatchArgs,

--- a/crates/edda-conductor/src/agent/launcher.rs
+++ b/crates/edda-conductor/src/agent/launcher.rs
@@ -51,6 +51,18 @@ pub trait AgentLauncher: Send + Sync {
     fn last_observed_model(&self) -> Option<String> {
         None
     }
+
+    /// The session id the backend reported **in-band** during the most
+    /// recent turn, on the same terms as [`Self::last_observed_model`]: an
+    /// observation, never the id the caller asked for. It matters because
+    /// asking is not getting — `claude --resume <id>` "starts a copy and
+    /// says so when the session is already running", so only the reported
+    /// id says whether a resume continued the conversation or forked it.
+    /// `None` means the backend reported nothing and callers must render
+    /// `"unknown"` (GH-708).
+    fn last_observed_session(&self) -> Option<String> {
+        None
+    }
 }
 
 /// Fixed namespace UUID for conductor sessions.
@@ -88,6 +100,9 @@ pub struct ClaudeCodeLauncher {
     /// In-band model report from the most recent turn (stream-json
     /// `system/init`), for [`AgentLauncher::last_observed_model`].
     observed_model: std::sync::Mutex<Option<String>>,
+    /// In-band session id from the same `system/init` message, for
+    /// [`AgentLauncher::last_observed_session`] (GH-708).
+    observed_session: std::sync::Mutex<Option<String>>,
 }
 
 impl Default for ClaudeCodeLauncher {
@@ -194,6 +209,7 @@ impl ClaudeCodeLauncher {
             transcript_dir: None,
             resume: false,
             observed_model: std::sync::Mutex::new(None),
+            observed_session: std::sync::Mutex::new(None),
         }
     }
 
@@ -204,6 +220,7 @@ impl ClaudeCodeLauncher {
             transcript_dir: None,
             resume: false,
             observed_model: std::sync::Mutex::new(None),
+            observed_session: std::sync::Mutex::new(None),
         }
     }
 
@@ -217,6 +234,12 @@ impl ClaudeCodeLauncher {
     fn record_observed_model(&self, model: Option<String>) {
         if let Ok(mut slot) = self.observed_model.lock() {
             *slot = model;
+        }
+    }
+
+    fn record_observed_session(&self, session: Option<String>) {
+        if let Ok(mut slot) = self.observed_session.lock() {
+            *slot = session;
         }
     }
 
@@ -288,6 +311,10 @@ impl AgentLauncher for ClaudeCodeLauncher {
                 // In-band model observation: whatever the backend itself
                 // reported, or nothing. Never inferred from config.
                 self.record_observed_model(monitor_result.model.clone());
+                // Same terms for the session id: what claude says it ran,
+                // which is the only way to see a --resume that forked
+                // instead of continuing (GH-708).
+                self.record_observed_session(monitor_result.session_id.clone());
                 let exit = child.wait().await?;
                 Ok(classify_result(&monitor_result, exit.code()))
             }
@@ -305,6 +332,13 @@ impl AgentLauncher for ClaudeCodeLauncher {
 
     fn last_observed_model(&self) -> Option<String> {
         self.observed_model
+            .lock()
+            .ok()
+            .and_then(|slot| slot.clone())
+    }
+
+    fn last_observed_session(&self) -> Option<String> {
+        self.observed_session
             .lock()
             .ok()
             .and_then(|slot| slot.clone())
@@ -621,6 +655,17 @@ mod tests {
 
     /// GH-574: the in-band observation starts empty and is only filled by
     /// what the backend itself reports — never from config or session files.
+    /// GH-708: the same rule for the session id. A launcher that has run
+    /// nothing has observed nothing — it must not report the id a caller
+    /// would have passed, or a forked `--resume` would look like a clean one.
+    #[test]
+    fn claude_observed_session_starts_unknown() {
+        let launcher = ClaudeCodeLauncher::with_bin(PathBuf::from("claude"));
+        assert_eq!(launcher.last_observed_session(), None);
+        let resuming = ClaudeCodeLauncher::with_bin(PathBuf::from("claude")).with_resume(true);
+        assert_eq!(resuming.last_observed_session(), None);
+    }
+
     #[test]
     fn claude_observed_model_starts_unknown() {
         let launcher = ClaudeCodeLauncher::with_bin(PathBuf::from("claude"));

--- a/crates/edda-conductor/src/agent/launcher.rs
+++ b/crates/edda-conductor/src/agent/launcher.rs
@@ -78,6 +78,13 @@ pub struct ClaudeCodeLauncher {
     pub verbose: bool,
     /// If set, raw agent stdout is captured to `{transcript_dir}/{phase_id}-{session_id_prefix}.jsonl`.
     pub transcript_dir: Option<PathBuf>,
+    /// Continue the conversation the session id already names instead of
+    /// starting a new one: `claude --resume <id>` rather than
+    /// `claude --session-id <id>` (GH-708). Claude Code refuses a
+    /// `--session-id` that already exists ("Session ID <id> is already in
+    /// use", exit 1), so a caller that wants a second turn on the same
+    /// conversation has no other spelling.
+    pub resume: bool,
     /// In-band model report from the most recent turn (stream-json
     /// `system/init`), for [`AgentLauncher::last_observed_model`].
     observed_model: std::sync::Mutex<Option<String>>,
@@ -102,12 +109,21 @@ impl ClaudeCodeLauncher {
         cwd: &Path,
     ) -> tokio::process::Command {
         let mut cmd = tokio::process::Command::new(&self.claude_bin);
+        // `--session-id` NAMES a new conversation; `--resume` continues the
+        // one already stored under that id. They are mutually exclusive, and
+        // reusing `--session-id` on an existing conversation is an error, not
+        // a resume (GH-708) — so the caller's intent picks the flag.
+        let session_flag = if self.resume {
+            "--resume"
+        } else {
+            "--session-id"
+        };
         cmd.arg("-p")
             .arg(prompt)
             .arg("--verbose")
             .arg("--output-format")
             .arg("stream-json")
-            .arg("--session-id")
+            .arg(session_flag)
             .arg(session_id)
             .arg("--permission-mode")
             .arg(&phase.permission_mode)
@@ -176,6 +192,7 @@ impl ClaudeCodeLauncher {
             claude_bin: PathBuf::from("claude"),
             verbose: false,
             transcript_dir: None,
+            resume: false,
             observed_model: std::sync::Mutex::new(None),
         }
     }
@@ -185,8 +202,16 @@ impl ClaudeCodeLauncher {
             claude_bin,
             verbose: false,
             transcript_dir: None,
+            resume: false,
             observed_model: std::sync::Mutex::new(None),
         }
+    }
+
+    /// Continue the conversation named by the session id instead of
+    /// starting a new one (GH-708).
+    pub fn with_resume(mut self, resume: bool) -> Self {
+        self.resume = resume;
+        self
     }
 
     fn record_observed_model(&self, model: Option<String>) {
@@ -424,6 +449,42 @@ mod tests {
             .expect("test plan parses")
             .phases
             .remove(0)
+    }
+
+    // ── GH-708: a second turn on the same conversation ──
+
+    #[test]
+    fn claude_default_names_a_new_session() {
+        let args = args_of(&claude_command_for("  - id: a\n    prompt: x\n"));
+        let pos = args
+            .iter()
+            .position(|a| a == "--session-id")
+            .expect("--session-id must appear when not resuming");
+        assert_eq!(args[pos + 1], "sess-1");
+        assert!(
+            !args.contains(&"--resume".to_string()),
+            "a non-resuming spawn must not carry --resume: {args:?}"
+        );
+    }
+
+    #[test]
+    fn claude_resume_continues_the_session_instead_of_naming_it() {
+        // Claude Code refuses a --session-id that already exists ("Session
+        // ID <id> is already in use"), so round 2+ of a per-PR reviewer
+        // session must spell the same id as --resume (GH-708).
+        let launcher = ClaudeCodeLauncher::with_bin(PathBuf::from("claude")).with_resume(true);
+        let phase = phase_from_yaml("  - id: a\n    prompt: x\n");
+        let args =
+            args_of(&launcher.build_command(&phase, "do the task", "", "sess-1", Path::new(".")));
+        let pos = args
+            .iter()
+            .position(|a| a == "--resume")
+            .expect("--resume must appear in a resuming claude spawn");
+        assert_eq!(args[pos + 1], "sess-1");
+        assert!(
+            !args.contains(&"--session-id".to_string()),
+            "--resume and --session-id are mutually exclusive: {args:?}"
+        );
     }
 
     #[test]

--- a/crates/edda-conductor/src/agent/stream.rs
+++ b/crates/edda-conductor/src/agent/stream.rs
@@ -72,6 +72,14 @@ pub struct MonitorResult {
     /// if any. In-band observation only — `None` means claude did not
     /// report one (GH-574).
     pub model: Option<String>,
+    /// The session id the backend itself reported in the `system/init`
+    /// message, if any. In-band observation only, on the same terms as
+    /// `model`: it is what claude says it is running, not what the caller
+    /// asked for. The two can differ — `claude --resume <id>` "starts a copy
+    /// and says so when the session is already running" — so a caller that
+    /// wants to know whether a resume actually continued the conversation
+    /// has to compare this against the id it passed (GH-708).
+    pub session_id: Option<String>,
 }
 
 /// Reads Claude Code's `--output-format stream-json` stdout line by line,
@@ -177,12 +185,20 @@ impl StreamMonitor {
             StreamMessage::System { model: Some(m), .. } => Some(m.clone()),
             _ => None,
         });
+        let session_id = self.messages.iter().rev().find_map(|m| match m {
+            StreamMessage::System {
+                session_id: Some(s),
+                ..
+            } => Some(s.clone()),
+            _ => None,
+        });
 
         Ok(MonitorResult {
             total_cost_usd: self.total_cost_usd,
             result: result_info,
             result_text,
             model,
+            session_id,
         })
     }
 }
@@ -413,6 +429,7 @@ mod tests {
             }),
             result_text: None,
             model: None,
+            session_id: None,
         };
         let r = classify_result(&monitor, Some(0));
         assert!(
@@ -433,6 +450,7 @@ mod tests {
             }),
             result_text: None,
             model: None,
+            session_id: None,
         };
         let r = classify_result(&monitor, Some(1));
         assert!(matches!(r, PhaseResult::MaxTurns { .. }));
@@ -451,6 +469,7 @@ mod tests {
             }),
             result_text: None,
             model: None,
+            session_id: None,
         };
         let r = classify_result(&monitor, Some(1));
         assert!(matches!(r, PhaseResult::BudgetExceeded { .. }));
@@ -469,6 +488,7 @@ mod tests {
             }),
             result_text: None,
             model: None,
+            session_id: None,
         };
         let r = classify_result(&monitor, Some(1));
         match r {
@@ -533,6 +553,7 @@ mod tests {
             result_text: info.result_text.clone(),
             result: Some(info),
             model: Some("claude-opus-5[1m]".into()),
+            session_id: None,
         };
         match classify_result(&monitor, Some(1)) {
             PhaseResult::AgentCrash { error } => {
@@ -558,6 +579,7 @@ mod tests {
             }),
             result_text: None,
             model: None,
+            session_id: None,
         };
         match classify_result(&monitor, Some(1)) {
             PhaseResult::AgentCrash { error } => assert!(!error.is_empty()),
@@ -585,6 +607,7 @@ mod tests {
                 }),
                 result_text: None,
                 model: None,
+                session_id: None,
             };
             let classified = classify_result(&monitor, Some(1));
             let ok = matches!(
@@ -609,6 +632,7 @@ mod tests {
             }),
             result_text: None,
             model: None,
+            session_id: None,
         };
         let r = classify_result(&monitor, Some(2));
         assert!(matches!(r, PhaseResult::AgentCrash { .. }));
@@ -621,6 +645,7 @@ mod tests {
             result: None,
             result_text: None,
             model: None,
+            session_id: None,
         };
         let r = classify_result(&monitor, Some(137));
         match r {
@@ -638,6 +663,7 @@ mod tests {
             result: None,
             result_text: None,
             model: None,
+            session_id: None,
         };
         let r = classify_result(&monitor, None);
         match r {

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -111,6 +111,9 @@
    第 1 輪 `--session-id` 開，之後每輪 `--resume` 續，所以第 2 輪只讀 delta
    （`fleet.reviewer-agent` 當初選 pi 就是為了這個性質，GH-708 把它帶進 Opus 路徑）；
    worktree 一輪結束就刪、下輪原地重建（續談與 cwd 無關，實測過）。
+   **前置條件**：lane 的續談用 `edda dispatch --resume`，所以 PATH 上的 `edda` 必須是
+   GH-708 之後建的；舊的 `edda` 第 1 輪照跑，第 2 輪會因未知旗標失敗（大聲失敗、標
+   `review:unreviewed`，不會產生假判決）。`cargo install --path crates/edda-cli --force` 更新。
    檢查方式：`Get-ScheduledTask edda-pr-review-watcher`、`tail ~/.edda/fleet/watch.log`、PR 留言與 label。
    provider 過載時：同模型探測通過後重試一次（同一 `edda dispatch --agent claude` 運輸），仍沒有判決就標
    `review:unreviewed` 並對該 head 停手
@@ -163,7 +166,7 @@ Brief 必含：assigned build lane、verification budget（L0 while iterating；
 | 規則 | 決策 key |
 |---|---|
 | 執行用便宜模型（pi 預設 glm-5.3-flash）；**審查一律 Claude Opus**（`claude-opus-5`，顯式 `--model` 釘死，正常臂走 `edda dispatch --agent claude` 訂閱運輸——本機 pi/openrouter 到不了任何 Anthropic 模型；brief 超出 spawn 上限的 fallback 走唯讀 allowlist 的 `claude -p` stdin，表頭印實際臂） | `fleet.review-engine-model`、`fleet.review-backend`（supersede `fleet.agent-model-split` 的審查半邊） |
-| 審查 provider 過載：**改運輸不降模型**——(1) 同 `--model` 先用最低成本探測，通了才重試一次（同一 claude 訂閱運輸）；(2) 仍沒有判決就對該 head 標 `review:unreviewed` 並停——未審查是誠實狀態，便宜模型的判決不是。watcher 無 Codex 路線（superseding 決策 `…codex-route-withdrawn-for-automated-watcher`：Codex 對 watcher 做不到唯讀；人類控制者仍可手動用 Codex）。**GH-708 註記：此決策原文的 `edda dispatch --agent codex` 降級步驟與「審查一律 Opus」矛盾——codex 跑不了 Opus；程式碼無 codex 路線，等待操作者改判** | `fleet.review-provider-overload` |
+| 審查 provider 過載：**改運輸不降模型**——(1) 同 `--model` 先用最低成本探測，通了才重試一次（同一 claude 訂閱運輸）；(2) 仍沒有判決就對該 head 標 `review:unreviewed` 並停——未審查是誠實狀態，便宜模型的判決不是。watcher 無 Codex 路線（superseding 決策 `…codex-route-withdrawn-for-automated-watcher`：Codex 對 watcher 做不到唯讀；人類控制者仍可手動用 Codex）。**2026-09-03 操作者裁決（`opus-default-sol-via-pi-fallback-no-codex`）：不是矛盾，是過時——Opus 是預設引擎，`fleet.review-engine-pool` 的錨仍是 sol（走 pi）；codex 自 `fleet.reviewer-agent` 起就不是審查運輸。watcher 自己不換模型，降到錨引擎是操作者動作** | `fleet.review-provider-overload` |
 | **lane 啟動走 Task Scheduler，不走 nohup／Start-Process**：Claude Code 的工具 shell 在 Windows Job Object 裡，nohup 的子程序仍隨 session 死。`Register-ScheduledTask` + `Start-ScheduledTask`（父程序是 svchost）；該環境 `HOME` 為空，lane wrapper 必須顯式設；`CARGO_TARGET_DIR` 只在 `-BuildLane` 指名四個允許 build lane 之一時設（不編譯的 session 沒有 build lane——`.claude/CLAUDE.md`、`verification.cost-discipline`；要編譯的必須給四擇一，launcher 拒絕其他名字）。`lane-launch.ps1` 不合成 build lane：`-BuildLane` 只收 `worker-1|worker-2|verifier|verifier-2`，設 `CARGO_TARGET_DIR`＝lane root（`$env:LOCALAPPDATA\fleet-workstation\lanes`，可用 `FLEET_LANE_ROOT` 改）\`<BuildLane>`；docs lane 不傳，wrapper 不設。`Get-ScheduledTaskInfo` 可輪詢，`Unregister-ScheduledTask` 清理。重派前先讀 worktree／branch／PR 狀態，不信任 live handle。**手續已脚本化**：用 `scripts/fleet/lane-launch.ps1` 註冊起 lane、`scripts/fleet/lane-status.ps1` 盯狀態（用法見 START HERE），不要再手寫 wrapper | `fleet.lane-launch`、`fleet.lane-dispatch` |
 | **停 lane 一律走 `scripts/fleet/lane-stop.ps1 -Name <lane>`**：`Stop-ScheduledTask` 與 `Unregister-ScheduledTask` 都只終止任務的 wrapper，**不殺它 spawn 的 process tree**（GH-672：被「停」的 lane 照樣 commit／push／開 PR，任務卻顯示 `State = Ready`）。`lane-stop.ps1` 停任務、殺整棵樹（wrapper 已死時依 `CommandLine` 比對 wrapper／brief 路徑抓孤兒）、驗證無殘留、回報實際終止了什麼，並補寫結束記錄（done-file + lane log 的 `=== EXIT ===` 行）——wrapper 本身也在 `finally` 寫同樣的結束記錄，所以正常結束、出錯、被停三種 endings 都有 EXIT | `fleet.lane-stop-4090` |
 | 一 issue ＝ 一單 phase plan ＝ 一 worktree ＝ 一 build lane；並行在 plan 之間；plan 裡不寫沒理由的 `depends_on`；並行 plan 不用 verdict gate | `cleanup.parallel-exec`、`cleanup.review-gate` |

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -105,8 +105,12 @@
    worktree 在 `$EDDA_FLEET_SCRATCH/wt-review-prN`；brief 超過 Windows 32767 字元 spawn 上限時，
    lane 的 fallback 以唯讀工具集 `--allowedTools "Read,Glob,Grep,Bash"` 經 `claude -p` stdin 跑同一份 brief，
    判決留言表頭印的是 `.done` `TRANSPORT=` 收據上的實際臂）並貼確認留言 `review: started on <full sha>`；
-   判決（含 observed model、cost、釘死的 head SHA）在審查者跑完後（約 5–15 分鐘）自動貼上 PR，
+   判決（含 observed model、cost、`reviewer_session`、釘死的 head SHA）在審查者跑完後（約 5–15 分鐘）自動貼上 PR，
    並加 label `review:lgtm`／`review:changes-requested`；push 後 head 變了自動再審一輪。
+   **一張 PR 一個審查者對話**：session id 由 PR 編號推導（`SHA-1("edda-review-pr<N>")` 排成 v5 UUID），
+   第 1 輪 `--session-id` 開，之後每輪 `--resume` 續，所以第 2 輪只讀 delta
+   （`fleet.reviewer-agent` 當初選 pi 就是為了這個性質，GH-708 把它帶進 Opus 路徑）；
+   worktree 一輪結束就刪、下輪原地重建（續談與 cwd 無關，實測過）。
    檢查方式：`Get-ScheduledTask edda-pr-review-watcher`、`tail ~/.edda/fleet/watch.log`、PR 留言與 label。
    provider 過載時：同模型探測通過後重試一次（同一 `edda dispatch --agent claude` 運輸），仍沒有判決就標
    `review:unreviewed` 並對該 head 停手

--- a/docs/guides/pr-review-watcher.md
+++ b/docs/guides/pr-review-watcher.md
@@ -16,6 +16,9 @@
    - 在 `$EDDA_FLEET_SCRATCH/wt-review-prN` 建立/更新 **--sha 指定那個 SHA** 的 detached
      worktree；若 PR head 已經移走（第二次讀 head 只用來拒審，不用來選審什麼）就拒絕、
      下一輪掃描重來——審什麼由 watcher 掃描當下釘死，不會有兩次獨立讀 head 的 race；
+     這個 worktree **一輪結束就由 lane 移除**（判決那時已經在 log 裡），下一輪在同一個
+     路徑重建；每次啟動前先 `git worktree prune`（GH-708：曾經累積 14 個沒清掉的
+     `wt-review-pr*`）；
    - Windows 上照決策 `fleet.lane-launch` 用 Task Scheduler 起隱藏排程任務
      `edda-review-prN-rR`（wrapper 設 `HOME`、UTF-8；父程序是 svchost，不受
      session 的 Job Object 牽連）；Linux 上退化成 `nohup`。
@@ -34,6 +37,29 @@
    都成功才記 state**；留言失敗就保留判決檔、下一輪重貼（重試 5 次仍失敗 →
    label `review:post-failed`）。
 4. head 被 push 之後（SHA 變了）自動再審一輪（round+1，delta brief，`prev-sha` 帶入）。
+
+## 一張 PR 一個審查者對話（GH-708）
+
+`fleet.reviewer-agent=pi-with-per-pr-resumable-session` 當初選 pi 只為一個量到的性質：
+**per-PR 的審查者 session 可以續**，所以第 2 輪以後只讀 delta，不用重讀整張 PR。
+換成 Claude Opus 之後這個性質必須留著，作法是把 session id **從 PR 編號推導**：
+
+- id ＝ `SHA-1("edda-review-pr<N>")` 排成 name-based（v5）UUID，
+  例如 PR #740 → `435cc101-9d69-56ca-878d-e454d6725f1a`。
+  跨機器、跨輪、跨重跑都一樣，也不可能撞到實作者的 session（`review.independence-policy`）。
+- **開新的 vs 續舊的看磁碟，不看輪次**：`~/.claude/projects/*/<uuid>.jsonl` 存在就續
+  （輪次是 2 但第 1 輪根本沒建起 session 的情況也有）。`review-pr.sh --dry-run` 會印
+  `session=` 與 `session_mode=new|resume`。
+- 兩條運輸的拼法不同，這是最容易寫錯的地方：
+  `edda dispatch` 保留 `--session-id <id>` 再加 `--resume`（旗標要求要有 id）；
+  `claude -p` 則是把 `--session-id` **換成** `--resume <id>`——在那裡兩者互斥，而且
+  重複用同一個 `--session-id` 不是續談，是直接失敗：`Session ID <id> is already in use`。
+- 續談與 cwd 無關（GH-708 實測：從無關目錄 `--resume` 一樣續得到，而且是**同一個**
+  transcript 繼續長，不會多出一個檔），所以 lane 每輪刪掉又重建 worktree 不影響它。
+- 判決表頭帶 `reviewer_session`：watcher 那一行印的是 lane 記在 `.done` 的
+  `SESSION=`／`SESSION_MODE=`（**發起時**的事實），並跟 log 裡後端自己回報的
+  `Session:` 行對照；兩者不一致代表這輪其實沒跑在該續的對話裡，表頭會直接寫出來
+  （`BACKEND REPORTED ...`），不會拿發起值蓋過去。
 
 ## Provider 過載怎麼辦（v1：無 codex 後備）
 

--- a/docs/guides/pr-review-watcher.md
+++ b/docs/guides/pr-review-watcher.md
@@ -57,11 +57,20 @@
 - 續談與 cwd 無關（GH-708 實測：從無關目錄 `--resume` 一樣續得到，而且是**同一個**
   transcript 繼續長，不會多出一個檔），所以 lane 每輪刪掉又重建 worktree 不影響它。
 - 判決表頭帶 `reviewer_session`：watcher 那一行印的是 lane 記在 `.done` 的
-  `SESSION=`／`SESSION_MODE=`（**發起時**的事實），並跟 log 裡後端自己回報的
-  `Session:` 行對照；兩者不一致代表這輪其實沒跑在該續的對話裡，表頭會直接寫出來
-  （`BACKEND REPORTED ...`），不會拿發起值蓋過去。
+  `SESSION=`／`SESSION_MODE=`（**發起時**的事實），並跟 log 裡的
+  `Session observed:` 行對照 —— 那一行是**後端自己回報**的（`edda dispatch` 取自
+  claude stream-json 的 `system/init`，fallback 臂取自 claude 的 JSON `session_id`），
+  跟 `Session:`（我們要求的 id）是兩個不同來源。兩者不一致代表這輪沒跑在該續的
+  對話裡（`claude --resume` 在 session 已在跑時會「開一份副本並說明」），表頭直接
+  寫出來（`BACKEND REPORTED ...`）；後端什麼都沒回報就是 `unknown`，不會假裝相符。
 
 ## Provider 過載怎麼辦（v1：無 codex 後備）
+
+> 決策現值：`fleet.review-provider-overload=opus-default-sol-via-pi-fallback-no-codex`
+> （操作者裁決 2026-09-03）。Opus 是**預設**審查引擎，不是唯一——`fleet.review-engine-pool`
+> 的錨仍是 `gpt-5.6-sol`（走 pi）。但 watcher 自己**永遠不換模型**：降到錨引擎是操作者的
+> 動作，自動路徑到 `review:unreviewed` 就停。codex 這條運輸自 `fleet.reviewer-agent`
+> 起就不用於審查（做不到唯讀，也到不了 Opus）。
 
 判決死掉或空白（log 沒有 verdict 區塊、zero-byte log、或超過 45 分鐘沒有 `.done`）時：
 
@@ -125,8 +134,8 @@ sh scripts/test-pr-review-watch.sh         # 離線測試：審/跳過決策 + v
 | `review-acks.tsv` | `pr<TAB>sha<TAB>attempts<TAB>status`——已啟動但 ack 未貼出的 head；成功即移除；3 次失敗 → 加 `review:post-failed`，條目標記 `post-failed`（終態）；label 呼叫也失敗則條目保留、下一輪重試 |
 | `review-fails.tsv` | `pr<TAB>sha<TAB>count`——連續啟動失敗次數（連續 3 次 → `review:unreviewed` 並停） |
 | `watch.log` | watcher 每一步的時間戳紀錄 |
-| `review-prN-rR-brief.md` / `.log` / `.done` / `-verdict.md`（`.posted`） / `-comment.md` | 每輪審查的 brief、審查者轉錄（`edda dispatch` 輸出，或 oversized-brief fallback 的 claude stdin 輸出）、結束旗標（`TRANSPORT=<實際走的臂>` ＋ `DISPATCH_EXIT=<code>`）、抽出來的判決（`.posted` = 留言已貼出）、貼出的留言 |
-| `wt-review-prN/` | 該 PR 的 detached worktree |
+| `review-prN-rR-brief.md` / `.log` / `.done` / `-verdict.md`（`.posted`） / `-comment.md` | 每輪審查的 brief、審查者轉錄（`edda dispatch` 輸出，或 oversized-brief fallback 的 claude stdin 輸出）、結束旗標（`TRANSPORT=<實際走的臂>`、`SESSION=<uuid>`、`SESSION_MODE=new|resume`、`DISPATCH_EXIT=<code>`）、抽出來的判決（`.posted` = 留言已貼出）、貼出的留言 |
+| `wt-review-prN/` | 該 PR 的 detached worktree；一輪結束由 lane 移除，下輪原地重建 |
 
 ## Labels（watcher 啟動時自動建立，缺了才建）
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -667,7 +667,10 @@ edda dispatch --agent <AGENT> --prompt-file <FILE> [OPTIONS]
 | `--json` | Print exactly one JSON object to stdout instead of text lines |
 
 With `--json` the object has the shape
-`{"outcome":"done\|crash\|timeout\|max_turns\|budget_exceeded", "result_text":string\|null, "cost_usd":number\|null, "session_id":string, "error":string\|null}`.
+`{"outcome":"done\|crash\|timeout\|max_turns\|budget_exceeded", "result_text":string\|null, "cost_usd":number\|null, "session_id":string, "error":string\|null, "model_requested":string, "model_observed":string, "session_observed":string}`.
+`session_id` is the id edda asked for; `session_observed` is the one the
+backend reported in-band, or `"unknown"`. They differ when a `--resume` forked
+instead of continuing, which is the only way to see that from outside.
 
 Exit codes:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -658,7 +658,8 @@ edda dispatch --agent <AGENT> --prompt-file <FILE> [OPTIONS]
 |--------|-------------|
 | `--agent AGENT` | Backend that runs the turn: `claude` (default), `pi`, or `codex` |
 | `--prompt-file FILE` | Path to the file containing the prompt, read verbatim (required) |
-| `--session-id ID` | Session id passed to the backend verbatim; generated and printed when omitted so the caller can reuse it on the next call |
+| `--session-id ID` | Session id passed to the backend verbatim; generated and printed when omitted so the caller can reuse it on the next call. pi and codex resume a prior conversation by repeating the id; claude refuses an id that already exists (`Session ID <id> is already in use`) and needs `--resume` |
+| `--resume` | Continue the conversation `--session-id` names instead of starting a new one (`claude --resume <id>`). claude only — pi and codex resume by repeating `--session-id` alone and refuse this flag. Requires `--session-id` |
 | `--cwd DIR` | Working directory for the agent (default: current directory) |
 | `--budget-usd N` | Per-turn budget in USD (codex cannot enforce budgets) |
 | `--timeout-sec S` | Turn timeout in seconds (default: 1800, like a conduct phase) |

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -270,6 +270,29 @@ session_model_cost() { # $1=log file -> sets REQ, OBSERVED, COST, SIDO
   [ -n "${SIDO:-}" ] || SIDO="unknown"
 }
 
+# The reviewer conversation this round ran in, as a header fragment. Two
+# independent facts are compared, never merged (GH-708): SESSION=/SESSION_MODE=
+# are what review-pr.sh LAUNCHED with, and $2 is the id the backend REPORTED
+# in its own receipt. Round 2+ of a PR is supposed to continue round 1's
+# conversation, so a disagreement means the resume silently forked into a new
+# one — printed as the defect it is instead of quietly showing the launched id.
+reviewer_session_desc() { # $1=.done file  $2=session id observed in the log
+  sid=$(sed -n 's/^SESSION=//p' "$1" 2>/dev/null | tail -1)
+  mode=$(sed -n 's/^SESSION_MODE=//p' "$1" 2>/dev/null | tail -1)
+  [ -n "${sid:-}" ] || sid=${2:-unknown}
+  case "${mode:-}" in
+    resume) mdesc=resumed ;;
+    new)    mdesc=new ;;
+    *)      mdesc='mode unknown — no SESSION_MODE receipt in .done' ;;
+  esac
+  if [ -n "${2:-}" ] && [ "$2" != "unknown" ] && [ -n "${sid:-}" ] && [ "$2" != "$sid" ]; then
+    printf '`%s` (%s; BACKEND REPORTED `%s` — this round did not run in the launched conversation)' \
+      "$sid" "$mdesc" "$2"
+  else
+    printf '`%s` (%s)' "$sid" "$mdesc"
+  fi
+}
+
 pr_is_open() { # $1=pr
   [ "$(gh pr view "$1" --repo "$REPO" --json state --jq .state 2>/dev/null)" = "OPEN" ]
 }
@@ -421,7 +444,7 @@ settle_pending() {
         esac
         COMMENT="$SCRATCH/review-pr$pr-r$round-comment.md"
         {
-          echo "> **Round $round review** — automatic watcher (\`scripts/pr-review-watch.sh\`): transport \`$tdesc\`, model \`$REQ\` (observed \`$OBSERVED\`), session \`$SIDO\`, $costline, read-only, detached worktree at \`$sha\`. Reviewed head SHA: \`$sha\`."
+          echo "> **Round $round review** — automatic watcher (\`scripts/pr-review-watch.sh\`): transport \`$tdesc\`, model \`$REQ\` (observed \`$OBSERVED\`), reviewer_session $(reviewer_session_desc "$DONE" "$SIDO"), $costline, read-only, detached worktree at \`$sha\`. Reviewed head SHA: \`$sha\`."
           echo
           cat "$VERDICT"
         } > "$COMMENT"

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -30,17 +30,19 @@
 #   review-fails.tsv     pr<TAB>sha<TAB>consecutive launch failures
 #   watch.log            everything the watcher did
 #
-# Provider-overload rule, v1 (no Codex fallback — it cannot be made read-only;
-# fleet.review-provider-overload=…codex-route-withdrawn-for-automated-watcher):
+# Provider-overload rule, v1 (no Codex fallback — it cannot be made read-only,
+# and it cannot reach Opus either; fleet.review-provider-overload=
+# opus-default-sol-via-pi-fallback-no-codex, operator ruling 2026-09-03):
 # on a dead/empty verdict, retry the review once through the same dispatch
 # transport with the same model; if that also yields no verdict, label the PR
-# `review:unreviewed`, log it, and stop for that head. model_requested /
-# model_observed / cost are read from the dispatch transcript — the `Model
-# requested:` / `Model observed:` / `Cost:` lines `edda dispatch` prints — and
-# are NEVER fabricated; a missing line is reported as unknown.
-# (GH-708: the decision text's `edda dispatch --agent codex` fallback step
-# cannot run Opus — that contradiction awaits an operator re-ruling; the code
-# has no codex path.)
+# `review:unreviewed`, log it, and stop for that head. Opus is the DEFAULT
+# review engine, not the only one — the pool's anchor is still gpt-5.6-sol via
+# pi — but the watcher itself never changes model: dropping to the anchor is an
+# operator action, so the automated path stops at `review:unreviewed`.
+# model_requested / model_observed / cost are read from the dispatch
+# transcript — the `Model requested:` / `Model observed:` / `Cost:` lines
+# `edda dispatch` prints — and are NEVER fabricated; a missing line is
+# reported as unknown.
 #
 # review:unreviewed is per head: it blocks only while the PR's current head
 # equals the head recorded as unreviewed. A new head drops the label and is
@@ -263,7 +265,13 @@ session_model_cost() { # $1=log file -> sets REQ, OBSERVED, COST, SIDO
   REQ=$(printf '%s\n' "$t" | sed -n 's/^Model requested: //p' | tail -1)
   OBSERVED=$(printf '%s\n' "$t" | sed -n 's/^Model observed: //p' | tail -1)
   COST=$(printf '%s\n' "$t" | sed -n 's/^Cost: \$\([0-9.]*\)$/\1/p' | tail -1)
-  SIDO=$(printf '%s\n' "$t" | sed -n 's/^Session: //p' | tail -1)
+  # `Session observed:` is the backend's OWN report of the conversation it ran
+  # (dispatch prints `last_observed_session()` from claude's stream-json
+  # `system/init`; the fallback arm prints claude's JSON `session_id`). The
+  # `Session:` line above it is only the id edda asked for, so reading THAT one
+  # here would compare the launched id with itself and never see a fork
+  # (GH-708 round 1, P1). A reviewer that reported none stays "unknown".
+  SIDO=$(printf '%s\n' "$t" | sed -n 's/^Session observed: //p' | tail -1)
   [ -n "${REQ:-}" ] || REQ="unknown"
   [ -n "${OBSERVED:-}" ] || OBSERVED="unknown"
   [ -n "${COST:-}" ] || COST="?"
@@ -273,9 +281,11 @@ session_model_cost() { # $1=log file -> sets REQ, OBSERVED, COST, SIDO
 # The reviewer conversation this round ran in, as a header fragment. Two
 # independent facts are compared, never merged (GH-708): SESSION=/SESSION_MODE=
 # are what review-pr.sh LAUNCHED with, and $2 is the id the backend REPORTED
-# in its own receipt. Round 2+ of a PR is supposed to continue round 1's
-# conversation, so a disagreement means the resume silently forked into a new
-# one — printed as the defect it is instead of quietly showing the launched id.
+# in-band (`Session observed:`), which is a different source, not an echo.
+# Round 2+ of a PR is supposed to continue round 1's conversation, so a
+# disagreement means the resume forked into a new one — printed as the defect
+# it is instead of quietly showing the launched id. A reviewer that reported
+# no observation at all leaves `$2` "unknown", which claims nothing.
 reviewer_session_desc() { # $1=.done file  $2=session id observed in the log
   sid=$(sed -n 's/^SESSION=//p' "$1" 2>/dev/null | tail -1)
   mode=$(sed -n 's/^SESSION_MODE=//p' "$1" 2>/dev/null | tail -1)

--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -6,6 +6,12 @@
 # and explicitly pinned with --model; reviews run on the Claude subscription
 # because pi's openrouter routing cannot reach any Anthropic model — GH-708).
 #
+# One reviewer conversation per PR, resumed across rounds
+# (fleet.reviewer-agent=pi-with-per-pr-resumable-session, carried over to the
+# claude transport by GH-708): the session id is derived from the PR number,
+# so round 1 opens it with --session-id and every later round continues it
+# with --resume and reads only the delta.
+#
 # The brief is BUILT BY READING REVIEW.md, the repo's executable review spec.
 # This script contributes only the PR's facts (head SHA, surface, the linked
 # issue's doneWhen); every review rule, severity, check command, the class
@@ -46,8 +52,13 @@
 #                                  `Model observed:` / `Cost:` lines follow it)
 #   review-pr<N>-r<R>.done         written when the dispatch exits
 #                                  ("TRANSPORT=<arm>" naming the arm that
-#                                  actually ran, then "DISPATCH_EXIT=<code>")
-#   wt-review-pr<N>/               detached worktree at the PR head
+#                                  actually ran, "SESSION=<uuid>",
+#                                  "SESSION_MODE=new|resume", then
+#                                  "DISPATCH_EXIT=<code>")
+#   wt-review-pr<N>/               detached worktree at the PR head, removed by
+#                                  the lane once the round's verdict is in the
+#                                  log and recreated at the same path next
+#                                  round
 #
 # --dry-run generates the brief and prints what would be launched, but does not
 # create the worktree, register the scheduled task, or start any process.
@@ -250,27 +261,65 @@ if [ -z "$CLASSES" ] || [ -z "$CANON_CLASS" ]; then
   exit 1
 fi
 
-# ---- session id -------------------------------------------------------------
+# ---- reviewer session id: one resumable conversation per PR -----------------
 # The claude backend (`claude -p`) accepts only valid UUIDs: the old
 # `review-pr$PR` shape made every launch die with "Invalid session ID. Must be
 # a valid UUID." (issue #694's second half, walked into by GH-708's transport
-# switch). A fresh UUID v4 per launch; rounds are SHA-pinned independent
-# reviews, not resumed conversations.
-gen_uuid() {
-  r=$(od -An -N16 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')
-  if [ "${#r}" -ne 32 ]; then
-    echo "review-pr.sh: cannot read 16 random bytes for a session UUID" >&2
+# switch).
+#
+# The id is DERIVED FROM THE PR NUMBER, not random, so every round of PR #N
+# lands in the same reviewer conversation and round 2+ reads only the delta —
+# the measured property `fleet.reviewer-agent=pi-with-per-pr-resumable-session`
+# chose pi for, and which GH-708's transport switch must not give up. It is a
+# name-based UUID (RFC 4122 §4.3 layout: SHA-1 digest, version nibble 5,
+# variant 10xx) over the literal `edda-review-pr<N>`, so it is stable across
+# machines, rounds and reruns, and can never collide with an implementer's
+# session id (`review.independence-policy`).
+review_session_uuid() { # $1 = PR number
+  if command -v sha1sum >/dev/null 2>&1; then
+    h=$(printf 'edda-review-pr%s' "$1" | sha1sum | cut -d' ' -f1)
+  elif command -v shasum >/dev/null 2>&1; then
+    h=$(printf 'edda-review-pr%s' "$1" | shasum -a 1 | cut -d' ' -f1)
+  else
+    echo "review-pr.sh: neither sha1sum nor shasum found — cannot derive the reviewer session UUID" >&2
     exit 1
   fi
-  # version nibble -> 4, variant nibble -> a (10xx)
-  printf '%s-%s-4%s-a%s-%s\n' \
-    "$(printf '%s' "$r" | cut -c 1-8)" \
-    "$(printf '%s' "$r" | cut -c 9-12)" \
-    "$(printf '%s' "$r" | cut -c 14-16)" \
-    "$(printf '%s' "$r" | cut -c 18-20)" \
-    "$(printf '%s' "$r" | cut -c 21-32)"
+  if [ "${#h}" -lt 32 ]; then
+    echo "review-pr.sh: SHA-1 of the session name is too short ('$h')" >&2
+    exit 1
+  fi
+  # Variant nibble: (digit & 0x3) | 0x8, i.e. the RFC's 10xx bits.
+  case $(printf '%s' "$h" | cut -c17) in
+    0|4|8|c) v=8 ;;
+    1|5|9|d) v=9 ;;
+    2|6|a|e) v=a ;;
+    3|7|b|f) v=b ;;
+    *) echo "review-pr.sh: SHA-1 digest is not hex ('$h')" >&2; exit 1 ;;
+  esac
+  printf '%s-%s-5%s-%s%s-%s\n' \
+    "$(printf '%s' "$h" | cut -c1-8)" \
+    "$(printf '%s' "$h" | cut -c9-12)" \
+    "$(printf '%s' "$h" | cut -c14-16)" \
+    "$v" \
+    "$(printf '%s' "$h" | cut -c18-20)" \
+    "$(printf '%s' "$h" | cut -c21-32)"
 }
-SID=$(gen_uuid)
+SID=$(review_session_uuid "$PR")
+
+# New conversation or continued one? Claude Code refuses a `--session-id` that
+# already exists ("Session ID <id> is already in use", exit 1), so the two are
+# different flags and the choice must be made from what is actually on disk —
+# not from the round number, which is 2 both when round 1 produced a session
+# and when round 1 died before creating one. The session store is keyed by the
+# launch cwd, so the glob spans every project dir; resume itself is
+# cwd-independent (verified GH-708: a `--resume` from an unrelated directory
+# still continued the conversation and kept appending to the SAME transcript),
+# which is why deleting and recreating the per-PR worktree between rounds does
+# not break it.
+SESSION_MODE=new
+for f in "$HOME/.claude/projects"/*/"$SID.jsonl"; do
+  if [ -f "$f" ]; then SESSION_MODE=resume; break; fi
+done
 
 # ---- brief: PR facts + REVIEW.md verbatim (fleet.review-brief-framing) ------
 BRIEF="$SCRATCH/review-pr$PR-r$ROUND-brief.md"
@@ -280,6 +329,11 @@ BRIEF="$SCRATCH/review-pr$PR-r$ROUND-brief.md"
   echo "You stand in a detached worktree at PR head **$SHA** (branch \`$BR\`). The workspace ledger is reachable (\`edda ask\` works). Title: $TITLE. Issue(s): ${ISSUES:-none}. Files changed by the PR: ${SURFACE:-none}"
   if [ -n "$PREV" ]; then
     echo "This is a DELTA round: your prior verdict on $PREV is posted on the PR; review \`git diff $PREV..$SHA\` and RAN-confirm each prior finding is resolved; do not re-review the whole PR."
+    if [ "$SESSION_MODE" = "resume" ]; then
+      echo "You are the SAME reviewer session that produced it (\`$SID\`, resumed), so your earlier rounds are above this message — read the delta, not the PR."
+    else
+      echo "NOTE: the reviewer session \`$SID\` carries no prior transcript, so the earlier rounds are NOT in your context — read your posted verdict on $PREV from the PR before judging the delta."
+    fi
   fi
   echo
   echo "## The spec you run"
@@ -321,6 +375,9 @@ BRIEF="$SCRATCH/review-pr$PR-r$ROUND-brief.md"
   echo "…the rest exactly as REVIEW.md §7 specifies (model_requested: $MODEL, spec: $SPEC_VERSION, class: $CANON_CLASS)…"
   echo "VERDICT>>>"
   echo
+  echo "Add one field to that header, directly under \`model_observed\`, so a reader can tell which reviewer conversation judged this round (GH-708):"
+  echo "\`reviewer_session: $SID\` (this round: **$SESSION_MODE**)"
+  echo
   echo "---"
   echo
   echo "(End of brief — the spec itself is at \`.edda-review-spec.md\` in the worktree root, from $SPEC_SOURCE.)"
@@ -334,6 +391,8 @@ echo "classes=${CLASSES:-code-plain}"
 echo "canonical_class=$CANON_CLASS"
 echo "spec=$SPEC_SOURCE ($SPEC_VERSION)"
 echo "base=$BASE_SHA"
+echo "session=$SID"
+echo "session_mode=$SESSION_MODE"
 
 # ---- what would be launched: lane script + exact -File argument -------------
 # Both launchers are GENERATED BEFORE the dry-run exit so the whole transport
@@ -348,6 +407,17 @@ DONE="$SCRATCH/review-pr$PR-r$ROUND.done"
 LANE="$SCRATCH/review-pr$PR-r$ROUND-lane.ps1"
 LANE_FILE_ARG=$LANE
 RUNNER="$SCRATCH/review-pr$PR-r$ROUND-run.sh"
+
+# The two arms spell "continue this conversation" differently: `edda dispatch`
+# keeps --session-id and adds --resume (which requires it), while `claude -p`
+# swaps --session-id for --resume — there they are mutually exclusive, and a
+# repeated --session-id is a hard error rather than a resume (GH-708).
+DISPATCH_SESSION_ARGS="--session-id '$SID'"
+CLAUDE_SESSION_ARGS="--session-id '$SID'"
+if [ "$SESSION_MODE" = "resume" ]; then
+  DISPATCH_SESSION_ARGS="--session-id '$SID' --resume"
+  CLAUDE_SESSION_ARGS="--resume '$SID'"
+fi
 if [ "$IS_WIN" = "1" ]; then
   command -v cygpath >/dev/null 2>&1 || { echo "review-pr.sh: cygpath not found" >&2; exit 1; }
   WTW=$(cygpath -w "$WT")
@@ -356,6 +426,11 @@ if [ "$IS_WIN" = "1" ]; then
   DONEW=$(cygpath -w "$DONE")
   ERRW=$(cygpath -w "$DONE.err")
   LANE_FILE_ARG=$(cygpath -w "$LANE")
+  SCRATCHW=$(cygpath -w "$SCRATCH")
+  # Empty only when the main checkout could not be located; the launch path
+  # refuses that case below, and a dry-run never runs the lane.
+  ROOTW=""
+  [ -n "$ROOT" ] && ROOTW=$(cygpath -w "$ROOT")
   # Resolve pwsh to a full Windows path for the task action: on a Store (MSIX)
   # install the bare "pwsh.exe" execution alias does not launch under Task
   # Scheduler — the task dies with LastTaskResult=0x80070002 before the lane
@@ -376,6 +451,19 @@ if [ "$IS_WIN" = "1" ]; then
 \$OutputEncoding = [System.Text.UTF8Encoding]::new(\$false)
 \$env:HOME = \$env:USERPROFILE
 Set-Location '$WTW'
+function Remove-ReviewWorktree {
+  # The verdict is in the log by the time this runs, so the detached worktree
+  # has served its purpose. Left behind, they accumulate: 14 stale
+  # wt-review-pr* trees sat on this workstation when GH-708 was written. The
+  # path stays per-PR and is recreated at the same place next round, which
+  # does not break --resume (verified: resume is cwd-independent and keeps
+  # appending to the same transcript). --force because the launcher copies
+  # the untracked .edda-review-spec.md into the tree. A failure here (a file
+  # still locked, say) must not change the round's exit code.
+  if ('$ROOTW' -eq '') { return }
+  Set-Location '$SCRATCHW'
+  & git -C '$ROOTW' worktree remove --force '$WTW' 2>&1 | Out-Null
+}
 # edda dispatch hands the prompt to 'claude -p' as a command-line argument,
 # and Windows caps a command line at 32767 chars — an oversized prompt dies in
 # the spawn with os error 206 before claude starts. The brief stays far under
@@ -389,13 +477,17 @@ Set-Location '$WTW'
 # prints that receipt verbatim instead of a hardcoded transport.
 \$briefChars = (Get-Content -Raw "$BRIEFW").Length
 if (\$briefChars -lt 30000) {
-  & edda dispatch --agent claude --model '$MODEL' --exclude-tools 'Edit,Write,NotebookEdit' --session-id '$SID' --prompt-file "$BRIEFW" 2>&1 | Out-File -FilePath "$LOGW" -Encoding utf8
+  & edda dispatch --agent claude --model '$MODEL' --exclude-tools 'Edit,Write,NotebookEdit' $DISPATCH_SESSION_ARGS --prompt-file "$BRIEFW" 2>&1 | Out-File -FilePath "$LOGW" -Encoding utf8
+  \$code = \$LASTEXITCODE
   "TRANSPORT=edda-dispatch" | Out-File "$DONEW" -Encoding utf8
-  "DISPATCH_EXIT=\$LASTEXITCODE" | Out-File "$DONEW" -Append -Encoding utf8
-  exit \$LASTEXITCODE
+  "SESSION=$SID" | Out-File "$DONEW" -Append -Encoding utf8
+  "SESSION_MODE=$SESSION_MODE" | Out-File "$DONEW" -Append -Encoding utf8
+  "DISPATCH_EXIT=\$code" | Out-File "$DONEW" -Append -Encoding utf8
+  Remove-ReviewWorktree
+  exit \$code
 }
 \$raw = Get-Content -Raw "$BRIEFW"
-\$json = \$raw | & claude -p --model '$MODEL' --output-format json --session-id '$SID' --allowedTools 'Read,Glob,Grep,Bash' --disallowedTools 'Edit,Write,NotebookEdit' 2>"$ERRW"
+\$json = \$raw | & claude -p --model '$MODEL' --output-format json $CLAUDE_SESSION_ARGS --allowedTools 'Read,Glob,Grep,Bash' --disallowedTools 'Edit,Write,NotebookEdit' 2>"$ERRW"
 \$code = \$LASTEXITCODE
 \$r = \$null
 try { \$r = \$json | ConvertFrom-Json } catch { }
@@ -416,7 +508,10 @@ if (\$r -and \$r.result) {
 }
 if (Test-Path "$ERRW") { Get-Content "$ERRW" | Add-Content -Path "$LOGW" -Encoding utf8; Remove-Item "$ERRW" -ErrorAction SilentlyContinue }
 "TRANSPORT=claude-stdin" | Out-File "$DONEW" -Encoding utf8
+"SESSION=$SID" | Out-File "$DONEW" -Append -Encoding utf8
+"SESSION_MODE=$SESSION_MODE" | Out-File "$DONEW" -Append -Encoding utf8
 "DISPATCH_EXIT=\$code" | Out-File "$DONEW" -Append -Encoding utf8
+Remove-ReviewWorktree
 exit \$code
 PS
 else
@@ -425,18 +520,29 @@ else
 #!/bin/sh
 export HOME="\${HOME:-$(getent passwd "\$(id -u)" 2>/dev/null | cut -d: -f6)}"
 cd '$WT' || exit 1
+# Same lifecycle as the Windows lane's Remove-ReviewWorktree (see there): the
+# verdict is in the log once the reviewer exits, so the detached worktree is
+# removed rather than left to accumulate. Never changes the round's exit code.
+remove_review_worktree() {
+  [ -n '$ROOT' ] || return 0
+  cd '$SCRATCH' || return 0
+  git -C '$ROOT' worktree remove --force '$WT' >/dev/null 2>&1 || true
+}
 # Same size guard as the Windows lane (see there): edda dispatch while the
 # brief fits the Windows-shaped spawn budget, the read-only-allowlisted
 # claude-via-stdin fallback above it. TRANSPORT= names the arm that ran.
 chars=\$(wc -m < '$BRIEF')
 if [ "\$chars" -lt 30000 ]; then
-  edda dispatch --agent claude --model '$MODEL' --exclude-tools Edit,Write,NotebookEdit --session-id '$SID' --prompt-file '$BRIEF' > '$LOG' 2>&1
+  edda dispatch --agent claude --model '$MODEL' --exclude-tools Edit,Write,NotebookEdit $DISPATCH_SESSION_ARGS --prompt-file '$BRIEF' > '$LOG' 2>&1
   code=\$?
   echo "TRANSPORT=edda-dispatch" > '$DONE'
+  echo "SESSION=$SID" >> '$DONE'
+  echo "SESSION_MODE=$SESSION_MODE" >> '$DONE'
   echo "DISPATCH_EXIT=\$code" >> '$DONE'
+  remove_review_worktree
   exit \$code
 fi
-claude -p --model '$MODEL' --output-format json --session-id '$SID' --allowedTools Read,Glob,Grep,Bash --disallowedTools Edit,Write,NotebookEdit < '$BRIEF' > '$LOG.json' 2>'$LOG.err'
+claude -p --model '$MODEL' --output-format json $CLAUDE_SESSION_ARGS --allowedTools Read,Glob,Grep,Bash --disallowedTools Edit,Write,NotebookEdit < '$BRIEF' > '$LOG.json' 2>'$LOG.err'
 code=\$?
 if command -v jq >/dev/null 2>&1; then
   jq -r '.result // empty' '$LOG.json' > '$LOG'
@@ -458,7 +564,10 @@ fi
 [ -f '$LOG.err' ] && cat '$LOG.err' >> '$LOG'
 rm -f '$LOG.json' '$LOG.err'
 echo "TRANSPORT=claude-stdin" > '$DONE'
+echo "SESSION=$SID" >> '$DONE'
+echo "SESSION_MODE=$SESSION_MODE" >> '$DONE'
 echo "DISPATCH_EXIT=\$code" >> '$DONE'
+remove_review_worktree
 exit \$code
 RUN
   sh -n "$RUNNER" || exit 1
@@ -485,6 +594,11 @@ command -v edda >/dev/null 2>&1 || {
 }
 
 # ---- detached worktree at the PR head ---------------------------------------
+# Prune first: the lane removes its worktree when the round ends, so a
+# registration whose directory is gone is either that removal (recorded but
+# not yet pruned) or a tree deleted by hand. Either way `worktree add` at the
+# same per-PR path would refuse it as "already registered" (GH-708).
+git -C "$ROOT" worktree prune
 git -C "$ROOT" fetch -q origin "$BR"
 if [ -d "$WT" ]; then
   git -C "$WT" checkout -q --detach "$SHA"

--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -304,7 +304,7 @@ review_session_uuid() { # $1 = PR number
     "$(printf '%s' "$h" | cut -c18-20)" \
     "$(printf '%s' "$h" | cut -c21-32)"
 }
-SID=$(review_session_uuid "$PR")
+SID=$(review_session_uuid "$PR") || exit 1
 
 # New conversation or continued one? Claude Code refuses a `--session-id` that
 # already exists ("Session ID <id> is already in use", exit 1), so the two are
@@ -502,7 +502,8 @@ if (\$r -and \$r.result) {
     # "0,33", which the watcher's [0-9.]* pattern drops to cost: unknown.
     Add-Content -Path "$LOGW" -Value ("Cost: \$" + [math]::Round(\$r.total_cost_usd, 2).ToString([System.Globalization.CultureInfo]::InvariantCulture)) -Encoding utf8
   }
-  Add-Content -Path "$LOGW" -Value "Session: \$(\$r.session_id)" -Encoding utf8
+  Add-Content -Path "$LOGW" -Value "Session: $SID" -Encoding utf8
+  Add-Content -Path "$LOGW" -Value "Session observed: \$(\$r.session_id)" -Encoding utf8
 } else {
   \$json | Out-File -FilePath "$LOGW" -Encoding utf8
 }
@@ -550,7 +551,9 @@ if command -v jq >/dev/null 2>&1; then
   printf 'Model requested: %s\n' '$MODEL' >> '$LOG'
   printf 'Model observed: %s\n' "\$mu" >> '$LOG'
   jq -r 'if .total_cost_usd != null then "Cost: \$" + ((.total_cost_usd * 100 | round) / 100 | tostring) else empty end' '$LOG.json' >> '$LOG'
-  jq -r '"Session: " + (.session_id // "")' '$LOG.json' >> '$LOG'
+  printf 'Session: %s
+' '$SID' >> '$LOG'
+  jq -r '"Session observed: " + (.session_id // "unknown")' '$LOG.json' >> '$LOG'
 else
   # No jq is not a silent degradation into a dead verdict: name the fault in
   # the log the watcher reads, keep the raw JSON for diagnosis, and fail the

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -522,6 +522,49 @@ grep -qF 'transport `unknown — no TRANSPORT receipt in .done`' "$cfile" || {
     printf 'live: a missing TRANSPORT receipt must render as unknown, not a guessed transport, got header:\n%s\n' "$(head -1 "$cfile")" >&2
     exit 1
 }
+export GH_HEAD="$sha"
+
+# --- live loop: the header names the reviewer conversation (GH-708) ------------
+# The per-PR reviewer session is what makes round 2+ a delta review, so the
+# verdict header carries it. Two independent facts are compared, never merged:
+# SESSION=/SESSION_MODE= are what review-pr.sh LAUNCHED with, and the log's
+# `Session:` line is what the backend REPORTED. A disagreement means the resume
+# forked into a fresh conversation, and the header must say so.
+
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+printf 'TRANSPORT=edda-dispatch\nSESSION=11111111-2222-4333-8444-555555555555\nSESSION_MODE=resume\nDISPATCH_EXIT=0\n' \
+    >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
+verdict_log_fixture
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (header: session)\n' >&2; exit 1; }
+cfile=$(header_comment_path)
+grep -qF 'reviewer_session `11111111-2222-4333-8444-555555555555` (resumed)' "$cfile" || {
+    printf 'live: header must name the resumed reviewer conversation, got header:\n%s\n' "$(head -1 "$cfile")" >&2
+    exit 1
+}
+
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+printf 'TRANSPORT=edda-dispatch\nSESSION=99999999-8888-4777-8666-555555555555\nSESSION_MODE=resume\nDISPATCH_EXIT=0\n' \
+    >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
+verdict_log_fixture
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (header: session mismatch)\n' >&2; exit 1; }
+cfile=$(header_comment_path)
+grep -qF 'BACKEND REPORTED `11111111-2222-4333-8444-555555555555`' "$cfile" || {
+    printf 'live: a resume that ran in a different conversation must be reported, not hidden, got header:\n%s\n' "$(head -1 "$cfile")" >&2
+    exit 1
+}
+
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+printf 'TRANSPORT=edda-dispatch\nDISPATCH_EXIT=0\n' >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
+verdict_log_fixture
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (header: no session receipt)\n' >&2; exit 1; }
+cfile=$(header_comment_path)
+grep -qF 'mode unknown — no SESSION_MODE receipt in .done' "$cfile" || {
+    printf 'live: a missing SESSION_MODE receipt must render as unknown, got header:\n%s\n' "$(head -1 "$cfile")" >&2
+    exit 1
+}
 unset GH_HEAD
 
 # --- offline guarantee: the real watcher log was never touched -----------------

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -480,6 +480,13 @@ verdict_log_fixture() {
         printf '## Code Review: Round 1 — PR #42 @ %s\n\n### Verdict\nLGTM (P0=0, P1=0)\n' "$sha"
         printf 'VERDICT>>>\n'
         printf 'Model requested: claude-opus-5\nModel observed: claude-opus-5\nCost: $0.33\nSession: 11111111-2222-4333-8444-555555555555\n'
+        # The backend's OWN report of the conversation it ran, which is what
+        # the header cross-checks against the launched SESSION= (GH-708).
+        # FIXTURE_NO_SESSION_OBSERVED=1 fixtures a reviewer that reported none.
+        if [ "${FIXTURE_NO_SESSION_OBSERVED:-0}" != "1" ]; then
+            printf 'Session observed: %s\n' \
+                "${FIXTURE_SESSION_OBSERVED:-11111111-2222-4333-8444-555555555555}"
+        fi
     } >"$EDDA_FLEET_SCRATCH/review-pr42-r1.log"
 }
 
@@ -545,15 +552,37 @@ grep -qF 'reviewer_session `11111111-2222-4333-8444-555555555555` (resumed)' "$c
 
 reset_stubs
 pending_set 42 1 "$sha" 0 0
-printf 'TRANSPORT=edda-dispatch\nSESSION=99999999-8888-4777-8666-555555555555\nSESSION_MODE=resume\nDISPATCH_EXIT=0\n' \
+printf 'TRANSPORT=edda-dispatch\nSESSION=11111111-2222-4333-8444-555555555555\nSESSION_MODE=resume\nDISPATCH_EXIT=0\n' \
     >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
+FIXTURE_SESSION_OBSERVED=99999999-8888-4777-8666-555555555555
 verdict_log_fixture
+FIXTURE_SESSION_OBSERVED=
 run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (header: session mismatch)\n' >&2; exit 1; }
 cfile=$(header_comment_path)
-grep -qF 'BACKEND REPORTED `11111111-2222-4333-8444-555555555555`' "$cfile" || {
+grep -qF 'BACKEND REPORTED `99999999-8888-4777-8666-555555555555`' "$cfile" || {
     printf 'live: a resume that ran in a different conversation must be reported, not hidden, got header:\n%s\n' "$(head -1 "$cfile")" >&2
     exit 1
 }
+
+# A reviewer that reported no session at all claims no agreement either: the
+# launched id is rendered plainly, with no mismatch and no invented match.
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+printf 'TRANSPORT=edda-dispatch\nSESSION=11111111-2222-4333-8444-555555555555\nSESSION_MODE=resume\nDISPATCH_EXIT=0\n' \
+    >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
+FIXTURE_NO_SESSION_OBSERVED=1
+verdict_log_fixture
+FIXTURE_NO_SESSION_OBSERVED=0
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (header: no observation)\n' >&2; exit 1; }
+cfile=$(header_comment_path)
+grep -qF 'reviewer_session `11111111-2222-4333-8444-555555555555` (resumed)' "$cfile" || {
+    printf 'live: a reviewer that observed no session must render the launched id plainly, got header:\n%s\n' "$(head -1 "$cfile")" >&2
+    exit 1
+}
+if grep -qF 'BACKEND REPORTED' "$cfile"; then
+    printf 'live: no observation is not a mismatch — the header must not claim one, got header:\n%s\n' "$(head -1 "$cfile")" >&2
+    exit 1
+fi
 
 reset_stubs
 pending_set 42 1 "$sha" 0 0

--- a/scripts/test-review-pr.sh
+++ b/scripts/test-review-pr.sh
@@ -469,8 +469,19 @@ grep -q 'function Remove-ReviewWorktree' "$lane" \
 if [ "$(grep -c 'Remove-ReviewWorktree$' "$lane")" -lt 2 ]; then
     fail 'D9i: the lane does not remove the worktree on both arms'
 fi
-grep -q 'worktree prune' "$root/scripts/review-pr.sh" \
+# Anchored at the start of a line so the assertion cannot be satisfied by the
+# comment block above the call (round 1 P2: the loose grep matched prose).
+grep -qE '^[[:space:]]*git -C "\$ROOT" worktree prune' "$root/scripts/review-pr.sh" \
     || fail 'D9i: review-pr.sh does not prune stale worktree registrations before adding one at the same per-PR path'
+
+# D9j (round 1 P1): the id the watcher cross-checks must be the backend's OWN
+# report, not an echo of the one we launched with — a comparison of a value
+# with itself can never fire. Both arms therefore record the launched id AND
+# the observed one, on separate lines from separate sources.
+grep -q -- 'Session observed: ' "$lane" \
+    || fail 'D9j: the fallback arm records no `Session observed:` line, so the watcher has nothing to cross-check the launched id against'
+grep -q -- "Session: $EXPECTED_SID_9999" "$lane" \
+    || fail 'D9j: the fallback arm no longer records the launched session id alongside the observed one'
 
 # --- offline guarantee: the real fleet scratch carries none of our output -----
 # Only our own fixture PR is asserted, not the whole listing: a live watcher or

--- a/scripts/test-review-pr.sh
+++ b/scripts/test-review-pr.sh
@@ -156,6 +156,23 @@ dry_run() { # $1 = body text
     brief="$EDDA_FLEET_SCRATCH/review-pr$FIXTURE_PR-r1-brief.md"
 }
 
+# Same, for a specific round — and optionally under a HOME whose Claude
+# session store decides whether the round opens a session or resumes one.
+dry_run_round() { # $1=body  $2=round  $3=prev sha (may be empty)  $4=HOME (may be empty)
+    case_number=$((case_number + 1))
+    printf '%b' "$1" >"$tmp/body"
+    export GH_BODY_FILE="$tmp/body"
+    rm -f "$EDDA_FLEET_SCRATCH/review-pr$FIXTURE_PR-"* 2>/dev/null || true
+    out=$(HOME="${4:-$HOME}" timeout 60 sh "$root/scripts/review-pr.sh" \
+            "$FIXTURE_PR" "$2" ${3:+"$3"} --dry-run 2>"$tmp/err") || {
+        printf 'review-pr.sh --dry-run (round %s) exited non-zero; stderr:\n%s\n' \
+            "$2" "$(cat "$tmp/err")" >&2
+        return 1
+    }
+    brief="$EDDA_FLEET_SCRATCH/review-pr$FIXTURE_PR-r$2-brief.md"
+    lane="$EDDA_FLEET_SCRATCH/review-pr$FIXTURE_PR-r$2-lane.ps1"
+}
+
 field() { printf '%s\n' "$out" | sed -n "s/^$1=//p"; }
 
 # --- D1 (#683): the -File argument the scheduled task will receive ------------
@@ -297,8 +314,8 @@ if ! grep -q '(read-only, claude-opus-5, session ' "$brief"; then
 fi
 sid=$(sed -n 's/.*session \([0-9a-f-]*\))/\1/p' "$brief" | head -1)
 case "$sid" in
-    ????????-????-4???-[89ab]???-????????????) : ;;
-    *) fail "D5b: the session id is not a valid UUID v4 — the claude backend rejects anything else (GH-694 second half): $sid" ;;
+    ????????-????-5???-[89ab]???-????????????) : ;;
+    *) fail "D5b: the session id is not a valid name-based (v5) UUID — the claude backend rejects anything that is not a UUID at all (GH-694 second half), and GH-708 requires it to be derived from the PR number: $sid" ;;
 esac
 lane="$EDDA_FLEET_SCRATCH/review-pr$FIXTURE_PR-r1-lane.ps1"
 if [ ! -f "$lane" ]; then
@@ -375,6 +392,85 @@ grep -q 'TRANSPORT=edda-dispatch' "$lane" \
     || fail 'D8g: the dispatch arm writes no TRANSPORT=edda-dispatch receipt — the verdict header cannot name the transport that actually ran'
 grep -q 'TRANSPORT=claude-stdin' "$lane" \
     || fail 'D8h: the fallback arm writes no TRANSPORT=claude-stdin receipt'
+
+# --- D9 (GH-708 scope addition): one resumable reviewer conversation per PR ---
+# fleet.reviewer-agent=pi-with-per-pr-resumable-session chose pi for one
+# measured property: a per-PR reviewer session that RESUMES, so round 2+ reads
+# the delta instead of the whole PR. The claude transport must keep it. The id
+# is therefore derived from the PR number (identical every round, never the
+# implementer's), round 1 opens the conversation and later rounds continue it —
+# and the two backends spell "continue" differently, which is the part a
+# string-level change silently gets wrong.
+
+# D9a: derivation is deterministic and pinned. If the name string ever changes,
+# every PR's reviewer conversation silently forks; this is the tripwire.
+EXPECTED_SID_9999=0dc98ad1-d4ae-5321-b81b-b249644368c6   # SHA-1("edda-review-pr9999"), v5 layout
+dry_run_round 'Issue: #650\n' 1 '' ''
+if [ "$(field session)" != "$EXPECTED_SID_9999" ]; then
+    fail "D9a: the reviewer session id for PR $FIXTURE_PR is $(field session), not the derived $EXPECTED_SID_9999"
+fi
+if [ "$(field session_mode)" != "new" ]; then
+    fail "D9a: a PR with no recorded reviewer conversation must open one (session_mode=new), got $(field session_mode)"
+fi
+grep -q -- "--session-id '$EXPECTED_SID_9999'" "$lane" \
+    || fail 'D9b: round 1 does not open the conversation with --session-id'
+if grep -qE '(edda dispatch|claude -p) .*--resume' "$lane"; then
+    fail 'D9b: round 1 asks to resume a conversation that does not exist yet — claude exits 1 with "No conversation found"'
+fi
+grep -q "SESSION=$EXPECTED_SID_9999" "$lane" \
+    || fail 'D9c: the lane writes no SESSION= receipt, so the watcher cannot report which conversation ran'
+grep -q 'SESSION_MODE=new' "$lane" \
+    || fail 'D9c: the lane writes no SESSION_MODE= receipt'
+grep -q "reviewer_session: $EXPECTED_SID_9999" "$brief" \
+    || fail 'D9d: the brief does not tell the reviewer to carry reviewer_session in the REVIEW.md §7 header'
+
+# The same id on the next round — that is the whole point of deriving it.
+dry_run_round 'Issue: #650\n' 2 'cccccccccccccccccccccccccccccccccccccccc' ''
+if [ "$(field session)" != "$EXPECTED_SID_9999" ]; then
+    fail "D9e: round 2 uses a different reviewer session ($(field session)) — rounds would not accumulate context"
+fi
+
+# D9f: with the conversation on disk, both arms must switch to the resume
+# spelling — `edda dispatch` keeps --session-id and ADDS --resume (it requires
+# the id), while `claude -p` REPLACES --session-id with --resume. Reusing
+# --session-id there is not a resume: claude exits 1, "Session ID <id> is
+# already in use".
+FAKE_HOME="$tmp/home"
+mkdir -p "$FAKE_HOME/.claude/projects/C--some-worktree"
+: >"$FAKE_HOME/.claude/projects/C--some-worktree/$EXPECTED_SID_9999.jsonl"
+dry_run_round 'Issue: #650\n' 2 'cccccccccccccccccccccccccccccccccccccccc' "$FAKE_HOME"
+if [ "$(field session_mode)" != "resume" ]; then
+    fail "D9f: a recorded reviewer conversation was not resumed (session_mode=$(field session_mode))"
+fi
+grep -q -- "edda dispatch .*--session-id '$EXPECTED_SID_9999' --resume" "$lane" \
+    || fail 'D9f: the dispatch arm does not continue the recorded conversation (--session-id <id> --resume)'
+grep -q -- "claude -p .*--resume '$EXPECTED_SID_9999'" "$lane" \
+    || fail 'D9f: the fallback arm does not continue the recorded conversation (--resume <id>)'
+if grep -q -- "claude -p .*--session-id" "$lane"; then
+    fail 'D9f: the fallback arm still names the session with --session-id while resuming — claude refuses an id that already exists'
+fi
+grep -q 'SESSION_MODE=resume' "$lane" \
+    || fail 'D9f: the resumed round writes no SESSION_MODE=resume receipt'
+if ! grep -q 'SAME reviewer session' "$brief"; then
+    fail 'D9g: a resumed delta round does not tell the reviewer its earlier rounds are in context'
+fi
+
+# D9h: a delta round whose conversation is NOT on disk must say so rather than
+# let the reviewer assume a context it does not have.
+dry_run_round 'Issue: #650\n' 2 'cccccccccccccccccccccccccccccccccccccccc' ''
+if ! grep -q 'carries no prior transcript' "$brief"; then
+    fail 'D9h: a delta round with no recorded conversation does not warn that the earlier rounds are missing from context'
+fi
+
+# D9i: the per-PR worktree is removed when the round ends and pruned before the
+# next one — 14 stale wt-review-pr* trees were the reason (GH-708 comment).
+grep -q 'function Remove-ReviewWorktree' "$lane" \
+    || fail 'D9i: the lane defines no worktree removal'
+if [ "$(grep -c 'Remove-ReviewWorktree$' "$lane")" -lt 2 ]; then
+    fail 'D9i: the lane does not remove the worktree on both arms'
+fi
+grep -q 'worktree prune' "$root/scripts/review-pr.sh" \
+    || fail 'D9i: review-pr.sh does not prune stale worktree registrations before adding one at the same per-PR path'
 
 # --- offline guarantee: the real fleet scratch carries none of our output -----
 # Only our own fixture PR is asserted, not the whole listing: a live watcher or


### PR DESCRIPTION
Issue: #708

Second tranche of #708. #720 moved the shipped review path onto Claude Opus; the operator's scope-addition comments on the issue (2026-09-03 02:25Z / 02:37Z) are what remained: **the per-PR reviewer session must resume**, and the review worktree must not accumulate.

## Why #720 could not keep the resumable session

`fleet.reviewer-agent=pi-with-per-pr-resumable-session` chose pi for one measured property — round 2+ reads only the delta instead of the whole PR. The claude transport as merged gives that up: `review-pr.sh` mints a **fresh UUID v4 per launch**, and its comment says so outright ("rounds are SHA-pinned independent reviews, not resumed conversations").

It had no alternative, because two things were missing:

```
$ edda dispatch --agent claude --session-id 0dc98ad1-…-000000000001 --prompt-file p2.txt --json
{"outcome":"crash","error":"agent exited with code 1 without result", …}
```

Claude Code refuses a `--session-id` that already exists (`Session ID <id> is already in use`), and `edda dispatch` had no `--resume`. So a stable per-PR id under the merged code would have crashed **every round after the first** — the pre-fix FAIL receipt for this half of the issue. (The first half's receipt still reproduces verbatim: `pi -p --model openrouter/anthropic/claude-opus-5 …` → `404 … quantization: fp8`, rc=1.)

The `--session-id` help text also claimed all three backends resume on a repeated id. They do not; claude is the exception.

## What changed

**`edda dispatch --resume`** (claude only, requires `--session-id`) spawns `claude --resume <id>` in place of `--session-id <id>`. pi and codex resume by repeating the id, so they **refuse** the flag rather than accept a switch that does nothing — the GH-574 honesty gate, one more row. `edda conduct` passes `resume: false`: its ids are per plan/phase/attempt, and a retry changes the attempt.

**`review-pr.sh` derives the reviewer session id from the PR number** — `SHA-1("edda-review-pr<N>")` in the RFC 4122 §4.3 v5 layout, e.g. PR #740 → `435cc101-9d69-56ca-878d-e454d6725f1a`. Stable across machines, rounds and reruns; cannot collide with an implementer's session (`review.independence-policy`).

**New-vs-resume is decided from the on-disk transcript, not the round number.** Round 2 is round 2 both when round 1 produced a session and when round 1 died before creating one; only `~/.claude/projects/*/<uuid>.jsonl` distinguishes them. Both spellings are generated correctly, and they differ per arm — `edda dispatch` keeps `--session-id` and *adds* `--resume`; `claude -p` *replaces* it.

**The reviewer session is observed, not echoed.** `MonitorResult` now carries the `session_id` from claude's stream-json `system/init` (the message was already parsed; the field just never surfaced), `AgentLauncher::last_observed_session()` exposes it on the same terms as `last_observed_model()`, and `edda dispatch` prints `Session observed:` / `session_observed` beside the requested id. Both lane arms record both lines and the watcher compares them, so a `--resume` that forked — `claude --resume` "starts a copy and says so when the session is already running" — is reported (`BACKEND REPORTED …`) instead of being invisible.

**Worktree lifecycle**: the lane removes `wt-review-pr<N>` once the round's verdict is in the log, and `review-pr.sh` prunes stale registrations before adding one at the same path. Resume is cwd-independent (below), so recreating it next round is safe.

## Verification (RAN, this workstation)

| Claim | Command | Result |
|---|---|---|
| pre-fix: repeating `--session-id` crashes | `edda dispatch --agent claude --session-id <id> …` (2nd turn) | `outcome=crash`, `agent exited with code 1 without result` |
| the fix resumes | same + `--resume` | `outcome=done`, `result_text="DISPATCH-708"` — round 1's codeword recalled |
| same conversation, not a fork | `find ~/.claude/projects -name '<id>.jsonl'` | one file, grown to 23 lines |
| delta rounds are cheaper | round 1 vs round 2 `cost_usd` | **$0.2154 → $0.0245** (and $0.22 → $0.02 on the second pair) |
| model pinned, requested + observed | `--json` | `model_requested=claude-opus-5`, `model_observed=claude-opus-5` |
| the observed session is a real observation | `claude -p --resume <A> --fork-session --output-format stream-json` | `system/init` reported `0aa32ab5-…` while `<A>` was `0dc98ad1-…` — the field diverges from the argument, so the fork guard is reachable |
| resume survives worktree deletion | delete + recreate the cwd, then `--resume` | codeword recalled |
| resume is cwd-independent | `--resume` from an unrelated directory | codeword recalled, same transcript grew |
| worktree removal takes the Windows path form | `git worktree remove --force "$(cygpath -w …)"` against a `/`-registered worktree | rc=0, worktree gone (round 1 P2 disproved by measurement) |
| pi/codex refuse the flag | `edda dispatch --agent pi --resume …` | `agent "pi" does not support: --resume true` |

Gates on `d6701ab`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (`CARGO_INCREMENTAL=0`), `sh scripts/lint-markdown-content.sh`, `sh scripts/test-review-pr.sh` (19 cases), `sh scripts/test-pr-review-watch.sh`. Baseline for the two shell suites was recorded green on `df3bd4d` before the first edit. `edda-bridge-claude`'s env-var tests fail on this machine regardless of this diff (GH-646 / #719, non-hermetic under concurrent agents; the crate depends on neither touched crate, and the failure count varies run to run).

New offline fixtures: `D9a`–`D9j` in `test-review-pr.sh` (derivation pinned to a literal so a changed name string cannot silently fork every PR's conversation; round-1 opens, round-2 resumes, both arms' spellings, the `.done` receipts, the brief's `reviewer_session`, both session lines, worktree removal + an anchored prune assertion) and four watcher cases (resumed header, fork detection driven by the observed line, no-observation, missing receipt). Rust: 4 new tests for the flag, the argv selection and the requested-vs-observed split.

## Round 1 review (isolated sub-agent, `Changes Requested`, P0=0 P1=1) — answered in `d6701ab`

- **P1** the `reviewer_session` cross-check compared the launched id against an echo of itself on the `edda dispatch` arm. Confirmed at `cmd_dispatch.rs:430 → :590 → :264`. Fixed by making the observed id a real in-band reading (above), with the fork case demonstrated against a live backend.
- **P2** the installed `edda` has no `--resume` → runbook now states the lane needs an `edda` built at or after this commit; an older one fails the resume round loudly (`review:unreviewed`), never with a false verdict.
- **P2** `D9i` asserted text that a comment could satisfy → anchored to the command line. The related worry that `git worktree remove` might silently no-op on the `cygpath -w` path was measured and disproved.
- **P2** `exit 1` inside `SID=$(review_session_uuid …)` only left the subshell → `|| exit 1`.

## Out of scope, resolved by the operator

1. **`fleet.review-provider-overload`** — ruled 2026-09-03: not a contradiction, an outdated reading. Opus is the *default* engine; `fleet.review-engine-pool`'s anchor is still `gpt-5.6-sol` via pi, and codex has not been a review transport since `fleet.reviewer-agent`. Recorded as `opus-default-sol-via-pi-fallback-no-codex`; the watcher itself still never changes model — dropping to the anchor is an operator action.
2. **`REVIEW.md` §7 does not name `reviewer_session`** — correctly not bundled here; tracked as #756 (docs lane: add the field, bump the spec version, assert it in fixtures).
3. **The 14 stale `wt-review-pr*` worktrees** predating this change — swept: 12 merged removed, the one belonging to open #717 left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
