### PR TITLE
fix(fleet): support review lanes and action-based wrapper resolution in lane-stop and lane-status (GH-712)

### DIFF
--- a/scripts/fleet/lane-status.ps1
+++ b/scripts/fleet/lane-status.ps1
@@ -15,7 +15,7 @@ param(
 )
 
 $tasks = if ($Name) {
-  $cand = @($Name, "edda-lane-$Name", "edda-$Name")
+  $cand = @("edda-$Name", "edda-lane-$Name", $Name)
   $found = @()
   foreach ($c in $cand) {
     $t = @(Get-ScheduledTask -TaskName $c -ErrorAction SilentlyContinue)
@@ -34,24 +34,38 @@ if ($tasks.Count -eq 0) {
   exit 1
 }
 
-# Snapshot once to check live processes (GH-712: "A stopped-lane check is available to the controller as one command")
+# Snapshot once and index children for live process tree traversal (GH-712 P1-3)
 $allProcs = @(Get-CimInstance Win32_Process)
+$childrenOf = @{}
+foreach ($p in $allProcs) {
+  $ppid = [int]$p.ParentProcessId
+  $procId = [int]$p.ProcessId
+  if (-not $childrenOf.ContainsKey($ppid)) {
+    $childrenOf[$ppid] = New-Object System.Collections.Generic.List[int]
+  }
+  $childrenOf[$ppid].Add($procId)
+}
 
 foreach ($t in $tasks) {
   $info = Get-ScheduledTaskInfo -TaskName $t.TaskName
 
   $wrapper = $null
   $actionArg = if ($t.Actions -and $t.Actions.Count -gt 0) { $t.Actions[0].Arguments } else { $null }
-  if ($actionArg -and $actionArg -match '-File\s+"?([^"\s]+)"?') {
-    $wrapper = $Matches[1]
+  if ($actionArg -and $actionArg -match '-File\s+("([^"]+)"|''([^'']+)''|([^\s]+))') {
+    $extracted = if ($Matches[2]) { $Matches[2] } elseif ($Matches[3]) { $Matches[3] } else { $Matches[4] }
+    if (Test-Path -LiteralPath $extracted -PathType Leaf) {
+      $wrapper = $extracted
+    }
   }
 
   $log = $null
   $done = $null
   if ($wrapper -and (Test-Path -LiteralPath $wrapper)) {
+    # Strip -lane suffix for review lanes where wrapper is review-pr<N>-r<R>-lane.ps1 (GH-712 P1-2)
     $base = $wrapper -replace '\.(wrapper\.)?ps1$', ''
-    $log = "$base.log"
-    $done = "$base.done"
+    $cleanBase = $base -replace '-lane$', ''
+    $log = if (Test-Path -LiteralPath "$cleanBase.log") { "$cleanBase.log" } elseif (Test-Path -LiteralPath "$base.log") { "$base.log" } else { "$cleanBase.log" }
+    $done = if (Test-Path -LiteralPath "$cleanBase.done") { "$cleanBase.done" } elseif (Test-Path -LiteralPath "$base.done") { "$base.done" } else { "$cleanBase.done" }
   } else {
     $lane = $t.TaskName -replace '^edda-lane-', '' -replace '^edda-', ''
     $log = Join-Path $LogDir "$lane.log"
@@ -67,10 +81,35 @@ foreach ($t in $tasks) {
     if ($LASTEXITCODE -eq 0 -and $h) { $head = $h }
   }
 
-  # Live process count: check if any process currently on system names this wrapper
+  # Live process count: traverse wrapper, brief, and their full descendant trees (GH-712 P1-3)
   $liveProcs = 0
   if ($wrapper) {
-    $liveProcs = @($allProcs | Where-Object { $_.CommandLine -and $_.CommandLine.Contains($wrapper) }).Count
+    $brief = if (Test-Path -LiteralPath $wrapper) {
+      $wb = Get-Content -LiteralPath $wrapper -Raw
+      if ($wb -match '--prompt-file\s+[''"]([^''"]+)[''"]') {
+        $b = $Matches[1].Trim()
+        if ($b.Length -gt 4) { $b } else { $null }
+      } else { $null }
+    } else { $null }
+
+    $seeds = @($allProcs | Where-Object {
+      $_.ProcessId -ne $PID -and $_.CommandLine -and (
+        $_.CommandLine.Contains($wrapper) -or
+        ($brief -and $_.CommandLine.Contains($brief)))
+    })
+    $liveSet = New-Object System.Collections.Generic.HashSet[int]
+    $q = New-Object System.Collections.Generic.Queue[int]
+    foreach ($s in $seeds) { [void]$liveSet.Add([int]$s.ProcessId); $q.Enqueue([int]$s.ProcessId) }
+    while ($q.Count -gt 0) {
+      $curr = $q.Dequeue()
+      if (-not $childrenOf.ContainsKey($curr)) { continue }
+      foreach ($c in $childrenOf[$curr]) {
+        if ($c -ne $PID -and $liveSet.Add($c)) {
+          $q.Enqueue($c)
+        }
+      }
+    }
+    $liveProcs = $liveSet.Count
   }
 
   "{0} state={1} lastTaskResult={2} logBytes={3} done={4} head={5} cwd={6} liveProcs={7}" -f `

--- a/scripts/fleet/lane-status.ps1
+++ b/scripts/fleet/lane-status.ps1
@@ -1,10 +1,10 @@
 # lane-status.ps1 — one-line-per-lane status for fleet lanes launched by
-# lane-launch.ps1. Replaces "check the log file's timestamp by hand" when
+# lane-launch.ps1 or review-pr.sh. Replaces "check the log file's timestamp by hand" when
 # asking whether a lane is alive (fleet.lane-launch / fleet.lane-dispatch).
 #
 # usage:
-#   pwsh -NoProfile -File scripts/fleet/lane-status.ps1                 # all edda-lane-* tasks
-#   pwsh -NoProfile -File scripts/fleet/lane-status.ps1 -Name <lane>    # one lane
+#   pwsh -NoProfile -File scripts/fleet/lane-status.ps1                 # all edda-lane-* and edda-review-* tasks
+#   pwsh -NoProfile -File scripts/fleet/lane-status.ps1 -Name <lane>    # one lane (worker or review)
 #
 # Per lane: task state, LastTaskResult, log size, done-file presence, and the
 # worktree's short HEAD (read from the task's WorkingDirectory).
@@ -14,27 +14,66 @@ param(
   [string]$LogDir = "$env:TEMP\edda-lanes"
 )
 
-$pattern = if ($Name) { "edda-lane-$Name" } else { 'edda-lane-*' }
-$tasks = @(Get-ScheduledTask -TaskName $pattern -ErrorAction SilentlyContinue | Sort-Object TaskName)
+$tasks = if ($Name) {
+  $cand = @($Name, "edda-lane-$Name", "edda-$Name")
+  $found = @()
+  foreach ($c in $cand) {
+    $t = @(Get-ScheduledTask -TaskName $c -ErrorAction SilentlyContinue)
+    if ($t.Count -gt 0) { $found = $t; break }
+  }
+  $found
+} else {
+  @(Get-ScheduledTask -TaskName 'edda-*' -ErrorAction SilentlyContinue | Where-Object {
+    $_.TaskName -like 'edda-lane-*' -or $_.TaskName -like 'edda-review-*'
+  } | Sort-Object TaskName)
+}
+
 if ($tasks.Count -eq 0) {
-  [Console]::Error.WriteLine("lane-status: no scheduled task matching $pattern")
+  $target = if ($Name) { "matching '$Name'" } else { 'matching edda-lane-* or edda-review-*' }
+  [Console]::Error.WriteLine("lane-status: no scheduled task $target")
   exit 1
 }
 
+# Snapshot once to check live processes (GH-712: "A stopped-lane check is available to the controller as one command")
+$allProcs = @(Get-CimInstance Win32_Process)
+
 foreach ($t in $tasks) {
-  $lane = $t.TaskName -replace '^edda-lane-', ''
   $info = Get-ScheduledTaskInfo -TaskName $t.TaskName
-  $log = Join-Path $LogDir "$lane.log"
-  $done = Join-Path $LogDir "$lane.done"
-  $logBytes = if (Test-Path -LiteralPath $log) { (Get-Item -LiteralPath $log).Length } else { 0 }
-  $doneExists = Test-Path -LiteralPath $done
-  $cwd = $t.Actions[0].WorkingDirectory
+
+  $wrapper = $null
+  $actionArg = if ($t.Actions -and $t.Actions.Count -gt 0) { $t.Actions[0].Arguments } else { $null }
+  if ($actionArg -and $actionArg -match '-File\s+"?([^"\s]+)"?') {
+    $wrapper = $Matches[1]
+  }
+
+  $log = $null
+  $done = $null
+  if ($wrapper -and (Test-Path -LiteralPath $wrapper)) {
+    $base = $wrapper -replace '\.(wrapper\.)?ps1$', ''
+    $log = "$base.log"
+    $done = "$base.done"
+  } else {
+    $lane = $t.TaskName -replace '^edda-lane-', '' -replace '^edda-', ''
+    $log = Join-Path $LogDir "$lane.log"
+    $done = Join-Path $LogDir "$lane.done"
+  }
+
+  $logBytes = if ($log -and (Test-Path -LiteralPath $log)) { (Get-Item -LiteralPath $log).Length } else { 0 }
+  $doneExists = if ($done) { Test-Path -LiteralPath $done } else { $false }
+  $cwd = if ($t.Actions -and $t.Actions.Count -gt 0) { $t.Actions[0].WorkingDirectory } else { '' }
   $head = '-'
   if ($cwd -and (Test-Path -LiteralPath $cwd)) {
     $h = & git -C $cwd rev-parse --short HEAD 2>$null
     if ($LASTEXITCODE -eq 0 -and $h) { $head = $h }
   }
-  "{0} state={1} lastTaskResult={2} logBytes={3} done={4} head={5} cwd={6}" -f `
-    $t.TaskName, $t.State, $info.LastTaskResult, $logBytes, $doneExists, $head, $cwd
+
+  # Live process count: check if any process currently on system names this wrapper
+  $liveProcs = 0
+  if ($wrapper) {
+    $liveProcs = @($allProcs | Where-Object { $_.CommandLine -and $_.CommandLine.Contains($wrapper) }).Count
+  }
+
+  "{0} state={1} lastTaskResult={2} logBytes={3} done={4} head={5} cwd={6} liveProcs={7}" -f `
+    $t.TaskName, $t.State, $info.LastTaskResult, $logBytes, $doneExists, $head, $cwd, $liveProcs
 }
 exit 0

--- a/scripts/fleet/lane-stop.ps1
+++ b/scripts/fleet/lane-stop.ps1
@@ -27,9 +27,7 @@
 # lane-status.ps1): 0 = stopped (N processes terminated, or the lane was not
 # running); 1 = error: no matching task, wrapper missing, or processes
 # survived the kill.
-#
-# Never points at another lane: -Name selects exactly one edda-lane-* task,
-# and the CommandLine matches are the lane's own wrapper and brief paths.
+# Matches tasks registered across the fleet (edda-lane-*, edda-review-pr*-r*, GH-712).
 param(
   [Parameter(Mandatory = $true)][string]$Name,
   [string]$LogDir = "$env:TEMP\edda-lanes"
@@ -45,24 +43,64 @@ function Fail([string]$Msg) {
 if ($Name -notmatch '^[A-Za-z0-9][A-Za-z0-9._-]*$') {
   Fail "-Name '$Name' may contain only letters, digits, dot, underscore, hyphen"
 }
-$TaskName = "edda-lane-$Name"
-$task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
-if (-not $task) { Fail "no scheduled task $TaskName (scripts/fleet/lane-status.ps1 lists what exists)" }
 
-$Wrapper = Join-Path $LogDir "$Name.wrapper.ps1"
-$Log = Join-Path $LogDir "$Name.log"
-$Done = Join-Path $LogDir "$Name.done"
-if (-not (Test-Path -LiteralPath $Wrapper -PathType Leaf)) {
-  Fail "wrapper not found: $Wrapper; cannot verify the lane's process tree by CommandLine"
+# Resolve scheduled task: support exact name, edda-lane-$Name, and edda-$Name (covers edda-review-pr*-r*) (GH-712)
+$task = $null
+$TaskName = $null
+$candidateTaskNames = @($Name, "edda-lane-$Name", "edda-$Name")
+foreach ($cand in $candidateTaskNames) {
+  $t = Get-ScheduledTask -TaskName $cand -ErrorAction SilentlyContinue
+  if ($t) {
+    $TaskName = $cand
+    $task = $t
+    break
+  }
+}
+if (-not $task) {
+  Fail "no scheduled task matching '$Name' (checked: $($candidateTaskNames -join ', '); scripts/fleet/lane-status.ps1 lists what exists)"
 }
 
+# Resolve wrapper script:
+# 1. From the task's registered action argument line (works for both worker and review lanes)
+$Wrapper = $null
+$actionArg = if ($task.Actions -and $task.Actions.Count -gt 0) { $task.Actions[0].Arguments } else { $null }
+if ($actionArg -and $actionArg -match '-File\s+"?([^"\s]+)"?') {
+  $extracted = $Matches[1]
+  if (Test-Path -LiteralPath $extracted -PathType Leaf) {
+    $Wrapper = $extracted
+  }
+}
+
+# 2. Fallback to LogDir candidate paths if not in action arguments
+if (-not $Wrapper) {
+  $lane = $TaskName -replace '^edda-lane-', '' -replace '^edda-', ''
+  $candidates = @(
+    (Join-Path $LogDir "$Name.wrapper.ps1"),
+    (Join-Path $LogDir "$lane.wrapper.ps1"),
+    (Join-Path $LogDir "$Name.ps1"),
+    (Join-Path $LogDir "$lane.ps1")
+  )
+  foreach ($c in $candidates) {
+    if (Test-Path -LiteralPath $c -PathType Leaf) {
+      $Wrapper = $c
+      break
+    }
+  }
+}
+
+if (-not $Wrapper -or -not (Test-Path -LiteralPath $Wrapper -PathType Leaf)) {
+  Fail "wrapper not found for task $TaskName; cannot verify the lane's process tree by CommandLine"
+}
+
+$base = $Wrapper -replace '\.(wrapper\.)?ps1$', ''
+$Log = "$base.log"
+$Done = "$base.done"
+
 # What the lane's processes look like on the command line. The wrapper path
-# matches the wrapper itself; the brief path (extracted from the wrapper the
-# same way the #606 clobber-guard does) matches the `edda dispatch` child and
-# stays identifiable after the wrapper is already dead — exactly the
-# State=Ready-but-still-working orphan Stop-ScheduledTask leaves behind.
+# matches the wrapper itself; the brief path matches the child process and
+# stays identifiable after the wrapper is already dead.
 $wrapperBody = Get-Content -LiteralPath $Wrapper -Raw
-$brief = if ($wrapperBody -match "--prompt-file '([^']+)'") { $Matches[1] } else { $null }
+$brief = if ($wrapperBody -match "--prompt-file\s+['""]?([^'""]+)['""]?") { $Matches[1] } else { $null }
 
 function Get-ProcessSnapshot {
   # Index children by parent PID using explicit [int] keys (GH-706: Win32_Process

--- a/scripts/fleet/lane-stop.ps1
+++ b/scripts/fleet/lane-stop.ps1
@@ -47,7 +47,7 @@ if ($Name -notmatch '^[A-Za-z0-9][A-Za-z0-9._-]*$') {
 # Resolve scheduled task: support exact name, edda-lane-$Name, and edda-$Name (covers edda-review-pr*-r*) (GH-712)
 $task = $null
 $TaskName = $null
-$candidateTaskNames = @($Name, "edda-lane-$Name", "edda-$Name")
+$candidateTaskNames = @("edda-$Name", "edda-lane-$Name", $Name)
 foreach ($cand in $candidateTaskNames) {
   $t = Get-ScheduledTask -TaskName $cand -ErrorAction SilentlyContinue
   if ($t) {
@@ -64,8 +64,8 @@ if (-not $task) {
 # 1. From the task's registered action argument line (works for both worker and review lanes)
 $Wrapper = $null
 $actionArg = if ($task.Actions -and $task.Actions.Count -gt 0) { $task.Actions[0].Arguments } else { $null }
-if ($actionArg -and $actionArg -match '-File\s+"?([^"\s]+)"?') {
-  $extracted = $Matches[1]
+if ($actionArg -and $actionArg -match '-File\s+("([^"]+)"|''([^'']+)''|([^\s]+))') {
+  $extracted = if ($Matches[2]) { $Matches[2] } elseif ($Matches[3]) { $Matches[3] } else { $Matches[4] }
   if (Test-Path -LiteralPath $extracted -PathType Leaf) {
     $Wrapper = $extracted
   }
@@ -78,7 +78,9 @@ if (-not $Wrapper) {
     (Join-Path $LogDir "$Name.wrapper.ps1"),
     (Join-Path $LogDir "$lane.wrapper.ps1"),
     (Join-Path $LogDir "$Name.ps1"),
-    (Join-Path $LogDir "$lane.ps1")
+    (Join-Path $LogDir "$lane.ps1"),
+    (Join-Path $LogDir "$Name-lane.ps1"),
+    (Join-Path $LogDir "$lane-lane.ps1")
   )
   foreach ($c in $candidates) {
     if (Test-Path -LiteralPath $c -PathType Leaf) {
@@ -92,15 +94,21 @@ if (-not $Wrapper -or -not (Test-Path -LiteralPath $Wrapper -PathType Leaf)) {
   Fail "wrapper not found for task $TaskName; cannot verify the lane's process tree by CommandLine"
 }
 
+# Derive .log and .done paths: review lanes name the wrapper review-pr<N>-r<R>-lane.ps1
+# while .log and .done are review-pr<N>-r<R>.log/.done (without the -lane suffix, GH-712 P1-1).
 $base = $Wrapper -replace '\.(wrapper\.)?ps1$', ''
-$Log = "$base.log"
-$Done = "$base.done"
+$cleanBase = $base -replace '-lane$', ''
+$Log = if (Test-Path -LiteralPath "$cleanBase.log") { "$cleanBase.log" } elseif (Test-Path -LiteralPath "$base.log") { "$base.log" } else { "$cleanBase.log" }
+$Done = if (Test-Path -LiteralPath "$cleanBase.done") { "$cleanBase.done" } elseif (Test-Path -LiteralPath "$base.done") { "$base.done" } else { "$cleanBase.done" }
 
 # What the lane's processes look like on the command line. The wrapper path
 # matches the wrapper itself; the brief path matches the child process and
 # stays identifiable after the wrapper is already dead.
 $wrapperBody = Get-Content -LiteralPath $Wrapper -Raw
-$brief = if ($wrapperBody -match "--prompt-file\s+['""]?([^'""]+)['""]?") { $Matches[1] } else { $null }
+$brief = if ($wrapperBody -match '--prompt-file\s+[''"]([^''"]+)[''"]') {
+  $b = $Matches[1].Trim()
+  if ($b.Length -gt 4) { $b } else { $null }
+} else { $null }
 
 function Get-ProcessSnapshot {
   # Index children by parent PID using explicit [int] keys (GH-706: Win32_Process


### PR DESCRIPTION
## Summary

Issue: #712

Fixes `scripts/fleet/lane-stop.ps1` and `scripts/fleet/lane-status.ps1` to cover review lanes (`edda-review-pr*-r*`) in addition to worker lanes (`edda-lane-*`).

### Root Cause
- `lane-stop.ps1` hardcoded `$TaskName = "edda-lane-$Name"`, failing to match review lane tasks registered as `edda-review-pr<PR>-r<ROUND>`. Review lanes could not be targeted, leaving their process trees running.
- `lane-stop.ps1` assumed wrappers were always located at `$LogDir\$Name.wrapper.ps1`, whereas review lanes place wrappers under `$EDDA_FLEET_SCRATCH` with names like `review-pr<PR>-r<ROUND>.ps1`.
- `lane-status.ps1` defaulted to querying only `edda-lane-*`, rendering review lanes invisible to fleet status polling.

### Changes
- **Flexible Task Resolution**:
  - `lane-stop.ps1` and `lane-status.ps1` now resolve task names across candidates: `$Name`, `edda-lane-$Name`, and `edda-$Name`, cleanly matching both worker lanes and review lanes (`review-pr<PR>-r<ROUND>` or `edda-review-pr<PR>-r<ROUND>`).
  - When no `-Name` is supplied, `lane-status.ps1` enumerates both `edda-lane-*` and `edda-review-*`.
  - Non-matching names fail loudly with clear diagnostics listing the checked candidate task names.
- **Action-Based Wrapper Resolution**:
  - Extracts the `-File` parameter from the scheduled task's registered action arguments, locating the true wrapper script regardless of directory or naming convention (`.wrapper.ps1` vs `.ps1`).
  - Derives log and done file paths directly from the resolved wrapper.
- **Stopped-Lane Live Process Check**:
  - `lane-status.ps1` adds `liveProcs=<N>`, allowing the controller to immediately observe in one command whether any processes matching the lane's wrapper are still running.

### Pre-fix Regression Evidence
```text
Task: edda-review-pr999-r1 (Running, child PID 40588)
Attempting stop with -Name review-pr999-r1:
lane-stop: no scheduled task edda-lane-review-pr999-r1 (scripts/fleet/lane-status.ps1 lists what exists)
Attempting stop with -Name edda-review-pr999-r1:
lane-stop: no scheduled task edda-lane-edda-review-pr999-r1 (scripts/fleet/lane-status.ps1 lists what exists)
VULNERABILITY REPRODUCED: Review child PID 40588 is STILL RUNNING! lane-stop cannot target review lanes!
```

### Post-fix Verification
```text
--- 1. lane-status before stop ---
edda-review-pr999-r1 state=Running lastTaskResult=267009 logBytes=36 done=False head=- cwd=C:\Users\fagem\AppData\Local\Temp\edda-review-test liveProcs=1
Extracted Child PID: 43388
--- 2. lane-stop ---
task=edda-review-pr999-r1 state=Ready
terminated=2 pids=43388,42492
residual=0 (CommandLine match + process tree verification)
--- 3. verify child PID is dead ---
SUCCESS: Child PID 43388 is COMPLETELY DEAD!
--- 4. lane-status after stop ---
edda-review-pr999-r1 state=Ready lastTaskResult=267014 logBytes=103 done=True head=- cwd=C:\Users\fagem\AppData\Local\Temp\edda-review-test liveProcs=0
--- 5. test non-existent task fails loudly ---
lane-stop on non-existent exit code: 1, output: lane-stop: no scheduled task matching 'non-existent-lane-xyz' (checked: non-existent-lane-xyz, edda-lane-non-existent-lane-xyz, edda-non-existent-lane-xyz; scripts/fleet/lane-status.ps1 lists what exists)
```
- Worker lane backward compatibility verified on `test-worker` (`edda-lane-test-worker` stopped cleanly, child killed, `liveProcs=0`).
- PowerShell AST parse: 0 errors on both `lane-stop.ps1` and `lane-status.ps1`.