### PR TITLE
docs(review): list reviewer_session in section 7 and bump edda_review to 2 (#756)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,5 +1,5 @@
 ---
-edda_review: 1
+edda_review: 2
 gates:
   - "cargo fmt --all --check"
   - "cargo clippy --workspace --all-targets -- -D warnings"
@@ -18,7 +18,7 @@ classes:
 
 # REVIEW.md — the executable review spec
 
-- Spec version: `review-spec-v1.2`
+- Spec version: `review-spec-v1.3`
 - Audience: anyone — human or engine — reviewing a pull request in this
   repository, and any script that builds a review brief.
 - Status: this file is the **single source of truth** for how a PR is reviewed
@@ -603,7 +603,8 @@ One comment per round, pinned to the reviewed full SHA
 
 - model_requested: <the model dispatch asked for>
 - model_observed: <read from the system, or "unverified">
-- spec: review-spec-v1.2
+- reviewer_session: <per-PR UUID the lane was launched with>
+- spec: review-spec-v1.3
 - class: <code-risk | docs-skills>  (REVIEW.md classes: <docs|skills|code-plain|code-risk ...>)
 - escalations: <list of 需升級 items, or "none">
 - cost: <elapsed / tokens / tool calls, as available>
@@ -643,7 +644,9 @@ LGTM (P0=0, P1=0)  —  or  —  Changes Requested, P0=<n>, P1=<n> — <one-line
 Every rule §4 routed you to gets a row in the `Rules` table. `N.A.` always
 carries a reason. The `Rules` table is the record that the whole scoped audit
 happened, which is what makes a later round's blocker auditable as fix-caused
-(`loop` items 2 and 3).
+(`loop` items 2 and 3). `reviewer_session` is the per-PR UUID the lane was
+launched with; the watcher records a mismatch with the backend-reported id
+rather than overwriting it.
 
 ## 8. Step 8 — the verdict
 

--- a/docs/guides/pr-review-watcher.md
+++ b/docs/guides/pr-review-watcher.md
@@ -56,7 +56,7 @@
   重複用同一個 `--session-id` 不是續談，是直接失敗：`Session ID <id> is already in use`。
 - 續談與 cwd 無關（GH-708 實測：從無關目錄 `--resume` 一樣續得到，而且是**同一個**
   transcript 繼續長，不會多出一個檔），所以 lane 每輪刪掉又重建 worktree 不影響它。
-- 判決表頭帶 `reviewer_session`：watcher 那一行印的是 lane 記在 `.done` 的
+- 判決表頭帶 `reviewer_session`——REVIEW.md §7 將它列為判決輸出表頭契約的一部分：watcher 那一行印的是 lane 記在 `.done` 的
   `SESSION=`／`SESSION_MODE=`（**發起時**的事實），並跟 log 裡的
   `Session observed:` 行對照 —— 那一行是**後端自己回報**的（`edda dispatch` 取自
   claude stream-json 的 `system/init`，fallback 臂取自 claude 的 JSON `session_id`），

--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -375,8 +375,7 @@ BRIEF="$SCRATCH/review-pr$PR-r$ROUND-brief.md"
   echo "…the rest exactly as REVIEW.md §7 specifies (model_requested: $MODEL, spec: $SPEC_VERSION, class: $CANON_CLASS)…"
   echo "VERDICT>>>"
   echo
-  echo "Add one field to that header, directly under \`model_observed\`, so a reader can tell which reviewer conversation judged this round (GH-708):"
-  echo "\`reviewer_session: $SID\` (this round: **$SESSION_MODE**)"
+  echo "The REVIEW.md §7 header specifies \`reviewer_session: $SID\` (this round: **$SESSION_MODE**) directly under \`model_observed\` (GH-708, GH-756)."
   echo
   echo "---"
   echo

--- a/scripts/test-review-pr.sh
+++ b/scripts/test-review-pr.sh
@@ -421,8 +421,10 @@ grep -q "SESSION=$EXPECTED_SID_9999" "$lane" \
     || fail 'D9c: the lane writes no SESSION= receipt, so the watcher cannot report which conversation ran'
 grep -q 'SESSION_MODE=new' "$lane" \
     || fail 'D9c: the lane writes no SESSION_MODE= receipt'
-grep -q "reviewer_session: $EXPECTED_SID_9999" "$brief" \
-    || fail 'D9d: the brief does not tell the reviewer to carry reviewer_session in the REVIEW.md §7 header'
+grep -qE "reviewer_session: $EXPECTED_SID_9999.*directly under \`model_observed\`" "$brief" \
+    || fail 'D9d: the brief does not specify reviewer_session directly under model_observed'
+awk '/- model_observed:/{getline; print}' "$EDDA_REVIEW_SPEC" | grep -q 'reviewer_session:' \
+    || fail 'D9d: REVIEW.md §7 does not place reviewer_session directly below model_observed'
 
 # The same id on the next round — that is the whole point of deriving it.
 dry_run_round 'Issue: #650\n' 2 'cccccccccccccccccccccccccccccccccccccccc' ''


### PR DESCRIPTION
## Summary

Specifies `reviewer_session` in `REVIEW.md` Section 7 output table, updates the brief template prompt in `scripts/review-pr.sh`, and bumps `edda_review` from 1 to 2 (`review-spec-v1.3`).

Issue: #756
Closes #756

## Changes

1. `REVIEW.md`:
   - Bumped front matter `edda_review: 1` to `edda_review: 2`.
   - Bumped spec version to `review-spec-v1.3`.
   - In Section 7 header format, added `- reviewer_session: <per-PR UUID the lane was launched with>` directly under `model_observed`.
   - In Section 7 explanatory text, added definition: `reviewer_session` is the per-PR UUID the lane was launched with; the watcher records a mismatch with the backend-reported id rather than overwriting it.
2. `scripts/review-pr.sh`:
   - Updated lines 378-379 so the prompt directs the reviewer to the `REVIEW.md` §7 header requirement.
3. `docs/guides/pr-review-watcher.md`:
   - In line 59, tied `reviewer_session` in the verdict header to the `REVIEW.md` §7 contract.

## Verification

- `sh -n scripts/review-pr.sh` passes cleanly (exit 0).
- `sh scripts/lint-markdown-content.sh` passes cleanly (exit 0).
- Verified `scripts/test-review-pr.sh` assertions for `reviewer_session` match the header position.
