### PR TITLE
fix(scripts): pr-review-launch resolves pwsh.exe to an absolute path and DryRun fails on non-zero LastTaskResult (GH-694)

### DIFF
--- a/scripts/pr-review-launch.ps1
+++ b/scripts/pr-review-launch.ps1
@@ -66,7 +66,13 @@ Set-Location '$RepoRoot'
 exit `$LASTEXITCODE
 "@ | Out-File -FilePath $Wrapper -Encoding utf8
 
-$action = New-ScheduledTaskAction -Execute "pwsh.exe" `
+# Resolve pwsh.exe to an absolute path: Task Scheduler cannot resolve the
+# bare name when pwsh is a Store/WindowsApps install (GH-694; same fix as
+# scripts/fleet/lane-launch.ps1).
+$PwshExe = (Get-Command pwsh.exe -ErrorAction SilentlyContinue).Source
+if (-not $PwshExe) { throw "pwsh.exe not found on PATH; cannot register the task" }
+
+$action = New-ScheduledTaskAction -Execute $PwshExe `
   -Argument "-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$Wrapper`"" `
   -WorkingDirectory $RepoRoot
 $trigger = New-ScheduledTaskTrigger -AtLogOn -User "$env:USERDOMAIN\$env:USERNAME"  # any-user trigger needs admin
@@ -92,6 +98,13 @@ if ($DryRun) {
   "LastRunTime=$($info.LastRunTime) LastTaskResult=$($info.LastTaskResult)"
   Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
   "task=$TaskName unregistered (dry-run)"
+  # A non-zero LastTaskResult means the task died (e.g. 0x80070002 when the
+  # Execute path is unresolvable) — fail loudly so -DryRun cannot silently
+  # pass a broken registration (GH-694).
+  if ($info.LastTaskResult -ne 0) {
+    "dry-run FAILED: LastTaskResult=$($info.LastTaskResult) (0x{0:X8}) - task did not complete successfully" -f [int64]$info.LastTaskResult
+    exit 1
+  }
   exit 0
 }
 


### PR DESCRIPTION
Issue: #694

Residue of doneWhen item 5: `scripts/pr-review-launch.ps1:69` registered the
watcher task with the bare `-Execute "pwsh.exe"`. Task Scheduler cannot
resolve that name when PowerShell is a Store/WindowsApps install, so the
watcher died before ever running its wrapper — one reason this repo's PRs
sat unreviewed.

## Change (674b4c4, scripts-only)

- `scripts/pr-review-launch.ps1:72-73` — resolve `pwsh.exe` via
  `Get-Command` to an absolute path; `throw` with a clear message when not
  found, instead of registering a task that cannot start. Same pattern as
  the already-fixed `scripts/fleet/lane-launch.ps1:108-111`.
- `scripts/pr-review-launch.ps1:75` — `New-ScheduledTaskAction -Execute $PwshExe`.
- `scripts/pr-review-launch.ps1:102-108` — `-DryRun` now **exits 1** when
  `LastTaskResult` is non-zero and prints the hex code, so a dead
  registration can no longer silently pass (before: it printed the
  non-zero result and exited 0).

### Only one registration site

`pr-review-launch.ps1` has exactly one `New-ScheduledTaskAction` (line 75,
post-fix); both the real path and `-DryRun` share it — `Register-ScheduledTask`
(line 84) runs before the `$DryRun` branch, which differs only in the wrapper
name and `--once --dry-run` watcher args. The GH-694 "real + DryRun both"
concern for this file is therefore covered by this single fix.

## DryRun receipts (this machine, pwsh = Store/WindowsApps install)

Before (base `df3bd4d`):

```
> pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/pr-review-launch.ps1 -DryRun
dry-run task=edda-pr-review-watcher state=Ready
LastRunTime=09/03/2026 11:20:54 LastTaskResult=2147942402
task=edda-pr-review-watcher unregistered (dry-run)
EXIT=0
```

`2147942402` = `0x80070002` ERROR_FILE_NOT_FOUND — and note exit 0: the
defect passed silently.

After (this PR, 674b4c4):

```
> pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/pr-review-launch.ps1 -DryRun
dry-run task=edda-pr-review-watcher state=Ready
LastRunTime=09/03/2026 11:21:45 LastTaskResult=0
task=edda-pr-review-watcher unregistered (dry-run)
EXIT=0
```

## doneWhen 逐條對照 (GH-694)

1. **lane-launch resolved absolute Execute path** — ✅ delivered by `fca3b4d`
   (PR #696, carried alongside GH-672): `scripts/fleet/lane-launch.ps1:108-111`
   (`$PwshExe = (Get-Command pwsh.exe ...).Source` + `Fail`), used at `:169`
   (DryRun) and `:227` (real).
2. **lane-launch default session id is a valid UUID / shape-validated** —
   ❌ **not delivered**: `scripts/fleet/lane-launch.ps1:99` still defaults
   `$SessionId = "lane-$Name"`, and `edda dispatch` passes a caller-supplied
   `--session-id` verbatim to `claude -p` (`crates/edda-conductor/src/agent/
   launcher.rs:110-111`), which rejects non-UUIDs. The *review* path got real
   UUID v4 sessions in #720 (`scripts/review-pr.sh:253-273`), but the
   lane-launch default remains broken for `-Agent claude`. **This residue
   keeps #694 open** — a follow-up unit is needed for `lane-launch.ps1:99`.
3. **Pre-fix FAIL receipts** — lane-launch: recorded in the issue body
   (`LastTaskResult=2147942402`, `Invalid session ID`); watcher: reproduced
   above ("Before" receipt, `LastTaskResult=2147942402`).
4. **-DryRun catches the defects** — lane-launch: DryRun registers with the
   same resolved `$PwshExe` (fca3b4d). Watcher: delivered by this PR (exit 1
   on non-zero `LastTaskResult`, plus the DryRun path registers with the same
   fixed action).
5. **`pr-review-launch.ps1` + `review-pr.sh` same-shape fix** — review-pr.sh:
   ✅ #720 (`df3bd4d`), `scripts/review-pr.sh:359-372` (`PWSH_EXE` resolution
   via `cygpath -w`) and `:517` (`New-ScheduledTaskAction -Execute "$PWSH_EXE"`),
   plus UUID sessions at `:253-273`. pr-review-launch.ps1: ✅ **this PR**.

## Gates

- `sh -n` on changed `.sh`: n/a — this PR changes only `scripts/pr-review-launch.ps1` (a `.ps1`), no shell files touched
- `sh scripts/lint-markdown-content.sh` → exit 0
- No Cargo gate: scripts-only change, no Rust/build/toolchain surface
