### PR TITLE
feat(fleet): post the Independent Review commit status from the PR review watcher (GH-742)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -662,6 +662,14 @@ Internal verifier reports, task receipts and CI do not replace this comment
 (`loop`). For a local-only delivery with no PR, record the same fields in the
 strongest durable local carrier; do not invent a PR.
 
+The watcher also posts the merge gate's commit status: context
+`Independent Review`, pinned to the reviewed SHA in §7's heading. Its state
+is the union of every §7 verdict comment on that SHA plus the round just
+posted: `success` only when at least one verdict is `LGTM (P0=0, P1=0)` and
+no verdict on that SHA is anything else; any standing non-qualifying verdict
+is `failure`; no verdict at all is `error`. A later LGTM therefore does not
+override an earlier Changes Requested on the same SHA (GH-742).
+
 ## 9. Provenance of the check commands
 
 `RAN` means the command was executed on the authoring workstation

--- a/docs/guides/pr-review-watcher.md
+++ b/docs/guides/pr-review-watcher.md
@@ -38,6 +38,17 @@
    label `review:post-failed`）。
 4. head 被 push 之後（SHA 變了）自動再審一輪（round+1，delta brief，`prev-sha` 帶入）。
 
+## Independent Review commit status（GH-742）
+
+判決留言貼出後，watcher 會對**被審的那個 SHA**（不是目前 head）發 commit status：
+context `Independent Review`，state 是該 SHA 上所有 §7 判決留言（加上這一輪）的聯集
+（union rule）——至少一筆 `LGTM (P0=0, P1=0)` 且沒有任何其他判決在場才是 `success`；
+有任一筆不合格判決就是 `failure`；一筆都沒有是 `error`。後到的 LGTM 不會蓋過先前的
+Changes Requested。貼 status 不用 best-effort：照判決留言同一條 bounded retry 路徑
+（`postfails`、`review:post-failed`）。這段聯集邏輯是暫時的 `#769` 區塊，退役方式是
+整塊換成 `edda review gate <sha>`，把 exit 0/1/2 對應到 success/failure/error；
+從 PR 留言讀判決的 `#671` 區塊同理，等帳本（ledger）能跨機器攜帶判決後退役。
+
 ## 一張 PR 一個審查者對話（GH-708）
 
 `fleet.reviewer-agent=pi-with-per-pr-resumable-session` 當初選 pi 只為一個量到的性質：

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -85,6 +85,8 @@ LABEL_PR="$SCRIPT_DIR/review-pr.sh"   # always the real script (verdict-label is
 ONCE=0
 DRY=0
 TAB=$(printf '\t')   # literal tab; "\t" inside quotes is backslash-t in POSIX sh
+WATCHLOG=${PR_REVIEW_WATCH_LOG:-$SCRATCH/watch.log}   # set early: offline
+                     # subcommands log gh failures too, not just the main loop
 log() { echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') $*" >> "$WATCHLOG"; }
 
 # ---- offline helpers (unit-tested by scripts/test-pr-review-watch.sh) --------
@@ -131,6 +133,14 @@ decide() {
 # current head still equals the reviewed SHA (and is known).
 label_verdict() { # $1=reviewed sha  $2=current head
   if [ -n "${2:-}" ] && [ "$2" = "$1" ]; then echo apply; else echo skip; fi
+}
+
+# is_full_sha: true only for exactly 40 lowercase hex characters. Every SHA
+# that reaches a pin regex or a status URL is validated with this first
+# (REVIEW.md R5): a validated sha contains no regex metacharacters, so
+# concatenating it into an ERE matches it literally.
+is_full_sha() {
+  printf '%s\n' "${1:-}" | grep -Eq '^[0-9a-f]{40}$'
 }
 
 # gate-state: the union rule for the "Independent Review" commit status.
@@ -183,6 +193,9 @@ verdict_body_lines() { # $1=reviewed sha; stdin: one body per <<<COMMENT>>>
       n = split(buf, L, "\n")
       pinned = 0; inh = 0; vline = ""
       for (i = 1; i <= n; i++) {
+        # $2 is validated with is_full_sha by every caller before it gets
+        # here, so it is exactly 40 lowercase hex characters — no regex
+        # metacharacters — and this pin match is literal.
         if (L[i] ~ ("^## Code Review: Round [0-9]+ — PR #[0-9]+ @ " sha "$")) {
           pinned = 1; continue
         }
@@ -208,8 +221,19 @@ verdict_body_lines() { # $1=reviewed sha; stdin: one body per <<<COMMENT>>>
 }
 
 collect_verdicts() { # $1=pr $2=reviewed sha — every verdict comment pinned to that sha
-  gh pr view "$1" --repo "$REPO" --json comments \
-    --jq '.comments[] | "<<<COMMENT>>>", .body' 2>/dev/null | verdict_body_lines "$2"
+  # Return codes: 0 = ok (verdict lines on stdout, possibly none); 3 = the
+  # comments fetch failed. An unreadable comment list is NOT "no prior
+  # verdicts" — callers must withhold the status, never let the union rule
+  # run on this round's verdict file alone (see post_review_status).
+  is_full_sha "$2" || { log "pr$1 collect-verdicts: $2 is not a full lowercase 40-hex SHA"; return 3; }
+  comments=$(gh pr view "$1" --repo "$REPO" --json comments \
+    --jq '.comments[] | "<<<COMMENT>>>", .body' 2>&1)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    log "pr$1 comments fetch failed (gh exit $rc): $comments"
+    return 3
+  fi
+  printf '%s\n' "$comments" | verdict_body_lines "$2"
 }
 # /D8-debt
 
@@ -261,8 +285,12 @@ case "${1:-}" in
   gate-state) gate_state; exit 0 ;;
   collect-verdicts)
     if [ $# -lt 3 ]; then echo "usage: pr-review-watch.sh collect-verdicts <pr> <reviewed-sha>" >&2; exit 1; fi
+    if ! is_full_sha "$3"; then
+      echo "pr-review-watch.sh: collect-verdicts: $3 is not a full lowercase 40-hex SHA" >&2
+      exit 2
+    fi
     collect_verdicts "$2" "$3"
-    exit 0
+    exit $?
     ;;
   ack-try)
     if [ $# -lt 4 ]; then echo "usage: pr-review-watch.sh ack-try <pr> <sha> <attempts>" >&2; exit 1; fi
@@ -460,7 +488,12 @@ mark_post_failed() { # $1=pr $2=sha $3=round $4=verdict file
 # this round's verdict file (the comment carrying it was posted just before;
 # the union rule makes the duplicate harmless). The description names this
 # round's verdict; unreadable counts render as "?" — never a made-up number.
+# Returns non-zero WITHOUT posting anything when the sha is not a validated
+# 40-hex value or the comment list is unreadable: a withheld status is
+# retried on the same bounded path as a failed post, never replaced by a
+# union computed from this round's verdict alone.
 post_review_status() { # $1=pr $2=reviewed sha $3=verdict file
+  is_full_sha "$2" || { log "pr$1 status: $2 is not a full lowercase 40-hex SHA; status withheld"; return 3; }
   cur=$(verdict_body_lines "$2" < "$3" | head -1)
   v=$(printf '%s\n' "$cur" | cut -f1)
   p0=$(printf '%s\n' "$cur" | cut -f2)
@@ -468,7 +501,13 @@ post_review_status() { # $1=pr $2=reviewed sha $3=verdict file
   [ -n "$v" ] || v=unknown
   [ -n "$p0" ] || p0="?"
   [ -n "$p1" ] || p1="?"
-  state=$({ collect_verdicts "$1" "$2" 2>/dev/null; verdict_body_lines "$2" < "$3"; } | gate_state)
+  comments=$(collect_verdicts "$1" "$2")
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    log "pr$1 comments unreadable (gh exit $rc); status withheld, will retry next poll"
+    return 3
+  fi
+  state=$(printf '%s\n%s\n' "$comments" "$(verdict_body_lines "$2" < "$3")" | gate_state)
   gh api "repos/$REPO/statuses/$2" \
     -f state="$state" -f context="Independent Review" \
     -f description="$v P0=$p0 P1=$p1" >/dev/null

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -8,6 +8,8 @@
 #        pr-review-watch.sh decide                 (offline helper; TSV on stdin)
 #        pr-review-watch.sh label-verdict <reviewed-sha> <current-head>
 #        pr-review-watch.sh ack-try <pr> <sha> <attempts>
+#        pr-review-watch.sh gate-state                  (offline helper; verdict TSV on stdin)
+#        pr-review-watch.sh collect-verdicts <pr> <sha> (offline helper; PR comments via gh)
 #
 # Environment:
 #   EDDA_REPO                  owner/repo            (default fagemx/edda)
@@ -56,6 +58,13 @@
 # verdict is kept and posting retries on the next poll; after 5 failed
 # attempts the PR is labeled `review:post-failed` (verdict file kept in
 # $EDDA_FLEET_SCRATCH for manual posting).
+#
+# After the verdict comment, the watcher also posts the "Independent Review"
+# commit status on the REVIEWED sha (never the current head). Its state is the
+# union rule over every §7 verdict comment on that sha plus this round's
+# verdict (see gate_state), so a later LGTM cannot override an earlier
+# Changes Requested on the same sha. Posting reuses the comment's bounded
+# retry path (postfails, POSTFAIL_CAP, review:post-failed) — never best-effort.
 #
 # The watcher NEVER merges. Merge stays behind operator authorization
 # (pr.merge-policy).
@@ -124,6 +133,86 @@ label_verdict() { # $1=reviewed sha  $2=current head
   if [ -n "${2:-}" ] && [ "$2" = "$1" ]; then echo apply; else echo skip; fi
 }
 
+# gate-state: the union rule for the "Independent Review" commit status.
+# Input: one verdict per line, `verdict<TAB>p0<TAB>p1` (blank lines ignored).
+# Output, exactly one word:
+#   success — at least one verdict is LGTM with P0=0 and P1=0, and no other
+#             verdict on the input is anything other than that;
+#   failure — at least one verdict is present and any one of them does not
+#             qualify (a missing or non-numeric count counts as non-zero);
+#   error   — no verdict lines at all.
+# A later LGTM never overrides an earlier Changes Requested on the same sha:
+# while any non-qualifying verdict stands, the answer is failure.
+gate_state() {
+# D8-debt(#769)
+# The whole union rule lives in this one block so it can be lifted in one
+# piece and replaced by `edda review gate <sha>` (exit 0/1/2 mapped to
+# success/failure/error). No other code decides what a verdict means.
+  awk -F'\t' '
+    { sub(/\r$/, "") }
+    /^[[:space:]]*$/ { next }
+    {
+      n++
+      if ($1 == "LGTM" && $2 ~ /^[0-9]+$/ && $2 + 0 == 0 &&
+          $3 ~ /^[0-9]+$/ && $3 + 0 == 0) next
+      bad = 1
+    }
+    END {
+      if (n == 0)   print "error"
+      else if (bad) print "failure"
+      else          print "success"
+    }
+  '
+# /D8-debt
+}
+
+# D8-debt(#671)
+# Reading verdicts out of GitHub PR comments is a stand-in until the ledger
+# can carry them across machines. Comment shape is REVIEW.md §7 verbatim: the
+# heading `## Code Review: Round <N> — PR #<n> @ <full 40-hex SHA>` pins the
+# reviewed sha, and the first LGTM / Changes Requested line after the
+# `### Verdict` heading carries the verdict and its P0/P1 counts (the same
+# line scripts/review-pr.sh verdict-label reads). Missing counts are passed
+# through as empty fields — the union rule treats them as non-zero.
+verdict_body_lines() { # $1=reviewed sha; stdin: one body per <<<COMMENT>>>
+                       # block (a single raw body also works); stdout: verdict<TAB>p0<TAB>p1
+  awk -v sha="$1" '
+    function flush(   i, n, vline, v, p0, p1, inh, pinned) {
+      if (!inb) return
+      inb = 0
+      n = split(buf, L, "\n")
+      pinned = 0; inh = 0; vline = ""
+      for (i = 1; i <= n; i++) {
+        if (L[i] ~ ("^## Code Review: Round [0-9]+ — PR #[0-9]+ @ " sha "$")) {
+          pinned = 1; continue
+        }
+        if (L[i] ~ /^#{1,}[[:space:]]*Verdict/) { inh = 1; continue }
+        if (pinned && inh && vline == "" && L[i] ~ /LGTM|Changes Requested/) {
+          vline = L[i]
+        }
+      }
+      if (!pinned || vline == "") return
+      v = "LGTM"
+      if (vline ~ /Changes Requested/) v = "Changes Requested"
+      p0 = ""; p1 = ""
+      if (match(vline, /P0=[0-9]+/)) p0 = substr(vline, RSTART + 3, RLENGTH - 3)
+      if (match(vline, /P1=[0-9]+/)) p1 = substr(vline, RSTART + 3, RLENGTH - 3)
+      print v "\t" p0 "\t" p1
+    }
+    { sub(/\r$/, "") }
+    /^<<<COMMENT>>>$/ { flush(); inb = 1; buf = ""; next }
+    { if (!inb) { inb = 1; buf = "" }
+      buf = buf $0 "\n" }
+    END { flush() }
+  '
+}
+
+collect_verdicts() { # $1=pr $2=reviewed sha — every verdict comment pinned to that sha
+  gh pr view "$1" --repo "$REPO" --json comments \
+    --jq '.comments[] | "<<<COMMENT>>>", .body' 2>/dev/null | verdict_body_lines "$2"
+}
+# /D8-debt
+
 # ---- acknowledgement (retried, bounded; never best-effort) -------------------
 
 ack_register() { # $1=pr $2=sha $3=attempts $4=status(""=pending, "post-failed"=terminal)
@@ -169,6 +258,12 @@ ack_try() { # $1=pr $2=sha $3=attempts — one attempt.
 case "${1:-}" in
   decide) decide; exit 0 ;;
   label-verdict) label_verdict "${2:-}" "${3:-}"; exit 0 ;;
+  gate-state) gate_state; exit 0 ;;
+  collect-verdicts)
+    if [ $# -lt 3 ]; then echo "usage: pr-review-watch.sh collect-verdicts <pr> <reviewed-sha>" >&2; exit 1; fi
+    collect_verdicts "$2" "$3"
+    exit 0
+    ;;
   ack-try)
     if [ $# -lt 4 ]; then echo "usage: pr-review-watch.sh ack-try <pr> <sha> <attempts>" >&2; exit 1; fi
     mkdir -p "$SCRATCH"
@@ -360,6 +455,25 @@ mark_post_failed() { # $1=pr $2=sha $3=round $4=verdict file
   state_set "$1" "$2" "$3"
 }
 
+# The "Independent Review" commit status for the reviewed sha. The state is
+# the union rule (gate_state) over every §7 verdict comment on that sha plus
+# this round's verdict file (the comment carrying it was posted just before;
+# the union rule makes the duplicate harmless). The description names this
+# round's verdict; unreadable counts render as "?" — never a made-up number.
+post_review_status() { # $1=pr $2=reviewed sha $3=verdict file
+  cur=$(verdict_body_lines "$2" < "$3" | head -1)
+  v=$(printf '%s\n' "$cur" | cut -f1)
+  p0=$(printf '%s\n' "$cur" | cut -f2)
+  p1=$(printf '%s\n' "$cur" | cut -f3)
+  [ -n "$v" ] || v=unknown
+  [ -n "$p0" ] || p0="?"
+  [ -n "$p1" ] || p1="?"
+  state=$({ collect_verdicts "$1" "$2" 2>/dev/null; verdict_body_lines "$2" < "$3"; } | gate_state)
+  gh api "repos/$REPO/statuses/$2" \
+    -f state="$state" -f context="Independent Review" \
+    -f description="$v P0=$p0 P1=$p1" >/dev/null
+}
+
 # ---- in-flight handling ------------------------------------------------------
 settle_pending() {
   [ -s "$PENDING" ] || return 0
@@ -377,6 +491,7 @@ settle_pending() {
     LOG="$SCRATCH/review-pr$pr-r$round.log"
     VERDICT="$SCRATCH/review-pr$pr-r$round-verdict.md"
     POSTED="$VERDICT.posted"
+    STATUSOK="$POSTED.status-posted"
 
     # Apply the verdict label + record reviewed. The label goes on only if the
     # PR's current head still equals the reviewed SHA; a moved head keeps the
@@ -395,6 +510,28 @@ settle_pending() {
         state_set "$pr" "$sha" "$round"
         pending_drop "$pr"
         return 0
+      fi
+      # The Independent Review status goes to the REVIEWED sha, on the same
+      # bounded retry path as the comment (never best-effort): a failed post
+      # increments postfails and keeps the pending entry; at the cap the PR
+      # is labeled review:post-failed, exactly like the comment path. The
+      # posted state is the union over every verdict on this sha, so a later
+      # LGTM cannot override an earlier Changes Requested (GH-742).
+      if [ ! -f "$STATUSOK" ]; then
+        if post_review_status "$pr" "$sha" "$1"; then
+          : > "$STATUSOK"
+          log "pr$pr r$round status posted: Independent Review on $sha"
+        else
+          postfails=$((postfails + 1))
+          log "pr$pr r$round status post failed (attempt $postfails)"
+          if [ "$postfails" -ge "$POSTFAIL_CAP" ]; then
+            mark_post_failed "$pr" "$sha" "$round" "$1"
+            pending_drop "$pr"
+          else
+            pending_update "$pr" "$round" "$sha" "$attempts" "$launched" "$postfails"
+          fi
+          return 0
+        fi
       fi
       vl=$(sh "$LABEL_PR" verdict-label < "$1")
       if [ -n "$vl" ] && gh pr edit "$pr" --repo "$REPO" --add-label "$vl" >/dev/null 2>&1; then

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -56,6 +56,7 @@ case "$1" in
       view)
         case "$*" in
           *"--json comments"*)
+            [ -n "${GH_FAIL_COMMENTS:-}" ] && exit 1
             [ -n "${GH_COMMENTS_FILE:-}" ] && cat "$GH_COMMENTS_FILE"
             exit 0
             ;;
@@ -116,7 +117,7 @@ reset_stubs() {
     : >"$GH_STUB_LOG"; : >"$PI_STUB_LOG"; : >"$EDDA_STUB_LOG"; : >"$REVIEW_STUB_LOG"
     unset GH_FAIL_COMMENT_FIRST GH_FAIL_COMMENT_ALWAYS GH_FAIL_EDIT GH_FAIL_HEAD \
           GH_PR_LIST_FILE GH_HEAD GH_HEAD_FILE DISPATCH_FAIL_PROBE \
-          GH_COMMENTS_FILE GH_FAIL_STATUS 2>/dev/null || true
+          GH_COMMENTS_FILE GH_FAIL_STATUS GH_FAIL_COMMENTS 2>/dev/null || true
     rm -f "$EDDA_FLEET_SCRATCH"/review-* 2>/dev/null || true
     : >"$EDDA_FLEET_SCRATCH/review-state.tsv"
     : >"$EDDA_FLEET_SCRATCH/review-acks.tsv"
@@ -426,6 +427,54 @@ f="$tmp/comments-wrong-sha"
 verdict_comment 1 "$csha2" 'Changes Requested, P0=1, P1=0 — x' >"$f"
 expect_collect 'a verdict pinned to another sha contributes nothing' \
     '' "$f" "$csha1"
+
+# T1: a failed comments fetch must be an error, never "no prior verdicts" —
+# otherwise the union rule would run on this round's verdict alone.
+expect_collect_fail() {
+    name=$1
+    csha=$2
+    case_number=$((case_number + 1))
+    out=$(GH_FAIL_COMMENTS=1 timeout 60 \
+        sh "$root/scripts/pr-review-watch.sh" collect-verdicts 42 "$csha" 2>/dev/null) && rc=0 || rc=$?
+    if [ "$rc" -eq 0 ]; then
+        printf '%s: expected non-zero exit when the comments fetch fails, got 0\n' "$name" >&2
+        return 1
+    fi
+    if [ -n "$out" ]; then
+        printf '%s: expected no stdout when the comments fetch fails, got:\n  %s\n' "$name" "$out" >&2
+        return 1
+    fi
+}
+
+expect_collect_fail 'a failed comments fetch is an error, never "no prior verdicts"' "$csha1"
+
+# T3: the reviewed sha is validated at the subcommand boundary before it can
+# reach the pin regex or the status URL (REVIEW.md R5).
+expect_collect_badsha() {
+    name=$1
+    value=$2
+    case_number=$((case_number + 1))
+    out=$(timeout 60 sh "$root/scripts/pr-review-watch.sh" collect-verdicts 42 "$value" \
+        2>"$tmp/stderr-$case_number") && rc=0 || rc=$?
+    if [ "$rc" != "2" ]; then
+        printf '%s: expected exit 2 for a non-40-hex sha, got %s\n' "$name" "$rc" >&2
+        return 1
+    fi
+    if [ -n "$out" ]; then
+        printf '%s: expected no stdout for a non-40-hex sha, got:\n  %s\n' "$name" "$out" >&2
+        return 1
+    fi
+    if ! grep -q 'not a full lowercase 40-hex SHA' "$tmp/stderr-$case_number"; then
+        printf '%s: expected the validation error on stderr, got:\n  %s\n' \
+            "$name" "$(cat "$tmp/stderr-$case_number")" >&2
+        return 1
+    fi
+}
+
+expect_collect_badsha 'a regex metacharacter is not a sha' '.*'
+expect_collect_badsha 'a 39-hex value is not a sha' '111122223333444455556666777788889999aaa'
+expect_collect_badsha 'an uppercase 40-hex value is not a sha' '111122223333444455556666777788889999AAAA'
+expect_collect_badsha 'an alternation is not a sha' "${csha2}\$|${csha1}"
 
 # --- the two debt blocks are exactly their four marker lines (GH-742) ---------
 # The union rule block and the comment-reading block must each be liftable in
@@ -834,6 +883,51 @@ if ! grep -qF -- '--add-label review:lgtm' "$GH_STUB_LOG"; then
 fi
 if [ -n "$(pending_get)" ]; then
     printf 'live: after the status recovery the pending entry should be dropped, got:\n%s\n' "$(pending_get)" >&2
+    exit 1
+fi
+
+# T2: an unreadable comment list withholds the status entirely — the union is
+# never computed from this round's verdict file alone — and the failure lands
+# on the same bounded retry path as any other status post failure.
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+printf 'TRANSPORT=edda-dispatch\nDISPATCH_EXIT=0\n' >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
+verdict_log_fixture
+printf '<<<COMMENT>>>\n## Code Review: Round 1 — PR #42 @ %s\n\n### Verdict\nChanges Requested, P0=0, P1=3 — blocking P1\n' \
+    "$sha" >"$tmp/comments-pr42-withheld"
+export GH_HEAD="$sha"
+export GH_COMMENTS_FILE="$tmp/comments-pr42-withheld"
+export GH_FAIL_COMMENTS=1
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (status: comments unreadable)\n' >&2; exit 1; }
+if [ "$(statuses_calls)" != "0" ]; then
+    printf 'live: an unreadable comment list must not post any status, got %s calls\n' "$(statuses_calls)" >&2
+    exit 1
+fi
+if grep -qF -- '--add-label review:lgtm' "$GH_STUB_LOG"; then
+    printf 'live: an unreadable comment list must not apply the verdict label\n' >&2
+    exit 1
+fi
+if [ -z "$(pending_get)" ]; then
+    printf 'live: an unreadable comment list must keep the pending entry, got empty\n' >&2
+    exit 1
+fi
+if [ "$(printf '%s' "$(pending_get)" | cut -f6)" != "1" ]; then
+    printf 'live: an unreadable comment list must bump postfails by one, got:\n%s\n' "$(pending_get)" >&2
+    exit 1
+fi
+if ! grep -qF 'comments unreadable' "$PR_REVIEW_WATCH_LOG"; then
+    printf 'live: an unreadable comment list must be logged\n' >&2
+    exit 1
+fi
+unset GH_FAIL_COMMENTS
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (status: comments recovered)\n' >&2; exit 1; }
+if ! grep -qF -- '-f state=failure' "$GH_STUB_LOG"; then
+    printf 'live: a healthy fetch must post the union failure, got:\n%s\n' \
+        "$(grep 'statuses/' "$GH_STUB_LOG")" >&2
+    exit 1
+fi
+if ! grep -qF -- '--add-label review:lgtm' "$GH_STUB_LOG"; then
+    printf 'live: the label should be applied after the comments recover\n' >&2
     exit 1
 fi
 

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -55,6 +55,10 @@ case "$1" in
         ;;
       view)
         case "$*" in
+          *"--json comments"*)
+            [ -n "${GH_COMMENTS_FILE:-}" ] && cat "$GH_COMMENTS_FILE"
+            exit 0
+            ;;
           *headRefOid*)
             [ -n "${GH_FAIL_HEAD:-}" ] && exit 1
             if [ -n "${GH_HEAD_FILE:-}" ]; then cat "$GH_HEAD_FILE"; else echo "${GH_HEAD:-}"; fi
@@ -68,6 +72,10 @@ case "$1" in
         exit 0
         ;;
     esac
+    exit 0
+    ;;
+  api)
+    [ -n "${GH_FAIL_STATUS:-}" ] && exit 1
     exit 0
     ;;
   label) exit 0 ;;
@@ -107,7 +115,8 @@ export PATH="$STUBBIN:$PATH"
 reset_stubs() {
     : >"$GH_STUB_LOG"; : >"$PI_STUB_LOG"; : >"$EDDA_STUB_LOG"; : >"$REVIEW_STUB_LOG"
     unset GH_FAIL_COMMENT_FIRST GH_FAIL_COMMENT_ALWAYS GH_FAIL_EDIT GH_FAIL_HEAD \
-          GH_PR_LIST_FILE GH_HEAD GH_HEAD_FILE DISPATCH_FAIL_PROBE 2>/dev/null || true
+          GH_PR_LIST_FILE GH_HEAD GH_HEAD_FILE DISPATCH_FAIL_PROBE \
+          GH_COMMENTS_FILE GH_FAIL_STATUS 2>/dev/null || true
     rm -f "$EDDA_FLEET_SCRATCH"/review-* 2>/dev/null || true
     : >"$EDDA_FLEET_SCRATCH/review-state.tsv"
     : >"$EDDA_FLEET_SCRATCH/review-acks.tsv"
@@ -319,6 +328,121 @@ expect_label_verdict \
     'skip' \
     'aaa111' \
     ''
+
+# --- gate-state: union rule for the Independent Review commit status ----------
+# Input: one verdict per line, `verdict<TAB>p0<TAB>p1` (blank lines ignored).
+# Output, exactly one word: success only when at least one verdict is
+# LGTM P0=0 P1=0 and no other verdict on the input is anything else; failure
+# when any verdict is present and does not qualify (missing or non-numeric
+# counts count as non-zero); error when there are no verdict lines at all.
+
+expect_gate_state() {
+    name=$1
+    expected=$2
+    input=$3
+    case_number=$((case_number + 1))
+    if ! actual=$(printf '%b' "$input" | \
+        timeout 60 sh "$root/scripts/pr-review-watch.sh" gate-state); then
+        printf '%s: gate-state exited non-zero\n' "$name" >&2
+        return 1
+    fi
+    if [ "$actual" != "$expected" ]; then
+        printf '%s: expected %s, got %s\n' "$name" "$expected" "$actual" >&2
+        return 1
+    fi
+}
+
+expect_gate_state 'no verdict lines at all' 'error' ''
+expect_gate_state 'blank lines only are still no verdicts' 'error' '\n\n'
+expect_gate_state 'one LGTM 0 0' 'success' 'LGTM\t0\t0\n'
+expect_gate_state 'one Changes Requested' 'failure' 'Changes Requested\t0\t3\n'
+expect_gate_state 'a later LGTM does not override an earlier Changes Requested (union rule)' \
+    'failure' \
+    'Changes Requested\t0\t3\nLGTM\t0\t0\n'
+expect_gate_state 'an earlier LGTM does not pre-clear a later Changes Requested' \
+    'failure' \
+    'LGTM\t0\t0\nChanges Requested\t0\t3\n'
+expect_gate_state 'LGTM with P0=1 does not qualify' 'failure' 'LGTM\t1\t0\n'
+expect_gate_state 'LGTM with P1=1 does not qualify' 'failure' 'LGTM\t0\t1\n'
+expect_gate_state 'blank lines mixed in are ignored' 'success' '\nLGTM\t0\t0\n\n\n'
+expect_gate_state 'two qualifying LGTMs are success' 'success' 'LGTM\t0\t0\nLGTM\t0\t0\n'
+expect_gate_state 'a missing count is non-zero, never success' 'failure' 'LGTM\t0\n'
+expect_gate_state 'a non-numeric count is non-zero, never success' 'failure' 'LGTM\tx\ty\n'
+expect_gate_state 'an unknown verdict word is failure' 'failure' 'Needs Discussion\t0\t0\n'
+
+# --- collect-verdicts: read the §7 verdict comments pinned to one SHA ---------
+# The fixture holds the OUTPUT of the gh --jq pipeline (sentinel + raw
+# bodies), the same shape the real gh prints — consistent with
+# GH_PR_LIST_FILE, which also stores jq output rather than raw JSON.
+
+verdict_comment() { # $1=round $2=sha $3=verdict line — the shape the watcher posts
+    printf '<<<COMMENT>>>\n> **Round %s review** — automatic watcher, reviewed head SHA: `%s`.\n\n## Code Review: Round %s — PR #42 @ %s\n\n### Verdict\n%s\n' \
+        "$1" "$2" "$1" "$2" "$3"
+}
+
+expect_collect() {
+    name=$1
+    expected=$2
+    file=$3
+    csha=$4
+    case_number=$((case_number + 1))
+    if ! actual=$(GH_COMMENTS_FILE="$file" timeout 60 \
+        sh "$root/scripts/pr-review-watch.sh" collect-verdicts 42 "$csha"); then
+        printf '%s: collect-verdicts exited non-zero\n' "$name" >&2
+        return 1
+    fi
+    if [ "$actual" != "$expected" ]; then
+        printf '%s: expected\n  %s\ngot\n  %s\n' "$name" "$expected" "$actual" >&2
+        return 1
+    fi
+}
+
+csha1=111122223333444455556666777788889999aaaa
+csha2=9999888877776666555544443333222211110000
+
+f="$tmp/comments-two-shas"
+{
+    verdict_comment 1 "$csha1" 'Changes Requested, P0=0, P1=3 — blocking P1: input Y crashes'
+    verdict_comment 2 "$csha2" 'LGTM (P0=0, P1=0)'
+    printf '<<<COMMENT>>>\nquestion about the diff, no verdict here\n'
+} >"$f"
+expect_collect 'only verdict comments pinned to the reviewed sha are collected' \
+    "$(printf 'Changes Requested\t0\t3')" "$f" "$csha1"
+expect_collect 'the other sha collects its own verdict' \
+    "$(printf 'LGTM\t0\t0')" "$f" "$csha2"
+
+f="$tmp/comments-malformed"
+verdict_comment 1 "$csha1" 'LGTM' >"$f"
+expect_collect 'a verdict line without counts yields empty count fields (never success)' \
+    "$(printf 'LGTM\t\t')" "$f" "$csha1"
+
+f="$tmp/comments-prose"
+printf '<<<COMMENT>>>\n## Code Review: Round 1 — PR #42 @ %s\n\n### Verdict\n\n修掉這一項就可以 LGTM。\n' \
+    "$csha1" >"$f"
+expect_collect 'prose that merely says LGTM is not a verdict line' \
+    "$(printf 'LGTM\t\t')" "$f" "$csha1"
+
+f="$tmp/comments-wrong-sha"
+verdict_comment 1 "$csha2" 'Changes Requested, P0=1, P1=0 — x' >"$f"
+expect_collect 'a verdict pinned to another sha contributes nothing' \
+    '' "$f" "$csha1"
+
+# --- the two debt blocks are exactly their four marker lines (GH-742) ---------
+# The union rule block and the comment-reading block must each be liftable in
+# one piece: two opening markers and two closing markers, nothing else.
+
+wscript="$root/scripts/pr-review-watch.sh"
+if [ "$(grep -c 'D8-debt' "$wscript")" != "4" ]; then
+    printf 'D8 markers: expected exactly 4 lines (2 open + 2 close), got %s\n' \
+        "$(grep -c 'D8-debt' "$wscript")" >&2
+    exit 1
+fi
+if [ "$(grep -c '^# D8-debt(#769)' "$wscript")" != "1" ] || \
+   [ "$(grep -c '^# D8-debt(#671)' "$wscript")" != "1" ] || \
+   [ "$(grep -c '^# /D8-debt' "$wscript")" != "2" ]; then
+    printf 'D8 markers: expected one #769 opener, one #671 opener, two closers\n' >&2
+    exit 1
+fi
 
 # --- ack retry ----------------------------------------------------------------
 
@@ -595,6 +719,123 @@ grep -qF 'mode unknown — no SESSION_MODE receipt in .done' "$cfile" || {
     exit 1
 }
 unset GH_HEAD
+
+# --- live loop: the Independent Review commit status (GH-742) ------------------
+# Posted to the REVIEWED sha (never the current head), state = the union rule
+# over the §7 verdict comments on that sha plus this round's verdict, retried
+# on the same bounded path as the comment (review:post-failed at the cap).
+
+statuses_calls() { grep -c 'statuses/' "$GH_STUB_LOG" 2>/dev/null || true; }
+
+# the head moved before the verdict settled: no status for anything
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+printf 'TRANSPORT=edda-dispatch\nDISPATCH_EXIT=0\n' >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
+verdict_log_fixture
+export GH_HEAD=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (status: head moved)\n' >&2; exit 1; }
+if [ "$(statuses_calls)" != "0" ]; then
+    printf 'live: a moved head must not get a commit status, got %s calls\n' "$(statuses_calls)" >&2
+    exit 1
+fi
+
+# LGTM with no other verdict on the sha: status success, then the label
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+printf 'TRANSPORT=edda-dispatch\nDISPATCH_EXIT=0\n' >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
+verdict_log_fixture
+export GH_HEAD="$sha"
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (status: lgtm)\n' >&2; exit 1; }
+if ! grep -qF "repos/fagemx/edda/statuses/$sha" "$GH_STUB_LOG"; then
+    printf 'live: the status must be posted to the reviewed sha, got:\n%s\n' \
+        "$(grep 'statuses/' "$GH_STUB_LOG")" >&2
+    exit 1
+fi
+if ! grep -qF -- '-f state=success' "$GH_STUB_LOG"; then
+    printf 'live: LGTM P0=0 P1=0 alone must post state=success, got:\n%s\n' \
+        "$(grep 'statuses/' "$GH_STUB_LOG")" >&2
+    exit 1
+fi
+if ! grep -qF -- '-f context=Independent Review' "$GH_STUB_LOG"; then
+    printf 'live: the status context must be Independent Review\n' >&2
+    exit 1
+fi
+if ! grep -qF -- '-f description=LGTM P0=0 P1=0' "$GH_STUB_LOG"; then
+    printf 'live: the description must name the verdict, got:\n%s\n' \
+        "$(grep 'statuses/' "$GH_STUB_LOG")" >&2
+    exit 1
+fi
+if ! grep -qF -- '--add-label review:lgtm' "$GH_STUB_LOG"; then
+    printf 'live: the verdict label should still be applied\n' >&2
+    exit 1
+fi
+if [ "$(state_get)" != "$(printf '42\t%s\t1' "$sha")" ]; then
+    printf 'live: a successful status + label should record reviewed, got:\n%s\n' "$(state_get)" >&2
+    exit 1
+fi
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (status: second cycle)\n' >&2; exit 1; }
+if [ "$(statuses_calls)" != "1" ]; then
+    printf 'live: the status must be posted once per verdict, got %s calls\n' "$(statuses_calls)" >&2
+    exit 1
+fi
+
+# an earlier Changes Requested on the same sha keeps the union at failure even
+# though this round's verdict is LGTM — the case the whole issue exists for
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+printf 'TRANSPORT=edda-dispatch\nDISPATCH_EXIT=0\n' >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
+verdict_log_fixture
+printf '<<<COMMENT>>>\n## Code Review: Round 1 — PR #42 @ %s\n\n### Verdict\nChanges Requested, P0=0, P1=3 — blocking P1\n' \
+    "$sha" >"$tmp/comments-pr42-earlier-cr"
+export GH_HEAD="$sha"
+export GH_COMMENTS_FILE="$tmp/comments-pr42-earlier-cr"
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (status: union)\n' >&2; exit 1; }
+if ! grep -qF -- '-f state=failure' "$GH_STUB_LOG"; then
+    printf 'live: a standing Changes Requested must hold the union at failure, got:\n%s\n' \
+        "$(grep 'statuses/' "$GH_STUB_LOG")" >&2
+    exit 1
+fi
+if ! grep -qF -- '--add-label review:lgtm' "$GH_STUB_LOG"; then
+    printf 'live: the label still reflects the current LGTM verdict\n' >&2
+    exit 1
+fi
+
+# posting the status is not best-effort: the comment path\'s bounded retry,
+# and no label until the status is out
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+printf 'TRANSPORT=edda-dispatch\nDISPATCH_EXIT=0\n' >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
+verdict_log_fixture
+export GH_HEAD="$sha"
+export GH_FAIL_STATUS=1
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (status: post fails)\n' >&2; exit 1; }
+if [ -z "$(pending_get)" ]; then
+    printf 'live: a failed status post must keep the pending entry for retry, got empty\n' >&2
+    exit 1
+fi
+if grep -qF -- '--add-label review:lgtm' "$GH_STUB_LOG"; then
+    printf 'live: a failed status post must not apply the verdict label yet\n' >&2
+    exit 1
+fi
+if ! grep -qF 'status post failed (attempt 1)' "$PR_REVIEW_WATCH_LOG"; then
+    printf 'live: a failed status post must be logged\n' >&2
+    exit 1
+fi
+unset GH_FAIL_STATUS
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (status: recovery)\n' >&2; exit 1; }
+if ! grep -qF -- '-f state=success' "$GH_STUB_LOG"; then
+    printf 'live: the status should succeed on the retry, got:\n%s\n' \
+        "$(grep 'statuses/' "$GH_STUB_LOG")" >&2
+    exit 1
+fi
+if ! grep -qF -- '--add-label review:lgtm' "$GH_STUB_LOG"; then
+    printf 'live: the label should be applied after the status recovery\n' >&2
+    exit 1
+fi
+if [ -n "$(pending_get)" ]; then
+    printf 'live: after the status recovery the pending entry should be dropped, got:\n%s\n' "$(pending_get)" >&2
+    exit 1
+fi
 
 # --- offline guarantee: the real watcher log was never touched -----------------
 size_after=0


### PR DESCRIPTION
Issue: #742

## What changed

Closes the gap where nothing tracked in the repository posts the `Independent Review` commit status the main-branch ruleset requires (the interim untracked `~/.edda/fleet/review-queue.sh` still covers the gap until this lands — this PR does not retire it).

- **`scripts/pr-review-watch.sh`**
  - `gate_state`, exposed as subcommand `pr-review-watch.sh gate-state`: the union rule. Input `verdict<TAB>p0<TAB>p1` per line; prints exactly one word — `success` (at least one `LGTM` P0=0 P1=0 and no other verdict), `failure` (any verdict present that does not qualify; missing/non-numeric counts count as non-zero), `error` (no verdict lines). The whole rule lives in one block marked `# D8-debt(#769)` … `# /D8-debt`, scheduled to be replaced by `edda review gate <sha>` (exit 0/1/2 → success/failure/error). No other new code decides what a verdict means.
  - `verdict_body_lines` / `collect_verdicts` (exposed as `collect-verdicts <pr> <sha>`): reads the reviewed SHA's existing verdict comments in the exact REVIEW.md §7 shape (`## Code Review: Round <N> — PR #<n> @ <full 40-hex SHA>` heading + first `LGTM`/`Changes Requested` line after `### Verdict`), marked `# D8-debt(#671)` … `# /D8-debt` (stand-in until the ledger carries verdicts across machines).
  - `post_review_status`: posts `gh api repos/$REPO/statuses/<reviewed-sha> -f state=… -f context="Independent Review" -f description="<verdict> P0=<n> P1=<n>"` where `$SHA` is the reviewed SHA already tracked in the pending entry (never the current head; the head-moved path returns before any status is posted). Posting is **not best-effort**: it reuses the comment path's bounded retry (`postfails`, `POSTFAIL_CAP=5`, `review:post-failed` via `mark_post_failed`) — a failed status post keeps the pending entry and the verdict label is not applied until the status is out. A `STATUSOK` marker file makes the post once-per-verdict.
- **`scripts/test-pr-review-watch.sh`** — tests written **first**; new stub arms (`gh api`, `gh pr view --json comments`) follow the existing fixture style (fixtures hold jq output, offline, no real `gh`). 13 `gate-state` cases, 5 `collect-verdicts` cases, the D8 marker-count check (exactly 2 openers + 2 closers), and 4 live-loop status scenarios (head moved → no status; LGTM → `state=success` + description; earlier Changes Requested on the same SHA holds the union at `failure` even though this round is LGTM; failed post → pending kept, no label, logged, then recovery).
- **`REVIEW.md`** (§8) — paragraph naming the context and the exact success condition.
- **`docs/guides/pr-review-watcher.md`** — one paragraph (file already existed): the `#769` block is temporary; retirement = replace the block with `edda review gate <sha>` and map exit 0/1/2 to success/failure/error.

## Evidence — tests written first (failing run before the fix)

`sh scripts/test-pr-review-watch.sh` (the harness is `set -eu`, so it aborts at the first failing case):

```text
== full test run (set -eu harness aborts at first failure) ==
pr-review-watch.sh: unexpected argument 'gate-state'
no verdict lines at all: gate-state exited non-zero
exit=1

== gate-state subcommand does not exist yet ==
pr-review-watch.sh: unexpected argument 'gate-state'
exit=1

== collect-verdicts subcommand does not exist yet ==
pr-review-watch.sh: unexpected argument 'collect-verdicts'
exit=1

== D8 marker count: 0 found, test expects exactly 4 ==
0
exit=1

== no status posting exists: watcher never calls gh api statuses ==
0
exit=1
```

## Evidence — passing run after the fix

```text
pr-review-watch fixtures passed
```

## Required commands

```text
$ sh -n scripts/pr-review-watch.sh
OK (exit 0)

$ sh -n scripts/test-pr-review-watch.sh
OK (exit 0)

$ sh scripts/test-pr-review-watch.sh
pr-review-watch fixtures passed
OK (exit 0)

$ sh scripts/lint-markdown-content.sh
OK (exit 0)
```

## Notes / things I was unsure about

1. **Branch base**: the brief pinned base `1aaab0c`, but `main` had moved to `03c604f` (two repo chores touching only `crates/`/Cargo — no overlap with my files). I fast-forwarded the branch to `03c604f` before committing so the PR is against the current base; the diff contains only my four files.
2. **Retry-cap sharing**: the status post reuses the *same* `postfails` counter as the verdict comment rather than a second counter ("do not add a new failure mechanism"). Since the status posts before the label each poll, the status effectively gets first claim on the 5 attempts; combined attempts are capped at 5.
3. **Status is posted only when the PR head still equals the reviewed SHA** — the same condition under which the verdict label is applied (per the brief, the status goes where the label goes). A moved head gets its status from its own next review round.
4. **`error` as a posted state**: if neither the PR comments nor the local verdict file yield a parseable verdict line, the status posts `state=error` honestly rather than guessing.
5. **Verdict-line parsing mirrors `review-pr.sh verdict-label`** (first keyword line after the `### Verdict` heading, `Changes Requested` wins if both appear); prose that merely says "LGTM" yields empty counts → never `success`, matching the #697 lesson.
6. Not touched (per brief): `.github/`, Cargo files, `crates/`, the ruleset itself. **Adding a bypass actor for this PR is the operator's action.**

## Expected: this PR is itself blocked

Nothing has posted the `Independent Review` status for this PR's head SHA either — the tracked watcher that would post it is the code in this PR. The block is expected and is left for the operator (the interim controller script may post it manually if desired).

