### PR TITLE
fix(conductor): reconcile in-memory state with disk before phase selection (GH-750)

### DIFF
--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -17,7 +17,7 @@ use crate::state::machine::{
     transition, CheckResult, CheckStatus, ErrorInfo, ErrorType, PhaseStatus, PhaseUpdate,
     PlanState, PlanStatus,
 };
-use crate::state::persist::save_state_reconciled;
+use crate::state::persist::{reconcile_with_disk, save_state_reconciled};
 use crate::tmux::TmuxSession;
 use anyhow::Context;
 use anyhow::Result;
@@ -106,6 +106,9 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
             println!("Shutdown. Run `edda conduct run` to resume.");
             break;
         }
+
+        // Reconcile in-memory state with disk under lock before evaluating plan status (GH-750).
+        reconcile_with_disk(cwd, state)?;
 
         update_plan_status(state);
 
@@ -718,6 +721,10 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
             write_brief(cwd, state, None);
             continue;
         }
+
+        // Reconcile before phase selection so an externally skipped phase can
+        // never be selected or dispatched by the live runner (GH-750).
+        reconcile_with_disk(cwd, state)?;
 
         // 2. Find next runnable phase
         let Some(phase_id) = find_next_phase(plan, state, &order) else {
@@ -5574,5 +5581,65 @@ phases:
             })
             .unwrap_or_default();
         assert!(paths.is_empty());
+    }
+
+    /// GH-750: an externally skipped phase on disk must never be selected or dispatched
+    /// by the live runner, even if the runner's in-memory state has it as Pending on resume.
+    #[tokio::test]
+    async fn resume_does_not_dispatch_externally_skipped_phase() {
+        let yaml = r#"
+name: test-skip-resume
+phases:
+  - id: a
+    prompt: "do a"
+"#;
+        let plan = parse_plan(yaml).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut disk_state = PlanState::from_plan(&plan, "test.yaml");
+        disk_state.started_at = Some("2026-09-03T10:00:00Z".into());
+        disk_state.plan_status = PlanStatus::Running;
+        let a = disk_state.get_phase_mut("a").unwrap();
+        a.status = PhaseStatus::Skipped;
+        a.skip_reason = Some("skipped by operator via edda conduct skip".into());
+        crate::state::persist::save_state(dir.path(), &disk_state).unwrap();
+
+        // Runner starts with stale in-memory state where "a" is still Pending, but plan was already started
+        let mut mem_state = PlanState::from_plan(&plan, "test.yaml");
+        mem_state.started_at = Some("2026-09-03T10:00:00Z".into());
+        mem_state.plan_status = PlanStatus::Running;
+
+        let launcher = MockLauncher::new();
+        let engine = CheckEngine::new(dir.path().to_path_buf());
+        let notifier = CollectNotifier::new();
+        let mut budget = BudgetTracker::new(plan.budget_usd);
+        let cancel = CancellationToken::new();
+
+        run_plan(
+            &plan,
+            &mut mem_state,
+            RunContext {
+                launcher: &launcher,
+                check_engine: &engine,
+                notifier: &notifier,
+                budget: &mut budget,
+                cancel,
+                cwd: dir.path(),
+                interactive: false,
+                json_events: false,
+                tmux_session: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            launcher.call_count("a"),
+            0,
+            "externally skipped phase 'a' must never be dispatched"
+        );
+        assert_eq!(
+            mem_state.get_phase("a").unwrap().status,
+            PhaseStatus::Skipped
+        );
     }
 }

--- a/crates/edda-conductor/src/state/persist.rs
+++ b/crates/edda-conductor/src/state/persist.rs
@@ -102,37 +102,55 @@ pub fn save_state(cwd: &Path, state: &PlanState) -> Result<()> {
     Ok(())
 }
 
-/// Save state from a long-lived writer (the runner) after reconciling with
-/// the state currently on disk under the plan's exclusive lock (GH-556, GH-714).
+/// Reconcile in-memory state with a disk state under the plan lock (GH-556, GH-714, GH-750).
 ///
 /// The runner holds `PlanState` in memory for the whole run while other
 /// processes (`edda conduct skip`, `retry`, ...) mutate the same file. A
-/// plain `save_state` then clobbers those external writes with the stale
-/// in-memory copy — observed as a manual skip on a Pending phase reverting
-/// to Pending when a sibling phase transitioned to Stale in the runner.
+/// plain `save_state` or unreconciled phase selection would clobber those
+/// external writes or dispatch skipped phases.
 ///
 /// Reconciliation rule: a phase that is Skipped on disk but still Pending in
 /// memory is a manual skip recorded by another writer while this runner had
-/// not started the phase — operator intent wins, and the disk phase
-/// (including its skip reason) is folded into the in-memory state before
-/// saving. Every other divergence keeps the in-memory value: the runner is
-/// the authority for phases it has started (Running/Checking/terminal
-/// transitions it observed itself).
+/// not started the phase — operator intent wins.
+/// Field-scoped merge: we fold the status, skip_reason, and completed_at from the disk
+/// phase into the in-memory phase without wholesale-replacing unrelated fields (GH-750).
+pub fn reconcile_state(mem_state: &mut PlanState, disk_state: &PlanState) {
+    for disk_phase in &disk_state.phases {
+        if disk_phase.status != PhaseStatus::Skipped {
+            continue;
+        }
+        if let Some(mem) = mem_state
+            .phases
+            .iter_mut()
+            .find(|p| p.id == disk_phase.id && p.status == PhaseStatus::Pending)
+        {
+            mem.status = PhaseStatus::Skipped;
+            mem.skip_reason = disk_phase.skip_reason.clone();
+            if disk_phase.completed_at.is_some() {
+                mem.completed_at = disk_phase.completed_at.clone();
+            }
+        }
+    }
+}
+
+/// Reconcile in-memory state with disk state under the plan's exclusive lock (GH-750).
+/// Returns Ok(true) if state on disk was loaded and reconciled, Ok(false) if no state file exists.
+pub fn reconcile_with_disk(cwd: &Path, state: &mut PlanState) -> Result<bool> {
+    let _lock = PlanStateLock::acquire(cwd, &state.plan_name)?;
+    if let Some(disk) = load_state(cwd, &state.plan_name)? {
+        reconcile_state(state, &disk);
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+/// Save state from a long-lived writer (the runner) after reconciling with
+/// the state currently on disk under the plan's exclusive lock (GH-556, GH-714, GH-750).
 pub fn save_state_reconciled(cwd: &Path, state: &mut PlanState) -> Result<()> {
     let _lock = PlanStateLock::acquire(cwd, &state.plan_name)?;
     if let Some(disk) = load_state(cwd, &state.plan_name)? {
-        for disk_phase in &disk.phases {
-            if disk_phase.status != PhaseStatus::Skipped {
-                continue;
-            }
-            if let Some(mem) = state
-                .phases
-                .iter_mut()
-                .find(|p| p.id == disk_phase.id && p.status == PhaseStatus::Pending)
-            {
-                *mem = disk_phase.clone();
-            }
-        }
+        reconcile_state(state, &disk);
     }
     save_state(cwd, state)
 }
@@ -507,5 +525,62 @@ mod tests {
         // The on-disk file content must remain unchanged
         let on_disk = std::fs::read_to_string(&p).unwrap();
         assert_eq!(on_disk, "{ not valid json }");
+    }
+
+    #[test]
+    fn reconcile_with_disk_fails_on_corrupted_state_with_diagnostic() {
+        let dir = tempfile::tempdir().unwrap();
+        let plan =
+            parse_plan("name: corrupt-reconcile\nphases:\n  - id: p1\n    prompt: \"one\"\n")
+                .unwrap();
+        let mut state = PlanState::from_plan(&plan, "corrupt-reconcile.yaml");
+
+        let p = state_path(dir.path(), "corrupt-reconcile");
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, b"{ invalid json }").unwrap();
+
+        let res = reconcile_with_disk(dir.path(), &mut state);
+        assert!(
+            res.is_err(),
+            "reconcile_with_disk must fail on unreadable state.json, but got: {:?}",
+            res
+        );
+        let err_msg = format!("{:#}", res.unwrap_err());
+        assert!(
+            err_msg.contains("parsing state"),
+            "error diagnostic must surface failure reason: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn reconcile_state_field_scoped_merge_preserves_unrelated_fields() {
+        let plan =
+            parse_plan("name: field-scoped\nphases:\n  - id: p1\n    prompt: \"one\"\n").unwrap();
+        let mut mem_state = PlanState::from_plan(&plan, "field-scoped.yaml");
+        let p = mem_state.get_phase_mut("p1").unwrap();
+        p.status = PhaseStatus::Pending;
+        p.attempts = 2;
+        p.env_retries = 1;
+        p.retry_context = Some("previous failure context".into());
+
+        let mut disk_state = PlanState::from_plan(&plan, "field-scoped.yaml");
+        let dp = disk_state.get_phase_mut("p1").unwrap();
+        dp.status = PhaseStatus::Skipped;
+        dp.skip_reason = Some("skipped externally".into());
+        dp.completed_at = Some("2026-09-03T10:00:00Z".into());
+        dp.attempts = 0; // disk had attempts 0 before runner attempts
+
+        reconcile_state(&mut mem_state, &disk_state);
+
+        let p = mem_state.get_phase("p1").unwrap();
+        // Reconciled fields updated
+        assert_eq!(p.status, PhaseStatus::Skipped);
+        assert_eq!(p.skip_reason.as_deref(), Some("skipped externally"));
+        assert_eq!(p.completed_at.as_deref(), Some("2026-09-03T10:00:00Z"));
+        // Unrelated in-memory fields preserved (not wholesale wiped by disk phase)
+        assert_eq!(p.attempts, 2);
+        assert_eq!(p.env_retries, 1);
+        assert_eq!(p.retry_context.as_deref(), Some("previous failure context"));
     }
 }


### PR DESCRIPTION
## Summary

Issue: #750

Fixes `edda-conductor` runner to reconcile in-memory `PlanState` with disk state before phase selection, preventing externally skipped phases from ever being selected or dispatched by a running conductor.

### Root Cause
- `find_next_phase` in `sequential.rs` read in-memory status and transitioned `Pending` -> `Running` *before* `save_state_reconciled` ran.
- If an external process (e.g. `edda conduct skip`) skipped a phase on disk, the in-memory copy remained `Pending`. `find_next_phase` selected it, transitioned it to `Running`, and the subsequent `save_state_reconciled` reconcile guard (`p.status == PhaseStatus::Pending`) no longer matched, dispatching the skipped phase anyway.
- `save_state_reconciled` previously wholesale replaced the in-memory phase struct with `*mem = disk_phase.clone()`, potentially wiping out attempt/cost/retry bookkeeping.

### Changes
1. **Reconciliation Before Selection**:
   - Added `reconcile_with_disk(cwd, state)` which acquires `PlanStateLock`, loads disk state (propagating errors via `?`), and calls `reconcile_state`.
   - Called `reconcile_with_disk` at the start of the runner loop (before `update_plan_status`) and immediately before `find_next_phase`.
   - Any external skip on disk is folded into in-memory state before selection, so `find_next_phase` never selects a skipped phase and the live runner never dispatches it.
2. **Diagnostic Error Propagation**:
   - `reconcile_with_disk` propagates `load_state` failures (e.g. corrupted `state.json`) directly with context, surfacing diagnostics instead of silently ignoring errors.
3. **Field-Scoped Merge**:
   - `reconcile_state` performs a field-scoped merge updating `status`, `skip_reason`, and `completed_at` from the disk phase while preserving all in-memory execution fields (such as `attempts`, `env_retries`, `retry_context`).
4. **Regression & Unit Tests**:
   - `resume_does_not_dispatch_externally_skipped_phase`: verified failing before fix (`left: 1, right: 0`) and passing after fix.
   - `reconcile_with_disk_fails_on_corrupted_state_with_diagnostic`: verifies corrupted state produces a clear diagnostic.
   - `reconcile_state_field_scoped_merge_preserves_unrelated_fields`: verifies non-status fields are not wiped.

### Pre-fix Regression Evidence
```text
running 1 test
test runner::sequential::tests::resume_does_not_dispatch_externally_skipped_phase ... FAILED

failures:
---- runner::sequential::tests::resume_does_not_dispatch_externally_skipped_phase stdout ----
thread 'runner::sequential::tests::resume_does_not_dispatch_externally_skipped_phase' (17740) panicked at crates\edda-conductor\src\runner\sequential.rs:5628:9:
assertion `left == right` failed: externally skipped phase 'a' must never be dispatched
  left: 1
 right: 0
```

### Post-fix Verification
```text
test runner::sequential::tests::resume_does_not_dispatch_externally_skipped_phase ... ok
test state::persist::tests::reconcile_with_disk_fails_on_corrupted_state_with_diagnostic ... ok
test state::persist::tests::reconcile_state_field_scoped_merge_preserves_unrelated_fields ... ok

test result: ok. 366 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 19.39s
```
- `cargo fmt --all --check` PASS
- `cargo clippy -p edda-conductor --all-targets -- -D warnings` PASS