### PR TITLE
chore(skills): point five skills at REVIEW.md instead of restating rules

### DIFF
--- a/.claude/skills/coord-review/SKILL.md
+++ b/.claude/skills/coord-review/SKILL.md
@@ -132,21 +132,8 @@ it as a `FOLLOW-UP ISSUE`, and do not block a product-green PR on it.
 ## Wiring verdict — REQUIRED for every new surface in the diff
 
 「存在」≠「有接線」。diff 裡每一個**新面**都必填一列四問，這是必填槽，不是「考慮」bullet；缺槽等同沒審。
-「新面」= 新的 `pub` fn / field / enum variant、CLI 旗標、config 鍵、事件 payload 欄位、被寫出的檔案或 side-file。docs-only 或無新面的 PR 也要寫一行「no new surfaces」——一行不能省，省了就是槽沒填。
-
-每個新面一列，四問各附 `file:line`（本 PR 內或既有碼）：
-
-| 新面 | Writer & shape | Reader（本 PR 內或既有；或「no consumer」） | Failure signal（吞錯／success-only／best-effort？） | Layer reach（旗標→builder→spawn；欄位→store→read-back） |
-|---|---|---|---|---|
-
-判定規則（寫死，不留給審查者裁量）：
-
-- 「no consumer」且沒有具名的後續 issue → **P1**（dead on arrival）。有後續 issue 編號 → 列入 FOLLOW-UP ISSUE，放行。
-- 在 ledger / coordination / cost 路徑上吞錯（`let _ =`、`.ok();`、`unwrap_or_default()` 於寫端、best-effort、只記成功）→ **P1**。
-- doneWhen 要求到達某層而無測試證明（旗標未斷言出現在 spawn 命令列；欄位未 read-back）→ **P1**；doneWhen 沒要求 → FOLLOW-UP。
-- 新增寫端而任何輸出都沒有 freshness / coverage 訊號，且該路徑有報表或決策依賴 → **P1**（death visibility；對齊 issue-create 既有條款）。
-
-機器輔助（審查者 RAN，不是 CI 閘）：`sh scripts/wiring-scan.sh <base> <head>` 列出 diff 新增的 `pub` 項目及其在 `crates/` 內定義檔以外的引用數，並對新增行 grep 吞錯樣式（`let _ = `、`.ok();`、`unwrap_or_default()`、`best-effort`、`silently`）；輸出附在 RAN 段。誤報需要人判，故不進 CI。
+槽的定義——何謂新面、四問表、P1 判定規則、docs-only 的「no new surfaces」行、機器輔助——以
+`REVIEW.md` §5.5 為唯一真實來源，本 skill 不重述；照 §5.5 填滿每個槽，機器輔助輸出附在 RAN 段。
 
 ### Step 6: Generate Report
 

--- a/.claude/skills/coord-review/SKILL.md
+++ b/.claude/skills/coord-review/SKILL.md
@@ -129,11 +129,9 @@ an already-receipted SHA without a reason, full gates for a docs-only push, an
 ad-hoc build directory — is a process finding: note it in the cost line, route
 it as a `FOLLOW-UP ISSUE`, and do not block a product-green PR on it.
 
-## Wiring verdict — REQUIRED for every new surface in the diff
+## Wiring verdict
 
-「存在」≠「有接線」。diff 裡每一個**新面**都必填一列四問，這是必填槽，不是「考慮」bullet；缺槽等同沒審。
-槽的定義——何謂新面、四問表、P1 判定規則、docs-only 的「no new surfaces」行、機器輔助——以
-`REVIEW.md` §5.5 為唯一真實來源，本 skill 不重述；照 §5.5 填滿每個槽，機器輔助輸出附在 RAN 段。
+填 `REVIEW.md` §5.5 定義的必填槽；本 skill 不重述其表格或 P1 判定規則。
 
 ### Step 6: Generate Report
 

--- a/.claude/skills/fleet-review/SKILL.md
+++ b/.claude/skills/fleet-review/SKILL.md
@@ -24,7 +24,7 @@ context: fork
 | §5.5 | wiring verdict——每個新面一列的必填槽；無新面也要寫一行 |
 | §6 | `[判斷]` 項只能標「需升級」，不准自行裁定；升級紀錄進判決欄位 |
 | §7 | 判決的固定格式（規則表、wiring 表、findings、RAN vs READ） |
-| §8 | 裁定規則：任何 P0/P1 → Changes Requested；P0=0 且 P1=0 → LGTM |
+| §8 | 裁定規則：見 `REVIEW.md` §8（唯一真實來源，本 skill 不重述） |
 
 `REVIEW.md` 的每條規則都指回既有正典（`.claude/CLAUDE.md` 的 review-fix loop
 與驗證階梯、#629 的 wiring verdict、#618 的 brief 模板 v1）。這份 skill **不重述**
@@ -40,8 +40,8 @@ context: fork
 
 `gh pr comment <n> --body-file <tmp>`，格式照 `REVIEW.md` §7 一字不改。
 
-- **LGTM**（P0=0、P1=0）→ `gh pr edit <n> --add-label fleet:reviewed`。停，交操作者 merge。
-- **Changes Requested**（有 P0 或 P1）→ comment 已貼、PR 留開。停，回報操作者。
+- **LGTM** → `gh pr edit <n> --add-label fleet:reviewed`。停，交操作者 merge。何時成立由 `REVIEW.md` §8 裁定。
+- **Changes Requested** → comment 已貼、PR 留開。停，回報操作者。
   修是 `fleet-worker`／後續 pass 的事，不是你。
 
 ## 四禁（fleet 專屬，違反即停）

--- a/.claude/skills/fleet-review/SKILL.md
+++ b/.claude/skills/fleet-review/SKILL.md
@@ -41,8 +41,8 @@ context: fork
 `gh pr comment <n> --body-file <tmp>`，格式照 `REVIEW.md` §7 一字不改。
 
 - **LGTM** → `gh pr edit <n> --add-label fleet:reviewed`。停，交操作者 merge。何時成立由 `REVIEW.md` §8 裁定。
-- **Changes Requested** → comment 已貼、PR 留開。停，回報操作者。
-  修是 `fleet-worker`／後續 pass 的事，不是你。
+- **Changes Requested** → comment 已貼、PR 留開。停，回報操作者。何時成立由
+  `REVIEW.md` §8 裁定。修是 `fleet-worker`／後續 pass 的事，不是你。
 
 ## 四禁（fleet 專屬，違反即停）
 

--- a/.claude/skills/fleet-worker/SKILL.md
+++ b/.claude/skills/fleet-worker/SKILL.md
@@ -26,12 +26,7 @@ description: Use when running one lane of the Fleet execution loop — pick a si
 3. **隔離**：用 `the using-git-worktrees skill` 開一個 worktree，絕不在主工作樹動工。
 4. **TDD**：用 `the test-driven-development skill`——先把 doneWhen 寫成失敗測試，再實作到綠。
 5. **驗證**：跑單上的 verify 指令，範圍照正典的驗證階梯（迭代時只跑觸及的 crate；全套留給凍結的 SHA）。
-6. **開 PR**：`gh pr create --title "<單標題>" --body "closes #<n>\n\n<測試輸出證據>"`。body 必須含**自報接線表**——每個新面（新 `pub` fn / field / enum variant、CLI 旗標、config 鍵、事件 payload 欄位、被寫出的檔案或 side-file）一列，四問各附 `file:line`：
-
-   | 新面 | Writer & shape | Reader（本 PR 內或既有；或「no consumer」） | Failure signal（吞錯／success-only／best-effort？） | Layer reach（旗標→builder→spawn；欄位→store→read-back） |
-   |---|---|---|---|---|
-
-   docs-only 或無新面也要寫一行「no new surfaces」——一行不能省。宣稱錯誤本身就是一個 finding：審查者會用 `scripts/wiring-scan.sh` 核對自報表，而不是從零挖。回到步驟 1。
+6. **開 PR**：`gh pr create --title "<單標題>" --body "closes #<n>\n\n<測試輸出證據>"`。body 必須含**自報接線表**——這是 `REVIEW.md` §5.5 定義的必填槽（唯一真實來源，本 skill 不重述其表格與判定規則）：每個新面一列四問、各附 `file:line`；docs-only 或無新面也要寫一行「no new surfaces」——一行不能省。宣稱錯誤本身就是一個 finding：審查者會用 `scripts/wiring-scan.sh`（§5.5）核對自報表，而不是從零挖。回到步驟 1。
 
 ## 四禁（違反即停）
 

--- a/.claude/skills/fleet-worker/SKILL.md
+++ b/.claude/skills/fleet-worker/SKILL.md
@@ -26,7 +26,7 @@ description: Use when running one lane of the Fleet execution loop — pick a si
 3. **隔離**：用 `the using-git-worktrees skill` 開一個 worktree，絕不在主工作樹動工。
 4. **TDD**：用 `the test-driven-development skill`——先把 doneWhen 寫成失敗測試，再實作到綠。
 5. **驗證**：跑單上的 verify 指令，範圍照正典的驗證階梯（迭代時只跑觸及的 crate；全套留給凍結的 SHA）。
-6. **開 PR**：`gh pr create --title "<單標題>" --body "closes #<n>\n\n<測試輸出證據>"`。body 必須含**自報接線表**——這是 `REVIEW.md` §5.5 定義的必填槽（唯一真實來源，本 skill 不重述其表格與判定規則）：每個新面一列四問、各附 `file:line`；docs-only 或無新面也要寫一行「no new surfaces」——一行不能省。宣稱錯誤本身就是一個 finding：審查者會用 `scripts/wiring-scan.sh`（§5.5）核對自報表，而不是從零挖。回到步驟 1。
+6. **開 PR**：`gh pr create --title "<單標題>" --body "closes #<n>\n\n<測試輸出證據>"`。body 必須含自報接線表——填 `REVIEW.md` §5.5 定義的必填槽；本 skill 不重述其表格與判定規則。回到步驟 1。
 
 ## 四禁（違反即停）
 

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -6,14 +6,10 @@ context: fork
 
 You are an author self-check and fix specialist for the Edda project (Rust). Your role is to iteratively inspect a pull request, post findings as an author self-check comment each pass, fix all high-priority issues, and repeat until the self-check is clean. This is an author self-check, not a Code Review; independent review is a separate step required before merge.
 
-## Wiring audit — REQUIRED for every new surface in the diff
+## Wiring audit
 
-Every self-check pass below is subject to the mandatory Wiring audit slot. The
-slot is defined in `REVIEW.md` §5.5 (the canonical wiring verdict, which owns
-the four-question table and the P1 adjudication rules) — fill it exactly as
-§5.5 requires: one four-question row per new surface, or a single
-"no new surfaces" line for docs-only PRs. Do not skip the slot; a missing
-line means the self-check pass is incomplete.
+Every self-check pass fills the wiring audit slot defined in `REVIEW.md` §5.5;
+this skill does not restate the table or the P1 rules.
 
 ## Architecture
 

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -8,11 +8,12 @@ You are an author self-check and fix specialist for the Edda project (Rust). You
 
 ## Wiring audit — REQUIRED for every new surface in the diff
 
-Every self-check pass below is subject to the mandatory Wiring audit slot defined in
-`fleet-review/SKILL.md` (「Wiring verdict — REQUIRED for every new surface in the diff」):
-one four-question row per new surface (new `pub` fn/field/variant, CLI flag, config key,
-event payload field, written file or side-file), and a mandatory "no new surfaces" line
-for docs-only PRs. Do not skip the slot; a missing line means the self-check pass is incomplete.
+Every self-check pass below is subject to the mandatory Wiring audit slot. The
+slot is defined in `REVIEW.md` §5.5 (the canonical wiring verdict, which owns
+the four-question table and the P1 adjudication rules) — fill it exactly as
+§5.5 requires: one four-question row per new surface, or a single
+"no new surfaces" line for docs-only PRs. Do not skip the slot; a missing
+line means the self-check pass is incomplete.
 
 ## Architecture
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -88,11 +88,9 @@ Run every PR through these four checks, in order:
 
 **Example**: "unstub is unnecessary, the test framework automatically cleans up after tests finish"
 
-## Wiring verdict — REQUIRED for every new surface in the diff
+## Wiring verdict
 
-「存在」≠「有接線」。diff 裡每一個**新面**都必填一列四問，這是必填槽，不是「考慮」bullet；缺槽等同沒審。
-槽的定義——何謂新面、四問表、P1 判定規則、docs-only 的「no new surfaces」行、機器輔助——以
-`REVIEW.md` §5.5 為唯一真實來源，本 skill 不重述；照 §5.5 填滿每個槽，機器輔助輸出附在 RAN 段。
+填 `REVIEW.md` §5.5 定義的必填槽；本 skill 不重述其表格或 P1 判定規則。
 
 ### Step 3: Generate PR Comment
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -91,21 +91,8 @@ Run every PR through these four checks, in order:
 ## Wiring verdict — REQUIRED for every new surface in the diff
 
 「存在」≠「有接線」。diff 裡每一個**新面**都必填一列四問，這是必填槽，不是「考慮」bullet；缺槽等同沒審。
-「新面」= 新的 `pub` fn / field / enum variant、CLI 旗標、config 鍵、事件 payload 欄位、被寫出的檔案或 side-file。docs-only 或無新面的 PR 也要寫一行「no new surfaces」——一行不能省，省了就是槽沒填。
-
-每個新面一列，四問各附 `file:line`（本 PR 內或既有碼）：
-
-| 新面 | Writer & shape | Reader（本 PR 內或既有；或「no consumer」） | Failure signal（吞錯／success-only／best-effort？） | Layer reach（旗標→builder→spawn；欄位→store→read-back） |
-|---|---|---|---|---|
-
-判定規則（寫死，不留給審查者裁量）：
-
-- 「no consumer」且沒有具名的後續 issue → **P1**（dead on arrival）。有後續 issue 編號 → 列入 FOLLOW-UP ISSUE，放行。
-- 在 ledger / coordination / cost 路徑上吞錯（`let _ =`、`.ok();`、`unwrap_or_default()` 於寫端、best-effort、只記成功）→ **P1**。
-- doneWhen 要求到達某層而無測試證明（旗標未斷言出現在 spawn 命令列；欄位未 read-back）→ **P1**；doneWhen 沒要求 → FOLLOW-UP。
-- 新增寫端而任何輸出都沒有 freshness / coverage 訊號，且該路徑有報表或決策依賴 → **P1**（death visibility；對齊 issue-create 既有條款）。
-
-機器輔助（審查者 RAN，不是 CI 閘）：`sh scripts/wiring-scan.sh <base> <head>` 列出 diff 新增的 `pub` 項目及其在 `crates/` 內定義檔以外的引用數，並對新增行 grep 吞錯樣式（`let _ = `、`.ok();`、`unwrap_or_default()`、`best-effort`、`silently`）；輸出附在 RAN 段。誤報需要人判，故不進 CI。
+槽的定義——何謂新面、四問表、P1 判定規則、docs-only 的「no new surfaces」行、機器輔助——以
+`REVIEW.md` §5.5 為唯一真實來源，本 skill 不重述；照 §5.5 填滿每個槽，機器輔助輸出附在 RAN 段。
 
 ### Step 3: Generate PR Comment
 


### PR DESCRIPTION
Closes #704
Issue: #704

## Summary

Five skills restated rules owned by `REVIEW.md` (drift class **S3**, `REVIEW.md` §5.2). Replaced each restatement with a bare pointer to the canonical section, so the rules now live in exactly one place. No behaviour change: every pointer resolves to a rule that, today, says what the copy said.

- `fleet-review/SKILL.md` — the §8 index row and the LGTM / Changes Requested bullets no longer restate the P0/P1 threshold; both point at `REVIEW.md` §8. The file's 「不重述」 claim is now true. The §-index table stays (it is already a pointer table).
- `coord-review/SKILL.md`, `pr-review/SKILL.md`, `fleet-worker/SKILL.md`, `pr-review-loop/SKILL.md` — the #629 wiring verdict (four-question table, new-surface definition, P1 adjudication bullets, "no new surfaces" obligation, machine aid) is no longer copied in; each now points at `REVIEW.md` §5.5 as the single source and says "fill the slot defined there".
- `pr-review-loop/SKILL.md` previously pointed at `fleet-review/SKILL.md` for the wiring slot — that restatement chain is gone; it points directly at `REVIEW.md` §5.5.

## Changes

| File | Change |
|---|---|
| `.claude/skills/fleet-review/SKILL.md` | §8 row → `見 REVIEW.md §8（唯一真實來源，本 skill 不重述）`; LGTM/CR bullets → threshold dropped, 「何時成立由 REVIEW.md §8 裁定」 |
| `.claude/skills/coord-review/SKILL.md` | Wiring section: table + new-surface definition + P1 bullets + machine aid → pointer to `REVIEW.md` §5.5 |
| `.claude/skills/pr-review/SKILL.md` | Same as coord-review |
| `.claude/skills/fleet-worker/SKILL.md` | Step 6 self-report table → pointer to the §5.5 required slot (kept: one row per new surface with `file:line`; docs-only needs the line) |
| `.claude/skills/pr-review-loop/SKILL.md` | Slot pointer re-routed from `fleet-review/SKILL.md` to `REVIEW.md` §5.5; copied definition dropped |

5 files changed, 14 insertions(+), 44 deletions(-). No frontmatter (name/description) touched. Only the five owned skill files changed.

## Wiring

no new surfaces

## Verification

Docs-only push: no Cargo gate locally (per ladder); L0 budget ran.

`grep -nE '新面|no new surfaces' .claude/skills/*/SKILL.md` after the change — only pointer text and output-format placeholders remain (no four-question table, no P1 bullets):

```
.claude/skills/coord-review/SKILL.md:134:「存在」≠「有接線」。diff 裡每一個**新面**都必填一列四問，這是必填槽，不是「考慮」bullet；缺槽等同沒審。
.claude/skills/coord-review/SKILL.md:135:槽的定義——何謂新面、四問表、P1 判定規則、docs-only 的「no new surfaces」行、機器輔助——以
.claude/skills/coord-review/SKILL.md:190:Wiring verdict: <per-surface four-question table, or "no new surfaces">
.claude/skills/fleet-review/SKILL.md:24:| §5.5 | wiring verdict——每個新面一列的必填槽；無新面也要寫一行 |
.claude/skills/fleet-worker/SKILL.md:29:6. **開 PR**：…這是 `REVIEW.md` §5.5 定義的必填槽（唯一真實來源，本 skill 不重述其表格與判定規則）…
.claude/skills/pr-review-loop/SKILL.md:15:"no new surfaces" line for docs-only PRs. Do not skip the slot; a missing
.claude/skills/pr-review/SKILL.md:93:「存在」≠「有接線」。diff 裡每一個**新面**都必填一列四問，這是必填槽，不是「考慮」bullet；缺槽等同沒審。
.claude/skills/pr-review/SKILL.md:94:槽的定義——何謂新面、四問表、P1 判定規則、docs-only 的「no new surfaces」行、機器輔助——以
.claude/skills/pr-review/SKILL.md:125:| Wiring | ✅ or ❌ | <per-surface wiring table filled, or "no new surfaces"> |
```

(`:190` and pr-review `:125` are the fixed output-format placeholders that mirror `REVIEW.md` §7's own template, not restated rules.)

```
$ sh scripts/lint-markdown-content.sh
(exit 0)
```

Pointer-resolution check (no behaviour change): `REVIEW.md` §8 today states any P0/P1 → Changes Requested, P0=0 and P1=0 → LGTM + `fleet:reviewed` — exactly what the deleted copies said. `REVIEW.md` §5.5 today states the new-surface definition, the four-question table, the "no new surfaces" line, the four P1 adjudication rules, and the `scripts/wiring-scan.sh` machine aid — exactly what the deleted copies said.

## Open question — #618 brief template (recorded, not re-litigated)

`docs/superpowers/specs/2026-09-02-reviewer-brief-template-v1.md` (#618) contains no `REVIEW.md` reference, and this PR does not add one. Reading adopted: the template is **upstream canon that `REVIEW.md` cites** (listed under Canonical sources), not a third place that should point downward — adding a downward pointer would invert the citation direction. Settled here so the next review does not reopen it.
