### PR TITLE
fix(review): embed write-end swallow lens from wiring-scan into brief (#733)

### DIFF
--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -368,6 +368,13 @@ BRIEF="$SCRATCH/review-pr$PR-r$ROUND-brief.md"
     done
   fi
   echo
+  echo "### Wiring and write-end swallow scan (scripts/wiring-scan.sh)"
+  echo "Reviewer aid: scan for swallow patterns on added lines (\`let _ =\`, \`.ok();\`, \`unwrap_or_default()\`, \`best-effort\`, \`silently\`):"
+  echo '```'
+  sh "$SELF_REPO/scripts/wiring-scan.sh" "$BASE_SHA" "$SHA" 2>/dev/null | awk '/^== Swallow patterns/,0' || echo "(wiring scan unavailable)"
+  echo '```'
+  echo "A write-end swallow on a path where coordination, ledger, heartbeat, session-ledger, L3-store, or digest state is written is **P1** (REVIEW.md §5.5, GH-692, GH-733)."
+  echo
   echo "## Output"
   echo "Print the REVIEW.md §7 verdict — every field, the Rules table with one row per routed rule, the Wiring table — between the markers below, with this header line filled in:"
   echo "<<<VERDICT"

--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -218,9 +218,11 @@ if [ -n "$SPEC_OVERRIDE" ]; then
   SPEC=$SPEC_OVERRIDE
   SPEC_SOURCE="$SPEC_OVERRIDE (EDDA_REVIEW_SPEC override)"
 else
-  # The base commit must be in this object database before it can be read.
+  # The base and head commits must be in this object database before they can be read.
   git -C "$SELF_REPO" cat-file -e "$BASE_SHA^{commit}" 2>/dev/null ||
     git -C "$SELF_REPO" fetch -q origin "$BASE_REF" 2>/dev/null || true
+  git -C "$SELF_REPO" cat-file -e "$SHA^{commit}" 2>/dev/null ||
+    git -C "$SELF_REPO" fetch -q origin "$BR" 2>/dev/null || true
   if git -C "$SELF_REPO" show "$BASE_SHA:REVIEW.md" > "$SPEC" 2>/dev/null; then
     SPEC_SOURCE="REVIEW.md@$BASE_SHA (base of $BASE_REF)"
   elif [ -f "$SELF_REPO/REVIEW.md" ]; then
@@ -371,7 +373,17 @@ BRIEF="$SCRATCH/review-pr$PR-r$ROUND-brief.md"
   echo "### Wiring and write-end swallow scan (scripts/wiring-scan.sh)"
   echo "Reviewer aid: scan for swallow patterns on added lines (\`let _ =\`, \`.ok();\`, \`unwrap_or_default()\`, \`best-effort\`, \`silently\`):"
   echo '```'
-  sh "$SELF_REPO/scripts/wiring-scan.sh" "$BASE_SHA" "$SHA" 2>/dev/null | awk '/^== Swallow patterns/,0' || echo "(wiring scan unavailable)"
+  swallow_scan=$(sh "$SELF_REPO/scripts/wiring-scan.sh" "$BASE_SHA" "$SHA" 2>/dev/null)
+  scan_rc=$?
+  swallow_lens=""
+  if [ "$scan_rc" -eq 0 ] && [ -n "$swallow_scan" ]; then
+    swallow_lens=$(printf '%s\n' "$swallow_scan" | awk '/^== Swallow patterns/,0')
+  fi
+  if [ -n "$swallow_lens" ]; then
+    printf '%s\n' "$swallow_lens"
+  else
+    echo "(wiring scan unavailable)"
+  fi
   echo '```'
   echo "A write-end swallow on a path where coordination, ledger, heartbeat, session-ledger, L3-store, or digest state is written is **P1** (REVIEW.md §5.5, GH-692, GH-733)."
   echo

--- a/scripts/test-review-pr.sh
+++ b/scripts/test-review-pr.sh
@@ -485,6 +485,14 @@ grep -q -- 'Session observed: ' "$lane" \
 grep -q -- "Session: $EXPECTED_SID_9999" "$lane" \
     || fail 'D9j: the fallback arm no longer records the launched session id alongside the observed one'
 
+# D10 (GH-733): the brief embeds the write-end swallow lens — the wiring-scan
+# section and the P1 statement the reviewer needs to act on it. Both asserted
+# on the generated brief so the lens cannot silently disappear from the brief.
+grep -q 'Wiring and write-end swallow scan' "$brief" \
+    || fail 'D10: the brief does not embed the Wiring and write-end swallow scan section (GH-733)'
+grep -q 'write-end swallow.*is \*\*P1\*\*' "$brief" \
+    || fail 'D10: the brief does not state that a write-end swallow on coordination/ledger/heartbeat/session-ledger/L3-store/digest paths is **P1** (GH-733)'
+
 # --- offline guarantee: the real fleet scratch carries none of our output -----
 # Only our own fixture PR is asserted, not the whole listing: a live watcher or
 # another lane may legitimately be writing its own review-pr<N>-* files there

--- a/scripts/test-review-pr.sh
+++ b/scripts/test-review-pr.sh
@@ -492,6 +492,8 @@ grep -q 'Wiring and write-end swallow scan' "$brief" \
     || fail 'D10: the brief does not embed the Wiring and write-end swallow scan section (GH-733)'
 grep -q 'write-end swallow.*is \*\*P1\*\*' "$brief" \
     || fail 'D10: the brief does not state that a write-end swallow on coordination/ledger/heartbeat/session-ledger/L3-store/digest paths is **P1** (GH-733)'
+grep -q '(wiring scan unavailable)' "$brief" \
+    || fail 'D10: the brief does not surface (wiring scan unavailable) when revisions cannot be resolved (GH-733)'
 
 # --- offline guarantee: the real fleet scratch carries none of our output -----
 # Only our own fixture PR is asserted, not the whole listing: a live watcher or


### PR DESCRIPTION
Issue: #733
Closes #733

### Summary

Embeds the write-end swallow lens from `scripts/wiring-scan.sh` section 2 into `scripts/review-pr.sh` and adds D10 test coverage to `scripts/test-review-pr.sh`:
- Auto-review brief gains a section `### Wiring and write-end swallow scan (scripts/wiring-scan.sh)` that attaches the swallow pattern scan on added lines from `scripts/wiring-scan.sh "$BASE_SHA" "$SHA"`.
- States the rule: a write-end swallow on a path where coordination, ledger, heartbeat, session-ledger, L3-store, or digest state is written is **P1** (REVIEW.md §5.5, GH-692, GH-733).
- Adds D10 test case in `scripts/test-review-pr.sh` asserting both the section and the P1 statement are present in the generated brief.

### Verification

- `sh -n scripts/review-pr.sh` — exit 0
- `sh -n scripts/test-review-pr.sh` — exit 0
- `sh scripts/test-review-pr.sh` — 19 fixture test cases pass
