### PR TITLE
chore(repo): halve the debug build footprint locally and cut Windows link time 12-21% — [profile.dev] line-tables-only plus rust-lld

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,9 +2,17 @@
 # and every CI runner, not just this workstation.
 
 [target.x86_64-pc-windows-msvc]
-# rust-lld ships inside the toolchain, so no external install is required.
-# Measured on this workstation at f0750ad (clean target, CARGO_INCREMENTAL=0,
-# debug = "line-tables-only"): a full `--workspace --all-targets` build takes
-# 149s with rust-lld against 193s with the default MSVC link.exe, for the same
-# 2.07 GB of output. See GH-810.
+# rust-lld ships inside the toolchain, so no external install is required, and
+# a bare name resolves because rustc adds the sysroot target `bin` directory.
+#
+# Measured on this workstation (clean target, CARGO_INCREMENTAL=0,
+# debug = "line-tables-only", `cargo build --workspace --all-targets`):
+# 153s with rust-lld, against an MSVC link.exe arm whose three runs spanned
+# 173-193s. So the honest range is -12% to -21%, not a single figure -- the
+# direction is solid because both rust-lld runs (149s via -Clinker, 153s via
+# this file) sit below that arm's floor, but the magnitude is a range.
+#
+# Consumers beyond `cargo build`: `cargo test`, and release.yml's tagged
+# Windows binary, which is built with --release and is first exercised at tag
+# time. See GH-810.
 linker = "rust-lld.exe"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,10 @@
+# Shared build configuration. Committed, so it must hold for every contributor
+# and every CI runner, not just this workstation.
+
+[target.x86_64-pc-windows-msvc]
+# rust-lld ships inside the toolchain, so no external install is required.
+# Measured on this workstation at f0750ad (clean target, CARGO_INCREMENTAL=0,
+# debug = "line-tables-only"): a full `--workspace --all-targets` build takes
+# 149s with rust-lld against 193s with the default MSVC link.exe, for the same
+# 2.07 GB of output. See GH-810.
+linker = "rust-lld.exe"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -226,7 +226,8 @@ across 88,789 files:
 Two thirds of that is avoidable rather than intrinsic. Every one of the 509
 incremental session directories was older than 24 hours — orphans left by
 interrupted or killed builds, which nothing in Cargo ever reclaims. The
-workspace tunes `[profile.release]` only, so debug builds carry full symbols
+workspace sets `debug = "line-tables-only"` for dev builds (GH-810); before
+that it tuned `[profile.release]` only and debug builds carried full symbols
 into every statically linked test binary.
 
 **Any lane pool ceiling stated before that footprint is fixed is provisional.**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,12 @@ too_many_lines = "warn"
 lto = true
 codegen-units = 1
 strip = true
+
+[profile.dev]
+# Debug info is 64% of a clean `--all-targets` build here (2.64 GB of 4.14 GB,
+# `edda.pdb` alone 312 MB against a 53 MB `edda.exe`), because every one of the
+# workspace's test and binary executables links statically and carries full
+# symbols. `line-tables-only` keeps file and line numbers in backtraces — what
+# a failing test actually needs — and drops the type and variable information
+# that a debugger would use. Measured before/after in GH-810.
+debug = "line-tables-only"


### PR DESCRIPTION
Issue: #810

Two build-configuration changes, both measured on this Windows workstation rather than adopted on reputation. One hypothesis in the issue held and one did not; both are reported.

## What changed

- Root `Cargo.toml` — a `[profile.dev]` section setting `debug = "line-tables-only"`. The workspace previously tuned `[profile.release]` only, so debug builds carried full symbols.
- New `.cargo/config.toml` — the workspace had none. It sets `rust-lld` as the linker for `x86_64-pc-windows-msvc` only; other targets are untouched.

## Measurements

All runs: clean `target/`, `CARGO_INCREMENTAL=0`, `cargo build --workspace --all-targets`, base `f0750ad`, rustc 1.93.1, this workstation.

| run | profile | linker | wall | target | `.pdb` | `edda.pdb` |
|---|---|---|---:|---:|---:|---:|
| baseline | `debug = 2` (default) | MSVC `link.exe` | 187s | 4.14 GB | 2.64 GB | 312 MB |
| A | `line-tables-only` | MSVC `link.exe` | 193s | **2.07 GB** | 1.04 GB | 141 MB |
| B | `line-tables-only` | `rust-lld` (RUSTFLAGS) | 149s | 2.08 GB | — | — |
| C | `line-tables-only` | `rust-lld` (committed config) | **153s** | 2.07 GB | — | — |

Baseline and A have identical artifact counts (3330 files, 143 `.pdb`, 120 `.exe`, 330 `.rlib`), so the two totals are directly comparable.

**Disk: −50% overall, −61% on debug symbols.** Debug info was 64% of a clean build, because all 120 executables link statically and each carried full symbols.

**Build time: the debug-info hypothesis failed, and CI never tested it anyway.** The issue predicted that cutting symbol volume would cut link time. It did not — 187s → 193s, inside the noise band.

Round 1 found the more important half, which this PR had wrong: **`ci.yml:16-17` has set `CARGO_PROFILE_DEV_DEBUG: line-tables-only` and `CARGO_PROFILE_TEST_DEBUG: line-tables-only` since #411 (`cd63a0c`)**, and environment settings beat the manifest. So on CI the new `[profile.dev]` key is inert, the green `Test (windows-latest)` validates only the linker half, and this body's original premise — "debug builds carried full symbols" — was false for CI. It was only ever true locally.

That also means the finding was not new. The comment above those two CI lines already says the quiet part: *"skips the heavy PDB generation and linking that dominate Windows build time"*. The conclusion this PR reports as a correction was recorded in `ci.yml` ten months ago.

What remains genuinely new is narrower, and is the part that matters for the problem #810 was opened about: **the manifest extends this to local and lane builds**, which the CI-only environment variables never touched, and that is exactly where the measured multi-gigabyte target directories live. The `[profile.dev]` change is worth making on that ground alone. A follow-up should decide whether the now-redundant CI environment variables should go.

One negative result worth recording so nobody repeats it: pointing `-Clinker` at `lib/rustlib/<target>/bin/gcc-ld/lld-link.exe` fails. That binary is the gcc-driver shim; it ignores the `-flavor link` rustc passes and then tries to open a file literally named `link`. The usable binary is `lib/rustlib/<target>/bin/rust-lld.exe`.

## Backtrace quality — verified, not assumed

`line-tables-only` drops the type and variable information a debugger uses, so the risk was losing usable test failures. A deliberately panicking test under `RUST_BACKTRACE=1` still reports its panic site and a fully symbolicated stack with `file:line` on every frame:

```
panicked at crates\edda-core\tests\tmp_backtrace_probe.rs:4:14
   5: tmp_backtrace_probe::probe_panics_to_show_backtrace_quality
             at .\tests\tmp_backtrace_probe.rs:4
```

The probe file was removed before committing.

## Gate receipt — not green, and the reason is not this change

Build-affecting change (`Cargo.toml`), so full L1. Clean tree, `CARGO_INCREMENTAL=0`, rustc 1.93.1, no build lane (solo work, worktree default `target/`).

| gate | result |
|---|---|
| `cargo fmt --all --check` | pass (4s) |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass (92s) |
| `cargo test --workspace` | **pass — 2680 passed, 0 failed, 56 suites** (304s) |

The first run of this gate reported `1261 passed, 1 failed` and was **incomplete**: `cargo test` fails fast, so it stopped after 15 of 56 suites. A complete re-run at `0d1da1c` is green (2680 passed, 0 failed, 56 suites, 304s). See the correction comment for the full account.

The one failure in that first run was `bg_scan::tests::draft_storage_roundtrip` — **#757**, an open P1 flake, unassigned, whose body already lists `bg_scan` among the affected modules. It is non-deterministic on the same binary at the same SHA (run 1 failed, run 2 `ok. 635 passed`), passes in isolation and with its whole module, and its mechanism is `store_root()` re-reading `EDDA_STORE_ROOT` while `digest/tests.rs` redirects it to a `TempDir` that is then dropped. A debug-info setting cannot affect that. A sharper reader-side diagnosis is posted on #757.

## Risk to check in CI

The linker line is verified locally on rustc 1.93.1. CI installs floating `stable` (currently 1.98.1 — see #809), so **CI is the check that a bare `rust-lld.exe` resolves there too**. If either Windows job fails to link, the fix is to drop the `linker` line and keep `.cargo/config.toml` with its comment; the profile change stands on its own and is where the disk win lives.

Not addressed here: the 21.6 GB of orphan `incremental` session directories in long-lived lane target dirs. That is reclamation, owned by the fleet-workstation lane tool, and needs no change in this repo.
