### PR TITLE
fix(bridge): surface swallowed hook-path write errors in agent_phase (GH-745)

### DIFF
--- a/crates/edda-bridge-claude/src/dispatch/tests.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tests.rs
@@ -26,6 +26,7 @@ use super::session::{
 };
 use super::tools::{
     check_offlimits, check_pending_requests, dispatch_post_tool_use, dispatch_pre_tool_use,
+    try_update_agent_phase, try_write_phase_change_event,
 };
 // Imports from crate
 use crate::parse::resolve_project_id;
@@ -1901,6 +1902,145 @@ fn try_write_task_completed_note_event_reports_readonly_ledger() {
     );
 
     set_ledger_readonly(&paths, false);
+}
+
+#[test]
+fn try_write_phase_change_event_reports_readonly_ledger() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace = tmp.path().to_path_buf();
+    let paths = edda_ledger::EddaPaths::discover(&workspace);
+    edda_ledger::ledger::init_workspace(&paths).unwrap();
+    edda_ledger::ledger::init_head(&paths, "main").unwrap();
+    edda_ledger::ledger::init_branches_json(&paths, "main").unwrap();
+
+    set_ledger_readonly(&paths, true);
+
+    let raw = serde_json::json!({
+        "tool_name": "Bash",
+        "tool_input": { "command": "cargo test" },
+        "cwd": workspace.to_str().unwrap()
+    });
+
+    let transition = edda_core::agent_phase::AgentPhaseTransition {
+        from: edda_core::agent_phase::AgentPhase::Implement,
+        to: edda_core::agent_phase::AgentPhase::Review,
+        state: edda_core::agent_phase::AgentPhaseState {
+            phase: edda_core::agent_phase::AgentPhase::Review,
+            session_id: "test-sess-ro".to_string(),
+            label: Some("test-label".to_string()),
+            issue: Some(745),
+            pr: None,
+            branch: Some("main".to_string()),
+            confidence: 0.9,
+            detected_at: "2026-09-04T00:00:00Z".to_string(),
+            signals: vec!["cargo test".to_string()],
+        },
+    };
+
+    // GH-745: a failed ledger append/open must NOT look like success.
+    let result = try_write_phase_change_event(&raw, &transition);
+    assert!(
+        result.is_err(),
+        "read-only ledger must surface the failed phase change event write"
+    );
+
+    set_ledger_readonly(&paths, false);
+}
+
+#[test]
+fn try_update_agent_phase_records_dropped_write_on_state_failure() {
+    let _env = env_guard();
+    let pid = "test_phase_dropped_state";
+    let sid = "sess-phase-dropped-state";
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    let _ = edda_store::ensure_dirs(pid);
+
+    // Make the phase file path a directory so write_phase_state fails
+    let phase_path = edda_store::project_dir(pid)
+        .join("state")
+        .join(format!("phase.{sid}.json"));
+    fs::create_dir_all(&phase_path).unwrap();
+
+    let raw = serde_json::json!({
+        "session_id": sid,
+        "cwd": "."
+    });
+
+    assert_eq!(crate::state::read_dropped_writes(pid, sid), 0);
+
+    // GH-745: Calling try_update_agent_phase when write_phase_state fails must record a dropped write
+    try_update_agent_phase(&raw, pid, sid, ".");
+
+    assert!(
+        crate::state::read_dropped_writes(pid, sid) >= 1,
+        "failed write_phase_state must record a dropped write"
+    );
+
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+#[test]
+fn try_update_agent_phase_records_dropped_write_on_ledger_failure() {
+    let _env = env_guard();
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace = tmp.path().to_path_buf();
+    let paths = edda_ledger::EddaPaths::discover(&workspace);
+    edda_ledger::ledger::init_workspace(&paths).unwrap();
+    edda_ledger::ledger::init_head(&paths, "main").unwrap();
+    edda_ledger::ledger::init_branches_json(&paths, "main").unwrap();
+
+    let pid = "test_phase_dropped_ledger";
+    let sid = "sess-phase-dropped-ledger";
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    let _ = edda_store::ensure_dirs(pid);
+
+    // Set initial phase as Triage
+    let initial_state = edda_core::agent_phase::AgentPhaseState {
+        phase: edda_core::agent_phase::AgentPhase::Triage,
+        session_id: sid.to_string(),
+        label: None,
+        issue: None,
+        pr: None,
+        branch: None,
+        confidence: 0.8,
+        detected_at: "2020-01-01T00:00:00Z".to_string(),
+        signals: vec![],
+    };
+    crate::agent_phase::write_phase_state(pid, &initial_state).unwrap();
+
+    // Create an active task that indicates Review phase with confidence >= 0.8
+    let tasks_json = serde_json::json!({
+        "tasks": [
+            { "status": "in_progress", "subject": "review PR #745" }
+        ]
+    });
+    let tasks_path = edda_store::project_dir(pid)
+        .join("state")
+        .join("active_tasks.json");
+    fs::write(&tasks_path, serde_json::to_string(&tasks_json).unwrap()).unwrap();
+
+    // Make ledger readonly so appending the phase change event fails
+    set_ledger_readonly(&paths, true);
+
+    let raw = serde_json::json!({
+        "session_id": sid,
+        "cwd": workspace.to_str().unwrap(),
+        "tool_name": "Bash",
+        "tool_input": { "command": "git commit -m \"feat: implement stuff\"" }
+    });
+
+    assert_eq!(crate::state::read_dropped_writes(pid, sid), 0);
+
+    // GH-745: Calling try_update_agent_phase when ledger append fails must record a dropped write
+    try_update_agent_phase(&raw, pid, sid, workspace.to_str().unwrap());
+
+    assert!(
+        crate::state::read_dropped_writes(pid, sid) >= 1,
+        "failed phase change ledger write must record a dropped write"
+    );
+
+    set_ledger_readonly(&paths, false);
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
 }
 
 // ── Auto-claim in PostToolUse (#56) ──

--- a/crates/edda-bridge-claude/src/dispatch/tools.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tools.rs
@@ -445,39 +445,62 @@ pub(super) fn try_update_agent_phase(
         crate::agent_phase::detect_transition(&current, previous.as_ref(), &config)
     {
         // Write updated phase state
-        let _ = crate::agent_phase::write_phase_state(project_id, &transition.state);
+        if let Err(e) = crate::agent_phase::write_phase_state(project_id, &transition.state) {
+            crate::state::record_dropped_write(
+                project_id,
+                session_id,
+                "agent phase state",
+                &format!("{e:#}"),
+            );
+        }
 
         // Emit ledger event (best-effort, try-lock)
-        try_write_phase_change_event(raw, &transition);
+        if let Err(e) = try_write_phase_change_event(raw, &transition) {
+            crate::state::record_dropped_write(
+                project_id,
+                session_id,
+                "ledger event (agent-phase-change)",
+                &format!("{e:#}"),
+            );
+        }
     } else {
         // Always persist latest state (updates detected_at for staleness tracking)
-        let _ = crate::agent_phase::write_phase_state(project_id, &current);
+        if let Err(e) = crate::agent_phase::write_phase_state(project_id, &current) {
+            crate::state::record_dropped_write(
+                project_id,
+                session_id,
+                "agent phase state",
+                &format!("{e:#}"),
+            );
+        }
     }
 }
 
-/// Write an agent_phase_change event to the workspace ledger (best-effort).
-fn try_write_phase_change_event(
+/// Write an agent_phase_change event to the workspace ledger (best-effort, try-lock).
+///
+/// GH-745: failed ledger open or append propagates as an error instead of being
+/// silently swallowed — only a missing workspace and a contended lock are
+/// legitimate silent skips.
+pub(super) fn try_write_phase_change_event(
     raw: &serde_json::Value,
     transition: &edda_core::agent_phase::AgentPhaseTransition,
-) {
+) -> anyhow::Result<()> {
     let cwd = get_str(raw, "cwd");
     if cwd.is_empty() {
-        return;
+        return Ok(());
     }
     let Some(root) = edda_ledger::EddaPaths::find_root(Path::new(&cwd)) else {
-        return;
+        return Ok(());
     };
-    let Ok(ledger) = edda_ledger::Ledger::open(&root) else {
-        return;
-    };
+    let ledger = edda_ledger::Ledger::open(&root)?;
     let Ok(_lock) = edda_ledger::WorkspaceLock::acquire(&ledger.paths) else {
-        return; // locked by another process — skip
+        return Ok(()); // locked by another process — skip
     };
     let Ok(branch) = ledger.head_branch() else {
-        return;
+        return Ok(());
     };
     let Ok(parent_hash) = ledger.last_event_hash() else {
-        return;
+        return Ok(());
     };
     let params = edda_core::event::AgentPhaseChangeParams {
         branch: &branch,
@@ -491,7 +514,7 @@ fn try_write_phase_change_event(
         signals: &transition.state.signals,
     };
     if let Ok(event) = edda_core::event::new_agent_phase_change_event(&params) {
-        let _ = ledger.append_event(&event);
+        ledger.append_event(&event)?;
     }
 
     // Push notification (best-effort)
@@ -507,6 +530,7 @@ fn try_write_phase_change_event(
             },
         );
     }
+    Ok(())
 }
 
 /// Read active task names from state file for phase detection heuristics.

--- a/scripts/file-length-ceilings.txt
+++ b/scripts/file-length-ceilings.txt
@@ -9,7 +9,7 @@ crates/edda-bridge-claude/src/bg_extract.rs 1406
 crates/edda-bridge-claude/src/bg_scan.rs 1266
 crates/edda-bridge-claude/src/digest/orchestrate.rs 1138
 crates/edda-bridge-claude/src/digest/tests.rs 3260
-crates/edda-bridge-claude/src/dispatch/tests.rs 3098
+crates/edda-bridge-claude/src/dispatch/tests.rs 3238
 crates/edda-bridge-claude/src/peers/tests.rs 3588
 crates/edda-bridge-claude/src/signals.rs 2252
 crates/edda-cli/src/cmd_bridge/tests.rs 1208

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -121,7 +121,7 @@ done <"$staged_z"
 # narrowed to hook-path write calls):
 #   1. let _ = .*(append_event|append_to_session_ledger|save_project|
 #                  save_digest_state|save_detect_state|update_heartbeat|
-#                  write_heartbeat|fs::write|writeln!)
+#                  write_heartbeat|write_phase_state|fs::write|writeln!)
 #   2. the same write calls ending in .ok();
 # An added line matching either is rejected unless that line — or the line
 # directly above it — carries '// swallow-ok: <reason>'.
@@ -161,8 +161,8 @@ while IFS= read -r -d '' meta; do
         /^\+/ {
             line++
             text = substr($0, 2)
-            if (text ~ /let _ = .*(append_event|append_to_session_ledger|save_project|save_digest_state|save_detect_state|update_heartbeat|write_heartbeat|fs::write|writeln!)/ ||
-                text ~ /(append_event|append_to_session_ledger|save_project|save_digest_state|save_detect_state|update_heartbeat|write_heartbeat|fs::write|writeln!).*\.ok\(\);/) {
+            if (text ~ /let _ = .*(append_event|append_to_session_ledger|save_project|save_digest_state|save_detect_state|update_heartbeat|write_heartbeat|write_phase_state|fs::write|writeln!)/ ||
+                text ~ /(append_event|append_to_session_ledger|save_project|save_digest_state|save_detect_state|update_heartbeat|write_heartbeat|write_phase_state|fs::write|writeln!).*\.ok\(\);/) {
                 if (text !~ /swallow-ok/ && prev !~ /swallow-ok/) {
                     print file ":" line ": " text
                 }
@@ -175,7 +175,7 @@ done <"$staged_z"
 if [ -s "$ratchet_violations" ]; then
     echo "pre-commit: GH-692 ratchet — swallowed hook-path write on ADDED line(s):" >&2
     cat "$ratchet_violations" >&2
-    fail "style: 'let _ = <write-call>(...)' or '<write-call>(...).ok();' on added lines under crates/*/src (tests.rs / tests/ excluded), where <write-call> is one of append_event, append_to_session_ledger, save_project, save_digest_state, save_detect_state, update_heartbeat, write_heartbeat, fs::write, writeln! — propagate the error, or justify with '// swallow-ok: <reason>' on the same or previous line"
+    fail "style: 'let _ = <write-call>(...)' or '<write-call>(...).ok();' on added lines under crates/*/src (tests.rs / tests/ excluded), where <write-call> is one of append_event, append_to_session_ledger, save_project, save_digest_state, save_detect_state, update_heartbeat, write_heartbeat, write_phase_state, fs::write, writeln! — propagate the error, or justify with '// swallow-ok: <reason>' on the same or previous line"
 fi
 
 if [ "$fmt_needed" -eq 1 ]; then

--- a/scripts/githooks/test.sh
+++ b/scripts/githooks/test.sh
@@ -326,6 +326,27 @@ expect_accept "accept: same write line with '// swallow-ok: cleanup only' passes
     git commit -m "feat(test): swallowed hook write justified"
 git reset -q --hard "$prev"
 
+# --- GH-745: swallowed write_phase_state on an added line is rejected --------
+# Adding 'let _ = write_phase_state(pid, &state);' without swallow-ok must be
+# rejected by the ratchet, and accepted with '// swallow-ok: ...'.
+prev=$(git rev-parse HEAD)
+: > "$stub_log"
+printf '\nfn gh745_swallow() {
+    let _ = write_phase_state(pid, &state);
+}
+' >> crates/hooktest/src/main.rs
+git add crates/hooktest/src/main.rs
+expect_reject "reject: added 'let _ = write_phase_state(...);' without swallow-ok (GH-745)" \
+    "let _ = write_phase_state" \
+    env PATH="$stub_dir:$PATH" CARGO_STUB_LOG="$stub_log" \
+    git commit -m "feat(test): swallowed write_phase_state"
+sed -i 's|let _ = write_phase_state(pid, &state);|let _ = write_phase_state(pid, &state); // swallow-ok: test justification|' crates/hooktest/src/main.rs
+git add crates/hooktest/src/main.rs
+expect_accept "accept: same write line with '// swallow-ok: ...' passes (GH-745)" \
+    env PATH="$stub_dir:$PATH" CARGO_STUB_LOG="$stub_log" \
+    git commit -m "feat(test): swallowed write_phase_state justified"
+git reset -q --hard "$prev"
+
 # --- GH-692 round 1: a hunk with deletions must report the true new-file line
 # Deletion ('-') lines do not exist in the new file: they must not advance the
 # line counter (previously each deletion inflated the reported line number).


### PR DESCRIPTION
## Summary

Addresses Issue #745: surfaces swallowed hook-path write errors in `agent_phase` and extends the pre-commit ratchet.

### 1. Defect & Motivation
On the `PostToolUse` path in `edda-bridge-claude`:
- `write_phase_state` swallowed disk write failures with `let _ =` on both the transition and always-persist arms.
- `try_write_phase_change_event` swallowed errors on `Ledger::open` and `ledger.append_event`.
- The GH-692 pre-commit ratchet (`scripts/githooks/pre-commit`) checked various write functions on added lines, but omitted `write_phase_state`.

### 2. Changes
- **`crates/edda-bridge-claude/src/dispatch/tools.rs`**:
  - `try_write_phase_change_event`: returns `anyhow::Result<()>` and propagates `Ledger::open` and `ledger.append_event` errors.
  - `try_update_agent_phase`: catches write errors from `write_phase_state` and `try_write_phase_change_event`, recording them via `crate::state::record_dropped_write(...)`.
- **`crates/edda-bridge-claude/src/dispatch/tests.rs`**:
  - `try_write_phase_change_event_reports_readonly_ledger`: asserts that read-only ledger returns `Err(_)`.
  - `try_update_agent_phase_records_dropped_write_on_state_failure`: asserts that phase state write failure increments dropped-write counter.
  - `try_update_agent_phase_records_dropped_write_on_ledger_failure`: asserts that ledger failure on phase transition increments dropped-write counter.
- **`scripts/githooks/pre-commit`**:
  - Added `write_phase_state` to the `<write-call>` regex on added lines and the failure diagnostic message.
- **`scripts/githooks/test.sh`**:
  - Added test scenario verifying `let _ = write_phase_state(...);` without `swallow-ok` is rejected by the ratchet, and accepted with `// swallow-ok: ...`.
- **`scripts/file-length-ceilings.txt`**:
  - Adjusted `crates/edda-bridge-claude/src/dispatch/tests.rs` ceiling to 3238.

### 3. Wiring Audit

| Component | 1. Writer & shape | 2. Reader | 3. Failure signal | 4. Layer reach |
|---|---|---|---|---|
| `write_phase_state` at `PostToolUse` | `tools.rs:448,469` | `read_phase_state`, `edda peers` | `record_dropped_write("agent phase state", ...)` | State file -> SessionEnd warning -> Session Digest |
| `try_write_phase_change_event` | `tools.rs:482` | `edda log`, digest | `record_dropped_write("ledger event (agent-phase-change)", ...)` | Workspace ledger -> SQLite DB -> SessionEnd warning -> Session Digest |
| Pre-commit ratchet | `scripts/githooks/pre-commit` | Committer / lane | Rejects commit on added lines without `// swallow-ok` | Local commit hook -> Developer feedback |

Issue: #745
