### PR TITLE
feat(release): publish workspace before GitHub release

### DIFF
--- a/.github/workflows/publish-crates-check.yml
+++ b/.github/workflows/publish-crates-check.yml
@@ -1,0 +1,31 @@
+name: Crates publication check
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/release.yml'
+      - '.github/workflows/publish-crates-check.yml'
+      - 'scripts/publish-crates*'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**/Cargo.toml'
+      - 'rust-toolchain.toml'
+
+permissions:
+  contents: read
+
+jobs:
+  dry-run:
+    name: Workspace publish dry-run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: rustup show
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: publish-dry-run
+      - run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
+      - name: Test release ordering and registry failure boundaries
+        run: python3 scripts/publish-crates-test.py
+      - name: Verify every workspace package without uploading
+        run: cargo publish --dry-run --workspace --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,49 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  prepare-crates:
+    name: Prepare crates.io publication
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.token.outputs.enabled }}
+    steps:
+      - uses: actions/checkout@v6
+      - run: rustup show
+      - name: Validate tag and derive workspace publish order
+        run: python3 scripts/publish-crates.py plan --tag "$GITHUB_REF_NAME"
+      - name: Check publication credential
+        id: token
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          if [ -n "$CARGO_REGISTRY_TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CARGO_REGISTRY_TOKEN is absent; publish-crates and downstream GitHub Release jobs are skipped."
+            echo "CARGO_REGISTRY_TOKEN is absent. Crates publication and GitHub Release are skipped; configure the repository secret and rerun." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  publish-crates:
+    name: Publish workspace to crates.io
+    needs: prepare-crates
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && needs.prepare-crates.outputs.enabled == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: rustup show
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: publish-crates
+      - run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
+      - name: Publish in dependency order and verify immutable source
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: python3 scripts/publish-crates.py publish --tag "$GITHUB_REF_NAME"
+
   create-release:
     name: Create Release
+    needs: publish-crates
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
@@ -31,72 +72,8 @@ jobs:
       - name: Get tag
         id: tag
         run: echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-      - name: Validate release metadata
-        shell: bash
-        run: |
-          version="${GITHUB_REF_NAME#v}"
-          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Tag must use vMAJOR.MINOR.PATCH, got ${GITHUB_REF_NAME}"
-            exit 1
-          fi
-
-          metadata="$(cargo metadata --locked --no-deps --format-version 1)"
-          mismatches="$(jq -r --arg version "$version" '
-            .workspace_members as $members
-            | .packages[]
-            | select(.id as $id | $members | index($id))
-            | select(.version != $version)
-            | "\(.name)=\(.version)"
-          ' <<<"$metadata")"
-          if [ -n "$mismatches" ]; then
-            echo "::error::Workspace package versions do not match tag $version"
-            printf '%s\n' "$mismatches"
-            exit 1
-          fi
-      - name: Verify crates.io release parity
-        shell: bash
-        run: |
-          version="${GITHUB_REF_NAME#v}"
-          mapfile -t crates < <(
-            cargo metadata --locked --no-deps --format-version 1 \
-              | jq -r '
-                  .workspace_members as $members
-                  | .packages[]
-                  | select(.id as $id | $members | index($id))
-                  | select(.publish != [])
-                  | .name
-                ' \
-              | tr -d '\r'
-          )
-
-          if ((${#crates[@]} == 0)); then
-            echo "::error::No publishable workspace crates found"
-            exit 1
-          fi
-
-          missing=()
-          yanked=()
-          for crate in "${crates[@]}"; do
-            response="$RUNNER_TEMP/crates-io-${crate}.json"
-            if ! curl --fail --silent --show-error \
-              --retry 3 --retry-all-errors --retry-delay 2 \
-              --user-agent "edda-release-ci/${GITHUB_REPOSITORY}" \
-              "https://crates.io/api/v1/crates/${crate}/${version}" \
-              --output "$response"; then
-              missing+=("$crate")
-            elif [ "$(jq -r '.version.yanked' "$response")" != "false" ]; then
-              yanked+=("$crate")
-            fi
-          done
-
-          if (( ${#missing[@]} || ${#yanked[@]} )); then
-            echo "::error::Publish every workspace crate to crates.io before pushing the release tag"
-            ((${#missing[@]})) && printf 'missing %s: %s\n' "$version" "${missing[*]}"
-            ((${#yanked[@]})) && printf 'yanked %s: %s\n' "$version" "${yanked[*]}"
-            exit 1
-          fi
-          printf 'crates.io parity verified for %s workspace crates at %s\n' \
-            "${#crates[@]}" "$version"
+      - name: Verify crates.io release parity and tag source
+        run: python3 scripts/publish-crates.py verify --tag "$GITHUB_REF_NAME"
       - name: Prepare release notes
         shell: bash
         run: |

--- a/scripts/publish-crates-test.py
+++ b/scripts/publish-crates-test.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Offline regressions for GH648. No token and no registry writes."""
+
+import hashlib
+import importlib.util
+import io
+import json
+from pathlib import Path
+import subprocess
+import tarfile
+import unittest
+from unittest.mock import patch
+import urllib.error
+
+spec = importlib.util.spec_from_file_location("publisher", Path(__file__).with_name("publish-crates.py"))
+publisher = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(publisher)
+SHA = "a" * 40
+
+
+def package(name, dependencies=()):
+    return {"id": name, "name": name, "version": "1.2.3", "publish": None,
+            "manifest_path": f"/repo/crates/{name}/Cargo.toml",
+            "dependencies": [{"name": d, "kind": None, "path": f"/repo/crates/{d}", "req": "^1.2.3"}
+                             for d in dependencies]}
+
+
+def metadata(*packages):
+    return {"workspace_members": [p["id"] for p in packages], "packages": list(packages)}
+
+
+def archive(sha=SHA, dirty=False, path="crates/edda", has_vcs=True):
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        if has_vcs:
+            data = json.dumps({"git": {"sha1": sha, "dirty": dirty}, "path_in_vcs": path}).encode()
+            entry = tarfile.TarInfo("edda-1.2.3/.cargo_vcs_info.json")
+            entry.size = len(data)
+            tar.addfile(entry, io.BytesIO(data))
+    return buffer.getvalue()
+
+
+class PublisherTests(unittest.TestCase):
+    def test_order_derived_after_dependency_changes_and_cli_last(self):
+        edda, a, z = package("edda", ["a"]), package("a", ["z"]), package("z")
+        self.assertEqual([p["name"] for p in publisher.publish_order(metadata(edda, a, z), "1.2.3")],
+                         ["z", "a", "edda"])
+        a["dependencies"] = []
+        z["dependencies"] = package("z", ["a"])["dependencies"]
+        self.assertEqual([p["name"] for p in publisher.publish_order(metadata(edda, z, a), "1.2.3")],
+                         ["a", "z", "edda"])
+
+    def test_rejects_cycle_private_dependency_and_version_mismatch(self):
+        cases = [metadata(package("edda"), package("a", ["b"]), package("b", ["a"])),
+                 metadata(package("edda", ["private"]), dict(package("private"), publish=[])),
+                 metadata(dict(package("edda"), version="9.9.9"))]
+        for data in cases:
+            with self.subTest(data=data), self.assertRaises(publisher.ReleaseError):
+                publisher.publish_order(data, "1.2.3")
+
+    def test_versioned_dev_and_optional_target_dependencies_affect_order(self):
+        edda, z = package("edda", ["z"]), package("z")
+        edda["dependencies"][0].update(kind="dev", optional=True, target="cfg(windows)")
+        self.assertEqual([p["name"] for p in publisher.publish_order(metadata(edda, z), "1.2.3")],
+                         ["z", "edda"])
+
+    def registry(self, data, **fields):
+        record = {"crate": "edda", "num": "1.2.3", "yanked": False,
+                  "checksum": hashlib.sha256(data).hexdigest(), **fields}
+        registry = publisher.Registry(SHA, "/repo")
+        registry.fetch = lambda url, **kwargs: json.dumps({"version": record}).encode() if "/api/" in url else data
+        return registry
+
+    def test_archive_source_identity_not_presence_is_success(self):
+        self.assertTrue(self.registry(archive()).verified(package("edda")))
+        for data, fields in [(archive("b" * 40), {}), (archive(dirty=True), {}),
+                             (archive(path="crates/not-edda"), {}), (archive(has_vcs=False), {}),
+                             (archive(), {"yanked": True}), (archive(), {"checksum": "0" * 64}),
+                             (archive(), {"num": "9.9.9"})]:
+            with self.subTest(fields=fields), self.assertRaises(publisher.ReleaseError):
+                self.registry(data, **fields).verified(package("edda"))
+
+    def test_404_is_missing_other_http_failures_do_not_authorize_upload(self):
+        registry = publisher.Registry(SHA, "/repo")
+        with patch.object(publisher.urllib.request, "urlopen", side_effect=urllib.error.HTTPError(
+                "url", 404, "missing", {}, None)):
+            self.assertIsNone(registry.fetch("https://crates.io/example", missing_ok=True))
+        with patch.object(publisher.urllib.request, "urlopen", side_effect=urllib.error.HTTPError(
+                "url", 403, "denied", {}, None)), self.assertRaises(publisher.ReleaseError):
+            registry.fetch("https://crates.io/example", missing_ok=True)
+
+    def test_rerun_skips_existing_and_accepts_upload_timeout_then_continues(self):
+        seen, uploaded = [], {"core"}
+
+        class Registry:
+            def verified(self, p):
+                return p["name"] in uploaded
+
+        def run(args, check):
+            self.assertFalse(check)
+            seen.append(args[-1])
+            uploaded.add(args[-1])
+            return subprocess.CompletedProcess(args, 101)
+
+        packages = [package("core"), package("other"), package("edda")]
+        publisher.publish(packages, Registry(), run=run, sleep=lambda _: None)
+        self.assertEqual(seen, ["other", "edda"])
+        publisher.publish(packages, Registry(), run=run, sleep=lambda _: None)
+        self.assertEqual(seen, ["other", "edda"])
+
+    def test_missing_final_version_is_red_even_when_cargo_exits_zero(self):
+        class Registry:
+            def verified(self, p):
+                return False
+
+        with self.assertRaisesRegex(publisher.ReleaseError, "crates.io incomplete: edda"):
+            publisher.publish([package("edda")], Registry(),
+                              run=lambda args, check: subprocess.CompletedProcess(args, 0), sleep=lambda _: None)
+
+    def test_workflow_token_skip_and_release_dependency_are_wired(self):
+        workflow = Path(__file__).resolve().parents[1] / ".github/workflows/release.yml"
+        text = workflow.read_text()
+        prepare = text.split("  prepare-crates:", 1)[1].split("  publish-crates:", 1)[0]
+        publish = text.split("  publish-crates:", 1)[1].split("  create-release:", 1)[0]
+        create = text.split("  create-release:", 1)[1].split("  build-release:", 1)[0]
+        self.assertIn('echo "enabled=false"', prepare)
+        self.assertIn("::notice::CARGO_REGISTRY_TOKEN is absent", prepare)
+        self.assertIn("needs.prepare-crates.outputs.enabled == 'true'", publish)
+        self.assertIn("github.event_name == 'push'", publish)
+        self.assertIn("needs: publish-crates", create)
+        self.assertIn("publish-crates.py verify", create)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/publish-crates.py
+++ b/scripts/publish-crates.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Tag release publishing; only Python's standard library and Cargo/Git are used."""
+
+import argparse
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tarfile
+import time
+import urllib.error
+import urllib.request
+
+
+class ReleaseError(Exception):
+    """A release invariant failed; downstream release jobs must not run."""
+
+
+def command(*args):
+    return subprocess.check_output(args, text=True).strip()
+
+
+def publish_order(metadata, version):
+    members = set(metadata["workspace_members"])
+    packages = {p["name"]: p for p in metadata["packages"] if p["id"] in members}
+    selected = {n: p for n, p in packages.items() if p.get("publish") != []}
+    if "edda" not in selected:
+        raise ReleaseError("No publishable edda CLI package in workspace")
+    for name, package in packages.items():
+        if package["version"] != version:
+            raise ReleaseError(f"Tag {version} disagrees with {name}={package['version']}")
+        if name in selected and package.get("publish") not in (None, ["crates-io"]):
+            raise ReleaseError(f"{name}: registry restrictions do not permit this release")
+    dependencies = {}
+    for name, package in selected.items():
+        edges = set()
+        for dependency in package["dependencies"]:
+            # Cargo drops unversioned dev-dependencies when publishing. All
+            # normal/build workspace edges, including target/optional ones,
+            # must precede their reader. Versioned dev edges matter too.
+            if dependency.get("kind") == "dev" and dependency.get("req") == "*":
+                continue
+            target = dependency["name"]
+            if dependency.get("path") and target in packages:
+                if target not in selected:
+                    raise ReleaseError(f"{name} depends on unpublished workspace crate {target}")
+                edges.add(target)
+        dependencies[name] = edges
+    # CLI last is an invariant, not an accident of alphabetic iteration.
+    dependencies["edda"].update(set(selected) - {"edda"})
+    result = []
+    while dependencies:
+        ready = sorted(n for n, edges in dependencies.items() if not edges)
+        if not ready:
+            raise ReleaseError("Workspace publish dependency cycle (or a crate depends on edda)")
+        for name in ready:
+            result.append(selected[name])
+            del dependencies[name]
+        for edges in dependencies.values():
+            edges.difference_update(ready)
+    return result
+
+
+class Registry:
+    def __init__(self, sha, root):
+        self.sha = sha
+        self.root = Path(root).resolve()
+
+    def fetch(self, url, missing_ok=False):
+        for attempt in range(4):
+            try:
+                request = urllib.request.Request(url, headers={"User-Agent": "edda-release-ci/GH648"})
+                with urllib.request.urlopen(request, timeout=60) as response:
+                    return response.read()
+            except urllib.error.HTTPError as error:
+                if error.code == 404 and missing_ok:
+                    return None
+                if error.code not in (429, 500, 502, 503, 504):
+                    raise ReleaseError(f"Registry HTTP {error.code}: {url}") from error
+            except (urllib.error.URLError, TimeoutError):
+                pass
+            if attempt < 3:
+                time.sleep(2 ** attempt)
+        raise ReleaseError(f"Registry unavailable after retries: {url}")
+
+    def verified(self, package):
+        name, version = package["name"], package["version"]
+        raw = self.fetch(f"https://crates.io/api/v1/crates/{name}/{version}", missing_ok=True)
+        if raw is None:
+            return False
+        record = json.loads(raw)["version"]
+        if record.get("yanked") is not False:
+            raise ReleaseError(f"{name}@{version} is yanked or has invalid registry metadata")
+        if record.get("num") != version or record.get("crate") != name:
+            raise ReleaseError(f"Registry returned the wrong identity for {name}@{version}")
+        archive = self.fetch(f"https://static.crates.io/crates/{name}/{name}-{version}.crate")
+        if hashlib.sha256(archive).hexdigest() != record.get("checksum"):
+            raise ReleaseError(f"{name}@{version}: archive checksum mismatch")
+        # Read a single member in memory; never extract registry-controlled paths.
+        member = f"{name}-{version}/.cargo_vcs_info.json"
+        try:
+            with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as tar:
+                info_file = tar.extractfile(member)
+                if info_file is None:
+                    raise ReleaseError(f"{name}@{version}: missing VCS provenance")
+                info = json.load(info_file)
+        except (KeyError, tarfile.TarError) as error:
+            raise ReleaseError(f"{name}@{version}: invalid VCS provenance") from error
+        expected_path = Path(package["manifest_path"]).resolve().parent.relative_to(self.root).as_posix()
+        vcs = info.get("git", {})
+        if vcs.get("sha1") != self.sha or vcs.get("dirty", False) is not False:
+            raise ReleaseError(f"{name}@{version}: published source is not clean tag SHA {self.sha}")
+        if info.get("path_in_vcs") != expected_path:
+            raise ReleaseError(f"{name}@{version}: published source has wrong workspace path")
+        print(f"VERIFIED {name}@{version} source={self.sha}", flush=True)
+        return True
+
+
+def publish(packages, registry, run=subprocess.run, sleep=time.sleep):
+    failures = []
+    for package in packages:
+        name = package["name"]
+        if registry.verified(package):
+            print(f"NO-OP {name}: matching version already uploaded", flush=True)
+            continue
+        result = run(["cargo", "publish", "--locked", "--registry", "crates-io", "-p", name], check=False)
+        # A timed-out upload or an already-uploaded race can be successful.
+        # Registry evidence, not Cargo's error wording, decides the outcome.
+        for attempt in range(12):
+            if registry.verified(package):
+                break
+            if attempt < 11:
+                sleep(10)
+        else:
+            failures.append(f"{name} (cargo exit {result.returncode})")
+    # Recheck all versions after uploads; detect yanks and any still-missing
+    # version even if another crate's upload appeared to succeed.
+    missing = [p["name"] for p in packages if not registry.verified(p)]
+    if missing:
+        raise ReleaseError(f"crates.io incomplete: {', '.join(missing)}; upload observations: {failures}")
+    print(f"SUCCESS: all {len(packages)} workspace versions verified", flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=("plan", "publish", "verify"))
+    parser.add_argument("--tag", required=True)
+    args = parser.parse_args()
+    if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", args.tag):
+        raise ReleaseError("Tag must use vMAJOR.MINOR.PATCH")
+    sha = command("git", "rev-parse", "HEAD")
+    tag_sha = command("git", "rev-parse", "--verify", f"refs/tags/{args.tag}^{{commit}}")
+    if not re.fullmatch(r"[0-9a-f]{40}", sha) or sha != tag_sha:
+        raise ReleaseError("HEAD must be the tag's full commit SHA")
+    if command("git", "status", "--porcelain", "--untracked-files=no"):
+        raise ReleaseError("Release source has tracked modifications")
+    metadata = json.loads(command("cargo", "metadata", "--locked", "--no-deps", "--format-version", "1"))
+    packages = publish_order(metadata, args.tag[1:])
+    print("ORDER: " + " -> ".join(p["name"] for p in packages), flush=True)
+    if args.mode == "plan":
+        return
+    registry = Registry(sha, metadata["workspace_root"])
+    if args.mode == "publish":
+        if not os.environ.get("CARGO_REGISTRY_TOKEN"):
+            raise ReleaseError("CARGO_REGISTRY_TOKEN missing; workflow must skip publish-crates")
+        publish(packages, registry)
+    else:
+        missing = [p["name"] for p in packages if not registry.verified(p)]
+        if missing:
+            raise ReleaseError("crates.io incomplete: " + ", ".join(missing))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (ReleaseError, subprocess.CalledProcessError, ValueError, KeyError, OSError) as error:
+        print(f"::error::{error}. GitHub Release has not been created or published by this run.", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
The release workflow currently checks crates.io parity before creating a GitHub Release but never publishes missing crates. This PR inserts a token-aware preflight and dependency-ordered publication before that gate, following the corrected crates.io-first acceptance in #648.

Issue: #648
Closes #648

- Derive all 23 workspace packages from Cargo metadata, respect dependency edges, and publish the `edda` CLI last.
- Treat already-uploaded versions as no-ops only after checking non-yanked metadata, archive checksum, and clean VCS tag SHA plus workspace path. Cargo upload timeouts are accepted only when registry evidence subsequently confirms publication.
- Missing `CARGO_REGISTRY_TOKEN` prints a notice and job summary; the publication job and downstream release jobs are skipped. No secret was configured or registry upload performed by this PR.
- Add an unprivileged PR workflow that runs `cargo publish --dry-run --workspace --locked`, with verification enabled.

Verification so far: 8 offline Python regression tests pass; real Cargo metadata produces a 23-package topological order with `edda` last; both YAML files load and every Bash run block parses; `git diff --check` passes. No local Cargo compilation. Workspace publish dry-run passed in CI run 33852477743 at a4c8c5456254b55725122121f21cbd43a5693bc7 (all 23 packages; final edda upload explicitly aborted by dry-run). Exact-head CI run 33852477794 has Format, Clippy on all three OSes, and Linux/macOS tests green; Windows tests pending at this update. Missing description/license metadata, if exposed by dry-run, remains outside this issue's manifest-edit scope.

The operator prerequisite remains adding `CARGO_REGISTRY_TOKEN` to repository secrets. Publication automation is delivered here; existing versions built from a different SHA are deliberately rejected rather than mislabeled as tag parity.
