### PR TITLE
docs(review): U3 must not claim an empty doneWhen without Issue:

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -286,9 +286,15 @@ git log --format=%B "origin/$BASE..$SHA" \
   | grep -Ein '(^|[^a-z])(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+'
 ```
 
-**U3 — the `Issue: #N` line exists. P1.** `scripts/review-pr.sh` parses exactly
-this line to load the `doneWhen` into the brief; without it the next round
-silently loses its acceptance ceiling. Empty output is the failure.
+**U3 — the `Issue: #N` line exists. P1.** This is a convention miss, not a data
+dependency: `scripts/review-pr.sh` collects issue numbers from **three**
+sources (see its issue-number collection block) — `Issue:`/`Issues:` lines,
+closing keywords anywhere in the body, and GitHub's
+closingIssuesReferences — so a body carrying only `Closes #N` still supplies
+the brief with the issue's `doneWhen`, and an empty ceiling is never a
+consequence of the missing line. Missing `Issue: #N` is still P1 because the
+repo wants the issue named in this exact conventional form. Empty output is
+the failure.
 
 ```sh
 gh pr view "$N" --json body --jq .body | awk 'tolower($0) ~ /^issues?[[:space:]]*:/'


### PR DESCRIPTION
## Summary
Fixes Issue #820 by correcting REVIEW.md U3: missing `Issue: #N` is a convention miss, not an empty doneWhen. `scripts/review-pr.sh` already mines three sources (`Issue:` lines, closing keywords, `closingIssuesReferences`). U2 was already narrowed on main (PR #720 / GH-708); this PR does not restore a blanket closing-keyword ban.

Issue: #820
Closes #820

## Changes
- U3 no longer claims the brief loses its acceptance ceiling without `Issue: #N`.
- U3 still P1 when the conventional `Issue: #N` line is missing.
- Check command unchanged. `scripts/review-pr.sh` untouched.

## Verification & doneWhen
- [x] U2 already names `pr.closing-keyword=only-when-all-donewhen-delivered`
- [x] No remaining blanket `no closing keywords` ban in the spec
- [x] Severity: full-delivery `Closes #N` is not a P1; partial/design `Closes #N` is U2 P1; missing `Issue: #N` is U3 P1 as convention
- [x] `sh scripts/lint-markdown-content.sh` passes

Frozen SHA: `67a39dc3e21bf6e88fce1b49869ede7cfec0d19a`
