### PR TITLE
ci: add MSRV (1.91.0) check job to CI gate (#824)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -148,6 +148,7 @@ checks only.
 | Clippy | `cargo clippy --workspace --all-targets` on Linux, macOS **and** Windows |
 | Test (Linux, macOS) | `cargo test --workspace` — all 23 crates |
 | Test (Windows) | **only 7 crates** — `edda-store`, `edda-ledger`, `edda-search-fts`, `edda-transcript`, `edda-bridge-claude`, `edda-conductor`, `edda` (Windows build/link is ~5x slower; the subset is derived from process-spawn, file-lock, and mmap criteria — GH-433) |
+| MSRV (1.91.0) | `cargo +1.91.0 check --workspace --all-targets --locked` on Linux (MSRV compile check only — no tests run on 1.91) |
 
 So on Windows every crate is **type-checked and linted** (Clippy is
 workspace-wide on all three OSes), and every crate's *library* is also linked,
@@ -165,7 +166,7 @@ focused Windows-gap run is load-bearing rather than redundant.
 | Level | When | Run |
 |---|---|---|
 | L0 iterate | while editing | `cargo fmt --all --check`; `cargo clippy -p <crate> --all-targets -- -D warnings`; `cargo test -p <crate>` for each touched crate; `scripts/lint-file-length.sh --tree` |
-| L1 freeze | once per frozen full SHA, clean tree | **exact-head CI** — Format; Clippy ×3 OS; Test on Linux + macOS full workspace; Test on the Windows 7-crate subset — **plus one focused local run by the verifier**, once per frozen SHA, of `cargo test -p <crate>` on Windows for each touched crate outside the subset (the C5 selector — every touched crate minus the 7-subset; the loop is quoted in the Pre-commit Checklist L1 block and the two are kept identical). The implementer / fix lane runs L0 on touched crates, pushes, posts the `Review Response`, and does not run the workspace gate. Record the CI run id together with the full SHA (gate receipt: `CI run <id> @ <sha>`) |
+| L1 freeze | once per frozen full SHA, clean tree | **exact-head CI** — Format; Clippy ×3 OS; Test on Linux + macOS full workspace; Test on the Windows 7-crate subset; MSRV (1.91.0) check on Linux — **plus one focused local run by the verifier**, once per frozen SHA, of `cargo test -p <crate>` on Windows for each touched crate outside the subset (the C5 selector — every touched crate minus the 7-subset; the loop is quoted in the Pre-commit Checklist L1 block and the two are kept identical). The implementer / fix lane runs L0 on touched crates, pushes, posts the `Review Response`, and does not run the workspace gate. Record the CI run id together with the full SHA (gate receipt: `CI run <id> @ <sha>`) |
 | L2 review | verifier, once per frozen full SHA | READ the L1 receipt (exact-head CI, `CI run <id> @ <sha>`) and its job results; RAN only focused or adversarial checks they do not cover — **including Windows behavior in any crate outside the CI Windows subset above**, which L1 itself assigns to the verifier as the C5 selector run. A full local rerun needs a stated reason: red or absent exact-head CI, or grounds to distrust it. A coverage gap earns a **focused** check for that gap, not a full rerun — running the workspace to reach one uncovered crate is the cost this ladder exists to remove. Deterministically red CI already blocks the SHA — audit and request changes instead of spending a full run; if the red is environmental, re-run only the failed job |
 | L3 pre-merge | merge authority | READ exact-head CI and the final current-head LGTM; RAN only a merge check against the current base. A draft/ready, label, or status flip is not a push — nothing reruns |
 
@@ -257,8 +258,9 @@ cargo test -p <touched crate>
 
 # L1 (once per frozen full SHA, clean tree) = exact-head CI (Format; Clippy
 # ×3 OS; Test on Linux + macOS full workspace; Test on the Windows 7-crate
-# subset) + one focused local run by the verifier: `cargo test -p <crate>` on
-# Windows for each touched crate outside the subset — the C5 selector loop.
+# subset; MSRV (1.91.0) check on Linux) + one focused local run by the
+# verifier: `cargo test -p <crate>` on Windows for each touched crate outside
+# the subset — the C5 selector loop.
 # The implementer / fix lane runs L0 on touched crates, pushes, posts the
 # `Review Response`, and does not run the workspace gate.
 for crate in $(git diff --name-only "origin/$BASE...$SHA" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ env:
 
 jobs:
   # Path-aware triage (#631): decide once whether the diff touches code. If it
-  # does not (docs-only), clippy/test are skipped and the CI Gate treats those
-  # skips as a pass. When in doubt — any diff-computation error or unknown
+  # does not (docs-only), clippy/test/msrv are skipped and the CI Gate treats
+  # those skips as a pass. When in doubt — any diff-computation error or unknown
   # base — we set code=true and run everything.
   detect:
     name: Detect code changes
@@ -177,16 +177,34 @@ jobs:
           cargo build -p edda
           EDDA_BIN=target/debug/edda bash scripts/check-cli-docs.sh
 
+  # MSRV gate (GH-824): Cargo.toml declares rust-version = "1.91", but the
+  # pinned build toolchain (rust-toolchain.toml) is newer, so no other CI job
+  # would catch code using 1.92+ APIs. Compile the workspace with exactly
+  # 1.91.0 — check only, no tests — so downstream consumers on 1.91 keep
+  # building when the crates are published.
+  msrv:
+    name: MSRV (1.91.0)
+    needs: [detect]
+    if: needs.detect.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: rustup toolchain install 1.91.0 --profile minimal
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: msrv-1.91.0
+      - run: cargo +1.91.0 check --workspace --all-targets --locked
+
   # Aggregate gate: the single check the branch ruleset will pin instead of
-  # enumerating the seven individual jobs. `if: always()` keeps it running even
+  # enumerating the eight individual jobs. `if: always()` keeps it running even
   # when an upstream job fails or is skipped, so the verdict table is always
-  # printed. #631: clippy/test being skipped is accepted only when detect
+  # printed. #631: clippy/test/msrv being skipped is accepted only when detect
   # decided the change was docs-only (code=false); any other skip, failure,
   # or cancellation still fails the gate.
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
-    needs: [detect, fmt, clippy, test]
+    needs: [detect, fmt, clippy, test, msrv]
     if: always()
     steps:
       - name: Evaluate upstream job results
@@ -196,20 +214,22 @@ jobs:
           FMT_RESULT: ${{ needs.fmt.result }}
           CLIPPY_RESULT: ${{ needs.clippy.result }}
           TEST_RESULT: ${{ needs.test.result }}
+          MSRV_RESULT: ${{ needs.msrv.result }}
         run: |
           fail() { echo "::error::$1"; exit 1; }
           printf '%-10s -> %s\n' detect "$DETECT_RESULT"
           printf '%-10s -> %s\n' fmt "$FMT_RESULT"
           printf '%-10s -> %s\n' clippy "$CLIPPY_RESULT"
           printf '%-10s -> %s\n' test "$TEST_RESULT"
+          printf '%-10s -> %s\n' msrv "$MSRV_RESULT"
           [ "$DETECT_RESULT" = "success" ] || fail "detect did not succeed (result: $DETECT_RESULT)."
           [ "$FMT_RESULT" = "success" ] || fail "fmt did not succeed (result: $FMT_RESULT)."
-          if [ "$CLIPPY_RESULT" = "success" ] && [ "$TEST_RESULT" = "success" ]; then
+          if [ "$CLIPPY_RESULT" = "success" ] && [ "$TEST_RESULT" = "success" ] && [ "$MSRV_RESULT" = "success" ]; then
             echo "All upstream jobs succeeded."
             exit 0
           fi
-          if [ "$CLIPPY_RESULT" = "skipped" ] && [ "$TEST_RESULT" = "skipped" ] && [ "$CODE" = "false" ]; then
-            echo "Docs-only change (detect: code=false): clippy/test skipped, gate passes."
+          if [ "$CLIPPY_RESULT" = "skipped" ] && [ "$TEST_RESULT" = "skipped" ] && [ "$MSRV_RESULT" = "skipped" ] && [ "$CODE" = "false" ]; then
+            echo "Docs-only change (detect: code=false): clippy/test/msrv skipped, gate passes."
             exit 0
           fi
-          fail "clippy/test did not succeed (clippy: $CLIPPY_RESULT, test: $TEST_RESULT, detect.code: $CODE)."
+          fail "clippy/test/msrv did not succeed (clippy: $CLIPPY_RESULT, test: $TEST_RESULT, msrv: $MSRV_RESULT, detect.code: $CODE)."


### PR DESCRIPTION
## Summary

Adds an MSRV (1.91.0) compilation check job to GitHub Actions CI (`.github/workflows/ci.yml`) and updates `.claude/CLAUDE.md`.

Issue: #824
Closes #824

## Root Cause & Changes

- `[workspace.package] rust-version = "1.91"` was declared in `Cargo.toml`, but CI only checked against the pinned toolchain 1.98.1.
- Added `msrv` job in `.github/workflows/ci.yml`:
  - Runs on `ubuntu-latest`.
  - Gated by `detect.code == 'true'`.
  - Installs `1.91.0 --profile minimal` and runs `cargo +1.91.0 check --workspace --all-targets --locked`.
  - Uses `Swatinem/rust-cache@v2` with `key: msrv-1.91.0`.
- Integrated with `CI Gate`:
  - `msrv` added to `needs: [detect, fmt, clippy, test, msrv]`.
  - Added `MSRV_RESULT` to evaluation step, printed in verdict table, and included in both the all-success and docs-only skip branches.
- Updated `.claude/CLAUDE.md`:
  - Added MSRV row to CI coverage table under § Verification ladder.
  - Synchronized L1 row and Pre-commit Checklist L1 block with the new exact-head job.

## Acceptance Criteria & Verification (doneWhen)

- [x] **AC1 (MSRV Job execution)**: Gated on code changes, runs `cargo +1.91.0 check --workspace --all-targets --locked`. Passed in CI.
- [x] **AC2 (CI Gate dependency)**: `ci-gate` requires `msrv`, evaluates its result, and allows clean skip for docs-only PRs. Passed in CI.
- [x] **AC3 (Known-Red / Known-Green Regression Runs)**:
  - **Known-Red Run (FAIL)**: https://github.com/fagemx/edda/actions/runs/33848190617 (Job: https://github.com/fagemx/edda/actions/runs/33848190617/job/100944812187) — Probe branch introducing Rust 1.92+ API (`Location::file_as_c_str`) failed on `MSRV (1.91.0)` with `error[E0658]: use of unstable library feature 'file_with_nul'` while passing Clippy/Format.
  - **Known-Green Run (PASS)**: https://github.com/fagemx/edda/actions/runs/33846798017 (Job: https://github.com/fagemx/edda/actions/runs/33846798017/job/100940392270) — Compliant 1.91 code passed all checks including `MSRV (1.91.0)` and `CI Gate`.
- [x] **AC4 (Documentation)**: `.claude/CLAUDE.md` CI table documents the MSRV job and its check-only scope.
- [x] **Syntax & Linting**: YAML syntax validated via `yaml.safe_load`, file-length lint passed, markdown content lint passed.
