### PR TITLE
chore(fleet): drop fleet:ready at merge and skip delivered issues when picking

### DIFF
--- a/.claude/skills/fleet-worker/SKILL.md
+++ b/.claude/skills/fleet-worker/SKILL.md
@@ -16,7 +16,7 @@ description: Use when running one lane of the Fleet execution loop — pick a si
 ## 一圈流程
 
 1. **領單**（claim 協議，原子）：
-   - 找最老 ready 單：`gh issue list --label fleet:ready --state open --json number,title,createdAt --jq 'sort_by(.createdAt)[0]'`
+   - 找最老 ready 單：`sh scripts/fleet/ready-queue-lint.sh --oldest`——只回傳最老且**尚未交付**的 ready 單。腳本用合併 PR 機器檢查（GH-665）剔除已交付仍掛 `fleet:ready` 的單，不做記憶判斷；gh 失敗會 fail closed，絕不把壞掉的查詢誤判成「隊列空」。
    - 無單 → **idle 退避**，回報「隊列空」並結束。絕不自己發明工作。
    - 搶：`gh issue edit <n> --add-label fleet:claimed --remove-label fleet:ready --add-assignee @me`
    - 留 lease：`gh issue comment <n> --body "claimed by <session-id> at <ISO8601 now>"`

--- a/.claude/skills/parallel-wave/SKILL.md
+++ b/.claude/skills/parallel-wave/SKILL.md
@@ -21,6 +21,12 @@ invariant, API/schema order). Plan YAMLs live outside the repo (scratchpad or
 
 ## Layer 1 — static judgment (before dispatch)
 
+Ready-queue intake is a machine check, not memory (GH-665): source candidate
+issues from `scripts/fleet/ready-queue-lint.sh`, never a raw
+`gh issue list --label fleet:ready` — the script excludes open issues whose
+delivery PR already merged, so a delivered issue still carrying `fleet:ready`
+is never dispatched.
+
 Derive each issue's predicted write surface (paths + symbols) from its scope
 against the crate map. Pairwise intersect:
 

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -274,9 +274,13 @@ clear labels on its own:
 # Issues delivered by this PR: closing-keyword references in the PR body
 # ('Closes #N', 'Fixes #N', 'Resolves #N' with inflections). 'Issue: #N',
 # 'tracked in #N', 'see #N' are mentions, not delivery — never match them.
+# The second grep extracts only the number after '#': the first match's
+# leading boundary group is part of the -o output and may itself be a digit
+# ('v2Closes #20' matches '2Closes #20'), so extracting every digit run
+# would turn that digit into a second label target.
 for issue in $(gh pr view --json body -q .body \
     | grep -ioE '(^|[^A-Za-z])(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' \
-    | grep -oE '[0-9]+' | sort -u); do
+    | grep -oE '#[0-9]+' | tr -d '#' | sort -u); do
     for label in fleet:ready fleet:claimed; do
         if gh issue view "$issue" --json labels -q '.labels[].name' \
             | grep -qx "$label"; then

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -265,12 +265,17 @@ another session's active branch or worktree, and sources — stays untouched (se
 `Closes #N` closes the issue but does **not** touch its labels: after the
 merge, the delivered issue still carries `fleet:ready` and stays pickable
 (GH-665). Immediately after a squash merge succeeds, clear the fleet queue
-labels from every issue the PR delivers:
+labels from every issue the PR delivers — a **closing keyword**
+(`Closes`/`Fixes`/`Resolves` `#N`) is what marks delivery. `Issue: #N` is the
+partial-delivery / non-closing reference (REVIEW.md U2/U3) and must never
+clear labels on its own:
 
 ```bash
-# Issues delivered by this PR: closing references in the PR body
+# Issues delivered by this PR: closing-keyword references in the PR body
+# ('Closes #N', 'Fixes #N', 'Resolves #N' with inflections). 'Issue: #N',
+# 'tracked in #N', 'see #N' are mentions, not delivery — never match them.
 for issue in $(gh pr view --json body -q .body \
-    | grep -ioE '(closes|fixes|resolves|issue):? #[0-9]+' \
+    | grep -ioE '(^|[^A-Za-z])(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' \
     | grep -oE '[0-9]+' | sort -u); do
     for label in fleet:ready fleet:claimed; do
         if gh issue view "$issue" --json labels -q '.labels[].name' \
@@ -443,7 +448,7 @@ gh pr comment "$PR_NUMBER" --body "$COMMENT_CONTENT"
 2. **Run pre-commit checks** - Never skip quality checks
 3. **Never merge with failing checks** - Code quality is non-negotiable
 4. **Use squash merge** - Keeps main history clean
-5. **Clear fleet delivery labels after merge** - `Closes #N` closes the issue but not its labels; a delivered issue without the label clear stays pickable forever
+5. **Clear fleet delivery labels after merge** - `Closes #N` closes the issue but not its labels; a delivered issue without the label clear stays pickable forever. Only closing keywords (`Closes`/`Fixes`/`Resolves` #N) count — `Issue: #N` alone never clears labels
 6. **Confirm merge completion** - Verify PR state is MERGED
 7. **Keep user informed** - Clear status at each step
 

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -260,7 +260,33 @@ another session's active branch or worktree, and sources — stays untouched (se
 - Keeps main branch history clean and linear
 - Combines all commits into single commit
 
-### Step 4: Switch to Main and Pull Latest
+### Step 4: Clear Delivery Labels from the Delivered Issue
+
+`Closes #N` closes the issue but does **not** touch its labels: after the
+merge, the delivered issue still carries `fleet:ready` and stays pickable
+(GH-665). Immediately after a squash merge succeeds, clear the fleet queue
+labels from every issue the PR delivers:
+
+```bash
+# Issues delivered by this PR: closing references in the PR body
+for issue in $(gh pr view --json body -q .body \
+    | grep -ioE '(closes|fixes|resolves|issue):? #[0-9]+' \
+    | grep -oE '[0-9]+' | sort -u); do
+    for label in fleet:ready fleet:claimed; do
+        if gh issue view "$issue" --json labels -q '.labels[].name' \
+            | grep -qx "$label"; then
+            gh issue edit "$issue" --remove-label "$label"
+        fi
+    done
+done
+```
+
+Only a squash-merged PR counts as delivery. If the merge was blocked or the PR
+closed unmerged, skip this step. Do not invent a `fleet:delivered` label —
+removing `fleet:ready` at the merge end plus the machine check in
+`scripts/fleet/ready-queue-lint.sh` at the pick end are the whole mechanism.
+
+### Step 5: Switch to Main and Pull Latest
 
 ```bash
 git checkout main
@@ -340,8 +366,9 @@ Actions Completed:
    1. Merge preconditions verified (final current-head LGTM, P0=0, P1=0, required checks green)
    2. CI checks validated
    3. PR squash merged
-   4. Switched to main
-   5. Pulled latest changes
+   4. fleet:ready / fleet:claimed cleared from delivered issue(s)
+   5. Switched to main
+   6. Pulled latest changes
 
 Latest commit: <hash> <message>
 ```
@@ -416,8 +443,9 @@ gh pr comment "$PR_NUMBER" --body "$COMMENT_CONTENT"
 2. **Run pre-commit checks** - Never skip quality checks
 3. **Never merge with failing checks** - Code quality is non-negotiable
 4. **Use squash merge** - Keeps main history clean
-5. **Confirm merge completion** - Verify PR state is MERGED
-6. **Keep user informed** - Clear status at each step
+5. **Clear fleet delivery labels after merge** - `Closes #N` closes the issue but not its labels; a delivered issue without the label clear stays pickable forever
+6. **Confirm merge completion** - Verify PR state is MERGED
+7. **Keep user informed** - Clear status at each step
 
 ## Related Skills
 

--- a/scripts/fleet/ready-queue-lint.sh
+++ b/scripts/fleet/ready-queue-lint.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# ready-queue-lint.sh — machine check that `fleet:ready` never selects a
+# delivered issue (GH-665). A merged PR closes the issue but not its labels,
+# so delivered issues can still carry `fleet:ready` and stay pickable. This
+# script filters the queue against merged PR bodies (`Closes #N`, `Issue: #N`,
+# `Fixes #N`, `Resolves #N`) — a machine check against live data, not memory.
+#
+# Usage:
+#   sh scripts/fleet/ready-queue-lint.sh             # list pickable issues, oldest first
+#   sh scripts/fleet/ready-queue-lint.sh --oldest    # print only the oldest pickable issue
+#   sh scripts/fleet/ready-queue-lint.sh --check     # exit 1 if any open fleet:ready
+#                                                    # issue already has a merged PR
+#
+# Output: pickable issues on stdout as `#<number> <title>`. Issues excluded as
+# delivered are reported on stderr. Any gh failure aborts (fail closed) — a
+# broken gh must never look like "queue empty" (same rule as
+# scripts/fleet-claim-issue.sh).
+set -eu
+
+cd "$(git rev-parse --show-toplevel)"
+
+check=0
+oldest=0
+for arg in "$@"; do
+    case "$arg" in
+        --check) check=1 ;;
+        --oldest) oldest=1 ;;
+        *) echo "usage: $0 [--check] [--oldest]" >&2; exit 2 ;;
+    esac
+done
+
+issues=$(mktemp)
+prs=$(mktemp)
+trap 'rm -f "$issues" "$prs"' 0 HUP INT TERM
+
+gh issue list --label fleet:ready --state open --json number,title,createdAt >"$issues"
+gh pr list --state merged --limit 500 --json number,body >"$prs"
+
+# delivered($n): some merged PR body references issue $n with a word boundary
+# (#12 must not match #123 or #1234). Bodies without a reference are ignored.
+jq_filter='
+    def delivered($prs; $num):
+        any($prs[];
+            .body != null
+            and (.body | test("([^0-9]|^)#" + ($num|tostring) + "([^0-9]|$)")));
+'
+
+pickable=$(jq -r --slurpfile prs "$prs" "$jq_filter"'
+    sort_by(.createdAt)
+    | .[]
+    | select(delivered($prs[0]; .number) | not)
+    | "#\(.number) \(.title)"
+' "$issues")
+
+stale=$(jq -r --slurpfile prs "$prs" "$jq_filter"'
+    sort_by(.createdAt)
+    | .[]
+    | select(delivered($prs[0]; .number))
+    | "#\(.number) \(.title)"
+' "$issues")
+
+if [ "$oldest" -eq 1 ]; then
+    pickable=$(printf '%s\n' "$pickable" | head -n 1)
+fi
+
+if [ -n "$stale" ]; then
+    printf '%s\n' "$stale" | while IFS= read -r line; do
+        echo "ready-queue-lint: delivered but still fleet:ready (drop the label at merge): $line" >&2
+    done
+fi
+
+if [ -n "$pickable" ]; then
+    printf '%s\n' "$pickable"
+fi
+
+if [ "$check" -eq 1 ] && [ -n "$stale" ]; then
+    exit 1
+fi

--- a/scripts/fleet/ready-queue-lint.sh
+++ b/scripts/fleet/ready-queue-lint.sh
@@ -2,8 +2,11 @@
 # ready-queue-lint.sh — machine check that `fleet:ready` never selects a
 # delivered issue (GH-665). A merged PR closes the issue but not its labels,
 # so delivered issues can still carry `fleet:ready` and stay pickable. This
-# script filters the queue against merged PR bodies (`Closes #N`, `Issue: #N`,
-# `Fixes #N`, `Resolves #N`) — a machine check against live data, not memory.
+# script filters the queue against merged PR bodies, counting only closing
+# keywords (`Closes #N`, `Fixes #N`, `Resolves #N`) as delivery — a machine
+# check against live data, not memory. An ordinary mention (`Issue: #N`,
+# `tracked in #N`, `see #N`) is the partial-delivery / non-closing reference
+# (REVIEW.md U2/U3) and must never hide a ready issue.
 #
 # Usage:
 #   sh scripts/fleet/ready-queue-lint.sh             # list pickable issues, oldest first
@@ -36,13 +39,16 @@ trap 'rm -f "$issues" "$prs"' 0 HUP INT TERM
 gh issue list --label fleet:ready --state open --json number,title,createdAt >"$issues"
 gh pr list --state merged --limit 500 --json number,body >"$prs"
 
-# delivered($n): some merged PR body references issue $n with a word boundary
-# (#12 must not match #123 or #1234). Bodies without a reference are ignored.
+# delivered($n): some merged PR body closes issue $n — a closing keyword
+# (`closes`/`fixes`/`resolves`, with inflections, case-insensitive) followed
+# by a word-bounded issue reference (#12 must not match #123 or #1234).
+# Mentions without a closing keyword (`Issue: #N`, `tracked in #N`, `see #N`)
+# are not delivery and bodies without a reference are ignored.
 jq_filter='
     def delivered($prs; $num):
         any($prs[];
             .body != null
-            and (.body | test("([^0-9]|^)#" + ($num|tostring) + "([^0-9]|$)")));
+            and (.body | test("(^|[^A-Za-z])(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#" + ($num|tostring) + "([^0-9]|$)"; "i")));
 '
 
 pickable=$(jq -r --slurpfile prs "$prs" "$jq_filter"'

--- a/scripts/fleet/test-ready-queue-lint.sh
+++ b/scripts/fleet/test-ready-queue-lint.sh
@@ -34,18 +34,19 @@ esac
 STUB
 chmod +x "$work/bin/gh"
 
-# Issue 12 delivered by PR 100 ("Closes #12"), issue 34 by PR 101
-# ("Issue: #34"). Issue 123 must be picked even though PR bodies mention
-# "#123" as part of "#1234" (word-boundary proof), and issue 20 is clean.
+# Issue 12 delivered by PR 100 ("Closes #12"). Issue 34 is only mentioned
+# ("tracked in #34") — a non-closing reference must NOT deliver it. Issue 123
+# must be picked even though PR bodies mention "#123" as part of "#1234"
+# (word-boundary proof), and issue 20 is clean.
 MIXED_ISSUES='[
   {"number":20,"title":"clean ready","createdAt":"2026-01-02T00:00:00Z"},
   {"number":12,"title":"delivered still ready","createdAt":"2026-01-01T00:00:00Z"},
-  {"number":34,"title":"delivered too","createdAt":"2026-01-03T00:00:00Z"},
+  {"number":34,"title":"mention only stays ready","createdAt":"2026-01-03T00:00:00Z"},
   {"number":123,"title":"boundary ready","createdAt":"2026-01-04T00:00:00Z"}
 ]'
 MIXED_PRS='[
   {"number":100,"body":"Closes #12\n\nTest evidence."},
-  {"number":101,"body":"Issue: #34\nalso mentions #1234 in prose"},
+  {"number":101,"body":"Follow-up tracked in #34.\nalso mentions #1234 in prose"},
   {"number":102,"body":null}
 ]'
 CLEAN_ISSUES='[
@@ -81,7 +82,8 @@ grep -q '#20 clean ready' "$out" || fail "clean ready issue must be listed: $(ca
 grep -q 'boundary ready' "$out" \
     || fail "#123 must survive a '#1234' mention (word boundary): $(cat "$out")"
 grep -q '#12 delivered' "$out" && fail "delivered issue #12 must be excluded: $(cat "$out")"
-grep -q '#34 delivered' "$out" && fail "delivered issue #34 must be excluded: $(cat "$out")"
+grep -q '#34 mention' "$out" \
+    || fail "a mention-only body ('tracked in #34') must not deliver #34: $(cat "$out")"
 [ "$(head -n 1 "$out")" = "#20 clean ready" ] \
     || fail "listing must be oldest first: $(cat "$out")"
 grep -q '#12' "$err" || fail "excluded issue must be reported on stderr: $(cat "$err")"
@@ -92,15 +94,17 @@ rc=0
 run_case "$MIXED_ISSUES" "$MIXED_PRS" --oldest > "$out" 2> "$err" || rc=$?
 [ "$rc" -eq 0 ] || fail "--oldest should exit 0, got $rc"
 [ "$(wc -l < "$out")" -eq 1 ] || fail "--oldest must print one line: $(cat "$out")"
-[ "$(cat "$out")" = "#20 clean ready" ] || fail "--oldest picked the wrong issue: $(cat "$out")"
+[ "$(cat "$out")" = "#20 clean ready" ] \
+    || fail "--oldest picked the wrong issue: $(cat "$out")"
 echo "ok 2 --oldest returns exactly the oldest pickable issue"
 
 # ── 3. --check: stale ready issues fail the check and are named ──
 rc=0
 run_case "$MIXED_ISSUES" "$MIXED_PRS" --check > "$out" 2> "$err" || rc=$?
 [ "$rc" -eq 1 ] || fail "--check with stale issues should exit 1, got $rc"
-grep -q '#12' "$err" && grep -q '#34' "$err" \
+grep -q '#12' "$err" \
     || fail "--check must name the stale issues: $(cat "$err")"
+grep -q '#34' "$err" && fail "mention-only #34 must not be flagged stale: $(cat "$err")"
 echo "ok 3 --check exits 1 and names the stale issues"
 
 # ── 4. --check on a clean queue: exit 0 ──
@@ -122,18 +126,36 @@ run_case "$ISSUE_123" "$HIT" --check > "$out" 2> "$err" || rc=$?
 [ "$rc" -eq 1 ] || fail "'Fixes #123' must deliver #123, got exit $rc"
 echo "ok 5 boundary: '#1234' is not a delivery, 'Fixes #123' is"
 
-# ── 6. usage errors exit 2 ──
+# ── 6. closing keyword only: mentions never deliver, any keyword inflection does ──
+ISSUE_20='[{"number":20,"title":"keyword semantics","createdAt":"2026-01-01T00:00:00Z"}]'
+for body in 'Follow-up tracked in #20.' 'Issue: #20' 'see #20 for context' 'Closing: #20'; do
+    rc=0
+    run_case "$ISSUE_20" "[{\"number\":7,\"body\":\"$body\"}]" --check \
+        > "$out" 2> "$err" || rc=$?
+    [ "$rc" -eq 0 ] || fail "non-closing body '$body' must not deliver #20, got exit $rc: $(cat "$err")"
+    grep -q '#20 keyword semantics' "$out" \
+        || fail "non-closing body '$body' must leave #20 pickable: $(cat "$out")"
+done
+for body in 'Closes #20' 'closes #20' 'Fixed #20' 'Resolves #20' 'PR resolves #20 tonight'; do
+    rc=0
+    run_case "$ISSUE_20" "[{\"number\":7,\"body\":\"$body\"}]" --check \
+        > "$out" 2> "$err" || rc=$?
+    [ "$rc" -eq 1 ] || fail "closing body '$body' must deliver #20, got exit $rc"
+done
+echo "ok 6 closing keywords deliver; 'tracked in', 'Issue:', 'see' do not"
+
+# ── 7. usage errors exit 2 ──
 rc=0
 GH_ISSUES="$work/issues.json" GH_PRS="$work/prs.json" \
     PATH="$work/bin:$PATH" sh "$script" --bogus > "$out" 2>&1 || rc=$?
 [ "$rc" -eq 2 ] || fail "unknown flag should exit 2, got $rc"
-echo "ok 6 usage errors -> exit 2"
+echo "ok 7 usage errors -> exit 2"
 
-# ── 7. a broken gh fails closed, never looks like "queue empty" ──
+# ── 8. a broken gh fails closed, never looks like "queue empty" ──
 rc=0
 GH_ISSUES="$work/nonexistent.json" GH_PRS="$work/prs.json" \
     PATH="$work/bin:$PATH" sh "$script" > "$out" 2>&1 || rc=$?
 [ "$rc" -ne 0 ] || fail "a broken gh must not exit 0 (fail closed)"
-echo "ok 7 broken gh -> fail closed"
+echo "ok 8 broken gh -> fail closed"
 
 echo "all ready-queue-lint.sh self-tests passed"

--- a/scripts/fleet/test-ready-queue-lint.sh
+++ b/scripts/fleet/test-ready-queue-lint.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# Self-test for scripts/fleet/ready-queue-lint.sh (GH-665). Drives the script
+# through a stub `gh` on PATH: fixture JSON stands in for `gh issue list` and
+# `gh pr list`, so the tests prove which fleet:ready issues a picker sees when
+# some already have a merged PR.
+set -eu
+
+cd "$(git rev-parse --show-toplevel)"
+script=scripts/fleet/ready-queue-lint.sh
+
+sh -n "$script" || {
+    echo "FAIL: sh -n $script" >&2
+    exit 1
+}
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+mkdir -p "$work/bin"
+cat > "$work/bin/gh" <<'STUB'
+#!/bin/sh
+mode=other
+while [ $# -gt 0 ]; do
+    case "$1" in
+        issue) mode=issues ;;
+        pr) mode=prs ;;
+    esac
+    shift
+done
+case "$mode" in
+    issues) cat "$GH_ISSUES" ;;
+    prs) cat "$GH_PRS" ;;
+esac
+STUB
+chmod +x "$work/bin/gh"
+
+# Issue 12 delivered by PR 100 ("Closes #12"), issue 34 by PR 101
+# ("Issue: #34"). Issue 123 must be picked even though PR bodies mention
+# "#123" as part of "#1234" (word-boundary proof), and issue 20 is clean.
+MIXED_ISSUES='[
+  {"number":20,"title":"clean ready","createdAt":"2026-01-02T00:00:00Z"},
+  {"number":12,"title":"delivered still ready","createdAt":"2026-01-01T00:00:00Z"},
+  {"number":34,"title":"delivered too","createdAt":"2026-01-03T00:00:00Z"},
+  {"number":123,"title":"boundary ready","createdAt":"2026-01-04T00:00:00Z"}
+]'
+MIXED_PRS='[
+  {"number":100,"body":"Closes #12\n\nTest evidence."},
+  {"number":101,"body":"Issue: #34\nalso mentions #1234 in prose"},
+  {"number":102,"body":null}
+]'
+CLEAN_ISSUES='[
+  {"number":20,"title":"clean ready","createdAt":"2026-01-02T00:00:00Z"}
+]'
+CLEAN_PRS='[
+  {"number":100,"body":"Closes #999\n\nUnrelated delivery."}
+]'
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+run_case() {
+    issues_fixture=$1
+    prs_fixture=$2
+    shift 2
+    printf '%s' "$issues_fixture" > "$work/issues.json"
+    printf '%s' "$prs_fixture" > "$work/prs.json"
+    GH_ISSUES="$work/issues.json" GH_PRS="$work/prs.json" \
+        PATH="$work/bin:$PATH" sh "$script" "$@"
+}
+
+out="$work/out.txt"
+err="$work/err.txt"
+
+# ── 1. default listing: delivered issues excluded, oldest-first, no false hit ──
+rc=0
+run_case "$MIXED_ISSUES" "$MIXED_PRS" > "$out" 2> "$err" || rc=$?
+[ "$rc" -eq 0 ] || fail "default listing should exit 0, got $rc"
+grep -q '#20 clean ready' "$out" || fail "clean ready issue must be listed: $(cat "$out")"
+grep -q 'boundary ready' "$out" \
+    || fail "#123 must survive a '#1234' mention (word boundary): $(cat "$out")"
+grep -q '#12 delivered' "$out" && fail "delivered issue #12 must be excluded: $(cat "$out")"
+grep -q '#34 delivered' "$out" && fail "delivered issue #34 must be excluded: $(cat "$out")"
+[ "$(head -n 1 "$out")" = "#20 clean ready" ] \
+    || fail "listing must be oldest first: $(cat "$out")"
+grep -q '#12' "$err" || fail "excluded issue must be reported on stderr: $(cat "$err")"
+echo "ok 1 delivered issues excluded, oldest first, word-boundary holds"
+
+# ── 2. --oldest: exactly one line, the oldest pickable issue ──
+rc=0
+run_case "$MIXED_ISSUES" "$MIXED_PRS" --oldest > "$out" 2> "$err" || rc=$?
+[ "$rc" -eq 0 ] || fail "--oldest should exit 0, got $rc"
+[ "$(wc -l < "$out")" -eq 1 ] || fail "--oldest must print one line: $(cat "$out")"
+[ "$(cat "$out")" = "#20 clean ready" ] || fail "--oldest picked the wrong issue: $(cat "$out")"
+echo "ok 2 --oldest returns exactly the oldest pickable issue"
+
+# ── 3. --check: stale ready issues fail the check and are named ──
+rc=0
+run_case "$MIXED_ISSUES" "$MIXED_PRS" --check > "$out" 2> "$err" || rc=$?
+[ "$rc" -eq 1 ] || fail "--check with stale issues should exit 1, got $rc"
+grep -q '#12' "$err" && grep -q '#34' "$err" \
+    || fail "--check must name the stale issues: $(cat "$err")"
+echo "ok 3 --check exits 1 and names the stale issues"
+
+# ── 4. --check on a clean queue: exit 0 ──
+rc=0
+run_case "$CLEAN_ISSUES" "$CLEAN_PRS" --check > "$out" 2> "$err" || rc=$?
+[ "$rc" -eq 0 ] || fail "--check on a clean queue should exit 0, got $rc: $(cat "$err")"
+grep -q '#20 clean ready' "$out" || fail "clean queue must still list: $(cat "$out")"
+echo "ok 4 --check on a clean queue exits 0"
+
+# ── 5. word boundary: a body mention '#1234' does not deliver #123, but '#123' does ──
+ISSUE_123='[{"number":123,"title":"boundary exact","createdAt":"2026-01-01T00:00:00Z"}]'
+NO_HIT='[{"number":7,"body":"refs #1234 and #1235"}]'
+HIT='[{"number":7,"body":"Fixes #123"}]'
+rc=0
+run_case "$ISSUE_123" "$NO_HIT" --check > "$out" 2> "$err" || rc=$?
+[ "$rc" -eq 0 ] || fail "'#1234' must not deliver #123, got exit $rc: $(cat "$err")"
+rc=0
+run_case "$ISSUE_123" "$HIT" --check > "$out" 2> "$err" || rc=$?
+[ "$rc" -eq 1 ] || fail "'Fixes #123' must deliver #123, got exit $rc"
+echo "ok 5 boundary: '#1234' is not a delivery, 'Fixes #123' is"
+
+# ── 6. usage errors exit 2 ──
+rc=0
+GH_ISSUES="$work/issues.json" GH_PRS="$work/prs.json" \
+    PATH="$work/bin:$PATH" sh "$script" --bogus > "$out" 2>&1 || rc=$?
+[ "$rc" -eq 2 ] || fail "unknown flag should exit 2, got $rc"
+echo "ok 6 usage errors -> exit 2"
+
+# ── 7. a broken gh fails closed, never looks like "queue empty" ──
+rc=0
+GH_ISSUES="$work/nonexistent.json" GH_PRS="$work/prs.json" \
+    PATH="$work/bin:$PATH" sh "$script" > "$out" 2>&1 || rc=$?
+[ "$rc" -ne 0 ] || fail "a broken gh must not exit 0 (fail closed)"
+echo "ok 7 broken gh -> fail closed"
+
+echo "all ready-queue-lint.sh self-tests passed"


### PR DESCRIPTION
## Summary

Nothing removed `fleet:ready` after delivery: `Closes #N` closes the issue but
not its labels, so delivered issues stayed pickable forever. This PR wires the
durable mechanism at **both ends** — no `fleet:delivered` label needed:

- **Delivery end** — `pull-request` skill, new Step 4: after a squash merge
  succeeds, clear `fleet:ready` (and `fleet:claimed` if present) from every
  issue the PR delivers (closing references in the PR body).
- **Consumption end** — new `scripts/fleet/ready-queue-lint.sh`: the pick
  queue is filtered against merged PR bodies by machine check, never memory.
  A picker cannot select an issue that has a merged PR even if it still
  carries `fleet:ready` and is open.
- `fleet-worker` step 1 and `parallel-wave` Layer 1 now source candidates from
  the lint script instead of a raw `gh issue list --label fleet:ready`.
- Self-test `scripts/fleet/test-ready-queue-lint.sh` in the style of
  `scripts/test-fleet-claim-issue.sh`: stubbed `gh`, canned JSON fixtures.

The already-closed one-shot batch of 12 stale issues was not touched.

## Test plan (doneWhen evidence)

- [x] **(1) Picker cannot return a delivered issue** —
  `sh scripts/fleet/ready-queue-lint.sh --check` against live repo data flags
  5 open `fleet:ready` issues that already have a merged PR (#648, #671,
  #674, #685, #757) and excludes them from the pickable listing (exit 1),
  while #742 (ready, no merged PR) remains listed. Exit codes: `--check` → 1,
  default listing → 0.
- [x] **(2) Merge instructions include the label-clear step** —
  `pull-request` SKILL.md Step 4 ("Clear Delivery Labels from the Delivered
  Issue") with the exact command loop; Merge Output format and Best Practices
  updated to match.
- [x] **(3) The closed 12 were not reopened** — no `gh issue` write calls made
  by this PR; all gh usage in scripts/tests is read-only or stubbed.
- [x] **(4) Regression proof** — `sh scripts/fleet/test-ready-queue-lint.sh`:
  7 checks pass (delivered excluded / oldest-first / `--check` exit 1 + names
  stale issues / clean queue exit 0 / `#1234`-vs-`#123` word boundary /
  usage exit 2 / broken gh fails closed), with canned JSON fixtures.
- [x] **(5)** `sh scripts/lint-markdown-content.sh` → exit 0. Also ran
  `sh scripts/lint-file-length.sh --tree` → exit 0.

## Wiring table (REVIEW.md §5.5)

| 新面 (new surface) | Writer & shape | Reader (this PR or existing; or "no consumer") | Failure signal (swallowed? success-only? best-effort?) | Layer reach (flag→builder→spawn; field→store→read-back) |
|---|---|---|---|---|
| `scripts/fleet/ready-queue-lint.sh:36-58` — filtered ready-queue read surface (stdout `#<n> <title>`) | Script reads `gh issue list`/`gh pr list` live JSON; jq `delivered($prs; $num)` word-boundary filter; temp files only, no repo writes | Read by `fleet-worker` SKILL.md step 1 (`--oldest`) and `parallel-wave` SKILL.md Layer 1 (both this PR) | gh failure aborts via `set -eu` — fail closed, never looks like "queue empty"; usage errors exit 2; `--check` exits 1 naming stale issues | skill pick step → lint script → worker claims next issue; `--check` reachable as standalone lint |
| `scripts/fleet/test-ready-queue-lint.sh:1` — self-test harness (stub `gh`, canned fixtures) | Writes temp fixture/stub files only; asserts stdout/stderr/exit codes | Reviewer / future maintainers running the script's own checks | `set -eu` + explicit `fail()` on every assertion; `sh -n` gate on the target script | test → target script → jq filter behavior (regression proof for doneWhen 4) |
| `.claude/skills/pull-request/SKILL.md:263` — delivery label-clear step | Written instruction (skill doc), no runtime artifact | Merge operator executing Operation 2 (existing consumer, new step) | Only runs after a confirmed squash merge (Step 3 verifies state); skipped on unmerged close | merge step → PR body closing refs → `gh issue edit --remove-label` on delivered issue |

No Cargo surface touched: docs/skills + shell scripts only; no
`CARGO_TARGET_DIR`, no build lane. Lane: n/a (no local build).

Closes #665

Issue: #665
