### PR TITLE
chore(build): build-hygiene cleanup (7 unused dirs deps, redundant CI env, CLAUDE.md §3.1, thin ban reason) (#821)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -52,6 +52,18 @@ Rust development principles and conventions for the edda project.
 - CI runs: `cargo clippy --workspace --all-targets`
 - `RUSTFLAGS: -Dwarnings` in CI — warnings are errors
 
+Workspace method bans:
+
+- Method bans are configured in `clippy.toml` under `disallowed-methods`, each
+  entry carrying the concrete failure reason it prevents (e.g. `dirs::home_dir`
+  vs `std::env::home_dir` disagreeing on Windows).
+- Bans are DefId-matched: aliases, re-exports, and fully-qualified paths are
+  all caught.
+- Limitation: a `disallowed-methods` entry for a crate absent from a given
+  crate's dependency graph is silently inert for that crate — clippy cannot
+  resolve the DefId, so the ban does not fire there. A ban on `dirs` therefore
+  only protects crates that (transitively) depend on `dirs`.
+
 ### 3.2 No unsafe
 
 ```rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
-  # Trim debug info in CI: keeps readable backtraces (function name + line) but
-  # skips the heavy PDB generation and linking that dominate Windows build time.
-  CARGO_PROFILE_DEV_DEBUG: line-tables-only
-  CARGO_PROFILE_TEST_DEBUG: line-tables-only
 
 jobs:
   # Path-aware triage (#631): decide once whether the diff touches code. If it

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,6 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "blake3",
- "dirs",
  "edda-aggregate",
  "edda-core",
  "edda-derive",
@@ -797,7 +796,6 @@ name = "edda-bridge-codex"
 version = "0.4.0"
 dependencies = [
  "anyhow",
- "dirs",
  "edda-bridge-claude",
  "edda-core",
  "edda-derive",
@@ -816,7 +814,6 @@ name = "edda-bridge-cursor"
 version = "0.4.0"
 dependencies = [
  "anyhow",
- "dirs",
  "edda-bridge-claude",
  "edda-core",
  "edda-pack",
@@ -833,7 +830,6 @@ name = "edda-bridge-hermes"
 version = "0.4.0"
 dependencies = [
  "anyhow",
- "dirs",
  "edda-bridge-claude",
  "edda-core",
  "edda-derive",
@@ -853,7 +849,6 @@ name = "edda-bridge-openclaw"
 version = "0.4.0"
 dependencies = [
  "anyhow",
- "dirs",
  "edda-bridge-claude",
  "edda-core",
  "edda-derive",
@@ -974,7 +969,6 @@ name = "edda-ledger"
 version = "0.4.0"
 dependencies = [
  "anyhow",
- "dirs",
  "edda-core",
  "fs2",
  "globset",
@@ -1124,7 +1118,6 @@ name = "edda-transcript"
 version = "0.4.0"
 dependencies = [
  "anyhow",
- "dirs",
  "edda-core",
  "edda-store",
  "fs2",

--- a/clippy.toml
+++ b/clippy.toml
@@ -9,5 +9,5 @@ too-many-lines-threshold = 150
 # Methods banned workspace-wide, each with the failure it prevents.
 disallowed-methods = [
     { path = "dirs::home_dir", reason = "on Windows this is SHGetKnownFolderPath(FOLDERID_Profile) (dirs 6.0.0 src/win.rs:5 -> dirs-sys 0.5.0 src/lib.rs:172) and reads neither HOME nor USERPROFILE, so it disagrees with the lane wrapper that fleet.lane-launcher requires to set HOME, and with any Node tool's os.homedir(); resolve through edda_core::paths::home_dir" },
-    { path = "std::env::home_dir", reason = "resolve through edda_core::paths::home_dir so every home-anchored path in the workspace agrees" },
+    { path = "std::env::home_dir", reason = "on Windows reads USERPROFILE whereas dirs::home_dir reads SHGetKnownFolderPath, producing silent divergence across home-anchored paths; resolve through edda_core::paths::home_dir" },
 ]

--- a/crates/edda-bridge-claude/Cargo.toml
+++ b/crates/edda-bridge-claude/Cargo.toml
@@ -29,7 +29,6 @@ serde_json.workspace = true
 time.workspace = true
 ulid.workspace = true
 globset.workspace = true
-dirs.workspace = true
 regex.workspace = true
 blake3.workspace = true
 ureq = "3"

--- a/crates/edda-bridge-codex/Cargo.toml
+++ b/crates/edda-bridge-codex/Cargo.toml
@@ -22,7 +22,6 @@ anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 time.workspace = true
-dirs.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/edda-bridge-cursor/Cargo.toml
+++ b/crates/edda-bridge-cursor/Cargo.toml
@@ -17,7 +17,6 @@ edda-pack = { path = "../edda-pack", version = "0.4.0" }
 edda-postmortem = { path = "../edda-postmortem", version = "0.4.0" }
 edda-store = { path = "../edda-store", version = "0.4.0" }
 anyhow.workspace = true
-dirs.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 time.workspace = true

--- a/crates/edda-bridge-hermes/Cargo.toml
+++ b/crates/edda-bridge-hermes/Cargo.toml
@@ -23,7 +23,6 @@ serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 time.workspace = true
-dirs.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/edda-bridge-openclaw/Cargo.toml
+++ b/crates/edda-bridge-openclaw/Cargo.toml
@@ -20,7 +20,6 @@ anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 time.workspace = true
-dirs.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/edda-ledger/Cargo.toml
+++ b/crates/edda-ledger/Cargo.toml
@@ -25,7 +25,6 @@ sha2.workspace = true
 hex.workspace = true
 tracing.workspace = true
 globset.workspace = true
-dirs.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/edda-transcript/Cargo.toml
+++ b/crates/edda-transcript/Cargo.toml
@@ -18,7 +18,6 @@ thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 fs2.workspace = true
-dirs.workspace = true
 time.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
Issue: #821
Closes #821

### Summary

Build-hygiene cleanup per Issue #821:
1. Drop `dirs.workspace = true` from 7 crates where it is never called (`edda-bridge-{claude,codex,cursor,hermes,openclaw}`, `edda-ledger`, `edda-transcript`). Real users `edda-core` and `edda-store` keep the dependency.
2. Remove `CARGO_PROFILE_DEV_DEBUG` / `CARGO_PROFILE_TEST_DEBUG` from `.github/workflows/ci.yml` env; root Cargo.toml `[profile.dev] debug = "line-tables-only"` is now the single source of truth.
3. Document workspace method bans in `.claude/CLAUDE.md` §3.1 (`disallowed-methods`, DefId matching, inert-when-crate-absent limitation).
4. State the Windows divergence (`USERPROFILE` vs `SHGetKnownFolderPath`) in `clippy.toml` `std::env::home_dir` ban reason.

### Self-Reported Wiring & Verification

- `cargo check --workspace` clean
- `cargo fmt --all --check` clean
- `cargo clippy -p <crate> --all-targets -- -D warnings` on all 7 touched crates clean
- `sh scripts/lint-markdown-content.sh` clean
