### PR TITLE
fix(conductor): clear stale waivers on retry, wire gate-timeout ledger recorder, and bucket in runner-status (GH-747)

### DIFF
--- a/crates/edda-conductor/src/runner/event_log.rs
+++ b/crates/edda-conductor/src/runner/event_log.rs
@@ -3,7 +3,7 @@
 //! Writes append-only JSONL to `.edda/conductor/{plan}/events.jsonl`.
 //! Independent of edda/edda — works even if edda CLI is not installed.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -179,7 +179,7 @@ fn append_line(path: &Path, line: &str) -> std::io::Result<()> {
 // ── RunnerStatus ──
 
 /// Lightweight status file for external tools to poll.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RunnerStatus {
     pub plan: String,
     pub status: String,
@@ -189,6 +189,10 @@ pub struct RunnerStatus {
     /// Phases holding AWAITING_VERDICT (D4) — external actors poll this
     /// to learn the subject + gate_sha they must issue a verdict against.
     pub awaiting_verdict: Vec<String>,
+    /// Phases holding GATE_TIMED_OUT (GH-552, GH-747) — blocked awaiting operator
+    /// resolution (retry or waive).
+    #[serde(default)]
+    pub gate_timed_out: Vec<String>,
     pub updated_at: String,
 }
 
@@ -220,6 +224,12 @@ pub fn write_runner_status(
             .phases
             .iter()
             .filter(|p| p.status == PhaseStatus::AwaitingVerdict)
+            .map(|p| p.id.clone())
+            .collect(),
+        gate_timed_out: state
+            .phases
+            .iter()
+            .filter(|p| p.status == PhaseStatus::GateTimedOut)
             .map(|p| p.id.clone())
             .collect(),
         updated_at: now_rfc3339(),
@@ -397,17 +407,49 @@ mod tests {
     fn runner_status_serialization() {
         let status = RunnerStatus {
             plan: "my-plan".into(),
-            status: "running".into(),
-            current_phase: Some("build".into()),
+            status: "blocked".into(),
+            current_phase: None,
             completed: vec!["lint".into()],
             failed: vec![],
-            awaiting_verdict: vec!["build".into()],
+            awaiting_verdict: vec![],
+            gate_timed_out: vec!["build".into()],
             updated_at: "2026-02-18T10:00:00Z".into(),
         };
         let json = serde_json::to_string_pretty(&status).unwrap();
         assert!(json.contains(r#""plan": "my-plan""#));
-        assert!(json.contains(r#""current_phase": "build""#));
-        assert!(json.contains(r#""completed""#));
+        assert!(json.contains(r#""gate_timed_out""#));
+        assert!(json.contains(r#""build""#));
+
+        let deserialized: RunnerStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.gate_timed_out, vec!["build"]);
+    }
+
+    #[test]
+    fn write_runner_status_buckets_gate_timed_out() {
+        use crate::plan::parser::parse_plan;
+        use crate::state::machine::{PhaseStatus, PlanState, PlanStatus};
+
+        let dir = tempfile::tempdir().unwrap();
+        let plan = parse_plan(
+            "name: test-gated\nphases:\n  - id: p1\n    prompt: x\n  - id: p2\n    prompt: y\n",
+        )
+        .unwrap();
+        let mut state = PlanState::from_plan(&plan, "test.yaml");
+        state.plan_status = PlanStatus::Blocked;
+        state.get_phase_mut("p1").unwrap().status = PhaseStatus::GateTimedOut;
+        state.get_phase_mut("p2").unwrap().status = PhaseStatus::Failed;
+
+        write_runner_status(dir.path(), &state, None);
+        let path = dir
+            .path()
+            .join(".edda")
+            .join("conductor")
+            .join("test-gated")
+            .join("runner-status.json");
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: RunnerStatus = serde_json::from_str(&content).unwrap();
+        assert_eq!(parsed.failed, vec!["p2"]);
+        assert_eq!(parsed.gate_timed_out, vec!["p1"]);
     }
 
     #[test]

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -602,7 +602,7 @@ pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -
                         let _ = tmux.update_phase_status(&gated_id, "GateTimedOut");
                     }
                     let gate_cost = state.get_phase(&gated_id).ok().and_then(|p| p.cost_usd);
-                    edda::record_phase_failed_with_plan(
+                    edda::record_phase_gate_timed_out(
                         cwd,
                         Some(&plan.name),
                         &gated_id,
@@ -4673,6 +4673,14 @@ phases:
             (tv[0].1.as_str(), tv[0].2.as_str(), tv[0].3),
             ("a", "GateTimedOut", 1)
         );
+
+        // GH-747: the workspace ledger must record the honest "gate_timed_out" classification, never "failed".
+        let notes = read_structured_notes(&root, "conductor_phase");
+        assert_eq!(notes.len(), 1, "exactly one structured phase note");
+        let payload = &notes[0].payload["conductor_phase"];
+        assert_eq!(payload["plan_id"], "gated");
+        assert_eq!(payload["status"], "gate_timed_out");
+
         let _ = std::fs::remove_dir_all(&root);
     }
 
@@ -4735,6 +4743,112 @@ phases:
             events.contains("\"auto\":true"),
             "the auto waiver must be marked automatic: {events}"
         );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// GH-747 P1-1: retrying a waived gate clears the stale waiver, so that
+    /// re-entering the gate and timing out again will block rather than auto-waiving.
+    #[tokio::test]
+    async fn retry_clears_stale_waiver_so_reentered_gate_timeout_blocks_again() {
+        let root = fresh_root("waiver_retry");
+        init_git_repo(&root);
+        let launcher = MockLauncher::new();
+        launcher.set_results(
+            "b",
+            vec![PhaseResult::AgentDone {
+                cost_usd: None,
+                result_text: Some("done".into()),
+            }],
+        );
+        let yaml = r#"
+name: waiverplan
+timeout_sec: 600
+phases:
+  - id: a
+    prompt: "do it"
+    gate: verdict
+    gate_timeout_sec: 1
+    on_gate_timeout: skip
+  - id: b
+    prompt: "next"
+    depends_on: [a]
+"#;
+        let plan = parse_plan(yaml).unwrap();
+        let state = PlanState::from_plan(&plan, "test.yaml");
+        let (mut state, _notifier, _launcher) = tokio::time::timeout(
+            GATE_TEST_DEADLINE,
+            spawn_runner(yaml, root.clone(), launcher, state),
+        )
+        .await
+        .expect("gate test exceeded 30s")
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(state.phases[0].status, PhaseStatus::GateTimedOut);
+        assert!(state.phases[0].skip_reason.is_some());
+        assert_eq!(state.plan_status, PlanStatus::Completed);
+
+        // Operator retries "a" (e.g. edda conduct retry a)
+        // Transitioning to Pending must clear the stale waiver (skip_reason) and error!
+        transition(
+            &mut state,
+            "a",
+            PhaseStatus::GateTimedOut,
+            PhaseStatus::Pending,
+            None,
+        )
+        .unwrap();
+
+        assert!(
+            state.phases[0].skip_reason.is_none(),
+            "skip_reason must be cleared on transition to Pending, got: {:?}",
+            state.phases[0].skip_reason
+        );
+        assert!(
+            state.phases[0].error.is_none(),
+            "error must be cleared on transition to Pending, got: {:?}",
+            state.phases[0].error
+        );
+
+        // Re-run plan without on_gate_timeout: skip.
+        // If a stale waiver had survived, the plan would have auto-proceeded;
+        // with the stale waiver cleared, the re-entered gate must block again upon timeout.
+        let yaml2 = r#"
+name: waiverplan
+timeout_sec: 600
+phases:
+  - id: a
+    prompt: "do it"
+    gate: verdict
+    gate_timeout_sec: 1
+  - id: b
+    prompt: "next"
+    depends_on: [a]
+"#;
+        let launcher2 = MockLauncher::new();
+        state.plan_status = PlanStatus::Running;
+        let (state2, _notifier2, launcher2) = tokio::time::timeout(
+            GATE_TEST_DEADLINE,
+            spawn_runner(yaml2, root.clone(), launcher2, state),
+        )
+        .await
+        .expect("gate test exceeded 30s")
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(state2.phases[0].status, PhaseStatus::GateTimedOut);
+        assert!(state2.phases[0].skip_reason.is_none(), "no stale waiver");
+        assert_eq!(
+            state2.plan_status,
+            PlanStatus::Blocked,
+            "plan must block on re-entered timeout"
+        );
+        assert_eq!(
+            launcher2.call_count("b"),
+            0,
+            "dependent phase b must not run"
+        );
+
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/crates/edda-conductor/src/state/machine.rs
+++ b/crates/edda-conductor/src/state/machine.rs
@@ -323,6 +323,18 @@ pub fn transition(
         bail!("invalid transition: {phase_id} {from:?} → {to:?}");
     }
     phase.status = to;
+    if to == PhaseStatus::Pending {
+        // GH-747 P1-1: transitioning to Pending (retry) clears transient terminal state
+        // from previous attempts (skip_reason/waiver, error, and gate metadata) so that
+        // a retried phase starts clean and never re-inherits a stale waiver.
+        phase.skip_reason = None;
+        phase.error = None;
+        phase.gate_sha = None;
+        phase.gate_entered_at = None;
+        phase.verdict_decision = None;
+        phase.verdict_actor = None;
+        phase.verdict_comment = None;
+    }
     if let Some(update) = side_effect {
         update.apply(phase);
     }

--- a/demo/openclaw-skill/edda-conductor/SKILL.md
+++ b/demo/openclaw-skill/edda-conductor/SKILL.md
@@ -91,7 +91,7 @@ The output is a `PlanState` object (or array if multiple plans):
 ### Status values
 
 **Plan status:** `pending`, `running`, `blocked`, `completed`, `aborted`
-**Phase status:** `pending`, `running`, `checking`, `passed`, `failed`, `skipped`, `stale`
+**Phase status:** `pending`, `running`, `checking`, `passed`, `failed`, `skipped`, `stale`, `gate_timed_out`
 
 ### Report format (phone-optimized)
 
@@ -175,7 +175,7 @@ phases:
 
 ## 4. Handle Errors
 
-When plan status is `blocked`, a phase has failed beyond max attempts.
+When plan status is `blocked`, a phase has failed beyond max attempts or timed out at an unattended verdict gate (`gate_timed_out`).
 
 ### Read error details
 
@@ -183,7 +183,7 @@ When plan status is `blocked`, a phase has failed beyond max attempts.
 edda conduct status --json
 ```
 
-Look for phases with `"status": "failed"` and their `error` field:
+Or inspect `runner-status.json` (`failed` and `gate_timed_out` buckets). Look for phases with `"status": "failed"` or `"status": "gate_timed_out"` and their `error` field:
 
 ```json
 {


### PR DESCRIPTION
## Summary

Issue: #747

Follow-ups from independent review of GH-552 covering gate-timeout ledger classification, retry waiver clearance, and runner-status bucketing.

### Root Causes
1. **P1-1 (Stale Waiver Survives Retry)**:
   - When a waived `GateTimedOut` phase was retried (transitioned to `Pending`), `transition` in `machine.rs` only mutated `phase.status = to`, leaving `skip_reason` and `error` intact.
   - Upon next execution, if the re-entered gate timed out again, it re-inherited the stale waiver (`skip_reason.is_some()`), silently auto-waiving instead of blocking.
2. **P1-2 (`record_phase_gate_timed_out` Unwired)**:
   - In `runner/sequential.rs:605`, the gate timeout arm called `edda::record_phase_failed_with_plan` instead of `edda::record_phase_gate_timed_out`.
   - The workspace ledger note was recorded with `"status": "failed"` instead of the honest `"status": "gate_timed_out"`.
3. **P1-3 (`runner-status.json` Drops `GateTimedOut`)**:
   - `RunnerStatus` had buckets for `completed`, `failed`, and `awaiting_verdict`.
   - Phases in `GateTimedOut` were dropped from every bucket, leaving external callers with `failed: []` and no phase to point at when plan status was `blocked`.

### Changes
1. **Clear Transient Terminal State on Transition to `Pending` (P1-1)**:
   - In `machine.rs::transition`, when `to == PhaseStatus::Pending`, reset `skip_reason = None`, `error = None`, `gate_sha = None`, `gate_entered_at = None`, and `verdict_* = None`.
   - Retrying any phase resets terminal state so a re-entered gate starts clean.
2. **Wire `record_phase_gate_timed_out` (P1-2)**:
   - Replaced `record_phase_failed_with_plan` with `record_phase_gate_timed_out` at `sequential.rs:605`.
   - Added ledger-note assertions to `gate_timeout_records_honest_gate_timed_out_state` verifying `status: "gate_timed_out"` in `conductor_phase`.
3. **Bucket `GateTimedOut` in `RunnerStatus` & Update Docs (P1-3)**:
   - Added `pub gate_timed_out: Vec<String>` to `RunnerStatus` and populated it in `write_runner_status`.
   - Updated `demo/openclaw-skill/edda-conductor/SKILL.md` to document `gate_timed_out` in phase statuses and `runner-status.json`.
4. **Regression & Unit Tests**:
   - Added `retry_clears_stale_waiver_so_reentered_gate_timeout_blocks_again`: proves pre-fix retained `skip_reason` on retry; verifies post-fix clears it and re-blocks on second timeout.
   - Added `write_runner_status_buckets_gate_timed_out` in `event_log.rs`.
   - Added ledger note assertion in `gate_timeout_records_honest_gate_timed_out_state`: proves pre-fix wrote `failed` instead of `gate_timed_out`.

### Pre-fix Regression Evidence

**P1-1 (Stale Waiver Survives Retry)**:
```text
thread 'runner::sequential::tests::retry_clears_stale_waiver_so_reentered_gate_timeout_blocks_again' (11704) panicked at crates\edda-conductor\src\runner\sequential.rs:4802:9:
skip_reason must be cleared on transition to Pending, got: Some("gate waived after timeout (2s waited, 1s configured): work completed and checks passed; auto-waived by on_gate_timeout: skip")
```

**P1-2 (`record_phase_gate_timed_out` Unwired)**:
```text
thread 'runner::sequential::tests::gate_timeout_records_honest_gate_timed_out_state' (32212) panicked at crates\edda-conductor\src\runner\sequential.rs:4682:9:
assertion `left == right` failed
  left: String("failed")
 right: "gate_timed_out"
```

### Post-fix Verification
```text
test runner::sequential::tests::gate_timeout_records_honest_gate_timed_out_state ... ok
test runner::sequential::tests::retry_clears_stale_waiver_so_reentered_gate_timeout_blocks_again ... ok
test runner::event_log::tests::write_runner_status_buckets_gate_timed_out ... ok

test result: ok. 368 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 20.53s
```
- `cargo fmt --all --check` PASS
- `cargo clippy -p edda-conductor --all-targets -- -D warnings` PASS