### PR TITLE
chore(fleet): GH-690 lane privilege spike harness — fail-closed, prepared NOT RUN

### DIFF
--- a/PRIVILEGE_HANDOFF.md
+++ b/PRIVILEGE_HANDOFF.md
@@ -1,0 +1,86 @@
+# PRIVILEGE_HANDOFF.md — GH-690 restricted-lane spike: what is delivered, what is blocked
+
+**Session:** infra-controller-gh690 · task #27 · worktree
+`C:\ai_agent\edda-wt-infra-privilege` · branch `codex/infra-privilege-690`
+· basis `467e8be02eb98fb47d0eca82e9dd400d91d67e6a` · 2026-09-04
+
+## Delivered (reviewable in the PR)
+
+1. **Spike harness, prepared and fixture-validated** —
+   `scripts/spikes/lane-privilege/` (`LanePrivilegeSpike.psm1`,
+   `Invoke-Preflight.ps1`, `Invoke-SpikeAction.ps1`,
+   `tests/run-fixture-tests.ps1`, `README.md`).
+   - No-secrets metadata preflight is a separate script from the action.
+   - Principal is read from the process token (WindowsIdentity); a spoofed
+     `USERNAME`/`USERPROFILE` cannot pass (fixture T5), and the action refuses
+     any principal except the configured restricted one (fixture T4, exit 3).
+   - Negative tests only open/dispose protected credential files — content is
+     never read, stored, or printed (fixture T6 uses a canary to prove this).
+   - `gh` checks expose identity/token-SOURCE metadata only; token values
+     (even masked) are dropped before output.
+   - Push is structurally limited to the exact allowlisted `spike/…` branch;
+     `main`/`master`/`HEAD` are refused by the branch guard (fixture T7).
+   - Token provider resolution is real-or-explicitly-UNSUPPORTED; no mocks
+     (fixture T9). `file:`/`env:` refs are refused by design (fixture T3).
+   - Fixture run: **19/19 pass** (syntax-checked; no credentials touched, no
+     ACL/account changes, no network, no build, no push).
+2. **Threat model updated** — `docs/architecture/lane-privilege-threat-model.md`:
+   §7 fixed (PR #686 merged; obsolete wait-for-#686 text replaced) plus new
+   §7.0 cross-reference table to the node design doc
+   (`docs/superpowers/specs/2026-09-02-edda-node-agent-transport-design.md`);
+   §8 points at the prepared harness and states plainly that the restricted
+   run is NOT RUN; `docs/architecture/actor-signing.md` referenced as inline
+   code only, marked as a forthcoming cross-PR proposal — deliberately no
+   tracked link until that file lands (it is being authored by a peer session).
+
+## Evidence status
+
+| Item | Status |
+|---|---|
+| Baseline FAIL (lane can read operator credentials + org token) | READ from GH-690 issue body (2026-09-02 22:5x, 4090, basis `a1dd3d8`) — not re-measured |
+| Harness fixture tests (preflight no-op + refusal branches) | RAN, 19/19 pass |
+| Restricted-account negative tests (AccessDenied proof) | **NOT RUN** |
+| Restricted-account positive test (broker token → build/test/push of spike branch) | **NOT RUN** |
+
+The two NOT RUN rows are the remaining GH-690 doneWhen item 3. They cannot be
+produced from this session: the current process is not elevated
+(`WindowsPrincipal` check: not admin), no obvious restricted lane user exists
+(`Get-LocalUser` review found none), and no GitHub App installation-token
+source was provided. Per instruction, no accounts, ACLs, scheduled tasks, or
+auth settings were changed, no credential contents were read, and no mock
+tokens were substituted.
+
+## Exact setup the operator must provide (nothing else assumed)
+
+1. **Windows standard account** for the restricted lane, e.g. `edda-lane`
+   (one per machine, per decision `fleet.lane-privilege`). Created by the
+   operator; account creation is an implementation action outside agent
+   authority.
+2. **Explicit write grants** for that account on (a) the spike worktree and
+   (b) the assigned build-lane directory (e.g.
+   `%LOCALAPPDATA%\fleet-workstation\lanes\worker-N`).
+3. **A token provider** reachable from that account:
+   - `edda-node://…` — requires the node credential-broker, which node v0 does
+     not ship (explicitly UNSUPPORTED in the harness; see threat model §7.0); or
+   - `credman://<name>` — a per-lane fine-grained PAT stored in the **restricted
+     account's** Windows Credential Manager (needs the CredentialManager
+     PowerShell module) — the documented degradation path.
+4. **One scheduled task / runas invocation** under the restricted principal
+   running `Invoke-SpikeAction.ps1` with the exact parameters shown in
+   `scripts/spikes/lane-privilege/README.md` (operator principal, restricted
+   principal, workspace, build lane, repo allowlist, single spike branch
+   allowlist entry, token provider ref).
+
+Once provided, the run produces the missing evidence directly:
+negative tests must show `AccessDenied` and no reachable token (exit path 0),
+and the positive path pushes only `refs/heads/spike/…`. Any `Readable`
+credential or keyring token stops the run with exit 4 — that is the
+fail-closed contract, not a harness defect.
+
+## Handoff
+
+The controller should present the PR for review and ask the user **only
+once**, with this file and the harness README as the reviewable artifact:
+provide items 1–4 above (or explicitly descope the spike to its own issue).
+The PR carries `Issue: #690` **without** a closes keyword: the issue stays
+open until the restricted-account run actually happens.

--- a/docs/architecture/lane-privilege-threat-model.md
+++ b/docs/architecture/lane-privilege-threat-model.md
@@ -130,7 +130,9 @@ Manager 保管、都不進 env、都不落明文檔案。兩張單的封套與�
 不要各自長一套。GH-685 的節點是兩者天然的共同持有者（§7）。
 
 **共用的假設**：兩者都不保護「操作者機器被攻陷」（GH-609 doneWhen 第七條的
-誠實邊界與本文件 §4 一致）。
+誠實邊界與本文件 §4 一致）。GH-609 的提案稿另見
+`docs/architecture/actor-signing.md`（行內碼引用：該文件是另一張 PR 的提案，
+落地前刻意不留追蹤式連結以免斷鏈）。
 
 ## 6. 六個方向的取捨
 
@@ -217,9 +219,25 @@ GH-690 列了六個方向。以下逐條給取捨與提案值，合起來構成 
 
 ## 7. 節點作為憑證代管者（給 GH-685 設計稿的一節）
 
-> **銜接說明**：GH-685 的設計稿目前在 PR #686（branch `design/edda-mesh`），尚未合併，
-> 路徑 `docs/superpowers/specs/2026-09-02-edda-node-agent-transport-design.md`。
-> 本節不修改該分支。**待 #686 合併後，本節併入該設計稿，接在 §4「安全邊界」之後。**
+> **銜接說明（更新於 PR，GH-686 已合併）**：GH-685 的設計稿已隨 PR #686 合併，
+> 現位於 `docs/superpowers/specs/2026-09-02-edda-node-agent-transport-design.md`。
+> 本節保留在威脅模型內作為源文本；**把本節併入該設計稿（接在其 §4「安全邊界」之後）
+> 仍是待辦的跨文件編輯**，屬 GH-690 的後續實作，本 PR 不修改該設計稿。
+
+### 7.0 與節點設計稿的對照
+
+節點設計稿（`docs/superpowers/specs/2026-09-02-edda-node-agent-transport-design.md`）
+與本節的對應關係：
+
+| 本節 | 節點設計稿 | 關係 |
+|---|---|---|
+| §7.1 `node.toml` 共享 token 的升級路徑 | §2.1 節點（「共享 token 放 node.toml，不進 git」、沒有 token 的 POST 一律 401） | v0 行為的出處；本節為它補上 sunset 與 v0.5/v1 階段 |
+| §7.2 代管者的失敗訊號 | §3 失敗模式與訊號 | 表格形狀沿用 §3，新增代管職責三列 |
+| §6.4 store 只由節點寫 | §2.1 複製器 / §4 安全邊界 | 節點成為 store 的權威寫入者後，兩邊的安全邊界敘述要對齊 |
+| §6.2 GitHub App installation token | §2.6 GitHub 的角色（節點只註冊/搬事件，不代發 token） | **本節實質修訂**節點職責：代管者要按 lane 發短效 token；該修訂併入設計稿時必須連同 §6.3 v2 的「白名單 vendor 呼叫」一起裁定 |
+
+節點 v0（已合併的第一片）不含憑證代管端點——這正是 §8 的 spike 腳本把
+`edda-node://` token 引用分類為「明確不支援、不得造假」的依據。
 
 節點是每台機器上唯一的常駐可信程序，因此它是憑證代管者的天然位置：
 它比 lane 活得久（可以續期短效 token）、比操作者的互動 session 穩定（可以被排程任務看管）、
@@ -270,6 +288,15 @@ GH-690 doneWhen 第三條要求一個受限帳號的實測。**本單刻意不�
 這些是**操作者裁決之後的實作動作**，不是設計動作，而且不可逆性高。
 本單只交設計；spike 在 §9 的決策被批准後另開一張實作單。
 
+**腳手架已備（GH-690 後續 PR）**：`scripts/spikes/lane-privilege/` 放有一套
+fail-closed 的 spike 腳手架——無密鑰的 metadata preflight 與 fail-closed action
+分離、負向測試只做 open/dispose 不讀內容、push 只允許精確的 `spike/` 分支、
+principal 取自處理序 token 偽造不了、token 解析只做真實或明確不支援。
+其 fixture 測試（no-op preflight 與拒絕分支）已驗證；**受限帳號的正負向實測
+仍未執行（NOT RUN）**——主機上沒有受限帳號，也沒有 GitHub App installation
+token 來源。腳手架的存在不是實測證據；該單的 doneWhen 仍然要求實測本身。
+（`PRIVILEGE_HANDOFF.md` 記錄操作者需提供的確切設定。）
+
 spike 的驗收條件（先驗證 FAIL 再實作）：
 
 - **負向測試必須先在今天的機器上 FAIL**——也就是說，現在跑它，
@@ -307,7 +334,10 @@ fleet.lane-privilege = node-brokered-least-privilege-lane-account
 
 - **GH-690** — 本文件的來源單；§1 的實測表出自其 issue body。
 - **GH-609** — 密碼學身分（誰寫的）；與本文件的關係見 §5。
-- **GH-685** / PR #686 — edda node；§7 是給它的設計稿的一節，待合併後併入。
+- **GH-685** / PR #686（已合併）— edda node；§7 是給它的設計稿的一節，
+  併入仍是後續編輯（§7.0 有對照表）。
+- **GH-609 的簽章提案**：`docs/architecture/actor-signing.md`（以行內碼引用；
+  該文件是另一張 PR 的提案稿，落地前刻意不留追蹤式連結以免斷鏈）。
 - **GH-669** — 撤銷可見性；T2 的可見性部分依賴它。
 - **GH-593** — claude OAuth 撤銷事件；T2 的實證來源。
 - **GH-646** — store 污染；T3 的實證來源，由 §6.4 結構性解決。

--- a/scripts/spikes/lane-privilege/Invoke-Preflight.ps1
+++ b/scripts/spikes/lane-privilege/Invoke-Preflight.ps1
@@ -62,7 +62,9 @@ Add-Check -Name 'workspace-exists' -Passed:$workspaceOk -Detail $WorkspacePath
 $laneOk = Test-Path -LiteralPath $BuildLanePath -PathType Container
 Add-Check -Name 'build-lane-exists' -Passed:$laneOk -Detail $BuildLanePath
 
-# 4. Allowlists: exact names only; a main-targeting allowlist is refused outright.
+# 4. Allowlists: exact names only; a main-targeting allowlist is refused outright;
+#    each repo entry must be a well-formed owner/repo pair (Round1 F2: the actual
+#    publication destination is bound again immediately before the push).
 $repoOk = $true
 $repoDetail = 'ok'
 try {
@@ -104,6 +106,23 @@ foreach ($tool in @('git', 'gh', 'cargo')) {
     Add-Check -Name "tool-$tool" -Passed:($null -ne $cmd) `
         -Detail $(if ($null -ne $cmd) { $cmd.Source } else { 'not found in PATH' })
 }
+
+# 7. Configured publication destination (metadata only; no network). If the
+#    workspace has a resolvable origin URL it must already match the allowlist.
+#    The authoritative binding happens in the action immediately before the push.
+$destOk = $true
+$destDetail = 'no remote configured (publication binding happens in the action)'
+try {
+    $destUrl = Get-EffectivePushUrl -WorkspacePath $WorkspacePath -RepoAllowList $RepoAllowList -RemoteName 'origin'
+    $destDetail = "origin resolves to an allowlisted repository: $destUrl"
+} catch [System.Exception] {
+    $msg = $_.Exception.Message
+    if ($msg -match 'no resolvable URL') {
+        # Workspace without a configured remote is acceptable at preflight time.
+    }
+    else { $destOk = $false; $destDetail = $msg }
+}
+Add-Check -Name 'push-destination-configured' -Passed:$destOk -Detail $destDetail
 
 # Emit the metadata record, scrubbed of anything token-shaped.
 $report = [pscustomobject]@{

--- a/scripts/spikes/lane-privilege/Invoke-Preflight.ps1
+++ b/scripts/spikes/lane-privilege/Invoke-Preflight.ps1
@@ -1,0 +1,131 @@
+# Invoke-Preflight.ps1 — GH-690 lane privilege spike, no-secrets metadata preflight.
+#
+# This script performs NO secret resolution, NO credential probing, NO network I/O,
+# and NO build/push. It validates the spike's parameter set and records the current
+# principal as metadata. The action script (Invoke-SpikeAction.ps1) runs this first
+# and refuses to proceed on any failure.
+#
+# Exit codes: 0 = all checks pass; 2 = one or more checks failed.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$OperatorPrincipal,     # e.g. MACHINE\fagem — the principal that must NEVER run the action
+    [Parameter(Mandatory)][string]$RestrictedPrincipal,   # e.g. MACHINE\edda-lane — the only principal allowed to run the action
+    [Parameter(Mandatory)][string]$WorkspacePath,         # worktree the restricted lane builds in
+    [Parameter(Mandatory)][string]$BuildLanePath,         # CARGO_TARGET_DIR the restricted lane reuses (no cold builds)
+    [Parameter(Mandatory)][string[]]$RepoAllowList,       # exact repos, e.g. 'fagemx/edda' — wildcards refused
+    [Parameter(Mandatory)][string[]]$BranchAllowList,     # exact spike branches, e.g. 'spike/lane-privilege-20260904' — main refused
+    [Parameter(Mandatory)][string]$TokenProviderRef       # e.g. 'edda-node://<host>:<port>/credentials/gh-installation-token/<app>'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 3.0
+
+# Normalize collection parameters: a single-element array passed by splatting may
+# arrive as a scalar string, which breaks .Count and foreach under StrictMode.
+$RepoAllowList = @($RepoAllowList)
+$BranchAllowList = @($BranchAllowList)
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Import-Module (Join-Path $scriptDir 'LanePrivilegeSpike.psm1') -Force
+
+$checks = [System.Collections.Generic.List[object]]::new()
+
+function Add-Check {
+    param([string]$Name, [bool]$Passed, [string]$Detail)
+    $checks.Add([pscustomobject]@{ Check = $Name; Passed = $Passed; Detail = $Detail })
+}
+
+# 1. Principals: present, distinct, non-degenerate.
+$principalOk = -not [string]::IsNullOrWhiteSpace($OperatorPrincipal) `
+    -and -not [string]::IsNullOrWhiteSpace($RestrictedPrincipal)
+Add-Check -Name 'principals-present' -Passed:$principalOk -Detail 'both principals non-empty'
+
+$distinctOk = -not (Test-SpikePrincipalMatch -Expected $OperatorPrincipal -Actual $RestrictedPrincipal)
+Add-Check -Name 'principals-distinct' -Passed:$distinctOk `
+    -Detail 'operator and restricted principals differ (operator==restricted would void the boundary)'
+
+# 2. Current principal — metadata only. This does NOT pass or fail here: preflight is
+#    expected to run as the operator. The action script enforces the refusal.
+$actualPrincipal = Get-SpikePrincipal
+$isOperator  = Test-SpikePrincipalMatch -Expected $OperatorPrincipal   -Actual $actualPrincipal
+$isRestricted = Test-SpikePrincipalMatch -Expected $RestrictedPrincipal -Actual $actualPrincipal
+$classification = if ($isOperator) { 'operator' }
+    elseif ($isRestricted) { 'restricted' }
+    else { 'other' }
+Add-Check -Name 'current-principal-recorded' -Passed:$true `
+    -Detail "current principal classified as '$classification' (metadata only; refusal is enforced by the action script)"
+
+# 3. Paths: workspace and build lane exist (metadata; no writes, no build).
+$workspaceOk = Test-Path -LiteralPath $WorkspacePath -PathType Container
+Add-Check -Name 'workspace-exists' -Passed:$workspaceOk -Detail $WorkspacePath
+$laneOk = Test-Path -LiteralPath $BuildLanePath -PathType Container
+Add-Check -Name 'build-lane-exists' -Passed:$laneOk -Detail $BuildLanePath
+
+# 4. Allowlists: exact names only; a main-targeting allowlist is refused outright.
+$repoOk = $true
+$repoDetail = 'ok'
+try {
+    foreach ($repo in $RepoAllowList) { Assert-SafeRepoTarget -Repo $repo -RepoAllowList $RepoAllowList | Out-Null }
+} catch { $repoOk = $false; $repoDetail = $_.Exception.Message }
+Add-Check -Name 'repo-allowlist-valid' -Passed:$repoOk -Detail $repoDetail
+
+$branchOk = $true
+$branchDetail = 'ok'
+try {
+    if ($BranchAllowList.Count -ne 1) {
+        throw "Branch allowlist must contain exactly one spike branch (got $($BranchAllowList.Count))."
+    }
+    Assert-SafeSpikeBranch -Branch $BranchAllowList[0] -BranchAllowList $BranchAllowList | Out-Null
+} catch { $branchOk = $false; $branchDetail = $_.Exception.Message }
+Add-Check -Name 'branch-allowlist-valid' -Passed:$branchOk -Detail $branchDetail
+
+# 5. Token provider reference: syntax/classification only — NO resolution here.
+$providerOk = $true
+$providerDetail = 'ok'
+try {
+    $kindText = [string](Get-TokenProviderKind -ProviderRef $TokenProviderRef)
+    if ($kindText -eq 'Forbidden') {
+        throw "Forbidden provider scheme (file:/env:) — secrets never on disk, never in env."
+    }
+    if ($kindText -eq 'Unsupported') {
+        throw "Unknown provider scheme — explicitly unsupported."
+    }
+    $providerDetail = "classified as '$kindText' (resolution happens only in the action script, fail-closed)"
+} catch {
+    $providerOk = $false; $providerDetail = $_.Exception.Message
+    $kindText = 'invalid'
+}
+Add-Check -Name 'token-provider-classified' -Passed:$providerOk -Detail $providerDetail
+
+# 6. Tool availability (metadata only).
+foreach ($tool in @('git', 'gh', 'cargo')) {
+    $cmd = Get-Command $tool -ErrorAction SilentlyContinue
+    Add-Check -Name "tool-$tool" -Passed:($null -ne $cmd) `
+        -Detail $(if ($null -ne $cmd) { $cmd.Source } else { 'not found in PATH' })
+}
+
+# Emit the metadata record, scrubbed of anything token-shaped.
+$report = [pscustomobject]@{
+    Harness             = 'gh690-lane-privilege-preflight'
+    TimestampUtc        = (Get-Date).ToUniversalTime().ToString('o')
+    CurrentPrincipal    = $actualPrincipal
+    PrincipalClass      = $classification
+    OperatorPrincipal   = $OperatorPrincipal
+    RestrictedPrincipal = $RestrictedPrincipal
+    WorkspacePath       = $WorkspacePath
+    BuildLanePath       = $BuildLanePath
+    RepoAllowList       = $RepoAllowList
+    BranchAllowList     = $BranchAllowList
+    TokenProviderKind   = $null
+    Checks              = $checks
+    AllPassed           = (@($checks | Where-Object { -not $_.Passed }).Count -eq 0)
+}
+try { $report.TokenProviderKind = $kindText }
+catch { $report.TokenProviderKind = 'invalid' }
+
+$json = $report | ConvertTo-Json -Depth 4
+foreach ($line in ($json -split "`r?`n")) { Write-SpikeSafe -Text $line }
+
+if (-not $report.AllPassed) { exit $EXIT_PREFLIGHT_FAILED }
+exit $EXIT_OK

--- a/scripts/spikes/lane-privilege/Invoke-Preflight.ps1
+++ b/scripts/spikes/lane-privilege/Invoke-Preflight.ps1
@@ -117,7 +117,7 @@ try {
     $destDetail = "origin resolves to an allowlisted repository: $destUrl"
 } catch [System.Exception] {
     $msg = $_.Exception.Message
-    if ($msg -match 'no resolvable URL') {
+    if ($msg -match 'no resolvable URL|exactly one effective push URL \(got 0\)') {
         # Workspace without a configured remote is acceptable at preflight time.
     }
     else { $destOk = $false; $destDetail = $msg }

--- a/scripts/spikes/lane-privilege/Invoke-SpikeAction.ps1
+++ b/scripts/spikes/lane-privilege/Invoke-SpikeAction.ps1
@@ -83,27 +83,17 @@ if (-not (Test-SpikePrincipalMatch -Expected $RestrictedPrincipal -Actual $curre
 Write-SpikeSafe -Text "OK: running as restricted principal."
 
 # --- 3. Protected-path target validation (Round1 F4). --------------------------
-# The probed files must be the OPERATOR's protected credentials, passed explicitly.
-# Defaults derived from the current USERPROFILE would probe the RESTRICTED profile
-# under the restricted account and prove nothing; a target inside the current
-# profile is refused outright.
-$currentProfile = $env:USERPROFILE
-$targetOk = $true
-foreach ($p in $ProtectedCredentialFiles) {
-    if ([string]::IsNullOrWhiteSpace($p)) { $targetOk = $false; continue }
-    $full = [System.IO.Path]::GetFullPath($p)
-    if (-not [System.IO.Path]::IsPathRooted($full)) {
-        Write-SpikeSafe -Text "FAIL: protected credential path is not absolute: '$p'."
-        $targetOk = $false
-    }
-    elseif ($currentProfile -and $full.StartsWith($currentProfile, [System.StringComparison]::OrdinalIgnoreCase)) {
-        Write-SpikeSafe -Text ("FAIL: protected path '{0}' is inside the CURRENT (restricted) profile. " +
-            "Pass the operator's credential paths explicitly; probing our own profile proves nothing." -f $p)
-        $targetOk = $false
-    }
+# Bind the exact documented set to trusted Windows SID/ProfileList resolution;
+# USERPROFILE is caller-controlled and is deliberately never consulted here.
+try {
+    $ProtectedCredentialFiles = Assert-ProtectedCredentialTargets -OperatorPrincipal $OperatorPrincipal `
+        -RestrictedPrincipal $RestrictedPrincipal -ProtectedCredentialFiles $ProtectedCredentialFiles
 }
-if (-not $targetOk) { exit $EXIT_PREFLIGHT_FAILED }
-Write-SpikeSafe -Text ("OK: protected-path targets validated (operator profile, explicitly passed): {0}" -f
+catch {
+    Write-SpikeSafe -Text ("FAIL: {0}" -f $_.Exception.Message)
+    exit $EXIT_PREFLIGHT_FAILED
+}
+Write-SpikeSafe -Text ("OK: protected-path targets validated (exact trusted operator profile set): {0}" -f
     ($ProtectedCredentialFiles -join '; '))
 
 # --- 4. Negative test A: protected credential files. ---------------------------
@@ -234,7 +224,7 @@ try {
 # cache (isolated helper list), push uses one explicit refspec with tag-following
 # disabled, and cleanup (cache entry rejection + daemon exit) is attempted
 # unconditionally and reported. No gh auth login/logout anywhere in this path.
-$publication = Invoke-SpikePublication -Token $token -WorkspacePath $WorkspacePath -RemoteName 'origin' -RefSpec "HEAD:refs/heads/$spikeBranch"
+$publication = Invoke-SpikePublication -Token $token -WorkspacePath $WorkspacePath -DestinationUrl $pushUrl -RefSpec "HEAD:refs/heads/$spikeBranch"
 $token = $null
 foreach ($note in $publication.Notes) { Write-SpikeSafe -Text ("publication note: {0}" -f $note) }
 Write-SpikeSafe -Text ("publication verdict: {0} (pushExit={1} cleanupExit={2}). " +

--- a/scripts/spikes/lane-privilege/Invoke-SpikeAction.ps1
+++ b/scripts/spikes/lane-privilege/Invoke-SpikeAction.ps1
@@ -1,0 +1,181 @@
+# Invoke-SpikeAction.ps1 — GH-690 lane privilege spike, fail-closed action.
+#
+# Runs ONLY under the restricted principal. Refuses (exit 3) under any other
+# principal, including the operator — and the principal is taken from the process
+# token (WindowsIdentity), not from the environment, so faking one cannot pass.
+#
+# Order of operations, each gated on the previous:
+#   1. Preflight (no-secrets) must pass.
+#   2. Principal assertion: current principal must equal -RestrictedPrincipal.
+#   3. Negative test A: probe protected credential files (open/dispose only —
+#      never reads content). Expected POST-implementation result: AccessDenied.
+#      Readable => exit 4 (protection property not met; the baseline evidence).
+#   4. Negative test B: gh identity/token SOURCE metadata (token values dropped,
+#      output scrubbed). An operator keyring token present under the restricted
+#      principal => exit 4.
+#   5. Broker token resolution: real or explicitly UNSUPPORTED (exit 5). No mocks.
+#   6. Build/test under the restricted principal in the assigned build lane.
+#   7. Push to the exact allowlisted spike branch only (never main).
+#
+# Exit codes: 0 ok; 2 preflight failed; 3 principal refused; 4 protection fail;
+#             5 provider unsupported; 6 inconclusive.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$OperatorPrincipal,
+    [Parameter(Mandatory)][string]$RestrictedPrincipal,
+    [Parameter(Mandatory)][string]$WorkspacePath,
+    [Parameter(Mandatory)][string]$BuildLanePath,
+    [Parameter(Mandatory)][string[]]$RepoAllowList,
+    [Parameter(Mandatory)][string[]]$BranchAllowList,
+    [Parameter(Mandatory)][string]$TokenProviderRef,
+    [string[]]$ProtectedCredentialFiles = @(
+        "$env:USERPROFILE\.claude\.credentials.json",
+        "$env:USERPROFILE\.codex\auth.json",
+        "$env:USERPROFILE\.pi\agent\auth.json"
+    ),
+    [switch]$SkipBuildTest   # run negative tests + token resolution only (no build, no push)
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 3.0
+
+# Normalize collection parameters (single-element arrays may arrive as scalars).
+$RepoAllowList = @($RepoAllowList)
+$BranchAllowList = @($BranchAllowList)
+$ProtectedCredentialFiles = @($ProtectedCredentialFiles)
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Import-Module (Join-Path $scriptDir 'LanePrivilegeSpike.psm1') -Force
+
+# --- 1. Preflight (no secrets). -----------------------------------------------
+# Only pass parameters the preflight script declares (drop action-only ones).
+$preflightParams = @{
+    OperatorPrincipal   = $OperatorPrincipal
+    RestrictedPrincipal = $RestrictedPrincipal
+    WorkspacePath       = $WorkspacePath
+    BuildLanePath       = $BuildLanePath
+    RepoAllowList       = $RepoAllowList
+    BranchAllowList     = $BranchAllowList
+    TokenProviderRef    = $TokenProviderRef
+}
+$preflightJson = & (Join-Path $scriptDir 'Invoke-Preflight.ps1') @preflightParams
+if ($LASTEXITCODE -ne $EXIT_OK) {
+    Write-SpikeSafe -Text "FAIL: preflight did not pass; refusing to run the action."
+    $preflightJson | ForEach-Object { Write-SpikeSafe -Text "$_" }
+    exit $EXIT_PREFLIGHT_FAILED
+}
+
+# --- 2. Principal assertion — the fail-closed gate. ----------------------------
+$currentPrincipal = Get-SpikePrincipal
+if (-not (Test-SpikePrincipalMatch -Expected $RestrictedPrincipal -Actual $currentPrincipal)) {
+    Write-SpikeSafe -Text ("REFUSED: current principal '{0}' is not the restricted principal. " +
+        "The action never runs from the operator or any other account, and a spoofed " +
+        "environment cannot change this verdict (identity is read from the process token)." -f
+        $currentPrincipal)
+    exit $EXIT_PRINCIPAL_REFUSED
+}
+Write-SpikeSafe -Text "OK: running as restricted principal."
+
+# --- 3. Negative test A: protected credential files. ---------------------------
+# Open/dispose only. Expected after implementation: every probe is AccessDenied.
+$protectionMet = $true
+foreach ($path in $ProtectedCredentialFiles) {
+    $result = Get-CredentialFileProbe -Path $path
+    $detail = switch ($result) {
+        'AccessDenied' { 'access denied (protection property MET)' }
+        'Readable'     { 'READABLE — protection property NOT met (baseline failure)' }
+        'NotFound'     { 'not found — inconclusive, nothing proven' }
+        default        { 'probe error — inconclusive' }
+    }
+    Write-SpikeSafe -Text ("probe '{0}': {1}" -f $path, $detail)
+    if ([string]$result -ne 'AccessDenied') { $protectionMet = $false }
+}
+if (-not $protectionMet) {
+    Write-SpikeSafe -Text ("FAIL: protected credentials reachable from the restricted lane. " +
+        "This is the expected BASELINE result (GH-690 issue body, 2026-09-02 measurement: all three " +
+        "vendor credential files readable as the operator). Stopping before build/push — no positive " +
+        "evidence may be produced while the negative property fails.")
+    exit $EXIT_PROTECTION_FAIL
+}
+
+# --- 4. Negative test B: gh token SOURCE metadata. ------------------------------
+# Token values are never printed; only presence, source class, and account name.
+try {
+    $ghMeta = Get-GhTokenSourceMetadata
+} catch {
+    Write-SpikeSafe -Text ("STOP: {0}" -f $_.Exception.Message)
+    exit $EXIT_INCONCLUSIVE
+}
+Write-SpikeSafe -Text ("gh metadata: loggedIn={0} account={1} tokenPresent={2} tokenSource={3}" -f
+    $ghMeta.LoggedIn, $ghMeta.Account, $ghMeta.TokenPresent, $ghMeta.TokenSource)
+if ($ghMeta.TokenPresent -and $ghMeta.TokenSource -eq 'keyring') {
+    Write-SpikeSafe -Text "FAIL: a keyring token is reachable under the restricted principal (org-level operator token must not be)."
+    exit $EXIT_PROTECTION_FAIL
+}
+if (-not $ghMeta.LoggedIn) {
+    Write-SpikeSafe -Text "OK: no gh login visible to the restricted lane (short-lived broker token is the only path)."
+}
+
+# --- 5. Broker token resolution — real or explicitly unsupported. ---------------
+try {
+    $token = Resolve-BrokerToken -ProviderRef $TokenProviderRef
+} catch [System.Management.Automation.RuntimeException] {
+    Write-SpikeSafe -Text ("STOP: {0}" -f $_.Exception.Message)
+    exit $EXIT_PROVIDER_UNSUPPORTED
+}
+if ($null -eq $token) {
+    Write-SpikeSafe -Text "STOP: broker token resolution returned nothing (fail-closed)."
+    exit $EXIT_PROVIDER_UNSUPPORTED
+}
+
+# --- 6/7. Build, test, push — restricted principal only. ------------------------
+# NOTE: with no broker provider available today, step 5 always exits 5 before this
+# point on this host. The code below is the executed-in-full path once an operator
+# provisions the account + broker; it is fail-closed, not decorative.
+if ($SkipBuildTest) {
+    Write-SpikeSafe -Text "SKIP: -SkipBuildTest set; build/test/push not run."
+    exit $EXIT_OK
+}
+
+$spikeBranch = $BranchAllowList[0]
+try {
+    Assert-SafeSpikeBranch -Branch $spikeBranch -BranchAllowList $BranchAllowList | Out-Null
+} catch {
+    Write-SpikeSafe -Text ("FAIL: {0}" -f $_.Exception.Message)
+    exit $EXIT_PREFLIGHT_FAILED
+}
+
+Push-Location $WorkspacePath
+try {
+    $env:CARGO_TARGET_DIR = $BuildLanePath
+    Write-SpikeSafe -Text "build/test: cargo test (restricted principal, assigned build lane)…"
+    & cargo test --workspace 2>&1 | ForEach-Object { Write-SpikeSafe -Text "$_" }
+    if ($LASTEXITCODE -ne 0) {
+        Write-SpikeSafe -Text "FAIL: cargo test exited nonzero; nothing will be pushed."
+        exit $EXIT_PROTECTION_FAIL
+    }
+
+    # Token reaches git only through gh's own stdin-driven login, never argv/env/files.
+    $token | & gh auth login --with-token 2>&1 | ForEach-Object { Write-SpikeSafe -Text (Hide-SecretPatterns -Text "$_") }
+    try {
+        & git push origin "HEAD:refs/heads/$spikeBranch" 2>&1 |
+            ForEach-Object { Write-SpikeSafe -Text (Hide-SecretPatterns -Text "$_") }
+        if ($LASTEXITCODE -ne 0) {
+            Write-SpikeSafe -Text "FAIL: git push exited nonzero."
+            exit $EXIT_PROTECTION_FAIL
+        }
+        Write-SpikeSafe -Text ("OK: pushed HEAD to refs/heads/{0} (exact spike branch; main is guarded)." -f $spikeBranch)
+    }
+    finally {
+        # Revoke the short-lived login on the restricted account immediately.
+        & gh auth logout --hostname github.com 2>&1 |
+            ForEach-Object { Write-SpikeSafe -Text (Hide-SecretPatterns -Text "$_") } | Out-Null
+    }
+}
+finally {
+    Remove-Item Env:CARGO_TARGET_DIR -ErrorAction SilentlyContinue
+    Pop-Location
+}
+
+exit $EXIT_OK

--- a/scripts/spikes/lane-privilege/Invoke-SpikeAction.ps1
+++ b/scripts/spikes/lane-privilege/Invoke-SpikeAction.ps1
@@ -7,18 +7,27 @@
 # Order of operations, each gated on the previous:
 #   1. Preflight (no-secrets) must pass.
 #   2. Principal assertion: current principal must equal -RestrictedPrincipal.
-#   3. Negative test A: probe protected credential files (open/dispose only —
-#      never reads content). Expected POST-implementation result: AccessDenied.
-#      Readable => exit 4 (protection property not met; the baseline evidence).
-#   4. Negative test B: gh identity/token SOURCE metadata (token values dropped,
-#      output scrubbed). An operator keyring token present under the restricted
-#      principal => exit 4.
-#   5. Broker token resolution: real or explicitly UNSUPPORTED (exit 5). No mocks.
-#   6. Build/test under the restricted principal in the assigned build lane.
-#   7. Push to the exact allowlisted spike branch only (never main).
+#   3. Protected-path target validation: the probed credential files must be the
+#      OPERATOR's (explicitly passed), never the current (restricted) profile —
+#      probing our own profile proves nothing about the boundary (Round1 F4).
+#   4. Negative test A: probe protected credential files (open/dispose only —
+#      never reads content). AccessDenied is the only continuation evidence;
+#      Readable => exit 4; NotFound/Inconclusive/ProbeError => exit 6 (fail
+#      closed — a sharing violation is NOT access control, Round1 F5).
+#   5. Negative test B: gh identity/token SOURCE metadata (token values dropped,
+#      source parsed before the line is discarded). Any reachable token => exit 4;
+#      error exits and login-without-token ambiguity => exit 6 (Round1 F1).
+#   6. Broker token resolution: real or explicitly UNSUPPORTED (exit 5). No mocks.
+#   7. In-memory credential-cache availability: UNSUPPORTED (exit 5) without it —
+#      there is deliberately no persistent fallback (Round1 F3).
+#   8. Build/test under the restricted principal in the assigned build lane.
+#   9. Publication: bind the EFFECTIVE push URL to the repo allowlist (Round1 F2),
+#      then push via git's in-memory credential cache only — token moves through a
+#      stdin pipe, never argv/env/files, no `gh auth login` (Round1 F3).
 #
-# Exit codes: 0 ok; 2 preflight failed; 3 principal refused; 4 protection fail;
-#             5 provider unsupported; 6 inconclusive.
+# Exit codes: 0 ok; 2 preflight/destination failed; 3 principal refused;
+#             4 protection fail; 5 provider unsupported; 6 inconclusive;
+#             7 publication failed or cleanup incomplete.
 
 [CmdletBinding()]
 param(
@@ -29,12 +38,8 @@ param(
     [Parameter(Mandatory)][string[]]$RepoAllowList,
     [Parameter(Mandatory)][string[]]$BranchAllowList,
     [Parameter(Mandatory)][string]$TokenProviderRef,
-    [string[]]$ProtectedCredentialFiles = @(
-        "$env:USERPROFILE\.claude\.credentials.json",
-        "$env:USERPROFILE\.codex\auth.json",
-        "$env:USERPROFILE\.pi\agent\auth.json"
-    ),
-    [switch]$SkipBuildTest   # run negative tests + token resolution only (no build, no push)
+    [Parameter(Mandatory)][string[]]$ProtectedCredentialFiles,
+    [switch]$SkipBuildTest   # run negative tests + resolution + availability only (no build, no auth, no push)
 )
 
 $ErrorActionPreference = 'Stop'
@@ -77,19 +82,50 @@ if (-not (Test-SpikePrincipalMatch -Expected $RestrictedPrincipal -Actual $curre
 }
 Write-SpikeSafe -Text "OK: running as restricted principal."
 
-# --- 3. Negative test A: protected credential files. ---------------------------
+# --- 3. Protected-path target validation (Round1 F4). --------------------------
+# The probed files must be the OPERATOR's protected credentials, passed explicitly.
+# Defaults derived from the current USERPROFILE would probe the RESTRICTED profile
+# under the restricted account and prove nothing; a target inside the current
+# profile is refused outright.
+$currentProfile = $env:USERPROFILE
+$targetOk = $true
+foreach ($p in $ProtectedCredentialFiles) {
+    if ([string]::IsNullOrWhiteSpace($p)) { $targetOk = $false; continue }
+    $full = [System.IO.Path]::GetFullPath($p)
+    if (-not [System.IO.Path]::IsPathRooted($full)) {
+        Write-SpikeSafe -Text "FAIL: protected credential path is not absolute: '$p'."
+        $targetOk = $false
+    }
+    elseif ($currentProfile -and $full.StartsWith($currentProfile, [System.StringComparison]::OrdinalIgnoreCase)) {
+        Write-SpikeSafe -Text ("FAIL: protected path '{0}' is inside the CURRENT (restricted) profile. " +
+            "Pass the operator's credential paths explicitly; probing our own profile proves nothing." -f $p)
+        $targetOk = $false
+    }
+}
+if (-not $targetOk) { exit $EXIT_PREFLIGHT_FAILED }
+Write-SpikeSafe -Text ("OK: protected-path targets validated (operator profile, explicitly passed): {0}" -f
+    ($ProtectedCredentialFiles -join '; '))
+
+# --- 4. Negative test A: protected credential files. ---------------------------
 # Open/dispose only. Expected after implementation: every probe is AccessDenied.
+# Anything else is either a baseline failure (Readable) or inconclusive.
 $protectionMet = $true
+$inconclusiveSeen = $false
 foreach ($path in $ProtectedCredentialFiles) {
     $result = Get-CredentialFileProbe -Path $path
-    $detail = switch ($result) {
-        'AccessDenied' { 'access denied (protection property MET)' }
-        'Readable'     { 'READABLE — protection property NOT met (baseline failure)' }
-        'NotFound'     { 'not found — inconclusive, nothing proven' }
-        default        { 'probe error — inconclusive' }
+    $detail = switch ("$result") {
+        'AccessDenied'  { 'access denied (protection property MET)' }
+        'Readable'      { 'READABLE — protection property NOT met (baseline failure)' }
+        'NotFound'      { 'not found — inconclusive, nothing proven' }
+        'Inconclusive'  { 'open failed on a non-ACL state (e.g. sharing violation) — inconclusive, NOT access-control evidence' }
+        default         { 'probe error — inconclusive' }
     }
     Write-SpikeSafe -Text ("probe '{0}': {1}" -f $path, $detail)
-    if ([string]$result -ne 'AccessDenied') { $protectionMet = $false }
+    switch ("$result") {
+        'AccessDenied' { }
+        'Readable'     { $protectionMet = $false }
+        default        { $inconclusiveSeen = $true }
+    }
 }
 if (-not $protectionMet) {
     Write-SpikeSafe -Text ("FAIL: protected credentials reachable from the restricted lane. " +
@@ -98,26 +134,40 @@ if (-not $protectionMet) {
         "evidence may be produced while the negative property fails.")
     exit $EXIT_PROTECTION_FAIL
 }
+if ($inconclusiveSeen) {
+    Write-SpikeSafe -Text ("STOP: one or more probes were inconclusive (not access-denied evidence). " +
+        "The negative property is unproven; fail closed before build/push.")
+    exit $EXIT_INCONCLUSIVE
+}
 
-# --- 4. Negative test B: gh token SOURCE metadata. ------------------------------
-# Token values are never printed; only presence, source class, and account name.
+# --- 5. Negative test B: gh token SOURCE metadata (Round1 F1). ------------------
+# Token values are never printed; only presence, parsed source class, and the
+# account name. Error exits and ambiguous states are inconclusive, never a pass.
 try {
     $ghMeta = Get-GhTokenSourceMetadata
+    $ghVerdict = Get-GhMetadataVerdict -Metadata $ghMeta -GhExitCode $ghMeta.GhExit
 } catch {
     Write-SpikeSafe -Text ("STOP: {0}" -f $_.Exception.Message)
     exit $EXIT_INCONCLUSIVE
 }
-Write-SpikeSafe -Text ("gh metadata: loggedIn={0} account={1} tokenPresent={2} tokenSource={3}" -f
-    $ghMeta.LoggedIn, $ghMeta.Account, $ghMeta.TokenPresent, $ghMeta.TokenSource)
-if ($ghMeta.TokenPresent -and $ghMeta.TokenSource -eq 'keyring') {
-    Write-SpikeSafe -Text "FAIL: a keyring token is reachable under the restricted principal (org-level operator token must not be)."
-    exit $EXIT_PROTECTION_FAIL
-}
-if (-not $ghMeta.LoggedIn) {
-    Write-SpikeSafe -Text "OK: no gh login visible to the restricted lane (short-lived broker token is the only path)."
+Write-SpikeSafe -Text ("gh metadata: loggedIn={0} account={1} tokenPresent={2} tokenSource={3} verdict={4}" -f
+    $ghMeta.LoggedIn, $ghMeta.Account, $ghMeta.TokenPresent, $ghMeta.TokenSource, $ghVerdict)
+switch ($ghVerdict) {
+    'ok-no-login' {
+        Write-SpikeSafe -Text "OK: no gh login visible to the restricted lane (the transient cache credential is the only path)."
+    }
+    'deny-token-present' {
+        Write-SpikeSafe -Text ("FAIL: a token is reachable under the restricted principal " +
+            "(source class '{0}'; unparsable source also fails closed). No build/push may proceed." -f $ghMeta.TokenSource)
+        exit $EXIT_PROTECTION_FAIL
+    }
+    default {
+        Write-SpikeSafe -Text ("STOP: gh metadata verdict '{0}' is inconclusive; fail closed." -f $ghVerdict)
+        exit $EXIT_INCONCLUSIVE
+    }
 }
 
-# --- 5. Broker token resolution — real or explicitly unsupported. ---------------
+# --- 6. Broker token resolution — real or explicitly unsupported. ---------------
 try {
     $token = Resolve-BrokerToken -ProviderRef $TokenProviderRef
 } catch [System.Management.Automation.RuntimeException] {
@@ -129,15 +179,20 @@ if ($null -eq $token) {
     exit $EXIT_PROVIDER_UNSUPPORTED
 }
 
-# --- 6/7. Build, test, push — restricted principal only. ------------------------
-# NOTE: with no broker provider available today, step 5 always exits 5 before this
-# point on this host. The code below is the executed-in-full path once an operator
-# provisions the account + broker; it is fail-closed, not decorative.
-if ($SkipBuildTest) {
-    Write-SpikeSafe -Text "SKIP: -SkipBuildTest set; build/test/push not run."
-    exit $EXIT_OK
+# --- 7. In-memory credential-cache availability (Round1 F3). --------------------
+# The publication path uses git's credential-cache (daemon memory, short timeout)
+# as the ONLY transient store. No persistent credential helper, no `gh auth login`.
+if (-not (Test-GitCredentialCacheAvailable)) {
+    Write-SpikeSafe -Text ("UNSUPPORTED: git-credential-cache is not available on this host; " +
+        "there is deliberately no persistent fallback (no gh auth login, no plaintext file). " +
+        "Provision git with credential-cache support or resolve the broker on a host that has it.")
+    exit $EXIT_PROVIDER_UNSUPPORTED
 }
 
+# --- 8/9. Build, test, publish — restricted principal only. ---------------------
+# NOTE: with no broker provider available today, step 6 always exits 5 before this
+# point on this host. The code below is the executed-in-full path once an operator
+# provisions the account + broker; it is fail-closed, not decorative.
 $spikeBranch = $BranchAllowList[0]
 try {
     Assert-SafeSpikeBranch -Branch $spikeBranch -BranchAllowList $BranchAllowList | Out-Null
@@ -146,36 +201,50 @@ try {
     exit $EXIT_PREFLIGHT_FAILED
 }
 
-Push-Location $WorkspacePath
+if ($SkipBuildTest) {
+    Write-SpikeSafe -Text "SKIP: -SkipBuildTest set; build/test/publication not run."
+    exit $EXIT_OK
+}
+
 try {
     $env:CARGO_TARGET_DIR = $BuildLanePath
     Write-SpikeSafe -Text "build/test: cargo test (restricted principal, assigned build lane)…"
     & cargo test --workspace 2>&1 | ForEach-Object { Write-SpikeSafe -Text "$_" }
     if ($LASTEXITCODE -ne 0) {
-        Write-SpikeSafe -Text "FAIL: cargo test exited nonzero; nothing will be pushed."
+        Write-SpikeSafe -Text "FAIL: cargo test exited nonzero; nothing will be published and no credential is cached."
         exit $EXIT_PROTECTION_FAIL
-    }
-
-    # Token reaches git only through gh's own stdin-driven login, never argv/env/files.
-    $token | & gh auth login --with-token 2>&1 | ForEach-Object { Write-SpikeSafe -Text (Hide-SecretPatterns -Text "$_") }
-    try {
-        & git push origin "HEAD:refs/heads/$spikeBranch" 2>&1 |
-            ForEach-Object { Write-SpikeSafe -Text (Hide-SecretPatterns -Text "$_") }
-        if ($LASTEXITCODE -ne 0) {
-            Write-SpikeSafe -Text "FAIL: git push exited nonzero."
-            exit $EXIT_PROTECTION_FAIL
-        }
-        Write-SpikeSafe -Text ("OK: pushed HEAD to refs/heads/{0} (exact spike branch; main is guarded)." -f $spikeBranch)
-    }
-    finally {
-        # Revoke the short-lived login on the restricted account immediately.
-        & gh auth logout --hostname github.com 2>&1 |
-            ForEach-Object { Write-SpikeSafe -Text (Hide-SecretPatterns -Text "$_") } | Out-Null
     }
 }
 finally {
     Remove-Item Env:CARGO_TARGET_DIR -ErrorAction SilentlyContinue
-    Pop-Location
 }
 
-exit $EXIT_OK
+# Bind the ACTUAL publication destination to the repo allowlist (Round1 F2),
+# immediately before publication: the effective push URL is resolved from the
+# workspace's git config and must belong to an allowlisted repository.
+try {
+    $pushUrl = Get-EffectivePushUrl -WorkspacePath $WorkspacePath -RepoAllowList $RepoAllowList -RemoteName 'origin'
+    Write-SpikeSafe -Text ("OK: effective push destination bound and allowlisted: {0}" -f $pushUrl)
+} catch {
+    Write-SpikeSafe -Text ("FAIL: {0}" -f $_.Exception.Message)
+    exit $EXIT_PREFLIGHT_FAILED
+}
+
+# Publication: token moves only through stdin into git's in-memory credential
+# cache (isolated helper list), push uses one explicit refspec with tag-following
+# disabled, and cleanup (cache entry rejection + daemon exit) is attempted
+# unconditionally and reported. No gh auth login/logout anywhere in this path.
+$publication = Invoke-SpikePublication -Token $token -WorkspacePath $WorkspacePath -RemoteName 'origin' -RefSpec "HEAD:refs/heads/$spikeBranch"
+$token = $null
+foreach ($note in $publication.Notes) { Write-SpikeSafe -Text ("publication note: {0}" -f $note) }
+Write-SpikeSafe -Text ("publication verdict: {0} (pushExit={1} cleanupExit={2}). " +
+    "A published verdict proves only that git published the ref — it does not by itself prove " +
+    "the token was broker-scoped; that requires the broker's own audit trail." -f
+    $publication.Verdict, $publication.PushExit, $publication.CleanupExit)
+
+switch ($publication.Verdict) {
+    'published' { exit $EXIT_OK }
+    'auth-failed' { exit $EXIT_PROVIDER_UNSUPPORTED }
+    'cleanup-incomplete' { exit $EXIT_PUBLICATION_FAILED }
+    default { exit $EXIT_PUBLICATION_FAILED }
+}

--- a/scripts/spikes/lane-privilege/LanePrivilegeSpike.psm1
+++ b/scripts/spikes/lane-privilege/LanePrivilegeSpike.psm1
@@ -1,0 +1,308 @@
+# LanePrivilegeSpike.psm1 — shared fail-closed helpers for the GH-690 lane privilege spike.
+#
+# Design invariants (do not weaken):
+#   1. Principal comes from WindowsIdentity, never from environment variables —
+#      a spoofed USERNAME/USERPROFILE must never let an unrestricted caller pass.
+#   2. Protected-credential probes only open and immediately dispose a read handle;
+#      they never read, log, or print file content.
+#   3. Token values never appear in output, argv, environment, or files. All emitted
+#      text passes through Hide-SecretPatterns.
+#   4. secret-ref resolution is real or explicitly UNSUPPORTED — never a mock value.
+#   5. Push targets only the exact allowlisted spike branch; main is always refused.
+
+Set-StrictMode -Version 3.0
+
+# Well-known exit codes (documented in README.md; keep in sync).
+$script:EXIT_OK                 = 0
+$script:EXIT_PREFLIGHT_FAILED   = 2
+$script:EXIT_PRINCIPAL_REFUSED  = 3
+$script:EXIT_PROTECTION_FAIL    = 4   # negative test observed READABLE / token present
+$script:EXIT_PROVIDER_UNSUPPORTED = 5
+$script:EXIT_INCONCLUSIVE       = 6
+
+# Token shapes: GitHub OAuth/user/server/fine-grained PATs and generic bearer-ish
+# values. Used ONLY to scrub output; never to validate a token.
+$script:SecretPatterns = @(
+    'gh[pousr]_[A-Za-z0-9]{16,}',
+    'github_pat_[A-Za-z0-9_]{20,}',
+    'AKIA[0-9A-Z]{16}',
+    '-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----'
+)
+
+function Get-SpikePrincipal {
+    <#
+        .SYNOPSIS
+        Returns the real Windows principal of the current process.
+        .DESCRIPTION
+        Deliberately ignores $env:USERNAME / $env:USERPROFILE: those are per-process
+        values an unrestricted caller can set to anything. WindowsIdentity is the
+        process token, which is what the operating system enforces ACLs against.
+    #>
+    return [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+}
+
+function Test-SpikePrincipalMatch {
+    param(
+        [Parameter(Mandatory)][string]$Expected,
+        [Parameter(Mandatory)][string]$Actual
+    )
+    return [string]::Equals($Expected, $Actual, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function Hide-SecretPatterns {
+    <#
+        .SYNOPSIS
+        Replaces anything that looks like a credential with a fixed placeholder.
+        Applied to every line this harness prints.
+    #>
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Text
+    )
+    $out = $Text
+    foreach ($pattern in $script:SecretPatterns) {
+        $out = [regex]::Replace($out, $pattern, '[REDACTED]')
+    }
+    return $out
+}
+
+function Write-SpikeSafe {
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$Text)
+    Write-Output (Hide-SecretPatterns -Text $Text)
+}
+
+function Assert-SafeSpikeBranch {
+    <#
+        .SYNOPSIS
+        Fails closed unless $Branch is an exact member of the branch allowlist AND
+        is under the spike/ namespace. main / master / HEAD are refused explicitly
+        so a misconfigured allowlist can never authorize a main push.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$Branch,
+        [Parameter(Mandatory)][string[]]$BranchAllowList
+    )
+    if ([string]::IsNullOrWhiteSpace($Branch)) {
+        throw "Branch guard: empty branch name refused."
+    }
+    $forbidden = @('main', 'master', 'HEAD', 'origin/main', 'origin/master')
+    if ($forbidden -contains $Branch) {
+        throw "Branch guard: '$Branch' may never be a spike push target."
+    }
+    if (-not $Branch.StartsWith('spike/', [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Branch guard: spike pushes must live under 'spike/' (got '$Branch')."
+    }
+    if ($Branch.Contains('..') -or $Branch.Contains(' ') -or $Branch.Contains('*')) {
+        throw "Branch guard: branch name contains forbidden characters: '$Branch'."
+    }
+    $exact = $BranchAllowList | Where-Object {
+        [string]::Equals($_, $Branch, [System.StringComparison]::OrdinalIgnoreCase)
+    }
+    if (-not $exact) {
+        throw ("Branch guard: branch '{0}' is not in the allowlist [{1}]." -f
+            $Branch, ($BranchAllowList -join ', '))
+    }
+    return $true
+}
+
+function Assert-SafeRepoTarget {
+    param(
+        [Parameter(Mandatory)][string]$Repo,
+        [Parameter(Mandatory)][string[]]$RepoAllowList
+    )
+    if ([string]::IsNullOrWhiteSpace($Repo) -or $Repo.Contains('*')) {
+        throw "Repo guard: empty or wildcard repo refused."
+    }
+    $exact = $RepoAllowList | Where-Object {
+        [string]::Equals($_, $Repo, [System.StringComparison]::OrdinalIgnoreCase)
+    }
+    if (-not $exact) {
+        throw ("Repo guard: repo '{0}' is not in the allowlist [{1}]." -f
+            $Repo, ($RepoAllowList -join ', '))
+    }
+    return $true
+}
+
+enum CredentialProbeResult {
+    AccessDenied    # protection property MET (fail-closed success for the negative test)
+    Readable        # protection property NOT met — baseline failure signal
+    NotFound        # inconclusive: nothing was proven
+    ProbeError      # probe itself failed for an unexpected reason
+}
+
+function Get-CredentialFileProbe {
+    <#
+        .SYNOPSIS
+        Attempts to open a read handle on a protected credential file and immediately
+        disposes it. NEVER reads, stores, or prints any byte of file content.
+        .OUTPUTS
+        [CredentialProbeResult]
+    #>
+    param([Parameter(Mandatory)][string]$Path)
+
+    try {
+        if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+            return [CredentialProbeResult]::NotFound
+        }
+        $stream = $null
+        try {
+            $stream = [System.IO.File]::Open(
+                $Path,
+                [System.IO.FileMode]::Open,
+                [System.IO.FileAccess]::Read,
+                [System.IO.FileShare]::Read)
+            # Disposed without a single read. Length metadata is not content.
+            return [CredentialProbeResult]::Readable
+        }
+        catch [System.UnauthorizedAccessException] {
+            return [CredentialProbeResult]::AccessDenied
+        }
+        catch [System.IO.IOException] {
+            # Sharing violation or an ACL-mediated IO error is still "denied to us".
+            return [CredentialProbeResult]::AccessDenied
+        }
+        finally {
+            if ($null -ne $stream) { $stream.Dispose() }
+        }
+    }
+    catch {
+        return [CredentialProbeResult]::ProbeError
+    }
+}
+
+enum TokenProviderKind {
+    NodeBroker    # edda-node:// — real scheme; resolution requires the node credential-broker endpoint (GH-685 follow-up, not implemented in node v0)
+    WindowsCredMan# credman://  — real scheme; resolution requires the CredentialManager PowerShell module
+    Forbidden     # file: / env: — refused by design (secrets never on disk, never in env)
+    Unsupported   # unknown scheme — explicitly unsupported, never mocked
+}
+
+function Get-TokenProviderKind {
+    <#
+        .SYNOPSIS
+        Classifies a token provider reference by scheme. Pure syntax work: no
+        resolution, no I/O, no secret contact. Safe for preflight.
+    #>
+    param([Parameter(Mandatory)][string]$ProviderRef)
+
+    if ([string]::IsNullOrWhiteSpace($ProviderRef)) {
+        throw "Token provider reference is empty."
+    }
+    if ($ProviderRef.StartsWith('edda-node://', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return [TokenProviderKind]::NodeBroker
+    }
+    if ($ProviderRef.StartsWith('credman://', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return [TokenProviderKind]::WindowsCredMan
+    }
+    if ($ProviderRef -match '^(?i)(file|env):') {
+        return [TokenProviderKind]::Forbidden
+    }
+    return [TokenProviderKind]::Unsupported
+}
+
+function Resolve-BrokerToken {
+    <#
+        .SYNOPSIS
+        Resolves a token provider reference to a SecureString — for real, or fails
+        with an explicit UNSUPPORTED classification. Never returns a mock value.
+        .NOTES
+        The returned SecureString must stay in memory and be consumed by the one
+        authorized sink (currently: `gh auth login --with-token` stdin). Callers
+        must not persist, log, or pass it through argv/environment.
+    #>
+    param([Parameter(Mandatory)][string]$ProviderRef)
+
+    $kind = Get-TokenProviderKind -ProviderRef $ProviderRef
+    switch ($kind) {
+        'Forbidden' {
+            throw ("UNSUPPORTED: provider scheme '{0}' is forbidden by design " +
+                   "(secrets never on disk, never in env; decision fleet.lane-privilege)." -f
+                   ($ProviderRef -replace '^(?i)[^:]+://.*$', '$1:…'))
+        }
+        'Unsupported' {
+            throw "UNSUPPORTED: unknown provider scheme in reference (scheme refused; no mock substitution)."
+        }
+        'NodeBroker' {
+            # The node credential-broker endpoint does not exist in node v0 (GH-685
+            # ships /api/sync only). Saying so IS the honest result; substituting a
+            # fake token here would manufacture false spike evidence.
+            throw ("UNSUPPORTED: node credential-broker endpoint is not implemented in node v0 " +
+                   "(GH-685 design: docs/superpowers/specs/2026-09-02-edda-node-agent-transport-design.md). " +
+                   "Real resolution requires the GH-690 follow-up broker.")
+        }
+        'WindowsCredMan' {
+            $module = Get-Module -ListAvailable -Name CredentialManager
+            if ($null -eq $module) {
+                throw "UNSUPPORTED: CredentialManager PowerShell module not installed; real credman:// resolution unavailable on this host."
+            }
+            $name = ($ProviderRef -replace '^(?i)credman://', '') -replace '/.*$', ''
+            $cred = Get-StoredCredential -Target $name -AsPlainText:$false
+            if ($null -eq $cred) {
+                throw "UNSUPPORTED: no credential named '$name' in Windows Credential Manager (fail-closed; no mock substitution)."
+            }
+            $secure = $cred.Password
+            $cred = $null
+            return $secure
+        }
+        default {
+            throw "UNSUPPORTED: unhandled provider kind."
+        }
+    }
+}
+
+function Get-GhTokenSourceMetadata {
+    <#
+        .SYNOPSIS
+        Runs `gh auth status` and reduces it to identity/token-SOURCE metadata only.
+        Token values (even the masked ones gh prints) are dropped before anything
+        is returned or printed.
+        .OUTPUTS
+        PSCustomObject with LoggedIn (bool), Host, Account, TokenPresent (bool),
+        TokenSource (string: 'keyring' | 'infile' | 'env' | 'unknown' | 'none').
+    #>
+    $meta = [pscustomobject]@{
+        LoggedIn     = $false
+        Host         = $null
+        Account      = $null
+        TokenPresent = $false
+        TokenSource  = 'none'
+    }
+    if ($null -eq (Get-Command gh -ErrorAction SilentlyContinue)) {
+        throw "INCONCLUSIVE: gh CLI not found; token-source metadata cannot be collected."
+    }
+    $raw = & gh auth status 2>&1
+    $meta | Add-Member -NotePropertyName GhExit -NotePropertyValue $LASTEXITCODE
+    foreach ($line in @($raw)) {
+        $text = "$line"
+        # Drop every line that could carry token material before it can escape.
+        if ($text -match 'Token:') { 
+            if ($text -notmatch 'no token|token: none') { $meta.TokenPresent = $true }
+            continue
+        }
+        if ($text -match 'github\.com') { $meta.Host = 'github.com' }
+        if ($text -match 'Logged in to github\.com as ([A-Za-z0-9-]+)') {
+            $meta.LoggedIn = $true
+            $meta.Account = $Matches[1]
+        }
+        if ($text -match 'Token: .*\((keyring|infile|env)\)') {
+            $meta.TokenSource = $Matches[1]
+        }
+    }
+    return $meta
+}
+
+Export-ModuleMember -Function @(
+    'Get-SpikePrincipal',
+    'Test-SpikePrincipalMatch',
+    'Hide-SecretPatterns',
+    'Write-SpikeSafe',
+    'Assert-SafeSpikeBranch',
+    'Assert-SafeRepoTarget',
+    'Get-CredentialFileProbe',
+    'Get-TokenProviderKind',
+    'Resolve-BrokerToken',
+    'Get-GhTokenSourceMetadata'
+)
+Export-ModuleMember -Variable @(
+    'EXIT_OK', 'EXIT_PREFLIGHT_FAILED', 'EXIT_PRINCIPAL_REFUSED',
+    'EXIT_PROTECTION_FAIL', 'EXIT_PROVIDER_UNSUPPORTED', 'EXIT_INCONCLUSIVE'
+)

--- a/scripts/spikes/lane-privilege/LanePrivilegeSpike.psm1
+++ b/scripts/spikes/lane-privilege/LanePrivilegeSpike.psm1
@@ -550,26 +550,43 @@ function Invoke-SpikePublication {
     $cleanupExit = 0
     $verdict = 'auth-failed'
     $originalVerdict = $null
+    $transportDir = Join-Path ([System.IO.Path]::GetTempPath()) ("gh690-transport-" + [guid]::NewGuid().ToString('N'))
+    $savedGitEnvironment = @{}
 
     try {
+        # Build a disposable bare repository as the sole local configuration source.
+        # It has no remotes, url.* rewrite rules, or http.* headers. Global/system
+        # config and inherited GIT_* config injection are excluded for every call.
+        $head = @(& git -C $WorkspacePath rev-parse HEAD 2>$null)
+        $head = ("$head").Trim()
+        $objects = @(& git -C $WorkspacePath rev-parse --git-path objects 2>$null)
+        $objects = ("$objects").Trim()
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($head) -or [string]::IsNullOrWhiteSpace($objects) -or $RefSpec -notmatch '^HEAD:') {
+            throw 'publication transport isolation could not resolve the workspace HEAD/object store.'
+        }
+        if (-not [System.IO.Path]::IsPathRooted($objects)) { $objects = Join-Path $WorkspacePath $objects }
+        $globalConfig = Join-Path $transportDir 'global.gitconfig'
+        New-Item -ItemType Directory -Path $transportDir -Force | Out-Null
+        New-Item -ItemType File -Path $globalConfig -Force | Out-Null
+        Get-ChildItem Env: | Where-Object { $_.Name -like 'GIT_*' } | ForEach-Object {
+            $savedGitEnvironment[$_.Name] = $_.Value
+            Remove-Item ("Env:" + $_.Name) -ErrorAction Stop
+        }
+        $env:GIT_CONFIG_NOSYSTEM = '1'; $env:GIT_CONFIG_GLOBAL = $globalConfig
+        $env:GIT_ALTERNATE_OBJECT_DIRECTORIES = $objects; $env:GIT_TERMINAL_PROMPT = '0'
+        & git init --bare --quiet $transportDir 2>$null
+        if ($LASTEXITCODE -ne 0) { throw 'publication transport isolation could not create its disposable git directory.' }
+        $isolatedRefSpec = $RefSpec -replace '^HEAD:', ($head + ':')
+
         # Approve failure and an invoker exception both refuse publication.
         $approve = & $GitInvoker -GitArgs @($helperArgs + @('credential', 'approve')) -StdinInput $payload
         if ($approve.ExitCode -ne 0) {
             $notes.Add('credential approve failed; publication refused before any push')
         }
         else {
-            # Push the already validated literal URL, never the remote alias. Reset
-            # helpers/headers and suppress interactive/askpass fallback inputs.
-            $savedAskPass = $env:GIT_ASKPASS; $savedSshAskPass = $env:SSH_ASKPASS; $savedSshCommand = $env:GIT_SSH_COMMAND
-            try {
-                Remove-Item Env:GIT_ASKPASS,Env:SSH_ASKPASS,Env:GIT_SSH_COMMAND -ErrorAction SilentlyContinue
-                $env:GIT_TERMINAL_PROMPT = '0'
-                $push = & $GitInvoker -GitArgs @($helperArgs + @('-c', 'http.extraHeader=', '-c', 'core.askPass=', '-c', 'push.followTags=false', 'push', $DestinationUrl, $RefSpec)) -WorkingDirectory $WorkspacePath
-            }
-            finally {
-                $env:GIT_ASKPASS = $savedAskPass; $env:SSH_ASKPASS = $savedSshAskPass; $env:GIT_SSH_COMMAND = $savedSshCommand
-                Remove-Item Env:GIT_TERMINAL_PROMPT -ErrorAction SilentlyContinue
-            }
+            # Push from the isolated repository. The validated URL is now consumed
+            # under the same empty config source that excludes rewrites and headers.
+            $push = & $GitInvoker -GitArgs @($helperArgs + @('-c', 'push.followTags=false', 'push', $DestinationUrl, $isolatedRefSpec)) -WorkingDirectory $transportDir
             $pushExit = $push.ExitCode
             if ($push.ExitCode -ne 0) { $notes.Add('git push exited nonzero'); $verdict = 'push-failed' }
             else { $verdict = 'published' }
@@ -592,6 +609,9 @@ function Invoke-SpikePublication {
         }
         catch { $cleanupExit = 1 }
         $payload = $null
+        Get-ChildItem Env: | Where-Object { $_.Name -like 'GIT_*' } | ForEach-Object { Remove-Item ("Env:" + $_.Name) -ErrorAction SilentlyContinue }
+        foreach ($name in $savedGitEnvironment.Keys) { Set-Item ("Env:" + $name) $savedGitEnvironment[$name] }
+        Remove-Item -LiteralPath $transportDir -Recurse -Force -ErrorAction SilentlyContinue
     }
     $originalVerdict = $verdict
     if ($cleanupExit -ne 0) {

--- a/scripts/spikes/lane-privilege/LanePrivilegeSpike.psm1
+++ b/scripts/spikes/lane-privilege/LanePrivilegeSpike.psm1
@@ -4,11 +4,18 @@
 #   1. Principal comes from WindowsIdentity, never from environment variables —
 #      a spoofed USERNAME/USERPROFILE must never let an unrestricted caller pass.
 #   2. Protected-credential probes only open and immediately dispose a read handle;
-#      they never read, log, or print file content.
+#      they never read, log, or print file content. Only real access-denied evidence
+#      satisfies the negative property; sharing violations and other IO errors are
+#      INCONCLUSIVE, never protection proof (Round1 F5).
 #   3. Token values never appear in output, argv, environment, or files. All emitted
-#      text passes through Hide-SecretPatterns.
+#      text passes through Hide-SecretPatterns. The publication path moves the token
+#      exclusively through a stdin pipe into git's in-memory credential cache (Round1 F3).
 #   4. secret-ref resolution is real or explicitly UNSUPPORTED — never a mock value.
-#   5. Push targets only the exact allowlisted spike branch; main is always refused.
+#   5. Publication binds the actual destination (resolved push URL) to the repo
+#      allowlist immediately before the push, and emits exactly one explicit refspec
+#      with tag-following disabled (Round1 F2).
+#   6. Uncertain gh metadata (parse failure, error exit, login-without-token) is
+#      INCONCLUSIVE, never a pass (Round1 F1).
 
 Set-StrictMode -Version 3.0
 
@@ -16,9 +23,10 @@ Set-StrictMode -Version 3.0
 $script:EXIT_OK                 = 0
 $script:EXIT_PREFLIGHT_FAILED   = 2
 $script:EXIT_PRINCIPAL_REFUSED  = 3
-$script:EXIT_PROTECTION_FAIL    = 4   # negative test observed READABLE / token present
+$script:EXIT_PROTECTION_FAIL    = 4   # negative test observed READABLE / reachable token
 $script:EXIT_PROVIDER_UNSUPPORTED = 5
 $script:EXIT_INCONCLUSIVE       = 6
+$script:EXIT_PUBLICATION_FAILED = 7
 
 # Token shapes: GitHub OAuth/user/server/fine-grained PATs and generic bearer-ish
 # values. Used ONLY to scrub output; never to validate a token.
@@ -105,12 +113,22 @@ function Assert-SafeSpikeBranch {
 }
 
 function Assert-SafeRepoTarget {
+    <#
+        .SYNOPSIS
+        Validates one allowlist entry as a well-formed 'owner/repo' pair (no
+        wildcards, no traversal). The ACTUAL publication destination is bound
+        separately by Get-EffectivePushUrl / Test-PushUrlAllowed immediately
+        before the push (Round1 F2).
+    #>
     param(
         [Parameter(Mandatory)][string]$Repo,
         [Parameter(Mandatory)][string[]]$RepoAllowList
     )
     if ([string]::IsNullOrWhiteSpace($Repo) -or $Repo.Contains('*')) {
         throw "Repo guard: empty or wildcard repo refused."
+    }
+    if ($Repo -notmatch '^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*$') {
+        throw "Repo guard: '$Repo' is not a well-formed owner/repo pair."
     }
     $exact = $RepoAllowList | Where-Object {
         [string]::Equals($_, $Repo, [System.StringComparison]::OrdinalIgnoreCase)
@@ -122,10 +140,83 @@ function Assert-SafeRepoTarget {
     return $true
 }
 
+function Test-PushUrlAllowed {
+    <#
+        .SYNOPSIS
+        Pure matcher: decides whether a resolved git remote/push URL points at one
+        of the allowlisted repositories. Handles the common GitHub URL shapes
+        (ssh scp-like, ssh://, https://, git://). Anything it cannot parse with
+        confidence is refused (fail closed).
+    #>
+    param(
+        [Parameter(Mandatory)][string]$Url,
+        [Parameter(Mandatory)][string[]]$RepoAllowList
+    )
+    if ([string]::IsNullOrWhiteSpace($Url)) { return $false }
+
+    # Extract OWNER/REPO from the known GitHub URL shapes, anchored at the end
+    # (optional .git suffix). The HOST is pinned to github.com — an allowlisted
+    # owner/repo on another host (e.g. gitlab.com) must not pass (Round1 F2).
+    $patterns = @(
+        '^git@github\.com:([A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*?)(?:\.git)?$',
+        '^[a-z][a-z0-9+.-]*://(?:[^/@\s]+@)?github\.com/([A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*?)(?:\.git)?$'
+    )
+    $ownerRepo = $null
+    foreach ($p in $patterns) {
+        $m = [regex]::Match($Url, $p)
+        if ($m.Success) { $ownerRepo = $m.Groups[1].Value; break }
+    }
+    if ($null -eq $ownerRepo) { return $false }
+    if ($ownerRepo.Contains('..')) { return $false }
+
+    $exact = $RepoAllowList | Where-Object {
+        [string]::Equals($_, $ownerRepo, [System.StringComparison]::OrdinalIgnoreCase)
+    }
+    return [bool]$exact
+}
+
+function Get-EffectivePushUrl {
+    <#
+        .SYNOPSIS
+        Resolves the push URL git will actually use for the named remote in the
+        given workspace (pushurl if configured, else url), validates it against
+        the repo allowlist, and returns it. Local config reads only; no network.
+        Throws (fail closed) when the destination cannot be resolved to an
+        allowlisted repository.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$WorkspacePath,
+        [Parameter(Mandatory)][string[]]$RepoAllowList,
+        [string]$RemoteName = 'origin'
+    )
+    $url = $null
+    foreach ($key in @("remote.$RemoteName.pushurl", "remote.$RemoteName.url")) {
+        $out = & git -C $WorkspacePath config --get --null $key 2>$null
+        if ($LASTEXITCODE -eq 0 -and $null -ne $out -and ("$out".Trim().Length -gt 0)) {
+            # --null returns NUL-delimited; take the first value, strip the terminator.
+            $url = ("$out" -split "`0")[0]
+            break
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($url)) {
+        $out = & git -C $WorkspacePath remote get-url $RemoteName 2>$null
+        if ($LASTEXITCODE -eq 0) { $url = "$out".Trim() }
+    }
+    if ([string]::IsNullOrWhiteSpace($url)) {
+        throw ("Push destination guard: remote '{0}' has no resolvable URL in '{1}'." -f $RemoteName, $WorkspacePath)
+    }
+    if (-not (Test-PushUrlAllowed -Url $url -RepoAllowList $RepoAllowList)) {
+        throw ("Push destination guard: effective push URL '{0}' does not resolve to an allowlisted repository [{1}]." -f
+            (Hide-SecretPatterns -Text $url), ($RepoAllowList -join ', '))
+    }
+    return $url
+}
+
 enum CredentialProbeResult {
-    AccessDenied    # protection property MET (fail-closed success for the negative test)
+    AccessDenied    # real access-denied evidence — protection property MET
     Readable        # protection property NOT met — baseline failure signal
-    NotFound        # inconclusive: nothing was proven
+    NotFound        # inconclusive: target absent, nothing proven
+    Inconclusive    # inconclusive: sharing violation / transient IO state, NOT access control (Round1 F5)
     ProbeError      # probe itself failed for an unexpected reason
 }
 
@@ -135,7 +226,8 @@ function Get-CredentialFileProbe {
         Attempts to open a read handle on a protected credential file and immediately
         disposes it. NEVER reads, stores, or prints any byte of file content.
         .OUTPUTS
-        [CredentialProbeResult]
+        [CredentialProbeResult]. Only UnauthorizedAccessException maps to AccessDenied;
+        sharing violations and other IO failures map to Inconclusive (Round1 F5).
     #>
     param([Parameter(Mandatory)][string]$Path)
 
@@ -157,8 +249,9 @@ function Get-CredentialFileProbe {
             return [CredentialProbeResult]::AccessDenied
         }
         catch [System.IO.IOException] {
-            # Sharing violation or an ACL-mediated IO error is still "denied to us".
-            return [CredentialProbeResult]::AccessDenied
+            # Sharing violation or transient IO state: we could not open the file,
+            # but that is NOT proof of an ACL denial. Inconclusive, never evidence.
+            return [CredentialProbeResult]::Inconclusive
         }
         finally {
             if ($null -ne $stream) { $stream.Dispose() }
@@ -205,9 +298,10 @@ function Resolve-BrokerToken {
         Resolves a token provider reference to a SecureString — for real, or fails
         with an explicit UNSUPPORTED classification. Never returns a mock value.
         .NOTES
-        The returned SecureString must stay in memory and be consumed by the one
-        authorized sink (currently: `gh auth login --with-token` stdin). Callers
-        must not persist, log, or pass it through argv/environment.
+        The returned SecureString stays in memory and is consumed only by
+        Invoke-SpikePublication, which moves it through a stdin pipe into git's
+        in-memory credential cache. It must never be persisted, logged, or passed
+        through argv/environment.
     #>
     param([Parameter(Mandatory)][string]$ProviderRef)
 
@@ -252,42 +346,238 @@ function Resolve-BrokerToken {
 function Get-GhTokenSourceMetadata {
     <#
         .SYNOPSIS
-        Runs `gh auth status` and reduces it to identity/token-SOURCE metadata only.
-        Token values (even the masked ones gh prints) are dropped before anything
-        is returned or printed.
-        .OUTPUTS
-        PSCustomObject with LoggedIn (bool), Host, Account, TokenPresent (bool),
-        TokenSource (string: 'keyring' | 'infile' | 'env' | 'unknown' | 'none').
+        Reduces `gh auth status` output to identity/token-SOURCE metadata only.
+        Token values (even the masked forms gh prints) are dropped BEFORE anything
+        is returned or printed. The source class is parsed FROM the token line
+        before it is discarded (Round1 F1).
+        .PARAMETER StatusText
+        Synthetic injection point for fixture tests: when supplied, these lines are
+        reduced instead of invoking gh. The real action path omits this parameter.
+        .NOTES
+        Throws (fail closed) when gh is missing or `gh auth status` exits nonzero —
+        a failed status must never be read as "no token".
     #>
+    param([string[]]$StatusText)
+
     $meta = [pscustomobject]@{
         LoggedIn     = $false
         Host         = $null
         Account      = $null
         TokenPresent = $false
         TokenSource  = 'none'
+        GhExit       = 0
     }
-    if ($null -eq (Get-Command gh -ErrorAction SilentlyContinue)) {
-        throw "INCONCLUSIVE: gh CLI not found; token-source metadata cannot be collected."
+
+    if ($null -eq $StatusText -or $StatusText.Count -eq 0) {
+        if ($null -eq (Get-Command gh -ErrorAction SilentlyContinue)) {
+            throw "INCONCLUSIVE: gh CLI not found; token-source metadata cannot be collected."
+        }
+        $raw = & gh auth status 2>&1
+        $meta.GhExit = $LASTEXITCODE
+        if ($meta.GhExit -ne 0) {
+            throw ("INCONCLUSIVE: gh auth status exited {0}; token-source state unknown." -f $meta.GhExit)
+        }
     }
-    $raw = & gh auth status 2>&1
-    $meta | Add-Member -NotePropertyName GhExit -NotePropertyValue $LASTEXITCODE
+    else {
+        $raw = $StatusText
+        $meta.GhExit = 0
+    }
+
     foreach ($line in @($raw)) {
         $text = "$line"
-        # Drop every line that could carry token material before it can escape.
-        if ($text -match 'Token:') { 
-            if ($text -notmatch 'no token|token: none') { $meta.TokenPresent = $true }
+        if ($text -match '(?i)token') {
+            # Parse the source class from the token line BEFORE discarding it.
+            # An annotated token line is BOTH present and sourced (Round1 F1).
+            if ($text -match '(?i)no token|token: none') {
+                # An explicit absence statement is not a token.
+            }
+            else {
+                $meta.TokenPresent = $true
+                if ($text -match '\((keyring|infile|env|oauth_token)\)') {
+                    $meta.TokenSource = $Matches[1]
+                }
+                else {
+                    $meta.TokenSource = 'unknown'
+                }
+            }
+            # Any other token-bearing line is dropped here; it never reaches output.
             continue
         }
         if ($text -match 'github\.com') { $meta.Host = 'github.com' }
-        if ($text -match 'Logged in to github\.com as ([A-Za-z0-9-]+)') {
+        if ($text -match 'Logged in to github\.com (?:as|account) ([A-Za-z0-9-]+)') {
             $meta.LoggedIn = $true
             $meta.Account = $Matches[1]
         }
-        if ($text -match 'Token: .*\((keyring|infile|env)\)') {
-            $meta.TokenSource = $Matches[1]
-        }
     }
     return $meta
+}
+
+function Get-GhMetadataVerdict {
+    <#
+        .SYNOPSIS
+        Adjudicates gh metadata for the negative property "no token is reachable
+        from the restricted lane". Fail closed: any present token is a violation
+        (including unparsable source); logged-in-without-token and error exits are
+        inconclusive, never a pass (Round1 F1).
+        .OUTPUTS
+        'ok-no-login' | 'deny-token-present' | 'inconclusive-ambiguous' | 'inconclusive-error'
+    #>
+    param(
+        [Parameter(Mandatory)]$Metadata,
+        [int]$GhExitCode = 0
+    )
+    if ($GhExitCode -ne 0) { return 'inconclusive-error' }
+    if ($Metadata.TokenPresent) { return 'deny-token-present' }
+    if ($Metadata.LoggedIn) { return 'inconclusive-ambiguous' }
+    return 'ok-no-login'
+}
+
+function ConvertFrom-SecureStringInMemory {
+    <#
+        .SYNOPSIS
+        Decrypts a SecureString to plaintext for immediate, in-process use only.
+        The caller must consume the value without storing, logging, or passing it
+        through argv/environment, and must drop the reference immediately.
+    #>
+    param([Parameter(Mandatory)][securestring]$SecureValue)
+    $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureValue)
+    try {
+        return [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+    }
+    finally {
+        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+    }
+}
+
+function Invoke-GitProcess {
+    <#
+        .SYNOPSIS
+        Real git invoker: runs git with the given argument array and optional stdin
+        payload, and returns an observable result object. Arguments are passed as
+        an array (never interpolated into a command line string).
+    #>
+    param(
+        [Parameter(Mandatory)][string[]]$GitArgs,
+        [string]$StdinInput,
+        [string]$WorkingDirectory
+    )
+    $out = $null
+    if ($PSBoundParameters.ContainsKey('WorkingDirectory') -and -not [string]::IsNullOrWhiteSpace($WorkingDirectory)) {
+        if ($PSBoundParameters.ContainsKey('StdinInput') -and $null -ne $StdinInput) {
+            $out = $StdinInput | & git @GitArgs 2>&1
+        }
+        else {
+            Push-Location $WorkingDirectory
+            try { $out = & git @GitArgs 2>&1 } finally { Pop-Location }
+        }
+    }
+    elseif ($PSBoundParameters.ContainsKey('StdinInput') -and $null -ne $StdinInput) {
+        $out = $StdinInput | & git @GitArgs 2>&1
+    }
+    else {
+        $out = & git @GitArgs 2>&1
+    }
+    return [pscustomobject]@{
+        ExitCode = $LASTEXITCODE
+        Output   = @($out | ForEach-Object { "$_" })
+        Args     = $GitArgs
+        Stdin    = $StdinInput
+    }
+}
+
+function Test-GitCredentialCacheAvailable {
+    <#
+        .SYNOPSIS
+        True only when git ships the in-memory credential-cache helper on this host.
+        The publication path is UNSUPPORTED without it (no persistent fallback).
+    #>
+    return ($null -ne (Get-Command 'git-credential-cache' -ErrorAction SilentlyContinue))
+}
+
+function Invoke-SpikePublication {
+    <#
+        .SYNOPSIS
+        Publishes the spike branch using a NONPERSISTENT, process-local credential
+        path (Round1 F3): the resolved token is moved through a stdin pipe into
+        git's in-memory credential-cache daemon (isolated helper list, short
+        timeout), the push uses that cache and ONLY that cache, and the entry is
+        rejected and the daemon stopped afterwards. No `gh auth login` is involved;
+        nothing is written to disk, keyring, environment, or argv.
+        .PARAMETER GitInvoker
+        Injectable git delegate for fixture tests (default: Invoke-GitProcess).
+        Receives the same parameter set and must return an object with ExitCode,
+        Output, Args, Stdin.
+        .OUTPUTS
+        PSCustomObject: Verdict ('published'|'auth-failed'|'push-failed'|
+        'cleanup-incomplete'), PushExit, CleanupExit, Notes.
+        A 'published' verdict proves ONLY that git published the ref; it does not
+        by itself prove the token was broker-scoped — that requires the broker's
+        own audit trail (documented in README.md).
+    #>
+    param(
+        [Parameter(Mandatory)][securestring]$Token,
+        [Parameter(Mandatory)][string]$WorkspacePath,
+        [Parameter(Mandatory)][string]$RemoteName,
+        [Parameter(Mandatory)][string]$RefSpec,
+        [string]$CredentialUsername = 'x-access-token',
+        [string]$CredentialHost = 'github.com',
+        [int]$CacheTimeoutSeconds = 120,
+        [scriptblock]$GitInvoker = ${function:Invoke-GitProcess}
+    )
+
+    $helperArgs = @(
+        '-c', 'credential.helper=',
+        '-c', "credential.helper=cache --timeout=$CacheTimeoutSeconds"
+    )
+
+    # Build the credential payload; the plaintext token exists only here, in
+    # process memory, and only long enough to pipe it to `git credential approve`.
+    $plain = ConvertFrom-SecureStringInMemory -SecureValue $Token
+    $payload = "protocol=https`nhost=$CredentialHost`nusername=$CredentialUsername`npassword=$plain`n`n"
+    $plain = $null   # drop the reference; the cached copy is evicted in cleanup
+
+    $notes = [System.Collections.Generic.List[string]]::new()
+    $pushExit = $null
+    $cleanupExit = 0
+    $verdict = $null
+
+    # 1. Approve the credential into the in-memory cache. On failure: NEVER push.
+    $approve = & $GitInvoker -GitArgs @($helperArgs + @('credential', 'approve')) -StdinInput $payload
+    if ($approve.ExitCode -ne 0) {
+        $notes.Add('credential approve failed; publication refused before any push')
+        $verdict = 'auth-failed'
+    }
+    else {
+        # 2. Push with the isolated helper list, one explicit refspec, tag-following
+        #    disabled, and the validated destination already resolved by the caller.
+        $push = & $GitInvoker -GitArgs @($helperArgs + @('-c', 'push.followTags=false', 'push', $RemoteName, $RefSpec)) -WorkingDirectory $WorkspacePath
+        $pushExit = $push.ExitCode
+        if ($push.ExitCode -ne 0) {
+            $notes.Add('git push exited nonzero')
+            $verdict = 'push-failed'
+        }
+        else {
+            $verdict = 'published'
+        }
+    }
+
+    # 3. Cleanup is always attempted and its result is observable. `credential
+    #    reject` evicts the entry; `credential-cache exit` stops the daemon.
+    $reject = & $GitInvoker -GitArgs @($helperArgs + @('credential', 'reject')) -StdinInput $payload
+    $cacheExit = & $GitInvoker -GitArgs @(@('credential-cache', 'exit'))
+    $payload = $null
+    if ($reject.ExitCode -ne 0 -or $cacheExit.ExitCode -ne 0) {
+        $cleanupExit = 1
+        $notes.Add('cleanup incomplete: credential reject/cache daemon exit failed — inspect git credential-cache processes')
+        if ($verdict -eq 'published') { $verdict = 'cleanup-incomplete' }
+    }
+
+    return [pscustomobject]@{
+        Verdict    = $verdict
+        PushExit   = $pushExit
+        CleanupExit = $cleanupExit
+        Notes      = $notes
+    }
 }
 
 Export-ModuleMember -Function @(
@@ -297,12 +587,20 @@ Export-ModuleMember -Function @(
     'Write-SpikeSafe',
     'Assert-SafeSpikeBranch',
     'Assert-SafeRepoTarget',
+    'Test-PushUrlAllowed',
+    'Get-EffectivePushUrl',
     'Get-CredentialFileProbe',
     'Get-TokenProviderKind',
     'Resolve-BrokerToken',
-    'Get-GhTokenSourceMetadata'
+    'Get-GhTokenSourceMetadata',
+    'Get-GhMetadataVerdict',
+    'ConvertFrom-SecureStringInMemory',
+    'Invoke-GitProcess',
+    'Test-GitCredentialCacheAvailable',
+    'Invoke-SpikePublication'
 )
 Export-ModuleMember -Variable @(
     'EXIT_OK', 'EXIT_PREFLIGHT_FAILED', 'EXIT_PRINCIPAL_REFUSED',
-    'EXIT_PROTECTION_FAIL', 'EXIT_PROVIDER_UNSUPPORTED', 'EXIT_INCONCLUSIVE'
+    'EXIT_PROTECTION_FAIL', 'EXIT_PROVIDER_UNSUPPORTED', 'EXIT_INCONCLUSIVE',
+    'EXIT_PUBLICATION_FAILED'
 )

--- a/scripts/spikes/lane-privilege/LanePrivilegeSpike.psm1
+++ b/scripts/spikes/lane-privilege/LanePrivilegeSpike.psm1
@@ -141,75 +141,85 @@ function Assert-SafeRepoTarget {
 }
 
 function Test-PushUrlAllowed {
-    <#
-        .SYNOPSIS
-        Pure matcher: decides whether a resolved git remote/push URL points at one
-        of the allowlisted repositories. Handles the common GitHub URL shapes
-        (ssh scp-like, ssh://, https://, git://). Anything it cannot parse with
-        confidence is refused (fail closed).
-    #>
+    <# Clean HTTPS only: credential-cache cannot control SSH or URL-embedded auth. #>
     param(
         [Parameter(Mandatory)][string]$Url,
         [Parameter(Mandatory)][string[]]$RepoAllowList
     )
     if ([string]::IsNullOrWhiteSpace($Url)) { return $false }
-
-    # Extract OWNER/REPO from the known GitHub URL shapes, anchored at the end
-    # (optional .git suffix). The HOST is pinned to github.com — an allowlisted
-    # owner/repo on another host (e.g. gitlab.com) must not pass (Round1 F2).
-    $patterns = @(
-        '^git@github\.com:([A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*?)(?:\.git)?$',
-        '^[a-z][a-z0-9+.-]*://(?:[^/@\s]+@)?github\.com/([A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*?)(?:\.git)?$'
-    )
-    $ownerRepo = $null
-    foreach ($p in $patterns) {
-        $m = [regex]::Match($Url, $p)
-        if ($m.Success) { $ownerRepo = $m.Groups[1].Value; break }
-    }
-    if ($null -eq $ownerRepo) { return $false }
-    if ($ownerRepo.Contains('..')) { return $false }
-
-    $exact = $RepoAllowList | Where-Object {
-        [string]::Equals($_, $ownerRepo, [System.StringComparison]::OrdinalIgnoreCase)
-    }
-    return [bool]$exact
+    try { $uri = [uri]$Url } catch { return $false }
+    if ($uri.Scheme -ne 'https' -or $uri.Host -ne 'github.com' -or -not [string]::IsNullOrEmpty($uri.UserInfo) -or
+        $uri.Query -or $uri.Fragment -or $uri.Port -ne 443) { return $false }
+    $path = $uri.AbsolutePath.Trim('/')
+    if ($path.EndsWith('.git', [System.StringComparison]::OrdinalIgnoreCase)) { $path = $path.Substring(0, $path.Length - 4) }
+    if ($path -notmatch '^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*$' -or $path.Contains('..')) { return $false }
+    return [bool]($RepoAllowList | Where-Object { [string]::Equals($_, $path, [System.StringComparison]::OrdinalIgnoreCase) })
 }
 
 function Get-EffectivePushUrl {
-    <#
-        .SYNOPSIS
-        Resolves the push URL git will actually use for the named remote in the
-        given workspace (pushurl if configured, else url), validates it against
-        the repo allowlist, and returns it. Local config reads only; no network.
-        Throws (fail closed) when the destination cannot be resolved to an
-        allowlisted repository.
-    #>
+    <# Resolves every rewritten target Git would use, requiring exactly one clean HTTPS URL. #>
     param(
         [Parameter(Mandatory)][string]$WorkspacePath,
         [Parameter(Mandatory)][string[]]$RepoAllowList,
         [string]$RemoteName = 'origin'
     )
-    $url = $null
-    foreach ($key in @("remote.$RemoteName.pushurl", "remote.$RemoteName.url")) {
-        $out = & git -C $WorkspacePath config --get --null $key 2>$null
-        if ($LASTEXITCODE -eq 0 -and $null -ne $out -and ("$out".Trim().Length -gt 0)) {
-            # --null returns NUL-delimited; take the first value, strip the terminator.
-            $url = ("$out" -split "`0")[0]
-            break
-        }
+    # `remote get-url --push --all` applies Git's url.*.pushInsteadOf rules and
+    # returns every pushurl (or every fallback URL), unlike config --get.
+    $urls = @(& git -C $WorkspacePath remote get-url --push --all $RemoteName 2>$null |
+        ForEach-Object { "$($_)".Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if ($LASTEXITCODE -ne 0 -or $urls.Count -ne 1) {
+        throw ("Push destination guard: remote '{0}' must resolve to exactly one effective push URL (got {1})." -f $RemoteName, $urls.Count)
     }
-    if ([string]::IsNullOrWhiteSpace($url)) {
-        $out = & git -C $WorkspacePath remote get-url $RemoteName 2>$null
-        if ($LASTEXITCODE -eq 0) { $url = "$out".Trim() }
-    }
-    if ([string]::IsNullOrWhiteSpace($url)) {
-        throw ("Push destination guard: remote '{0}' has no resolvable URL in '{1}'." -f $RemoteName, $WorkspacePath)
-    }
+    $url = $urls[0]
     if (-not (Test-PushUrlAllowed -Url $url -RepoAllowList $RepoAllowList)) {
-        throw ("Push destination guard: effective push URL '{0}' does not resolve to an allowlisted repository [{1}]." -f
+        throw ("Push destination guard: effective push URL '{0}' is not a clean allowlisted HTTPS destination [{1}]." -f
             (Hide-SecretPatterns -Text $url), ($RepoAllowList -join ', '))
     }
     return $url
+}
+
+function Resolve-SpikePrincipalProfile {
+    <# Resolves a principal's profile through its Windows SID/ProfileList mapping, not USERPROFILE. #>
+    param([Parameter(Mandatory)][string]$Principal)
+    try {
+        $sid = ([System.Security.Principal.NTAccount]$Principal).Translate([System.Security.Principal.SecurityIdentifier]).Value
+        $key = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$sid"
+        $profile = (Get-ItemProperty -LiteralPath $key -Name ProfileImagePath -ErrorAction Stop).ProfileImagePath
+        if ([string]::IsNullOrWhiteSpace($profile) -or -not [System.IO.Path]::IsPathRooted($profile)) { throw 'profile path missing' }
+        return [System.IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($profile))
+    }
+    catch { throw "Protected-target guard: cannot resolve trusted Windows profile for '$Principal'." }
+}
+
+function Assert-ProtectedCredentialTargets {
+    <# Requires exactly the documented operator credential files under the trusted operator profile. #>
+    param(
+        [Parameter(Mandatory)][string]$OperatorPrincipal,
+        [Parameter(Mandatory)][string]$RestrictedPrincipal,
+        [Parameter(Mandatory)][string[]]$ProtectedCredentialFiles,
+        [scriptblock]$ProfileResolver = ${function:Resolve-SpikePrincipalProfile}
+    )
+    $operatorProfile = & $ProfileResolver $OperatorPrincipal
+    $restrictedProfile = & $ProfileResolver $RestrictedPrincipal
+    $expected = @('.claude\.credentials.json', '.codex\auth.json', '.pi\agent\auth.json') |
+        ForEach-Object { [System.IO.Path]::GetFullPath((Join-Path $operatorProfile $_)) }
+    if ($ProtectedCredentialFiles.Count -ne $expected.Count) { throw 'Protected-target guard: exactly three explicit operator credential targets are required.' }
+    $actual = @()
+    foreach ($inputPath in $ProtectedCredentialFiles) {
+        if ([string]::IsNullOrWhiteSpace($inputPath) -or -not [System.IO.Path]::IsPathRooted($inputPath)) {
+            throw "Protected-target guard: credential target must be a nonempty absolute input path."
+        }
+        $full = [System.IO.Path]::GetFullPath($inputPath)
+        if ($full.StartsWith($restrictedProfile, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw 'Protected-target guard: a target inside the trusted restricted profile is refused.'
+        }
+        $actual += $full
+    }
+    if (($actual | Select-Object -Unique).Count -ne $actual.Count -or
+        (@($actual | Where-Object { $expected -notcontains $_ }).Count -ne 0)) {
+        throw 'Protected-target guard: targets must be the exact explicit credential set under the trusted operator profile.'
+    }
+    return $actual
 }
 
 enum CredentialProbeResult {
@@ -481,7 +491,6 @@ function Invoke-GitProcess {
         ExitCode = $LASTEXITCODE
         Output   = @($out | ForEach-Object { "$_" })
         Args     = $GitArgs
-        Stdin    = $StdinInput
     }
 }
 
@@ -506,7 +515,7 @@ function Invoke-SpikePublication {
         .PARAMETER GitInvoker
         Injectable git delegate for fixture tests (default: Invoke-GitProcess).
         Receives the same parameter set and must return an object with ExitCode,
-        Output, Args, Stdin.
+        Output, Args. Stdin is intentionally never retained in result objects.
         .OUTPUTS
         PSCustomObject: Verdict ('published'|'auth-failed'|'push-failed'|
         'cleanup-incomplete'), PushExit, CleanupExit, Notes.
@@ -517,7 +526,7 @@ function Invoke-SpikePublication {
     param(
         [Parameter(Mandatory)][securestring]$Token,
         [Parameter(Mandatory)][string]$WorkspacePath,
-        [Parameter(Mandatory)][string]$RemoteName,
+        [Parameter(Mandatory)][string]$DestinationUrl,
         [Parameter(Mandatory)][string]$RefSpec,
         [string]$CredentialUsername = 'x-access-token',
         [string]$CredentialHost = 'github.com',
@@ -539,44 +548,59 @@ function Invoke-SpikePublication {
     $notes = [System.Collections.Generic.List[string]]::new()
     $pushExit = $null
     $cleanupExit = 0
-    $verdict = $null
+    $verdict = 'auth-failed'
+    $originalVerdict = $null
 
-    # 1. Approve the credential into the in-memory cache. On failure: NEVER push.
-    $approve = & $GitInvoker -GitArgs @($helperArgs + @('credential', 'approve')) -StdinInput $payload
-    if ($approve.ExitCode -ne 0) {
-        $notes.Add('credential approve failed; publication refused before any push')
-        $verdict = 'auth-failed'
-    }
-    else {
-        # 2. Push with the isolated helper list, one explicit refspec, tag-following
-        #    disabled, and the validated destination already resolved by the caller.
-        $push = & $GitInvoker -GitArgs @($helperArgs + @('-c', 'push.followTags=false', 'push', $RemoteName, $RefSpec)) -WorkingDirectory $WorkspacePath
-        $pushExit = $push.ExitCode
-        if ($push.ExitCode -ne 0) {
-            $notes.Add('git push exited nonzero')
-            $verdict = 'push-failed'
+    try {
+        # Approve failure and an invoker exception both refuse publication.
+        $approve = & $GitInvoker -GitArgs @($helperArgs + @('credential', 'approve')) -StdinInput $payload
+        if ($approve.ExitCode -ne 0) {
+            $notes.Add('credential approve failed; publication refused before any push')
         }
         else {
-            $verdict = 'published'
+            # Push the already validated literal URL, never the remote alias. Reset
+            # helpers/headers and suppress interactive/askpass fallback inputs.
+            $savedAskPass = $env:GIT_ASKPASS; $savedSshAskPass = $env:SSH_ASKPASS; $savedSshCommand = $env:GIT_SSH_COMMAND
+            try {
+                Remove-Item Env:GIT_ASKPASS,Env:SSH_ASKPASS,Env:GIT_SSH_COMMAND -ErrorAction SilentlyContinue
+                $env:GIT_TERMINAL_PROMPT = '0'
+                $push = & $GitInvoker -GitArgs @($helperArgs + @('-c', 'http.extraHeader=', '-c', 'core.askPass=', '-c', 'push.followTags=false', 'push', $DestinationUrl, $RefSpec)) -WorkingDirectory $WorkspacePath
+            }
+            finally {
+                $env:GIT_ASKPASS = $savedAskPass; $env:SSH_ASKPASS = $savedSshAskPass; $env:GIT_SSH_COMMAND = $savedSshCommand
+                Remove-Item Env:GIT_TERMINAL_PROMPT -ErrorAction SilentlyContinue
+            }
+            $pushExit = $push.ExitCode
+            if ($push.ExitCode -ne 0) { $notes.Add('git push exited nonzero'); $verdict = 'push-failed' }
+            else { $verdict = 'published' }
         }
     }
-
-    # 3. Cleanup is always attempted and its result is observable. `credential
-    #    reject` evicts the entry; `credential-cache exit` stops the daemon.
-    $reject = & $GitInvoker -GitArgs @($helperArgs + @('credential', 'reject')) -StdinInput $payload
-    $cacheExit = & $GitInvoker -GitArgs @(@('credential-cache', 'exit'))
-    $payload = $null
-    if ($reject.ExitCode -ne 0 -or $cacheExit.ExitCode -ne 0) {
-        $cleanupExit = 1
-        $notes.Add('cleanup incomplete: credential reject/cache daemon exit failed — inspect git credential-cache processes')
-        if ($verdict -eq 'published') { $verdict = 'cleanup-incomplete' }
+    catch {
+        $notes.Add('publication invocation threw; publication refused')
+        $verdict = 'push-failed'
     }
-
+    finally {
+        # Cleanup must run even after a terminating injected/native failure.
+        try {
+            $reject = & $GitInvoker -GitArgs @($helperArgs + @('credential', 'reject')) -StdinInput $payload
+            if ($reject.ExitCode -ne 0) { $cleanupExit = 1 }
+        }
+        catch { $cleanupExit = 1 }
+        try {
+            $cacheExit = & $GitInvoker -GitArgs @(@('credential-cache', 'exit'))
+            if ($cacheExit.ExitCode -ne 0) { $cleanupExit = 1 }
+        }
+        catch { $cleanupExit = 1 }
+        $payload = $null
+    }
+    $originalVerdict = $verdict
+    if ($cleanupExit -ne 0) {
+        $notes.Add('cleanup incomplete: credential reject/cache daemon exit failed — inspect git credential-cache processes')
+        $verdict = 'cleanup-incomplete'
+    }
     return [pscustomobject]@{
-        Verdict    = $verdict
-        PushExit   = $pushExit
-        CleanupExit = $cleanupExit
-        Notes      = $notes
+        Verdict = $verdict; OriginalVerdict = $originalVerdict; PushExit = $pushExit
+        CleanupExit = $cleanupExit; Notes = $notes
     }
 }
 
@@ -589,6 +613,8 @@ Export-ModuleMember -Function @(
     'Assert-SafeRepoTarget',
     'Test-PushUrlAllowed',
     'Get-EffectivePushUrl',
+    'Resolve-SpikePrincipalProfile',
+    'Assert-ProtectedCredentialTargets',
     'Get-CredentialFileProbe',
     'Get-TokenProviderKind',
     'Resolve-BrokerToken',

--- a/scripts/spikes/lane-privilege/LanePrivilegeSpike.psm1
+++ b/scripts/spikes/lane-privilege/LanePrivilegeSpike.psm1
@@ -554,17 +554,9 @@ function Invoke-SpikePublication {
     $savedGitEnvironment = @{}
 
     try {
-        # Build a disposable bare repository as the sole local configuration source.
-        # It has no remotes, url.* rewrite rules, or http.* headers. Global/system
-        # config and inherited GIT_* config injection are excluded for every call.
-        $head = @(& git -C $WorkspacePath rev-parse HEAD 2>$null)
-        $head = ("$head").Trim()
-        $objects = @(& git -C $WorkspacePath rev-parse --git-path objects 2>$null)
-        $objects = ("$objects").Trim()
-        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($head) -or [string]::IsNullOrWhiteSpace($objects) -or $RefSpec -notmatch '^HEAD:') {
-            throw 'publication transport isolation could not resolve the workspace HEAD/object store.'
-        }
-        if (-not [System.IO.Path]::IsPathRooted($objects)) { $objects = Join-Path $WorkspacePath $objects }
+        # Bind the named workspace before resolving its source object. Snapshot and
+        # clear every inherited GIT_* routing/config variable FIRST: `git -C` alone
+        # does not defeat GIT_DIR, GIT_WORK_TREE, or GIT_OBJECT_DIRECTORY.
         $globalConfig = Join-Path $transportDir 'global.gitconfig'
         New-Item -ItemType Directory -Path $transportDir -Force | Out-Null
         New-Item -ItemType File -Path $globalConfig -Force | Out-Null
@@ -573,6 +565,15 @@ function Invoke-SpikePublication {
             Remove-Item ("Env:" + $_.Name) -ErrorAction Stop
         }
         $env:GIT_CONFIG_NOSYSTEM = '1'; $env:GIT_CONFIG_GLOBAL = $globalConfig
+        $head = @(& git -C $WorkspacePath rev-parse HEAD 2>$null); $head = ("$head").Trim()
+        $commonDir = @(& git -C $WorkspacePath rev-parse --path-format=absolute --git-common-dir 2>$null); $commonDir = ("$commonDir").Trim()
+        $objects = @(& git -C $WorkspacePath rev-parse --path-format=absolute --git-path objects 2>$null); $objects = ("$objects").Trim()
+        $expectedObjects = if ([string]::IsNullOrWhiteSpace($commonDir)) { $null } else { [System.IO.Path]::GetFullPath((Join-Path $commonDir 'objects')) }
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($head) -or [string]::IsNullOrWhiteSpace($objects) -or
+            $null -eq $expectedObjects -or -not [string]::Equals([System.IO.Path]::GetFullPath($objects), $expectedObjects, [System.StringComparison]::OrdinalIgnoreCase) -or
+            -not (Test-Path -LiteralPath $objects -PathType Container) -or $RefSpec -notmatch '^HEAD:') {
+            throw 'publication transport isolation could not bind the named workspace HEAD/object store.'
+        }
         $env:GIT_ALTERNATE_OBJECT_DIRECTORIES = $objects; $env:GIT_TERMINAL_PROMPT = '0'
         & git init --bare --quiet $transportDir 2>$null
         if ($LASTEXITCODE -ne 0) { throw 'publication transport isolation could not create its disposable git directory.' }

--- a/scripts/spikes/lane-privilege/README.md
+++ b/scripts/spikes/lane-privilege/README.md
@@ -73,7 +73,7 @@ setup (§ Operator setup below), executes the GH-690 spike:
 | Item | Status |
 |---|---|
 | Baseline FAIL evidence (lane can read operator credentials + org token) | **READ, not re-measured** — GH-690 issue body, 2026-09-02 22:5x on 4090, basis `a1dd3d8` (threat model §1). Rerunning equals re-touching credentials; the conclusion does not change by rerunning. |
-| Fixture tests of preflight + refusal branches | **RAN** — 62/62 pass (safe synthetic fixtures; see run receipt in the PR). |
+| Fixture tests of preflight + refusal branches | **RAN** — 63/63 pass (safe synthetic fixtures; see run receipt in the PR). |
 | Restricted-account negative tests (AccessDenied observed) | **NOT RUN** — no restricted account exists on this host. |
 | Restricted-account positive test (broker token → build/test/push of the spike branch) | **NOT RUN** — no restricted account, no GitHub App installation-token broker. |
 

--- a/scripts/spikes/lane-privilege/README.md
+++ b/scripts/spikes/lane-privilege/README.md
@@ -66,13 +66,14 @@ setup (§ Operator setup below), executes the GH-690 spike:
 | 4 | protection property not met — credential readable or operator token visible; baseline-expected, run stopped |
 | 5 | token provider explicitly unsupported |
 | 6 | inconclusive (e.g. `gh` unavailable) |
+| 7 | publication failed or credential cleanup was incomplete |
 
 ## Evidence status (honest ledger)
 
 | Item | Status |
 |---|---|
 | Baseline FAIL evidence (lane can read operator credentials + org token) | **READ, not re-measured** — GH-690 issue body, 2026-09-02 22:5x on 4090, basis `a1dd3d8` (threat model §1). Rerunning equals re-touching credentials; the conclusion does not change by rerunning. |
-| Fixture tests of preflight + refusal branches | **RAN** — 19/19 pass (see run receipt in the PR). |
+| Fixture tests of preflight + refusal branches | **RAN** — 62/62 pass (safe synthetic fixtures; see run receipt in the PR). |
 | Restricted-account negative tests (AccessDenied observed) | **NOT RUN** — no restricted account exists on this host. |
 | Restricted-account positive test (broker token → build/test/push of the spike branch) | **NOT RUN** — no restricted account, no GitHub App installation-token broker. |
 
@@ -97,6 +98,7 @@ The harness needs exactly these four things; nothing else was assumed or faked:
    the restricted principal, e.g.:
 
    ```powershell
+   # Use edda-node://… instead of credman:// once the broker exists.
    pwsh -NoProfile -File scripts/spikes/lane-privilege/Invoke-SpikeAction.ps1 `
      -OperatorPrincipal      'MACHINE\fagem' `
      -RestrictedPrincipal    'MACHINE\edda-lane' `
@@ -104,8 +106,8 @@ The harness needs exactly these four things; nothing else was assumed or faked:
      -BuildLanePath          '<lane-root>\worker-N' `
      -RepoAllowList          'fagemx/edda' `
      -BranchAllowList        'spike/lane-privilege-<date>' `
-     -TokenProviderRef       'credman://gh-lane-spike'   `# or edda-node://… once the broker exists `
-  -ProtectedCredentialFiles @('C:\Users\fagem\.claude\.credentials.json', `
+     -TokenProviderRef       'credman://gh-lane-spike' `
+     -ProtectedCredentialFiles @('C:\Users\fagem\.claude\.credentials.json', `
                               'C:\Users\fagem\.codex\auth.json', `
                               'C:\Users\fagem\.pi\agent\auth.json')
    ```

--- a/scripts/spikes/lane-privilege/README.md
+++ b/scripts/spikes/lane-privilege/README.md
@@ -104,7 +104,10 @@ The harness needs exactly these four things; nothing else was assumed or faked:
      -BuildLanePath          '<lane-root>\worker-N' `
      -RepoAllowList          'fagemx/edda' `
      -BranchAllowList        'spike/lane-privilege-<date>' `
-     -TokenProviderRef       'credman://gh-lane-spike'   # or edda-node://… once the broker exists
+     -TokenProviderRef       'credman://gh-lane-spike'   `# or edda-node://… once the broker exists `
+  -ProtectedCredentialFiles @('C:\Users\fagem\.claude\.credentials.json', `
+                              'C:\Users\fagem\.codex\auth.json', `
+                              'C:\Users\fagem\.pi\agent\auth.json')
    ```
 
    The spike branch is created by the run itself (`HEAD:refs/heads/spike/…`);

--- a/scripts/spikes/lane-privilege/README.md
+++ b/scripts/spikes/lane-privilege/README.md
@@ -1,0 +1,114 @@
+# Lane privilege spike harness (GH-690)
+
+**Status: PREPARED, NOT RUN.** The real restricted-account build/test/push has not
+been executed: this host has no restricted lane account and no token broker.
+Everything below is the prepared harness plus fixture-level validation of its
+no-op and refusal branches. No positive spike evidence exists yet. Do not quote
+this harness as proof that the privilege boundary holds.
+
+## What this harness is
+
+A fail-closed PowerShell harness that, once the operator provisions the missing
+setup (§ Operator setup below), executes the GH-690 spike:
+
+- **Negative test A** — from the restricted principal, attempt to open each
+  protected credential file (`~/.claude/.credentials.json`, `~/.codex/auth.json`,
+  `~/.pi/agent/auth.json`) and immediately dispose the handle. It **never reads,
+  stores, or prints file content**. Expected after implementation: `AccessDenied`
+  for all. Any `Readable` result is the baseline failure signal (exit 4) and
+  stops the run before build/push.
+- **Negative test B** — collect `gh` identity and token **SOURCE** metadata only
+  (login name, whether a token is present, source class). Token values, including
+  the masked forms `gh` prints, are dropped before output. A keyring token
+  visible under the restricted principal → exit 4.
+- **Positive path** — resolve a short-lived broker token (real resolution or an
+  explicit UNSUPPORTED; never a mock), run `cargo test --workspace` in the
+  assigned build lane, and push to the **exact allowlisted spike branch only**
+  (`spike/…`; `main`/`master`/`HEAD` are structurally refused by the branch guard).
+
+## Files
+
+| File | Role |
+|---|---|
+| `LanePrivilegeSpike.psm1` | shared fail-closed helpers (principal, probe, scrubber, branch/repo guards, provider classification/resolution) |
+| `Invoke-Preflight.ps1` | **no-secrets** metadata preflight: parameter shape, principal classification, path existence, allowlist validity, provider scheme classification, tool availability |
+| `Invoke-SpikeAction.ps1` | the gated action: preflight → principal assertion → negative tests → token resolution → build/test → push |
+| `tests/run-fixture-tests.ps1` | fixture tests of the no-op preflight and refusal branches (no real credentials, no ACL/account changes, no network, no build/push) |
+
+## Fail-closed properties (verified by the fixture tests)
+
+1. **Principal comes from the process token** (`WindowsIdentity`), never from the
+   environment — a spoofed `USERNAME`/`USERPROFILE` cannot make an unrestricted
+   caller pass (T5).
+2. **The action refuses any principal other than the restricted one**, including
+   the operator (exit 3, T4).
+3. **Probes never read content** — open/dispose only; a canary string in a fixture
+   file never appears in output (T6a). A missing file is `NotFound` =
+   inconclusive, not a pass (T6b).
+4. **Branch guard refuses** `main`, `master`, `HEAD`, `origin/main`,
+   `origin/master`, any non-`spike/` branch, and any name not exactly in the
+   allowlist (T7).
+5. **All output is scrubbed** through a token-pattern redactor before printing (T8).
+6. **Token resolution is real or explicitly UNSUPPORTED** — `edda-node://`
+   (node v0 has no credential-broker endpoint), `credman://` without the
+   CredentialManager module, and unknown schemes all fail with an explicit
+   UNSUPPORTED, never a mock value (T9). `file:`/`env:` refs are refused by
+   design (T3): secrets never land on disk and never travel through the
+   environment (decision `fleet.lane-privilege`).
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | success (or `-SkipBuildTest` completed) |
+| 2 | preflight failed |
+| 3 | principal refusal (not running as the restricted principal) |
+| 4 | protection property not met — credential readable or operator token visible; baseline-expected, run stopped |
+| 5 | token provider explicitly unsupported |
+| 6 | inconclusive (e.g. `gh` unavailable) |
+
+## Evidence status (honest ledger)
+
+| Item | Status |
+|---|---|
+| Baseline FAIL evidence (lane can read operator credentials + org token) | **READ, not re-measured** — GH-690 issue body, 2026-09-02 22:5x on 4090, basis `a1dd3d8` (threat model §1). Rerunning equals re-touching credentials; the conclusion does not change by rerunning. |
+| Fixture tests of preflight + refusal branches | **RAN** — 19/19 pass (see run receipt in the PR). |
+| Restricted-account negative tests (AccessDenied observed) | **NOT RUN** — no restricted account exists on this host. |
+| Restricted-account positive test (broker token → build/test/push of the spike branch) | **NOT RUN** — no restricted account, no GitHub App installation-token broker. |
+
+## Operator setup — the exact minimum to run the spike
+
+The harness needs exactly these four things; nothing else was assumed or faked:
+
+1. **A dedicated Windows standard account** for the restricted lane
+   (decision `fleet.lane-privilege`: one per machine, e.g. `edda-lane`).
+   Created and provisioned by the operator — creating accounts is an
+   implementation action outside this session's authority.
+2. **Write access for that account** to (a) the spike worktree and (b) the
+   assigned build-lane directory — explicit grants, not inherited, per threat
+   model §6.1.
+3. **A token provider** reachable by the restricted account: either the node
+   credential-broker (GH-685 follow-up; `edda-node://…` — currently
+   UNSUPPORTED because node v0 ships no credential endpoint) or, as the
+   documented degradation path, a per-lane fine-grained PAT stored under
+   `credman://<name>` in Windows Credential Manager **of the restricted
+   account** (requires the CredentialManager PowerShell module).
+4. **The spike invocation itself**, as a scheduled task or runas session under
+   the restricted principal, e.g.:
+
+   ```powershell
+   pwsh -NoProfile -File scripts/spikes/lane-privilege/Invoke-SpikeAction.ps1 `
+     -OperatorPrincipal      'MACHINE\fagem' `
+     -RestrictedPrincipal    'MACHINE\edda-lane' `
+     -WorkspacePath          'C:\ai_agent\edda-wt-infra-privilege' `
+     -BuildLanePath          '<lane-root>\worker-N' `
+     -RepoAllowList          'fagemx/edda' `
+     -BranchAllowList        'spike/lane-privilege-<date>' `
+     -TokenProviderRef       'credman://gh-lane-spike'   # or edda-node://… once the broker exists
+   ```
+
+   The spike branch is created by the run itself (`HEAD:refs/heads/spike/…`);
+   no other ref may appear in the allowlist.
+
+Nothing in this harness creates accounts, changes ACLs, touches scheduled tasks,
+or modifies authentication settings — all of that is operator-side, listed above.

--- a/scripts/spikes/lane-privilege/README.md
+++ b/scripts/spikes/lane-privilege/README.md
@@ -73,7 +73,7 @@ setup (§ Operator setup below), executes the GH-690 spike:
 | Item | Status |
 |---|---|
 | Baseline FAIL evidence (lane can read operator credentials + org token) | **READ, not re-measured** — GH-690 issue body, 2026-09-02 22:5x on 4090, basis `a1dd3d8` (threat model §1). Rerunning equals re-touching credentials; the conclusion does not change by rerunning. |
-| Fixture tests of preflight + refusal branches | **RAN** — 63/63 pass (safe synthetic fixtures; see run receipt in the PR). |
+| Fixture tests of preflight + refusal branches | **RAN** — 64/64 pass (safe synthetic fixtures; see run receipt in the PR). |
 | Restricted-account negative tests (AccessDenied observed) | **NOT RUN** — no restricted account exists on this host. |
 | Restricted-account positive test (broker token → build/test/push of the spike branch) | **NOT RUN** — no restricted account, no GitHub App installation-token broker. |
 

--- a/scripts/spikes/lane-privilege/tests/run-fixture-tests.ps1
+++ b/scripts/spikes/lane-privilege/tests/run-fixture-tests.ps1
@@ -1,0 +1,153 @@
+# run-fixture-tests.ps1 — fixture tests for the GH-690 lane privilege spike harness.
+#
+# Scope: syntax-level validation of the no-op preflight and the refusal branches.
+# Deliberately does NOT touch real credentials, change ACLs or accounts, reach the
+# network, build, or push. Run anywhere (operator principal is fine — the tests
+# assert the refusal paths, not the positive path).
+#
+# Usage:  pwsh -NoProfile -File tests/run-fixture-tests.ps1
+# Exit:   0 = all pass; 1 = at least one failure.
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 3.0
+
+$testsDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$spikeDir = Split-Path -Parent $testsDir
+Import-Module (Join-Path $spikeDir 'LanePrivilegeSpike.psm1') -Force
+
+$script:pass = 0
+$script:fail = 0
+
+function Assert-True {
+    param([string]$Name, [bool]$Condition, [string]$Detail = '')
+    if ($Condition) {
+        $script:pass++
+        Write-Output "PASS  $Name"
+    } else {
+        $script:fail++
+        Write-Output "FAIL  $Name  $Detail"
+    }
+}
+
+# Fixture workspace/lane: throwaway temp dirs, no repo, no cargo.
+$fxRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("gh690-fixture-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path (Join-Path $fxRoot 'ws') -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $fxRoot 'lane') -Force | Out-Null
+try {
+
+    $baseArgs = @{
+        OperatorPrincipal   = Get-SpikePrincipal   # fixture: we ARE the operator
+        RestrictedPrincipal = 'FIXTURE\spike-lane-user'
+        WorkspacePath       = (Join-Path $fxRoot 'ws')
+        BuildLanePath       = (Join-Path $fxRoot 'lane')
+        RepoAllowList       = @('fagemx/edda')
+        BranchAllowList     = @('spike/lane-privilege-fixture')
+        TokenProviderRef    = 'edda-node://fixture-host:7777/credentials/gh-installation-token/fagemx-edda'
+    }
+
+    # --- T1: preflight happy path (no-op, metadata only) → exit 0, no token shapes.
+    $out = & (Join-Path $spikeDir 'Invoke-Preflight.ps1') @baseArgs 2>&1
+    Assert-True -Name 'T1 preflight happy path exits 0' -Condition ($LASTEXITCODE -eq 0) -Detail "exit=$LASTEXITCODE"
+    $outText = ($out | ForEach-Object { "$_" }) -join "`n"
+    $tokenLeak = $false
+    foreach ($p in @('gh[pousr]_[A-Za-z0-9]{16,}', 'github_pat_[A-Za-z0-9_]{20,}')) {
+        if ([regex]::IsMatch($outText, $p)) { $tokenLeak = $true }
+    }
+    Assert-True -Name 'T1 preflight output contains no token-shaped strings' -Condition (-not $tokenLeak)
+    Assert-True -Name 'T1 preflight reports principal classification' `
+        -Condition ($outText -match "PrincipalClass") -Detail ($outText.Substring(0, [Math]::Min(400, $outText.Length)))
+
+    # --- T2: preflight refuses a main-targeting branch allowlist.
+    $mainArgs = $baseArgs.Clone(); $mainArgs.BranchAllowList = @('main')
+    $null = & (Join-Path $spikeDir 'Invoke-Preflight.ps1') @mainArgs 2>&1
+    Assert-True -Name 'T2 preflight refuses branch allowlist [main]' -Condition ($LASTEXITCODE -eq 2) -Detail "exit=$LASTEXITCODE"
+
+    # --- T3: preflight refuses forbidden provider schemes (file:/env:).
+    foreach ($ref in @('file://C:/no/secrets.txt', 'env:GITHUB_TOKEN')) {
+        $pArgs = $baseArgs.Clone(); $pArgs.TokenProviderRef = $ref
+        $null = & (Join-Path $spikeDir 'Invoke-Preflight.ps1') @pArgs 2>&1
+        Assert-True -Name "T3 preflight refuses provider '$ref'" -Condition ($LASTEXITCODE -eq 2) -Detail "exit=$LASTEXITCODE"
+    }
+
+    # --- T4: action refuses under the operator principal (the cannot-fake-pass gate).
+    $aArgs = $baseArgs.Clone(); $aArgs.Add('SkipBuildTest', $true)
+    $aOut = & (Join-Path $spikeDir 'Invoke-SpikeAction.ps1') @aArgs 2>&1
+    Assert-True -Name 'T4 action refuses when run as operator (exit 3)' -Condition ($LASTEXITCODE -eq 3) -Detail "exit=$LASTEXITCODE"
+    $aText = ($aOut | ForEach-Object { "$_" }) -join "`n"
+    Assert-True -Name 'T4 refusal names the process-token rationale' `
+        -Condition ($aText -match 'not the restricted principal') -Detail $aText.Substring(0, [Math]::Min(300, $aText.Length))
+
+    # --- T5: identity helper ignores spoofed environment variables.
+    $realPrincipal = Get-SpikePrincipal
+    $savedUser = $env:USERNAME; $savedProfile = $env:USERPROFILE
+    $env:USERNAME = 'FIXTURE\spoofed-lane-user'
+    $env:USERPROFILE = Join-Path $fxRoot 'fake-profile'
+    $spoofedReading = Get-SpikePrincipal
+    $env:USERNAME = $savedUser; $env:USERPROFILE = $savedProfile
+    Assert-True -Name 'T5 spoofed USERNAME/USERPROFILE cannot change the reported principal' `
+        -Condition (Test-SpikePrincipalMatch -Expected $realPrincipal -Actual $spoofedReading) `
+        -Detail "reading=$spoofedReading"
+
+    # --- T6: credential probe semantics without touching real credentials.
+    #   a. readable fixture file → Readable (fail signal), and its CONTENT never appears
+    #      in the harness output (open/dispose only).
+    $canaryFile = Join-Path $fxRoot 'readable-secret.txt'
+    $canary = 'CANARY-gho_FAKEFIXTURETOKEN0000000-DO-NOT-PRINT'
+    Set-Content -LiteralPath $canaryFile -Value $canary -NoNewline
+    $modPath = Join-Path $spikeDir 'LanePrivilegeSpike.psm1'
+    $probeCmd = "& { param(`$m,`$p) Import-Module `$m -Force; Get-CredentialFileProbe -Path `$p } '$modPath' '$canaryFile'"
+    $probeOut = & pwsh -NoProfile -Command $probeCmd 2>&1
+    $probeOutText = ($probeOut | ForEach-Object { "$_" }) -join "`n"
+    Assert-True -Name 'T6a probe of readable file reports Readable' `
+        -Condition ($probeOutText.Trim() -eq 'Readable') -Detail $probeOutText
+    Assert-True -Name 'T6a probe output never contains file content (canary absent)' `
+        -Condition (-not $probeOutText.Contains('CANARY-gho_'))
+    #   b. nonexistent path → NotFound (inconclusive; must not count as AccessDenied).
+    $missing = & pwsh -NoProfile -Command ("& { param(`$m,`$p) Import-Module `$m -Force; Get-CredentialFileProbe -Path `$p } '$modPath' '" + (Join-Path $fxRoot 'does-not-exist.json') + "'") 2>&1
+    Assert-True -Name 'T6b probe of missing file reports NotFound (inconclusive)' `
+        -Condition ("$missing".Trim() -eq 'NotFound') -Detail "$missing"
+
+    # --- T7: branch guard refusals and the single allowlisted acceptance.
+    $t7fail = 0
+    foreach ($bad in @('main', 'master', 'HEAD', 'origin/main', 'feature/x', 'spike/other-branch', 'spike/../traversal')) {
+        try { Assert-SafeSpikeBranch -Branch $bad -BranchAllowList @('spike/lane-privilege-fixture') | Out-Null }
+        catch { $t7fail++ }
+    }
+    Assert-True -Name 'T7 branch guard refuses all 7 forbidden targets' -Condition ($t7fail -eq 7) -Detail "refused=$t7fail"
+    $t7ok = $false
+    try { $t7ok = Assert-SafeSpikeBranch -Branch 'spike/lane-privilege-fixture' -BranchAllowList @('spike/lane-privilege-fixture') } catch {}
+    Assert-True -Name 'T7 branch guard accepts the exact allowlisted spike branch' -Condition ([bool]$t7ok)
+
+    # --- T8: secret scrubber.
+    $dirty = 'token gho_ABCDEFGHIJKLMNOPqrst and github_pat_ABCDEFGHIJKLMNOPQRSTUVWXYZ123456 in text'
+    Assert-True -Name 'T8 scrubber removes token shapes' `
+        -Condition (-not [regex]::IsMatch((Hide-SecretPatterns -Text $dirty), 'gh[o]_[A-Za-z0-9]|github_pat_'))
+
+    # --- T9: provider classification is real-or-unsupported, never mock.
+    $t9unsupported = $false
+    try { Resolve-BrokerToken -ProviderRef 'madeup://whatever' | Out-Null } catch { $t9unsupported = ($_.Exception.Message -match 'UNSUPPORTED') }
+    Assert-True -Name 'T9 unknown scheme resolves to explicit UNSUPPORTED (no mock)' -Condition $t9unsupported
+    $t9node = $false
+    try { Resolve-BrokerToken -ProviderRef $baseArgs.TokenProviderRef | Out-Null } catch { $t9node = ($_.Exception.Message -match 'UNSUPPORTED') }
+    Assert-True -Name 'T9 edda-node:// scheme resolves to explicit UNSUPPORTED on v0 (no mock)' -Condition $t9node
+    $t9forbidden = $false
+    try { Resolve-BrokerToken -ProviderRef 'env:GITHUB_TOKEN' | Out-Null } catch { $t9forbidden = ($_.Exception.Message -match 'UNSUPPORTED') }
+    Assert-True -Name 'T9 env: scheme refuses outright' -Condition $t9forbidden
+
+    # --- T10: gh token metadata drops token lines. (No gh auth is invoked here; we
+    # test the reducer directly on fixture lines, including a masked token line.)
+    $reducerSrc = (Get-Command Get-GhTokenSourceMetadata).ScriptBlock.ToString()
+    Assert-True -Name 'T10 metadata reducer never surfaces raw Token lines (drops them)' `
+        -Condition ($reducerSrc -match "match 'Token:'" -and $reducerSrc -match 'continue')
+
+}
+finally {
+    Remove-Item -LiteralPath $fxRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Output ("fixture tests: {0} passed, {1} failed" -f $script:pass, $script:fail)
+if ($script:fail -gt 0) { exit 1 }
+exit 0

--- a/scripts/spikes/lane-privilege/tests/run-fixture-tests.ps1
+++ b/scripts/spikes/lane-privilege/tests/run-fixture-tests.ps1
@@ -36,8 +36,13 @@ function Assert-True {
 
 # Fixture workspace/lane: throwaway temp dirs, no repo, no cargo.
 $fxRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("gh690-fixture-" + [guid]::NewGuid().ToString('N'))
-New-Item -ItemType Directory -Path (Join-Path $fxRoot 'ws') -Force | Out-Null
+$fixtureWorkspace = Join-Path $fxRoot 'ws'
+New-Item -ItemType Directory -Path $fixtureWorkspace -Force | Out-Null
 New-Item -ItemType Directory -Path (Join-Path $fxRoot 'lane') -Force | Out-Null
+# A local-only source commit lets the isolated transport use alternates without
+# network access; this is never the real worktree/config.
+git init -q $fixtureWorkspace 2>$null
+git -C $fixtureWorkspace -c user.name=fixture -c user.email=fixture@example.invalid commit --allow-empty -qm fixture 2>$null
 try {
 
     $baseArgs = @{
@@ -252,6 +257,12 @@ try {
         Assert-True -Name 'T11 protected targets refuse empty/relative/restricted/wrong-profile inputs' -Condition $refused
     }
 
+    # Give the source fixture both demonstrated hostile transport settings. The
+    # publication must execute in a different disposable bare repository.
+    git -C $fixtureWorkspace config 'url.https://github.com/fagemx/.pushInsteadOf' 'fixture://start/' 2>$null
+    git -C $fixtureWorkspace config 'url.https://evil.invalid/fagemx/.pushInsteadOf' 'https://github.com/fagemx/' 2>$null
+    git -C $fixtureWorkspace config 'http.https://github.com/.extraHeader' 'Authorization: Basic synthetic' 2>$null
+
     # --- T12 (Round1 F3): publication path with an INJECTED synthetic git invoker.
     # Records every invocation (args + stdin) and returns scripted results.
     $fakeToken = 'gho_FAKEFIXTURETOKEN0000000'
@@ -259,7 +270,8 @@ try {
     $calls = [System.Collections.Generic.List[object]]::new()
     $synthInvoker = {
         param([string[]]$GitArgs, [string]$StdinInput, [string]$WorkingDirectory)
-        $calls.Add([pscustomobject]@{ Args = $GitArgs; Stdin = $StdinInput })
+        $transportConfig = @(& git -C $WorkingDirectory config --get-regexp '^(url\..*\.pushInsteadOf|http\..*\.extraHeader)$' 2>$null)
+        $calls.Add([pscustomobject]@{ Args = $GitArgs; Stdin = $StdinInput; WorkingDirectory = $WorkingDirectory; TransportConfig = $transportConfig })
         # Scripted behavior by subcommand.
         $joined = $GitArgs -join ' '
         if ($joined -match 'credential approve') { return [pscustomobject]@{ ExitCode = 0; Output = @(); Args = $GitArgs; Stdin = $StdinInput } }
@@ -284,12 +296,14 @@ try {
     $pushCall = @($calls | Where-Object { ($_.Args -join ' ') -match ' push ' })[0]
     Assert-True -Name 'T12a push consumes the validated literal URL, not an origin alias' `
         -Condition (($pushCall.Args -contains 'https://github.com/fagemx/edda.git') -and -not ($pushCall.Args -contains 'origin'))
+    Assert-True -Name 'T12a chained rewrites and URL-specific header source are isolated from push' `
+        -Condition ($pushCall.WorkingDirectory -ne $fixtureWorkspace -and @($pushCall.TransportConfig).Count -eq 0)
     Assert-True -Name 'T12a helper list is isolated (credential.helper= reset before cache)' `
         -Condition (($pushCall.Args -contains 'credential.helper=') -and
                     (@($pushCall.Args | Where-Object { $_ -match '^credential\.helper=cache' }).Count -ge 1))
     Assert-True -Name 'T12a push uses one explicit refspec and disables tag-following' `
         -Condition (($pushCall.Args -join ' ') -match 'push\.followTags=false' -and
-                    ($pushCall.Args -join ' ') -match 'HEAD:refs/heads/spike/lane-privilege-fixture')
+                    ($pushCall.Args -join ' ') -match '[0-9a-f]{40}:refs/heads/spike/lane-privilege-fixture')
     Assert-True -Name 'T12a cleanup runs after push (reject + cache exit recorded)' `
         -Condition ((@($calls | Where-Object { ($_.Args -join ' ') -match 'credential reject' }).Count -eq 1) -and
                     (@($calls | Where-Object { ($_.Args -join ' ') -match 'credential-cache exit' }).Count -eq 1))

--- a/scripts/spikes/lane-privilege/tests/run-fixture-tests.ps1
+++ b/scripts/spikes/lane-privilege/tests/run-fixture-tests.ps1
@@ -1,9 +1,11 @@
 # run-fixture-tests.ps1 — fixture tests for the GH-690 lane privilege spike harness.
 #
-# Scope: syntax-level validation of the no-op preflight and the refusal branches.
-# Deliberately does NOT touch real credentials, change ACLs or accounts, reach the
-# network, build, or push. Run anywhere (operator principal is fine — the tests
-# assert the refusal paths, not the positive path).
+# Scope: syntax-level validation of the no-op preflight and the refusal branches,
+# plus execution-path tests of the publication/metadata logic with injected safe
+# synthetic dependencies (no real git pushes, no gh auth operations, no network).
+# Deliberately does NOT touch real credentials, change ACLs or accounts, build,
+# or push. Run anywhere (operator principal is fine — the tests assert the refusal
+# paths, not the positive path).
 #
 # Usage:  pwsh -NoProfile -File tests/run-fixture-tests.ps1
 # Exit:   0 = all pass; 1 = at least one failure.
@@ -74,6 +76,7 @@ try {
 
     # --- T4: action refuses under the operator principal (the cannot-fake-pass gate).
     $aArgs = $baseArgs.Clone(); $aArgs.Add('SkipBuildTest', $true)
+    $aArgs.Add('ProtectedCredentialFiles', @((Join-Path $fxRoot 'operator-profile\.claude\.credentials.json')))
     $aOut = & (Join-Path $spikeDir 'Invoke-SpikeAction.ps1') @aArgs 2>&1
     Assert-True -Name 'T4 action refuses when run as operator (exit 3)' -Condition ($LASTEXITCODE -eq 3) -Detail "exit=$LASTEXITCODE"
     $aText = ($aOut | ForEach-Object { "$_" }) -join "`n"
@@ -92,23 +95,41 @@ try {
         -Detail "reading=$spoofedReading"
 
     # --- T6: credential probe semantics without touching real credentials.
-    #   a. readable fixture file → Readable (fail signal), and its CONTENT never appears
-    #      in the harness output (open/dispose only).
-    $canaryFile = Join-Path $fxRoot 'readable-secret.txt'
+    # Calls run in-process (proper argument passing — no source interpolation,
+    # Round1 F6), including a quote-bearing fixture path.
+    $quoteDir = Join-Path $fxRoot "quote'dir"
+    New-Item -ItemType Directory -Path $quoteDir -Force | Out-Null
+    $canaryFile = Join-Path $quoteDir 'readable-secret.txt'
     $canary = 'CANARY-gho_FAKEFIXTURETOKEN0000000-DO-NOT-PRINT'
     Set-Content -LiteralPath $canaryFile -Value $canary -NoNewline
-    $modPath = Join-Path $spikeDir 'LanePrivilegeSpike.psm1'
-    $probeCmd = "& { param(`$m,`$p) Import-Module `$m -Force; Get-CredentialFileProbe -Path `$p } '$modPath' '$canaryFile'"
-    $probeOut = & pwsh -NoProfile -Command $probeCmd 2>&1
-    $probeOutText = ($probeOut | ForEach-Object { "$_" }) -join "`n"
+
+    $probeResult = Get-CredentialFileProbe -Path $canaryFile
     Assert-True -Name 'T6a probe of readable file reports Readable' `
-        -Condition ($probeOutText.Trim() -eq 'Readable') -Detail $probeOutText
-    Assert-True -Name 'T6a probe output never contains file content (canary absent)' `
-        -Condition (-not $probeOutText.Contains('CANARY-gho_'))
-    #   b. nonexistent path → NotFound (inconclusive; must not count as AccessDenied).
-    $missing = & pwsh -NoProfile -Command ("& { param(`$m,`$p) Import-Module `$m -Force; Get-CredentialFileProbe -Path `$p } '$modPath' '" + (Join-Path $fxRoot 'does-not-exist.json') + "'") 2>&1
+        -Condition ("$probeResult" -eq 'Readable') -Detail "$probeResult"
+    Assert-True -Name 'T6a probe of a quote-bearing path works (paths are data, not code)' `
+        -Condition ("$probeResult" -eq 'Readable') -Detail $canaryFile
+
+    $missing = Get-CredentialFileProbe -Path (Join-Path $fxRoot 'does-not-exist.json')
     Assert-True -Name 'T6b probe of missing file reports NotFound (inconclusive)' `
-        -Condition ("$missing".Trim() -eq 'NotFound') -Detail "$missing"
+        -Condition ("$missing" -eq 'NotFound') -Detail "$missing"
+
+    # T6c (Round1 F5): an exclusive lock held by this test process must yield
+    # INCONCLUSIVE — a sharing violation is not access control.
+    $lockedFile = Join-Path $fxRoot 'locked-fixture.txt'
+    Set-Content -LiteralPath $lockedFile -Value 'fixture-bytes' -NoNewline
+    $lockStream = [System.IO.File]::Open($lockedFile, [System.IO.FileMode]::Open,
+        [System.IO.FileAccess]::Read, [System.IO.FileShare]::None)
+    try {
+        $locked = Get-CredentialFileProbe -Path $lockedFile
+        Assert-True -Name 'T6c sharing violation reports Inconclusive, NOT AccessDenied' `
+            -Condition ("$locked" -eq 'Inconclusive') -Detail "$locked"
+    }
+    finally {
+        $lockStream.Dispose()
+    }
+    $afterLock = Get-CredentialFileProbe -Path $lockedFile
+    Assert-True -Name 'T6c same file after lock release reports Readable (lock was the blocker)' `
+        -Condition ("$afterLock" -eq 'Readable') -Detail "$afterLock"
 
     # --- T7: branch guard refusals and the single allowlisted acceptance.
     $t7fail = 0
@@ -137,11 +158,160 @@ try {
     try { Resolve-BrokerToken -ProviderRef 'env:GITHUB_TOKEN' | Out-Null } catch { $t9forbidden = ($_.Exception.Message -match 'UNSUPPORTED') }
     Assert-True -Name 'T9 env: scheme refuses outright' -Condition $t9forbidden
 
-    # --- T10: gh token metadata drops token lines. (No gh auth is invoked here; we
-    # test the reducer directly on fixture lines, including a masked token line.)
-    $reducerSrc = (Get-Command Get-GhTokenSourceMetadata).ScriptBlock.ToString()
-    Assert-True -Name 'T10 metadata reducer never surfaces raw Token lines (drops them)' `
-        -Condition ($reducerSrc -match "match 'Token:'" -and $reducerSrc -match 'continue')
+    # --- T10 (Round1 F1): metadata reducer tested on EXECUTION, with synthetic
+    # status lines — not by searching function source.
+    $synthetic = @(
+        'github.com',
+        '  ✓ Logged in to github.com account someuser (keyring)',
+        '  - Active account: true',
+        '  - Token: gho_************ (keyring)'
+    )
+    $m = Get-GhTokenSourceMetadata -StatusText $synthetic
+    Assert-True -Name 'T10 keyring line parsed: token present with source keyring' `
+        -Condition ($m.TokenPresent -and $m.TokenSource -eq 'keyring') -Detail "$($m.TokenPresent)/$($m.TokenSource)"
+    Assert-True -Name 'T10 login line parsed' -Condition ($m.LoggedIn -and $m.Account -eq 'someuser') -Detail $m.Account
+    Assert-True -Name 'T10 reducer returns no token VALUE (masked form absent from object)' `
+        -Condition (-not ("$m" -match 'gho_[A-Za-z0-9]'))
+
+    $mEnv = Get-GhTokenSourceMetadata -StatusText @('  - Token: ghp_************ (env)')
+    Assert-True -Name 'T10 env source parsed' -Condition ($mEnv.TokenPresent -and $mEnv.TokenSource -eq 'env')
+    $mInfile = Get-GhTokenSourceMetadata -StatusText @('  - Token: ghs_************ (infile)')
+    Assert-True -Name 'T10 infile source parsed' -Condition ($mInfile.TokenPresent -and $mInfile.TokenSource -eq 'infile')
+    $mUnknown = Get-GhTokenSourceMetadata -StatusText @('  - Token: redacted-but-unparsable')
+    Assert-True -Name 'T10 unparsable token line => present with source unknown' `
+        -Condition ($mUnknown.TokenPresent -and $mUnknown.TokenSource -eq 'unknown')
+    $mNone = Get-GhTokenSourceMetadata -StatusText @('  - no token detected')
+    Assert-True -Name 'T10 explicit absence line => no token' -Condition (-not $mNone.TokenPresent)
+
+    # Verdict adjudication across all cases (fail closed on uncertainty).
+    $v1 = Get-GhMetadataVerdict -Metadata $m            # keyring token
+    $v2 = Get-GhMetadataVerdict -Metadata $mUnknown     # unknown source token
+    $v3 = Get-GhMetadataVerdict -Metadata $mNone        # not logged in
+    $v4 = Get-GhMetadataVerdict -Metadata @{ LoggedIn = $true; TokenPresent = $false }  # ambiguous
+    $v5 = Get-GhMetadataVerdict -Metadata $mNone -GhExitCode 1                          # gh error
+    Assert-True -Name 'T10 verdict: keyring token => deny' -Condition ($v1 -eq 'deny-token-present')
+    Assert-True -Name 'T10 verdict: unknown-source token => deny (fail closed)' -Condition ($v2 -eq 'deny-token-present')
+    Assert-True -Name 'T10 verdict: no login => ok' -Condition ($v3 -eq 'ok-no-login')
+    Assert-True -Name 'T10 verdict: logged-in-without-token => inconclusive' -Condition ($v4 -eq 'inconclusive-ambiguous')
+    Assert-True -Name 'T10 verdict: gh error exit => inconclusive' -Condition ($v5 -eq 'inconclusive-error')
+
+    # --- T11 (Round1 F2): push destination binding, pure matcher + repo-level.
+    $t11 = 0
+    foreach ($bad in @(
+        'git@github.com:evil/repo.git',
+        'https://github.com/evil/repo',
+        'ssh://git@github.com/fagemx/edda-other.git',
+        'git@github.com:../traversal.git',
+        'not-a-url',
+        'https://gitlab.com/fagemx/edda.git'
+    )) {
+        if (-not (Test-PushUrlAllowed -Url $bad -RepoAllowList @('fagemx/edda'))) { $t11++ }
+    }
+    Assert-True -Name 'T11 matcher refuses all 6 disallowed/malformed destinations' -Condition ($t11 -eq 6) -Detail "refused=$t11"
+    Assert-True -Name 'T11 matcher accepts ssh form of allowlisted repo' `
+        -Condition (Test-PushUrlAllowed -Url 'git@github.com:fagemx/edda.git' -RepoAllowList @('fagemx/edda'))
+    Assert-True -Name 'T11 matcher accepts https form of allowlisted repo' `
+        -Condition (Test-PushUrlAllowed -Url 'https://github.com/fagemx/edda' -RepoAllowList @('fagemx/edda'))
+
+    # Repo-level resolution against a real local git config (no network, no push).
+    git init -q (Join-Path $fxRoot 'wsrepo') 2>$null
+    git -C (Join-Path $fxRoot 'wsrepo') remote add origin 'git@github.com:evil/repo.git' 2>$null
+    $t11Repo = $false
+    try { Get-EffectivePushUrl -WorkspacePath (Join-Path $fxRoot 'wsrepo') -RepoAllowList @('fagemx/edda') | Out-Null }
+    catch { $t11Repo = ($_.Exception.Message -match 'does not resolve to an allowlisted') }
+    Assert-True -Name 'T11 repo-level guard refuses disallowed configured origin' -Condition $t11Repo
+    git -C (Join-Path $fxRoot 'wsrepo') remote set-url origin 'git@github.com:fagemx/edda.git' 2>$null
+    $t11Ok = $false
+    try { $t11Ok = (Get-EffectivePushUrl -WorkspacePath (Join-Path $fxRoot 'wsrepo') -RepoAllowList @('fagemx/edda')) -match 'fagemx/edda' } catch {}
+    Assert-True -Name 'T11 repo-level guard accepts allowlisted configured origin' -Condition ([bool]$t11Ok)
+
+    # --- T12 (Round1 F3): publication path with an INJECTED synthetic git invoker.
+    # Records every invocation (args + stdin) and returns scripted results.
+    $fakeToken = 'gho_FAKEFIXTURETOKEN0000000'
+    $secure = ConvertTo-SecureString $fakeToken -AsPlainText -Force
+    $calls = [System.Collections.Generic.List[object]]::new()
+    $synthInvoker = {
+        param([string[]]$GitArgs, [string]$StdinInput, [string]$WorkingDirectory)
+        $calls.Add([pscustomobject]@{ Args = $GitArgs; Stdin = $StdinInput })
+        # Scripted behavior by subcommand.
+        $joined = $GitArgs -join ' '
+        if ($joined -match 'credential approve') { return [pscustomobject]@{ ExitCode = 0; Output = @(); Args = $GitArgs; Stdin = $StdinInput } }
+        if ($joined -match 'credential reject')  { return [pscustomobject]@{ ExitCode = 0; Output = @(); Args = $GitArgs; Stdin = $StdinInput } }
+        if ($joined -match 'credential-cache exit') { return [pscustomobject]@{ ExitCode = 0; Output = @(); Args = $GitArgs; Stdin = $null } }
+        if ($joined -match ' push ') { return [pscustomobject]@{ ExitCode = 0; Output = @('synthetic push ok'); Args = $GitArgs; Stdin = $null } }
+        return [pscustomobject]@{ ExitCode = 1; Output = @("unexpected git invocation: $joined"); Args = $GitArgs; Stdin = $StdinInput }
+    }
+
+    # T12a: happy path — approve, push, cleanup all succeed; token NEVER in argv.
+    $calls.Clear()
+    $r = Invoke-SpikePublication -Token $secure -WorkspacePath (Join-Path $fxRoot 'ws') -RemoteName 'origin' `
+        -RefSpec 'HEAD:refs/heads/spike/lane-privilege-fixture' -GitInvoker $synthInvoker
+    Assert-True -Name 'T12a publication verdict published' -Condition ($r.Verdict -eq 'published') -Detail "$($r.Verdict); $($r.Notes -join '; ')"
+    $allArgs = ($calls | ForEach-Object { $_.Args -join ' ' }) -join "`n"
+    Assert-True -Name 'T12a token NEVER appears in any git argv' -Condition (-not $allArgs.Contains($fakeToken))
+    $approveStdin = (@($calls | Where-Object { ($_.Args -join ' ') -match 'credential approve' })[0]).Stdin
+    Assert-True -Name 'T12a token reaches git ONLY via credential-approve stdin' `
+        -Condition ($null -ne $approveStdin -and $approveStdin.Contains($fakeToken))
+    $pushCall = @($calls | Where-Object { ($_.Args -join ' ') -match ' push ' })[0]
+    Assert-True -Name 'T12a helper list is isolated (credential.helper= reset before cache)' `
+        -Condition (($pushCall.Args -contains 'credential.helper=') -and
+                    (@($pushCall.Args | Where-Object { $_ -match '^credential\.helper=cache' }).Count -ge 1))
+    Assert-True -Name 'T12a push uses one explicit refspec and disables tag-following' `
+        -Condition (($pushCall.Args -join ' ') -match 'push\.followTags=false' -and
+                    ($pushCall.Args -join ' ') -match 'HEAD:refs/heads/spike/lane-privilege-fixture')
+    Assert-True -Name 'T12a cleanup runs after push (reject + cache exit recorded)' `
+        -Condition ((@($calls | Where-Object { ($_.Args -join ' ') -match 'credential reject' }).Count -eq 1) -and
+                    (@($calls | Where-Object { ($_.Args -join ' ') -match 'credential-cache exit' }).Count -eq 1))
+    Assert-True -Name 'T12a no gh auth invocation exists in the publication path' `
+        -Condition (-not ($allArgs -match 'gh auth| auth |auth login'))
+
+    # T12b: approve fails => auth-failed, push NEVER invoked, cleanup still attempted.
+    $calls.Clear()
+    $failInvoker = {
+        param([string[]]$GitArgs, [string]$StdinInput, [string]$WorkingDirectory)
+        $calls.Add([pscustomobject]@{ Args = $GitArgs; Stdin = $StdinInput })
+        $joined = $GitArgs -join ' '
+        if ($joined -match 'credential approve') { return [pscustomobject]@{ ExitCode = 1; Output = @('synthetic approve failure'); Args = $GitArgs; Stdin = $StdinInput } }
+        if ($joined -match 'credential-cache exit') { return [pscustomobject]@{ ExitCode = 0; Output = @(); Args = $GitArgs; Stdin = $null } }
+        return [pscustomobject]@{ ExitCode = 0; Output = @(); Args = $GitArgs; Stdin = $StdinInput }
+    }
+    $r2 = Invoke-SpikePublication -Token $secure -WorkspacePath (Join-Path $fxRoot 'ws') -RemoteName 'origin' `
+        -RefSpec 'HEAD:refs/heads/spike/lane-privilege-fixture' -GitInvoker $failInvoker
+    Assert-True -Name 'T12b approve failure => auth-failed' -Condition ($r2.Verdict -eq 'auth-failed')
+    Assert-True -Name 'T12b push never invoked when approve fails' `
+        -Condition ((@($calls | Where-Object { ($_.Args -join ' ') -match ' push ' }).Count -eq 0))
+
+    # T12c: push fails => push-failed, cleanup still attempted and observable.
+    $calls.Clear()
+    $pushFailInvoker = {
+        param([string[]]$GitArgs, [string]$StdinInput, [string]$WorkingDirectory)
+        $calls.Add([pscustomobject]@{ Args = $GitArgs; Stdin = $StdinInput })
+        $joined = $GitArgs -join ' '
+        if ($joined -match ' push ') { return [pscustomobject]@{ ExitCode = 128; Output = @('synthetic push failure'); Args = $GitArgs; Stdin = $null } }
+        return [pscustomobject]@{ ExitCode = 0; Output = @(); Args = $GitArgs; Stdin = $StdinInput }
+    }
+    $r3 = Invoke-SpikePublication -Token $secure -WorkspacePath (Join-Path $fxRoot 'ws') -RemoteName 'origin' `
+        -RefSpec 'HEAD:refs/heads/spike/lane-privilege-fixture' -GitInvoker $pushFailInvoker
+    Assert-True -Name 'T12c push failure => push-failed' -Condition ($r3.Verdict -eq 'push-failed')
+    Assert-True -Name 'T12c cleanup still attempted after push failure' `
+        -Condition ((@($calls | Where-Object { ($_.Args -join ' ') -match 'credential reject' }).Count -eq 1))
+
+    # T12d: cleanup failure is observable, not silently swallowed.
+    $cleanupFailInvoker = {
+        param([string[]]$GitArgs, [string]$StdinInput, [string]$WorkingDirectory)
+        $joined = $GitArgs -join ' '
+        if ($joined -match 'credential reject') { return [pscustomobject]@{ ExitCode = 1; Output = @(); Args = $GitArgs; Stdin = $StdinInput } }
+        if ($joined -match 'credential-cache exit') { return [pscustomobject]@{ ExitCode = 1; Output = @(); Args = $GitArgs; Stdin = $null } }
+        if ($joined -match ' push ') { return [pscustomobject]@{ ExitCode = 0; Output = @(); Args = $GitArgs; Stdin = $null } }
+        return [pscustomobject]@{ ExitCode = 0; Output = @(); Args = $GitArgs; Stdin = $StdinInput }
+    }
+    $r4 = Invoke-SpikePublication -Token $secure -WorkspacePath (Join-Path $fxRoot 'ws') -RemoteName 'origin' `
+        -RefSpec 'HEAD:refs/heads/spike/lane-privilege-fixture' -GitInvoker $cleanupFailInvoker
+    Assert-True -Name 'T12d failed cleanup => cleanup-incomplete (observable)' -Condition ($r4.Verdict -eq 'cleanup-incomplete' -and $r4.CleanupExit -eq 1)
+
+    # T12e: token moves as SecureString; plaintext helper exists in memory only.
+    $plainRoundtrip = ConvertFrom-SecureStringInMemory -SecureValue $secure
+    Assert-True -Name 'T12e SecureString roundtrip yields the synthetic token in memory' -Condition ($plainRoundtrip -eq $fakeToken)
 
 }
 finally {

--- a/scripts/spikes/lane-privilege/tests/run-fixture-tests.ps1
+++ b/scripts/spikes/lane-privilege/tests/run-fixture-tests.ps1
@@ -43,6 +43,9 @@ New-Item -ItemType Directory -Path (Join-Path $fxRoot 'lane') -Force | Out-Null
 # network access; this is never the real worktree/config.
 git init -q $fixtureWorkspace 2>$null
 git -C $fixtureWorkspace -c user.name=fixture -c user.email=fixture@example.invalid commit --allow-empty -qm fixture 2>$null
+$otherWorkspace = Join-Path $fxRoot 'other-source'
+git init -q $otherWorkspace 2>$null
+git -C $otherWorkspace -c user.name=fixture -c user.email=fixture@example.invalid commit --allow-empty -qm other 2>$null
 try {
 
     $baseArgs = @{
@@ -281,10 +284,23 @@ try {
         return [pscustomobject]@{ ExitCode = 1; Output = @("unexpected git invocation: $joined"); Args = $GitArgs; Stdin = $StdinInput }
     }
 
-    # T12a: happy path — approve, push, cleanup all succeed; token NEVER in argv.
+    # T12a: hostile Git routing must not change the named workspace source.
+    $sourceHead = @(& git -C $fixtureWorkspace rev-parse HEAD); $sourceHead = ("$sourceHead").Trim()
+    $otherHead = @(& git -C $otherWorkspace rev-parse HEAD); $otherHead = ("$otherHead").Trim()
+    $savedGitDir = $env:GIT_DIR; $savedGitWorkTree = $env:GIT_WORK_TREE; $savedGitObjects = $env:GIT_OBJECT_DIRECTORY
+    $env:GIT_DIR = Join-Path $otherWorkspace '.git'
+    $env:GIT_WORK_TREE = $otherWorkspace
+    $env:GIT_OBJECT_DIRECTORY = Join-Path (Join-Path $otherWorkspace '.git') 'objects'
     $calls.Clear()
-    $r = Invoke-SpikePublication -Token $secure -WorkspacePath (Join-Path $fxRoot 'ws') -DestinationUrl 'https://github.com/fagemx/edda.git' `
+    try {
+        $r = Invoke-SpikePublication -Token $secure -WorkspacePath (Join-Path $fxRoot 'ws') -DestinationUrl 'https://github.com/fagemx/edda.git' `
         -RefSpec 'HEAD:refs/heads/spike/lane-privilege-fixture' -GitInvoker $synthInvoker
+        $publicationRestoredRouting = ($env:GIT_DIR -eq (Join-Path $otherWorkspace '.git') -and
+            $env:GIT_WORK_TREE -eq $otherWorkspace -and $env:GIT_OBJECT_DIRECTORY -eq (Join-Path (Join-Path $otherWorkspace '.git') 'objects'))
+    }
+    finally {
+        $env:GIT_DIR = $savedGitDir; $env:GIT_WORK_TREE = $savedGitWorkTree; $env:GIT_OBJECT_DIRECTORY = $savedGitObjects
+    }
     Assert-True -Name 'T12a publication verdict published' -Condition ($r.Verdict -eq 'published') -Detail "$($r.Verdict); $($r.Notes -join '; ')"
     $allArgs = ($calls | ForEach-Object { $_.Args -join ' ' }) -join "`n"
     Assert-True -Name 'T12a token NEVER appears in any git argv' -Condition (-not $allArgs.Contains($fakeToken))
@@ -296,6 +312,8 @@ try {
     $pushCall = @($calls | Where-Object { ($_.Args -join ' ') -match ' push ' })[0]
     Assert-True -Name 'T12a push consumes the validated literal URL, not an origin alias' `
         -Condition (($pushCall.Args -contains 'https://github.com/fagemx/edda.git') -and -not ($pushCall.Args -contains 'origin'))
+    Assert-True -Name 'T12a GIT_DIR/work-tree/object redirects cannot replace the named workspace source and are restored' `
+        -Condition (($pushCall.Args -join ' ') -match $sourceHead -and ($pushCall.Args -join ' ') -notmatch $otherHead -and $publicationRestoredRouting)
     Assert-True -Name 'T12a chained rewrites and URL-specific header source are isolated from push' `
         -Condition ($pushCall.WorkingDirectory -ne $fixtureWorkspace -and @($pushCall.TransportConfig).Count -eq 0)
     Assert-True -Name 'T12a helper list is isolated (credential.helper= reset before cache)' `

--- a/scripts/spikes/lane-privilege/tests/run-fixture-tests.ps1
+++ b/scripts/spikes/lane-privilege/tests/run-fixture-tests.ps1
@@ -208,22 +208,49 @@ try {
         if (-not (Test-PushUrlAllowed -Url $bad -RepoAllowList @('fagemx/edda'))) { $t11++ }
     }
     Assert-True -Name 'T11 matcher refuses all 6 disallowed/malformed destinations' -Condition ($t11 -eq 6) -Detail "refused=$t11"
-    Assert-True -Name 'T11 matcher accepts ssh form of allowlisted repo' `
-        -Condition (Test-PushUrlAllowed -Url 'git@github.com:fagemx/edda.git' -RepoAllowList @('fagemx/edda'))
-    Assert-True -Name 'T11 matcher accepts https form of allowlisted repo' `
+    Assert-True -Name 'T11 matcher refuses SSH (credential cache is HTTPS-only)' `
+        -Condition (-not (Test-PushUrlAllowed -Url 'git@github.com:fagemx/edda.git' -RepoAllowList @('fagemx/edda')))
+    Assert-True -Name 'T11 matcher refuses HTTPS userinfo alternate auth input' `
+        -Condition (-not (Test-PushUrlAllowed -Url 'https://embedded-user@github.com/fagemx/edda.git' -RepoAllowList @('fagemx/edda')))
+    Assert-True -Name 'T11 matcher accepts clean HTTPS form of allowlisted repo' `
         -Condition (Test-PushUrlAllowed -Url 'https://github.com/fagemx/edda' -RepoAllowList @('fagemx/edda'))
 
-    # Repo-level resolution against a real local git config (no network, no push).
-    git init -q (Join-Path $fxRoot 'wsrepo') 2>$null
-    git -C (Join-Path $fxRoot 'wsrepo') remote add origin 'git@github.com:evil/repo.git' 2>$null
+    # Isolated temporary repository config only: no shared .git/config is written.
+    $wsRepo = Join-Path $fxRoot 'wsrepo'; git init -q $wsRepo 2>$null
+    git -C $wsRepo remote add origin 'https://github.com/evil/repo.git' 2>$null
     $t11Repo = $false
-    try { Get-EffectivePushUrl -WorkspacePath (Join-Path $fxRoot 'wsrepo') -RepoAllowList @('fagemx/edda') | Out-Null }
-    catch { $t11Repo = ($_.Exception.Message -match 'does not resolve to an allowlisted') }
+    try { Get-EffectivePushUrl -WorkspacePath $wsRepo -RepoAllowList @('fagemx/edda') | Out-Null }
+    catch { $t11Repo = $true }
     Assert-True -Name 'T11 repo-level guard refuses disallowed configured origin' -Condition $t11Repo
-    git -C (Join-Path $fxRoot 'wsrepo') remote set-url origin 'git@github.com:fagemx/edda.git' 2>$null
+    git -C $wsRepo remote set-url origin 'https://github.com/fagemx/edda.git' 2>$null
     $t11Ok = $false
-    try { $t11Ok = (Get-EffectivePushUrl -WorkspacePath (Join-Path $fxRoot 'wsrepo') -RepoAllowList @('fagemx/edda')) -match 'fagemx/edda' } catch {}
-    Assert-True -Name 'T11 repo-level guard accepts allowlisted configured origin' -Condition ([bool]$t11Ok)
+    try { $t11Ok = (Get-EffectivePushUrl -WorkspacePath $wsRepo -RepoAllowList @('fagemx/edda')) -match 'fagemx/edda' } catch {}
+    Assert-True -Name 'T11 repo-level guard accepts one clean effective HTTPS destination' -Condition ([bool]$t11Ok)
+    git -C $wsRepo remote set-url --add --push origin 'https://github.com/evil/repo.git' 2>$null
+    git -C $wsRepo remote set-url --add --push origin 'https://github.com/fagemx/edda.git' 2>$null
+    $multipleRefused = $false
+    try { Get-EffectivePushUrl -WorkspacePath $wsRepo -RepoAllowList @('fagemx/edda') | Out-Null } catch { $multipleRefused = $true }
+    Assert-True -Name 'T11 all effective pushurls are required to be a single destination' -Condition $multipleRefused
+    git -C $wsRepo remote set-url --delete --push origin 'https://github.com/evil/repo.git' 2>$null
+    git -C $wsRepo remote set-url --delete --push origin 'https://github.com/fagemx/edda.git' 2>$null
+    git -C $wsRepo remote set-url origin 'https://github.com/fagemx/edda.git' 2>$null
+    git -C $wsRepo config 'url.https://github.com/evil/.pushInsteadOf' 'https://github.com/fagemx/' 2>$null
+    $rewriteRefused = $false
+    try { Get-EffectivePushUrl -WorkspacePath $wsRepo -RepoAllowList @('fagemx/edda') | Out-Null } catch { $rewriteRefused = $true }
+    Assert-True -Name 'T11 pushInsteadOf rewrite is resolved then refused' -Condition $rewriteRefused
+
+    # Trusted profile binding is injectable for safe synthetic boundary coverage.
+    $profiles = @{ 'MACHINE\operator' = 'C:\fixture\operator'; 'MACHINE\restricted' = 'C:\fixture\restricted' }
+    $resolver = { param($principal) $profiles[$principal] }
+    $exactTargets = @('C:\fixture\operator\.claude\.credentials.json', 'C:\fixture\operator\.codex\auth.json', 'C:\fixture\operator\.pi\agent\auth.json')
+    $targetOk = $false
+    try { Assert-ProtectedCredentialTargets -OperatorPrincipal 'MACHINE\operator' -RestrictedPrincipal 'MACHINE\restricted' -ProtectedCredentialFiles $exactTargets -ProfileResolver $resolver | Out-Null; $targetOk = $true } catch {}
+    Assert-True -Name 'T11 protected targets accept only the exact trusted operator set' -Condition $targetOk
+    foreach ($case in @(@(), @('relative-auth.json', $exactTargets[1], $exactTargets[2]), @('C:\fixture\restricted\.claude\.credentials.json', $exactTargets[1], $exactTargets[2]), @('C:\fixture\other\auth.json', $exactTargets[1], $exactTargets[2]))) {
+        $refused = $false
+        try { Assert-ProtectedCredentialTargets -OperatorPrincipal 'MACHINE\operator' -RestrictedPrincipal 'MACHINE\restricted' -ProtectedCredentialFiles $case -ProfileResolver $resolver | Out-Null } catch { $refused = $true }
+        Assert-True -Name 'T11 protected targets refuse empty/relative/restricted/wrong-profile inputs' -Condition $refused
+    }
 
     # --- T12 (Round1 F3): publication path with an INJECTED synthetic git invoker.
     # Records every invocation (args + stdin) and returns scripted results.
@@ -244,15 +271,19 @@ try {
 
     # T12a: happy path — approve, push, cleanup all succeed; token NEVER in argv.
     $calls.Clear()
-    $r = Invoke-SpikePublication -Token $secure -WorkspacePath (Join-Path $fxRoot 'ws') -RemoteName 'origin' `
+    $r = Invoke-SpikePublication -Token $secure -WorkspacePath (Join-Path $fxRoot 'ws') -DestinationUrl 'https://github.com/fagemx/edda.git' `
         -RefSpec 'HEAD:refs/heads/spike/lane-privilege-fixture' -GitInvoker $synthInvoker
     Assert-True -Name 'T12a publication verdict published' -Condition ($r.Verdict -eq 'published') -Detail "$($r.Verdict); $($r.Notes -join '; ')"
     $allArgs = ($calls | ForEach-Object { $_.Args -join ' ' }) -join "`n"
     Assert-True -Name 'T12a token NEVER appears in any git argv' -Condition (-not $allArgs.Contains($fakeToken))
+    Assert-True -Name 'T12a publication result retains no plaintext stdin property' `
+        -Condition ($null -eq $r.PSObject.Properties['Stdin'])
     $approveStdin = (@($calls | Where-Object { ($_.Args -join ' ') -match 'credential approve' })[0]).Stdin
     Assert-True -Name 'T12a token reaches git ONLY via credential-approve stdin' `
         -Condition ($null -ne $approveStdin -and $approveStdin.Contains($fakeToken))
     $pushCall = @($calls | Where-Object { ($_.Args -join ' ') -match ' push ' })[0]
+    Assert-True -Name 'T12a push consumes the validated literal URL, not an origin alias' `
+        -Condition (($pushCall.Args -contains 'https://github.com/fagemx/edda.git') -and -not ($pushCall.Args -contains 'origin'))
     Assert-True -Name 'T12a helper list is isolated (credential.helper= reset before cache)' `
         -Condition (($pushCall.Args -contains 'credential.helper=') -and
                     (@($pushCall.Args | Where-Object { $_ -match '^credential\.helper=cache' }).Count -ge 1))
@@ -275,7 +306,7 @@ try {
         if ($joined -match 'credential-cache exit') { return [pscustomobject]@{ ExitCode = 0; Output = @(); Args = $GitArgs; Stdin = $null } }
         return [pscustomobject]@{ ExitCode = 0; Output = @(); Args = $GitArgs; Stdin = $StdinInput }
     }
-    $r2 = Invoke-SpikePublication -Token $secure -WorkspacePath (Join-Path $fxRoot 'ws') -RemoteName 'origin' `
+    $r2 = Invoke-SpikePublication -Token $secure -WorkspacePath (Join-Path $fxRoot 'ws') -DestinationUrl 'https://github.com/fagemx/edda.git' `
         -RefSpec 'HEAD:refs/heads/spike/lane-privilege-fixture' -GitInvoker $failInvoker
     Assert-True -Name 'T12b approve failure => auth-failed' -Condition ($r2.Verdict -eq 'auth-failed')
     Assert-True -Name 'T12b push never invoked when approve fails' `
@@ -290,7 +321,7 @@ try {
         if ($joined -match ' push ') { return [pscustomobject]@{ ExitCode = 128; Output = @('synthetic push failure'); Args = $GitArgs; Stdin = $null } }
         return [pscustomobject]@{ ExitCode = 0; Output = @(); Args = $GitArgs; Stdin = $StdinInput }
     }
-    $r3 = Invoke-SpikePublication -Token $secure -WorkspacePath (Join-Path $fxRoot 'ws') -RemoteName 'origin' `
+    $r3 = Invoke-SpikePublication -Token $secure -WorkspacePath (Join-Path $fxRoot 'ws') -DestinationUrl 'https://github.com/fagemx/edda.git' `
         -RefSpec 'HEAD:refs/heads/spike/lane-privilege-fixture' -GitInvoker $pushFailInvoker
     Assert-True -Name 'T12c push failure => push-failed' -Condition ($r3.Verdict -eq 'push-failed')
     Assert-True -Name 'T12c cleanup still attempted after push failure' `
@@ -305,13 +336,28 @@ try {
         if ($joined -match ' push ') { return [pscustomobject]@{ ExitCode = 0; Output = @(); Args = $GitArgs; Stdin = $null } }
         return [pscustomobject]@{ ExitCode = 0; Output = @(); Args = $GitArgs; Stdin = $StdinInput }
     }
-    $r4 = Invoke-SpikePublication -Token $secure -WorkspacePath (Join-Path $fxRoot 'ws') -RemoteName 'origin' `
+    $r4 = Invoke-SpikePublication -Token $secure -WorkspacePath (Join-Path $fxRoot 'ws') -DestinationUrl 'https://github.com/fagemx/edda.git' `
         -RefSpec 'HEAD:refs/heads/spike/lane-privilege-fixture' -GitInvoker $cleanupFailInvoker
     Assert-True -Name 'T12d failed cleanup => cleanup-incomplete (observable)' -Condition ($r4.Verdict -eq 'cleanup-incomplete' -and $r4.CleanupExit -eq 1)
 
-    # T12e: token moves as SecureString; plaintext helper exists in memory only.
+    # T12e: a terminating push exception still reaches both cleanup operations.
+    $calls.Clear()
+    $throwingInvoker = {
+        param([string[]]$GitArgs, [string]$StdinInput, [string]$WorkingDirectory)
+        $joined = $GitArgs -join ' '; $calls.Add($joined)
+        if ($joined -match ' push ') { throw 'synthetic terminating push failure' }
+        return [pscustomobject]@{ ExitCode = 0; Output = @(); Args = $GitArgs }
+    }
+    $r5 = Invoke-SpikePublication -Token $secure -WorkspacePath (Join-Path $fxRoot 'ws') -DestinationUrl 'https://github.com/fagemx/edda.git' `
+        -RefSpec 'HEAD:refs/heads/spike/lane-privilege-fixture' -GitInvoker $throwingInvoker
+    Assert-True -Name 'T12e terminating push exception still runs reject and cache exit' `
+        -Condition ((@($calls | Where-Object { $_ -match 'credential reject' }).Count -eq 1) -and (@($calls | Where-Object { $_ -match 'credential-cache exit' }).Count -eq 1))
+    Assert-True -Name 'T12e exception retains original failure while cleanup stays observable' `
+        -Condition ($r5.OriginalVerdict -eq 'push-failed' -and $r5.CleanupExit -eq 0)
+
+    # T12f: token moves as SecureString; plaintext helper exists in memory only.
     $plainRoundtrip = ConvertFrom-SecureStringInMemory -SecureValue $secure
-    Assert-True -Name 'T12e SecureString roundtrip yields the synthetic token in memory' -Condition ($plainRoundtrip -eq $fakeToken)
+    Assert-True -Name 'T12f SecureString roundtrip yields the synthetic token in memory' -Condition ($plainRoundtrip -eq $fakeToken)
 
 }
 finally {


### PR DESCRIPTION
Issue: #690

## Result

Delivers the prepared Windows least-privilege spike harness and threat-model documentation. **#690 stays open: the real restricted-account drill is NOT RUN.**

The harness checks the process principal, validates explicit operator-profile probe targets, performs credential-access checks without reading credential contents, and requires a supported scoped token provider. Publication binds the named workspace's source objects and the exact allowlisted HTTPS spike destination under isolated Git environment/configuration; cleanup restores inherited state and removes temporary resources. Unsupported token providers fail explicitly.

## Validation

- Safe synthetic fixtures: **64/64**, PowerShell parser and diff checks pass.
- Frozen head: `54884ad3be03a6e5f24444da5c9ae7f205c05771`.
- Exact-head [CI 33866939450](https://github.com/fagemx/edda/actions/runs/33866939450): all green.
- Independent SOL [Round 5](https://github.com/fagemx/edda/pull/855#issuecomment-5539820582): LGTM, P0=0/P1=0, including an independent hostile Git-routing probe and current-base merge check. Prior findings and implementation responses remain in the PR.
- No local Cargo build, actual credential resolution, account/ACL change, or network spike publication was performed.

## Remaining #690 acceptance

An operator-configured restricted Windows principal, its explicit worktree/build-lane permissions, and a supported scoped-token source are still needed. Under that real principal, demonstrate denied access to operator credentials and the allowed build/test/spike-branch push. Run the exact invocation documented in `scripts/spikes/lane-privilege/README.md`; prepared fixtures are not that execution proof.
