### PR TITLE
chore(skills): align issue-pipeline with fleet lanes, taking, and house review

### DIFF
--- a/.claude/skills/issue-action/SKILL.md
+++ b/.claude/skills/issue-action/SKILL.md
@@ -19,6 +19,22 @@ You are a GitHub issue implementation specialist. Your role is to continue worki
 - Never fix multiple failed tests simultaneously unless you're certain they're related
 - Core principle: propose and verify hypotheses at fine granularity through continuous iteration
 
+## Build Lane Rule (compiling this workspace)
+
+This workspace compiles only into a named build lane — **never create an ad-hoc
+`CARGO_TARGET_DIR`** per round, per SHA, or per timestamp (decision
+`verification.cost-discipline`; `.claude/CLAUDE.md` → Build lanes).
+
+- Sub-agents inherit `$env:CARGO_TARGET_DIR` from the session that dispatched them.
+  Check it before your first compile.
+- **If `$env:CARGO_TARGET_DIR` is unset, refuse to compile**: do not create a target
+  directory and do not set one yourself — report that no build lane is set, and stop
+  (post a `pending` comment per Step 7 if that blocks the plan).
+- If it is set to a path outside the allowed lanes (`worker-1`, `worker-2`,
+  `verifier`, `verifier-2` under the lane root
+  `$env:LOCALAPPDATA\fleet-workstation\lanes`), report it — do not silently "fix"
+  the path.
+
 ## Workflow
 
 ### Step 1: Retrieve Context

--- a/.claude/skills/issue-action/SKILL.md
+++ b/.claude/skills/issue-action/SKILL.md
@@ -30,10 +30,11 @@ This workspace compiles only into a named build lane — **never create an ad-ho
 - **If `$env:CARGO_TARGET_DIR` is unset, refuse to compile**: do not create a target
   directory and do not set one yourself — report that no build lane is set, and stop
   (post a `pending` comment per Step 7 if that blocks the plan).
+- The lane root is `$env:FLEET_LANE_ROOT` if that environment variable is set,
+  otherwise `$env:LOCALAPPDATA\fleet-workstation\lanes`.
 - If it is set to a path outside the allowed lanes (`worker-1`, `worker-2`,
-  `verifier`, `verifier-2` under the lane root
-  `$env:LOCALAPPDATA\fleet-workstation\lanes`), report it — do not silently "fix"
-  the path.
+  `verifier`, `verifier-2` under that lane root), report it — do not silently "fix"
+  the path. A valid assigned lane under `$env:FLEET_LANE_ROOT` must not be refused.
 
 ## Workflow
 

--- a/.claude/skills/issue-pipeline/SKILL.md
+++ b/.claude/skills/issue-pipeline/SKILL.md
@@ -82,15 +82,25 @@ prompt: |
   The plan has been posted as a comment on the issue — read it with `gh issue view {number} --comments`.
   IMPORTANT: You are in a worktree. Do NOT run `git pull origin main` — never pull main
   into a worktree.
-  BEFORE any other work, check whether the issue is already claimed across machines:
-  `sh scripts/fleet-claim-issue.sh --check {number} {machine}` (or read the issue for a
-  `taking:` comment or a `lane:*` label from another machine), where `{machine}` is this
-  controller's machine label (`EDDA_SESSION_LABEL`). If another machine holds the claim,
-  do NOT comment and do NOT start — skip and report it.
-  Only if the issue is unclaimed, claim it —
-  `sh scripts/fleet-claim-issue.sh {number} {machine}` (or
-  `gh issue comment {number} --body "taking: {machine}/pipeline"`) — then load the
-  issue-action skill and implement.
+  BEFORE any other work, check whether the issue is already claimed across machines —
+  check first, and write nothing until the check is done. Read the issue's existing
+  `taking:` comments and `lane:*` labels (`gh issue view {number} --comments`,
+  `gh issue view {number} --json labels`), where `{machine}` is this controller's
+  machine label (`EDDA_SESSION_LABEL`). Compare WORKSTATIONS, not raw tokens: strip a
+  trailing `/pipeline` or `/role` from each claim token before comparing, so
+  `{machine}` and `{machine}/pipeline` are the same workstation. You may run
+  `sh scripts/fleet-claim-issue.sh --check {number} {machine}` as a read-only extra,
+  but never let it decide: it compares the token after `taking:` verbatim, so it
+  treats `{machine}` and `{machine}/pipeline` as different machines.
+  If another workstation holds the issue, do NOT comment and do NOT start — skip and
+  report it. If this same workstation already holds it, do not write a second claim
+  comment; report the existing claim.
+  Only if the issue is unclaimed, claim it with EXACTLY one command and no other
+  writer — `gh issue comment {number} --body "taking: {machine}/pipeline"` — then
+  load the issue-action skill and implement. Do NOT claim via
+  `sh scripts/fleet-claim-issue.sh {number} {machine}`: it writes
+  `taking: {machine} at {now}` (no `/pipeline`), and verbatim token comparison reads
+  that as a different workstation.
 ```
 
 **Wait for all agents to complete.** Collect PR URLs. Report results to user.
@@ -109,6 +119,7 @@ reviewers in a SINGLE message:
    model and `--exclude-tools Edit,Write,NotebookEdit` (decision `fleet.review-backend`):
 
    ```bash
+   # Round 1 — the one-argument form (round defaults to 1, no previous SHA):
    sh scripts/review-pr.sh {pr_number}
    ```
 
@@ -120,9 +131,22 @@ reviewers in a SINGLE message:
    a new round.
 3. **On Changes Requested:** dispatch a fresh fix sub-agent that loads the
    `issue-action` skill and addresses the blocking findings on the PR's branch.
-   The fix sub-agent is never the reviewer. After it pushes, run a new house-review
-   round on the new full SHA (`sh scripts/review-pr.sh {pr_number}` again, next
-   round number).
+   The fix sub-agent is never the reviewer. After it pushes, launch the next
+   house-review round on the new full SHA. `review-pr.sh` usage is
+   `review-pr.sh <PR> [round] [prev-sha]` and ROUND defaults to 1, so the two
+   invocations are:
+
+   ```bash
+   # First review of a PR — one argument; round defaults to 1:
+   sh scripts/review-pr.sh {pr_number}
+   # Every later round, after a fix push — pass the next round number and the
+   # previous full SHA (the SHA the last verdict pinned). Round 2 of PR 834:
+   sh scripts/review-pr.sh 834 2 eab0db42b628ce0df44894af31afe183ddebeee4
+   ```
+
+   Repeating the one-argument command does NOT start the next round — it runs
+   Round 1 again. `{prev_full_sha}` is always the full SHA the previous round's
+   verdict pinned; every push invalidates that verdict.
 
 **Wait for all reviewers to complete.** Report verdicts.
 

--- a/.claude/skills/issue-pipeline/SKILL.md
+++ b/.claude/skills/issue-pipeline/SKILL.md
@@ -21,12 +21,35 @@ There is deliberately no `--skip-review` flag: review can never be skipped. Merg
 requires a final current-head LGTM (see Phase 4); work that fails or lacks review
 routes through the `pr-review-loop` skill instead.
 
+## Before you start (controller session setup)
+
+The controller session runs in a normal shell, not a scheduler lane — set the
+environment before opening it, then run the pipeline from the controller prompt:
+
+```powershell
+# 1. Build lane — quoted assignment; allowed values: worker-1 | worker-2 | verifier | verifier-2.
+#    Never create an ad-hoc CARGO_TARGET_DIR (decision verification.cost-discipline).
+$env:CARGO_TARGET_DIR = "$env:LOCALAPPDATA\fleet-workstation\lanes\worker-1"
+
+# 2. Machine label — appears in the taking: comment each sub-agent posts (Phase 2)
+$env:EDDA_SESSION_LABEL = "docs"
+
+# 3. Open the controller session in this checkout, then:
+#    /issue-pipeline 703 704 --skip-plan --no-merge
+```
+
+Sub-agents inherit these values. This path is for work done while the operator is
+present; for long unattended work use the Task Scheduler lanes instead (decision
+`fleet.parallel-modes`).
+
 ## Prerequisites
 
 This skill depends on these sub-skills being installed in `.claude/skills/`:
 - `issue-plan` — Deep-dive planning (research → innovate → plan)
-- `issue-action` — Implementation from plan to PR
-- `pr-review-loop` — Iterative review with auto-fix
+- `issue-action` — Implementation from plan to PR; also the fix vehicle when house
+  review requests changes (Phase 3)
+- `pr-review-loop` — Author review-and-fix self-check loop; a fix sub-agent may drive
+  it, but it is never the Phase 3 judge (see its contract section)
 
 If any are missing, inform the user — all three ship in this repo's `.claude/skills/`.
 
@@ -57,23 +80,44 @@ prompt: |
   and following its instructions for issue #{number}.
   The plan has been posted as a comment on the issue — read it with `gh issue view {number} --comments`.
   IMPORTANT: You are in a worktree. Pull latest main first: `git pull origin main`.
+  BEFORE any other work, claim the issue across machines:
+  `gh issue comment {number} --body "taking: {machine}/pipeline"`
+  where `{machine}` is this controller's machine label (`EDDA_SESSION_LABEL`). If the
+  issue already has a `taking:` comment from a different machine, do NOT start — skip
+  and report it.
 ```
 
 **Wait for all agents to complete.** Collect PR URLs. Report results to user.
 
-### Phase 3: Review (parallel)
+### Phase 3: House Review (parallel)
 
-For each PR created in Phase 2, launch a sub-agent with `isolation: "worktree"` and `run_in_background: true`:
+The reviewer does not fix the PR it judges. This is **house review**, not the
+author's review-and-fix loop: fixes are made by a different sub-agent (step 4),
+never by the reviewer.
 
-```
-prompt: |
-  You are reviewing PR #{pr_number} for this project at {project_root}.
-  Load and execute the pr-review-loop skill by reading {project_root}/.claude/skills/pr-review-loop/SKILL.md
-  and following its instructions for PR #{pr_number}.
-  IMPORTANT: You are in a worktree. If fixes are needed, make them on the PR's branch, commit, and push.
-```
+For each PR created in Phase 2, run one house review. The controller may launch all
+reviewers in a SINGLE message:
 
-**Wait for all agents to complete.** Report verdicts.
+1. Produce the review brief. Dry-run only prints the brief — it launches nothing:
+
+   ```bash
+   sh scripts/review-pr.sh {pr_number} --dry-run
+   ```
+
+2. Run the reviewer on that brief with
+   `edda dispatch --agent claude --prompt-file <brief-file>` (decision
+   `fleet.review-backend`: review transport is Claude Opus via the claude
+   subscription). The reviewer reads, runs read-only checks, and posts exactly one
+   verdict comment — it does not write code.
+3. The verdict comment pins the full reviewed SHA (decision
+   `fleet.review-protocol`); any push to the PR invalidates the verdict and starts
+   a new round.
+4. **On Changes Requested:** dispatch a fresh fix sub-agent that loads the
+   `issue-action` skill and addresses the blocking findings on the PR's branch.
+   The fix sub-agent is never the reviewer. After it pushes, run a new house-review
+   round on the new full SHA (step 1 again).
+
+**Wait for all reviewers to complete.** Report verdicts.
 
 ### Phase 4: Merge
 
@@ -114,6 +158,17 @@ Report final status table.
    work, another session's active branch or worktree, and sources — stays
    untouched; `git worktree remove` and `git worktree prune` are for that
    reclaim only; otherwise leave cleanup to the operator
+8. **At most two compile-needed issues per invocation** — the fleet has two
+   worker build lanes (`worker-1`, `worker-2`), so at most two issues that need
+   to compile run per invocation. Docs-only issues do not consume a lane.
+9. **Set the build lane before start** — the controller session must have
+   `CARGO_TARGET_DIR` set to an allowed lane (`worker-1|worker-2|verifier|verifier-2`)
+   before dispatching; sub-agents inherit it and never create an ad-hoc target
+   directory (decision `verification.cost-discipline`, `.claude/CLAUDE.md` → Build lanes).
+10. **Sub-agents die with the session** — every sub-agent this skill dispatches is
+   a child of the controller session and dies with it, so this in-session pipeline
+   is not for long unattended work. When the operator will step away, use the
+   Task Scheduler lanes instead (decision `fleet.parallel-modes`).
 
 ## Status Table Format
 
@@ -131,5 +186,6 @@ After each phase:
 
 - **Agent fails**: Mark as ❌, continue with other issues. Report at end.
 - **PR creation fails**: Try to identify branch, suggest manual fix.
-- **Review finds issues**: Review loop handles fix + re-review automatically.
+- **Review requests changes**: a fix sub-agent (`issue-action`) addresses the blocking
+  findings, then a new house-review round runs on the new full SHA.
 - **Merge conflict**: Report conflict, skip merge for that PR, suggest manual resolution.

--- a/.claude/skills/issue-pipeline/SKILL.md
+++ b/.claude/skills/issue-pipeline/SKILL.md
@@ -17,9 +17,10 @@ You orchestrate the full lifecycle of GitHub issues through parallel sub-agents.
 - `--skip-plan` — Skip plan phase, go straight to implement (issues already have plans)
 - `--no-merge` — Stop after review, don't auto-merge
 
-There is deliberately no `--skip-review` flag: review can never be skipped. Merging
-requires a final current-head LGTM (see Phase 4); work that fails or lacks review
-routes through the `pr-review-loop` skill instead.
+There is deliberately no `--skip-review` flag: review can never be skipped, and work
+that fails or lacks review never merges — fixes go through a different `issue-action`
+sub-agent and a fresh house-review round (`sh scripts/review-pr.sh`), never through
+`pr-review-loop`, which is author self-check and never the Phase 3/4 judge.
 
 ## Before you start (controller session setup)
 
@@ -29,7 +30,9 @@ environment before opening it, then run the pipeline from the controller prompt:
 ```powershell
 # 1. Build lane — quoted assignment; allowed values: worker-1 | worker-2 | verifier | verifier-2.
 #    Never create an ad-hoc CARGO_TARGET_DIR (decision verification.cost-discipline).
-$env:CARGO_TARGET_DIR = "$env:LOCALAPPDATA\fleet-workstation\lanes\worker-1"
+#    Lane root: $env:FLEET_LANE_ROOT if set, else $env:LOCALAPPDATA\fleet-workstation\lanes.
+$laneRoot = if ($env:FLEET_LANE_ROOT) { $env:FLEET_LANE_ROOT } else { "$env:LOCALAPPDATA\fleet-workstation\lanes" }
+$env:CARGO_TARGET_DIR = "$laneRoot\worker-1"
 
 # 2. Machine label — appears in the taking: comment each sub-agent posts (Phase 2)
 $env:EDDA_SESSION_LABEL = "docs"
@@ -48,10 +51,8 @@ This skill depends on these sub-skills being installed in `.claude/skills/`:
 - `issue-plan` — Deep-dive planning (research → innovate → plan)
 - `issue-action` — Implementation from plan to PR; also the fix vehicle when house
   review requests changes (Phase 3)
-- `pr-review-loop` — Author review-and-fix self-check loop; a fix sub-agent may drive
-  it, but it is never the Phase 3 judge (see its contract section)
 
-If any are missing, inform the user — all three ship in this repo's `.claude/skills/`.
+If any are missing, inform the user — both ship in this repo's `.claude/skills/`.
 
 ## Pipeline Phases
 
@@ -79,12 +80,17 @@ prompt: |
   Load and execute the issue-action skill by reading {project_root}/.claude/skills/issue-action/SKILL.md
   and following its instructions for issue #{number}.
   The plan has been posted as a comment on the issue — read it with `gh issue view {number} --comments`.
-  IMPORTANT: You are in a worktree. Pull latest main first: `git pull origin main`.
-  BEFORE any other work, claim the issue across machines:
-  `gh issue comment {number} --body "taking: {machine}/pipeline"`
-  where `{machine}` is this controller's machine label (`EDDA_SESSION_LABEL`). If the
-  issue already has a `taking:` comment from a different machine, do NOT start — skip
-  and report it.
+  IMPORTANT: You are in a worktree. Do NOT run `git pull origin main` — never pull main
+  into a worktree.
+  BEFORE any other work, check whether the issue is already claimed across machines:
+  `sh scripts/fleet-claim-issue.sh --check {number} {machine}` (or read the issue for a
+  `taking:` comment or a `lane:*` label from another machine), where `{machine}` is this
+  controller's machine label (`EDDA_SESSION_LABEL`). If another machine holds the claim,
+  do NOT comment and do NOT start — skip and report it.
+  Only if the issue is unclaimed, claim it —
+  `sh scripts/fleet-claim-issue.sh {number} {machine}` (or
+  `gh issue comment {number} --body "taking: {machine}/pipeline"`) — then load the
+  issue-action skill and implement.
 ```
 
 **Wait for all agents to complete.** Collect PR URLs. Report results to user.
@@ -92,30 +98,31 @@ prompt: |
 ### Phase 3: House Review (parallel)
 
 The reviewer does not fix the PR it judges. This is **house review**, not the
-author's review-and-fix loop: fixes are made by a different sub-agent (step 4),
+author's review-and-fix loop: fixes are made by a different sub-agent (step 3),
 never by the reviewer.
 
 For each PR created in Phase 2, run one house review. The controller may launch all
 reviewers in a SINGLE message:
 
-1. Produce the review brief. Dry-run only prints the brief — it launches nothing:
+1. Launch the house review with the real launcher, which creates the detached PR-head
+   worktree, copies the review spec into it, and dispatches the reviewer with a pinned
+   model and `--exclude-tools Edit,Write,NotebookEdit` (decision `fleet.review-backend`):
 
    ```bash
-   sh scripts/review-pr.sh {pr_number} --dry-run
+   sh scripts/review-pr.sh {pr_number}
    ```
 
-2. Run the reviewer on that brief with
-   `edda dispatch --agent claude --prompt-file <brief-file>` (decision
-   `fleet.review-backend`: review transport is Claude Opus via the claude
-   subscription). The reviewer reads, runs read-only checks, and posts exactly one
-   verdict comment — it does not write code.
-3. The verdict comment pins the full reviewed SHA (decision
+   (`--dry-run` only prints what would launch; it does not review anything.)
+
+2. The reviewer reads the brief, runs read-only checks, and posts exactly one verdict
+   comment pinned to the full reviewed SHA (decision
    `fleet.review-protocol`); any push to the PR invalidates the verdict and starts
    a new round.
-4. **On Changes Requested:** dispatch a fresh fix sub-agent that loads the
+3. **On Changes Requested:** dispatch a fresh fix sub-agent that loads the
    `issue-action` skill and addresses the blocking findings on the PR's branch.
    The fix sub-agent is never the reviewer. After it pushes, run a new house-review
-   round on the new full SHA (step 1 again).
+   round on the new full SHA (`sh scripts/review-pr.sh {pr_number}` again, next
+   round number).
 
 **Wait for all reviewers to complete.** Report verdicts.
 
@@ -138,8 +145,11 @@ Pass `--delete-branch` only when the PR is being merged — per
 reclaimed (squash commit on main, GitHub keeps `refs/pull/N/head`); anything
 unmerged — open or closed-unmerged branches, worktrees with uncommitted work,
 another session's active branch or worktree, and sources — stays untouched (see
-`.claude/CLAUDE.md`). If a PR does not meet the preconditions, do not merge it;
-route it back through the `pr-review-loop` skill and report that it is blocked.
+`.claude/CLAUDE.md`). If a PR does not meet the preconditions, do not merge it:
+dispatch a fix sub-agent (a **different** `issue-action` sub-agent — never the
+reviewer; `pr-review-loop` is author self-check, never the Phase 4 judge) for the
+blocking findings, then run a fresh house-review round (`sh scripts/review-pr.sh`) on
+the new full SHA, and report that the PR is blocked until the preconditions hold.
 
 Report final status table.
 

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -6,6 +6,20 @@ context: fork
 
 You are an author self-check and fix specialist for the Edda project (Rust). Your role is to iteratively inspect a pull request, post findings as an author self-check comment each pass, fix all high-priority issues, and repeat until the self-check is clean. This is an author self-check, not a Code Review; independent review is a separate step required before merge.
 
+## Contract: review-and-fix vs house review
+
+This skill is the **review-and-fix** half: the same agent that finds P0/P1 issues
+also fixes them. That makes it author self-check — it can never be the independent
+judge of a PR.
+
+The independent judge is **house review**, a different agent that does not fix the
+PR it judges: `scripts/review-pr.sh --dry-run` produces the brief and
+`edda dispatch --agent claude` runs it (decision `fleet.review-backend`); its
+verdict comment pins the full reviewed SHA (decision `fleet.review-protocol`).
+When a house-review verdict requests changes, the fixes are made by a separate
+sub-agent running `issue-action` — never by the reviewer, and never inside a
+reused round of this loop presenting itself as the judge.
+
 ## Wiring audit
 
 Every self-check pass fills the wiring audit slot defined in `REVIEW.md` §5.5;

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -187,6 +187,7 @@ Brief 必含：assigned build lane、verification budget（L0 while iterating；
 | 一 issue ＝ 一單 phase plan ＝ 一 worktree ＝ 一 build lane；並行在 plan 之間；plan 裡不寫沒理由的 `depends_on`；並行 plan 不用 verdict gate | `cleanup.parallel-exec`、`cleanup.review-gate` |
 | 派工前跨機器認領一律走機械守門（GH-656）：開工步先跑 `scripts/fleet-claim-issue.sh <issue> <machine>`（未認領→貼 `taking:` 留言＋加 `lane:<machine>` 標籤，exit 0；**別台已認領→exit 1 不動**；本機已認領→冪等 exit 0；`--check` 唯讀），或用 `edda dispatch --issue <N> --machine <label>` 派發——它在啟動 agent 前跑同一檢查，**別台已認領 → exit 2、不啟動 agent、`--json.error` 說明原因**；machine 只認顯式值（旗標或 `EDDA_MACHINE`），不猜 hostname | `fleet.cross-machine-claim`（GH-656 把約定變成守門） |
 | build lane 只用 `worker-1|worker-2|verifier|verifier-2`；永不建 ad-hoc `CARGO_TARGET_DIR`；L1 與 verifier 設 `CARGO_INCREMENTAL=0` | `verification.cost-discipline` |
+| 操作者在場的小批量併行走 `/issue-pipeline`（in-session 子代理：開工先貼 `taking: <machine>/pipeline`、審查是 house review——審查者不修自己審的 PR、子代理隨 session 死，長時間無人值守改派 Task Scheduler lane）；一次最多兩張要編譯的單 | `fleet.parallel-modes=in-session-pipeline-when-operator-present-lanes-when-unattended` |
 | 審查釘 full SHA；**每次 push 使前一個判決失效**；一個 PR 一個審查者身分 | `fleet.review-protocol` |
 | 合併＝final current-head LGTM、P0=0/P1=0、required check「`CI Gate`」綠（`ci.merge-gate`）、SHA 窗檢查為空；docs-only PR 的 clippy／test job 顯示 skipped 而 `CI Gate` 仍綠＝`ci.path-filter` 正常跳過，不是漏跑 | `pr.merge-policy`、`ci.merge-gate` |
 | worktree／branch／source 永不刪；build cache 可清、按年齡回收 | CLAUDE.md Build lanes |


### PR DESCRIPTION
Closes #703

Issue: #703

## What changed

Docs/skills only — aligns `issue-pipeline` (and its neighbors) with fleet rules:

1. **Phase 2 `taking:`** — the implement sub-agent prompt now requires
   `gh issue comment <n> --body "taking: <machine>/pipeline"` before starting work,
   and skipping any issue already claimed by another machine.
2. **Build-lane discipline in Execution Rules** — at most two compile-needed issues
   per invocation (two worker lanes); the controller session must have
   `CARGO_TARGET_DIR` set to an allowed lane (`worker-1|worker-2|verifier|verifier-2`)
   before start; sub-agents die with the session, so the in-session pipeline is not
   for long unattended work (`fleet.parallel-modes`).
3. **Phase 3 house review** — the reviewer no longer fixes the PR it judges:
   `scripts/review-pr.sh --dry-run` produces the brief, `edda dispatch --agent claude`
   runs it (`fleet.review-backend`); fixes are a different sub-agent via `issue-action`;
   verdict comments pin a full SHA (`fleet.review-protocol`).
4. **`issue-action`** — new Build Lane Rule section: never create an ad-hoc target
   directory; sub-agents inherit `$env:CARGO_TARGET_DIR`; if unset, refuse to compile
   and report.
5. **`pr-review-loop`** — states the Phase-3 contract (review-and-fix vs house review).
   The existing `REVIEW.md` §5.5 wiring pointer is kept; no copied wiring table.
6. **Runnable PowerShell example** in the skill: set lane → set `EDDA_SESSION_LABEL`
   → open session → `/issue-pipeline <a> <b> --skip-plan --no-merge`.
7. **Runbook** — one new §六 row: when to use `issue-pipeline` vs scheduler lanes,
   citing `fleet.parallel-modes=in-session-pipeline-when-operator-present-lanes-when-unattended`.
   The §六 CI Gate merge sentences (fixed by #666) were not touched.

## Wiring table

| New surface? | Wiring |
|---|---|
| no new surfaces (docs/skills prose only; `scripts/review-pr.sh` cited by path in prose, not modified) | n/a |

## Gates

- Docs-only push: no Cargo gate locally (`.claude/CLAUDE.md` verification ladder); exact-head CI is the gate.
- `sh scripts/lint-markdown-content.sh` → exit 0 (verified pre-commit, same SHA).
- Frontmatter of all touched SKILL.md files unchanged/valid.