### PR TITLE
feat(docs): gate anchored source citations in CI and staged commits

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,6 @@
 # Git Bash ("bad interpreter"), and core.autocrlf=true would otherwise rewrite
 # them on Windows checkout.
 scripts/githooks/* text eol=lf
+scripts/lint-doc-citations.sh text eol=lf
+scripts/lint-doc-citations.awk text eol=lf
+scripts/test-doc-citations.sh text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,11 @@ jobs:
         run: bash scripts/lint-file-length.sh --tree
       - name: Lint Markdown content
         run: sh scripts/lint-markdown-content.sh
+      - name: Lint documentation citations (GH-794)
+        run: |
+          bash -n scripts/lint-doc-citations.sh scripts/test-doc-citations.sh
+          bash scripts/lint-doc-citations.sh --tree
+          bash scripts/test-doc-citations.sh
       - name: Verify installer latest-version stdout
         shell: bash
         run: |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -13,6 +13,9 @@ retyping a contracted key turns the fixture red, so this page cannot silently
 go stale — if a fixture fails, the contract moved and this page must ship
 updated in the same release.
 
+Source citations are checked by the [documentation citation gate](docs/guides/doc-citations.md).
+Literal anchors detect when a cited range no longer contains its named source.
+
 ## 1. `schema_version` upgrade policy
 
 Ledger decision: `compat.schema-version-policy=read-older-refuse-newer-minor-bump-announced`
@@ -24,22 +27,22 @@ store version**:
 
 - **Ledger store version** — `schema_meta.version` in the SQLite ledger
   (`schema_meta` defined at
-  `crates/edda-ledger/src/sqlite_store/schema.rs:75-79`, read/written at
-  `schema.rs:342-356`). This is the number a binary compares against itself
+  `crates/edda-ledger/src/sqlite_store/schema.rs:76-79#CREATE TABLE IF NOT EXISTS schema_meta (`, read/written at
+  `crates/edda-ledger/src/sqlite_store/schema.rs:343-356#pub(super) fn schema_version(&self) -> anyhow::Result<u32> {`). This is the number a binary compares against itself
   when opening a ledger. The recorded history is a migration ladder from v1
-  to v13 (`schema.rs:249-341`): v5 added cross-project sync fields, v6 the
+  to v13 (`crates/edda-ledger/src/sqlite_store/schema.rs:250-341#pub(super) fn apply_schema(&self) -> anyhow::Result<()> {`): v5 added cross-project sync fields, v6 the
   `task_briefs` view, v7 `device_tokens`, v8 `decide_snapshots`, v9 hot-path
   indexes, v10 decision deepening columns, v11 `village_id`, v12 the
   suggestions queue, v13 the `task_leases` table
-  (`schema.rs:216-226`).
+  (`crates/edda-ledger/src/sqlite_store/schema.rs:217-226#pub(super) const SCHEMA_V13_SQL: &str = "`).
 - **Event payload version** — `edda_core::SCHEMA_VERSION`
-  (`crates/edda-core/src/types.rs:4`, stamped into every event payload at
-  `crates/edda-core/src/event.rs:186` and siblings). This has been `1` for
+  (`crates/edda-core/src/types.rs:4#pub const SCHEMA_VERSION: u32 = 1;`, stamped into every event payload at
+  `crates/edda-core/src/event.rs:186#schema_version: SCHEMA_VERSION,` and siblings). This has been `1` for
   the project's entire history and is part of the Layer 1 event format, whose
   stability is governed by the v1 event spec (#608), not by this page.
 - Decide-snapshot rows additionally carry a per-row
   `"schema_version": "snapshot.v1"` string
-  (`crates/edda-ledger/src/sqlite_store/schema.rs:152`); it identifies the
+  (`crates/edda-ledger/src/sqlite_store/schema.rs:152#schema_version  TEXT NOT NULL DEFAULT 'snapshot.v1',`); it identifies the
   snapshot shape, not the ledger.
 
 ### 1.2 The policy
@@ -51,18 +54,18 @@ store version**:
   (`crates/edda-cli/src/cmd_rebuild.rs`). This matches the ladder as it
   actually works today — `Ledger::open` → `SqliteStore::open_or_create` →
   `apply_schema` runs every missing migration upward
-  (`crates/edda-ledger/src/ledger.rs:32-41`,
-  `crates/edda-ledger/src/sqlite_store/mod.rs:45-53`,
-  `schema.rs:249-341`).
+  (`crates/edda-ledger/src/ledger.rs:32-41#/// Open an existing workspace. Fails if`,
+  `crates/edda-ledger/src/sqlite_store/mod.rs:45-53#pub fn open_or_create(db_path: &Path) -> anyhow::Result<Self> {`,
+  `crates/edda-ledger/src/sqlite_store/schema.rs:250-341#pub(super) fn apply_schema(&self) -> anyhow::Result<()> {`).
 - **Refuse newer.** A ledger with a store version **newer** than the binary
   is refused to open (exit 2, with a message naming both version numbers).
   Refusing is deliberate: the alternative is silently misinterpreting a
   ledger we cannot correctly read.
   **Enforced as of #735 (GH-729, closed):** opening a ledger checks the
   store version against `MAX_KNOWN_SCHEMA_VERSION` (13) and fails with
-  `UnsupportedSchemaVersionError` (`schema.rs:228-247`); the message names
+  `UnsupportedSchemaVersionError` (`crates/edda-ledger/src/sqlite_store/schema.rs:228-247#/// The maximum schema version known and supported by this binary.`); the message names
   both the stored and the maximum supported version, and `edda verify`
-  maps it to exit 2 (`crates/edda-cli/src/cmd_verify.rs:40-43`). The
+  maps it to exit 2 (`crates/edda-cli/src/cmd_verify.rs:40-43#if let Some(e) = err.downcast_ref::<edda_ledger::UnsupportedSchemaVersionError>() {`). The
   contract is pinned by `crates/edda-cli/tests/schema_refusal_contract.rs`.
 - **Minor bump, announced.** A `schema_version` jump is a **0.x minor bump**
   (e.g. 0.4 → 0.5), not a major-version event. The release that bumps the
@@ -72,8 +75,8 @@ store version**:
   the escape hatches: data can always be extracted in the form it was written.
 - **Read-only consumers never migrate.** `edda verify` opens the ledger
   `query_only` and never applies schema or migrations
-  (`crates/edda-ledger/src/sqlite_store/mod.rs:63-83`); an unreadable ledger
-  is reported at exit 2 (`crates/edda-cli/src/cmd_verify.rs:55-63`), never
+  (`crates/edda-ledger/src/sqlite_store/mod.rs:63-83#pub fn open_existing(db_path: &Path) -> anyhow::Result<Self> {`); an unreadable ledger
+  is reported at exit 2 (`crates/edda-cli/src/cmd_verify.rs:55-63#let report = match ledger.verify_chain_report() {`), never
   repaired by a verification command.
 
 ## 2. Stable `--json` contracts
@@ -83,7 +86,7 @@ Ledger decision: `compat.stable-json-surfaces=dispatch-verify-ask-status-mcp`
 Exactly the surfaces enumerated below are stable. **Everything not listed
 here is unstable by default** — including every other `--json` flag in the
 CLI (e.g. `edda phase --json`, `edda ask --fleet --json`
-(`crates/edda-cli/src/cmd_ask.rs:167-173`)): it may change shape in any
+(`crates/edda-cli/src/cmd_ask.rs:172-173#let payload = crate::fleet::json_envelope(projects, &misses);`)): it may change shape in any
 release without notice.
 
 Within 0.x, a stable surface may have keys **added**. Keys are never
@@ -93,12 +96,12 @@ is what "additive" means for them).
 ### `edda dispatch --json`
 
 One JSON object with exactly these keys (emitted at
-`crates/edda-cli/src/cmd_dispatch.rs:298-310`; mirrored in the long help,
-`crates/edda-cli/src/main.rs:492-497`):
+`crates/edda-cli/src/cmd_dispatch.rs#pub fn to_json(&self) -> String {`; mirrored in the long help,
+`crates/edda-cli/src/main.rs:492-497#With --json, exactly one object is printed to stdout:`):
 
 | Key | Type | Notes |
 |---|---|---|
-| `outcome` | string | one of `done`, `crash`, `timeout`, `max_turns`, `budget_exceeded` (`cmd_dispatch.rs:129-135`) |
+| `outcome` | string | one of `done`, `crash`, `timeout`, `max_turns`, `budget_exceeded` (`crates/edda-cli/src/cmd_dispatch.rs#pub enum Outcome {`) |
 | `result_text` | string \| null | agent summary; null except `done` |
 | `cost_usd` | number \| null | honest cost; null when the backend reported no usage |
 | `session_id` | string | id to reuse for continuity |
@@ -108,7 +111,7 @@ One JSON object with exactly these keys (emitted at
 | `session_observed` | string | the session id the backend reported in-band, or `unknown` |
 
 Exit-code table (contract, mirrors the long help; mapping at
-`cmd_dispatch.rs:151-159`): `0` done · `1` crash or any other failure ·
+`crates/edda-cli/src/cmd_dispatch.rs#pub fn exit_code_for(outcome: Outcome) -> i32 {`): `0` done · `1` crash or any other failure ·
 `2` timeout · `3` budget exceeded · `4` max turns.
 
 Golden fixture: `crates/edda-cli/src/cmd_dispatch.rs` →
@@ -118,7 +121,7 @@ Golden fixture: `crates/edda-cli/src/cmd_dispatch.rs` →
 ### `edda verify --json`
 
 One JSON object with exactly these keys (emitted at
-`crates/edda-cli/src/cmd_verify.rs:68-72`):
+`crates/edda-cli/src/cmd_verify.rs:68-72#let payload = serde_json::json!({`):
 
 | Key | Type | Notes |
 |---|---|---|
@@ -133,15 +136,15 @@ both the intact and the broken side, through the real binary).
 ### `edda ask --json`
 
 One JSON object — the `AskResult` envelope
-(`crates/edda-ask/src/lib.rs:52-75`), printed at
-`crates/edda-cli/src/cmd_ask.rs:80-82`. Keys always present: `query`
+(`crates/edda-ask/src/lib.rs:52-75#pub struct AskResult {`), printed at
+`crates/edda-cli/src/cmd_ask.rs:81-82#println!("{}", serde_json::to_string_pretty(&result)?);`. Keys always present: `query`
 (string), `input_type` (string), `decisions`, `timeline`, `related_commits`,
 `related_notes`, `conversations` (arrays). Keys `tasks` (array, GH-404),
 `dependents` (array), `override_risk` (object), `workspace_event_count`
 (integer, total events in the workspace ledger) and
 `workspace_decision_count` (integer, total decisions) are present **only
 when non-empty / Some** — they are serialized with `skip_serializing_if`
-(`lib.rs:62-73`; the two count keys were added by #728) and their absence
+(`crates/edda-ask/src/lib.rs:62-73##[serde(skip_serializing_if = "Vec::is_empty")]`; the two count keys were added by #728) and their absence
 means "none", not "removed".
 
 A `DecisionHit` (element of `decisions`/`timeline`;
@@ -158,11 +161,11 @@ Golden fixture: `crates/edda-cli/tests/ask_compat_contract.rs` →
 
 Of the MCP tools, two return JSON payloads, and their shapes are stable:
 
-- `edda_ask` (`crates/edda-mcp/src/lib.rs:263-287`) — returns the same
+- `edda_ask` (`crates/edda-mcp/src/lib.rs:263-287#async fn edda_ask(`) — returns the same
   `AskResult` envelope as `edda ask --json` (same key set, same optionality
   rules).
-- `edda_tool_tier` (`crates/edda-mcp/src/lib.rs:407-417`) — one JSON object,
-  the `ToolTierResult` shape (`crates/edda-core/src/tool_tier.rs:103-108`):
+- `edda_tool_tier` (`crates/edda-mcp/src/lib.rs:407-417#async fn edda_tool_tier(`) — one JSON object,
+  the `ToolTierResult` shape (`crates/edda-core/src/tool_tier.rs:103-108#pub struct ToolTierResult {`):
   `tool` (string), `tier` (string, `T0`–`T4`), `approval` (string,
   `none`/`lazy`/`required`/`blocked`), `description` (string).
 
@@ -175,8 +178,8 @@ Golden fixtures: `crates/edda-mcp/src/lib.rs` →
 ### `edda status --json`
 
 One JSON object with exactly these keys (emitted at
-`crates/edda-cli/src/cmd_status.rs:10-29`; flag declared at
-`crates/edda-cli/src/main.rs:290-295`, dispatched at `:1263`):
+`crates/edda-cli/src/cmd_status.rs:18-29#let payload = serde_json::json!({`; flag declared at
+`crates/edda-cli/src/main.rs:290-295#Status {`, dispatched at `crates/edda-cli/src/main.rs#Command::Status { json } =>`):
 
 | Key | Type | Notes |
 |---|---|---|
@@ -190,7 +193,7 @@ same contract:
 | Key | Type | Notes |
 |---|---|---|
 | `event_id` | string | the commit event's id |
-| `ts` | string | RFC 3339 UTC, as written by `now_rfc3339` (`crates/edda-core/src/event.rs:19-22`); sub-second precision is platform-dependent and not part of the contract |
+| `ts` | string | RFC 3339 UTC, as written by `now_rfc3339` (`crates/edda-core/src/event.rs:19-22#fn now_rfc3339() -> String {`); sub-second precision is platform-dependent and not part of the contract |
 | `title` | string | the commit title |
 
 **Failure side.** `--json` adds no failure mode of its own: with and without
@@ -198,7 +201,7 @@ it, `edda status` produces the same exit code and the same stderr in every
 state (measured). Success is exit `0` with the object on stdout. Failures do
 not emit JSON — a newer ledger schema exits `2` (§1.2), and every other
 failure (no `.edda/`, unreadable database) takes the CLI's shared error path
-and exits `1` (`crates/edda-cli/src/main.rs:1103-1110`).
+and exits `1` (`crates/edda-cli/src/main.rs:1103-1110#if let Err(err) = run(cli) {`).
 
 That last row differs from `edda verify --json`, which answers `2` to the
 same questions. The split is pre-existing and outside #730, but it is

--- a/crates/edda-cli/src/cmd_status.rs
+++ b/crates/edda-cli/src/cmd_status.rs
@@ -181,7 +181,7 @@ mod tests {
     /// Covers the two states reachable without hand-building a ledger: no
     /// workspace at all, and a `.edda/ledger.db` that is not a database. The
     /// third — a ledger whose schema is newer than the binary — is pinned for
-    /// the text form by `tests/schema_refusal_contract.rs`.
+    /// the text form by `crates/edda-cli/tests/schema_refusal_contract.rs`.
     #[test]
     fn status_json_adds_no_failure_mode() {
         let no_workspace = tempfile::tempdir().expect("no-workspace tempdir");

--- a/docs/guides/doc-citations.md
+++ b/docs/guides/doc-citations.md
@@ -1,0 +1,55 @@
+# Verifiable source citations
+
+Run `bash scripts/lint-doc-citations.sh --tree` for tracked working-tree
+documents. The pre-commit hook runs `--staged` against a complete index
+snapshot, including unchanged documents. A source-only edit or deletion can
+invalidate a citation, and an unstaged repair must not conceal it.
+
+Use repo-root paths in inline code:
+
+```text
+`crates/example/src/lib.rs:12`
+`crates/example/src/lib.rs:12-18#pub fn execute(`
+`crates/example/src/lib.rs#pub enum Outcome {`
+```
+
+The first form checks that the tracked target exists and the range is within
+its line count. The second also requires the literal text after `#` on the
+cited range. The last searches for literal text anywhere in the file,
+so a named declaration survives unrelated insertions. Anchors are literal
+substrings, not regular expressions or a Rust symbol resolver; use a specific
+declaration rather than a common word. Bounds alone cannot detect in-bounds
+drift, and no form verifies prose meaning or the end of a declaration.
+
+The gate enumerates tracked Markdown and `///` / `//!` comments under
+`crates/`. Numbered root paths under `crates/`, `scripts/`, `docs/`, `tests/`
+and `.github/` are checked; `edda-<crate>/...` is explicitly crate-anchored
+under `crates/`. Anchored paths are checked anywhere. Plain Rust source paths
+starting with `crates/` or `tests/` in doc comments are checked from the repo
+root too. Generated file names, Rust member names and contextual basename
+shorthand in older prose are not treated as root citations. `COMPATIBILITY.md`
+has no such shorthand exception: its numbered citations all use full paths
+and anchors.
+
+Fenced examples and plain paths in Rust paragraphs labeled `E.g.,` or
+`Example:` are examples, not assertions. Markdown under `tests/` is recorded
+test input/output, so only explicitly anchored citations there assert a live
+target. These are syntax/content categories, not a baseline of waived
+violations. File paths in the citation syntax use ASCII letters, numbers,
+underscores, dots, slashes and hyphens. Anchors cannot include backticks or
+span lines.
+
+`bash scripts/test-doc-citations.sh` exercises missing files, bounds, literal
+anchors, doc comments, and index/worktree divergence in disposable Git repos.
+With `--history`, it additionally reads the actual objects at `93eceee`,
+`0a94ecd` and `fb6ab1b` (full Git history required). Those documents predate
+anchor syntax: the test preserves their numeric citation ranges and target
+blobs, adding the semantic anchor used by today's contract. It isolates the
+dispatch long-help citation when comparing the first two commits because
+both contain separate dispatch citation drift. The third commit checks all
+three reported dispatch ranges independently. Range containment matters:
+the fixed `0a94ecd` range starts with a blank doc-comment line, followed by
+the long-help anchor; the broken `93eceee` range ends before that anchor.
+
+PR-body counts, old SHA receipts and prose that understates a test remain
+review concerns. This gate makes no claim to verify them.

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -64,6 +64,14 @@ staged_z=$(mktemp)
 ratchet_violations=$(mktemp)
 trap 'rm -f "$staged_z" "$ratchet_violations"' EXIT
 git diff --cached --raw -z --no-renames --diff-filter=ACMR >"$staged_z"
+# Check the whole index, including source-only modifications and deletions.
+# Run before the ACMR early return: deleting a cited file must also be gated.
+lint_doc_citations=$(cd "$(dirname "$0")" && pwd)/../lint-doc-citations.sh
+echo "pre-commit: bash scripts/lint-doc-citations.sh --staged"
+bash "$lint_doc_citations" --staged || {
+    echo "pre-commit: documentation citation lint failed" >&2
+    exit 1
+}
 [ -s "$staged_z" ] || exit 0
 
 fail() {

--- a/scripts/lint-doc-citations.awk
+++ b/scripts/lint-doc-citations.awk
@@ -1,0 +1,90 @@
+# Extract machine-readable inline citations; examples in fenced blocks are prose.
+# Plain contextual examples are not assertions about current repository files.
+BEGIN {
+    while ((getline file < tracked_file) > 0)
+        if (file ~ /^100(644|755) /) tracked[substr(file, 8)] = 1
+    close(tracked_file)
+}
+function error(message) {
+    printf "%s:%d: %s\n", doc, FNR, message > "/dev/stderr"
+    failed = 1
+}
+function citation(token,    path, rest, pos, range, anchor, n, first, last, text, hit, status) {
+    path = token
+    sub(/[:#].*$/, "", path)
+    # File paths, not URLs, Rust symbols, commands, globs or directory names.
+    if (path !~ /^[A-Za-z0-9_.\/-]+\.[A-Za-z0-9_-]+$/) return
+    rest = substr(token, length(path) + 1)
+    range = ""; anchor = ""
+    if (rest ~ /^:[0-9]+(-[0-9]+)?(#.*)?$/) {
+        range = substr(rest, 2); sub(/#.*/, "", range)
+        pos = index(rest, "#"); if (pos) anchor = substr(rest, pos + 1)
+    } else if (rest ~ /^#.+$/) {
+        # Rust raw member access (value.r#type) is not a filename anchor.
+        if (path !~ /\// && path !~ /\.(rs|md|sh|awk|ps1|yml|yaml|toml|json|txt|py|js|ts|lock)$/) return
+        anchor = substr(rest, 2)
+    } else if (rest != "" || !rust || path !~ /^(crates|tests)\/.*\.rs$/ || example) return
+    # Contextual basename shorthand in older prose is not a root citation.
+    # The contract page requires full paths; Rust doc comments do too.
+    if (path ~ /^edda-[^/]+\//) path = "crates/" path
+    if (!strict && anchor == "" && path !~ /^(crates|scripts|docs|tests|\.github)\//) return
+    # Markdown under tests/ is test input or recorded review output, not a
+    # current source contract. Explicit anchors remain checked everywhere.
+    if (doc ~ /^tests\// && anchor == "") return
+    if (anchor ~ /[\t\r\n]/) return
+    if (strict && range != "" && anchor == "") {
+        error("contract line citation requires a literal anchor: " token); return
+    }
+    if (path ~ /(^|\/)\.\.?(\/|$)/ || path ~ /^\//) {
+        error("citation must be repo-root-relative: " token); return
+    }
+    if (!(path in tracked)) { error("missing citation target " path " (repo root)"); return }
+    if (!(path in count)) {
+        count[path] = 0
+        while ((status = (getline text < ("./" path))) > 0) {
+            sub(/\r$/, "", text)
+            source[path, ++count[path]] = text
+        }
+        close("./" path)
+        if (status < 0) { error("cannot read citation target " path); return }
+    }
+    split(range, r, "-"); first=r[1]+0; last=(r[2] == "" ? first : r[2]+0)
+    if (range != "" && (first < 1 || last < first || last > count[path])) {
+        error("out-of-bounds citation " token); return
+    }
+    if (anchor != "") {
+        for (n=(first ? first : 1); n<=(first ? last : count[path]); n++)
+            if (index(source[path, n], anchor)) { hit=1; break }
+        if (!hit) error("literal anchor mismatch: " token)
+    }
+}
+FNR == 1 {
+    doc = FILENAME; sub(/^\.\//, "", doc)
+    rust = (doc ~ /^crates\/.*\.rs$/)
+    strict = (doc == "COMPATIBILITY.md")
+    fenced = 0
+    example = 0
+}
+{
+    line = $0; sub(/\r$/, "", line)
+    if (rust) {
+        if (line !~ /^[ \t]*\/\/[\/!]/) { example=0; fenced=0; next }
+        sub(/^[ \t]*\/\/[\/!] ?/, "", line)
+        if (line ~ /^[ \t]*$/) example=0
+        if (line ~ /[Ee]\.g\.,|[Ee]xample:/) example=1
+    }
+    fence_line=line; sub(/^[ \t]*/, "", fence_line)
+    if (fence_line ~ /^(```|~~~)/) {
+        char=substr(fence_line,1,1); width=0
+        while (substr(fence_line,width+1,1) == char) width++
+        rest=substr(fence_line,width+1)
+        if (!fenced) { fenced=1; fence_char=char; fence_width=width; next }
+        if (char == fence_char && width >= fence_width && rest ~ /^[ \t]*$/) { fenced=0; next }
+    }
+    if (fenced) next
+    while (match(line, /`[^`]+`/)) {
+        citation(substr(line, RSTART + 1, RLENGTH - 2))
+        line = substr(line, RSTART + RLENGTH)
+    }
+}
+END { exit failed }

--- a/scripts/lint-doc-citations.sh
+++ b/scripts/lint-doc-citations.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# GH-794. Zero added dependencies: bash + awk + git and shell utilities.
+set -euo pipefail
+mode=${1:---tree}
+case "$mode" in --tree|--staged) ;; *) echo "usage: $0 --tree|--staged" >&2; exit 2;; esac
+helper=$(cd "$(dirname "$0")" && pwd)/lint-doc-citations.awk
+cd "$(git rev-parse --show-toplevel)"
+tmp=$(mktemp -d)
+trap 'rm -rf -- "$tmp"' EXIT
+# Target syntax is ASCII without whitespace. Git quoting cannot turn any
+# other filename into a matching target. Citing paths are passed NUL-safely.
+git ls-files --format='%(objectmode) %(path)' > "$tmp/tracked"
+git ls-files -z --format='./%(path)' -- '*.md' 'crates/*.rs' > "$tmp/docs"
+# Do not follow a tracked or working-tree documentation symlink outside the
+# repository. Target symlinks are excluded by the mode manifest as well.
+git ls-files -z --format='%(objectmode) %(path)' -- '*.md' 'crates/*.rs' > "$tmp/doc-modes"
+while IFS= read -r -d '' entry; do
+    case "$entry" in 100644\ *|100755\ *) ;; *) echo "non-regular citing file: $entry" >&2; exit 1;; esac
+    if [ "$mode" = --tree ] && [ -L "${entry:7}" ]; then
+        echo "symlink citing file: ${entry:7}" >&2; exit 1
+    fi
+done < "$tmp/doc-modes"
+if [ "$mode" = --staged ]; then
+    # One coherent index snapshot, including unchanged documents: source-only
+    # changes must be checked and unstaged repairs must not mask stale refs.
+    # checkout-index fails closed on conflicts.
+    git checkout-index --all --prefix="$tmp/tree/"
+    cd "$tmp/tree"
+fi
+xargs -0 awk -v tracked_file="$tmp/tracked" -f "$helper" < "$tmp/docs"

--- a/scripts/test-doc-citations.sh
+++ b/scripts/test-doc-citations.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+root=$(git rev-parse --show-toplevel)
+lint="$root/scripts/lint-doc-citations.sh"
+hook="$root/scripts/githooks/pre-commit"
+tmp=$(mktemp -d)
+trap 'rm -rf -- "$tmp"' EXIT
+git init -q "$tmp/repo"
+cd "$tmp/repo"
+git config user.name citation-test
+git config user.email citation-test@example.invalid
+git config core.autocrlf false
+mkdir -p crates/demo/src crates/demo/tests
+printf '%s\n' 'header' 'pub fn alpha() {}' 'tail' > crates/demo/src/lib.rs
+printf '%s\n' 'test fixture' > crates/demo/tests/contract.rs
+printf '%s\n' '`crates/demo/src/lib.rs:2-3#pub fn alpha()`' > README.md
+git add .
+git -c core.hooksPath=/dev/null commit -qm fixture
+checks=0
+pass() {
+    bash "$lint" "${1:---tree}" > "$tmp/output" 2>&1 || {
+        cat "$tmp/output" >&2; echo "expected citation success" >&2; exit 1;
+    }
+    checks=$((checks+1))
+}
+fail() {
+    local expected=$1 mode=${2:---tree}
+    if bash "$lint" "$mode" > "$tmp/output" 2>&1; then
+        echo "expected citation rejection: $expected" >&2; exit 1
+    fi
+    if ! awk -v expected="$expected" 'index($0,expected) { found=1 } END {exit !found}' "$tmp/output"; then
+        cat "$tmp/output" >&2; echo "missing diagnostic: $expected" >&2; exit 1
+    fi
+    checks=$((checks+1))
+}
+pass
+pass --staged
+# Literal substring, not regex; metacharacters must match literally.
+printf '%s\n' '`crates/demo/src/lib.rs:2#pub fn alpha.*`' > README.md
+fail 'literal anchor mismatch'
+printf '%s\n' '`crates/demo/src/lib.rs:3-8`' > README.md
+fail 'out-of-bounds citation'
+printf '%s\n' '`crates/demo/src/lib.rs:3-2`' > README.md
+fail 'out-of-bounds citation'
+printf '%s\n' '`crates/demo/src/lib.rs:0`' > README.md
+fail 'out-of-bounds citation'
+printf '%s\n' '`crates/demo/src/missing.rs:1`' > README.md
+fail 'missing citation target'
+printf '%s\n' '`crates/demo/src/lib.rs#pub fn alpha()`' > README.md
+pass
+printf '%s\n' '`crates/demo/src/lib.rs#pub fn gone()`' > README.md
+fail 'literal anchor mismatch'
+# Inner and outer Rust doc comments, including plain root-relative paths.
+git checkout -- README.md
+printf '%s\n' '//! `tests/contract.rs`' '/// `crates/demo/src/lib.rs:99`' > crates/demo/src/docs.rs
+git add crates/demo/src/docs.rs
+fail 'tests/contract.rs'
+printf '%s\n' '//! `crates/demo/tests/contract.rs`' '/// `crates/demo/src/lib.rs:2#pub fn alpha()`' > crates/demo/src/docs.rs
+pass
+git add .
+git -c core.hooksPath=/dev/null commit -qm docs
+# Source-only shift: unchanged staged Markdown must still be checked.
+printf '%s\n' 'inserted one' 'inserted two' 'header' 'pub fn alpha() {}' 'tail' > crates/demo/src/lib.rs
+git add crates/demo/src/lib.rs
+fail 'README.md:1: literal anchor mismatch' --staged
+# Working-tree source repair must not mask a broken staged source.
+git show HEAD:crates/demo/src/lib.rs > crates/demo/src/lib.rs
+pass
+fail 'README.md:1: literal anchor mismatch' --staged
+# Inverse: a working-tree-only break cannot poison a good index.
+git reset -q HEAD -- crates/demo/src/lib.rs
+printf '%s\n' 'inserted one' 'inserted two' 'header' 'pub fn alpha() {}' 'tail' > crates/demo/src/lib.rs
+pass --staged
+fail 'literal anchor mismatch'
+git checkout -- crates/demo/src/lib.rs
+# Working-tree Markdown correction cannot conceal a stale staged citation.
+printf '%s\n' '`crates/demo/src/lib.rs:1#pub fn alpha()`' > README.md
+git add README.md
+git show HEAD:README.md > README.md
+pass
+fail 'README.md:1: literal anchor mismatch' --staged
+git reset -q HEAD -- README.md
+# Source deletion must fail through the actual hook, before its ACMR return.
+git rm -q crates/demo/src/lib.rs
+if bash "$hook" > "$tmp/output" 2>&1; then
+    echo 'source deletion escaped the pre-commit citation gate' >&2; exit 1
+fi
+awk '/missing citation target/ {found=1} END {exit !found}' "$tmp/output"
+checks=$((checks+1))
+git reset -q HEAD -- crates/demo/src/lib.rs
+git checkout -- crates/demo/src/lib.rs
+# Citing file names with spaces/newlines are not split by the scanner.
+printf '%s\n' '`crates/demo/src/lib.rs:90`' > $'space and\nnewline.md'
+git add .
+fail 'out-of-bounds citation'
+printf '%s\n' '```text' '`crates/demo/src/missing.rs:99`' '```' > $'space and\nnewline.md'
+pass
+
+if [ "${1:-}" = --history ]; then
+    # Use genuine historical documents and sources. Only add the anchor
+    # protocol to the original numeric range, without changing its endpoints.
+    historical() {
+        local rev=$1 path=$2 pattern=$3 anchor=$4 expected=$5
+        mkdir -p "$tmp/history/$rev/$(dirname "$path")"
+        cd "$tmp/history/$rev"
+        git init -q
+        git -C "$root" show "$rev:COMPATIBILITY.md" > "$tmp/historical-doc"
+        git -C "$root" show "$rev:$path" > "$path"
+        awk -v pattern="$pattern" -v anchor="$anchor" -v path="$path" '
+            index($0, pattern) {
+                line=$0
+                while (match(line, /`[^`]+`/)) {
+                    token=substr(line,RSTART+1,RLENGTH-2)
+                    if (index(token,pattern)) {
+                        sub(/^[^:]+:/, "", token)
+                        for (i=1; i<NR; i++) print ""
+                        print "`" path ":" token "#" anchor "`"
+                        found=1; exit
+                    }
+                    line=substr(line,RSTART+RLENGTH)
+                }
+            }
+            END {exit !found}
+        ' "$tmp/historical-doc" > COMPATIBILITY.md
+        git add .
+        if [ "$expected" = pass ]; then pass; else fail 'literal anchor mismatch'; fi
+        printf 'history %s %s: %s\n' "$rev" "$pattern" "$expected"
+    }
+    historical 93eceee crates/edda-cli/src/main.rs 'main.rs:483-489' 'With --json, exactly one object is printed to stdout:' fail
+    historical 0a94ecd crates/edda-cli/src/main.rs 'main.rs:488-494' 'With --json, exactly one object is printed to stdout:' pass
+    historical fb6ab1b crates/edda-cli/src/cmd_dispatch.rs 'cmd_dispatch.rs:259-268' 'pub fn to_json(&self) -> String {' fail
+    historical fb6ab1b crates/edda-cli/src/cmd_dispatch.rs 'cmd_dispatch.rs:114-122' 'pub enum Outcome {' fail
+    historical fb6ab1b crates/edda-cli/src/cmd_dispatch.rs 'cmd_dispatch.rs:127-134' 'pub fn exit_code_for(outcome: Outcome) -> i32 {' fail
+fi
+printf 'doc-citations: %s checks passed\n' "$checks"


### PR DESCRIPTION
Issue: #794
Closes #794

Source edits can leave valid-looking documentation ranges pointing at unrelated code. This adds a Bash/awk/Git citation gate that validates tracked targets and bounds, supports literal anchors within a cited range or anywhere in a file, and checks the complete index in pre-commit so source-only edits, deletions, and unstaged repairs cannot conceal staged drift.

All numbered COMPATIBILITY.md citations now carry anchors and full root paths. Rust `///` and `//!` citations are scanned too, including the corrected repo-root schema-refusal test path. The gate runs in CI Format and the pre-commit hook. The guide states its syntax, contextual/example categories, and limits; it does not validate prose or PR-receipt counts.

Frozen SHA: 81776c7794944a1ea02b610f83ada00afd24d0e8

Validation:
- RAN: `bash scripts/test-doc-citations.sh --history` — 26 checks passed, including staged/worktree divergence, source-only drift/deletion, literal matching, bounds, and Rust doc-comment paths.
- RAN: tree and index citation gates, Bash syntax, Markdown lint, and normal commit hooks — passed.
- READ: CI run 33853696601 at the frozen SHA — Format (including file length and generic citation fixtures), Clippy on all three platforms, Linux/macOS tests passed; Windows tests were still running when this receipt was written.
- No local Cargo build; the Rust diff only corrects one documentation path. Lane: n/a. The redundant local Windows tree-length scan was stopped after about 12 minutes once exact-head CI had passed that same gate.

Historical checks use actual 93eceee, 0a94ecd, and fb6ab1b document/source blobs. They retain the original COMPATIBILITY.md filename, citation line and numeric endpoints, add the new anchor syntax, and blank unrelated prose. 93eceee rejects main.rs:483-489; 0a94ecd accepts main.rs:488-494; fb6ab1b rejects all three reported dispatch ranges. The fixed 0a94ecd range begins with a blank doc-comment line, so anchors deliberately require range containment rather than first-line equality.
