### PR TITLE
fix(fleet): extend git-config-guard to detect and recover corrupt refs (GH-797)

### DIFF
--- a/scripts/fleet/git-config-guard.ps1
+++ b/scripts/fleet/git-config-guard.ps1
@@ -367,7 +367,12 @@ function Restore-BrokenRefs([string]$Repo, [string]$CommonDir, $BrokenRefs) {
 if ($VerifyRefs) {
   $refsHealth = Get-RefsHealth $RepoPath $commonDir
   if (-not $refsHealth.Healthy) {
-    Fail "refs UNHEALTHY: $($refsHealth.Reason)" 2
+    $repairHint = if ($refsHealth.CanRepair) {
+      "repair available from reflog: run scripts/fleet/git-config-guard.ps1 -RepoPath '$RepoPath' -RestoreRefs"
+    } else {
+      "automatic reflog repair unavailable; inspect repo manually"
+    }
+    Fail "refs UNHEALTHY: $($refsHealth.Reason) ($repairHint)" 2
   }
   "refs=healthy ($($refsHealth.Reason))"
   exit 0
@@ -382,12 +387,15 @@ if ($RestoreRefs) {
     exit 0
   }
   [Console]::Error.WriteLine("git-config-guard: refs UNHEALTHY: $($refsHealth.Reason)")
-  $restoreResult = Restore-BrokenRefs $RepoPath $commonDir $refsHealth.BrokenRefs
-  if (-not $restoreResult.Success) {
-    Fail "RESTORE FAILED: $($restoreResult.Reason)" 2
+  if (-not $refsHealth.CanRepair) {
+    Fail "cannot repair refs automatically: $($refsHealth.Reason)" 2
   }
+  $restoreResult = Restore-BrokenRefs $RepoPath $commonDir $refsHealth.BrokenRefs
   foreach ($r in $restoreResult.Restored) {
     "$r"
+  }
+  if (-not $restoreResult.Success) {
+    Fail "RESTORE FAILED: $($restoreResult.Reason)" 2
   }
   exit 0
 }
@@ -405,7 +413,12 @@ if ($Verify) {
   }
   $refsHealth = Get-RefsHealth $RepoPath $commonDir
   if (-not $refsHealth.Healthy) {
-    Fail "refs UNHEALTHY: $($refsHealth.Reason)" 2
+    $repairHint = if ($refsHealth.CanRepair) {
+      "repair available from reflog: run scripts/fleet/git-config-guard.ps1 -RepoPath '$RepoPath' -RestoreRefs"
+    } else {
+      "automatic reflog repair unavailable; inspect repo manually"
+    }
+    Fail "refs UNHEALTHY: $($refsHealth.Reason) ($repairHint)" 2
   }
   "config=$ConfigPath healthy ($($configHealth.Reason))"
   "refs=healthy ($($refsHealth.Reason))"
@@ -423,7 +436,12 @@ if ($Backup) {
   }
   $refsHealth = Get-RefsHealth $RepoPath $commonDir
   if (-not $refsHealth.Healthy) {
-    Fail "ref(s) unhealthy ($($refsHealth.Reason)); cannot guarantee repo consistency — repair with scripts/fleet/git-config-guard.ps1 -RepoPath '$RepoPath' -RestoreRefs" 2
+    $repairHint = if ($refsHealth.CanRepair) {
+      "repair with scripts/fleet/git-config-guard.ps1 -RepoPath '$RepoPath' -RestoreRefs"
+    } else {
+      "automatic repair from reflog unavailable; manual inspection of .git required"
+    }
+    Fail "ref(s) unhealthy ($($refsHealth.Reason)); cannot guarantee repo consistency — $repairHint" 2
   }
   try {
     if ((Get-ConfigHealth $BackupPath).Healthy) { Copy-Atomic $BackupPath $PrevBackupPath }
@@ -474,12 +492,15 @@ if (-not $configHealth.Healthy) {
 $refsHealth = Get-RefsHealth $RepoPath $commonDir
 if (-not $refsHealth.Healthy) {
   [Console]::Error.WriteLine("git-config-guard: refs UNHEALTHY: $($refsHealth.Reason)")
-  $restoreResult = Restore-BrokenRefs $RepoPath $commonDir $refsHealth.BrokenRefs
-  if (-not $restoreResult.Success) {
-    Fail "RESTORE FAILED: $($restoreResult.Reason)" 2
+  if (-not $refsHealth.CanRepair) {
+    Fail "cannot repair refs automatically: $($refsHealth.Reason)" 2
   }
+  $restoreResult = Restore-BrokenRefs $RepoPath $commonDir $refsHealth.BrokenRefs
   foreach ($r in $restoreResult.Restored) {
     "$r"
+  }
+  if (-not $restoreResult.Success) {
+    Fail "RESTORE FAILED: $($restoreResult.Reason)" 2
   }
 } else {
   "refs healthy ($($refsHealth.Reason)); nothing restored"

--- a/scripts/fleet/git-config-guard.ps1
+++ b/scripts/fleet/git-config-guard.ps1
@@ -1,45 +1,41 @@
-# git-config-guard.ps1 — keep the shared .git/config recoverable (GH-715).
+# git-config-guard.ps1 — keep the shared .git/config and refs recoverable (GH-715, GH-797).
 #
 # The main checkout and all 30+ linked worktrees read ONE .git/config to find
-# the remote. On 2026-09-02 17:16 and 2026-09-03 01:33 that file became a run
-# of NUL bytes (27328/27328 and 2561/2561) after lanes were hard-killed while
-# git was extending it — `fatal: bad config line 1` for every worktree at once.
-# There was no restore point: the .bak sitting next to it had been copied
-# AFTER the corruption, so it was all NULs too.
+# the remote, and shared git metadata under .git/refs to resolve branches.
+# On 2026-09-02 and 2026-09-03 hard-killing lanes mid-write resulted in NUL-corrupted
+# metadata files:
+#   * .git/config became runs of NUL bytes (27328/27328 and 2561/2561), breaking
+#     every worktree at once (GH-715).
+#   * refs/heads/<branch> became 41 NUL bytes, breaking branch checkout and log
+#     while rev-parse --is-inside-work-tree silently passed (GH-797).
 #
-# The fix that makes a backup worth having is validating BEFORE copying. This
-# script never writes a backup it has not parsed, and never reports a repair it
-# did not make.
+# The defense:
+#   * .git/config has no recovery source, so it requires a validated backup taken
+#     BEFORE the lane can write, never backing up an unparsed file.
+#   * Branch refs DO have a recovery source: git's own write-ahead reflog.
+#     The detector is `git fsck --connectivity-only` (and loose ref inspection).
+#     The repair is preserving the dead ref for forensics, removing it, and
+#     restoring the SHA from the reflog via `git update-ref`.
 #
 # usage:
 #   pwsh -NoProfile -File scripts/fleet/git-config-guard.ps1 -RepoPath <repo> -Backup
 #   pwsh -NoProfile -File scripts/fleet/git-config-guard.ps1 -RepoPath <repo> -Verify
 #   pwsh -NoProfile -File scripts/fleet/git-config-guard.ps1 -RepoPath <repo> -Restore
 #   pwsh -NoProfile -File scripts/fleet/git-config-guard.ps1 -RepoPath <repo> -VerifyOrRestore
+#   pwsh -NoProfile -File scripts/fleet/git-config-guard.ps1 -RepoPath <repo> -VerifyRefs
+#   pwsh -NoProfile -File scripts/fleet/git-config-guard.ps1 -RepoPath <repo> -RestoreRefs
 #
 # -RepoPath may be the main checkout or any linked worktree: the target is
-# always the SHARED config (`git rev-parse --git-common-dir`), because that is
-# the single file whose loss takes down every worktree.
-#
-# -Backup keeps one generation: the outgoing backup moves to <backup>.prev
-# before the new one is written. Be precise about what that buys. The
-# AUTOMATIC fallback only fires when the newest backup is DETECTABLY broken
-# (case 10). It cannot fire for the case that motivates keeping a generation
-# at all — a torn write ending on a boundary that still parses — because
-# nothing can tell that file from a good one; there, .prev is the copy an
-# operator points -BackupPath at by hand once they know the newest is wrong.
-#
-# A config that cannot be READ (held open by whatever is writing it) is a third
-# outcome, not a synonym for corrupt: nothing is backed up from it and nothing
-# is restored over it, because it may be perfectly good.
+# always the SHARED config and refs (`git rev-parse --git-common-dir`), because that
+# is the single directory whose loss takes down every worktree.
 #
 # Exit codes:
-#   0  the config is healthy (backed up / verified / restored)
+#   0  metadata is healthy (backed up / verified / restored)
 #   1  usage or resolution error (no mode, not a git repo, git unavailable)
-#   2  the config is unhealthy — and for -Restore/-VerifyOrRestore, could not
-#      be repaired (no usable backup, or the restored file still does not parse)
+#   2  metadata is unhealthy — and for -Restore/-VerifyOrRestore, could not
+#      be repaired (no usable backup/reflog, or the restored state still does not parse)
 #   3  no backup was taken: the config is healthy but the copy failed
-#   4  the config could not be judged at all, because it could not be read.
+#   4  config could not be judged at all, because it could not be read.
 #      Distinct from 2 on purpose: nothing is known to be wrong with it
 param(
   [string]$RepoPath = '.',
@@ -47,6 +43,8 @@ param(
   [switch]$Verify,
   [switch]$Restore,
   [switch]$VerifyOrRestore,
+  [switch]$VerifyRefs,
+  [switch]$RestoreRefs,
   [string]$BackupPath = ''
 )
 
@@ -62,28 +60,30 @@ function Fail([string]$Msg, [int]$Code = 1) {
   exit $Code
 }
 
-$modes = @($Backup, $Verify, $Restore, $VerifyOrRestore) | Where-Object { $_ }
+$modes = @($Backup, $Verify, $Restore, $VerifyOrRestore, $VerifyRefs, $RestoreRefs) | Where-Object { $_ }
 if ($modes.Count -ne 1) {
-  Fail 'give exactly one of -Backup, -Verify, -Restore, -VerifyOrRestore'
+  Fail 'give exactly one of -Backup, -Verify, -Restore, -VerifyOrRestore, -VerifyRefs, -RestoreRefs'
 }
 
-# --- resolve the shared config ----------------------------------------------
+# --- resolve the shared config & worktree gitdir ----------------------------
 
 if (-not (Test-Path -LiteralPath $RepoPath)) { Fail "-RepoPath '$RepoPath' does not exist" }
 $RepoPath = (Resolve-Path -LiteralPath $RepoPath).Path
 
-# Ask git first — it is authoritative and honours GIT_DIR and friends. But the
-# case this tool exists for is exactly the one where git refuses to answer:
-# once .git/config is a run of NULs, EVERY git command in the repo fails,
-# rev-parse included. So fall back to walking the same links git would.
+$script:WorktreeGitDir = $null
+
 function Resolve-CommonDir([string]$Start) {
   # Collect the whole stream before reading $LASTEXITCODE: `Select-Object
   # -First` stops the pipeline early and leaves the exit code unset.
-  $out = @(& git -C $Start rev-parse --path-format=absolute --git-common-dir 2>$null)
-  if ($LASTEXITCODE -eq 0 -and $out.Count -gt 0) {
-    $fromGit = "$($out[0])".Trim()
-    if ($fromGit -and (Test-Path -LiteralPath $fromGit -PathType Container)) {
-      return (Resolve-Path -LiteralPath $fromGit).Path
+  $out = @(& git -C $Start rev-parse --path-format=absolute --git-common-dir --git-dir 2>$null)
+  if ($LASTEXITCODE -eq 0 -and $out.Count -ge 2) {
+    $fromGitCommon = "$($out[0])".Trim()
+    $fromGitDir = "$($out[1])".Trim()
+    if ($fromGitDir -and (Test-Path -LiteralPath $fromGitDir -PathType Container)) {
+      $script:WorktreeGitDir = (Resolve-Path -LiteralPath $fromGitDir).Path
+    }
+    if ($fromGitCommon -and (Test-Path -LiteralPath $fromGitCommon -PathType Container)) {
+      return (Resolve-Path -LiteralPath $fromGitCommon).Path
     }
   }
 
@@ -109,6 +109,7 @@ function Resolve-CommonDir([string]$Start) {
   }
   if (-not $gitDir -or -not (Test-Path -LiteralPath $gitDir -PathType Container)) { return $null }
   $gitDir = (Resolve-Path -LiteralPath $gitDir).Path
+  $script:WorktreeGitDir = $gitDir
 
   $commonFile = Join-Path $gitDir 'commondir'
   if (Test-Path -LiteralPath $commonFile -PathType Leaf) {
@@ -127,16 +128,10 @@ if (-not $commonDir) {
 }
 $ConfigPath = Join-Path $commonDir 'config'
 if (-not $BackupPath) { $BackupPath = Join-Path $commonDir 'config.guard.bak' }
+$PrevBackupPath = "$BackupPath.prev"
 
-# --- health ------------------------------------------------------------------
+# --- config health -----------------------------------------------------------
 
-# Healthy means all three: the file has content, holds no NUL byte, and git
-# itself can parse it. The NUL check is what names the failure seen twice on
-# 2026-09-03; `git config --list` is the criterion GH-715 asks a backup to meet.
-#
-# "Unreadable" is a THIRD outcome, not a synonym for unhealthy: a config held
-# open by a process that is still writing it cannot be judged, and must not be
-# overwritten from a backup on the strength of a failed read.
 function Get-ConfigHealth([string]$Path) {
   if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
     return @{ Healthy = $false; Reason = 'file does not exist' }
@@ -161,10 +156,7 @@ function Get-ConfigHealth([string]$Path) {
   return @{ Healthy = $true; Reason = 'parses, no NUL bytes' }
 }
 
-# Copy through a sibling temp file so a reader never observes a half-written
-# destination — the same class of hazard that produced the NUL config. The temp
-# file is never left behind: a half-written .guard-tmp is the very thing this
-# script exists to keep out of the git directory.
+# Copy through a sibling temp file so a reader never observes a half-written destination.
 function Copy-Atomic([string]$From, [string]$To) {
   $tmp = "$To.guard-tmp"
   try {
@@ -177,8 +169,6 @@ function Copy-Atomic([string]$From, [string]$To) {
   }
 }
 
-# A name no existing file holds, so a second restore inside the same second
-# cannot overwrite the first one's evidence.
 function New-UniquePath([string]$Path) {
   if (-not (Test-Path -LiteralPath $Path)) { return $Path }
   $n = 2
@@ -186,39 +176,254 @@ function New-UniquePath([string]$Path) {
   return "$Path.$n"
 }
 
-$health = Get-ConfigHealth $ConfigPath
+# --- refs health & reflog recovery (GH-797) ----------------------------------
+
+function Resolve-RefRepairSha([string]$Repo, [string]$CommonDir, [string]$Ref) {
+  $normalizedRef = $Ref -replace '\\', '/'
+  $candidates = New-Object System.Collections.Generic.List[string]
+
+  # 1. Primary reflog: <commonDir>/logs/<ref>
+  $primaryReflog = Join-Path $CommonDir "logs\$($normalizedRef -replace '/', '\')"
+  if (Test-Path -LiteralPath $primaryReflog -PathType Leaf) {
+    $candidates.Add($primaryReflog)
+  }
+
+  # 2. Worktree HEAD reflog (if this worktree's HEAD points to this ref)
+  if ($script:WorktreeGitDir) {
+    $wtHeadPath = Join-Path $script:WorktreeGitDir 'HEAD'
+    if (Test-Path -LiteralPath $wtHeadPath -PathType Leaf) {
+      $wtHeadContent = "$(Get-Content -LiteralPath $wtHeadPath -TotalCount 1)".Trim()
+      if ($wtHeadContent -match '^\s*ref:\s*(.+?)\s*$' -and ($Matches[1] -replace '\\', '/') -eq $normalizedRef) {
+        $wtHeadLog = Join-Path $script:WorktreeGitDir 'logs\HEAD'
+        if (Test-Path -LiteralPath $wtHeadLog -PathType Leaf) {
+          $candidates.Add($wtHeadLog)
+        }
+      }
+    }
+  }
+
+  # 3. Common HEAD reflog (if common HEAD points to this ref)
+  $commonHeadPath = Join-Path $CommonDir 'HEAD'
+  if (Test-Path -LiteralPath $commonHeadPath -PathType Leaf) {
+    $commonHeadContent = "$(Get-Content -LiteralPath $commonHeadPath -TotalCount 1)".Trim()
+    if ($commonHeadContent -match '^\s*ref:\s*(.+?)\s*$' -and ($Matches[1] -replace '\\', '/') -eq $normalizedRef) {
+      $commonHeadLog = Join-Path $CommonDir 'logs\HEAD'
+      if (Test-Path -LiteralPath $commonHeadLog -PathType Leaf) {
+        $candidates.Add($commonHeadLog)
+      }
+    }
+  }
+
+  foreach ($logPath in $candidates) {
+    $lines = @(Get-Content -LiteralPath $logPath -ErrorAction SilentlyContinue)
+    for ($i = $lines.Count - 1; $i -ge 0; $i--) {
+      $line = $lines[$i]
+      $parts = $line -split '\s+'
+      if ($parts.Count -ge 2) {
+        $candidateSha = $parts[1]
+        if ($candidateSha -match '^[0-9a-fA-F]{40}$' -and $candidateSha -ne '0000000000000000000000000000000000000000') {
+          & git -C $Repo cat-file -e $candidateSha 2>&1 | Out-Null
+          if ($LASTEXITCODE -eq 0) {
+            return @{ Sha = $candidateSha; Source = $logPath }
+          }
+        }
+      }
+    }
+  }
+
+  return @{ Sha = $null; Source = $null }
+}
+
+function Get-RefsHealth([string]$Repo, [string]$CommonDir) {
+  $fsckRaw = @(& git -C $Repo fsck --connectivity-only 2>&1)
+  $fsckExit = $LASTEXITCODE
+  if ($fsckExit -eq 0) {
+    return @{ Healthy = $true; Reason = 'connectivity ok' }
+  }
+
+  # Parse fsck output for broken refs
+  $brokenMap = @{}
+  foreach ($line in $fsckRaw) {
+    if ($line -match 'error:\s+(refs/[^\s:]+):\s+(.*)') {
+      $r = ($Matches[1].Trim() -replace '\\', '/')
+      $msg = $Matches[2].Trim()
+      if (-not $brokenMap.ContainsKey($r)) {
+        $brokenMap[$r] = $msg
+      }
+    }
+  }
+
+  # Also inspect loose ref files under $CommonDir/refs/heads for NULs or bad length
+  $headsDir = Join-Path $CommonDir 'refs\heads'
+  if (Test-Path -LiteralPath $headsDir -PathType Container) {
+    $refFiles = Get-ChildItem -LiteralPath $headsDir -Recurse -File -ErrorAction SilentlyContinue
+    foreach ($rf in $refFiles) {
+      $relPath = ($rf.FullName.Substring($CommonDir.Length).TrimStart('\', '/') -replace '\\', '/')
+      if (-not $brokenMap.ContainsKey($relPath)) {
+        try {
+          $bytes = [System.IO.File]::ReadAllBytes($rf.FullName)
+          $hasNul = $false
+          foreach ($b in $bytes) { if ($b -eq 0) { $hasNul = $true; break } }
+          if ($hasNul) {
+            $brokenMap[$relPath] = "$($bytes.Length) bytes, contains NUL bytes (GH-797)"
+          }
+        } catch {}
+      }
+    }
+  }
+
+  if ($brokenMap.Count -eq 0) {
+    $firstLine = if ($fsckRaw.Count -gt 0) { "$($fsckRaw[0])" } else { "git fsck exit $fsckExit" }
+    return @{
+      Healthy = $false
+      BrokenRefs = @()
+      Reason = "git fsck failed: $firstLine"
+      CanRepair = $false
+    }
+  }
+
+  $brokenList = New-Object System.Collections.Generic.List[hashtable]
+  $allHaveRepairs = $true
+  $reasons = @()
+  foreach ($r in $brokenMap.Keys) {
+    $repairInfo = Resolve-RefRepairSha $Repo $CommonDir $r
+    $item = @{
+      Ref = $r
+      Error = $brokenMap[$r]
+      RepairSha = $repairInfo.Sha
+      RepairSource = $repairInfo.Source
+    }
+    $brokenList.Add($item)
+    if ($repairInfo.Sha) {
+      $reasons += "$r is broken ($($brokenMap[$r])); repair available from $($repairInfo.Source): $($repairInfo.Sha)"
+    } else {
+      $allHaveRepairs = $false
+      $reasons += "$r is broken ($($brokenMap[$r])); no repair SHA found in reflog"
+    }
+  }
+
+  return @{
+    Healthy = $false
+    BrokenRefs = @($brokenList)
+    Reason = ($reasons -join '; ')
+    CanRepair = $allHaveRepairs
+  }
+}
+
+function Restore-BrokenRefs([string]$Repo, [string]$CommonDir, $BrokenRefs) {
+  $restored = @()
+  foreach ($b in $BrokenRefs) {
+    if (-not $b.RepairSha) {
+      return @{
+        Success = $false
+        Restored = $restored
+        Reason = "no repair SHA available for ref $($b.Ref)"
+      }
+    }
+    $refName = $b.Ref
+    $sha = $b.RepairSha
+
+    # Preserve corrupt file outside .git/refs to avoid tripping git fsck
+    $targetFile = Join-Path $CommonDir ($refName -replace '/', '\')
+    $sanitized = $refName -replace '[/\\:]', '_'
+    $stamp = Get-Date -Format 'yyyy-MM-ddTHH-mm-ss'
+    $preserved = Join-Path $CommonDir "ref.CORRUPT.$sanitized.$stamp.bak"
+    $preserved = New-UniquePath $preserved
+
+    if (Test-Path -LiteralPath $targetFile) {
+      Copy-Item -LiteralPath $targetFile -Destination $preserved -Force
+      Remove-Item -LiteralPath $targetFile -Force
+    }
+
+    & git -C $Repo update-ref $refName $sha
+    if ($LASTEXITCODE -ne 0) {
+      return @{
+        Success = $false
+        Restored = $restored
+        Reason = "git update-ref $refName $sha failed with exit $LASTEXITCODE"
+      }
+    }
+    $restored += "RESTORED ref=$refName to sha=$sha from $($b.RepairSource); corrupt file preserved at $preserved"
+  }
+
+  $after = Get-RefsHealth $Repo $CommonDir
+  if (-not $after.Healthy) {
+    return @{
+      Success = $false
+      Restored = $restored
+      Reason = "refs still unhealthy after restoration: $($after.Reason)"
+    }
+  }
+
+  return @{
+    Success = $true
+    Restored = $restored
+    Reason = 'all refs restored and verified healthy'
+  }
+}
+
+# --- -VerifyRefs -------------------------------------------------------------
+
+if ($VerifyRefs) {
+  $refsHealth = Get-RefsHealth $RepoPath $commonDir
+  if (-not $refsHealth.Healthy) {
+    Fail "refs UNHEALTHY: $($refsHealth.Reason)" 2
+  }
+  "refs=healthy ($($refsHealth.Reason))"
+  exit 0
+}
+
+# --- -RestoreRefs ------------------------------------------------------------
+
+if ($RestoreRefs) {
+  $refsHealth = Get-RefsHealth $RepoPath $commonDir
+  if ($refsHealth.Healthy) {
+    "refs healthy ($($refsHealth.Reason)); nothing restored"
+    exit 0
+  }
+  [Console]::Error.WriteLine("git-config-guard: refs UNHEALTHY: $($refsHealth.Reason)")
+  $restoreResult = Restore-BrokenRefs $RepoPath $commonDir $refsHealth.BrokenRefs
+  if (-not $restoreResult.Success) {
+    Fail "RESTORE FAILED: $($restoreResult.Reason)" 2
+  }
+  foreach ($r in $restoreResult.Restored) {
+    "$r"
+  }
+  exit 0
+}
 
 # --- -Verify -----------------------------------------------------------------
 
+$configHealth = Get-ConfigHealth $ConfigPath
+
 if ($Verify) {
-  if ($health.Healthy) {
-    "config=$ConfigPath healthy ($($health.Reason))"
-    exit 0
+  if ($configHealth.Unreadable) {
+    Fail "config=$ConfigPath COULD NOT BE JUDGED: $($configHealth.Reason)" 4
   }
-  if ($health.Unreadable) {
-    Fail "config=$ConfigPath COULD NOT BE JUDGED: $($health.Reason)" 4
+  if (-not $configHealth.Healthy) {
+    Fail "config=$ConfigPath UNHEALTHY: $($configHealth.Reason)" 2
   }
-  Fail "config=$ConfigPath UNHEALTHY: $($health.Reason)" 2
+  $refsHealth = Get-RefsHealth $RepoPath $commonDir
+  if (-not $refsHealth.Healthy) {
+    Fail "refs UNHEALTHY: $($refsHealth.Reason)" 2
+  }
+  "config=$ConfigPath healthy ($($configHealth.Reason))"
+  "refs=healthy ($($refsHealth.Reason))"
+  exit 0
 }
 
 # --- -Backup -----------------------------------------------------------------
 
-# One generation back. The automatic fallback below only fires when the newest
-# backup is DETECTABLY broken; for a torn-but-parsing one nothing can tell it
-# from a good copy, and .prev is then the file an operator restores by hand
-# with -BackupPath. See the header.
-$PrevBackupPath = "$BackupPath.prev"
-
 if ($Backup) {
-  if ($health.Unreadable) {
-    # Nothing is known about the config, so nothing may be concluded from it:
-    # do not overwrite the backup, and do not claim the config is broken.
-    Fail "config could not be read, so no backup was taken ($($health.Reason)); $BackupPath left as it was" 4
+  if ($configHealth.Unreadable) {
+    Fail "config could not be read, so no backup was taken ($($configHealth.Reason)); $BackupPath left as it was" 4
   }
-  if (-not $health.Healthy) {
-    # Refusing here is the whole point: the real .bak files on this machine were
-    # copied after the corruption and were therefore useless.
-    Fail "refusing to back up an unhealthy config ($($health.Reason)); $BackupPath left as it was" 2
+  if (-not $configHealth.Healthy) {
+    Fail "refusing to back up an unhealthy config ($($configHealth.Reason)); $BackupPath left as it was" 2
+  }
+  $refsHealth = Get-RefsHealth $RepoPath $commonDir
+  if (-not $refsHealth.Healthy) {
+    Fail "ref(s) unhealthy ($($refsHealth.Reason)); cannot guarantee repo consistency — repair with scripts/fleet/git-config-guard.ps1 -RepoPath '$RepoPath' -RestoreRefs" 2
   }
   try {
     if ((Get-ConfigHealth $BackupPath).Healthy) { Copy-Atomic $BackupPath $PrevBackupPath }
@@ -227,46 +432,57 @@ if ($Backup) {
     Fail "config is healthy but the backup could not be written to ${BackupPath}: $($_.Exception.Message)" 3
   }
   "config=$ConfigPath healthy; backup=$BackupPath"
+  "refs=healthy ($($refsHealth.Reason))"
   exit 0
 }
 
 # --- -Restore / -VerifyOrRestore ---------------------------------------------
 
-if ($health.Healthy) {
-  "config=$ConfigPath healthy ($($health.Reason)); nothing restored"
-  exit 0
+$configRestored = $false
+if (-not $configHealth.Healthy) {
+  if ($configHealth.Unreadable) {
+    Fail "config=$ConfigPath could not be read, so it was NOT restored ($($configHealth.Reason)); check what holds it open" 4
+  }
+  [Console]::Error.WriteLine("git-config-guard: config=$ConfigPath UNHEALTHY: $($configHealth.Reason)")
+
+  $source = $null
+  foreach ($candidate in @($BackupPath, $PrevBackupPath)) {
+    $candidateHealth = Get-ConfigHealth $candidate
+    if ($candidateHealth.Healthy) { $source = $candidate; break }
+    [Console]::Error.WriteLine("git-config-guard: unusable backup ${candidate}: $($candidateHealth.Reason)")
+  }
+  if (-not $source) {
+    Fail "no usable backup to restore from (tried $BackupPath, $PrevBackupPath); config left untouched for forensics" 2
+  }
+
+  $stamp = Get-Date -Format 'yyyy-MM-ddTHH-mm-ss'
+  $preserved = New-UniquePath (Join-Path $commonDir "config.CORRUPT.$stamp.bak")
+  Copy-Item -LiteralPath $ConfigPath -Destination $preserved -Force
+  Copy-Atomic $source $ConfigPath
+
+  $after = Get-ConfigHealth $ConfigPath
+  if (-not $after.Healthy) {
+    Fail "RESTORE FAILED: config still unhealthy after copying $source ($($after.Reason))" 2
+  }
+  "RESTORED config=$ConfigPath from backup=$source; corrupt file preserved at $preserved"
+  $configRestored = $true
+} else {
+  "config=$ConfigPath healthy ($($configHealth.Reason)); nothing restored"
 }
 
-if ($health.Unreadable) {
-  # A locked config is not a corrupt one. Overwriting it here would destroy a
-  # file that may be perfectly good and is currently being written.
-  Fail "config=$ConfigPath could not be read, so it was NOT restored ($($health.Reason)); check what holds it open" 4
+# Check and restore refs
+$refsHealth = Get-RefsHealth $RepoPath $commonDir
+if (-not $refsHealth.Healthy) {
+  [Console]::Error.WriteLine("git-config-guard: refs UNHEALTHY: $($refsHealth.Reason)")
+  $restoreResult = Restore-BrokenRefs $RepoPath $commonDir $refsHealth.BrokenRefs
+  if (-not $restoreResult.Success) {
+    Fail "RESTORE FAILED: $($restoreResult.Reason)" 2
+  }
+  foreach ($r in $restoreResult.Restored) {
+    "$r"
+  }
+} else {
+  "refs healthy ($($refsHealth.Reason)); nothing restored"
 }
 
-[Console]::Error.WriteLine("git-config-guard: config=$ConfigPath UNHEALTHY: $($health.Reason)")
-
-$source = $null
-foreach ($candidate in @($BackupPath, $PrevBackupPath)) {
-  $candidateHealth = Get-ConfigHealth $candidate
-  if ($candidateHealth.Healthy) { $source = $candidate; break }
-  [Console]::Error.WriteLine("git-config-guard: unusable backup ${candidate}: $($candidateHealth.Reason)")
-}
-if (-not $source) {
-  Fail "no usable backup to restore from (tried $BackupPath, $PrevBackupPath); config left untouched for forensics" 2
-}
-
-# Keep the corrupt file: it is the only evidence of what the kill did, and the
-# name matches the ones already archived for the two 2026-09 incidents.
-$stamp = Get-Date -Format 'yyyy-MM-ddTHH-mm-ss'
-$preserved = New-UniquePath (Join-Path $commonDir "config.CORRUPT.$stamp.bak")
-Copy-Item -LiteralPath $ConfigPath -Destination $preserved -Force
-
-Copy-Atomic $source $ConfigPath
-
-$after = Get-ConfigHealth $ConfigPath
-if (-not $after.Healthy) {
-  Fail "RESTORE FAILED: config still unhealthy after copying $source ($($after.Reason))" 2
-}
-
-"RESTORED config=$ConfigPath from backup=$source; corrupt file preserved at $preserved"
 exit 0

--- a/scripts/fleet/git-config-guard.ps1
+++ b/scripts/fleet/git-config-guard.ps1
@@ -279,11 +279,13 @@ function Get-RefsHealth([string]$Repo, [string]$CommonDir) {
       BrokenRefs = @()
       Reason = "git fsck failed: $firstLine"
       CanRepair = $false
+      CanRepairAny = $false
     }
   }
 
   $brokenList = New-Object System.Collections.Generic.List[hashtable]
   $allHaveRepairs = $true
+  $anyHaveRepairs = $false
   $reasons = @()
   foreach ($r in $brokenMap.Keys) {
     $repairInfo = Resolve-RefRepairSha $Repo $CommonDir $r
@@ -295,6 +297,7 @@ function Get-RefsHealth([string]$Repo, [string]$CommonDir) {
     }
     $brokenList.Add($item)
     if ($repairInfo.Sha) {
+      $anyHaveRepairs = $true
       $reasons += "$r is broken ($($brokenMap[$r])); repair available from $($repairInfo.Source): $($repairInfo.Sha)"
     } else {
       $allHaveRepairs = $false
@@ -307,18 +310,25 @@ function Get-RefsHealth([string]$Repo, [string]$CommonDir) {
     BrokenRefs = @($brokenList)
     Reason = ($reasons -join '; ')
     CanRepair = $allHaveRepairs
+    CanRepairAny = $anyHaveRepairs
   }
 }
 
 function Restore-BrokenRefs([string]$Repo, [string]$CommonDir, $BrokenRefs) {
+  if (@($BrokenRefs).Count -eq 0) {
+    return @{
+      Success = $false
+      Restored = @()
+      Reason = "no broken refs identified to restore"
+    }
+  }
+
   $restored = @()
+  $failedRefs = @()
   foreach ($b in $BrokenRefs) {
     if (-not $b.RepairSha) {
-      return @{
-        Success = $false
-        Restored = $restored
-        Reason = "no repair SHA available for ref $($b.Ref)"
-      }
+      $failedRefs += "$($b.Ref) (no repair SHA available)"
+      continue
     }
     $refName = $b.Ref
     $sha = $b.RepairSha
@@ -337,13 +347,18 @@ function Restore-BrokenRefs([string]$Repo, [string]$CommonDir, $BrokenRefs) {
 
     & git -C $Repo update-ref $refName $sha
     if ($LASTEXITCODE -ne 0) {
-      return @{
-        Success = $false
-        Restored = $restored
-        Reason = "git update-ref $refName $sha failed with exit $LASTEXITCODE"
-      }
+      $failedRefs += "$refName (git update-ref failed with exit $LASTEXITCODE)"
+      continue
     }
     $restored += "RESTORED ref=$refName to sha=$sha from $($b.RepairSource); corrupt file preserved at $preserved"
+  }
+
+  if ($failedRefs.Count -gt 0) {
+    return @{
+      Success = $false
+      Restored = $restored
+      Reason = "cannot repair refs: $($failedRefs -join '; ')"
+    }
   }
 
   $after = Get-RefsHealth $Repo $CommonDir
@@ -369,6 +384,8 @@ if ($VerifyRefs) {
   if (-not $refsHealth.Healthy) {
     $repairHint = if ($refsHealth.CanRepair) {
       "repair available from reflog: run scripts/fleet/git-config-guard.ps1 -RepoPath '$RepoPath' -RestoreRefs"
+    } elseif ($refsHealth.CanRepairAny) {
+      "partial repair available via scripts/fleet/git-config-guard.ps1 -RepoPath '$RepoPath' -RestoreRefs; unrepairable refs require manual inspection of .git"
     } else {
       "automatic reflog repair unavailable; inspect repo manually"
     }
@@ -387,9 +404,6 @@ if ($RestoreRefs) {
     exit 0
   }
   [Console]::Error.WriteLine("git-config-guard: refs UNHEALTHY: $($refsHealth.Reason)")
-  if (-not $refsHealth.CanRepair) {
-    Fail "cannot repair refs automatically: $($refsHealth.Reason)" 2
-  }
   $restoreResult = Restore-BrokenRefs $RepoPath $commonDir $refsHealth.BrokenRefs
   foreach ($r in $restoreResult.Restored) {
     "$r"
@@ -415,6 +429,8 @@ if ($Verify) {
   if (-not $refsHealth.Healthy) {
     $repairHint = if ($refsHealth.CanRepair) {
       "repair available from reflog: run scripts/fleet/git-config-guard.ps1 -RepoPath '$RepoPath' -RestoreRefs"
+    } elseif ($refsHealth.CanRepairAny) {
+      "partial repair available via scripts/fleet/git-config-guard.ps1 -RepoPath '$RepoPath' -RestoreRefs; unrepairable refs require manual inspection of .git"
     } else {
       "automatic reflog repair unavailable; inspect repo manually"
     }
@@ -438,6 +454,8 @@ if ($Backup) {
   if (-not $refsHealth.Healthy) {
     $repairHint = if ($refsHealth.CanRepair) {
       "repair with scripts/fleet/git-config-guard.ps1 -RepoPath '$RepoPath' -RestoreRefs"
+    } elseif ($refsHealth.CanRepairAny) {
+      "partial repair available via scripts/fleet/git-config-guard.ps1 -RepoPath '$RepoPath' -RestoreRefs; unrepairable refs require manual inspection of .git"
     } else {
       "automatic repair from reflog unavailable; manual inspection of .git required"
     }
@@ -492,9 +510,6 @@ if (-not $configHealth.Healthy) {
 $refsHealth = Get-RefsHealth $RepoPath $commonDir
 if (-not $refsHealth.Healthy) {
   [Console]::Error.WriteLine("git-config-guard: refs UNHEALTHY: $($refsHealth.Reason)")
-  if (-not $refsHealth.CanRepair) {
-    Fail "cannot repair refs automatically: $($refsHealth.Reason)" 2
-  }
   $restoreResult = Restore-BrokenRefs $RepoPath $commonDir $refsHealth.BrokenRefs
   foreach ($r in $restoreResult.Restored) {
     "$r"

--- a/scripts/fleet/lane-launch.ps1
+++ b/scripts/fleet/lane-launch.ps1
@@ -113,10 +113,10 @@ $Cwd = (Resolve-Path -LiteralPath $Cwd).Path
 & (Join-Path $PSScriptRoot 'git-config-guard.ps1') -RepoPath $Cwd -Backup
 $guardExit = $LASTEXITCODE
 if ($guardExit -eq 2) {
-  Fail "the shared .git/config for '$Cwd' is not usable; repair it first (scripts/fleet/git-config-guard.ps1 -RepoPath '$Cwd' -Restore) — a lane launched against it cannot run git"
+  Fail "the shared git metadata (.git/config or refs) for '$Cwd' is not usable; repair it first (scripts/fleet/git-config-guard.ps1 -RepoPath '$Cwd' -Restore) — a lane launched against it cannot run git"
 }
 if ($guardExit -ne 0) {
-  [Console]::Error.WriteLine("lane-launch: warning: .git/config backup not written (git-config-guard exit $guardExit); launching anyway, but lane-stop will have nothing to restore from")
+  [Console]::Error.WriteLine("lane-launch: warning: git metadata backup/verify failed (git-config-guard exit $guardExit); launching anyway, but lane-stop will have nothing to restore from")
 }
 
 New-Item -ItemType Directory -Force -Path $LogDir | Out-Null

--- a/scripts/fleet/lane-stop.ps1
+++ b/scripts/fleet/lane-stop.ps1
@@ -318,21 +318,48 @@ if ($laneCwd -and (Test-Path -LiteralPath $laneCwd)) {
   try {
     $guardOut = & (Join-Path $PSScriptRoot 'git-config-guard.ps1') -RepoPath $laneCwd -VerifyOrRestore 2>&1
     $guardExit = $LASTEXITCODE
-    if ($guardExit -eq 0) {
-      $restoredConfigLine = @($guardOut | Where-Object { "$_" -match 'RESTORED config=' })
-      $gitConfigVerdict = if ($restoredConfigLine.Count -gt 0) { "$($restoredConfigLine[0])" } else { 'healthy' }
+    $restoredConfigLine = @($guardOut | Where-Object { "$_" -match 'RESTORED config=' })
+    $healthyConfigLine = @($guardOut | Where-Object { "$_" -match 'config=.*healthy' })
+    $restoredRefLine = @($guardOut | Where-Object { "$_" -match 'RESTORED ref=' })
+    $healthyRefLine = @($guardOut | Where-Object { "$_" -match '^refs healthy' -or "$_" -match '^refs=healthy' })
 
-      $restoredRefLine = @($guardOut | Where-Object { "$_" -match 'RESTORED ref=' })
+    if ($guardExit -eq 0) {
+      $gitConfigVerdict = if ($restoredConfigLine.Count -gt 0) { "$($restoredConfigLine[0])" } else { 'healthy' }
       $gitRefsVerdict = if ($restoredRefLine.Count -gt 0) { "$($restoredRefLine[0])" } else { 'healthy' }
     } else {
-      $gitConfigBroken = $true
-      $gitRefsBroken = $true
-      $gitConfigVerdict = if ($guardExit -eq 4) {
-        'UNVERIFIED (git-config-guard could not read the config; nothing was changed)'
+      # Guard exited non-zero. Accurately report what was actually measured (GH-797, P1-1).
+      if ($restoredConfigLine.Count -gt 0) {
+        $gitConfigVerdict = "$($restoredConfigLine[0])"
+        $gitConfigBroken = $false
+      } elseif ($healthyConfigLine.Count -gt 0) {
+        $gitConfigVerdict = 'healthy'
+        $gitConfigBroken = $false
       } else {
-        "UNREPAIRABLE (git-config-guard exit $guardExit)"
+        $gitConfigBroken = $true
+        $gitConfigVerdict = if ($guardExit -eq 4) {
+          'UNVERIFIED (git-config-guard could not read the config; nothing was changed)'
+        } else {
+          "UNREPAIRABLE (git-config-guard exit $guardExit)"
+        }
       }
-      $gitRefsVerdict = "UNREPAIRABLE (git-config-guard exit $guardExit)"
+
+      if ($gitConfigBroken) {
+        # Config failed or was unreadable, so refs verification was not reached.
+        $gitRefsBroken = $true
+        $gitRefsVerdict = if ($guardExit -eq 4) {
+          'UNVERIFIED (config unreadable; refs not checked)'
+        } else {
+          'UNVERIFIED (config failed; refs not checked)'
+        }
+      } else {
+        # Config is confirmed healthy/restored; the failure was specifically in refs!
+        $gitRefsBroken = $true
+        $gitRefsVerdict = if ($restoredRefLine.Count -gt 0) {
+          "$($restoredRefLine[0]); UNREPAIRABLE (git-config-guard exit $guardExit)"
+        } else {
+          "UNREPAIRABLE (git-config-guard exit $guardExit)"
+        }
+      }
     }
     $guardOut | ForEach-Object { [Console]::Error.WriteLine("lane-stop: git-config-guard: $_") }
   } catch {

--- a/scripts/fleet/lane-stop.ps1
+++ b/scripts/fleet/lane-stop.ps1
@@ -321,7 +321,6 @@ if ($laneCwd -and (Test-Path -LiteralPath $laneCwd)) {
     $restoredConfigLine = @($guardOut | Where-Object { "$_" -match 'RESTORED config=' })
     $healthyConfigLine = @($guardOut | Where-Object { "$_" -match 'config=.*healthy' })
     $restoredRefLine = @($guardOut | Where-Object { "$_" -match 'RESTORED ref=' })
-    $healthyRefLine = @($guardOut | Where-Object { "$_" -match '^refs healthy' -or "$_" -match '^refs=healthy' })
 
     if ($guardExit -eq 0) {
       $gitConfigVerdict = if ($restoredConfigLine.Count -gt 0) { "$($restoredConfigLine[0])" } else { 'healthy' }

--- a/scripts/fleet/lane-stop.ps1
+++ b/scripts/fleet/lane-stop.ps1
@@ -297,16 +297,18 @@ if ($residual.Count -gt 0) {
 $task = Get-ScheduledTask -TaskName $TaskName
 if ($task.State -eq 'Running') { Fail "task $TaskName still reports State = Running after the stop" }
 
-# --- 6. the shared .git/config must still parse after the kill (GH-715) -----
-# The lane's worktree shares one .git/config with the main checkout and every
-# other worktree; a kill landing on git's write to it NULs the file and takes
+# --- 6. the shared .git/config and refs must still be healthy after the kill (GH-715, GH-797) -----
+# The lane's worktree shares one .git/config and refs with the main checkout and every
+# other worktree; a kill landing on git's write to it NULs the files and takes
 # them all down. Check it here — the one moment we know a kill just happened —
-# and restore from the backup lane-launch took before the lane could write.
+# and restore from the backup/reflogs.
 # The end record below is written either way, so the verdict never costs the
 # log its === EXIT === line.
 
 $gitConfigVerdict = 'skipped (lane cwd not resolvable from the wrapper)'
+$gitRefsVerdict = 'skipped (lane cwd not resolvable from the wrapper)'
 $gitConfigBroken = $false
+$gitRefsBroken = $false
 if ($laneCwd -and (Test-Path -LiteralPath $laneCwd)) {
   # $ErrorActionPreference is Stop for this script, so an exception raised
   # inside the guard — a config held open by another process makes
@@ -317,22 +319,27 @@ if ($laneCwd -and (Test-Path -LiteralPath $laneCwd)) {
     $guardOut = & (Join-Path $PSScriptRoot 'git-config-guard.ps1') -RepoPath $laneCwd -VerifyOrRestore 2>&1
     $guardExit = $LASTEXITCODE
     if ($guardExit -eq 0) {
-      $restoredLine = @($guardOut | Where-Object { "$_" -match 'RESTORED' })
-      $gitConfigVerdict = if ($restoredLine.Count -gt 0) { "$($restoredLine[0])" } else { 'healthy' }
+      $restoredConfigLine = @($guardOut | Where-Object { "$_" -match 'RESTORED config=' })
+      $gitConfigVerdict = if ($restoredConfigLine.Count -gt 0) { "$($restoredConfigLine[0])" } else { 'healthy' }
+
+      $restoredRefLine = @($guardOut | Where-Object { "$_" -match 'RESTORED ref=' })
+      $gitRefsVerdict = if ($restoredRefLine.Count -gt 0) { "$($restoredRefLine[0])" } else { 'healthy' }
     } else {
-      # Exit 4 means the guard declined to judge the file (it could not read
-      # it), which is not the same claim as "corrupt and unrepairable".
       $gitConfigBroken = $true
+      $gitRefsBroken = $true
       $gitConfigVerdict = if ($guardExit -eq 4) {
         'UNVERIFIED (git-config-guard could not read the config; nothing was changed)'
       } else {
         "UNREPAIRABLE (git-config-guard exit $guardExit)"
       }
+      $gitRefsVerdict = "UNREPAIRABLE (git-config-guard exit $guardExit)"
     }
     $guardOut | ForEach-Object { [Console]::Error.WriteLine("lane-stop: git-config-guard: $_") }
   } catch {
     $gitConfigBroken = $true
+    $gitRefsBroken = $true
     $gitConfigVerdict = "CHECK FAILED ($($_.Exception.Message))"
+    $gitRefsVerdict = "CHECK FAILED ($($_.Exception.Message))"
     [Console]::Error.WriteLine("lane-stop: git-config-guard threw: $($_.Exception.Message)")
   }
 }
@@ -340,7 +347,7 @@ if ($laneCwd -and (Test-Path -LiteralPath $laneCwd)) {
 # --- 7. write the end record the killed wrapper cannot write ----------------
 
 if ($terminated.Count -gt 0 -or ((Test-Path -LiteralPath $Log) -and -not (Test-Path -LiteralPath $Done))) {
-  Add-Content -LiteralPath $Log -Value "=== EXIT (stopped by lane-stop.ps1; terminated $($terminated.Count) process(es); .git/config $gitConfigVerdict) ===" -Encoding utf8
+  Add-Content -LiteralPath $Log -Value "=== EXIT (stopped by lane-stop.ps1; terminated $($terminated.Count) process(es); .git/config $gitConfigVerdict; refs $gitRefsVerdict) ===" -Encoding utf8
   if (-not (Test-Path -LiteralPath $Done)) {
     Set-Content -LiteralPath $Done -Value 'stopped' -Encoding ascii
   }
@@ -356,7 +363,8 @@ if ($terminated.Count -gt 0) {
 }
 "residual=$($residual.Count) (CommandLine match + process tree verification)"
 "gitconfig=$gitConfigVerdict"
-if ($gitConfigBroken) {
-  Fail "the shared .git/config for '$laneCwd' was not confirmed healthy after the kill ($gitConfigVerdict); every worktree sharing it depends on that file, so check it before starting anything else (GH-715)"
+"gitrefs=$gitRefsVerdict"
+if ($gitConfigBroken -or $gitRefsBroken) {
+  Fail "the shared git metadata for '$laneCwd' was not confirmed healthy after the kill (config: $gitConfigVerdict; refs: $gitRefsVerdict); every worktree sharing it depends on those files, so check it before starting anything else (GH-715, GH-797)"
 }
 exit 0

--- a/scripts/test-git-config-guard.sh
+++ b/scripts/test-git-config-guard.sh
@@ -277,7 +277,7 @@ rm -rf "$repo_ref2/.git/logs"
 if guard -RepoPath "$repo_ref2" -RestoreRefs >"$tmp/out14" 2>&1; then
   fail "-RestoreRefs exited 0 when no reflog was available"
 fi
-grep -q 'RESTORE FAILED' "$tmp/out14" ||
+grep -q -E 'cannot repair refs automatically|RESTORE FAILED' "$tmp/out14" ||
   fail "-RestoreRefs did not report failure when reflog was missing: $(cat "$tmp/out14")"
 ok "-RestoreRefs fails loudly when no reflog is available"
 
@@ -391,6 +391,8 @@ if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
     fail "lane-stop terminated nothing, so the kill path was never exercised: $(cat "$tmp/out9")"
   grep -q 'gitconfig=RESTORED' "$tmp/out9" ||
     fail "lane-stop did not report a restore: $(cat "$tmp/out9")"
+  grep -q 'gitrefs=healthy' "$tmp/out9" ||
+    fail "lane-stop did not report healthy refs when only config was corrupt: $(cat "$tmp/out9")"
   git -C "$repo6" status >/dev/null 2>&1 ||
     fail "git still broken after lane-stop: $(cat "$tmp/out9")"
   cmp -s "$tmp/e2e-good" "$repo6/.git/config" || fail "lane-stop restored the wrong bytes"
@@ -417,6 +419,8 @@ if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
     fail "lane-stop terminated nothing in case 12: $(cat "$tmp/out10")"
   grep -q 'gitconfig=UNREPAIRABLE' "$tmp/out10" ||
     fail "lane-stop did not report the config as unrepairable: $(cat "$tmp/out10")"
+  grep -q 'gitrefs=UNVERIFIED' "$tmp/out10" ||
+    fail "lane-stop did not report refs as UNVERIFIED when config failed: $(cat "$tmp/out10")"
   grep -q '=== EXIT' "$logdir/$lane2.log" 2>/dev/null ||
     fail "lane-stop lost the end record on the unrepairable path: $(cat "$tmp/out10")"
   ok "lane-stop exits 1 when the config is corrupt and no backup can repair it"
@@ -439,6 +443,8 @@ if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
   [ "$stop_status3" -eq 0 ] || fail "lane-stop exited $stop_status3: $(cat "$tmp/out13")"
   grep -q 'gitconfig=RESTORED' "$tmp/out13" ||
     fail "a review-shaped wrapper skipped the config check: $(cat "$tmp/out13")"
+  grep -q 'gitrefs=healthy' "$tmp/out13" ||
+    fail "a review-shaped wrapper skipped the refs check: $(cat "$tmp/out13")"
   cmp -s "$tmp/e2e-review-good" "$repo10/.git/config" ||
     fail "the review lane's shared config was not repaired"
   ok "lane-stop resolves the cwd of review lanes too, not only lane-launch ones"
@@ -468,6 +474,8 @@ if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
     fail "lane-stop should exit 1 when it cannot verify the config, got: $(cat "$tmp/out14")"
   grep -q '\.git/config UNVERIFIED' "$logdir/$lane4.log" 2>/dev/null ||
     fail "an unreadable config must not be reported as UNREPAIRABLE: $(cat "$logdir/$lane4.log" 2>/dev/null)"
+  grep -q 'refs UNVERIFIED' "$logdir/$lane4.log" 2>/dev/null ||
+    fail "an unreadable config did not report refs as UNVERIFIED: $(cat "$logdir/$lane4.log" 2>/dev/null)"
   grep -q '=== EXIT' "$logdir/$lane4.log" 2>/dev/null ||
     fail "an unreadable config cost the lane its === EXIT === record (GH-672): $(cat "$tmp/out14")"
   [ -f "$logdir/$lane4.done" ] ||

--- a/scripts/test-git-config-guard.sh
+++ b/scripts/test-git-config-guard.sh
@@ -37,6 +37,7 @@ e2e_cleanup() {
     cl_wrapper=$(cygpath -w "$logdir/$cl_lane.wrapper.ps1" 2>/dev/null || echo "$logdir/$cl_lane.wrapper.ps1")
     # Written to a file, never passed as -Command: a query whose own command
     # line contains the pattern matches itself and kills the killer.
+
     {
       printf "Unregister-ScheduledTask -TaskName 'edda-lane-%s' -Confirm:\$false -ErrorAction SilentlyContinue\n" "$cl_lane"
       printf "\$w = '%s'\n" "$cl_wrapper"
@@ -227,7 +228,78 @@ cmp -s "$tmp/gen1" "$repo9/.git/config" || fail "-Restore used the wrong generat
 git -C "$repo9" status >/dev/null 2>&1 || fail "git still broken after the .prev restore"
 ok "-Backup keeps one previous generation and -Restore falls back to it"
 
-# --- case 11 (opt-in): lane-stop really restores after a real kill ----------
+# --- case 11: verify rejects a NUL-corrupt branch ref and names repair SHA --
+repo_ref1=$(new_repo ref-verify)
+ref1=$(git -C "$repo_ref1" symbolic-ref HEAD)
+ref1_file="$repo_ref1/.git/$ref1"
+good_sha1=$(git -C "$repo_ref1" rev-parse HEAD)
+nul_ise "$ref1_file"
+
+if guard -RepoPath "$repo_ref1" -Verify >"$tmp/out11" 2>&1; then
+  fail "-Verify exited 0 on a NUL-corrupt branch ref: $(cat "$tmp/out11")"
+fi
+grep -q 'refs UNHEALTHY' "$tmp/out11" ||
+  fail "-Verify did not report refs UNHEALTHY: $(cat "$tmp/out11")"
+grep -q "$good_sha1" "$tmp/out11" ||
+  fail "-Verify did not name the repair SHA ($good_sha1) in its output: $(cat "$tmp/out11")"
+ok "-Verify rejects a NUL-corrupted branch ref and names the repair SHA"
+
+# --- case 12: backup refuses when branch ref is NUL (protects lane dispatch) --
+if guard -RepoPath "$repo_ref1" -Backup >"$tmp/out12" 2>&1; then
+  fail "-Backup exited 0 on a repo with a NUL-corrupted branch ref"
+fi
+grep -q 'ref(s) unhealthy' "$tmp/out12" ||
+  fail "-Backup did not report ref(s) unhealthy: $(cat "$tmp/out12")"
+ok "-Backup refuses when a branch ref is NUL, preventing dispatch into broken worktree"
+
+# --- case 13: restore repairs NUL branch ref from reflog ---------------------
+if ! guard -RepoPath "$repo_ref1" -Restore >"$tmp/out13" 2>&1; then
+  fail "-Restore exited non-zero: $(cat "$tmp/out13")"
+fi
+grep -q "RESTORED ref=$ref1" "$tmp/out13" ||
+  fail "-Restore output missing RESTORED ref line: $(cat "$tmp/out13")"
+git -C "$repo_ref1" log --oneline -1 >/dev/null 2>&1 ||
+  fail "git log still broken after ref -Restore"
+git -C "$repo_ref1" fsck --connectivity-only >/dev/null 2>&1 ||
+  fail "git fsck still fails after ref -Restore"
+corrupt_ref_count=$(ls "$repo_ref1/.git/" | grep -c '^ref\.CORRUPT\.' || true)
+[ "$corrupt_ref_count" -ge 1 ] ||
+  fail "corrupt ref file was not preserved outside .git/refs"
+ok "-Restore repairs a NUL branch ref from reflog and preserves forensic backup"
+
+# --- case 14: restore with no reflog fails loudly and preserves state --------
+repo_ref2=$(new_repo ref-noreflog)
+ref2=$(git -C "$repo_ref2" symbolic-ref HEAD)
+ref2_file="$repo_ref2/.git/$ref2"
+nul_ise "$ref2_file"
+rm -rf "$repo_ref2/.git/logs"
+
+if guard -RepoPath "$repo_ref2" -RestoreRefs >"$tmp/out14" 2>&1; then
+  fail "-RestoreRefs exited 0 when no reflog was available"
+fi
+grep -q 'RESTORE FAILED' "$tmp/out14" ||
+  fail "-RestoreRefs did not report failure when reflog was missing: $(cat "$tmp/out14")"
+ok "-RestoreRefs fails loudly when no reflog is available"
+
+# --- case 15: linked worktree ref corruption is detected and repaired -------
+repo_main=$(new_repo wt-main)
+wt_dir="$tmp/wt-child"
+git -C "$repo_main" worktree add -b wt-branch "$wt_dir" -q
+wt_ref="refs/heads/wt-branch"
+wt_ref_file="$repo_main/.git/$wt_ref"
+good_wt_sha=$(git -C "$wt_dir" rev-parse HEAD)
+nul_ise "$wt_ref_file"
+
+if guard -RepoPath "$wt_dir" -Verify >"$tmp/out15a" 2>&1; then
+  fail "-Verify in linked worktree exited 0 on corrupt branch ref"
+fi
+guard -RepoPath "$wt_dir" -RestoreRefs >"$tmp/out15b" 2>&1 ||
+  fail "-RestoreRefs in linked worktree failed: $(cat "$tmp/out15b")"
+git -C "$wt_dir" log --oneline -1 >/dev/null 2>&1 ||
+  fail "git log in worktree still fails after -RestoreRefs"
+ok "linked worktree ref corruption is detected and repaired"
+
+# --- case 16 (opt-in): lane-stop really restores after a real kill ----------
 # Registers a scheduled task, so it is off by default; run with
 # GIT_CONFIG_GUARD_E2E=1 to exercise the whole lane-stop path end to end.
 if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
@@ -273,9 +345,14 @@ if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
       printf "Unregister-ScheduledTask -TaskName 'edda-lane-%s' -Confirm:\$false -ErrorAction SilentlyContinue\n" "$fl_lane"
       printf "Register-ScheduledTask -TaskName 'edda-lane-%s' -Action \$a -RunLevel Limited | Out-Null\n" "$fl_lane"
       printf "Start-ScheduledTask -TaskName 'edda-lane-%s'\n" "$fl_lane"
-      printf 'Start-Sleep -Seconds 3\n'
+      printf "\$deadline = (Get-Date).AddSeconds(10)\n"
       printf "\$t = Get-ScheduledTask -TaskName 'edda-lane-%s'\n" "$fl_lane"
+      printf "while (\$t.State -ne 'Running' -and (Get-Date) -lt \$deadline) {\n"
+      printf "  Start-Sleep -Milliseconds 500\n"
+      printf "  \$t = Get-ScheduledTask -TaskName 'edda-lane-%s'\n" "$fl_lane"
+      printf "}\n"
       printf 'if ($t.State -ne "Running") { Write-Error "fake lane state=$($t.State), expected Running"; exit 1 }\n'
+      printf 'Start-Sleep -Seconds 2\n'
       printf '"fake lane is Running"\n'
     } >"$tmp/$fl_lane-setup.ps1"
     pwsh -NoProfile -NonInteractive -File "$tmp/$fl_lane-setup.ps1" >"$tmp/$fl_lane-setup.out" 2>&1 ||
@@ -422,7 +499,7 @@ if [ "${GIT_CONFIG_GUARD_E2E:-}" = 1 ]; then
     fail "a raised guard error cost the lane its done-file (GH-672): $(cat "$tmp/out15")"
   ok "a guard that raises is caught, reported, and never skips the end record"
 else
-  echo "-- cases 11-15 (lane-stop end-to-end) skipped; set GIT_CONFIG_GUARD_E2E=1 to run them"
+  echo "-- cases 16-20 (lane-stop end-to-end) skipped; set GIT_CONFIG_GUARD_E2E=1 to run them"
 fi
 
 echo "all $case_number case(s) passed"

--- a/scripts/test-git-config-guard.sh
+++ b/scripts/test-git-config-guard.sh
@@ -267,7 +267,7 @@ corrupt_ref_count=$(ls "$repo_ref1/.git/" | grep -c '^ref\.CORRUPT\.' || true)
   fail "corrupt ref file was not preserved outside .git/refs"
 ok "-Restore repairs a NUL branch ref from reflog and preserves forensic backup"
 
-# --- case 14: restore with no reflog fails loudly and preserves state --------
+# --- case 14: restore with no reflog fails loudly, and mixed repairability restores what it can
 repo_ref2=$(new_repo ref-noreflog)
 ref2=$(git -C "$repo_ref2" symbolic-ref HEAD)
 ref2_file="$repo_ref2/.git/$ref2"
@@ -277,9 +277,45 @@ rm -rf "$repo_ref2/.git/logs"
 if guard -RepoPath "$repo_ref2" -RestoreRefs >"$tmp/out14" 2>&1; then
   fail "-RestoreRefs exited 0 when no reflog was available"
 fi
-grep -q -E 'cannot repair refs automatically|RESTORE FAILED' "$tmp/out14" ||
+grep -q 'RESTORE FAILED' "$tmp/out14" ||
   fail "-RestoreRefs did not report failure when reflog was missing: $(cat "$tmp/out14")"
-ok "-RestoreRefs fails loudly when no reflog is available"
+
+# Mixed repairability: one repairable ref and one unrepairable ref (GH-797 / F-2).
+# The recoverable ref must be restored and archived; the unrepairable one must fail loudly.
+repo_mixed=$(new_repo ref-mixed)
+head_ref=$(git -C "$repo_mixed" symbolic-ref HEAD)
+head_file="$repo_mixed/.git/$head_ref"
+head_sha=$(git -C "$repo_mixed" rev-parse HEAD)
+git -C "$repo_mixed" branch dead -q
+dead_file="$repo_mixed/.git/refs/heads/dead"
+rm -f "$repo_mixed/.git/logs/refs/heads/dead"
+nul_ise "$head_file"
+nul_ise "$dead_file"
+
+# Verify that -Backup and -Verify report partial repair advisory, not "unavailable"
+guard -RepoPath "$repo_mixed" -Backup >"$tmp/out14_bk" 2>&1 || true
+grep -q 'partial repair available' "$tmp/out14_bk" ||
+  fail "-Backup did not report partial repair for mixed refs: $(cat "$tmp/out14_bk")"
+
+guard -RepoPath "$repo_mixed" -Verify >"$tmp/out14_vf" 2>&1 || true
+grep -q 'partial repair available' "$tmp/out14_vf" ||
+  fail "-Verify did not report partial repair for mixed refs: $(cat "$tmp/out14_vf")"
+
+if guard -RepoPath "$repo_mixed" -RestoreRefs >"$tmp/out14_rest" 2>&1; then
+  fail "-RestoreRefs exited 0 when unrepairable refs remained"
+fi
+grep -q "RESTORED ref=$head_ref" "$tmp/out14_rest" ||
+  fail "-RestoreRefs did not restore the repairable ref: $(cat "$tmp/out14_rest")"
+grep -q 'RESTORE FAILED: cannot repair refs: refs/heads/dead' "$tmp/out14_rest" ||
+  fail "-RestoreRefs did not report unrepairable ref: $(cat "$tmp/out14_rest")"
+git -C "$repo_mixed" cat-file -e "$head_sha" >/dev/null 2>&1 ||
+  fail "head ref was not restored on disk"
+head_sanitized=$(echo "$head_ref" | tr '/' '_')
+mixed_corrupt_count=$(ls "$repo_mixed/.git/" | grep -c "^ref\\.CORRUPT\\.$head_sanitized\\." || true)
+[ "$mixed_corrupt_count" -ge 1 ] ||
+  fail "corrupt ref for $head_ref was not preserved outside .git/refs"
+
+ok "-RestoreRefs fails loudly when no reflog is available, and restores recoverable refs in mixed sets"
 
 # --- case 15: linked worktree ref corruption is detected and repaired -------
 repo_main=$(new_repo wt-main)


### PR DESCRIPTION
## Summary

Issue: #797

Extends `git-config-guard.ps1` and the fleet lane lifecycle (`lane-launch.ps1`, `lane-stop.ps1`) to detect and recover from corrupted git branch refs caused by interrupted writes during lane hard-kills.

### Details
- **`scripts/fleet/git-config-guard.ps1`**:
  - Adds `-VerifyRefs` and `-RestoreRefs` switches.
  - Detects broken refs via `git fsck --connectivity-only` and direct inspection for NUL bytes in loose refs.
  - Automatically recovers broken refs from reflog sources (common dir reflog, worktree HEAD reflog, common HEAD reflog), validating commit objects with `git cat-file -e`.
  - Consumes `CanRepair` across `-Backup`, `-Verify`, `-VerifyRefs`, `-RestoreRefs`, and `-Restore` to distinguish repairable issues from unrepairable ones and provide accurate hints.
  - Preserves dead ref files outside `.git/refs/` (`.git/ref.CORRUPT.*.bak`) so `git fsck` is not tripped by the backup, and restores using `git update-ref`. Emits all partially restored refs even if subsequent operations fail.
  - In `-Backup`, rejects dispatch (exit 2) if branch refs are corrupt.
  - In `-VerifyOrRestore` and `-Restore`, recovers both `.git/config` and broken branch refs.
- **`scripts/fleet/lane-launch.ps1`**:
  - Verifies git metadata via `git-config-guard.ps1 -Backup` and blocks launch if metadata is corrupt.
- **`scripts/fleet/lane-stop.ps1`**:
  - Evaluates and restores both `.git/config` and refs in step 6 post-kill verification.
  - Reports ground truth for both `gitconfig=` and `gitrefs=` (preserving healthy verdict if only refs failed, and reporting UNVERIFIED if config check failed before refs could be checked).
  - Records both verdicts in the durable `=== EXIT ===` record and final report.
- **`scripts/test-git-config-guard.sh`**:
  - Adds offline test cases 11-15 exercising ref corruption verification, backup refusal, reflog restore, unrecoverable missing reflog error, and linked worktree ref repair.
  - Adds safe trap cleanup (GH-786) and robust scheduled task startup polling.
  - Adds explicit assertions for `gitrefs=` across E2E test cases 16, 17, 18, 19.

## Validation (doneWhen 4 Receipt)
- Measured on a 27-worktree workstation repository (`edda`):
  * `git fsck --connectivity-only`: 2016 ms (cold), 1482 ms / 1400 ms (warm, avg ~1.44 s)
  * `git fsck` (full): 2381 ms (~65% slower)
  * `git-config-guard.ps1 -Verify` (full invocation): 2323 ms / 2379 ms / 2349 ms (~2.35 s)
- Ran offline tests: all 15 cases passed.
- Ran end-to-end tests (`GIT_CONFIG_GUARD_E2E=1`): all 20 cases passed.
- `git diff --check` and `lint-markdown-content.sh` clean.
