### PR TITLE
chore(githooks): file- and function-length ratchet (GH-779)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -162,7 +162,7 @@ from a Windows workstation is load-bearing rather than redundant.
 
 | Level | When | Run |
 |---|---|---|
-| L0 iterate | while editing | `cargo fmt --all --check`; `cargo clippy -p <crate> --all-targets -- -D warnings`; `cargo test -p <crate>` for each touched crate |
+| L0 iterate | while editing | `cargo fmt --all --check`; `cargo clippy -p <crate> --all-targets -- -D warnings`; `cargo test -p <crate>` for each touched crate; `scripts/lint-file-length.sh --tree` |
 | L1 freeze | once per frozen full SHA, clean tree, before push / PR update | `cargo fmt --all --check`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo test --workspace`, with `CARGO_INCREMENTAL=0`; record the result together with the full SHA (gate receipt) |
 | L2 review | verifier, once per frozen full SHA | READ the L1 receipt and exact-head CI; RAN only focused or adversarial checks they do not cover — **including Windows behavior in any crate outside the CI Windows subset above**. A full local rerun needs a stated reason: no receipt, red or absent CI, or grounds to distrust the receipt. A coverage gap earns a **focused** check for that gap, not a full rerun — running the workspace to reach one uncovered crate is the cost this ladder exists to remove. Deterministically red CI already blocks the SHA — audit and request changes instead of spending a full run; if the red is environmental, re-run only the failed job |
 | L3 pre-merge | merge authority | READ exact-head CI and the final current-head LGTM; RAN only a merge check against the current base. A draft/ready, label, or status flip is not a push — nothing reruns |
@@ -238,6 +238,8 @@ bound.
 cargo fmt --all --check
 cargo clippy -p <touched crate> --all-targets -- -D warnings
 cargo test -p <touched crate>
+# GH-779 file-length ratchet: scripts/lint-file-length.sh --tree (CI / L0);
+# pre-commit runs --staged on each staged *.rs blob.
 
 # Before freezing a SHA for push / PR update (L1 — once per frozen SHA,
 # clean tree, incremental off). Record the result with the full SHA.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,9 @@ jobs:
       - run: rustup toolchain install stable --profile minimal --component rustfmt
       - run: cargo fmt --check
       - run: sh -n install.sh scripts/lint-markdown-content.sh
+      - run: bash -n scripts/lint-file-length.sh
+      - name: Lint file length (GH-779)
+        run: bash scripts/lint-file-length.sh --tree
       - name: Lint Markdown content
         run: sh scripts/lint-markdown-content.sh
       - name: Verify installer latest-version stdout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,9 @@ rand = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+[workspace.lints.clippy]
+too_many_lines = "warn"
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-lines-threshold = 150

--- a/crates/edda-aggregate/Cargo.toml
+++ b/crates/edda-aggregate/Cargo.toml
@@ -20,3 +20,6 @@ time.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/edda-ask/Cargo.toml
+++ b/crates/edda-ask/Cargo.toml
@@ -19,3 +19,6 @@ time = { workspace = true, features = ["formatting", "parsing"] }
 
 [dev-dependencies]
 ulid = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/edda-ask/src/lib.rs
+++ b/crates/edda-ask/src/lib.rs
@@ -191,6 +191,7 @@ pub type TranscriptSearchFn = dyn Fn(&str, usize) -> Vec<ConversationHit>;
 
 // ── Core ask function ────────────────────────────────────────────────
 
+#[allow(clippy::too_many_lines)] // 264 lines at #779; split tracked in none
 pub fn ask(
     ledger: &Ledger,
     query: &str,

--- a/crates/edda-bridge-claude/Cargo.toml
+++ b/crates/edda-bridge-claude/Cargo.toml
@@ -37,3 +37,6 @@ tracing = { workspace = true }
 [dev-dependencies]
 tempfile.workspace = true
 rusqlite = { version = "0.32", features = ["bundled"] }
+
+[lints]
+workspace = true

--- a/crates/edda-bridge-claude/src/admin.rs
+++ b/crates/edda-bridge-claude/src/admin.rs
@@ -144,6 +144,7 @@ pub fn install(repo_root: &Path, no_claude_md: bool) -> anyhow::Result<()> {
 }
 
 /// Uninstall edda hooks from `.claude/settings.local.json`.
+#[allow(clippy::too_many_lines)] // 173 lines at #779; split tracked in none
 pub fn uninstall(repo_root: &Path) -> anyhow::Result<()> {
     let path = settings_path(repo_root);
 

--- a/crates/edda-bridge-claude/src/digest/orchestrate.rs
+++ b/crates/edda-bridge-claude/src/digest/orchestrate.rs
@@ -559,6 +559,7 @@ pub(super) fn harvest_inferred_decisions(
     written_ids
 }
 
+#[allow(clippy::too_many_lines)] // 309 lines at #779; split tracked in none
 fn digest_one_session(
     project_id: &str,
     session_id: &str,
@@ -868,6 +869,7 @@ fn digest_one_session(
 ///   costs a re-scan and never a duplicate;
 /// * the source ledger is never deleted, so a live producer's future
 ///   appends are always digestable.
+#[allow(clippy::too_many_lines)] // 204 lines at #779; split tracked in none
 pub fn digest_session_manual(
     project_id: &str,
     session_id: &str,

--- a/crates/edda-bridge-claude/src/dispatch/mod.rs
+++ b/crates/edda-bridge-claude/src/dispatch/mod.rs
@@ -112,6 +112,7 @@ pub(crate) fn render_write_back_protocol(_cwd: &str) -> Option<String> {
 
 /// Main hook entrypoint: parse stdin, dispatch by hook_event_name.
 /// Returns `HookResult` with optional stdout JSON and/or stderr warnings.
+#[allow(clippy::too_many_lines)] // 221 lines at #779; split tracked in none
 pub fn hook_entrypoint_from_stdin(stdin: &str) -> anyhow::Result<HookResult> {
     if stdin.trim().is_empty() {
         return Ok(HookResult::empty());

--- a/crates/edda-bridge-claude/src/dispatch/session.rs
+++ b/crates/edda-bridge-claude/src/dispatch/session.rs
@@ -261,6 +261,7 @@ pub(super) fn dispatch_subagent_context(
 // ── SessionEnd ──
 
 /// Dispatch SessionEnd — auto-digest, cleanup state, warn about pending tasks.
+#[allow(clippy::too_many_lines)] // 186 lines at #779; split tracked in none
 pub(super) fn dispatch_session_end(
     project_id: &str,
     session_id: &str,
@@ -484,6 +485,7 @@ pub(super) fn notify_session_end(project_id: &str, cwd: &str, session_id: &str) 
 ///
 /// Best-effort — all errors are silently swallowed. The session-end hook must
 /// never fail because of post-mortem logic.
+#[allow(clippy::too_many_lines)] // 176 lines at #779; split tracked in none
 pub(super) fn run_postmortem(project_id: &str, session_id: &str, cwd: &str) {
     if std::env::var("EDDA_POSTMORTEM").unwrap_or_else(|_| "1".into()) == "0" {
         return;
@@ -732,6 +734,7 @@ pub(super) fn collect_session_end_warnings(project_id: &str) -> Option<String> {
     ))
 }
 /// Dispatch SessionStart with pack + skills + optional digest warning.
+#[allow(clippy::too_many_lines)] // 228 lines at #779; split tracked in none
 pub(super) fn dispatch_session_start(
     project_id: &str,
     session_id: &str,

--- a/crates/edda-bridge-claude/src/dispatch/tools.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tools.rs
@@ -14,6 +14,7 @@ use super::{
     should_nudge, wrap_context_boundary, HookResult,
 };
 
+#[allow(clippy::too_many_lines)] // 159 lines at #779; split tracked in none
 pub(super) fn dispatch_pre_tool_use(
     raw: &serde_json::Value,
     cwd: &str,

--- a/crates/edda-bridge-claude/src/peers/board.rs
+++ b/crates/edda-bridge-claude/src/peers/board.rs
@@ -10,6 +10,7 @@ use crate::parse::now_rfc3339;
 // ── Board State Computation ──
 
 /// Read coordination.jsonl and compute current board state.
+#[allow(clippy::too_many_lines)] // 178 lines at #779; split tracked in none
 pub fn compute_board_state(project_id: &str) -> BoardState {
     let path = coordination_path(project_id);
     let content = match fs::read_to_string(&path) {

--- a/crates/edda-bridge-claude/src/peers/mod.rs
+++ b/crates/edda-bridge-claude/src/peers/mod.rs
@@ -49,6 +49,7 @@ fn env_label() -> Option<String> {
 }
 
 /// Detect git branch in a specific directory.
+#[allow(clippy::too_many_lines)] // 155 lines at #779; split tracked in none
 pub(crate) fn detect_git_branch_in(cwd: &str) -> Option<String> {
     std::process::Command::new("git")
         .args(["rev-parse", "--abbrev-ref", "HEAD"])

--- a/crates/edda-bridge-claude/src/peers/render_coord.rs
+++ b/crates/edda-bridge-claude/src/peers/render_coord.rs
@@ -106,6 +106,7 @@ fn distinct_senders(requests: &[&RequestEntry]) -> Vec<String> {
 ///
 /// "Pre-computed" refers to `peers` and `board` only — heartbeat writes and
 /// other per-session I/O still happen at the call site in `dispatch.rs`.
+#[allow(clippy::too_many_lines)] // 195 lines at #779; split tracked in none
 pub fn render_coordination_protocol_with(
     peers: &[PeerSummary],
     board: &BoardState,

--- a/crates/edda-bridge-claude/src/signals.rs
+++ b/crates/edda-bridge-claude/src/signals.rs
@@ -83,6 +83,7 @@ pub(crate) struct SubagentSummary {
 }
 
 /// One-pass transcript scan: extract tasks, files modified, and commits.
+#[allow(clippy::too_many_lines)] // 257 lines at #779; split tracked in none
 pub(crate) fn extract_session_signals(transcript_store_path: &Path) -> SessionSignals {
     use std::io::BufRead;
 

--- a/crates/edda-bridge-codex/Cargo.toml
+++ b/crates/edda-bridge-codex/Cargo.toml
@@ -25,3 +25,6 @@ dirs.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/edda-bridge-cursor/Cargo.toml
+++ b/crates/edda-bridge-cursor/Cargo.toml
@@ -22,3 +22,6 @@ time.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/edda-bridge-hermes/Cargo.toml
+++ b/crates/edda-bridge-hermes/Cargo.toml
@@ -26,3 +26,6 @@ dirs.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/edda-bridge-openclaw/Cargo.toml
+++ b/crates/edda-bridge-openclaw/Cargo.toml
@@ -23,3 +23,6 @@ dirs.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/edda-chronicle/Cargo.toml
+++ b/crates/edda-chronicle/Cargo.toml
@@ -28,3 +28,6 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/edda-cli/Cargo.toml
+++ b/crates/edda-cli/Cargo.toml
@@ -63,3 +63,6 @@ async-trait = "0.1"
 # Test-only: tamper tests must write raw SQL against a real SQLite ledger
 # (the repo does not mock internal crates), and the ledger DB is SQLite.
 rusqlite = { version = "0.32", features = ["bundled"] }
+
+[lints]
+workspace = true

--- a/crates/edda-cli/src/cmd_bridge.rs
+++ b/crates/edda-cli/src/cmd_bridge.rs
@@ -949,6 +949,7 @@ fn describe_claims(claims: &[edda_bridge_claude::peers::ClaimEntry]) -> String {
 /// 1. Peers `coordination.jsonl` — real-time broadcast to active peers
 /// 2. Workspace ledger — permanent record visible to all sessions
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_lines)] // 209 lines at #779; split tracked in #777
 pub fn decide(
     repo_root: &Path,
     decision: &str,

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -110,6 +110,7 @@ pub fn run_cmd(cmd: ConductCmd, repo_root: &Path) -> Result<()> {
 // ── Command Implementations ──
 
 /// Execute `edda conduct run <plan.yaml>`
+#[allow(clippy::too_many_lines)] // 201 lines at #779; split tracked in none
 pub fn run(
     plan_file: &Path,
     cwd_override: Option<&Path>,

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -404,6 +404,7 @@ pub fn run(args: DispatchArgs) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::too_many_lines)] // 162 lines at #779; split tracked in none
 fn run_inner(args: DispatchArgs) -> Result<i32> {
     // GH-574 honesty gate: refuse unsupported backend/option combinations
     // instead of accepting them and silently doing nothing. An explicitly

--- a/crates/edda-cli/src/cmd_draft.rs
+++ b/crates/edda-cli/src/cmd_draft.rs
@@ -588,6 +588,7 @@ pub struct ProposeParams<'a> {
     pub max_evidence: usize,
 }
 
+#[allow(clippy::too_many_lines)] // 167 lines at #779; split tracked in none
 pub fn propose(p: ProposeParams<'_>) -> anyhow::Result<()> {
     let ledger = Ledger::open(p.repo_root).context("cmd_draft::propose: opening ledger")?;
     let _lock = WorkspaceLock::acquire(&ledger.paths)?;
@@ -945,6 +946,7 @@ pub fn inbox(
     Ok(())
 }
 
+#[allow(clippy::too_many_lines)] // 169 lines at #779; split tracked in none
 pub fn approve(
     repo_root: &Path,
     id: &str,

--- a/crates/edda-cli/src/cmd_gc.rs
+++ b/crates/edda-cli/src/cmd_gc.rs
@@ -31,6 +31,7 @@ struct GcCandidate {
     reason: DeleteReason,
 }
 
+#[allow(clippy::too_many_lines)] // 376 lines at #779; split tracked in none
 pub fn execute(params: &GcParams) -> anyhow::Result<()> {
     if params.purge_archive {
         return purge_archive(params);

--- a/crates/edda-cli/src/cmd_plan.rs
+++ b/crates/edda-cli/src/cmd_plan.rs
@@ -571,6 +571,7 @@ fn escape_yaml_str(s: &str) -> String {
     s.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
+#[allow(clippy::too_many_lines)] // 280 lines at #779; split tracked in none
 fn detect_workspace_members(cwd: &Path) -> Option<Vec<String>> {
     let content = std::fs::read_to_string(cwd.join("Cargo.toml")).ok()?;
     // Simple parse: look for [workspace] section with members = [...]

--- a/crates/edda-cli/src/cmd_reconcile.rs
+++ b/crates/edda-cli/src/cmd_reconcile.rs
@@ -1064,6 +1064,7 @@ fn remove_unreferenced_scheduler_manifest(path: &Path) -> String {
 }
 
 #[cfg(any(windows, test))]
+#[allow(clippy::too_many_lines)] // 256 lines at #779; split tracked in #778
 fn scheduler_direct_exec_values(xml: &str) -> anyhow::Result<Vec<(String, String)>> {
     anyhow::ensure!(
         xml.len() <= SCHEDULER_OUTPUT_LIMIT,
@@ -1909,6 +1910,7 @@ fn static_prefix(path: &str) -> Option<StaticPrefix> {
     })
 }
 
+#[allow(clippy::too_many_lines)] // 153 lines at #779; split tracked in #778
 fn persist_reconciliation(
     repo_root: &Path,
     config: &ReconcileConfig,

--- a/crates/edda-cli/src/cmd_task.rs
+++ b/crates/edda-cli/src/cmd_task.rs
@@ -446,6 +446,7 @@ fn do_show(repo_root: &Path, id: u64) -> anyhow::Result<TaskView> {
     Ok(find_view(&views, id)?.clone())
 }
 
+#[allow(clippy::too_many_lines)] // 151 lines at #779; split tracked in none
 pub fn execute(cmd: TaskCmd, repo_root: &Path) -> anyhow::Result<()> {
     match cmd {
         TaskCmd::New {

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -1113,6 +1113,7 @@ fn find_unsupported_schema_version_error(
     None
 }
 
+#[allow(clippy::too_many_lines)] // 304 lines at #779; split tracked in none
 fn run(cli: Cli) -> anyhow::Result<()> {
     let cwd = std::env::current_dir()?;
     let repo_root = edda_ledger::EddaPaths::find_root(&cwd).unwrap_or(cwd);

--- a/crates/edda-cli/src/tui/ui.rs
+++ b/crates/edda-cli/src/tui/ui.rs
@@ -386,6 +386,7 @@ pub fn group_bindings(bindings: &[BindingEntry]) -> Vec<(&str, Vec<&BindingEntry
 // ── Event formatting ──
 
 /// Extract display type, preview text, and style from an event.
+#[allow(clippy::too_many_lines)] // 151 lines at #779; split tracked in none
 fn event_display(payload: &serde_json::Value, event_type: &str) -> (String, String, Style) {
     let default = Style::default();
     match event_type {

--- a/crates/edda-cli/tests/process_claim_contract.rs
+++ b/crates/edda-cli/tests/process_claim_contract.rs
@@ -187,6 +187,7 @@ fn claim_check_on_stale_session_subject_reports_clear() {
 }
 
 #[test]
+#[allow(clippy::too_many_lines)] // 193 lines at #779; split tracked in none
 fn check_merge_refuses_claimed_pr_unless_force() {
     let env = TestEnv::new();
     env.write_heartbeat("active-reviewer", 0); // live session

--- a/crates/edda-conductor/Cargo.toml
+++ b/crates/edda-conductor/Cargo.toml
@@ -34,3 +34,6 @@ tokio = { version = "1", features = ["process", "time", "rt-multi-thread", "io-u
 # GH-541: the gate's read-error tracker classifies SQLite busy/lock errors
 # as transient; tests construct those errors directly.
 rusqlite = { version = "0.32", features = ["bundled"] }
+
+[lints]
+workspace = true

--- a/crates/edda-conductor/src/agent/codex_rpc.rs
+++ b/crates/edda-conductor/src/agent/codex_rpc.rs
@@ -251,6 +251,7 @@ impl CodexLauncher {
 
 #[async_trait::async_trait]
 impl AgentLauncher for CodexLauncher {
+    #[allow(clippy::too_many_lines)] // 163 lines at #779; split tracked in none
     async fn run_phase(
         &self,
         phase: &Phase,

--- a/crates/edda-conductor/src/agent/pi_rpc.rs
+++ b/crates/edda-conductor/src/agent/pi_rpc.rs
@@ -372,6 +372,7 @@ impl PiRpcSession {
     /// Protocol-level failures (rejected prompt, malformed JSONL, EOF before
     /// settlement) surface as `PhaseResult::AgentCrash` — the runner retries
     /// crashes per its failure policy. `Err` is reserved for spawn/IO errors.
+    #[allow(clippy::too_many_lines)] // 172 lines at #779; split tracked in none
     async fn run_turn(
         &mut self,
         message: &str,

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -43,6 +43,7 @@ pub struct RunContext<'a> {
 }
 
 /// Run a plan sequentially. The main conductor loop.
+#[allow(clippy::too_many_lines)] // 863 lines at #779; split tracked in #776
 pub async fn run_plan(plan: &Plan, state: &mut PlanState, ctx: RunContext<'_>) -> Result<()> {
     let RunContext {
         launcher,
@@ -1294,6 +1295,7 @@ async fn fail_checking_phase(
 /// on_fail policy. Shared by the main loop and the post-rejection redispatch
 /// turn (D3).
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_lines)] // 400 lines at #779; split tracked in #776
 async fn process_phase_result(
     plan: &Plan,
     phase: &crate::plan::schema::Phase,
@@ -1788,6 +1790,7 @@ fn load_gate_output(cwd: &Path, plan_name: &str, phase_id: &str) -> Option<Strin
 /// the workspace root so the abort policy can write the structured plan
 /// abort event to the ledger (GH-584 round-2 P1-1).
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_lines)] // 173 lines at #779; split tracked in #776
 async fn handle_on_fail(
     plan: &Plan,
     phase: &crate::plan::schema::Phase,

--- a/crates/edda-core/Cargo.toml
+++ b/crates/edda-core/Cargo.toml
@@ -24,3 +24,6 @@ regex.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/edda-derive/Cargo.toml
+++ b/crates/edda-derive/Cargo.toml
@@ -17,3 +17,6 @@ time.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
+
+[lints]
+workspace = true

--- a/crates/edda-derive/src/context/mod.rs
+++ b/crates/edda-derive/src/context/mod.rs
@@ -11,6 +11,7 @@ use crate::types::*;
 use helpers::cmd_base_key;
 use session::render_session_history;
 
+#[allow(clippy::too_many_lines)] // 219 lines at #779; split tracked in none
 pub fn render_context(ledger: &Ledger, branch: &str, opt: DeriveOptions) -> Result<String> {
     let snap = build_branch_snapshot(ledger, branch)?;
     let n = opt.depth.max(1);

--- a/crates/edda-derive/src/context/session.rs
+++ b/crates/edda-derive/src/context/session.rs
@@ -74,6 +74,7 @@ pub(super) fn render_persistent_tasks(digests: &[SessionDigestEntry]) -> String 
 /// - Tier 1 (last session): Full detail — tasks, commits, files, notes, failed commands, outcome
 /// - Tier 2 (sessions 2-5): One-liner per session — date, outcome, commit count, key activity
 /// - Tier 3 (sessions 6+): Aggregate — N sessions, M commits, time span
+#[allow(clippy::too_many_lines)] // 199 lines at #779; split tracked in none
 pub(super) fn render_session_history(digests: &[SessionDigestEntry]) -> String {
     if digests.is_empty() {
         return String::new();

--- a/crates/edda-derive/src/snapshot.rs
+++ b/crates/edda-derive/src/snapshot.rs
@@ -86,6 +86,7 @@ pub(crate) fn resolve_branch_created_at_fallback(
     Ok(None)
 }
 
+#[allow(clippy::too_many_lines)] // 256 lines at #779; split tracked in none
 pub(crate) fn build_branch_snapshot(ledger: &Ledger, branch: &str) -> Result<BranchSnapshot> {
     let branch_events = collect_branch_events(ledger, branch)?;
 

--- a/crates/edda-derive/src/writers.rs
+++ b/crates/edda-derive/src/writers.rs
@@ -67,6 +67,7 @@ fn write_commit_md(dir: &Path, snap: &BranchSnapshot) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::too_many_lines)] // 178 lines at #779; split tracked in none
 fn write_log_md(dir: &Path, ledger: &Ledger, branch: &str) -> Result<()> {
     let branch_events = collect_branch_events(ledger, branch)?;
     let mut out = String::new();

--- a/crates/edda-index/Cargo.toml
+++ b/crates/edda-index/Cargo.toml
@@ -18,3 +18,6 @@ serde_json.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/edda-ingestion/Cargo.toml
+++ b/crates/edda-ingestion/Cargo.toml
@@ -20,3 +20,6 @@ time.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/edda-ledger/Cargo.toml
+++ b/crates/edda-ledger/Cargo.toml
@@ -29,3 +29,6 @@ dirs.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/edda-ledger/src/sqlite_store/events.rs
+++ b/crates/edda-ledger/src/sqlite_store/events.rs
@@ -84,6 +84,7 @@ impl SqliteStore {
     ///
     /// If the event is a decision (note with `"decision"` tag), the `decisions`
     /// table is also updated atomically within the same transaction.
+    #[allow(clippy::too_many_lines)] // 166 lines at #779; split tracked in none
     pub fn append_event(&self, event: &Event) -> anyhow::Result<()> {
         let payload = serde_json::to_string(&event.payload)?;
         let refs_blobs = serde_json::to_string(&event.refs.blobs)?;

--- a/crates/edda-ledger/src/sqlite_store/schema.rs
+++ b/crates/edda-ledger/src/sqlite_store/schema.rs
@@ -31,6 +31,7 @@ fn add_missing_columns(
     Ok(())
 }
 
+#[allow(clippy::too_many_lines)] // 204 lines at #779; split tracked in none
 fn set_schema_version_on(conn: &Connection, version: u32) -> anyhow::Result<()> {
     conn.execute(
         "INSERT OR REPLACE INTO schema_meta (key, value) VALUES ('version', ?1)",

--- a/crates/edda-ledger/src/sqlite_store/village.rs
+++ b/crates/edda-ledger/src/sqlite_store/village.rs
@@ -144,6 +144,7 @@ impl SqliteStore {
     /// 1. Recurring decisions (same key changed >= min_occurrences times)
     /// 2. Chief repeated actions (same authority+key >= min_occurrences times)
     /// 3. Rollback trends (supersession chains >= 2 within the window)
+    #[allow(clippy::too_many_lines)] // 161 lines at #779; split tracked in none
     pub fn detect_village_patterns(
         &self,
         village_id: &str,

--- a/crates/edda-mcp/Cargo.toml
+++ b/crates/edda-mcp/Cargo.toml
@@ -23,3 +23,6 @@ schemars = "1"
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/edda-notify/Cargo.toml
+++ b/crates/edda-notify/Cargo.toml
@@ -16,3 +16,6 @@ serde.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true
 tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/edda-pack/Cargo.toml
+++ b/crates/edda-pack/Cargo.toml
@@ -21,3 +21,6 @@ serde_json.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/edda-postmortem/Cargo.toml
+++ b/crates/edda-postmortem/Cargo.toml
@@ -22,3 +22,6 @@ hex.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/edda-search-fts/Cargo.toml
+++ b/crates/edda-search-fts/Cargo.toml
@@ -24,3 +24,6 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/edda-search-fts/src/indexer.rs
+++ b/crates/edda-search-fts/src/indexer.rs
@@ -324,6 +324,7 @@ impl PendingMeta {
 ///
 /// Returns the SQLite writes the caller must [`PendingMeta::flush`] *after*
 /// committing the Tantivy writer (GH-413).
+#[allow(clippy::too_many_lines)] // 212 lines at #779; split tracked in none
 pub fn index_session(
     writer: &IndexWriter,
     schema: &Schema,

--- a/crates/edda-search-fts/src/search.rs
+++ b/crates/edda-search-fts/src/search.rs
@@ -40,6 +40,7 @@ pub struct SearchOptions<'a> {
 ///   even inside a longer run; CJK *alternatives* need an explicit `OR`
 /// - Field boosting: title matches ranked 5x higher than body
 /// - Filtering by doc_type, event_type, project_id, session_id
+#[allow(clippy::too_many_lines)] // 151 lines at #779; split tracked in none
 pub fn search(
     index: &Index,
     query_str: &str,

--- a/crates/edda-search-fts/src/sync.rs
+++ b/crates/edda-search-fts/src/sync.rs
@@ -32,6 +32,7 @@ pub struct SyncStats {
 /// The cursor is owned here: callers never pass or reset it. `sync` resets to a
 /// full rebuild when the index was created fresh (schema upgrade, corruption,
 /// crash mid-wipe) or when the stored cursor no longer matches the ledger.
+#[allow(clippy::too_many_lines)] // 151 lines at #779; split tracked in none
 pub fn sync<F>(
     proj_dir: &Path,
     project_id: &str,

--- a/crates/edda-serve/Cargo.toml
+++ b/crates/edda-serve/Cargo.toml
@@ -41,3 +41,6 @@ tempfile.workspace = true
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
+
+[lints]
+workspace = true

--- a/crates/edda-serve/src/api/dashboard.rs
+++ b/crates/edda-serve/src/api/dashboard.rs
@@ -70,6 +70,7 @@ struct TimelineEntry {
     supersedes: Option<String>,
 }
 
+#[allow(clippy::too_many_lines)] // 153 lines at #779; split tracked in none
 async fn get_dashboard(
     State(_state): State<Arc<AppState>>,
     Query(params): Query<DashboardQuery>,

--- a/crates/edda-serve/src/api/drafts.rs
+++ b/crates/edda-serve/src/api/drafts.rs
@@ -272,6 +272,7 @@ async fn post_draft_deny(
 }
 
 /// Shared handler for approve/deny actions on drafts.
+#[allow(clippy::too_many_lines)] // 245 lines at #779; split tracked in none
 async fn handle_draft_action(
     state: &AppState,
     headers: &HeaderMap,

--- a/crates/edda-store/Cargo.toml
+++ b/crates/edda-store/Cargo.toml
@@ -20,3 +20,6 @@ dirs.workspace = true
 tempfile.workspace = true
 fs2.workspace = true
 time.workspace = true
+
+[lints]
+workspace = true

--- a/crates/edda-transcript/Cargo.toml
+++ b/crates/edda-transcript/Cargo.toml
@@ -21,3 +21,6 @@ time.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/edda-transcript/src/ingest.rs
+++ b/crates/edda-transcript/src/ingest.rs
@@ -30,6 +30,7 @@ pub struct IngestStats {
 ///
 /// If `index_writer` is Some, calls it for each kept record with
 /// (raw_line, store_offset, store_len, parsed_json) for index generation.
+#[allow(clippy::too_many_lines)] // 186 lines at #779; split tracked in none
 pub fn ingest_transcript_delta(
     project_dir: &Path,
     session_id: &str,

--- a/crates/edda-transcript/src/pi.rs
+++ b/crates/edda-transcript/src/pi.rs
@@ -144,6 +144,7 @@ const DEFAULT_MAX_BYTES: u64 = 8 * 1024 * 1024; // 8MB
 /// 2. Appends raw transcript lines to `transcripts/{session_id}.jsonl`.
 /// 3. Normalizes tool calls, tool results, and user prompts into `ledger/{session_id}.jsonl`.
 /// 4. Updates `state/usage.json` with observed model and token totals.
+#[allow(clippy::too_many_lines)] // 367 lines at #779; split tracked in none
 pub fn ingest_pi_transcript_delta(
     project_dir: &Path,
     session_id: &str,

--- a/scripts/file-length-ceilings.txt
+++ b/scripts/file-length-ceilings.txt
@@ -1,0 +1,36 @@
+# GH-779 file-length ceilings. Default for unlisted *.rs is 1000.
+# Lowering a ceiling is free; raising one is a reviewable diff.
+# Delete a line when that file drops to 1000 or below.
+
+crates/edda-aggregate/src/aggregate.rs 1168
+crates/edda-ask/src/lib.rs 2085
+crates/edda-bridge-claude/src/bg_detect.rs 1270
+crates/edda-bridge-claude/src/bg_extract.rs 1406
+crates/edda-bridge-claude/src/bg_scan.rs 1266
+crates/edda-bridge-claude/src/digest/orchestrate.rs 1138
+crates/edda-bridge-claude/src/digest/tests.rs 3260
+crates/edda-bridge-claude/src/dispatch/tests.rs 3098
+crates/edda-bridge-claude/src/peers/tests.rs 3588
+crates/edda-bridge-claude/src/signals.rs 2252
+crates/edda-cli/src/cmd_bridge.rs 3059
+crates/edda-cli/src/cmd_claim.rs 2539
+crates/edda-cli/src/cmd_dispatch.rs 1996
+crates/edda-cli/src/cmd_draft.rs 1705
+crates/edda-cli/src/cmd_gc.rs 1117
+crates/edda-cli/src/cmd_plan.rs 1022
+crates/edda-cli/src/cmd_prs/merge_gate.rs 1295
+crates/edda-cli/src/cmd_reconcile.rs 5653
+crates/edda-cli/src/main.rs 1451
+crates/edda-conductor/src/agent/codex_app_server.rs 1061
+crates/edda-conductor/src/agent/codex_rpc.rs 1378
+crates/edda-conductor/src/agent/pi_rpc.rs 1480
+crates/edda-conductor/src/runner/sequential.rs 5762
+crates/edda-core/src/event.rs 2191
+crates/edda-derive/src/context/session.rs 1072
+crates/edda-ledger/src/ledger.rs 1927
+crates/edda-ledger/src/sqlite_store/schema.rs 1081
+crates/edda-ledger/src/sqlite_store/tests.rs 4027
+crates/edda-mcp/src/lib.rs 1196
+crates/edda-pack/src/lib.rs 1185
+crates/edda-search-fts/src/indexer.rs 1461
+crates/edda-serve/src/tests.rs 5370

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -29,6 +29,10 @@
 #                                     examined. Same swallow-pattern family as
 #                                     scripts/wiring-scan.sh section 2 (#594),
 #                                     narrowed to hook-path write calls.
+#   - staged *.rs                  -> GH-779 file-length ratchet:
+#                                     scripts/lint-file-length.sh --staged
+#                                     (staged blob line count <= per-path
+#                                     ceiling; default 1000)
 #
 # Bypass everything with `git commit --no-verify`. CI runs on pull requests
 # and on pushes to main (.github/workflows/ci.yml), so a feature branch is
@@ -222,5 +226,13 @@ if [ "$md_needed" -eq 1 ]; then
     echo "pre-commit: sh scripts/lint-markdown-content.sh"
     sh scripts/lint-markdown-content.sh || fail "markdown content lint failed"
 fi
+
+# --- GH-779 file-length ratchet (staged *.rs blobs) -------------------------
+# Resolve the script next to this hook so a test repo using core.hooksPath
+# still runs the real lint; ceilings come from the committing repo.
+lint_file_length=$(cd "$(dirname "$0")" && pwd)/../lint-file-length.sh
+echo "pre-commit: bash scripts/lint-file-length.sh --staged"
+bash "$lint_file_length" --staged \
+    || fail "file-length ratchet: a staged *.rs blob exceeds its ceiling"
 
 exit 0

--- a/scripts/githooks/test.sh
+++ b/scripts/githooks/test.sh
@@ -403,6 +403,28 @@ expect_reject "reject: removed swallow-ok comment no longer suppresses (GH-692)"
     git commit -m "feat(test): stale swallow-ok removed"
 git reset -q --hard "$prev"
 
+# --- GH-779: staged .rs one line over / under its file-length ceiling ------
+# Default ceiling is 1000 for any unlisted path. A staged blob of 1001 lines
+# must be rejected with an output line naming path, count and ceiling; 999
+# lines must be accepted. Stub cargo keeps fmt/clippy green so only the
+# length ratchet decides.
+prev=$(git rev-parse HEAD)
+: > "$stub_log"
+awk 'BEGIN { for (i = 1; i <= 1001; i++) print "// line " i }' \
+    > crates/hooktest/src/long.rs
+git add crates/hooktest/src/long.rs
+expect_reject "reject: staged .rs one line over file-length ceiling (GH-779)" \
+    "crates/hooktest/src/long.rs is 1001 lines (ceiling 1000)" \
+    env PATH="$stub_dir:$PATH" CARGO_STUB_LOG="$stub_log" \
+    git commit -m "feat(test): over-ceiling rust file"
+awk 'BEGIN { for (i = 1; i <= 999; i++) print "// line " i }' \
+    > crates/hooktest/src/long.rs
+git add crates/hooktest/src/long.rs
+expect_accept "accept: staged .rs one line under file-length ceiling (GH-779)" \
+    env PATH="$stub_dir:$PATH" CARGO_STUB_LOG="$stub_log" \
+    git commit -m "feat(test): under-ceiling rust file"
+git reset -q --hard "$prev"
+
 echo
 if [ "$failed" -eq 0 ]; then
     echo "ALL SCENARIOS PASSED"

--- a/scripts/lint-file-length.sh
+++ b/scripts/lint-file-length.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# File-length ratchet (GH-779). Zero extra dependencies: bash + awk + git.
+#
+#   --staged  each staged *.rs blob  (git cat-file -p <newsha>) must be
+#             <= its ceiling. Called from scripts/githooks/pre-commit.
+#   --tree    each tracked *.rs (git ls-files) must be <= its ceiling.
+#             Called from the CI Format job.
+#
+# Default ceiling is 1000. scripts/file-length-ceilings.txt overrides
+# per path (`<path> <ceiling>`). Lowering a ceiling is free; raising one
+# is an ordinary reviewable diff to the data file, not a hook failure.
+
+set -eu
+
+mode=${1:-}
+if [ "$mode" != "--staged" ] && [ "$mode" != "--tree" ]; then
+    echo "usage: $0 --staged|--tree" >&2
+    exit 2
+fi
+
+root=$(git rev-parse --show-toplevel)
+cd "$root"
+
+ceilings_file="$root/scripts/file-length-ceilings.txt"
+default=1000
+zero40=0000000000000000000000000000000000000000
+
+ceiling_for() {
+    path=$1
+    if [ -f "$ceilings_file" ]; then
+        awk -v p="$path" '
+            $0 ~ /^[ \t]*#/ { next }
+            NF < 2 { next }
+            $1 == p { print $2; found = 1; exit }
+            END { if (!found) exit 1 }
+        ' "$ceilings_file" && return 0
+    fi
+    printf '%s\n' "$default"
+}
+
+violations=$(mktemp)
+trap 'rm -f "$violations"' EXIT
+
+check() {
+    path=$1
+    count=$2
+    ceil=$(ceiling_for "$path")
+    if [ "$count" -gt "$ceil" ]; then
+        printf '%s is %s lines (ceiling %s)\n' "$path" "$count" "$ceil" >>"$violations"
+    fi
+}
+
+line_count_from_blob() {
+    # NR counts records; an empty blob is 0 lines.
+    git cat-file -p "$1" | awk 'END { print NR+0 }'
+}
+
+if [ "$mode" = "--staged" ]; then
+    staged_z=$(mktemp)
+    trap 'rm -f "$violations" "$staged_z"' EXIT
+    git diff --cached --raw -z --no-renames --diff-filter=ACMR >"$staged_z"
+    [ -s "$staged_z" ] || exit 0
+    while IFS= read -r -d '' meta; do
+        IFS= read -r -d '' f || break
+        [ -n "$f" ] || continue
+        case "$f" in
+            *.rs) ;;
+            *) continue ;;
+        esac
+        rest=${meta#:}
+        rest=${rest#* }
+        rest=${rest#* }
+        rest=${rest#* }
+        newsha=${rest%% *}
+        [ "$newsha" != "$zero40" ] || continue
+        check "$f" "$(line_count_from_blob "$newsha")"
+    done <"$staged_z"
+else
+    while IFS= read -r -d '' f; do
+        [ -n "$f" ] || continue
+        check "$f" "$(line_count_from_blob ":$f")"
+    done < <(git ls-files -z -- '*.rs')
+fi
+
+if [ -s "$violations" ]; then
+    echo "file-length: these paths exceed their ceiling:" >&2
+    while IFS= read -r line; do
+        echo "file-length: $line" >&2
+    done <"$violations"
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Issue: #779

Seed a file- and function-length ratchet so the split sweep can only move down. Nothing is shrunk in this PR.

### Root Cause
Nothing in the repo bounded file or function length. `clippy::too_many_lines` is pedantic and was off; pre-commit gated fmt, per-crate clippy, markdown lint and a 1 MB blob cap, not line counts; no CI job measured size. Every long file got there one reasonable commit at a time.

### Changes
1. **Function length (clippy-native)**
   - Added `clippy.toml` with `too-many-lines-threshold = 150`.
   - Turned the lint on for every crate: `[workspace.lints.clippy] too_many_lines = "warn"` plus `[lints] workspace = true` in all 23 crates.
   - Marked current production functions over 150 awk-lines (plus the one clippy-flagged test) with `#[allow(clippy::too_many_lines)] // <len> lines at #779; split tracked in #<sibling or none>`.
   - 45 markers. Clippy's body-only count flags a subset (18); the allow list is the awk debt ledger so it stays grep-able. Sibling split issues: `#776` sequential.rs, `#777` cmd_bridge.rs, `#778` cmd_reconcile.rs.
2. **File length (pre-commit + CI)**
   - `scripts/lint-file-length.sh --staged|--tree` (bash + awk, NUL-safe).
   - `scripts/file-length-ceilings.txt`: one `<path> <ceiling>` for every tracked `*.rs` currently over 1000 (32 files, seeded at HEAD sizes). Default ceiling 1000.
   - Pre-commit calls `--staged` on each staged `*.rs` blob (`git cat-file -p <newsha>`).
   - CI Format job runs `bash -n` plus `--tree`.
3. **Docs**: L0 row and Pre-commit Checklist in `.claude/CLAUDE.md` point at the script.

### Pre-fix Regression Evidence
`scripts/githooks/test.sh` against the base hook (no length ratchet):

```text
FAIL: reject: staged .rs one line over file-length ceiling (GH-779)
  detail: expected rejection, got success: pre-commit: cargo fmt --all --check
pre-commit: cargo clippy -p hooktest --all-targets -- -D warnings
[master 561c2fb] feat(test): over-ceiling rust file
 1 file changed, 1001 insertions(+)
 create mode 100644 crates/hooktest/src/long.rs
```

`--tree` with a listed ceiling lowered by one line:

```text
file-length: crates/edda-aggregate/src/aggregate.rs is 1168 lines (ceiling 1167)
```

### Post-fix Verification
- Hook harness: `ALL SCENARIOS PASSED`, including
  - `PASS: reject: staged .rs one line over file-length ceiling (GH-779)`
  - `PASS: accept: staged .rs one line under file-length ceiling (GH-779)`
  - existing reject 1/4–4/4 and accept cases still pass.
- `bash scripts/lint-file-length.sh --tree` exits 0 on this HEAD.
- `cargo fmt --all --check` PASS
- `cargo clippy --workspace --all-targets -- -D warnings` PASS
