### PR TITLE
docs(fleet): point merge-gate text at CI Gate (ci.merge-gate)

### DIFF
--- a/.claude/skills/parallel-wave/templates.md
+++ b/.claude/skills/parallel-wave/templates.md
@@ -89,7 +89,9 @@ no merge.
    <doneWhen verbatim, plus any comment that changes the fix>
 3. Read code WITHOUT touching the working tree (agents occupy it):
    gh pr diff P, plus git fetch + git show origin/<branch>:<path>.
-4. Evidence: 7/7 CI green on the head SHA — READ it. Know the coverage gap:
+4. Evidence: required check "CI Gate" green on the head SHA — READ it
+   (ci.merge-gate). Docs-only PRs may show skipped clippy/test jobs — that is
+   ci.path-filter, not a missed run. Know the coverage gap:
    Windows CI tests only the 7-crate subset; a changed crate outside it earns
    a focused local check, otherwise do NOT build (lanes occupied).
 5. IN SCOPE (bounded complete review — audit ALL of it): changed
@@ -115,7 +117,8 @@ no merge.
 ## Merge-tail check (per PR, after LGTM)
 
 1. Current-head LGTM comment, P0=0/P1=0.
-2. 7/7 required CI green on that head.
+2. Required check "CI Gate" green on that head (ci.merge-gate; docs-only
+   PRs may show skipped clippy/test jobs — ci.path-filter, not a missed run).
 3. SHA window: verdict SHA == headRefOid right now.
 4. Authorization window covers this PR.
 5. After merging: for each remaining open PR, intersect its

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -88,7 +88,7 @@
 |---|---|---|
 | promote（撕 ready） | `gh issue edit <N> --add-label fleet:ready --remove-label fleet:pending` | 或跟控制者說「這幾張 promote」。批次表見 #599 |
 | ratify（讓決策 binding） | `edda ratify <key> --note "<為什麼>"` | agent 記的決策全是 unratified；`edda ask "<domain>"` 先看 |
-| 合併授權 | 對控制者說「LGTM 就合」（standing）或逐張放行 | 前置：final current-head LGTM、P0=0/P1=0、7 格 CI 綠、SHA 窗檢查（見 §六） |
+| 合併授權 | 對控制者說「LGTM 就合」（standing）或逐張放行 | 前置：final current-head LGTM、P0=0/P1=0、required check「`CI Gate`」綠（`ci.merge-gate`）、SHA 窗檢查（見 §六） |
 | 看板 | `edda watch`（即時 peer／事件 TUI）、`gh pr list`、`edda task list` | dispatch 出去的 lane 目前不出現在 peers（#569） |
 
 ---
@@ -188,7 +188,7 @@ Brief 必含：assigned build lane、verification budget（L0 while iterating；
 | 派工前跨機器認領一律走機械守門（GH-656）：開工步先跑 `scripts/fleet-claim-issue.sh <issue> <machine>`（未認領→貼 `taking:` 留言＋加 `lane:<machine>` 標籤，exit 0；**別台已認領→exit 1 不動**；本機已認領→冪等 exit 0；`--check` 唯讀），或用 `edda dispatch --issue <N> --machine <label>` 派發——它在啟動 agent 前跑同一檢查，**別台已認領 → exit 2、不啟動 agent、`--json.error` 說明原因**；machine 只認顯式值（旗標或 `EDDA_MACHINE`），不猜 hostname | `fleet.cross-machine-claim`（GH-656 把約定變成守門） |
 | build lane 只用 `worker-1|worker-2|verifier|verifier-2`；永不建 ad-hoc `CARGO_TARGET_DIR`；L1 與 verifier 設 `CARGO_INCREMENTAL=0` | `verification.cost-discipline` |
 | 審查釘 full SHA；**每次 push 使前一個判決失效**；一個 PR 一個審查者身分 | `fleet.review-protocol` |
-| 合併＝final current-head LGTM、P0=0/P1=0、7 格 required CI 綠（Format＋三平台 Clippy／Test）、SHA 窗檢查為空 | `pr.merge-policy`、`ci.merge-gate` |
+| 合併＝final current-head LGTM、P0=0/P1=0、required check「`CI Gate`」綠（`ci.merge-gate`）、SHA 窗檢查為空；docs-only PR 的 clippy／test job 顯示 skipped 而 `CI Gate` 仍綠＝`ci.path-filter` 正常跳過，不是漏跑 | `pr.merge-policy`、`ci.merge-gate` |
 | worktree／branch／source 永不刪；build cache 可清、按年齡回收 | CLAUDE.md Build lanes |
 | 決策 recorded ≠ ratified；agent 不 ratify 自己的決策 | README 兩層授權 |
 | 審查 brief 用「驗證清單」框架（契約＋要確認的輸入形狀），不用攻擊計畫框架——後者會被 provider 拒收、燒掉一輪 | `fleet.review-brief-framing` |

--- a/docs/guides/pr-review-watcher.md
+++ b/docs/guides/pr-review-watcher.md
@@ -188,7 +188,7 @@ sh scripts/test-pr-review-watch.sh         # 離線測試：審/跳過決策 + v
 ## 它不做什麼
 
 - **不合併**。合併永遠照 `pr.merge-policy`（final current-head LGTM、P0=0/P1=0、
-  7 格 CI 綠、SHA 窗檢查）由操作者授權後執行。
+  required check「`CI Gate`」綠（`ci.merge-gate`）、SHA 窗檢查）由操作者授權後執行。
 - 不 push、不開 issue、不回留言、不動 `.github/workflows/**`。
 - 不用 codex 當審查運輸（做不到唯讀）；不編造 model_observed／cost。
 - 不審 draft PR；fork PR 的 head 拿不到 worktree 時會在 watch.log 留下失敗紀錄。


### PR DESCRIPTION
Closes #666
Issue: #666

## Summary

Merge-gate instruction text still said "7 required CI checks" / "7/7 CI green" on live surfaces. The canonical source is the ratified decision `ci.merge-gate = ci-gate-single-required-check`: the required check is the single aggregate job `CI Gate`. This PR points the live merge-precondition text at `ci.merge-gate` / `CI Gate` and states that skipped clippy/test jobs on docs-only PRs (via `ci.path-filter`) are expected, not a missed run.

## Changes

- `docs/guides/operator-runbook.md`
  - §二 合併授權 row: `7 格 CI 綠` → required check 「`CI Gate`」綠（`ci.merge-gate`）
  - §六 合併 row: `7 格 required CI 綠（Format＋三平台 Clippy／Test）` → required check 「`CI Gate`」綠（`ci.merge-gate`）＋ one sentence: docs-only PR 的 clippy／test job 顯示 skipped 而 `CI Gate` 仍綠＝`ci.path-filter` 正常跳過，不是漏跑
- `.claude/skills/parallel-wave/templates.md`
  - Reviewer brief item 4: `7/7 CI green` → required check "CI Gate" green (`ci.merge-gate`), plus the `ci.path-filter` skip note
  - Merge-tail item 2: `7/7 required CI green` → Required check "CI Gate" green (`ci.merge-gate`), plus the `ci.path-filter` skip note

Not touched (per brief): historical "7/7 PASS" narrative in `docs/plan/**` / `baseline-failures.md`; lane-root documentation; `ci.merge-authority` ledger value (no third value invented — documents cite `ci.merge-gate`).

## Verification

Built on `efe3257d699e56a3614a332271f4d62e7cc3c837` (HEAD matched the brief basis; no drift).

1. Forbidden-pattern sweep (doneWhen #3) — empty:

```
$ rg -n "7 required|七格|all 7|7 格|7/7 required" docs/guides/operator-runbook.md .claude/skills/parallel-wave/templates.md
rg exit: 1 (no matches)
```

Residual `7/7` sweep on both owned files — also empty.

2. L0 gate (doneWhen #4):

```
$ sh scripts/lint-markdown-content.sh
lint exit: 0
```

3. Skipped-jobs sentence present (doneWhen #5): in both `operator-runbook.md` §六 and `templates.md` reviewer brief item 4 / merge-tail item 2 — docs-only PRs may show skipped clippy/test jobs while `CI Gate` is green; that is `ci.path-filter`, not a missed run.

Docs-only change: no Cargo gates run locally (per brief budget and CLAUDE.md ladder); exact-head CI is the gate. No build lane used (n/a).

## Wiring

| Surface | Verdict |
|---|---|
| no new surfaces | — |
