### PR TITLE
fix(fleet): validated .git/config backup and post-kill restore (GH-715)

### DIFF
--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -61,6 +61,8 @@
    ```bash
    pwsh -NoProfile -File scripts/fleet/git-config-guard.ps1 -RepoPath <worktree> -Verify
    pwsh -NoProfile -File scripts/fleet/git-config-guard.ps1 -RepoPath <worktree> -Restore
+   # 若最新備份本身破損或未被偵測為異常，可手動指向前一代備份：
+   pwsh -NoProfile -File scripts/fleet/git-config-guard.ps1 -RepoPath <worktree> -Restore -BackupPath <worktree>/.git/config.guard.bak.prev
    ```
 
 ---

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -49,6 +49,16 @@
    而任務顯示 `State = Ready`。停 lane 一律走 `lane-stop.ps1`：它停任務、殺整棵
    process tree、依 `CommandLine` 比對 wrapper／brief 路徑驗證無殘留，並補寫
    wrapper 已寫不出的結束記錄（done-file + `=== EXIT ===` 行）。
+   殺之前每個目標會先收到 `taskkill`（不帶 `/F`）並有 `-GraceSec` 秒（預設 5，
+   `0` 關閉）自己結束，之後才強殺——硬殺撞上 git 寫 `.git/config` 會把那個檔
+   變成整片 NUL，主 checkout 與全部 worktree 同時失去 git（GH-715）。殺完後
+   `lane-stop.ps1` 會驗證那份共用 config 仍可解析，壞了就用 `lane-launch.ps1`
+   開跑前存的已驗證備份還原，並在 stdout 印 `gitconfig=…`；還不回來就 exit 1。
+   手動檢查或修復用同一支脚本：
+   ```bash
+   pwsh -NoProfile -File scripts/fleet/git-config-guard.ps1 -RepoPath <worktree> -Verify
+   pwsh -NoProfile -File scripts/fleet/git-config-guard.ps1 -RepoPath <worktree> -Restore
+   ```
 
 ---
 
@@ -168,7 +178,7 @@ Brief 必含：assigned build lane、verification budget（L0 while iterating；
 | 執行用便宜模型（pi 預設 glm-5.3-flash）；**審查一律 Claude Opus**（`claude-opus-5`，顯式 `--model` 釘死，正常臂走 `edda dispatch --agent claude` 訂閱運輸——本機 pi/openrouter 到不了任何 Anthropic 模型；brief 超出 spawn 上限的 fallback 走唯讀 allowlist 的 `claude -p` stdin，表頭印實際臂） | `fleet.review-engine-model`、`fleet.review-backend`（supersede `fleet.agent-model-split` 的審查半邊） |
 | 審查 provider 過載：**改運輸不降模型**——(1) 同 `--model` 先用最低成本探測，通了才重試一次（同一 claude 訂閱運輸）；(2) 仍沒有判決就對該 head 標 `review:unreviewed` 並停——未審查是誠實狀態，便宜模型的判決不是。watcher 無 Codex 路線（superseding 決策 `…codex-route-withdrawn-for-automated-watcher`：Codex 對 watcher 做不到唯讀；人類控制者仍可手動用 Codex）。**2026-09-03 操作者裁決（`opus-default-sol-via-pi-fallback-no-codex`）：不是矛盾，是過時——Opus 是預設引擎，`fleet.review-engine-pool` 的錨仍是 sol（走 pi）；codex 自 `fleet.reviewer-agent` 起就不是審查運輸。watcher 自己不換模型，降到錨引擎是操作者動作** | `fleet.review-provider-overload` |
 | **lane 啟動走 Task Scheduler，不走 nohup／Start-Process**：Claude Code 的工具 shell 在 Windows Job Object 裡，nohup 的子程序仍隨 session 死。`Register-ScheduledTask` + `Start-ScheduledTask`（父程序是 svchost）；該環境 `HOME` 為空，lane wrapper 必須顯式設；`CARGO_TARGET_DIR` 只在 `-BuildLane` 指名四個允許 build lane 之一時設（不編譯的 session 沒有 build lane——`.claude/CLAUDE.md`、`verification.cost-discipline`；要編譯的必須給四擇一，launcher 拒絕其他名字）。`lane-launch.ps1` 不合成 build lane：`-BuildLane` 只收 `worker-1|worker-2|verifier|verifier-2`，設 `CARGO_TARGET_DIR`＝lane root（`$env:LOCALAPPDATA\fleet-workstation\lanes`，可用 `FLEET_LANE_ROOT` 改）\`<BuildLane>`；docs lane 不傳，wrapper 不設。`Get-ScheduledTaskInfo` 可輪詢，`Unregister-ScheduledTask` 清理。重派前先讀 worktree／branch／PR 狀態，不信任 live handle。**手續已脚本化**：用 `scripts/fleet/lane-launch.ps1` 註冊起 lane、`scripts/fleet/lane-status.ps1` 盯狀態（用法見 START HERE），不要再手寫 wrapper | `fleet.lane-launch`、`fleet.lane-dispatch` |
-| **停 lane 一律走 `scripts/fleet/lane-stop.ps1 -Name <lane>`**：`Stop-ScheduledTask` 與 `Unregister-ScheduledTask` 都只終止任務的 wrapper，**不殺它 spawn 的 process tree**（GH-672：被「停」的 lane 照樣 commit／push／開 PR，任務卻顯示 `State = Ready`）。`lane-stop.ps1` 停任務、殺整棵樹（wrapper 已死時依 `CommandLine` 比對 wrapper／brief 路徑抓孤兒）、驗證無殘留、回報實際終止了什麼，並補寫結束記錄（done-file + lane log 的 `=== EXIT ===` 行）——wrapper 本身也在 `finally` 寫同樣的結束記錄，所以正常結束、出錯、被停三種 endings 都有 EXIT | `fleet.lane-stop-4090` |
+| **停 lane 一律走 `scripts/fleet/lane-stop.ps1 -Name <lane>`**：`Stop-ScheduledTask` 與 `Unregister-ScheduledTask` 都只終止任務的 wrapper，**不殺它 spawn 的 process tree**（GH-672：被「停」的 lane 照樣 commit／push／開 PR，任務卻顯示 `State = Ready`）。`lane-stop.ps1` 停任務、殺整棵樹（wrapper 已死時依 `CommandLine` 比對 wrapper／brief 路徑抓孤兒）、驗證無殘留、回報實際終止了什麼，並補寫結束記錄（done-file + lane log 的 `=== EXIT ===` 行）——wrapper 本身也在 `finally` 寫同樣的結束記錄，所以正常結束、出錯、被停三種 endings 都有 EXIT。**殺是「先請、後強」**：每個目標先收不帶 `/F` 的 `taskkill`，`-GraceSec` 秒（預設 5）內自己結束就不強殺；殺完再驗證共用 `.git/config` 仍可解析，壞了就從 `lane-launch.ps1` 開跑前存的**已驗證**備份還原（`scripts/fleet/git-config-guard.ps1`），還不回來就 exit 1。硬殺撞上 git 寫 config 會把它變成整片 NUL，主 checkout 加全部 worktree 同時失去 git；2026-09-02／03 各發生一次，而當時的 `.bak` 是**損毀後**才複製的，所以也是整片 NUL——備份不驗證等於沒有備份（GH-715） | `fleet.lane-stop-4090` |
 | 一 issue ＝ 一單 phase plan ＝ 一 worktree ＝ 一 build lane；並行在 plan 之間；plan 裡不寫沒理由的 `depends_on`；並行 plan 不用 verdict gate | `cleanup.parallel-exec`、`cleanup.review-gate` |
 | 派工前跨機器認領一律走機械守門（GH-656）：開工步先跑 `scripts/fleet-claim-issue.sh <issue> <machine>`（未認領→貼 `taking:` 留言＋加 `lane:<machine>` 標籤，exit 0；**別台已認領→exit 1 不動**；本機已認領→冪等 exit 0；`--check` 唯讀），或用 `edda dispatch --issue <N> --machine <label>` 派發——它在啟動 agent 前跑同一檢查，**別台已認領 → exit 2、不啟動 agent、`--json.error` 說明原因**；machine 只認顯式值（旗標或 `EDDA_MACHINE`），不猜 hostname | `fleet.cross-machine-claim`（GH-656 把約定變成守門） |
 | build lane 只用 `worker-1|worker-2|verifier|verifier-2`；永不建 ad-hoc `CARGO_TARGET_DIR`；L1 與 verifier 設 `CARGO_INCREMENTAL=0` | `verification.cost-discipline` |

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -49,11 +49,14 @@
    而任務顯示 `State = Ready`。停 lane 一律走 `lane-stop.ps1`：它停任務、殺整棵
    process tree、依 `CommandLine` 比對 wrapper／brief 路徑驗證無殘留，並補寫
    wrapper 已寫不出的結束記錄（done-file + `=== EXIT ===` 行）。
-   殺之前每個目標會先收到 `taskkill`（不帶 `/F`）並有 `-GraceSec` 秒（預設 5，
-   `0` 關閉）自己結束，之後才強殺——硬殺撞上 git 寫 `.git/config` 會把那個檔
-   變成整片 NUL，主 checkout 與全部 worktree 同時失去 git（GH-715）。殺完後
-   `lane-stop.ps1` 會驗證那份共用 config 仍可解析，壞了就用 `lane-launch.ps1`
-   開跑前存的已驗證備份還原，並在 stdout 印 `gitconfig=…`；還不回來就 exit 1。
+   硬殺撞上 git 寫 `.git/config` 會把那個檔變成整片 NUL，主 checkout 與全部
+   worktree 同時失去 git（GH-715）。**殺法沒有變**（不帶 `/F` 的 `taskkill` 送的
+   是 WM_CLOSE，而 lane 的程序是沒有視窗的隱藏 console 程序，實測回 exit 128
+   「只能強制終止」且目標存活，所以沒有可用的優雅關閉），改成殺完之後修：
+   `lane-stop.ps1` 驗證那份共用 config 仍可解析，壞了就用 `lane-launch.ps1`
+   開跑前存的已驗證備份還原，並在 stdout 印 `gitconfig=…`；還不回來就 exit 1
+   ——但結束記錄（done-file + `=== EXIT ===`）一定先寫，不會因為 config 的事
+   丟掉（GH-672）。
    手動檢查或修復用同一支脚本：
    ```bash
    pwsh -NoProfile -File scripts/fleet/git-config-guard.ps1 -RepoPath <worktree> -Verify
@@ -178,7 +181,7 @@ Brief 必含：assigned build lane、verification budget（L0 while iterating；
 | 執行用便宜模型（pi 預設 glm-5.3-flash）；**審查一律 Claude Opus**（`claude-opus-5`，顯式 `--model` 釘死，正常臂走 `edda dispatch --agent claude` 訂閱運輸——本機 pi/openrouter 到不了任何 Anthropic 模型；brief 超出 spawn 上限的 fallback 走唯讀 allowlist 的 `claude -p` stdin，表頭印實際臂） | `fleet.review-engine-model`、`fleet.review-backend`（supersede `fleet.agent-model-split` 的審查半邊） |
 | 審查 provider 過載：**改運輸不降模型**——(1) 同 `--model` 先用最低成本探測，通了才重試一次（同一 claude 訂閱運輸）；(2) 仍沒有判決就對該 head 標 `review:unreviewed` 並停——未審查是誠實狀態，便宜模型的判決不是。watcher 無 Codex 路線（superseding 決策 `…codex-route-withdrawn-for-automated-watcher`：Codex 對 watcher 做不到唯讀；人類控制者仍可手動用 Codex）。**2026-09-03 操作者裁決（`opus-default-sol-via-pi-fallback-no-codex`）：不是矛盾，是過時——Opus 是預設引擎，`fleet.review-engine-pool` 的錨仍是 sol（走 pi）；codex 自 `fleet.reviewer-agent` 起就不是審查運輸。watcher 自己不換模型，降到錨引擎是操作者動作** | `fleet.review-provider-overload` |
 | **lane 啟動走 Task Scheduler，不走 nohup／Start-Process**：Claude Code 的工具 shell 在 Windows Job Object 裡，nohup 的子程序仍隨 session 死。`Register-ScheduledTask` + `Start-ScheduledTask`（父程序是 svchost）；該環境 `HOME` 為空，lane wrapper 必須顯式設；`CARGO_TARGET_DIR` 只在 `-BuildLane` 指名四個允許 build lane 之一時設（不編譯的 session 沒有 build lane——`.claude/CLAUDE.md`、`verification.cost-discipline`；要編譯的必須給四擇一，launcher 拒絕其他名字）。`lane-launch.ps1` 不合成 build lane：`-BuildLane` 只收 `worker-1|worker-2|verifier|verifier-2`，設 `CARGO_TARGET_DIR`＝lane root（`$env:LOCALAPPDATA\fleet-workstation\lanes`，可用 `FLEET_LANE_ROOT` 改）\`<BuildLane>`；docs lane 不傳，wrapper 不設。`Get-ScheduledTaskInfo` 可輪詢，`Unregister-ScheduledTask` 清理。重派前先讀 worktree／branch／PR 狀態，不信任 live handle。**手續已脚本化**：用 `scripts/fleet/lane-launch.ps1` 註冊起 lane、`scripts/fleet/lane-status.ps1` 盯狀態（用法見 START HERE），不要再手寫 wrapper | `fleet.lane-launch`、`fleet.lane-dispatch` |
-| **停 lane 一律走 `scripts/fleet/lane-stop.ps1 -Name <lane>`**：`Stop-ScheduledTask` 與 `Unregister-ScheduledTask` 都只終止任務的 wrapper，**不殺它 spawn 的 process tree**（GH-672：被「停」的 lane 照樣 commit／push／開 PR，任務卻顯示 `State = Ready`）。`lane-stop.ps1` 停任務、殺整棵樹（wrapper 已死時依 `CommandLine` 比對 wrapper／brief 路徑抓孤兒）、驗證無殘留、回報實際終止了什麼，並補寫結束記錄（done-file + lane log 的 `=== EXIT ===` 行）——wrapper 本身也在 `finally` 寫同樣的結束記錄，所以正常結束、出錯、被停三種 endings 都有 EXIT。**殺是「先請、後強」**：每個目標先收不帶 `/F` 的 `taskkill`，`-GraceSec` 秒（預設 5）內自己結束就不強殺；殺完再驗證共用 `.git/config` 仍可解析，壞了就從 `lane-launch.ps1` 開跑前存的**已驗證**備份還原（`scripts/fleet/git-config-guard.ps1`），還不回來就 exit 1。硬殺撞上 git 寫 config 會把它變成整片 NUL，主 checkout 加全部 worktree 同時失去 git；2026-09-02／03 各發生一次，而當時的 `.bak` 是**損毀後**才複製的，所以也是整片 NUL——備份不驗證等於沒有備份（GH-715） | `fleet.lane-stop-4090` |
+| **停 lane 一律走 `scripts/fleet/lane-stop.ps1 -Name <lane>`**：`Stop-ScheduledTask` 與 `Unregister-ScheduledTask` 都只終止任務的 wrapper，**不殺它 spawn 的 process tree**（GH-672：被「停」的 lane 照樣 commit／push／開 PR，任務卻顯示 `State = Ready`）。`lane-stop.ps1` 停任務、殺整棵樹（wrapper 已死時依 `CommandLine` 比對 wrapper／brief 路徑抓孤兒）、驗證無殘留、回報實際終止了什麼，並補寫結束記錄（done-file + lane log 的 `=== EXIT ===` 行）——wrapper 本身也在 `finally` 寫同樣的結束記錄，所以正常結束、出錯、被停三種 endings 都有 EXIT。**殺完要驗共用 `.git/config`**：硬殺撞上 git 寫 config 會把它變成整片 NUL，主 checkout 加全部 worktree 同時失去 git；2026-09-02／03 各發生一次，而當時的 `.bak` 是**損毀後**才複製的，所以也是整片 NUL——備份不驗證等於沒有備份（GH-715）。殺完 `lane-stop.ps1` 驗證 config 仍可解析，壞了就從 `lane-launch.ps1` 開跑前存的**已驗證**備份還原（`scripts/fleet/git-config-guard.ps1`），還不回來就 exit 1；結束記錄一定先寫。沒有優雅關閉窗口：不帶 `/F` 的 `taskkill` 對沒有視窗的隱藏 console 程序無效（實測 exit 128、目標存活），加一段等待只會讓每次停 lane 多付秒數而擋不住任何損毀 | `fleet.lane-stop-4090` |
 | 一 issue ＝ 一單 phase plan ＝ 一 worktree ＝ 一 build lane；並行在 plan 之間；plan 裡不寫沒理由的 `depends_on`；並行 plan 不用 verdict gate | `cleanup.parallel-exec`、`cleanup.review-gate` |
 | 派工前跨機器認領一律走機械守門（GH-656）：開工步先跑 `scripts/fleet-claim-issue.sh <issue> <machine>`（未認領→貼 `taking:` 留言＋加 `lane:<machine>` 標籤，exit 0；**別台已認領→exit 1 不動**；本機已認領→冪等 exit 0；`--check` 唯讀），或用 `edda dispatch --issue <N> --machine <label>` 派發——它在啟動 agent 前跑同一檢查，**別台已認領 → exit 2、不啟動 agent、`--json.error` 說明原因**；machine 只認顯式值（旗標或 `EDDA_MACHINE`），不猜 hostname | `fleet.cross-machine-claim`（GH-656 把約定變成守門） |
 | build lane 只用 `worker-1|worker-2|verifier|verifier-2`；永不建 ad-hoc `CARGO_TARGET_DIR`；L1 與 verifier 設 `CARGO_INCREMENTAL=0` | `verification.cost-discipline` |

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -61,8 +61,8 @@
    ```bash
    pwsh -NoProfile -File scripts/fleet/git-config-guard.ps1 -RepoPath <worktree> -Verify
    pwsh -NoProfile -File scripts/fleet/git-config-guard.ps1 -RepoPath <worktree> -Restore
-   # 若最新備份本身破損或未被偵測為異常，可手動指向前一代備份：
-   pwsh -NoProfile -File scripts/fleet/git-config-guard.ps1 -RepoPath <worktree> -Restore -BackupPath <worktree>/.git/config.guard.bak.prev
+   # 若最新備份本身破損（但仍可解析）已被套用，直接手動覆蓋為前一代備份：
+   Copy-Item <worktree>/.git/config.guard.bak.prev <worktree>/.git/config -Force
    ```
 
 ---

--- a/scripts/fleet/git-config-guard.ps1
+++ b/scripts/fleet/git-config-guard.ps1
@@ -213,7 +213,7 @@ if ($Backup) {
   if ($health.Unreadable) {
     # Nothing is known about the config, so nothing may be concluded from it:
     # do not overwrite the backup, and do not claim the config is broken.
-    Fail "config could not be read, so no backup was taken ($($health.Reason)); $BackupPath left as it was" 3
+    Fail "config could not be read, so no backup was taken ($($health.Reason)); $BackupPath left as it was" 4
   }
   if (-not $health.Healthy) {
     # Refusing here is the whole point: the real .bak files on this machine were

--- a/scripts/fleet/git-config-guard.ps1
+++ b/scripts/fleet/git-config-guard.ps1
@@ -1,0 +1,205 @@
+# git-config-guard.ps1 — keep the shared .git/config recoverable (GH-715).
+#
+# The main checkout and all 30+ linked worktrees read ONE .git/config to find
+# the remote. On 2026-09-02 17:16 and 2026-09-03 01:33 that file became a run
+# of NUL bytes (27328/27328 and 2561/2561) after lanes were hard-killed while
+# git was extending it — `fatal: bad config line 1` for every worktree at once.
+# There was no restore point: the .bak sitting next to it had been copied
+# AFTER the corruption, so it was all NULs too.
+#
+# The fix that makes a backup worth having is validating BEFORE copying. This
+# script never writes a backup it has not parsed, and never reports a repair it
+# did not make.
+#
+# usage:
+#   pwsh -NoProfile -File scripts/fleet/git-config-guard.ps1 -RepoPath <repo> -Backup
+#   pwsh -NoProfile -File scripts/fleet/git-config-guard.ps1 -RepoPath <repo> -Verify
+#   pwsh -NoProfile -File scripts/fleet/git-config-guard.ps1 -RepoPath <repo> -Restore
+#   pwsh -NoProfile -File scripts/fleet/git-config-guard.ps1 -RepoPath <repo> -VerifyOrRestore
+#
+# -RepoPath may be the main checkout or any linked worktree: the target is
+# always the SHARED config (`git rev-parse --git-common-dir`), because that is
+# the single file whose loss takes down every worktree.
+#
+# Exit codes:
+#   0  the config is healthy (backed up / verified / restored)
+#   1  usage or resolution error (no mode, not a git repo, git unavailable)
+#   2  the config is unhealthy — and for -Restore/-VerifyOrRestore, could not
+#      be repaired (no usable backup, or the restored file still does not parse)
+#   3  the config is healthy but the backup could not be written
+param(
+  [string]$RepoPath = '.',
+  [switch]$Backup,
+  [switch]$Verify,
+  [switch]$Restore,
+  [switch]$VerifyOrRestore,
+  [string]$BackupPath = ''
+)
+
+$ErrorActionPreference = 'Stop'
+# This script decides on $LASTEXITCODE from `git`, so a non-zero native exit
+# must not throw (PowerShell 7.4 turns that on by default).
+$PSNativeCommandUseErrorActionPreference = $false
+
+function Fail([string]$Msg, [int]$Code = 1) {
+  [Console]::Error.WriteLine("git-config-guard: $Msg")
+  exit $Code
+}
+
+$modes = @($Backup, $Verify, $Restore, $VerifyOrRestore) | Where-Object { $_ }
+if ($modes.Count -ne 1) {
+  Fail 'give exactly one of -Backup, -Verify, -Restore, -VerifyOrRestore'
+}
+
+# --- resolve the shared config ----------------------------------------------
+
+if (-not (Test-Path -LiteralPath $RepoPath)) { Fail "-RepoPath '$RepoPath' does not exist" }
+$RepoPath = (Resolve-Path -LiteralPath $RepoPath).Path
+
+# Ask git first — it is authoritative and honours GIT_DIR and friends. But the
+# case this tool exists for is exactly the one where git refuses to answer:
+# once .git/config is a run of NULs, EVERY git command in the repo fails,
+# rev-parse included. So fall back to walking the same links git would.
+function Resolve-CommonDir([string]$Start) {
+  # Collect the whole stream before reading $LASTEXITCODE: `Select-Object
+  # -First` stops the pipeline early and leaves the exit code unset.
+  $out = @(& git -C $Start rev-parse --path-format=absolute --git-common-dir 2>$null)
+  if ($LASTEXITCODE -eq 0 -and $out.Count -gt 0) {
+    $fromGit = "$($out[0])".Trim()
+    if ($fromGit -and (Test-Path -LiteralPath $fromGit -PathType Container)) {
+      return (Resolve-Path -LiteralPath $fromGit).Path
+    }
+  }
+
+  # .git is a directory in the main checkout, and a file holding "gitdir: <p>"
+  # in a linked worktree; <gitdir>/commondir then names the SHARED dir.
+  $gitDir = $null
+  $dir = $Start
+  while ($dir) {
+    $dotGit = Join-Path $dir '.git'
+    if (Test-Path -LiteralPath $dotGit -PathType Container) { $gitDir = $dotGit; break }
+    if (Test-Path -LiteralPath $dotGit -PathType Leaf) {
+      $line = Get-Content -LiteralPath $dotGit -TotalCount 1
+      if ($line -match '^\s*gitdir:\s*(.+?)\s*$') {
+        $g = $Matches[1]
+        if (-not [System.IO.Path]::IsPathRooted($g)) { $g = Join-Path $dir $g }
+        $gitDir = $g
+      }
+      break
+    }
+    $parent = Split-Path -Parent $dir
+    if (-not $parent -or $parent -eq $dir) { break }
+    $dir = $parent
+  }
+  if (-not $gitDir -or -not (Test-Path -LiteralPath $gitDir -PathType Container)) { return $null }
+  $gitDir = (Resolve-Path -LiteralPath $gitDir).Path
+
+  $commonFile = Join-Path $gitDir 'commondir'
+  if (Test-Path -LiteralPath $commonFile -PathType Leaf) {
+    $rel = "$(Get-Content -LiteralPath $commonFile -TotalCount 1)".Trim()
+    if ($rel) {
+      $c = if ([System.IO.Path]::IsPathRooted($rel)) { $rel } else { Join-Path $gitDir $rel }
+      if (Test-Path -LiteralPath $c -PathType Container) { return (Resolve-Path -LiteralPath $c).Path }
+    }
+  }
+  return $gitDir
+}
+
+$commonDir = Resolve-CommonDir $RepoPath
+if (-not $commonDir) {
+  Fail "-RepoPath '$RepoPath' is not a git worktree (neither git rev-parse nor a .git link resolved a common dir)"
+}
+$ConfigPath = Join-Path $commonDir 'config'
+if (-not $BackupPath) { $BackupPath = Join-Path $commonDir 'config.guard.bak' }
+
+# --- health ------------------------------------------------------------------
+
+# Healthy means all three: the file has content, holds no NUL byte, and git
+# itself can parse it. The NUL check is what names the failure seen twice on
+# 2026-09-03; `git config --list` is the criterion GH-715 asks a backup to meet.
+function Get-ConfigHealth([string]$Path) {
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    return @{ Healthy = $false; Reason = 'file does not exist' }
+  }
+  $bytes = [System.IO.File]::ReadAllBytes($Path)
+  if ($bytes.Length -eq 0) {
+    return @{ Healthy = $false; Reason = 'file is empty' }
+  }
+  $nul = 0
+  foreach ($b in $bytes) { if ($b -eq 0) { $nul++ } }
+  if ($nul -gt 0) {
+    return @{ Healthy = $false; Reason = "$nul NUL byte(s) in $($bytes.Length) — the GH-715 corruption shape" }
+  }
+  & git config --list --file $Path 2>&1 | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    return @{ Healthy = $false; Reason = 'git config --list cannot parse it' }
+  }
+  return @{ Healthy = $true; Reason = 'parses, no NUL bytes' }
+}
+
+# Copy through a sibling temp file so a reader never observes a half-written
+# destination — the same class of hazard that produced the NUL config.
+function Copy-Atomic([string]$From, [string]$To) {
+  $tmp = "$To.guard-tmp"
+  Copy-Item -LiteralPath $From -Destination $tmp -Force
+  Move-Item -LiteralPath $tmp -Destination $To -Force
+}
+
+$health = Get-ConfigHealth $ConfigPath
+
+# --- -Verify -----------------------------------------------------------------
+
+if ($Verify) {
+  if ($health.Healthy) {
+    "config=$ConfigPath healthy ($($health.Reason))"
+    exit 0
+  }
+  Fail "config=$ConfigPath UNHEALTHY: $($health.Reason)" 2
+}
+
+# --- -Backup -----------------------------------------------------------------
+
+if ($Backup) {
+  if (-not $health.Healthy) {
+    # Refusing here is the whole point: the real .bak files on this machine were
+    # copied after the corruption and were therefore useless.
+    Fail "refusing to back up an unhealthy config ($($health.Reason)); $BackupPath left as it was" 2
+  }
+  try {
+    Copy-Atomic $ConfigPath $BackupPath
+  } catch {
+    Fail "config is healthy but the backup could not be written to ${BackupPath}: $($_.Exception.Message)" 3
+  }
+  "config=$ConfigPath healthy; backup=$BackupPath"
+  exit 0
+}
+
+# --- -Restore / -VerifyOrRestore ---------------------------------------------
+
+if ($health.Healthy) {
+  "config=$ConfigPath healthy ($($health.Reason)); nothing restored"
+  exit 0
+}
+
+[Console]::Error.WriteLine("git-config-guard: config=$ConfigPath UNHEALTHY: $($health.Reason)")
+
+$backupHealth = Get-ConfigHealth $BackupPath
+if (-not $backupHealth.Healthy) {
+  Fail "no usable backup to restore from (backup=$BackupPath : $($backupHealth.Reason)); config left untouched for forensics" 2
+}
+
+# Keep the corrupt file: it is the only evidence of what the kill did, and the
+# name matches the ones already archived for the two 2026-09 incidents.
+$stamp = Get-Date -Format 'yyyy-MM-ddTHH-mm-ss'
+$preserved = Join-Path $commonDir "config.CORRUPT.$stamp.bak"
+Copy-Item -LiteralPath $ConfigPath -Destination $preserved -Force
+
+Copy-Atomic $BackupPath $ConfigPath
+
+$after = Get-ConfigHealth $ConfigPath
+if (-not $after.Healthy) {
+  Fail "RESTORE FAILED: config still unhealthy after copying $BackupPath ($($after.Reason))" 2
+}
+
+"RESTORED config=$ConfigPath from backup=$BackupPath; corrupt file preserved at $preserved"
+exit 0

--- a/scripts/fleet/git-config-guard.ps1
+++ b/scripts/fleet/git-config-guard.ps1
@@ -21,10 +21,13 @@
 # always the SHARED config (`git rev-parse --git-common-dir`), because that is
 # the single file whose loss takes down every worktree.
 #
-# -Backup keeps one generation: the outgoing backup moves to
-# <backup>.prev before the new one is written, and -Restore falls back to it.
-# A torn write can end on a byte boundary that still parses, and backing THAT
-# up would retire the last complete copy.
+# -Backup keeps one generation: the outgoing backup moves to <backup>.prev
+# before the new one is written. Be precise about what that buys. The
+# AUTOMATIC fallback only fires when the newest backup is DETECTABLY broken
+# (case 10). It cannot fire for the case that motivates keeping a generation
+# at all — a torn write ending on a boundary that still parses — because
+# nothing can tell that file from a good one; there, .prev is the copy an
+# operator points -BackupPath at by hand once they know the newest is wrong.
 #
 # A config that cannot be READ (held open by whatever is writing it) is a third
 # outcome, not a synonym for corrupt: nothing is backed up from it and nothing
@@ -35,8 +38,9 @@
 #   1  usage or resolution error (no mode, not a git repo, git unavailable)
 #   2  the config is unhealthy — and for -Restore/-VerifyOrRestore, could not
 #      be repaired (no usable backup, or the restored file still does not parse)
-#   3  no backup was taken: the config is healthy but the copy failed, or the
-#      config could not be read at all
+#   3  no backup was taken: the config is healthy but the copy failed
+#   4  the config could not be judged at all, because it could not be read.
+#      Distinct from 2 on purpose: nothing is known to be wrong with it
 param(
   [string]$RepoPath = '.',
   [switch]$Backup,
@@ -191,14 +195,18 @@ if ($Verify) {
     "config=$ConfigPath healthy ($($health.Reason))"
     exit 0
   }
+  if ($health.Unreadable) {
+    Fail "config=$ConfigPath COULD NOT BE JUDGED: $($health.Reason)" 4
+  }
   Fail "config=$ConfigPath UNHEALTHY: $($health.Reason)" 2
 }
 
 # --- -Backup -----------------------------------------------------------------
 
-# One generation back. A torn write can land on a byte boundary that still
-# parses, and backing that up would retire the last complete copy; keeping the
-# previous one means a single such event is still recoverable.
+# One generation back. The automatic fallback below only fires when the newest
+# backup is DETECTABLY broken; for a torn-but-parsing one nothing can tell it
+# from a good copy, and .prev is then the file an operator restores by hand
+# with -BackupPath. See the header.
 $PrevBackupPath = "$BackupPath.prev"
 
 if ($Backup) {
@@ -232,7 +240,7 @@ if ($health.Healthy) {
 if ($health.Unreadable) {
   # A locked config is not a corrupt one. Overwriting it here would destroy a
   # file that may be perfectly good and is currently being written.
-  Fail "config=$ConfigPath could not be read, so it was NOT restored ($($health.Reason)); check what holds it open" 2
+  Fail "config=$ConfigPath could not be read, so it was NOT restored ($($health.Reason)); check what holds it open" 4
 }
 
 [Console]::Error.WriteLine("git-config-guard: config=$ConfigPath UNHEALTHY: $($health.Reason)")

--- a/scripts/fleet/git-config-guard.ps1
+++ b/scripts/fleet/git-config-guard.ps1
@@ -21,12 +21,22 @@
 # always the SHARED config (`git rev-parse --git-common-dir`), because that is
 # the single file whose loss takes down every worktree.
 #
+# -Backup keeps one generation: the outgoing backup moves to
+# <backup>.prev before the new one is written, and -Restore falls back to it.
+# A torn write can end on a byte boundary that still parses, and backing THAT
+# up would retire the last complete copy.
+#
+# A config that cannot be READ (held open by whatever is writing it) is a third
+# outcome, not a synonym for corrupt: nothing is backed up from it and nothing
+# is restored over it, because it may be perfectly good.
+#
 # Exit codes:
 #   0  the config is healthy (backed up / verified / restored)
 #   1  usage or resolution error (no mode, not a git repo, git unavailable)
 #   2  the config is unhealthy — and for -Restore/-VerifyOrRestore, could not
 #      be repaired (no usable backup, or the restored file still does not parse)
-#   3  the config is healthy but the backup could not be written
+#   3  no backup was taken: the config is healthy but the copy failed, or the
+#      config could not be read at all
 param(
   [string]$RepoPath = '.',
   [switch]$Backup,
@@ -38,7 +48,9 @@ param(
 
 $ErrorActionPreference = 'Stop'
 # This script decides on $LASTEXITCODE from `git`, so a non-zero native exit
-# must not throw (PowerShell 7.4 turns that on by default).
+# must not throw. The default is $false on the pwsh in use (7.6.5, measured),
+# but it is settable per session and per profile, so state the contract here
+# rather than inherit it.
 $PSNativeCommandUseErrorActionPreference = $false
 
 function Fail([string]$Msg, [int]$Code = 1) {
@@ -117,11 +129,19 @@ if (-not $BackupPath) { $BackupPath = Join-Path $commonDir 'config.guard.bak' }
 # Healthy means all three: the file has content, holds no NUL byte, and git
 # itself can parse it. The NUL check is what names the failure seen twice on
 # 2026-09-03; `git config --list` is the criterion GH-715 asks a backup to meet.
+#
+# "Unreadable" is a THIRD outcome, not a synonym for unhealthy: a config held
+# open by a process that is still writing it cannot be judged, and must not be
+# overwritten from a backup on the strength of a failed read.
 function Get-ConfigHealth([string]$Path) {
   if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
     return @{ Healthy = $false; Reason = 'file does not exist' }
   }
-  $bytes = [System.IO.File]::ReadAllBytes($Path)
+  try {
+    $bytes = [System.IO.File]::ReadAllBytes($Path)
+  } catch {
+    return @{ Healthy = $false; Unreadable = $true; Reason = "cannot be read: $($_.Exception.Message)" }
+  }
   if ($bytes.Length -eq 0) {
     return @{ Healthy = $false; Reason = 'file is empty' }
   }
@@ -138,11 +158,28 @@ function Get-ConfigHealth([string]$Path) {
 }
 
 # Copy through a sibling temp file so a reader never observes a half-written
-# destination — the same class of hazard that produced the NUL config.
+# destination — the same class of hazard that produced the NUL config. The temp
+# file is never left behind: a half-written .guard-tmp is the very thing this
+# script exists to keep out of the git directory.
 function Copy-Atomic([string]$From, [string]$To) {
   $tmp = "$To.guard-tmp"
-  Copy-Item -LiteralPath $From -Destination $tmp -Force
-  Move-Item -LiteralPath $tmp -Destination $To -Force
+  try {
+    Copy-Item -LiteralPath $From -Destination $tmp -Force
+    Move-Item -LiteralPath $tmp -Destination $To -Force
+  } finally {
+    if (Test-Path -LiteralPath $tmp -PathType Leaf) {
+      Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+    }
+  }
+}
+
+# A name no existing file holds, so a second restore inside the same second
+# cannot overwrite the first one's evidence.
+function New-UniquePath([string]$Path) {
+  if (-not (Test-Path -LiteralPath $Path)) { return $Path }
+  $n = 2
+  while (Test-Path -LiteralPath "$Path.$n") { $n++ }
+  return "$Path.$n"
 }
 
 $health = Get-ConfigHealth $ConfigPath
@@ -159,13 +196,24 @@ if ($Verify) {
 
 # --- -Backup -----------------------------------------------------------------
 
+# One generation back. A torn write can land on a byte boundary that still
+# parses, and backing that up would retire the last complete copy; keeping the
+# previous one means a single such event is still recoverable.
+$PrevBackupPath = "$BackupPath.prev"
+
 if ($Backup) {
+  if ($health.Unreadable) {
+    # Nothing is known about the config, so nothing may be concluded from it:
+    # do not overwrite the backup, and do not claim the config is broken.
+    Fail "config could not be read, so no backup was taken ($($health.Reason)); $BackupPath left as it was" 3
+  }
   if (-not $health.Healthy) {
     # Refusing here is the whole point: the real .bak files on this machine were
     # copied after the corruption and were therefore useless.
     Fail "refusing to back up an unhealthy config ($($health.Reason)); $BackupPath left as it was" 2
   }
   try {
+    if ((Get-ConfigHealth $BackupPath).Healthy) { Copy-Atomic $BackupPath $PrevBackupPath }
     Copy-Atomic $ConfigPath $BackupPath
   } catch {
     Fail "config is healthy but the backup could not be written to ${BackupPath}: $($_.Exception.Message)" 3
@@ -181,25 +229,36 @@ if ($health.Healthy) {
   exit 0
 }
 
+if ($health.Unreadable) {
+  # A locked config is not a corrupt one. Overwriting it here would destroy a
+  # file that may be perfectly good and is currently being written.
+  Fail "config=$ConfigPath could not be read, so it was NOT restored ($($health.Reason)); check what holds it open" 2
+}
+
 [Console]::Error.WriteLine("git-config-guard: config=$ConfigPath UNHEALTHY: $($health.Reason)")
 
-$backupHealth = Get-ConfigHealth $BackupPath
-if (-not $backupHealth.Healthy) {
-  Fail "no usable backup to restore from (backup=$BackupPath : $($backupHealth.Reason)); config left untouched for forensics" 2
+$source = $null
+foreach ($candidate in @($BackupPath, $PrevBackupPath)) {
+  $candidateHealth = Get-ConfigHealth $candidate
+  if ($candidateHealth.Healthy) { $source = $candidate; break }
+  [Console]::Error.WriteLine("git-config-guard: unusable backup ${candidate}: $($candidateHealth.Reason)")
+}
+if (-not $source) {
+  Fail "no usable backup to restore from (tried $BackupPath, $PrevBackupPath); config left untouched for forensics" 2
 }
 
 # Keep the corrupt file: it is the only evidence of what the kill did, and the
 # name matches the ones already archived for the two 2026-09 incidents.
 $stamp = Get-Date -Format 'yyyy-MM-ddTHH-mm-ss'
-$preserved = Join-Path $commonDir "config.CORRUPT.$stamp.bak"
+$preserved = New-UniquePath (Join-Path $commonDir "config.CORRUPT.$stamp.bak")
 Copy-Item -LiteralPath $ConfigPath -Destination $preserved -Force
 
-Copy-Atomic $BackupPath $ConfigPath
+Copy-Atomic $source $ConfigPath
 
 $after = Get-ConfigHealth $ConfigPath
 if (-not $after.Healthy) {
-  Fail "RESTORE FAILED: config still unhealthy after copying $BackupPath ($($after.Reason))" 2
+  Fail "RESTORE FAILED: config still unhealthy after copying $source ($($after.Reason))" 2
 }
 
-"RESTORED config=$ConfigPath from backup=$BackupPath; corrupt file preserved at $preserved"
+"RESTORED config=$ConfigPath from backup=$source; corrupt file preserved at $preserved"
 exit 0

--- a/scripts/fleet/lane-launch.ps1
+++ b/scripts/fleet/lane-launch.ps1
@@ -14,7 +14,10 @@
 #
 # Every artifact the launcher writes lives under -LogDir (resolved to an
 # absolute path before anything is written or embedded — the task runs from a
-# different working directory); nothing is written into the repo.
+# different working directory). The one exception is the validated
+# .git/config backup taken before the lane starts (GH-715): it is written
+# beside the config it protects, inside the git common dir, and is not part
+# of the repo's tracked content.
 #
 # usage:
 #   pwsh -NoProfile -File scripts/fleet/lane-launch.ps1 -Name <lane> -Brief <brief.md> `
@@ -29,7 +32,8 @@
 # launcher never synthesizes a build lane; docs lanes compile nothing and
 # pass none.
 #
-# Prints, one line each: task name, state, wrapper path, log path, done path.
+# Prints, one line each: the .git/config backup verdict (GH-715), then task
+# name, state, wrapper path, log path, done path.
 # Poll with scripts/fleet/lane-status.ps1; the done-file appears (containing
 # the exit code) when the lane finishes. The wrapper writes its end record
 # (=== EXIT === log line + done-file) no matter how the run ends; when the
@@ -88,7 +92,10 @@ if ($existing -and $existing.State -eq 'Running') {
 }
 $inside = (& git -C $Cwd rev-parse --is-inside-work-tree 2>$null)
 if ($LASTEXITCODE -ne 0 -or $inside -ne 'true') {
-  Fail "-Cwd '$Cwd' is not a git worktree (git rev-parse --is-inside-work-tree failed)"
+  # A NUL-corrupted shared .git/config fails every git command in the repo,
+  # rev-parse included (GH-715), so this gate is where that shows up first —
+  # name the repair rather than leaving "not a git worktree" as the only clue.
+  Fail "-Cwd '$Cwd' is not a git worktree (git rev-parse --is-inside-work-tree failed). If the repo was a worktree until recently, check the shared config: scripts/fleet/git-config-guard.ps1 -RepoPath '$Cwd' -Verify, then -Restore"
 }
 
 # --- resolve paths (absolute BEFORE anything is written or embedded) --------
@@ -100,10 +107,13 @@ $Cwd = (Resolve-Path -LiteralPath $Cwd).Path
 # hard kill mid-write leaves it all NULs and every worktree loses git at once.
 # Copy it now, while nothing of this lane is writing — and only if it parses,
 # which is exactly the check the two useless .bak files of 2026-09 skipped.
+# Exit 2 (unhealthy) is reachable only for shapes git still tolerates — an
+# empty config, say — because the rev-parse gate above already rejects the
+# ones git cannot read at all.
 & (Join-Path $PSScriptRoot 'git-config-guard.ps1') -RepoPath $Cwd -Backup
 $guardExit = $LASTEXITCODE
 if ($guardExit -eq 2) {
-  Fail "the shared .git/config for '$Cwd' does not parse; repair it first (scripts/fleet/git-config-guard.ps1 -RepoPath '$Cwd' -Restore) — a lane launched against it cannot run git"
+  Fail "the shared .git/config for '$Cwd' is not usable; repair it first (scripts/fleet/git-config-guard.ps1 -RepoPath '$Cwd' -Restore) — a lane launched against it cannot run git"
 }
 if ($guardExit -ne 0) {
   [Console]::Error.WriteLine("lane-launch: warning: .git/config backup not written (git-config-guard exit $guardExit); launching anyway, but lane-stop will have nothing to restore from")

--- a/scripts/fleet/lane-launch.ps1
+++ b/scripts/fleet/lane-launch.ps1
@@ -94,6 +94,21 @@ if ($LASTEXITCODE -ne 0 -or $inside -ne 'true') {
 # --- resolve paths (absolute BEFORE anything is written or embedded) --------
 
 $Cwd = (Resolve-Path -LiteralPath $Cwd).Path
+
+# --- known-good .git/config, captured BEFORE the lane can write (GH-715) ----
+# The lane ends with `git push -u`, which extends the SHARED .git/config; a
+# hard kill mid-write leaves it all NULs and every worktree loses git at once.
+# Copy it now, while nothing of this lane is writing — and only if it parses,
+# which is exactly the check the two useless .bak files of 2026-09 skipped.
+& (Join-Path $PSScriptRoot 'git-config-guard.ps1') -RepoPath $Cwd -Backup
+$guardExit = $LASTEXITCODE
+if ($guardExit -eq 2) {
+  Fail "the shared .git/config for '$Cwd' does not parse; repair it first (scripts/fleet/git-config-guard.ps1 -RepoPath '$Cwd' -Restore) — a lane launched against it cannot run git"
+}
+if ($guardExit -ne 0) {
+  [Console]::Error.WriteLine("lane-launch: warning: .git/config backup not written (git-config-guard exit $guardExit); launching anyway, but lane-stop will have nothing to restore from")
+}
+
 New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
 $LogDir = (Resolve-Path -LiteralPath $LogDir).Path
 if (-not $SessionId) { $SessionId = "lane-$Name" }

--- a/scripts/fleet/lane-stop.ps1
+++ b/scripts/fleet/lane-stop.ps1
@@ -35,10 +35,11 @@
 # Prints what was terminated, one line each, plus the .git/config verdict.
 # Exit codes (style of lane-status.ps1): 0 = stopped (N processes terminated,
 # or the lane was not running); 1 = error: no matching task, wrapper missing,
-# processes survived the kill, or the lane's .git/config is corrupt and could
-# not be restored. The end record (step 7) is written before any of those
-# .git/config failures is reported, so a stop never costs the log its EXIT
-# line (GH-672).
+# processes survived the kill, or the lane's .git/config was not confirmed
+# healthy — either corrupt and unrepairable, or impossible to judge (the
+# gitconfig= line says which). The end record (step 7) is written before any
+# of those .git/config failures is reported, so a stop never costs the log its
+# EXIT line (GH-672).
 # Matches tasks registered across the fleet (edda-lane-*, edda-review-pr*-r*, GH-712).
 param(
   [Parameter(Mandatory = $true)][string]$Name,
@@ -124,7 +125,7 @@ $brief = if ($wrapperBody -match '--prompt-file\s+[''"]([^''"]+)[''"]') {
 
 # The worktree the lane ran in, which resolves the SHARED .git/config this
 # script checks after the kill (GH-715). Both wrapper generators this script
-# stops must match: lane-launch.ps1:143 writes `Set-Location -LiteralPath '<p>'`
+# stops must match: lane-launch.ps1:154 writes `Set-Location -LiteralPath '<p>'`
 # (single-quoted literal, embedded quotes doubled), while the review lanes of
 # review-pr.sh:453 and pr-review-launch.ps1:64 write a bare `Set-Location '<p>'`
 # — so the parameter name is optional here. Anchored to end of line because
@@ -319,8 +320,14 @@ if ($laneCwd -and (Test-Path -LiteralPath $laneCwd)) {
       $restoredLine = @($guardOut | Where-Object { "$_" -match 'RESTORED' })
       $gitConfigVerdict = if ($restoredLine.Count -gt 0) { "$($restoredLine[0])" } else { 'healthy' }
     } else {
+      # Exit 4 means the guard declined to judge the file (it could not read
+      # it), which is not the same claim as "corrupt and unrepairable".
       $gitConfigBroken = $true
-      $gitConfigVerdict = "UNREPAIRABLE (git-config-guard exit $guardExit)"
+      $gitConfigVerdict = if ($guardExit -eq 4) {
+        'UNVERIFIED (git-config-guard could not read the config; nothing was changed)'
+      } else {
+        "UNREPAIRABLE (git-config-guard exit $guardExit)"
+      }
     }
     $guardOut | ForEach-Object { [Console]::Error.WriteLine("lane-stop: git-config-guard: $_") }
   } catch {

--- a/scripts/fleet/lane-stop.ps1
+++ b/scripts/fleet/lane-stop.ps1
@@ -13,34 +13,36 @@
 #      wrapper is already dead (the orphan case above), every process still
 #      identifiable by CommandLine as the lane: the wrapper path and the
 #      brief path the wrapper was launched with — including each match's
-#      descendants, using type-safe [int] parent/child indexing. Each target
-#      is first asked to exit (taskkill without /F) and given -GraceSec to
-#      finish; only what is still alive after that window is terminated by
-#      force, so a lane in the middle of writing shared git state usually
-#      gets to finish the write (GH-715),
+#      descendants, using type-safe [int] parent/child indexing,
 #   5. verifies by both PID survival and tree/CommandLine match that nothing
 #      survived (GH-706),
 #   6. verifies the SHARED .git/config the lane was working in still parses and
 #      restores it from the known-good backup if it does not — a hard kill
 #      landing on git's config write NULs that file and takes down the main
-#      checkout and every linked worktree at once (GH-715), and
+#      checkout and every linked worktree at once (GH-715). There is no
+#      graceful-shutdown window before the kill: `taskkill` without /F posts
+#      WM_CLOSE, and a lane's processes are hidden console processes with no
+#      window, so it is refused with "can only be terminated forcefully"
+#      (exit 128, measured) and the target survives. The kill stays immediate
+#      and the damage is repaired here instead, and
 #   7. writes the end record the killed wrapper can no longer write: the
 #      done-file (sentinel "stopped") and a === EXIT === line in the lane log,
 #      so a lane log with START but no EXIT is never left ambiguous (GH-672).
 #
 # usage:
-#   pwsh -NoProfile -File scripts/fleet/lane-stop.ps1 -Name <lane> [-LogDir <dir>] [-GraceSec <s>]
+#   pwsh -NoProfile -File scripts/fleet/lane-stop.ps1 -Name <lane> [-LogDir <dir>]
 #
 # Prints what was terminated, one line each, plus the .git/config verdict.
 # Exit codes (style of lane-status.ps1): 0 = stopped (N processes terminated,
 # or the lane was not running); 1 = error: no matching task, wrapper missing,
 # processes survived the kill, or the lane's .git/config is corrupt and could
-# not be restored.
+# not be restored. The end record (step 7) is written before any of those
+# .git/config failures is reported, so a stop never costs the log its EXIT
+# line (GH-672).
 # Matches tasks registered across the fleet (edda-lane-*, edda-review-pr*-r*, GH-712).
 param(
   [Parameter(Mandatory = $true)][string]$Name,
-  [string]$LogDir = "$env:TEMP\edda-lanes",
-  [ValidateRange(0, 120)][int]$GraceSec = 5
+  [string]$LogDir = "$env:TEMP\edda-lanes"
 )
 
 $ErrorActionPreference = 'Stop'
@@ -120,10 +122,14 @@ $brief = if ($wrapperBody -match '--prompt-file\s+[''"]([^''"]+)[''"]') {
   if ($b.Length -gt 4) { $b } else { $null }
 } else { $null }
 
-# The worktree the lane ran in. lane-launch.ps1 writes it into the wrapper as a
-# single-quoted PowerShell literal (embedded quotes doubled), and it is what
-# resolves the SHARED .git/config this script checks after the kill (GH-715).
-$laneCwd = if ($wrapperBody -match "(?m)^\s*Set-Location\s+-LiteralPath\s+'((?:[^']|'')*)'") {
+# The worktree the lane ran in, which resolves the SHARED .git/config this
+# script checks after the kill (GH-715). Both wrapper generators this script
+# stops must match: lane-launch.ps1:143 writes `Set-Location -LiteralPath '<p>'`
+# (single-quoted literal, embedded quotes doubled), while the review lanes of
+# review-pr.sh:453 and pr-review-launch.ps1:64 write a bare `Set-Location '<p>'`
+# — so the parameter name is optional here. Anchored to end of line because
+# both generators put nothing after the path.
+$laneCwd = if ($wrapperBody -match "(?m)^\s*Set-Location\s+(?:-(?:LiteralPath|Path)\s+)?'((?:[^']|'')*)'\s*$") {
   $Matches[1] -replace "''", "'"
 } else { $null }
 
@@ -207,29 +213,11 @@ while ($queue.Count -gt 0) {
   }
 }
 
-# --- 4. stop the tree: ask first, force what ignores the ask (GH-715) -------
-# A hard kill that lands while git is extending the shared .git/config leaves
-# that file a run of NULs (twice on 2026-09-02/03). Asking the tree to exit
-# first — taskkill without /F — lets an in-flight write finish in the common
-# case; only what is still alive after -GraceSec is terminated by force.
+# --- 4. kill the whole tree -------------------------------------------------
 
 $terminated = New-Object System.Collections.Generic.List[int]
 $targetList = @($targets)
-$gracefulExits = 0
 if ($targetList.Count -gt 0) {
-  if ($GraceSec -gt 0) {
-    foreach ($t in $targetList) {
-      & taskkill /PID $t /T 2>$null | Out-Null
-    }
-    $graceDeadline = (Get-Date).AddSeconds($GraceSec)
-    while ((Get-Date) -lt $graceDeadline) {
-      if (-not (Get-Process -Id $targetList -ErrorAction SilentlyContinue)) { break }
-      Start-Sleep -Milliseconds 250
-    }
-    foreach ($t in $targetList) {
-      if (-not (Get-Process -Id $t -ErrorAction SilentlyContinue)) { $gracefulExits++ }
-    }
-  }
   foreach ($t in $targetList) {
     Stop-Process -Id $t -Force -ErrorAction SilentlyContinue
   }
@@ -319,16 +307,27 @@ if ($task.State -eq 'Running') { Fail "task $TaskName still reports State = Runn
 $gitConfigVerdict = 'skipped (lane cwd not resolvable from the wrapper)'
 $gitConfigBroken = $false
 if ($laneCwd -and (Test-Path -LiteralPath $laneCwd)) {
-  $guardOut = & (Join-Path $PSScriptRoot 'git-config-guard.ps1') -RepoPath $laneCwd -VerifyOrRestore 2>&1
-  $guardExit = $LASTEXITCODE
-  if ($guardExit -eq 0) {
-    $restoredLine = @($guardOut | Where-Object { "$_" -match 'RESTORED' })
-    $gitConfigVerdict = if ($restoredLine.Count -gt 0) { "$($restoredLine[0])" } else { 'healthy' }
-  } else {
+  # $ErrorActionPreference is Stop for this script, so an exception raised
+  # inside the guard — a config held open by another process makes
+  # ReadAllBytes throw, measured — would otherwise end lane-stop right here
+  # and cost the lane its end record. Catch it, carry it as the verdict, and
+  # let step 7 run.
+  try {
+    $guardOut = & (Join-Path $PSScriptRoot 'git-config-guard.ps1') -RepoPath $laneCwd -VerifyOrRestore 2>&1
+    $guardExit = $LASTEXITCODE
+    if ($guardExit -eq 0) {
+      $restoredLine = @($guardOut | Where-Object { "$_" -match 'RESTORED' })
+      $gitConfigVerdict = if ($restoredLine.Count -gt 0) { "$($restoredLine[0])" } else { 'healthy' }
+    } else {
+      $gitConfigBroken = $true
+      $gitConfigVerdict = "UNREPAIRABLE (git-config-guard exit $guardExit)"
+    }
+    $guardOut | ForEach-Object { [Console]::Error.WriteLine("lane-stop: git-config-guard: $_") }
+  } catch {
     $gitConfigBroken = $true
-    $gitConfigVerdict = "UNREPAIRABLE (git-config-guard exit $guardExit)"
+    $gitConfigVerdict = "CHECK FAILED ($($_.Exception.Message))"
+    [Console]::Error.WriteLine("lane-stop: git-config-guard threw: $($_.Exception.Message)")
   }
-  $guardOut | ForEach-Object { [Console]::Error.WriteLine("lane-stop: git-config-guard: $_") }
 }
 
 # --- 7. write the end record the killed wrapper cannot write ----------------
@@ -344,13 +343,13 @@ if ($terminated.Count -gt 0 -or ((Test-Path -LiteralPath $Log) -and -not (Test-P
 
 "task=$TaskName state=$($task.State)"
 if ($terminated.Count -gt 0) {
-  "terminated=$($terminated.Count) pids=$($terminated -join ',') graceful=$gracefulExits forced=$($terminated.Count - $gracefulExits)"
+  "terminated=$($terminated.Count) pids=$($terminated -join ',')"
 } else {
   "terminated=0 (lane was not running)"
 }
 "residual=$($residual.Count) (CommandLine match + process tree verification)"
 "gitconfig=$gitConfigVerdict"
 if ($gitConfigBroken) {
-  Fail "the shared .git/config for '$laneCwd' does not parse after the kill and no usable backup was available; every worktree sharing it has lost git until it is repaired (GH-715)"
+  Fail "the shared .git/config for '$laneCwd' was not confirmed healthy after the kill ($gitConfigVerdict); every worktree sharing it depends on that file, so check it before starting anything else (GH-715)"
 }
 exit 0

--- a/scripts/fleet/lane-stop.ps1
+++ b/scripts/fleet/lane-stop.ps1
@@ -13,24 +13,34 @@
 #      wrapper is already dead (the orphan case above), every process still
 #      identifiable by CommandLine as the lane: the wrapper path and the
 #      brief path the wrapper was launched with — including each match's
-#      descendants, using type-safe [int] parent/child indexing,
+#      descendants, using type-safe [int] parent/child indexing. Each target
+#      is first asked to exit (taskkill without /F) and given -GraceSec to
+#      finish; only what is still alive after that window is terminated by
+#      force, so a lane in the middle of writing shared git state usually
+#      gets to finish the write (GH-715),
 #   5. verifies by both PID survival and tree/CommandLine match that nothing
-#      survived (GH-706), and
-#   6. writes the end record the killed wrapper can no longer write: the
+#      survived (GH-706),
+#   6. verifies the SHARED .git/config the lane was working in still parses and
+#      restores it from the known-good backup if it does not — a hard kill
+#      landing on git's config write NULs that file and takes down the main
+#      checkout and every linked worktree at once (GH-715), and
+#   7. writes the end record the killed wrapper can no longer write: the
 #      done-file (sentinel "stopped") and a === EXIT === line in the lane log,
 #      so a lane log with START but no EXIT is never left ambiguous (GH-672).
 #
 # usage:
-#   pwsh -NoProfile -File scripts/fleet/lane-stop.ps1 -Name <lane> [-LogDir <dir>]
+#   pwsh -NoProfile -File scripts/fleet/lane-stop.ps1 -Name <lane> [-LogDir <dir>] [-GraceSec <s>]
 #
-# Prints what was terminated, one line each. Exit codes (style of
-# lane-status.ps1): 0 = stopped (N processes terminated, or the lane was not
-# running); 1 = error: no matching task, wrapper missing, or processes
-# survived the kill.
+# Prints what was terminated, one line each, plus the .git/config verdict.
+# Exit codes (style of lane-status.ps1): 0 = stopped (N processes terminated,
+# or the lane was not running); 1 = error: no matching task, wrapper missing,
+# processes survived the kill, or the lane's .git/config is corrupt and could
+# not be restored.
 # Matches tasks registered across the fleet (edda-lane-*, edda-review-pr*-r*, GH-712).
 param(
   [Parameter(Mandatory = $true)][string]$Name,
-  [string]$LogDir = "$env:TEMP\edda-lanes"
+  [string]$LogDir = "$env:TEMP\edda-lanes",
+  [ValidateRange(0, 120)][int]$GraceSec = 5
 )
 
 $ErrorActionPreference = 'Stop'
@@ -108,6 +118,13 @@ $wrapperBody = Get-Content -LiteralPath $Wrapper -Raw
 $brief = if ($wrapperBody -match '--prompt-file\s+[''"]([^''"]+)[''"]') {
   $b = $Matches[1].Trim()
   if ($b.Length -gt 4) { $b } else { $null }
+} else { $null }
+
+# The worktree the lane ran in. lane-launch.ps1 writes it into the wrapper as a
+# single-quoted PowerShell literal (embedded quotes doubled), and it is what
+# resolves the SHARED .git/config this script checks after the kill (GH-715).
+$laneCwd = if ($wrapperBody -match "(?m)^\s*Set-Location\s+-LiteralPath\s+'((?:[^']|'')*)'") {
+  $Matches[1] -replace "''", "'"
 } else { $null }
 
 function Get-ProcessSnapshot {
@@ -190,11 +207,29 @@ while ($queue.Count -gt 0) {
   }
 }
 
-# --- 4. kill the whole tree -------------------------------------------------
+# --- 4. stop the tree: ask first, force what ignores the ask (GH-715) -------
+# A hard kill that lands while git is extending the shared .git/config leaves
+# that file a run of NULs (twice on 2026-09-02/03). Asking the tree to exit
+# first — taskkill without /F — lets an in-flight write finish in the common
+# case; only what is still alive after -GraceSec is terminated by force.
 
 $terminated = New-Object System.Collections.Generic.List[int]
 $targetList = @($targets)
+$gracefulExits = 0
 if ($targetList.Count -gt 0) {
+  if ($GraceSec -gt 0) {
+    foreach ($t in $targetList) {
+      & taskkill /PID $t /T 2>$null | Out-Null
+    }
+    $graceDeadline = (Get-Date).AddSeconds($GraceSec)
+    while ((Get-Date) -lt $graceDeadline) {
+      if (-not (Get-Process -Id $targetList -ErrorAction SilentlyContinue)) { break }
+      Start-Sleep -Milliseconds 250
+    }
+    foreach ($t in $targetList) {
+      if (-not (Get-Process -Id $t -ErrorAction SilentlyContinue)) { $gracefulExits++ }
+    }
+  }
   foreach ($t in $targetList) {
     Stop-Process -Id $t -Force -ErrorAction SilentlyContinue
   }
@@ -273,10 +308,33 @@ if ($residual.Count -gt 0) {
 $task = Get-ScheduledTask -TaskName $TaskName
 if ($task.State -eq 'Running') { Fail "task $TaskName still reports State = Running after the stop" }
 
-# --- 6. write the end record the killed wrapper cannot write ----------------
+# --- 6. the shared .git/config must still parse after the kill (GH-715) -----
+# The lane's worktree shares one .git/config with the main checkout and every
+# other worktree; a kill landing on git's write to it NULs the file and takes
+# them all down. Check it here — the one moment we know a kill just happened —
+# and restore from the backup lane-launch took before the lane could write.
+# The end record below is written either way, so the verdict never costs the
+# log its === EXIT === line.
+
+$gitConfigVerdict = 'skipped (lane cwd not resolvable from the wrapper)'
+$gitConfigBroken = $false
+if ($laneCwd -and (Test-Path -LiteralPath $laneCwd)) {
+  $guardOut = & (Join-Path $PSScriptRoot 'git-config-guard.ps1') -RepoPath $laneCwd -VerifyOrRestore 2>&1
+  $guardExit = $LASTEXITCODE
+  if ($guardExit -eq 0) {
+    $restoredLine = @($guardOut | Where-Object { "$_" -match 'RESTORED' })
+    $gitConfigVerdict = if ($restoredLine.Count -gt 0) { "$($restoredLine[0])" } else { 'healthy' }
+  } else {
+    $gitConfigBroken = $true
+    $gitConfigVerdict = "UNREPAIRABLE (git-config-guard exit $guardExit)"
+  }
+  $guardOut | ForEach-Object { [Console]::Error.WriteLine("lane-stop: git-config-guard: $_") }
+}
+
+# --- 7. write the end record the killed wrapper cannot write ----------------
 
 if ($terminated.Count -gt 0 -or ((Test-Path -LiteralPath $Log) -and -not (Test-Path -LiteralPath $Done))) {
-  Add-Content -LiteralPath $Log -Value "=== EXIT (stopped by lane-stop.ps1; terminated $($terminated.Count) process(es)) ===" -Encoding utf8
+  Add-Content -LiteralPath $Log -Value "=== EXIT (stopped by lane-stop.ps1; terminated $($terminated.Count) process(es); .git/config $gitConfigVerdict) ===" -Encoding utf8
   if (-not (Test-Path -LiteralPath $Done)) {
     Set-Content -LiteralPath $Done -Value 'stopped' -Encoding ascii
   }
@@ -286,9 +344,13 @@ if ($terminated.Count -gt 0 -or ((Test-Path -LiteralPath $Log) -and -not (Test-P
 
 "task=$TaskName state=$($task.State)"
 if ($terminated.Count -gt 0) {
-  "terminated=$($terminated.Count) pids=$($terminated -join ',')"
+  "terminated=$($terminated.Count) pids=$($terminated -join ',') graceful=$gracefulExits forced=$($terminated.Count - $gracefulExits)"
 } else {
   "terminated=0 (lane was not running)"
 }
 "residual=$($residual.Count) (CommandLine match + process tree verification)"
+"gitconfig=$gitConfigVerdict"
+if ($gitConfigBroken) {
+  Fail "the shared .git/config for '$laneCwd' does not parse after the kill and no usable backup was available; every worktree sharing it has lost git until it is repaired (GH-715)"
+}
 exit 0

--- a/scripts/test-git-config-guard.sh
+++ b/scripts/test-git-config-guard.sh
@@ -154,7 +154,54 @@ grep -q 'git-config-guard.ps1' "$root/scripts/fleet/lane-stop.ps1" ||
   fail "lane-stop.ps1 kills the lane process tree but never validates .git/config afterwards (GH-715 doneWhen 2)"
 ok "lane-launch backs up before the lane runs and lane-stop validates after the kill"
 
-# --- case 9 (opt-in): lane-stop really restores after a real kill -----------
+# --- case 9: a config that cannot be READ is neither backed up nor overwritten
+# A config held open by whatever is writing it may be perfectly good. Treating
+# an unreadable file as corrupt would restore over it and destroy live state;
+# treating it as healthy would copy garbage into the backup.
+repo8=$(new_repo locked)
+guard -RepoPath "$repo8" -Backup >/dev/null 2>&1 || fail "setup: backup failed"
+cp "$repo8/.git/config" "$tmp/locked-good"
+repo8_w=$(cygpath -w "$repo8" 2>/dev/null || echo "$repo8")
+guard_w=$(cygpath -w "$GUARD" 2>/dev/null || echo "$GUARD")
+{
+  printf '$ErrorActionPreference = "Stop"\n'
+  printf '$fs = [System.IO.File]::Open("%s\\.git\\config", "Open", "Read", "None")\n' "$repo8_w"
+  printf 'try {\n'
+  printf '  & "%s" -RepoPath "%s" -Backup 2>&1 | Out-Null; "backup=$LASTEXITCODE"\n' "$guard_w" "$repo8_w"
+  printf '  & "%s" -RepoPath "%s" -Restore 2>&1 | Out-Null; "restore=$LASTEXITCODE"\n' "$guard_w" "$repo8_w"
+  printf '} finally { $fs.Close() }\n'
+} >"$tmp/locked.ps1"
+pwsh -NoProfile -NonInteractive -File "$tmp/locked.ps1" >"$tmp/out9" 2>&1 ||
+  fail "locked-config probe did not run: $(cat "$tmp/out9")"
+grep -q '^backup=3$' "$tmp/out9" ||
+  fail "-Backup on an unreadable config should exit 3 (no backup taken), got: $(cat "$tmp/out9")"
+grep -q '^restore=2$' "$tmp/out9" ||
+  fail "-Restore on an unreadable config should exit 2 and not restore, got: $(cat "$tmp/out9")"
+cmp -s "$tmp/locked-good" "$repo8/.git/config" ||
+  fail "the unreadable config was overwritten; a locked config is not a corrupt one"
+[ "$(corrupt_backups "$repo8")" -eq 0 ] || fail "a locked config was treated as corrupt and archived"
+ok "an unreadable config is neither backed up from nor restored over"
+
+# --- case 10: the backup keeps one generation, and restore falls back to it -
+# A torn write can end on a boundary that still parses; backing THAT up would
+# retire the last complete copy, so the outgoing backup is kept as .prev.
+repo9=$(new_repo rotate)
+guard -RepoPath "$repo9" -Backup >/dev/null 2>&1 || fail "setup: first backup failed"
+cp "$repo9/.git/config" "$tmp/gen1"
+printf '[core]\n\trepositoryformatversion = 0\n' >"$repo9/.git/config"
+guard -RepoPath "$repo9" -Backup >/dev/null 2>&1 || fail "setup: second backup failed"
+cmp -s "$tmp/gen1" "$repo9/.git/config.guard.bak.prev" ||
+  fail "the outgoing backup was discarded instead of kept as .prev"
+# Now lose both the config and the newest backup; .prev must still save it.
+nul_ise "$repo9/.git/config"
+nul_ise "$repo9/.git/config.guard.bak"
+guard -RepoPath "$repo9" -Restore >"$tmp/out10" 2>&1 ||
+  fail "-Restore did not fall back to the previous generation: $(cat "$tmp/out10")"
+cmp -s "$tmp/gen1" "$repo9/.git/config" || fail "-Restore used the wrong generation"
+git -C "$repo9" status >/dev/null 2>&1 || fail "git still broken after the .prev restore"
+ok "-Backup keeps one previous generation and -Restore falls back to it"
+
+# --- case 11 (opt-in): lane-stop really restores after a real kill ----------
 # Registers a scheduled task, so it is off by default; run with
 # GIT_CONFIG_GUARD_E2E=1 to exercise the whole lane-stop path end to end.
 if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
@@ -168,13 +215,22 @@ if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
   # — Stop-ScheduledTask kills only the wrapper, leaving the child to be found
   # and killed by lane-stop's tree traversal (GH-672/GH-706), and a child
   # killed mid-git-write is what corrupts the config in the first place.
-  # usage: start_fake_lane <lane> <repo>
+  # The two wrapper generators write the cwd differently: lane-launch.ps1 emits
+  # `Set-Location -LiteralPath '<p>'`, while the review lanes of review-pr.sh
+  # and pr-review-launch.ps1 emit a bare `Set-Location '<p>'`. lane-stop claims
+  # to stop both families, so both shapes are exercised.
+  # usage: start_fake_lane <lane> <repo> [literal|bare]
   start_fake_lane() {
     fl_lane=$1
     fl_repo_w=$(cygpath -w "$2" 2>/dev/null || echo "$2")
+    fl_shape=${3:-literal}
     : >"$logdir/$fl_lane.brief.md"
     {
-      printf "Set-Location -LiteralPath '%s'\n" "$fl_repo_w"
+      if [ "$fl_shape" = bare ]; then
+        printf "Set-Location '%s'\n" "$fl_repo_w"
+      else
+        printf "Set-Location -LiteralPath '%s'\n" "$fl_repo_w"
+      fi
       printf "# edda dispatch --prompt-file '%s'\n" "$logdir_w\\$fl_lane.brief.md"
       printf '$c = Start-Process -PassThru -WindowStyle Hidden -FilePath "$env:SystemRoot\\System32\\cmd.exe" -ArgumentList "/c","ping -n 300 127.0.0.1"\n'
       printf 'Start-Sleep -Seconds 300\n'
@@ -214,7 +270,7 @@ if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
   git -C "$repo6" status >/dev/null 2>&1 && fail "e2e precondition: git still works on the corrupt repo"
 
   # Read the status through an `if`, not `$?` on the next line: under `set -e`
-  # a non-zero exit (which case 10 expects) would end the script first.
+  # a non-zero exit (which case 12 expects) would end the script first.
   if pwsh -NoProfile -NonInteractive -File "$root/scripts/fleet/lane-stop.ps1" \
     -Name "$lane" -LogDir "$logdir_w" >"$tmp/out9" 2>&1
   then stop_status=0; else stop_status=$?; fi
@@ -234,7 +290,7 @@ if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
     fail "lane-stop wrote no done-file; lane-stop said: $(cat "$tmp/out9")"
   ok "lane-stop restores the shared .git/config after really killing a lane"
 
-  # --- case 10 (opt-in): unrepairable config is an error, not a clean stop ---
+  # --- case 12 (opt-in): unrepairable config is an error, not a clean stop --
   lane2=guard-e2e-nobak
   repo7=$(new_repo e2e-nobak)
   start_fake_lane "$lane2" "$repo7"
@@ -252,8 +308,59 @@ if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
   grep -q '=== EXIT' "$logdir/$lane2.log" 2>/dev/null ||
     fail "lane-stop lost the end record on the unrepairable path: $(cat "$tmp/out10")"
   ok "lane-stop exits 1 when the config is corrupt and no backup can repair it"
+
+  # --- case 13 (opt-in): review lanes get the check too ----------------------
+  # review-pr.sh:453 and pr-review-launch.ps1:64 write a bare `Set-Location`,
+  # and lane-stop.ps1 claims to stop those tasks (GH-712).
+  lane3=guard-e2e-review
+  repo10=$(new_repo e2e-review)
+  guard -RepoPath "$repo10" -Backup >/dev/null 2>&1 || fail "e2e setup: backup failed"
+  cp "$repo10/.git/config" "$tmp/e2e-review-good"
+  start_fake_lane "$lane3" "$repo10" bare
+  nul_ise "$repo10/.git/config"
+
+  if pwsh -NoProfile -NonInteractive -File "$root/scripts/fleet/lane-stop.ps1" \
+    -Name "$lane3" -LogDir "$logdir_w" >"$tmp/out13" 2>&1
+  then stop_status3=0; else stop_status3=$?; fi
+  drop_fake_lane "$lane3"
+
+  [ "$stop_status3" -eq 0 ] || fail "lane-stop exited $stop_status3: $(cat "$tmp/out13")"
+  grep -q 'gitconfig=RESTORED' "$tmp/out13" ||
+    fail "a review-shaped wrapper skipped the config check: $(cat "$tmp/out13")"
+  cmp -s "$tmp/e2e-review-good" "$repo10/.git/config" ||
+    fail "the review lane's shared config was not repaired"
+  ok "lane-stop resolves the cwd of review lanes too, not only lane-launch ones"
+
+  # --- case 14 (opt-in): a guard exception never costs the end record --------
+  # $ErrorActionPreference is Stop in lane-stop; a config held open makes the
+  # guard's ReadAllBytes throw. That must not skip the GH-672 end record.
+  lane4=guard-e2e-throw
+  repo11=$(new_repo e2e-throw)
+  guard -RepoPath "$repo11" -Backup >/dev/null 2>&1 || fail "e2e setup: backup failed"
+  start_fake_lane "$lane4" "$repo11"
+  repo11_w=$(cygpath -w "$repo11" 2>/dev/null || echo "$repo11")
+  {
+    printf '$ErrorActionPreference = "Stop"\n'
+    printf '$fs = [System.IO.File]::Open("%s\\.git\\config", "Open", "Read", "None")\n' "$repo11_w"
+    printf 'try {\n'
+    printf '  & "%s" -Name "%s" -LogDir "%s" 2>&1 | Out-Null\n' \
+      "$(cygpath -w "$root/scripts/fleet/lane-stop.ps1")" "$lane4" "$logdir_w"
+    printf '  "stop=$LASTEXITCODE"\n'
+    printf '} finally { $fs.Close() }\n'
+  } >"$tmp/throw.ps1"
+  pwsh -NoProfile -NonInteractive -File "$tmp/throw.ps1" >"$tmp/out14" 2>&1 ||
+    fail "locked-config lane-stop probe did not run: $(cat "$tmp/out14")"
+  drop_fake_lane "$lane4"
+
+  grep -q '^stop=1$' "$tmp/out14" ||
+    fail "lane-stop should exit 1 when it cannot verify the config, got: $(cat "$tmp/out14")"
+  grep -q '=== EXIT' "$logdir/$lane4.log" 2>/dev/null ||
+    fail "a guard exception cost the lane its === EXIT === record (GH-672): $(cat "$tmp/out14")"
+  [ -f "$logdir/$lane4.done" ] ||
+    fail "a guard exception cost the lane its done-file (GH-672): $(cat "$tmp/out14")"
+  ok "a guard exception is reported but never skips the end record"
 else
-  echo "-- cases 9-10 (lane-stop end-to-end) skipped; set GIT_CONFIG_GUARD_E2E=1 to run them"
+  echo "-- cases 11-14 (lane-stop end-to-end) skipped; set GIT_CONFIG_GUARD_E2E=1 to run them"
 fi
 
 echo "all $case_number case(s) passed"

--- a/scripts/test-git-config-guard.sh
+++ b/scripts/test-git-config-guard.sh
@@ -1,0 +1,259 @@
+#!/bin/sh
+# Offline fixtures for scripts/fleet/git-config-guard.ps1 (GH-715).
+#
+# The defect: killing a lane mid-write leaves .git/config as a run of NUL
+# bytes, which takes down git for the main checkout and every linked worktree
+# sharing that config — and the only "backup" on disk was copied after the
+# corruption, so it is NUL too. These cases pin the guard's contract:
+#   * a backup is taken only from a config that parses (never a NUL file),
+#   * a corrupt config is detected, not silently accepted,
+#   * a restore actually revives git and preserves the corrupt file,
+#   * a restore with no usable backup fails loudly instead of faking success,
+#   * a linked worktree resolves to the SHARED config (the single point of
+#     failure this issue is about), not to its own .git file.
+#
+# Everything runs in throwaway repos under a temp dir; no state outside it is
+# touched. Style follows scripts/test-lint-markdown-content.sh — no new tooling.
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+GUARD="$root/scripts/fleet/git-config-guard.ps1"
+
+command -v pwsh >/dev/null 2>&1 || { echo "SKIP: pwsh not on PATH"; exit 0; }
+command -v git >/dev/null 2>&1 || { echo "SKIP: git not on PATH"; exit 0; }
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' 0 HUP INT TERM
+
+case_number=0
+fail() { echo "FAIL (after case $case_number): $*" >&2; exit 1; }
+ok() { case_number=$((case_number + 1)); echo "ok $case_number - $*"; }
+
+guard() { pwsh -NoProfile -NonInteractive -File "$GUARD" "$@"; }
+
+# Byte count of NULs in a file (0 for a healthy config).
+nuls() { tr -dc '\000' <"$1" | wc -c | tr -d ' '; }
+
+# A throwaway repo with one commit; prints its path.
+new_repo() {
+  d="$tmp/$1"
+  mkdir -p "$d"
+  git -C "$d" init -q
+  git -C "$d" config user.email t@example.com
+  git -C "$d" config user.name tester
+  echo hello >"$d/f.txt"
+  git -C "$d" add f.txt
+  git -C "$d" -c commit.gpgsign=false commit -qm init
+  echo "$d"
+}
+
+# Overwrite a file with exactly as many NUL bytes as it had, which is the shape
+# both real corruptions took (27328/27328 and 2561/2561 bytes, GH-715).
+nul_ise() {
+  size=$(wc -c <"$1" | tr -d ' ')
+  head -c "$size" /dev/zero >"$1.zero"
+  mv "$1.zero" "$1"
+}
+
+corrupt_backups() { ls "$1/.git/" | grep -c '^config\.CORRUPT\.' || true; }
+
+# --- case 1: backup from a healthy repo is taken and is byte-identical -------
+repo=$(new_repo healthy)
+guard -RepoPath "$repo" -Backup >"$tmp/out1" 2>&1 ||
+  fail "-Backup exited non-zero on a healthy repo: $(cat "$tmp/out1")"
+[ -f "$repo/.git/config.guard.bak" ] || fail "-Backup wrote no backup file"
+cmp -s "$repo/.git/config" "$repo/.git/config.guard.bak" ||
+  fail "backup differs from the config it was taken from"
+ok "-Backup copies a parseable config to .git/config.guard.bak"
+
+# --- case 2: backup REFUSES a NUL config and keeps the good one -------------
+# This is the exact failure of the real .bak files: copied after corruption.
+cp "$repo/.git/config" "$tmp/known-good"
+nul_ise "$repo/.git/config"
+if guard -RepoPath "$repo" -Backup >"$tmp/out2" 2>&1; then
+  fail "-Backup exited 0 on a NUL-corrupt config (this is how the real .bak became all NULs)"
+fi
+cmp -s "$tmp/known-good" "$repo/.git/config.guard.bak" ||
+  fail "-Backup overwrote the good backup with the corrupt config"
+ok "-Backup refuses a NUL config and leaves the previous good backup intact"
+
+# --- case 3: verify distinguishes healthy / NUL / unparseable ---------------
+if guard -RepoPath "$repo" -Verify >"$tmp/out3a" 2>&1; then
+  fail "-Verify exited 0 on the NUL-corrupt config"
+fi
+repo2=$(new_repo verify-ok)
+guard -RepoPath "$repo2" -Verify >"$tmp/out3b" 2>&1 ||
+  fail "-Verify exited non-zero on a healthy config: $(cat "$tmp/out3b")"
+printf '[core\nthis is not ini\n' >"$repo2/.git/config"
+if guard -RepoPath "$repo2" -Verify >"$tmp/out3c" 2>&1; then
+  fail "-Verify exited 0 on an unparseable (non-NUL) config"
+fi
+ok "-Verify accepts a healthy config and rejects NUL and unparseable ones"
+
+# --- case 4: restore revives git and preserves the corrupt file -------------
+git -C "$repo" status >/dev/null 2>&1 &&
+  fail "precondition: git still works on the NUL-corrupt repo"
+guard -RepoPath "$repo" -Restore >"$tmp/out4" 2>&1 ||
+  fail "-Restore exited non-zero: $(cat "$tmp/out4")"
+git -C "$repo" status >/dev/null 2>&1 || fail "git still broken after -Restore"
+cmp -s "$tmp/known-good" "$repo/.git/config" ||
+  fail "restored config differs from the known-good backup"
+[ "$(corrupt_backups "$repo")" -ge 1 ] ||
+  fail "-Restore discarded the corrupt config instead of preserving it for forensics"
+ok "-Restore revives git from the backup and preserves the corrupt config"
+
+# --- case 5: restore with no usable backup fails loudly ---------------------
+repo3=$(new_repo no-backup)
+nul_ise "$repo3/.git/config"
+if guard -RepoPath "$repo3" -Restore >"$tmp/out5" 2>&1; then
+  fail "-Restore exited 0 with no backup available (silent fake success)"
+fi
+[ "$(nuls "$repo3/.git/config")" -gt 0 ] ||
+  fail "-Restore altered the config despite having nothing to restore from"
+ok "-Restore with no backup exits non-zero and changes nothing"
+
+# --- case 6: a linked worktree resolves to the SHARED config ----------------
+repo4=$(new_repo shared)
+guard -RepoPath "$repo4" -Backup >/dev/null 2>&1 || fail "setup: backup of shared repo failed"
+git -C "$repo4" worktree add -q "$tmp/wt" -b wt-branch >/dev/null 2>&1 ||
+  fail "setup: worktree add failed"
+[ -f "$tmp/wt/.git" ] || fail "setup: linked worktree has no .git file"
+cp "$repo4/.git/config" "$tmp/shared-good"
+nul_ise "$repo4/.git/config"
+if guard -RepoPath "$tmp/wt" -Verify >"$tmp/out6a" 2>&1; then
+  fail "-Verify from a linked worktree missed the corrupt SHARED config"
+fi
+guard -RepoPath "$tmp/wt" -Restore >"$tmp/out6b" 2>&1 ||
+  fail "-Restore from a linked worktree failed: $(cat "$tmp/out6b")"
+cmp -s "$tmp/shared-good" "$repo4/.git/config" ||
+  fail "-Restore from a linked worktree did not repair the shared config"
+git -C "$tmp/wt" status >/dev/null 2>&1 || fail "linked worktree still broken after -Restore"
+ok "-Verify/-Restore from a linked worktree act on the shared .git/config"
+
+# --- case 7: VerifyOrRestore is a no-op when healthy, repairs when not ------
+repo5=$(new_repo composite)
+guard -RepoPath "$repo5" -Backup >/dev/null 2>&1 || fail "setup: backup failed"
+before=$(git -C "$repo5" config --list | sort)
+guard -RepoPath "$repo5" -VerifyOrRestore >"$tmp/out7a" 2>&1 ||
+  fail "-VerifyOrRestore failed on a healthy repo: $(cat "$tmp/out7a")"
+[ "$(corrupt_backups "$repo5")" -eq 0 ] || fail "-VerifyOrRestore restored a healthy config"
+[ "$(git -C "$repo5" config --list | sort)" = "$before" ] ||
+  fail "-VerifyOrRestore changed a healthy config"
+nul_ise "$repo5/.git/config"
+guard -RepoPath "$repo5" -VerifyOrRestore >"$tmp/out7b" 2>&1 ||
+  fail "-VerifyOrRestore failed to repair: $(cat "$tmp/out7b")"
+git -C "$repo5" status >/dev/null 2>&1 || fail "git still broken after -VerifyOrRestore"
+grep -qi restor "$tmp/out7b" ||
+  fail "-VerifyOrRestore repaired the config without saying so"
+ok "-VerifyOrRestore is a no-op when healthy and repairs loudly when not"
+
+# --- case 8: the lane lifecycle is wired to the guard -----------------------
+grep -q 'git-config-guard.ps1' "$root/scripts/fleet/lane-launch.ps1" ||
+  fail "lane-launch.ps1 starts a lane without first taking a validated .git/config backup (GH-715 doneWhen 1)"
+grep -q 'git-config-guard.ps1' "$root/scripts/fleet/lane-stop.ps1" ||
+  fail "lane-stop.ps1 kills the lane process tree but never validates .git/config afterwards (GH-715 doneWhen 2)"
+ok "lane-launch backs up before the lane runs and lane-stop validates after the kill"
+
+# --- case 9 (opt-in): lane-stop really restores after a real kill -----------
+# Registers a scheduled task, so it is off by default; run with
+# GIT_CONFIG_GUARD_E2E=1 to exercise the whole lane-stop path end to end.
+if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
+  logdir="$tmp/lanes"
+  mkdir -p "$logdir"
+  logdir_w=$(cygpath -w "$logdir" 2>/dev/null || echo "$logdir")
+
+  # Register and start a lane shaped like the one lane-launch.ps1 generates:
+  # lane-stop reads the worktree out of its Set-Location line and the lane
+  # identity off the brief. It spawns a child, which is the shape that matters
+  # — Stop-ScheduledTask kills only the wrapper, leaving the child to be found
+  # and killed by lane-stop's tree traversal (GH-672/GH-706), and a child
+  # killed mid-git-write is what corrupts the config in the first place.
+  # usage: start_fake_lane <lane> <repo>
+  start_fake_lane() {
+    fl_lane=$1
+    fl_repo_w=$(cygpath -w "$2" 2>/dev/null || echo "$2")
+    : >"$logdir/$fl_lane.brief.md"
+    {
+      printf "Set-Location -LiteralPath '%s'\n" "$fl_repo_w"
+      printf "# edda dispatch --prompt-file '%s'\n" "$logdir_w\\$fl_lane.brief.md"
+      printf '$c = Start-Process -PassThru -WindowStyle Hidden -FilePath "$env:SystemRoot\\System32\\cmd.exe" -ArgumentList "/c","ping -n 300 127.0.0.1"\n'
+      printf 'Start-Sleep -Seconds 300\n'
+    } >"$logdir/$fl_lane.wrapper.ps1"
+
+    # Written as a file, not an inline -Command: a backtick line continuation
+    # inside a double-quoted shell string is eaten as command substitution.
+    {
+      printf '$ErrorActionPreference = "Stop"\n'
+      printf '$argLine = %s\n' "'-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File \"$logdir_w\\$fl_lane.wrapper.ps1\"'"
+      printf '$a = New-ScheduledTaskAction -Execute (Get-Command pwsh.exe).Source -Argument $argLine\n'
+      printf "Unregister-ScheduledTask -TaskName 'edda-lane-%s' -Confirm:\$false -ErrorAction SilentlyContinue\n" "$fl_lane"
+      printf "Register-ScheduledTask -TaskName 'edda-lane-%s' -Action \$a -RunLevel Limited | Out-Null\n" "$fl_lane"
+      printf "Start-ScheduledTask -TaskName 'edda-lane-%s'\n" "$fl_lane"
+      printf 'Start-Sleep -Seconds 3\n'
+      printf "\$t = Get-ScheduledTask -TaskName 'edda-lane-%s'\n" "$fl_lane"
+      printf 'if ($t.State -ne "Running") { Write-Error "fake lane state=$($t.State), expected Running"; exit 1 }\n'
+      printf '"fake lane is Running"\n'
+    } >"$tmp/$fl_lane-setup.ps1"
+    pwsh -NoProfile -NonInteractive -File "$tmp/$fl_lane-setup.ps1" >"$tmp/$fl_lane-setup.out" 2>&1 ||
+      fail "e2e setup: lane $fl_lane did not reach Running: $(cat "$tmp/$fl_lane-setup.out")"
+  }
+
+  drop_fake_lane() {
+    pwsh -NoProfile -NonInteractive -Command \
+      "Unregister-ScheduledTask -TaskName 'edda-lane-$1' -Confirm:\$false -ErrorAction SilentlyContinue" >/dev/null 2>&1
+  }
+
+  lane=guard-e2e
+  repo6=$(new_repo e2e)
+  guard -RepoPath "$repo6" -Backup >/dev/null 2>&1 || fail "e2e setup: backup failed"
+  cp "$repo6/.git/config" "$tmp/e2e-good"
+  start_fake_lane "$lane" "$repo6"
+
+  # The lane is live; now do to the shared config exactly what a kill does to it.
+  nul_ise "$repo6/.git/config"
+  git -C "$repo6" status >/dev/null 2>&1 && fail "e2e precondition: git still works on the corrupt repo"
+
+  # Read the status through an `if`, not `$?` on the next line: under `set -e`
+  # a non-zero exit (which case 10 expects) would end the script first.
+  if pwsh -NoProfile -NonInteractive -File "$root/scripts/fleet/lane-stop.ps1" \
+    -Name "$lane" -LogDir "$logdir_w" >"$tmp/out9" 2>&1
+  then stop_status=0; else stop_status=$?; fi
+  drop_fake_lane "$lane"
+
+  [ "$stop_status" -eq 0 ] || fail "lane-stop exited $stop_status: $(cat "$tmp/out9")"
+  grep -q 'terminated=[1-9]' "$tmp/out9" ||
+    fail "lane-stop terminated nothing, so the kill path was never exercised: $(cat "$tmp/out9")"
+  grep -q 'gitconfig=RESTORED' "$tmp/out9" ||
+    fail "lane-stop did not report a restore: $(cat "$tmp/out9")"
+  git -C "$repo6" status >/dev/null 2>&1 ||
+    fail "git still broken after lane-stop: $(cat "$tmp/out9")"
+  cmp -s "$tmp/e2e-good" "$repo6/.git/config" || fail "lane-stop restored the wrong bytes"
+  grep -q '=== EXIT' "$logdir/$lane.log" 2>/dev/null ||
+    fail "lane-stop skipped the end record while handling the config; lane-stop said: $(cat "$tmp/out9")"
+  [ -f "$logdir/$lane.done" ] ||
+    fail "lane-stop wrote no done-file; lane-stop said: $(cat "$tmp/out9")"
+  ok "lane-stop restores the shared .git/config after really killing a lane"
+
+  # --- case 10 (opt-in): unrepairable config is an error, not a clean stop ---
+  lane2=guard-e2e-nobak
+  repo7=$(new_repo e2e-nobak)
+  start_fake_lane "$lane2" "$repo7"
+  nul_ise "$repo7/.git/config"
+
+  if pwsh -NoProfile -NonInteractive -File "$root/scripts/fleet/lane-stop.ps1" \
+    -Name "$lane2" -LogDir "$logdir_w" >"$tmp/out10" 2>&1
+  then stop_status2=0; else stop_status2=$?; fi
+  drop_fake_lane "$lane2"
+
+  [ "$stop_status2" -eq 1 ] ||
+    fail "lane-stop exited $stop_status2 on an unrepairable config; expected 1: $(cat "$tmp/out10")"
+  grep -q 'gitconfig=UNREPAIRABLE' "$tmp/out10" ||
+    fail "lane-stop did not report the config as unrepairable: $(cat "$tmp/out10")"
+  grep -q '=== EXIT' "$logdir/$lane2.log" 2>/dev/null ||
+    fail "lane-stop lost the end record on the unrepairable path: $(cat "$tmp/out10")"
+  ok "lane-stop exits 1 when the config is corrupt and no backup can repair it"
+else
+  echo "-- cases 9-10 (lane-stop end-to-end) skipped; set GIT_CONFIG_GUARD_E2E=1 to run them"
+fi
+
+echo "all $case_number case(s) passed"

--- a/scripts/test-git-config-guard.sh
+++ b/scripts/test-git-config-guard.sh
@@ -173,8 +173,8 @@ guard_w=$(cygpath -w "$GUARD" 2>/dev/null || echo "$GUARD")
 } >"$tmp/locked.ps1"
 pwsh -NoProfile -NonInteractive -File "$tmp/locked.ps1" >"$tmp/out9" 2>&1 ||
   fail "locked-config probe did not run: $(cat "$tmp/out9")"
-grep -q '^backup=3$' "$tmp/out9" ||
-  fail "-Backup on an unreadable config should exit 3 (no backup taken), got: $(cat "$tmp/out9")"
+grep -q '^backup=4$' "$tmp/out9" ||
+  fail "-Backup on an unreadable config should exit 4 (could not be judged), got: $(cat "$tmp/out9")"
 grep -q '^restore=4$' "$tmp/out9" ||
   fail "-Restore on an unreadable config should exit 4 (could not be judged) and not restore, got: $(cat "$tmp/out9")"
 cmp -s "$tmp/locked-good" "$repo8/.git/config" ||
@@ -259,7 +259,7 @@ if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
       "Unregister-ScheduledTask -TaskName 'edda-lane-$1' -Confirm:\$false -ErrorAction SilentlyContinue" >/dev/null 2>&1
   }
 
-  lane=guard-e2e
+  lane=guard-e2e-$$
   repo6=$(new_repo e2e)
   guard -RepoPath "$repo6" -Backup >/dev/null 2>&1 || fail "e2e setup: backup failed"
   cp "$repo6/.git/config" "$tmp/e2e-good"
@@ -291,7 +291,7 @@ if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
   ok "lane-stop restores the shared .git/config after really killing a lane"
 
   # --- case 12 (opt-in): unrepairable config is an error, not a clean stop --
-  lane2=guard-e2e-nobak
+  lane2=guard-e2e-nobak-$$
   repo7=$(new_repo e2e-nobak)
   start_fake_lane "$lane2" "$repo7"
   nul_ise "$repo7/.git/config"
@@ -303,6 +303,8 @@ if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
 
   [ "$stop_status2" -eq 1 ] ||
     fail "lane-stop exited $stop_status2 on an unrepairable config; expected 1: $(cat "$tmp/out10")"
+  grep -q 'terminated=[1-9]' "$tmp/out10" ||
+    fail "lane-stop terminated nothing in case 12: $(cat "$tmp/out10")"
   grep -q 'gitconfig=UNREPAIRABLE' "$tmp/out10" ||
     fail "lane-stop did not report the config as unrepairable: $(cat "$tmp/out10")"
   grep -q '=== EXIT' "$logdir/$lane2.log" 2>/dev/null ||
@@ -312,7 +314,7 @@ if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
   # --- case 13 (opt-in): review lanes get the check too ----------------------
   # review-pr.sh:453 and pr-review-launch.ps1:64 write a bare `Set-Location`,
   # and lane-stop.ps1 claims to stop those tasks (GH-712).
-  lane3=guard-e2e-review
+  lane3=guard-e2e-review-$$
   repo10=$(new_repo e2e-review)
   guard -RepoPath "$repo10" -Backup >/dev/null 2>&1 || fail "e2e setup: backup failed"
   cp "$repo10/.git/config" "$tmp/e2e-review-good"
@@ -334,7 +336,7 @@ if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
   # --- case 14 (opt-in): a guard exception never costs the end record --------
   # $ErrorActionPreference is Stop in lane-stop; a config held open makes the
   # guard's ReadAllBytes throw. That must not skip the GH-672 end record.
-  lane4=guard-e2e-throw
+  lane4=guard-e2e-throw-$$
   repo11=$(new_repo e2e-throw)
   guard -RepoPath "$repo11" -Backup >/dev/null 2>&1 || fail "e2e setup: backup failed"
   start_fake_lane "$lane4" "$repo11"
@@ -366,7 +368,7 @@ if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
   # lane-stop runs under $ErrorActionPreference = Stop. The guard converts what
   # it can into exit codes, but anything it cannot — here, the script missing,
   # as in a partial checkout — still raises, and step 7 must survive it.
-  lane5=guard-e2e-noguard
+  lane5=guard-e2e-noguard-$$
   repo12=$(new_repo e2e-noguard)
   start_fake_lane "$lane5" "$repo12"
   crippled="$tmp/crippled"

--- a/scripts/test-git-config-guard.sh
+++ b/scripts/test-git-config-guard.sh
@@ -175,8 +175,8 @@ pwsh -NoProfile -NonInteractive -File "$tmp/locked.ps1" >"$tmp/out9" 2>&1 ||
   fail "locked-config probe did not run: $(cat "$tmp/out9")"
 grep -q '^backup=3$' "$tmp/out9" ||
   fail "-Backup on an unreadable config should exit 3 (no backup taken), got: $(cat "$tmp/out9")"
-grep -q '^restore=2$' "$tmp/out9" ||
-  fail "-Restore on an unreadable config should exit 2 and not restore, got: $(cat "$tmp/out9")"
+grep -q '^restore=4$' "$tmp/out9" ||
+  fail "-Restore on an unreadable config should exit 4 (could not be judged) and not restore, got: $(cat "$tmp/out9")"
 cmp -s "$tmp/locked-good" "$repo8/.git/config" ||
   fail "the unreadable config was overwritten; a locked config is not a corrupt one"
 [ "$(corrupt_backups "$repo8")" -eq 0 ] || fail "a locked config was treated as corrupt and archived"
@@ -354,13 +354,40 @@ if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
 
   grep -q '^stop=1$' "$tmp/out14" ||
     fail "lane-stop should exit 1 when it cannot verify the config, got: $(cat "$tmp/out14")"
+  grep -q '\.git/config UNVERIFIED' "$logdir/$lane4.log" 2>/dev/null ||
+    fail "an unreadable config must not be reported as UNREPAIRABLE: $(cat "$logdir/$lane4.log" 2>/dev/null)"
   grep -q '=== EXIT' "$logdir/$lane4.log" 2>/dev/null ||
-    fail "a guard exception cost the lane its === EXIT === record (GH-672): $(cat "$tmp/out14")"
+    fail "an unreadable config cost the lane its === EXIT === record (GH-672): $(cat "$tmp/out14")"
   [ -f "$logdir/$lane4.done" ] ||
-    fail "a guard exception cost the lane its done-file (GH-672): $(cat "$tmp/out14")"
-  ok "a guard exception is reported but never skips the end record"
+    fail "an unreadable config cost the lane its done-file (GH-672): $(cat "$tmp/out14")"
+  ok "an unreadable config is reported as UNVERIFIED and never skips the end record"
+
+  # --- case 15 (opt-in): the guard itself raising never costs the end record -
+  # lane-stop runs under $ErrorActionPreference = Stop. The guard converts what
+  # it can into exit codes, but anything it cannot — here, the script missing,
+  # as in a partial checkout — still raises, and step 7 must survive it.
+  lane5=guard-e2e-noguard
+  repo12=$(new_repo e2e-noguard)
+  start_fake_lane "$lane5" "$repo12"
+  crippled="$tmp/crippled"
+  mkdir -p "$crippled"
+  cp "$root/scripts/fleet/lane-stop.ps1" "$crippled/lane-stop.ps1"
+  if pwsh -NoProfile -NonInteractive -File "$crippled/lane-stop.ps1" \
+    -Name "$lane5" -LogDir "$logdir_w" >"$tmp/out15" 2>&1
+  then stop_status5=0; else stop_status5=$?; fi
+  drop_fake_lane "$lane5"
+
+  [ "$stop_status5" -eq 1 ] ||
+    fail "lane-stop should exit 1 when the guard cannot run at all, got $stop_status5: $(cat "$tmp/out15")"
+  grep -q 'gitconfig=CHECK FAILED' "$tmp/out15" ||
+    fail "a guard that cannot run must be reported, not swallowed: $(cat "$tmp/out15")"
+  grep -q '=== EXIT' "$logdir/$lane5.log" 2>/dev/null ||
+    fail "a raised guard error cost the lane its === EXIT === record (GH-672): $(cat "$tmp/out15")"
+  [ -f "$logdir/$lane5.done" ] ||
+    fail "a raised guard error cost the lane its done-file (GH-672): $(cat "$tmp/out15")"
+  ok "a guard that raises is caught, reported, and never skips the end record"
 else
-  echo "-- cases 11-14 (lane-stop end-to-end) skipped; set GIT_CONFIG_GUARD_E2E=1 to run them"
+  echo "-- cases 11-15 (lane-stop end-to-end) skipped; set GIT_CONFIG_GUARD_E2E=1 to run them"
 fi
 
 echo "all $case_number case(s) passed"


### PR DESCRIPTION
## Summary

Issue: #715

The main checkout and all 30+ linked worktrees read **one** `.git/config`. It became a run of NUL bytes twice on 2026-09-02/03 when lanes were hard-killed while git was extending it, and every worktree lost git at once. This makes that loss survivable: a backup validated *before* it is written, and a check at the one moment we know a kill just happened.

### Root cause

Two separate holes, both still open on `main`:

1. **The backup was worthless.** `.git/config.CORRUPT.2026-09-02T17-16.bak` (27328 bytes / 27328 NULs) and `.git/config.CORRUPT.2026-09-03T01-33.bak` (2561 / 2561) are both on this machine right now — copied *after* the corruption, so both are all NULs. Nothing ever checked that a backup parsed.
2. **`lane-stop.ps1` never looked back.** It knew the brief path but not the worktree, so after killing a tree it had no idea which repo to check. A kill landing on git's config write reported `exit 0` and walked away from a dead repo.

There is deliberately **no graceful-shutdown window** before the kill. `taskkill` without `/F` posts WM_CLOSE, and a lane's processes are hidden console processes with no window: measured exit 128, *"can only be terminated forcefully"*, target alive for the whole window. Round 1 of this PR shipped such a window; it was removed rather than documented, so no stop pays seconds for a mechanism that cannot fire. The damage is repaired after the kill instead.

### Changes

- **`scripts/fleet/git-config-guard.ps1` (new)** — `-Backup` / `-Verify` / `-Restore` / `-VerifyOrRestore` against the **shared** config (`git rev-parse --git-common-dir`), so a linked worktree acts on the file that actually matters. Healthy means all three of: has content, holds no NUL byte, and `git config --list --file` parses it.
  - `-Backup` refuses an unhealthy source, and keeps one generation (`config.guard.bak.prev`). Precisely what that buys: `-Restore`'s automatic fallback fires only when the newest backup is **detectably** broken (case 10). It cannot fire for the case that motivates keeping a generation — a torn write ending on a boundary that still parses — because nothing can tell that file from a good one; there, `.prev` is what an operator points `-BackupPath` at once they know the newest is wrong.
  - **Unreadable is a third outcome, not a synonym for corrupt** — and has its own exit code (4). A config held open by whatever is writing it is neither backed up from nor restored over, and `lane-stop` reports it as `UNVERIFIED`, never `UNREPAIRABLE`: the guard declined to judge that file, so calling it corrupt would be a claim nobody made.
  - `-Restore` preserves the corrupt file as `config.CORRUPT.<ts>.bak` (uniquified, so two restores in one second cannot overwrite each other's evidence), copies through a sibling temp file that is never left behind, and re-verifies the result.
  - It resolves the common dir by walking `.git` / `gitdir:` / `commondir` itself when git refuses to answer — which is exactly the case it exists for, since a NUL config makes *every* git command fail, `rev-parse` included.
- **`lane-launch.ps1`** — takes that validated backup after `-Cwd` resolves and before anything is written. Guard exit 2 fails the launch; exit 3 (no backup taken) warns and continues. The rev-parse gate above it now names the config as a suspect, because a NUL config is what makes that gate fire first.
- **`lane-stop.ps1`** — resolves the lane's worktree from the wrapper's `Set-Location` line (**both** generator shapes: `-LiteralPath` from `lane-launch.ps1:154`, and the bare form from `review-pr.sh:453` / `pr-review-launch.ps1:64`, since this script stops those lanes too — GH-712), runs `-VerifyOrRestore`, prints `gitconfig=…`, and exits 1 if the config was not confirmed healthy. The guard call is wrapped so that an exception inside it can never cost the lane its `=== EXIT ===` record and done-file (GH-672).
- **`docs/guides/operator-runbook.md`** — START HERE §5 and the §六 lane-stop rule row now say what the stop actually does, including why there is no graceful window.
- **`scripts/test-git-config-guard.sh` (new)** — 10 offline cases + 5 opt-in end-to-end cases (`GIT_CONFIG_GUARD_E2E=1`), styled on `scripts/test-lint-markdown-content.sh`.

### Pre-fix regression evidence

**The original defect.** Same scenario, run against **`origin/main`'s `lane-stop.ps1`** on a live fake lane (scheduled task + wrapper + child process, the GH-672 shape) whose shared config was NUL-ised while it ran — with a perfectly good backup sitting right there:

```
--- config NUL-ised: size=175 nuls=175
fatal: bad config line 1 in file .git/config
--- running PRE-FIX lane-stop:
terminated=3 pids=33984,36704,15792
residual=0 (CommandLine match + process tree verification)
--- pre-fix lane-stop exit=0
--- config AFTER pre-fix lane-stop: size=175 nuls=175
fatal: bad config line 1 in file .git/config
--- backup that was sitting there unused: config.guard.bak
```

`exit=0`, `residual=0`, nothing to see — and the repo is dead.

**The three round-1 defects.** Each has a case that fails against round 1 (`f380fa9`), measured by running the current test file against a tree whose `lane-stop.ps1` and `git-config-guard.ps1` are the round-1 versions:

```
FAIL (after case 12): a review-shaped wrapper skipped the config check:
  terminated=3 pids=19100,31788,33888
  gitconfig=skipped (lane cwd not resolvable from the wrapper)

FAIL (after case 13): locked-config lane-stop probe did not run:
  lane-stop.ps1: Exception calling "ReadAllBytes" with "1" argument(s):
  "The process cannot access the file '...\.git\config' because it is being
   used by another process."
  (round-1 lane-stop exit=255, no lane log, no done-file)

FAIL (after case 8): locked-config probe: -Backup on an unreadable config
  should exit 3 (no backup taken) — round 1 threw instead
```

And the graceful window, measured directly:

```
taskkill(no /F) exit=128  "This process can only be terminated forcefully (/F option)"
still alive after 3s = True
```

### Post-fix verification

Full suite at head `75fd02726ed6c996f52039c21859626a7eb2a5a0`:

```
$ GIT_CONFIG_GUARD_E2E=1 sh scripts/test-git-config-guard.sh
ok 1  - -Backup copies a parseable config to .git/config.guard.bak
ok 2  - -Backup refuses a NUL config and leaves the previous good backup intact
ok 3  - -Verify accepts a healthy config and rejects NUL and unparseable ones
ok 4  - -Restore revives git from the backup and preserves the corrupt config
ok 5  - -Restore with no backup exits non-zero and changes nothing
ok 6  - -Verify/-Restore from a linked worktree act on the shared .git/config
ok 7  - -VerifyOrRestore is a no-op when healthy and repairs loudly when not
ok 8  - lane-launch backs up before the lane runs and lane-stop validates after the kill
ok 9  - an unreadable config is neither backed up from nor restored over
ok 10 - -Backup keeps one previous generation and -Restore falls back to it
ok 11 - lane-stop restores the shared .git/config after really killing a lane
ok 12 - lane-stop exits 1 when the config is corrupt and no backup can repair it
ok 13 - lane-stop resolves the cwd of review lanes too, not only lane-launch ones
ok 14 - an unreadable config is reported as UNVERIFIED and never skips the end record
ok 15 - a guard that raises is caught, reported, and never skips the end record
all 15 case(s) passed
```

Also ran: `sh scripts/lint-markdown-content.sh` (clean, and again via the pre-commit hook), `sh -n` on the test script, PowerShell `Parser::ParseFile` clean on all three `.ps1` files, and the offline suite against a CRLF copy (the checkout form on Windows, matching `scripts/test-pr-review-watch.sh`). The five E2E cases register and unregister their own scheduled tasks; `Get-ScheduledTask` and `Win32_Process` both show none left behind.

**No Cargo gate:** this PR touches no Rust, no `Cargo.*`, and no toolchain — 3 `.ps1`, 1 `.sh`, 1 `.md`. **Note for the reviewer:** CI runs no `.ps1` and no `scripts/test-*.sh`, so a green CI here says nothing about this PR's product surface; the local receipts above are the evidence. `git merge-tree` against current `origin/main` (`4075ab5`) is clean, and the file sets are disjoint.

### doneWhen

| Issue doneWhen | Where |
|---|---|
| A pre-write/periodic backup **validated** before it is stored | `lane-launch.ps1:113` calls the guard, which refuses anything that does not parse (cases 1–2) and keeps one generation back (case 10) |
| lane-stop gives a graceful chance **or** verifies the config after the kill | The verification half (cases 11–14). The graceful half is **not** delivered and cannot be with `taskkill`: measured exit 128 against the only process shape lanes have. Recorded here rather than faked |
| Fail-first repro, then fixed | Pre-fix section above, for the original defect and for all three round-1 defects |
| Decide and record whether lanes should share one `.git` | `edda decide "fleet.shared-git-config=one-shared-config-guarded-not-split"` — keep one shared config (splitting it costs the single object store and shared refs, which is why worktrees are used here) and make its loss survivable instead. Recorded, unratified; not expanded into this PR per the issue |

### Wiring audit

| 新面 | Writer & shape | Reader | Failure signal | Layer reach |
|---|---|---|---|---|
| `git-config-guard.ps1` exit 0/1/2/3 | `Fail` (`git-config-guard.ps1:56-59`) and the mode blocks (`:189-199` verify, `:204-222` backup, `:226-264` restore) | `lane-launch.ps1:113-120` (2 → `Fail`, other non-zero → warn), `lane-stop.ps1:315-330` (non-zero → `gitConfigBroken`) | loud: every failure prints `git-config-guard: …` to stderr; no path returns 0 without a healthy config | operator/lane scripts only; no Rust, no CI change |
| `Unreadable` health outcome | `Get-ConfigHealth` catch (`:141-144`) | `-Backup` (`:205-208`, exit 3) and `-Restore` (`:232-236`, exit 2) | never silently healthy and never a restore trigger; both paths exit non-zero with the OS message | decides whether the guard writes at all; case 9 |
| `<git-common-dir>/config.guard.bak` and `.bak.prev` | `Copy-Atomic` via `<dest>.guard-tmp` + `Move-Item -Force` (`:164-176`), rotation at `:213` | `-Restore` / `-VerifyOrRestore` candidate loop (`:240-248`); cases 1, 4, 10 read them back | written only from a validated source; a refused backup exits 2/3 and leaves both generations (cases 2, 9) | inside `.git/`, untracked; no repo content changes |
| `<git-common-dir>/config.CORRUPT.<ts>.bak` | `-Restore` before overwriting (`:252-254`), name uniquified by `New-UniquePath` (`:178-183`) | humans / forensics; case 4 asserts it exists, case 9 asserts it is *not* written for a merely locked config | written before the destructive step; the restore re-verifies after (`:258-261`) | same |
| `lane-stop.ps1` stdout `gitconfig=<verdict>` and log `=== EXIT (…; .git/config <verdict>) ===` | `lane-stop.ps1:336,351` | operators; cases 11–14 assert both. `lane-status.ps1:75` reads only the log's byte length, so the extended EXIT line changes nothing for it | `UNREPAIRABLE …` or `CHECK FAILED …` + exit 1 — after the end record is written (`:353`) | log/done-file format extended, not replaced |
| `$laneCwd` (worktree parsed from the wrapper) | regex on the wrapper's `Set-Location` line (`lane-stop.ps1:126-132`) | the step-6 guard call (`:314`) | unresolvable → verdict `skipped (lane cwd not resolvable from the wrapper)`, printed, never silently "healthy" | reads a line both wrapper generators already write; no new contract between them |

Not changed, and deliberately: `terminated=0 (lane was not running)` still prints when `Stop-ScheduledTask` alone ended a childless lane — pre-existing wording, out of this issue's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018W1GKisB5EJQ9yREfZmSdD
