### PR TITLE
chore(repo): ban dirs::home_dir and resolve home through edda_core::paths — it ignores HOME on Windows while the lane wrapper sets it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,6 +818,7 @@ dependencies = [
  "anyhow",
  "dirs",
  "edda-bridge-claude",
+ "edda-core",
  "edda-pack",
  "edda-postmortem",
  "edda-store",
@@ -915,6 +916,7 @@ name = "edda-core"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "dirs",
  "globset",
  "hex",
  "regex",
@@ -1123,6 +1125,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "dirs",
+ "edda-core",
  "edda-store",
  "fs2",
  "serde",

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,13 @@
+# Clippy configuration for the workspace.
+#
+# Clippy reads the NEAREST clippy.toml and does not merge, so everything the
+# workspace needs has to live in this one file.
+
+# Function-length ratchet from GH-779 (#787). Do not remove.
 too-many-lines-threshold = 150
+
+# Methods banned workspace-wide, each with the failure it prevents.
+disallowed-methods = [
+    { path = "dirs::home_dir", reason = "on Windows this is SHGetKnownFolderPath(FOLDERID_Profile) (dirs 6.0.0 src/win.rs:5 -> dirs-sys 0.5.0 src/lib.rs:172) and reads neither HOME nor USERPROFILE, so it disagrees with the lane wrapper that fleet.lane-launcher requires to set HOME, and with any Node tool's os.homedir(); resolve through edda_core::paths::home_dir" },
+    { path = "std::env::home_dir", reason = "resolve through edda_core::paths::home_dir so every home-anchored path in the workspace agrees" },
+]

--- a/crates/edda-bridge-claude/src/dispatch/helpers.rs
+++ b/crates/edda-bridge-claude/src/dispatch/helpers.rs
@@ -20,7 +20,7 @@ const PLAN_EXCERPT_MAX_LINES: usize = 30;
 pub(crate) fn render_active_plan(project_id: Option<&str>) -> Option<String> {
     let plans_dir = match std::env::var("EDDA_PLANS_DIR") {
         Ok(dir) => PathBuf::from(dir),
-        Err(_) => dirs::home_dir()?.join(".claude").join("plans"),
+        Err(_) => edda_core::paths::home_dir()?.join(".claude").join("plans"),
     };
     render_active_plan_from_dir(&plans_dir, project_id)
 }

--- a/crates/edda-bridge-codex/src/admin.rs
+++ b/crates/edda-bridge-codex/src/admin.rs
@@ -35,7 +35,7 @@ const HOOK_EVENTS: &[&str] = &[
 ];
 
 fn default_hooks_path() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".codex").join("hooks.json"))
+    edda_core::paths::home_dir().map(|h| h.join(".codex").join("hooks.json"))
 }
 
 /// Write (or merge) edda hooks into the Codex hooks config.

--- a/crates/edda-bridge-cursor/Cargo.toml
+++ b/crates/edda-bridge-cursor/Cargo.toml
@@ -11,6 +11,7 @@ keywords.workspace = true
 
 [dependencies]
 edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.4.0" }
+edda-core = { path = "../edda-core", version = "0.4.0" }
 edda-pack = { path = "../edda-pack", version = "0.4.0" }
 edda-postmortem = { path = "../edda-postmortem", version = "0.4.0" }
 edda-store = { path = "../edda-store", version = "0.4.0" }

--- a/crates/edda-bridge-cursor/src/admin.rs
+++ b/crates/edda-bridge-cursor/src/admin.rs
@@ -15,7 +15,7 @@ const HOOK_EVENTS: &[&str] = &[
 ];
 
 fn default_hooks_path() -> anyhow::Result<PathBuf> {
-    dirs::home_dir()
+    edda_core::paths::home_dir()
         .map(|home| home.join(".cursor").join("hooks.json"))
         .ok_or_else(|| anyhow::anyhow!("cannot determine home directory"))
 }
@@ -185,7 +185,7 @@ fn store_is_writable(store_root: &Path) -> bool {
 }
 
 fn claude_hook_detected() -> bool {
-    let Some(home) = dirs::home_dir() else {
+    let Some(home) = edda_core::paths::home_dir() else {
         return false;
     };
     [

--- a/crates/edda-bridge-hermes/src/admin.rs
+++ b/crates/edda-bridge-hermes/src/admin.rs
@@ -35,7 +35,7 @@ fn default_config_path() -> Option<PathBuf> {
     // equivalent on Windows. The primary config filename is `cli-config.yaml`
     // (the codebase writes both cli-config.yaml and config.yaml in different
     // eras; cli-config.yaml is the current name).
-    dirs::home_dir().map(|h| h.join(".hermes").join("cli-config.yaml"))
+    edda_core::paths::home_dir().map(|h| h.join(".hermes").join("cli-config.yaml"))
 }
 
 /// Write (or merge) the edda hook into Hermes' cli-config.yaml.
@@ -231,7 +231,7 @@ pub fn doctor() -> anyhow::Result<()> {
     // Check consent status. Even if hooks are installed, they don't fire
     // until approved once via TTY/env/config.
     let allowlist_path =
-        dirs::home_dir().map(|h| h.join(".hermes").join("shell-hooks-allowlist.json"));
+        edda_core::paths::home_dir().map(|h| h.join(".hermes").join("shell-hooks-allowlist.json"));
     let approved_here = allowlist_path
         .as_ref()
         .and_then(|p| fs::read_to_string(p).ok())

--- a/crates/edda-bridge-openclaw/src/admin.rs
+++ b/crates/edda-bridge-openclaw/src/admin.rs
@@ -147,7 +147,7 @@ module.exports = plugin;
 
 /// Default plugin directory.
 fn default_plugin_dir() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".openclaw").join("extensions").join("edda-bridge"))
+    edda_core::paths::home_dir().map(|h| h.join(".openclaw").join("extensions").join("edda-bridge"))
 }
 
 /// Install the OpenClaw plugin files.

--- a/crates/edda-core/Cargo.toml
+++ b/crates/edda-core/Cargo.toml
@@ -19,6 +19,7 @@ hex.workspace = true
 ulid.workspace = true
 time.workspace = true
 serde_yaml.workspace = true
+dirs.workspace = true
 globset.workspace = true
 regex.workspace = true
 

--- a/crates/edda-core/src/lib.rs
+++ b/crates/edda-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod decision;
 pub mod event;
 pub mod git;
 pub mod hash;
+pub mod paths;
 pub mod policy;
 pub mod secret_guard;
 pub mod tool_tier;

--- a/crates/edda-core/src/paths.rs
+++ b/crates/edda-core/src/paths.rs
@@ -1,0 +1,37 @@
+//! Home-anchored path resolution.
+//!
+//! Every home-anchored path in the workspace resolves here, so all of them
+//! agree. `dirs::home_dir` is banned in `clippy.toml`; this module holds the
+//! one sanctioned call.
+
+use std::path::PathBuf;
+
+/// The current user's home directory.
+///
+/// # Platform behaviour, and why this wrapper exists
+///
+/// On Windows this is **not** `%HOME%` and **not** `%USERPROFILE%`. It is a
+/// shell known-folder lookup — `dirs` 6.0.0 `src/win.rs:5` calls
+/// `dirs_sys::known_folder_profile()`, which is `dirs-sys` 0.5.0
+/// `src/lib.rs:172` calling `known_folder(FOLDERID_Profile)`. Neither
+/// environment variable is read.
+///
+/// That matters here for two reasons:
+///
+/// 1. `fleet.lane-launcher` requires the generated lane wrapper to set `HOME`
+///    explicitly, because the Task Scheduler environment has none. Nothing
+///    reached through this function will observe that `HOME`.
+/// 2. Several callers locate *another tool's* configuration — `~/.codex`,
+///    `~/.hermes`, `~/.claude`. A Node-based tool's `os.homedir()` reads
+///    `USERPROFILE`, so if a profile is redirected the two disagree and edda
+///    writes its hook config where that tool will not look for it.
+///
+/// This function deliberately preserves the existing behaviour rather than
+/// switching to an environment-first lookup: changing it would move paths for
+/// users who already have state on disk. It exists so that the behaviour is
+/// stated once, in one place, instead of being rediscovered at ten call sites.
+pub fn home_dir() -> Option<PathBuf> {
+    // The one sanctioned call. See the module docs and clippy.toml.
+    #[allow(clippy::disallowed_methods)]
+    dirs::home_dir()
+}

--- a/crates/edda-ledger/src/paths.rs
+++ b/crates/edda-ledger/src/paths.rs
@@ -189,7 +189,7 @@ impl EddaPaths {
     }
 
     fn find_root_walk(start: &Path, ceiling: Option<&Path>) -> Option<PathBuf> {
-        let home = dirs::home_dir();
+        let home = edda_core::paths::home_dir();
 
         // Normalisation belongs to `find_root_bounded`, not here: the
         // unbounded `find_root` is production API and this PR does not

--- a/crates/edda-store/src/lib.rs
+++ b/crates/edda-store/src/lib.rs
@@ -56,7 +56,7 @@ pub fn store_root() -> PathBuf {
     }
     if let Some(data_dir) = dirs::data_dir() {
         data_dir.join("edda")
-    } else if let Some(home) = dirs::home_dir() {
+    } else if let Some(home) = edda_core::paths::home_dir() {
         home.join(".edda")
     } else {
         PathBuf::from(".edda-store")

--- a/crates/edda-transcript/Cargo.toml
+++ b/crates/edda-transcript/Cargo.toml
@@ -10,6 +10,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
+edda-core = { path = "../edda-core", version = "0.4.0" }
 edda-store = { path = "../edda-store", version = "0.4.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/edda-transcript/src/pi.rs
+++ b/crates/edda-transcript/src/pi.rs
@@ -53,7 +53,7 @@ pub fn pi_session_dir_for_cwd(cwd: &Path) -> Option<PathBuf> {
         }
     }
     safe.push_str("--");
-    let home = dirs::home_dir()?;
+    let home = edda_core::paths::home_dir()?;
     Some(home.join(".pi").join("agent").join("sessions").join(safe))
 }
 


### PR DESCRIPTION
Issue: #808

Ten call sites across eight crates each resolved the user's home directory by calling `dirs::home_dir()` directly, with no shared resolver. This routes them through one function and makes `clippy.toml` fail the build if a new call site bypasses it.

## The platform fact, read from the vendored source

Not repeated from another project — read out of the crate this workspace compiles:

```rust
// dirs 6.0.0, src/win.rs:5
pub fn home_dir() -> Option<PathBuf> { dirs_sys::known_folder_profile() }
// dirs-sys 0.5.0, src/lib.rs:172
pub fn known_folder_profile() -> Option<PathBuf> { known_folder(Shell::FOLDERID_Profile) }
```

On Windows it is `SHGetKnownFolderPath(FOLDERID_Profile)`. **It reads neither `HOME` nor `USERPROFILE`.**

Two consequences in this repo:

1. `fleet.lane-launcher` requires the generated lane wrapper to set `HOME` explicitly, because the Task Scheduler environment has none. Nothing reached through these calls observes that `HOME`.
2. The bridge-admin sites locate *another tool's* configuration — `~/.codex/hooks.json`, `~/.hermes/cli-config.yaml`, `~/.claude/plans`. A Node-based tool's `os.homedir()` reads `USERPROFILE`, so on a redirected profile edda writes hook config where that tool will not look for it.

## What changed

- New `crates/edda-core/src/paths.rs` — `home_dir()`, carrying the mechanism above in its doc comment with `file:line` citations, and the single `#[allow(clippy::disallowed_methods)]`. `edda-core` has no in-workspace dependencies, so it is a safe base with no cycle risk.
- `clippy.toml` — `disallowed-methods` for `dirs::home_dir` and `std::env::home_dir`, each `reason` naming the edda failure rather than a generic one.
- Ten call sites routed. `edda-bridge-cursor` and `edda-transcript` gain an `edda-core` dependency (one line each); the other six crates already had it.

**Behaviour is deliberately unchanged.** The resolver wraps the same call. Switching to an environment-first lookup would move paths for users who already have state on disk — that is a separate decision with a migration question attached, and it is not made here. What changes is that the fact is stated once instead of being rediscovered at ten sites.

## Fail-first evidence

With the ban in place and before routing, `cargo clippy --workspace --all-targets` reported exactly ten sites:

```
crates\edda-bridge-claude\src\dispatch\helpers.rs:23:19
crates\edda-bridge-codex\src\admin.rs:38:5
crates\edda-bridge-cursor\src\admin.rs:18:5      crates\edda-bridge-cursor\src\admin.rs:188:22
crates\edda-bridge-hermes\src\admin.rs:38:5      crates\edda-bridge-hermes\src\admin.rs:234:9
crates\edda-bridge-openclaw\src\admin.rs:150:5
crates\edda-ledger\src\paths.rs:192:20
crates\edda-store\src\lib.rs:59:32
crates\edda-transcript\src\pi.rs:56:16
```

After routing: zero.

## `clippy.toml` is edited additively — and nearly was not

`clippy.toml` already existed, added by #787 (the GH-779 function-length ratchet), containing `too-many-lines-threshold = 150`. I first wrote the new file with `cat >` and destroyed it, on a wrong premise from checking a worktree one day stale. The threshold fell back to clippy's built-in 100 and six functions in `edda-search-fts` and `edda-ledger` — crates this PR does not touch — began failing `-D warnings`. That is how the mistake surfaced.

It surfaced only because the deleted setting had a visible effect. A key whose loss did not immediately fail a gate would have vanished silently. The restored file now leads with the reason that is easy to get wrong: **clippy reads the nearest `clippy.toml` and does not merge**, so that one file is the only place any of this can live. The threshold is preserved with a `Do not remove` comment naming GH-779, and the diff is `+12` lines with no deletions.

## What was dropped from the issue

The issue also proposed banning `Command::spawn`. Reading the call sites killed it, and the review corrected my census — recorded here because the numbers in the original body were wrong.

Real inventory, 9 sites: **5 production** — `cmd_reconcile.rs:2314` and `:2549` (deliberately detached, `CREATE_NO_WINDOW`), `codex_app_server.rs:36` and `pi_rpc.rs:327` (`kill_on_drop(true)`), `launcher.rs:293` (managed and awaited) — and **4 test** — `codex_app_server.rs:998` and `:1023` (both inside the `#[cfg(test)]` module that opens at line 649; the original body counted `:998` as production) and `stream.rs:690` **and `:697`** (the second was enumerated nowhere).

The conclusion is unchanged: all 5 production sites are already correct, so a ban would need `#[allow]`s to preserve a correct status quo. The incident I originally cited, `fleet.lane-launch`, is the *opposite* failure — children dying too early through Windows Job Object inheritance — and was fixed in PowerShell with no Rust `spawn` implicated. Full reasoning is on the issue, which carries the same correction.

## Gate receipt

Clean tree, `CARGO_INCREMENTAL=0`, rustc 1.93.1, worktree default `target/`, no build lane.

| gate | result |
|---|---|
| `cargo fmt --all --check` | pass (4s) |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass (48s) |
| `cargo test --workspace` | **pass — 2680 passed, 0 failed, 56 suites** (441s) |

`#757` did not fire on this run; it is probabilistic, so a green run is not evidence it is fixed.
