### PR TITLE
fix(edda-cli): restore the build — dispatch golden fixture matches the 5-arg signature (GH-770)

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -105,6 +105,7 @@ One JSON object with exactly these keys (emitted at
 | `error` | string \| null | crash detail; null except `crash` |
 | `model_requested` | string | what edda passed to the backend, or `inherited` |
 | `model_observed` | string | what the backend reported in-band, or `unknown` |
+| `session_observed` | string | the session id the backend reported in-band, or `unknown` |
 
 Exit-code table (contract, mirrors the long help; mapping at
 `cmd_dispatch.rs:127-134`): `0` done · `1` crash or any other failure ·

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -689,6 +689,7 @@ mod tests {
             "sess-1".into(),
             "inherited".into(),
             "openai-codex/gpt-5.6-sol".into(),
+            "observed-session-1".into(),
         );
         let value: serde_json::Value = serde_json::from_str(&done.to_json()).expect("json parses");
 
@@ -709,6 +710,7 @@ mod tests {
                 "outcome",
                 "result_text",
                 "session_id",
+                "session_observed",
             ],
             "dispatch --json key set changed — this is a stable contract; \
              see COMPATIBILITY.md"
@@ -720,6 +722,7 @@ mod tests {
         assert!(value["error"].is_null());
         assert_eq!(value["model_requested"], "inherited");
         assert!(value["model_observed"].is_string());
+        assert_eq!(value["session_observed"], "observed-session-1");
 
         let crash = DispatchOutput::from_result(
             PhaseResult::AgentCrash {
@@ -727,6 +730,7 @@ mod tests {
             },
             "sess-1".into(),
             "inherited".into(),
+            "unknown".into(),
             "unknown".into(),
         );
         let value: serde_json::Value = serde_json::from_str(&crash.to_json()).expect("json parses");
@@ -737,6 +741,7 @@ mod tests {
         assert!(value["session_id"].is_string());
         assert!(value["model_requested"].is_string());
         assert!(value["model_observed"].is_string());
+        assert!(value["session_observed"].is_string());
 
         // Outcome wire vocabulary — the strings a consumer switches on.
         assert_eq!(Outcome::Done.as_str(), "done");


### PR DESCRIPTION
Issue: #770

`main` has not compiled its `edda` test target since `6a47e5e` (2026-09-03 07:43Z). CI is red on the last two commits on `main` and two merges landed on top of the break. **Until this lands, no branch in the repository can produce an honest gate receipt.**

## Root Cause

| Commit | PR | Effect |
|---|---|---|
| `50e58a3` | #754 (GH-708) | added a 5th parameter `session_observed: String` to `DispatchOutput::from_result` (`cmd_dispatch.rs:176-182`) and a `session_observed` field to the serialized struct (`cmd_dispatch.rs:172`) — CI **green** |
| `6a47e5e` | #732 (GH-651) | added `compat_golden_fixture_dispatch_json_keys_types_and_exit_code_table` (+88 lines) calling `from_result` with **4** arguments — CI **red** |
| `ddd6a81` | #736 (GH-692) | merged on top of the red — CI **red** |

#732's body claims current-base integration against `origin/main` `d185524`; #754 landed after that, so the fixture never saw the five-parameter signature. `git log -S 'session_observed: String,' -- crates/edda-cli/src/cmd_dispatch.rs` → `50e58a3`; `git log -L 680,690:crates/edda-cli/src/cmd_dispatch.rs` → `6a47e5e`.

## Second defect, same place

The fixture exists to pin `dispatch --json` as a stable contract, but its expected key list omitted `session_observed` and COMPATIBILITY.md §2 had no row for it — #754 added a key to a declared-stable surface without the fixture and page update the contract requires. Fixing the arity alone would leave the fixture asserting a key set that no longer matches the struct, i.e. green for the wrong reason.

## Changes

- `crates/edda-cli/src/cmd_dispatch.rs` — both fixture call sites pass the fifth argument; the pinned key set gains `session_observed`, asserted by value on the `done` side and by type on the `crash` (null-side) case
- `COMPATIBILITY.md` — `session_observed` row in the `dispatch --json` key table

Six added lines total. No production code touched; every change is inside `mod tests` or the docs page.

## Pre-fix Regression Evidence

`cargo clippy -p edda --all-targets -- -D warnings` at `ddd6a81`, clean tree, no local changes:

```
error[E0061]: this function takes 5 arguments but 4 arguments were supplied
   --> crates\edda-cli\src\cmd_dispatch.rs:684
   --> crates\edda-cli\src\cmd_dispatch.rs:724
    | argument #5 of type `std::string::String` is missing
note: associated function defined here
   --> crates\edda-cli\src\cmd_dispatch.rs:176
error: could not compile `edda` (bin "edda" test) due to 2 previous errors
```

## Post-fix Verification

Windows, `verifier` lane, `CARGO_INCREMENTAL=0`, rustc stable-x86_64-pc-windows-msvc:

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | **green** (exit 0) |
| `cargo clippy -p edda --all-targets -- -D warnings` | **green** (exit 0) |
| `cargo test -p edda --bin edda compat_golden_fixture` | **3 passed; 0 failed** |

```
test cmd_dispatch::tests::compat_golden_fixture_dispatch_json_keys_types_and_exit_code_table ... ok
test cmd_ask::tests::compat_golden_fixture_ask_json_keys_and_types ... ok
test cmd_verify::tests::compat_golden_fixture_verify_json_keys_and_types ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 468 filtered out
```

L0 scope (touched crate only) is the right ladder rung here: the change is six lines inside one crate's test module plus a docs row, and exact-head CI re-runs the full workspace on three platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HrxhJQcE2QDqcvY5MVqx4