### PR TITLE
feat(cli): include build identity in edda --version (GH-746)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -322,6 +322,9 @@ gh pr checks "$N"
 A docs-only head legitimately shows `Clippy`/`Test` as `skipping` while
 `CI Gate` passes (`ci.path-filter`). That is a correct run, not a broken one.
 
+
+Before claiming `RAN on this workstation`, confirm `edda --version` in the reviewed worktree prints the exact checked-out build identity (commit + date), or `unknown` when git metadata is unavailable.
+
 **U7 — the round is complete before it is posted. P1.** Finish the whole scoped
 audit and batch every blocking P0/P1 before `Changes Requested`. A blocker
 raised in a later round must be fix-caused or previously unobservable;

--- a/crates/edda-cli/build.rs
+++ b/crates/edda-cli/build.rs
@@ -1,0 +1,109 @@
+mod build_identity;
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    watch_git_metadata();
+
+    let version = std::env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "unknown".into());
+    let long_version = build_long_version(&version);
+    println!("cargo:rustc-env=EDDA_LONG_VERSION={long_version}");
+}
+
+fn watch_git_metadata() {
+    let (Some(head_path), Some(common_dir)) = (git_path("HEAD"), git_common_dir()) else {
+        return;
+    };
+
+    for path in build_identity::git_metadata_paths(&head_path, &common_dir) {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+}
+
+fn build_long_version(version: &str) -> String {
+    let git_ref = git_ref();
+    build_identity::format_long_version(version, git_ref.as_deref(), is_git_dirty(), &build_date())
+}
+
+fn git_ref() -> Option<String> {
+    let sha = run_git(&["rev-parse", "HEAD"])?;
+    if sha.len() < 12 || !sha.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+
+    Some(sha[..12].to_string())
+}
+
+fn git_path(path: &str) -> Option<PathBuf> {
+    run_git(&["rev-parse", "--path-format=absolute", "--git-path", path]).map(PathBuf::from)
+}
+
+fn git_common_dir() -> Option<PathBuf> {
+    run_git(&["rev-parse", "--path-format=absolute", "--git-common-dir"]).map(PathBuf::from)
+}
+
+fn is_git_dirty() -> bool {
+    !git_is_clean(&["diff", "--quiet"]) || !git_is_clean(&["diff", "--cached", "--quiet"])
+}
+
+fn git_is_clean(args: &[&str]) -> bool {
+    Command::new("git")
+        .args(args)
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+fn build_date() -> String {
+    if let Some(date) = run_command("date", &["-u", "+%Y-%m-%d"]) {
+        if is_utc_date(&date) {
+            return date;
+        }
+    }
+
+    if let Some(date) = run_command(
+        "powershell",
+        &[
+            "-NoProfile",
+            "-Command",
+            "(Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')",
+        ],
+    ) {
+        if is_utc_date(&date) {
+            return date;
+        }
+    }
+
+    "unknown".to_string()
+}
+
+fn is_utc_date(date: &str) -> bool {
+    let bytes = date.as_bytes();
+    bytes.len() == 10
+        && bytes[4] == b'-'
+        && bytes[7] == b'-'
+        && bytes
+            .iter()
+            .enumerate()
+            .all(|(index, byte)| matches!(index, 4 | 7) || byte.is_ascii_digit())
+}
+
+fn run_git(args: &[&str]) -> Option<String> {
+    run_command("git", args)
+}
+
+fn run_command(program: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(program).args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stdout = stdout.trim();
+    if stdout.is_empty() || stdout.contains('\n') || stdout.contains('\r') {
+        return None;
+    }
+
+    Some(stdout.to_string())
+}

--- a/crates/edda-cli/build_identity.rs
+++ b/crates/edda-cli/build_identity.rs
@@ -1,0 +1,31 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub fn format_long_version(version: &str, sha: Option<&str>, dirty: bool, date: &str) -> String {
+    match sha {
+        Some(sha) => {
+            let dirty = if dirty { "-dirty" } else { "" };
+            format!("{version} ({sha}{dirty} {date})")
+        }
+        None => format!("{version} (unknown)"),
+    }
+}
+
+pub fn git_metadata_paths(head_path: &Path, common_dir: &Path) -> Vec<PathBuf> {
+    let mut paths = vec![head_path.to_path_buf()];
+    let reference = fs::read_to_string(head_path)
+        .ok()
+        .and_then(|head| head.strip_prefix("ref: ").map(str::trim).map(str::to_owned))
+        .filter(|reference| reference.starts_with("refs/"));
+
+    if let Some(reference) = reference {
+        let ref_path = common_dir.join(reference);
+        paths.push(if ref_path.exists() {
+            ref_path
+        } else {
+            common_dir.join("packed-refs")
+        });
+    }
+
+    paths
+}

--- a/crates/edda-cli/build_identity.rs
+++ b/crates/edda-cli/build_identity.rs
@@ -20,11 +20,21 @@ pub fn git_metadata_paths(head_path: &Path, common_dir: &Path) -> Vec<PathBuf> {
 
     if let Some(reference) = reference {
         let ref_path = common_dir.join(reference);
-        paths.push(if ref_path.exists() {
-            ref_path
-        } else {
-            common_dir.join("packed-refs")
-        });
+        let ref_exists = ref_path.exists();
+        if ref_exists {
+            paths.push(ref_path.clone());
+        }
+
+        let packed_refs = common_dir.join("packed-refs");
+        if packed_refs.exists() {
+            paths.push(packed_refs);
+        }
+
+        if !ref_exists {
+            if let Some(parent) = ref_path.parent().filter(|parent| parent.is_dir()) {
+                paths.push(parent.to_path_buf());
+            }
+        }
     }
 
     paths

--- a/crates/edda-cli/build_identity.rs
+++ b/crates/edda-cli/build_identity.rs
@@ -31,8 +31,13 @@ pub fn git_metadata_paths(head_path: &Path, common_dir: &Path) -> Vec<PathBuf> {
         }
 
         if !ref_exists {
-            if let Some(parent) = ref_path.parent().filter(|parent| parent.is_dir()) {
-                paths.push(parent.to_path_buf());
+            let mut ancestor = ref_path.parent();
+            while let Some(candidate) = ancestor {
+                if candidate.is_dir() {
+                    paths.push(candidate.to_path_buf());
+                    break;
+                }
+                ancestor = candidate.parent();
             }
         }
     }

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -62,7 +62,7 @@ use clap::{Parser, Subcommand};
 use std::ffi::OsString;
 
 #[derive(Parser)]
-#[command(name = "edda", version, about = "Decision memory for coding agents")]
+#[command(name = "edda", version = env!("EDDA_LONG_VERSION"), about = "Decision memory for coding agents")]
 struct Cli {
     #[command(subcommand)]
     cmd: Command,

--- a/crates/edda-cli/tests/version_contract.rs
+++ b/crates/edda-cli/tests/version_contract.rs
@@ -1,0 +1,85 @@
+//! Integration tests for build identity in `edda --version` (GH-746).
+
+#[path = "../build_identity.rs"]
+mod build_identity;
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn edda_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_edda"))
+}
+
+#[test]
+fn format_long_version_has_dirty_and_gitless_forms() {
+    assert_eq!(
+        build_identity::format_long_version("0.4.0", Some("0123456789ab"), false, "2026-09-04"),
+        "0.4.0 (0123456789ab 2026-09-04)"
+    );
+    assert_eq!(
+        build_identity::format_long_version("0.4.0", Some("0123456789ab"), true, "2026-09-04"),
+        "0.4.0 (0123456789ab-dirty 2026-09-04)"
+    );
+    assert_eq!(
+        build_identity::format_long_version("0.4.0", None, false, "2026-09-04"),
+        "0.4.0 (unknown)"
+    );
+}
+
+#[test]
+fn git_metadata_paths_follow_a_worktree_head_to_its_ref() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let common_dir = temp.path().join("common");
+    let head_path = temp.path().join("worktrees").join("pr804").join("HEAD");
+    let ref_path = common_dir.join("refs").join("heads").join("feature");
+    std::fs::create_dir_all(head_path.parent().expect("HEAD parent")).expect("create HEAD parent");
+    std::fs::create_dir_all(ref_path.parent().expect("ref parent")).expect("create ref parent");
+    std::fs::write(&head_path, "ref: refs/heads/feature\n").expect("write HEAD");
+    std::fs::write(&ref_path, "0123456789abcdef\n").expect("write ref");
+
+    assert_eq!(
+        build_identity::git_metadata_paths(&head_path, &common_dir),
+        vec![head_path, ref_path]
+    );
+}
+
+#[test]
+fn version_reports_the_built_commit_and_date() {
+    let output = Command::new(edda_bin())
+        .arg("--version")
+        .output()
+        .expect("spawn edda --version");
+    assert!(output.status.success(), "stderr={:?}", output.stderr);
+
+    let built_sha = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .expect("read current git SHA");
+    assert!(built_sha.status.success());
+    let built_sha = String::from_utf8_lossy(&built_sha.stdout);
+    let expected_sha = &built_sha.trim()[..12];
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let prefix = format!("edda {} (", env!("CARGO_PKG_VERSION"));
+    let identity = stdout
+        .trim()
+        .strip_prefix(&prefix)
+        .and_then(|value| value.strip_suffix(')'))
+        .expect("version must include a parenthesized build identity");
+    let mut parts = identity.split_whitespace();
+    let sha = parts.next().expect("build SHA").trim_end_matches("-dirty");
+    let date = parts.next().expect("build date");
+    assert_eq!(parts.next(), None, "unexpected version fields: {identity}");
+    assert_eq!(sha, expected_sha, "identity={identity}");
+    assert!(sha.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    assert!(
+        date.len() == 10
+            && date.as_bytes()[4] == b'-'
+            && date.as_bytes()[7] == b'-'
+            && date
+                .bytes()
+                .enumerate()
+                .all(|(index, byte)| matches!(index, 4 | 7) || byte.is_ascii_digit()),
+        "date must be YYYY-MM-DD: {date}"
+    );
+}

--- a/crates/edda-cli/tests/version_contract.rs
+++ b/crates/edda-cli/tests/version_contract.rs
@@ -44,6 +44,25 @@ fn git_metadata_paths_follow_a_worktree_head_to_its_ref() {
 }
 
 #[test]
+fn git_metadata_paths_watch_packed_refs_and_a_new_loose_ref() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let common_dir = temp.path().join("common");
+    let ref_dir = common_dir.join("refs").join("heads");
+    let head_path = temp.path().join("worktrees").join("pr804").join("HEAD");
+    let packed_refs = common_dir.join("packed-refs");
+    std::fs::create_dir_all(head_path.parent().expect("HEAD parent")).expect("create HEAD parent");
+    std::fs::create_dir_all(&ref_dir).expect("create ref directory");
+    std::fs::write(&head_path, "ref: refs/heads/feature\n").expect("write HEAD");
+    std::fs::write(&packed_refs, "0123456789abcdef refs/heads/feature\n")
+        .expect("write packed refs");
+
+    assert_eq!(
+        build_identity::git_metadata_paths(&head_path, &common_dir),
+        vec![head_path, packed_refs, ref_dir]
+    );
+}
+
+#[test]
 fn version_reports_the_built_commit_and_date() {
     let output = Command::new(edda_bin())
         .arg("--version")

--- a/crates/edda-cli/tests/version_contract.rs
+++ b/crates/edda-cli/tests/version_contract.rs
@@ -63,6 +63,28 @@ fn git_metadata_paths_watch_packed_refs_and_a_new_loose_ref() {
 }
 
 #[test]
+fn git_metadata_paths_watch_nearest_existing_ancestor_for_nested_packed_ref() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let common_dir = temp.path().join("common");
+    let heads_dir = common_dir.join("refs").join("heads");
+    let head_path = temp.path().join("worktrees").join("pr804").join("HEAD");
+    let packed_refs = common_dir.join("packed-refs");
+    std::fs::create_dir_all(head_path.parent().expect("HEAD parent")).expect("create HEAD parent");
+    std::fs::create_dir_all(&heads_dir).expect("create refs/heads directory");
+    std::fs::write(&head_path, "ref: refs/heads/feature/release\n").expect("write HEAD");
+    std::fs::write(
+        &packed_refs,
+        "0123456789abcdef refs/heads/feature/release\n",
+    )
+    .expect("write packed refs");
+
+    assert_eq!(
+        build_identity::git_metadata_paths(&head_path, &common_dir),
+        vec![head_path, packed_refs, heads_dir]
+    );
+}
+
+#[test]
 fn version_reports_the_built_commit_and_date() {
     let output = Command::new(edda_bin())
         .arg("--version")

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,6 +43,29 @@ has one) and `uncommitted_events`. It is a stable contract: within 0.x keys
 may be added, never deleted, renamed, or retyped. The exact shape is in
 COMPATIBILITY.md § "Stable `--json` contracts".
 
+### `edda --version`
+
+Show installed CLI identity, including git commit and build date.
+
+```bash
+edda --version
+```
+
+Expected format:
+
+```text
+edda <semver> (<12-hex sha>[-dirty] <YYYY-MM-DD>)
+```
+
+The date is UTC. `-dirty` denotes tracked worktree or index changes present
+when the binary was built; untracked files do not change the build identity.
+
+In a build without git metadata (for example, from a source distribution), it prints:
+
+```text
+edda <semver> (unknown)
+```
+
 ### `edda doctor`
 
 Health check for bridge integration.


### PR DESCRIPTION
Implement GH-746: include git commit and build date in `edda --version` output, with dirty flag when tracked files are changed and fallback to `unknown` when git metadata is unavailable. Adds a build script, CLI version binding, documentation, reviewer checklist note, and regression coverage.

Issue: #746
