### PR TITLE
feat(conductor): add infrastructure contract plans

### DIFF
--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -120,7 +120,14 @@ pub fn run(
     tmux: bool,
     agent: AgentKind,
 ) -> Result<()> {
-    let plan = load_plan(plan_file)?;
+    let plan = if dry_run {
+        eprintln!(
+            "Schema preview only: draft carriers/checks are validated, not executed or accepted."
+        );
+        edda_conductor::plan::preview::load_preview(plan_file)?
+    } else {
+        load_plan(plan_file)?
+    };
     let cwd = cwd_override
         .map(|p| p.to_path_buf())
         .or_else(|| {

--- a/crates/edda-cli/tests/conduct_schema_preview.rs
+++ b/crates/edda-cli/tests/conduct_schema_preview.rs
@@ -1,0 +1,33 @@
+//! GH-603: exercise the real CLI, not just serde accepting unknown fields.
+use std::process::Command;
+
+#[test]
+fn carrier_examples_pass_dry_run_and_fail_before_execution() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    for shape in ["coding", "research", "loop"] {
+        let fixture = root.join(format!("docs/design/infra-contracts/{shape}.yaml"));
+        let dir = tempfile::tempdir().unwrap();
+        let output = Command::new(env!("CARGO_BIN_EXE_edda"))
+            .current_dir(dir.path())
+            .args(["conduct", "run"])
+            .arg(&fixture)
+            .arg("--dry-run")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(String::from_utf8_lossy(&output.stderr).contains("Schema preview only"));
+        assert!(String::from_utf8_lossy(&output.stdout).contains("[dry-run] Plan:"));
+        let output = Command::new(env!("CARGO_BIN_EXE_edda"))
+            .current_dir(dir.path())
+            .args(["conduct", "run"])
+            .arg(&fixture)
+            .output()
+            .unwrap();
+        assert!(!output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr).contains("preview"));
+    }
+}

--- a/crates/edda-conductor/src/plan/mod.rs
+++ b/crates/edda-conductor/src/plan/mod.rs
@@ -1,3 +1,4 @@
 pub mod parser;
+pub mod preview;
 pub mod schema;
 pub mod topo;

--- a/crates/edda-conductor/src/plan/parser.rs
+++ b/crates/edda-conductor/src/plan/parser.rs
@@ -13,6 +13,7 @@ pub fn load_plan(path: &Path) -> Result<Plan> {
 pub fn parse_plan(yaml: &str) -> Result<Plan> {
     // Step 1: Parse into raw Value for short-format normalization
     let mut raw: serde_yml::Value = serde_yml::from_str(yaml).context("invalid YAML syntax")?;
+    super::preview::reject_runtime_extensions(&raw)?;
 
     // Step 2: Normalize short-format checks
     normalize_checks(&mut raw)?;

--- a/crates/edda-conductor/src/plan/preview.rs
+++ b/crates/edda-conductor/src/plan/preview.rs
@@ -1,0 +1,344 @@
+//! GH-603 design-schema preview. This is deliberately not an executable Plan.
+//! Runtime parsing rejects these fields until carrier runners ship.
+use super::{parser::parse_plan, schema::Plan};
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use serde_yml::Value;
+use std::path::Path;
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+enum Basis {
+    Git { sha: String },
+    Document { uri: String, version: String },
+}
+
+impl Basis {
+    fn validate(&self) -> Result<()> {
+        match self {
+            Self::Git { sha } => full_sha(sha),
+            Self::Document { uri, version } => {
+                nonempty(uri, "document uri")?;
+                nonempty(version, "document immutable version")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+enum Deliverable {
+    Pr {
+        repository: String,
+        number: u64,
+        head_sha: String,
+    },
+    Finding {
+        finding_id: String,
+        basis: Basis,
+    },
+    Draft {
+        path: String,
+        version: String,
+        decision_refs: Vec<String>,
+    },
+}
+
+impl Deliverable {
+    fn validate(&self) -> Result<()> {
+        match self {
+            Self::Pr {
+                repository,
+                number,
+                head_sha,
+            } => {
+                nonempty(repository, "PR repository")?;
+                if *number == 0 {
+                    bail!("PR number must be positive");
+                }
+                full_sha(head_sha)
+            }
+            Self::Finding { finding_id, basis } => {
+                nonempty(finding_id, "finding_id")?;
+                basis.validate()
+            }
+            Self::Draft {
+                path,
+                version,
+                decision_refs,
+            } => {
+                nonempty(path, "draft path")?;
+                nonempty(version, "draft immutable version")?;
+                if decision_refs.is_empty() {
+                    bail!("draft requires decision_refs");
+                }
+                for decision in decision_refs {
+                    nonempty(decision, "decision reference")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Isolation {
+    None,
+    Scratch,
+    Worktree,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+enum PreviewCheck {
+    Fresh {
+        source: String,
+        instance: String,
+        within_sec: Option<u64>,
+    },
+    FindingVerdict {
+        finding_id: String,
+        basis: Basis,
+    },
+}
+
+impl PreviewCheck {
+    fn validate(&self) -> Result<()> {
+        match self {
+            Self::Fresh {
+                source,
+                instance,
+                within_sec,
+            } => {
+                nonempty(source, "fresh source")?;
+                nonempty(instance, "fresh instance")?;
+                if *within_sec == Some(0) {
+                    bail!("within_sec must be positive");
+                }
+                Ok(())
+            }
+            Self::FindingVerdict { finding_id, basis } => {
+                nonempty(finding_id, "finding_id")?;
+                basis.validate()
+            }
+        }
+    }
+}
+
+fn nonempty(value: &str, label: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        bail!("{label} must not be empty");
+    }
+    Ok(())
+}
+
+fn full_sha(sha: &str) -> Result<()> {
+    if sha.len() != 40 || !sha.bytes().all(|b| b.is_ascii_hexdigit()) {
+        bail!("basis/head_sha must be a full 40-character git SHA");
+    }
+    Ok(())
+}
+
+fn preview_check(check: &Value) -> bool {
+    matches!(
+        check.get("type").and_then(Value::as_str),
+        Some("fresh" | "finding_verdict")
+    )
+}
+
+/// Guard the normal parser, including callers other than the CLI.
+pub(super) fn reject_runtime_extensions(raw: &Value) -> Result<()> {
+    reject_strategy_override(raw)?;
+    if raw.get("strategy_run_id").is_some() {
+        bail!("strategy_run_id is schema-preview only; use conduct run --dry-run (GH-603)");
+    }
+    if let Some(phases) = raw.get("phases").and_then(Value::as_sequence) {
+        for phase in phases {
+            if ["deliverable", "isolation", "owns_objects"]
+                .iter()
+                .any(|key| phase.get(*key).is_some())
+            {
+                bail!(
+                    "carrier/isolation schema is preview-only; use conduct run --dry-run (GH-603)"
+                );
+            }
+            if let Some(checks) = phase.get("check").and_then(Value::as_sequence) {
+                for check in checks {
+                    reject_preview_check(check)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn reject_preview_check(check: &Value) -> Result<()> {
+    if preview_check(check) {
+        bail!("fresh/finding_verdict checks are schema-preview only; use conduct run --dry-run (GH-603)");
+    }
+    if let Some(inner) = check.get("check") {
+        reject_preview_check(inner)?;
+    }
+    Ok(())
+}
+
+/// Typed validation of draft fields, then existing plan validation/topology.
+/// The projected Plan omits draft checks and MUST only be used for display.
+pub fn load_preview(path: &Path) -> Result<Plan> {
+    let yaml =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    parse_preview(&yaml)
+}
+
+fn parse_preview(yaml: &str) -> Result<Plan> {
+    let mut raw: Value = serde_yml::from_str(yaml).context("invalid YAML syntax")?;
+    reject_strategy_override(&raw)?;
+    if let Some(map) = raw.as_mapping_mut() {
+        if let Some(id) = map.remove("strategy_run_id") {
+            let id: String =
+                serde_yml::from_value(id).context("strategy_run_id must be a string")?;
+            nonempty(&id, "strategy_run_id")?;
+        }
+    }
+    if let Some(phases) = raw.get_mut("phases").and_then(Value::as_sequence_mut) {
+        for phase in phases {
+            if let Some(map) = phase.as_mapping_mut() {
+                if let Some(value) = map.remove("deliverable") {
+                    serde_yml::from_value::<Deliverable>(value)
+                        .context("deliverable schema")?
+                        .validate()?;
+                }
+                if let Some(value) = map.remove("isolation") {
+                    serde_yml::from_value::<Isolation>(value).context("isolation schema")?;
+                }
+                if let Some(value) = map.remove("owns_objects") {
+                    let objects: Vec<String> =
+                        serde_yml::from_value(value).context("owns_objects schema")?;
+                    for object in objects {
+                        let Some((kind, id)) = object.split_once(':') else {
+                            bail!("object claim requires kind:id");
+                        };
+                        if !matches!(kind, "finding" | "source" | "draft") {
+                            bail!("unknown object claim kind: {kind}");
+                        }
+                        nonempty(id, "object claim id")?;
+                    }
+                }
+            }
+            if let Some(checks) = phase.get_mut("check").and_then(Value::as_sequence_mut) {
+                let mut legacy = Vec::new();
+                for check in checks.drain(..) {
+                    if !validate_preview_check(&check)? {
+                        legacy.push(check);
+                    }
+                }
+                *checks = legacy;
+            }
+        }
+    }
+    let plan = parse_plan(&serde_yml::to_string(&raw)?)?;
+    super::topo::topo_sort(&plan)?;
+    Ok(plan)
+}
+
+fn reject_strategy_override(raw: &Value) -> Result<()> {
+    if raw.get("strategy").is_some() {
+        bail!("strategy belongs to the wave adapter, not a conductor plan");
+    }
+    if let Some(phases) = raw.get("phases").and_then(Value::as_sequence) {
+        if phases
+            .iter()
+            .any(|phase| phase.get("strategy_run_id").is_some())
+        {
+            bail!("strategy_run_id belongs to the plan; phases cannot override it");
+        }
+    }
+    Ok(())
+}
+
+// Return true only when the entire check is a validated draft check.
+fn validate_preview_check(check: &Value) -> Result<bool> {
+    if preview_check(check) {
+        serde_yml::from_value::<PreviewCheck>(check.clone())
+            .context("preview check schema")?
+            .validate()?;
+        return Ok(true);
+    }
+    // Nested draft checks are intentionally outside this first schema draft.
+    if let Some(inner) = check.get("check") {
+        reject_preview_check(inner)?;
+    }
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn examples_validate_but_cannot_execute() {
+        for yaml in [
+            include_str!("../../../../docs/design/infra-contracts/coding.yaml"),
+            include_str!("../../../../docs/design/infra-contracts/research.yaml"),
+            include_str!("../../../../docs/design/infra-contracts/loop.yaml"),
+        ] {
+            parse_preview(yaml).unwrap();
+            assert!(parse_plan(yaml)
+                .unwrap_err()
+                .to_string()
+                .contains("preview"));
+        }
+    }
+
+    #[test]
+    fn malformed_drafts_and_unknown_checks_fail() {
+        let yaml = include_str!("../../../../docs/design/infra-contracts/research.yaml");
+        for bad in [
+            yaml.replace("580e98678fe6a39f57ad7a4dcbff74ecf47f2be4", "580e986"),
+            yaml.replace("isolation: scratch", "isolation: magic"),
+            yaml.replace("kind: finding", "kind: unknown"),
+            yaml.replace("type: finding_verdict", "type: unknown"),
+            yaml.replace("finding_id: finding-587", "finding_id: ''"),
+            yaml.replace("strategy_run_id: review-587", "strategy_run_id: ''"),
+        ] {
+            assert!(parse_preview(&bad).is_err(), "accepted {bad}");
+        }
+        let loop_yaml = include_str!("../../../../docs/design/infra-contracts/loop.yaml");
+        assert!(parse_preview(&loop_yaml.replace("within_sec: 60", "within_sec: 0")).is_err());
+    }
+
+    #[test]
+    fn legacy_plans_and_legacy_errors_are_preserved() {
+        let yaml = "name: legacy\nphases:\n  - id: one\n    prompt: hi\n    check:\n      - file_exists: x\n";
+        assert_eq!(parse_preview(yaml).unwrap().phases[0].check.len(), 1);
+        assert!(parse_plan(yaml).is_ok());
+        assert!(parse_preview(&yaml.replace("name: legacy", "name: Invalid")).is_err());
+    }
+
+    #[test]
+    fn each_runtime_extension_is_rejected_even_without_a_run_stamp() {
+        for fields in [
+            "    deliverable: null\n",
+            "    isolation: none\n",
+            "    owns_objects: []\n",
+            "    check:\n      - type: fresh\n        source: heartbeat\n        instance: lane\n",
+            "    check:\n      - type: wait_until\n        check:\n          type: fresh\n          source: heartbeat\n          instance: lane\n",
+        ] {
+            let yaml = format!("name: guarded\nphases:\n  - id: one\n    prompt: hi\n{fields}");
+            assert!(parse_plan(&yaml).unwrap_err().to_string().contains("preview"));
+        }
+    }
+
+    #[test]
+    fn draft_requires_version_and_decision_references() {
+        let yaml = "name: draft\nphases:\n  - id: one\n    prompt: hi\n    deliverable:\n      kind: draft\n      path: draft.md\n      version: sha256:example\n      decision_refs: [decision-1]\n";
+        parse_preview(yaml).unwrap();
+        assert!(parse_preview(&yaml.replace("[decision-1]", "[]")).is_err());
+        assert!(parse_preview(&yaml.replace("sha256:example", "''")).is_err());
+        assert!(
+            parse_preview(&yaml.replace("path: draft.md", "path: draft.md\n      typo: true"))
+                .is_err()
+        );
+    }
+}

--- a/crates/edda-conductor/src/plan/preview.rs
+++ b/crates/edda-conductor/src/plan/preview.rs
@@ -222,7 +222,18 @@ fn parse_preview(yaml: &str) -> Result<Plan> {
                         if !matches!(kind, "finding" | "source" | "draft") {
                             bail!("unknown object claim kind: {kind}");
                         }
-                        nonempty(id, "object claim id")?;
+                        if kind == "source" {
+                            // carrier.md: source claims must be instance-scoped
+                            // as `source:<source>/<instance>` with both parts
+                            // present and nonempty.
+                            let Some((source, instance)) = id.split_once('/') else {
+                                bail!("source object claim requires source/instance");
+                            };
+                            nonempty(source, "source object claim source")?;
+                            nonempty(instance, "source object claim instance")?;
+                        } else {
+                            nonempty(id, "object claim id")?;
+                        }
                     }
                 }
             }
@@ -327,6 +338,21 @@ mod tests {
         ] {
             let yaml = format!("name: guarded\nphases:\n  - id: one\n    prompt: hi\n{fields}");
             assert!(parse_plan(&yaml).unwrap_err().to_string().contains("preview"));
+        }
+    }
+
+    #[test]
+    fn source_object_claims_require_source_and_instance() {
+        let yaml = "name: src\nphases:\n  - id: one\n    prompt: hi\n    owns_objects: [source:heartbeat/lane-2]\n";
+        parse_preview(yaml).unwrap();
+        for bad in [
+            "source:heartbeat",
+            "source:/lane-2",
+            "source:heartbeat/",
+            "source:/",
+        ] {
+            let bad_yaml = yaml.replace("source:heartbeat/lane-2", bad);
+            assert!(parse_preview(&bad_yaml).is_err(), "accepted {bad}");
         }
     }
 

--- a/docs/design/infra-contracts/README.md
+++ b/docs/design/infra-contracts/README.md
@@ -1,0 +1,27 @@
+# Research, carrier and freshness design delivery
+
+This bundle answers the design acceptance in #602, #603 and #604. Decisions
+were recorded 2026-09-04 after querying the project ledger; they are
+agent-authored/unratified, not operator ratifications.
+
+| Design | Decision key | Contract | Implementation follow-ups |
+|---|---|---|---|
+| #602 | finding.model | [finding schema, matrix, lifecycle](finding.md) | [#844 finding events](https://github.com/fagemx/edda/issues/844), [#846 promotion and consumers](https://github.com/fagemx/edda/issues/846) |
+| #604 | signal.freshness | [cadence table and pack proof](freshness.md) | [#848 registry and consumers](https://github.com/fagemx/edda/issues/848) |
+| #603 | conductor.carrier | [carrier/check/stamp schema](carrier.md) | [#849 runtime carriers](https://github.com/fagemx/edda/issues/849) |
+
+Only the conductor dry-run schema preview and fail-closed runtime rejection
+ship here. The following three commands validate the draft fields and legacy
+plan topology without a network check or agent dispatch:
+
+```sh
+edda conduct run docs/design/infra-contracts/coding.yaml --dry-run
+edda conduct run docs/design/infra-contracts/research.yaml --dry-run
+edda conduct run docs/design/infra-contracts/loop.yaml --dry-run
+```
+
+Running these same plans without `--dry-run` fails before execution because
+runtime carrier support is intentionally deferred. Existing plans that omit
+the new declarations still run. A successful preview proves schema validity,
+not acceptance of the referenced artifact. Independent review and exact-head
+CI receipts are published on the delivery PR, pinned to its full SHA.

--- a/docs/design/infra-contracts/README.md
+++ b/docs/design/infra-contracts/README.md
@@ -20,8 +20,8 @@ edda conduct run docs/design/infra-contracts/research.yaml --dry-run
 edda conduct run docs/design/infra-contracts/loop.yaml --dry-run
 ```
 
-Running these same plans without `--dry-run` fails before execution because
-runtime carrier support is intentionally deferred. Existing plans that omit
+These plans fail before execution when run without `--dry-run`, because runtime
+carrier support is intentionally deferred. Existing plans that omit
 the new declarations still run. A successful preview proves schema validity,
 not acceptance of the referenced artifact. Independent review and exact-head
 CI receipts are published on the delivery PR, pinned to its full SHA.

--- a/docs/design/infra-contracts/carrier.md
+++ b/docs/design/infra-contracts/carrier.md
@@ -1,0 +1,124 @@
+# Conductor carrier contract (GH-603)
+
+Status: unratified design plus executable **schema preview only**.
+`conductor.carrier=typed-schema-preview-first` recorded 2026-09-04 after the
+[finding](finding.md) and [freshness](freshness.md) decisions.
+
+## Carrier and isolation
+
+Phase `deliverable` is optional. Existing plans omitting all new fields keep
+their existing behavior. Declaring it opts into a mandatory identity/acceptance
+contract in the future runtime; missing, inaccessible, or mismatched declared
+delivery fails completion. No implicit carrier is guessed from prose output.
+
+| kind | Required identity | Mandatory future acceptance |
+|---|---|---|
+| pr | repository, positive number, head_sha (full SHA) | exact-head CI + independent current-head review verdict |
+| finding | finding_id, basis (git SHA or immutable document version) | approved independent finding verdict at that basis/revision |
+| draft | path, immutable version, nonempty decision_refs | bound independent review against referenced ratified decisions |
+
+Identities are literal frozen references in this first schema. Plans can be
+materialized by the wave adapter after the artifact identity exists; automatic
+“create and discover the PR number” interpolation is a follow-up concern.
+Verification plan for a coding artifact is still the coding shape. Finding
+IDs may be allocated before research starts. Draft versions are immutable
+content digests or document revisions, not mutable names such as “latest”.
+
+Explicit check lists are additive: they cannot remove the carrier's mandatory
+acceptance. An operator waiver must be a separate audited receipt with waived
+status; it cannot turn a rejected carrier into accepted. Existing plans retain
+legacy `gate: verdict` semantics. A phase verdict does not substitute for a
+finding verdict. `on_fail: skip` reports skipped, never delivered/accepted.
+
+`isolation: none | scratch | worktree` is optional; omitted means the existing
+externally managed cwd arrangement. `none` means no filesystem write surface;
+`scratch` requires an adapter-created disposable directory; `worktree` requires
+an adapter-provisioned isolated checkout at cwd. Conductor validates the
+declared isolation before dispatch, but does not own provisioning or cleanup.
+Tool policy remains separate; `none` alone is not a sandbox.
+
+`owns` continues to mean file globs. `owns_objects: [finding:<id>, source:<source>/<instance>, draft:<id>]`
+is a separate typed namespace resolved within the project (and strategy run
+for run-local findings), not fake filesystem paths. Conflicting exclusive
+object ownership serializes work through the claim registry (GH-581).
+Read-only interests do not imply ownership or exclusion.
+
+## Checks and backwards compatibility
+
+New checks use tagged YAML only:
+
+```yaml
+check:
+  - type: finding_verdict
+    finding_id: finding-587
+    basis: {kind: git, sha: 580e98678fe6a39f57ad7a4dcbff74ecf47f2be4}
+  - type: fresh
+    source: heartbeat
+    instance: lane-2
+    within_sec: 60
+```
+
+Fresh uses the shared reducer; within_sec optionally tightens its limit.
+Finding-verdict consumes the object contract. When paired with a deliverable,
+extra checks may refer to other objects, but the declared carrier still gets
+its own mandatory guard. Nesting these draft checks in wait_until is not in
+this schema version and fails clearly; legacy checks and short syntax keep
+working. No runner or new approval CLI is implemented in this PR.
+
+The draft schema is typed in `edda-conductor/src/plan/preview.rs` and wired to
+the existing `edda conduct run <plan> --dry-run`. It validates new fields,
+then the existing plan parser and topology. Its legacy projection exists only
+for dry-run display: new checks are not executed, not represented as passed,
+and not installed into a runnable Plan. The display announces this limitation.
+Normal `parse_plan` rejects any carrier, isolation, object claim, run stamp or
+new check before dispatch, including explicit null fields. It must never
+silently discard a delivery or isolation promise.
+
+Examples: [coding](coding.yaml), [research](research.yaml), [loop](loop.yaml).
+Run each with `edda conduct run docs/design/infra-contracts/<shape>.yaml --dry-run`.
+The examples are design fixtures: they do not assert a live artifact passes
+acceptance. Dry-run performs no network lookup or agent dispatch. Parser tests
+also require malformed basis, kind, isolation, run identity and check fields
+to fail, and legacy plans to remain valid. CLI process tests exercise the real
+dry-run entry point and reject execution without spawning an agent.
+
+## Receipt and run stamp
+
+`strategy_run_id: Option<String>` is a nonempty opaque plan field, supplied by
+the wave adapter and copied unchanged to phase-start/progress/completed events,
+receipt, verdict request/response binding, and finding creation. Absent remains
+absent; a phase cannot override it. A finding from another run may be a cited
+input but cannot be relabeled. Conductor does not interpret the five strategy
+parameters, select candidates, or expand waves. Parallelism remains between
+single-phase plans; templates stay in parallel-wave assets or `.edda/` data.
+
+Proposed completion payload, extending the existing structured GH-584
+phase-result path rather than writing another prose-only note:
+
+```json
+{
+  "schema_version": 1,
+  "plan_id": "research-audit",
+  "phase_id": "review",
+  "attempt": 1,
+  "strategy_run_id": "review-587",
+  "status": "passed",
+  "deliverable": {
+    "kind": "finding", "finding_id": "finding-587",
+    "basis": {"kind": "git", "sha": "580e98678fe6a39f57ad7a4dcbff74ecf47f2be4"}
+  },
+  "checks": [{"type": "finding_verdict", "passed": true, "evidence_event_id": "verification-event-id"}],
+  "receipt_event_id": "completion-event-id"
+}
+```
+
+The example event IDs are placeholders. The append returns the receipt ID;
+the derived receipt can include it without self-hashing the event. Existing
+cost/token measuredness fields remain unchanged; unavailable evidence stays
+unknown. Report/status read structured identity and group run ID × problem
+class. A terminal result requires output references before emission; retried
+delivery reconciles the same `(plan, phase, attempt, carrier identity)` receipt.
+The actual stamped runtime events and readers ship in follow-ups.
+
+No parallel-wave/fleet-orchestrate rewrite is included. The reusable wave
+layer consumes these contracts when implementations are available.

--- a/docs/design/infra-contracts/coding.yaml
+++ b/docs/design/infra-contracts/coding.yaml
@@ -1,0 +1,14 @@
+name: coding-carrier-preview
+strategy_run_id: code-review-587
+phases:
+  - id: verify
+    prompt: Verify the frozen coding artifact against its issue acceptance.
+    isolation: worktree
+    deliverable:
+      kind: pr
+      repository: fagemx/edda
+      number: 587
+      head_sha: d2f3bb16a9155455cf6a0636346b389474000469
+    check:
+      - type: git_clean
+    gate: verdict

--- a/docs/design/infra-contracts/finding.md
+++ b/docs/design/infra-contracts/finding.md
@@ -1,0 +1,152 @@
+# Finding contract (GH-602)
+
+Status: design candidate, not a shipped finding API. Decision recorded on
+2026-09-04 as `finding.model=independent-events-bound-verdict-run-local` in
+the project ledger, agent-authored/unratified. Basis for this design:
+`467e8be02eb98fb47d0eca82e9dd400d91d67e6a`.
+
+## Storage and identity
+
+Use independent append-only `finding.created`, `finding.attempted`,
+`finding.verified`, `finding.promoted`, `finding.dropped`, and `finding.linked`
+events. A finding has a stable ID; the derived view folds these events in ledger
+order. Tasks still describe work and lease/dependency state; adding a task kind
+would conflate completed work with verified knowledge. Tasks may reference a
+finding ID in their receipt. No extra runtime crate is needed.
+
+All events carry project_id, finding_id, event_id, actor (stable principal plus
+session ID), timestamp, schema_version=1, and optional strategy_run_id. The
+ledger supplies the receipt event ID after append; it is not a circular input.
+The writer enforces valid prior revision and transition atomically. An import
+records original source time separately from ingestion time and never pretends
+historical evidence was executed by the importer.
+
+## Field and state matrix
+
+R = required, O = optional, inherited = immutable from creation.
+
+| Field | candidate creation | verified | decision / issued | dropped |
+|---|---|---|---|---|
+| question, author, project_id, finding_id | R, nonempty | inherited | inherited | inherited |
+| basis | R: git full SHA or document URI + immutable version | exact creation basis | inherited | inherited |
+| evidence_bar | R: nonempty list of repro / failing_test / trace / direct_code_proof | satisfied explicitly by verdict | inherited | inherited |
+| attempts | R list, may initially be empty | at least one evidence item | inherited | inherited |
+| next_experiment | R nonempty bounded experiment | O | O | O |
+| strategy_run_id | O, opaque string | inherited | inherited | inherited |
+| visibility | R, default run_local with run ID, otherwise private | project | project or explicit global | prior visibility |
+| verdict | absent | R approval, verifier, basis, RAN/READ and rationale | inherited | O rejection evidence |
+| outputs | empty | empty or prior issued refs | R nonempty typed references | no new output |
+| reason | O | R verdict rationale | R promotion rationale | R disposition reason |
+| receipt | event ID returned on every append | R verification event ID | R output/promotion IDs | R drop event ID |
+
+`basis: {kind: git, sha: <40 hex>}` or
+`basis: {kind: document, uri: <stable locator>, version: <immutable digest/version>}`.
+An attempt has actor, observed_at, kind, command_or_locator, outcome, and
+evidence_ref (durable blob or URL). A verdict identifies subject finding_id,
+basis, finding revision, verifier principal/session, approved/rejected,
+ran[] and read[] evidence references, rationale. Either evidence list may be
+empty, but their union must satisfy evidence_bar. READ names the original
+executor and source receipt; it never increments the current verifier's RAN.
+
+## Transitions, independence, and promotion
+
+| From | Event / actor | To | Required guard |
+|---|---|---|---|
+| absent | created / author | candidate | all creation fields valid |
+| candidate | attempted / contributing researcher | candidate | evidence append; no basis mutation |
+| candidate | verified / independent verifier | verified | approved bound verdict, evidence bar satisfied |
+| candidate | dropped / author or controller | dropped | reason plus any negative evidence |
+| verified | promoted / controller | decision or issued | approved exact revision/basis, durable output refs |
+| verified | dropped / controller | dropped | reason; retain verification history |
+| issued | promoted / controller | issued | append additional distinct output refs idempotently |
+| any | linked / controller | unchanged | same basis/question scope, preserve aliases/evidence |
+
+Verifier principal must differ from the original author and researchers who
+materially authored the candidate claim before verification. The verifier may
+run independent checks and attach their evidence to its verdict; that does
+not make it the candidate's author. Changing a session ID does not create
+independence. This is checked from the trusted host actor identity, not a
+self-asserted payload string. Changed basis or changed substantive claim creates
+a new candidate linked with `supersedes`; it cannot reuse the old verdict.
+Terminal decision/dropped states cannot be silently reopened.
+
+Finding owns a typed verdict rather than reusing the plan-phase `edda verdict`
+subject namespace: a phase approval is not proof of a finding. The conductor's
+`finding_verdict` check consumes the approved finding revision and exact basis
+([carrier contract](carrier.md)); it does not manufacture a verification.
+
+Promotion to a decision invokes the existing decision writer with
+`provenance: {finding_id, basis, verification_event_id}` and returns its event
+ID. That decision remains **unratified**; promotion never calls `ratify`.
+Promotion to issues renders the GH-599 body contract (What happened, Why it
+matters, Suspected surface, doneWhen, Relation to existing issues), attaching
+the same provenance, and records returned issue URLs. One verified audit may
+produce several issues, each mapped to its evidence and scope. External issue
+creation uses an idempotency marker `(finding_id, output_key)` and reconciliation
+before retry: a crash after HTTP success must not create a duplicate. Mark
+issued only after at least one durable output reference is recorded; partial
+fan-out remains visible with pending output keys.
+
+## Shared scent and reporting
+
+Candidates with strategy_run_id are immediately visible to the same project's
+same run through pack/hook delivery after durable append. Candidate with no run
+ID is private to its author/controller; it must not fall into a project-wide
+NULL run bucket. Verified findings become project-visible. Global export is an
+explicit operator action after verification, with source project provenance;
+it is never the default. Doorbells carry event IDs; readers resume from a
+ledger cursor after dropped notifications rather than polling every lane.
+
+Deduplication suggests matches by normalized question + basis + source scope
+within the project/run. A controller confirms equivalence; similar text alone
+cannot merge distinct claims. Canonical ID is the earliest ledger event (event
+ID tie-break), all other IDs become aliases, contributors/evidence retain their
+authorship. Stronger evidence augments the canonical object, never steals credit
+or silently upgrades its state. Conflicting findings remain separate and linked.
+
+The control report groups by project, strategy_run_id (including explicit
+unattributed bucket), and ISO UTC week. Count created/verified/issued/decision/
+dropped transitions once per canonical finding; report verification survival
+as verified members of a creation-week cohort / created members, plus its
+as-of time. Report pending members and zero denominator as n/a. Deduped aliases
+and imported historical records are separate counts, preventing a backfill from
+inflating this week's discovery rate. Output issue count is distinct from
+finding count. No transcript mining is necessary.
+
+## Historical lifecycle: PR #587
+
+This is a **backfill mapping**, not a new verification or a claim that the
+finding command exists. Authoritative source:
+[#587 post-merge review](https://github.com/fagemx/edda/pull/587#issuecomment-5502748470),
+basis `580e98678fe6a39f57ad7a4dcbff74ecf47f2be4`. The source names the detached
+read-only pi reviewer session `review-pr587-postmerge`, observed model
+`gpt-5.6-sol`, 19 turns / 9m52s / $1.20, and independent controller verification.
+
+1. `finding.created`: ID `finding-587`; question “Does the merged skill export
+   satisfy its safety and policy contract?”; author the research reviewer;
+   basis above; run `review-587`; visibility run_local; evidence_bar
+   `[repro, direct_code_proof]`; attempts `[]`; next_experiment “Audit the
+   frozen skill behaviors and reproduce each failing branch without mutation.”
+2. `finding.attempted`: reviewer evidence from that comment: RAN shell control
+   flow printed `WOULD_DELETE_EXISTING_INTEL_TREE`; RAN backup check-ignore
+   returned exit 1; READ exact merge-tree merge-authority and verification
+   ladder text. Four separately scoped claims are attached to this audit.
+3. `finding.verified`: the **controller**, distinct from the research author,
+   independently reproduced the backup omission and read the cited hazardous
+   shell/policy blocks. Its bound approved verdict certifies that the four
+   defects exist, not that PR #587 passes review. READ references preserve
+   which repro belonged to the reviewer; controller RAN is only the
+   check-ignore reproduction stated in the source. Project visibility begins.
+4. `finding.promoted`: state issued; four outputs, each with its own output key:
+   [#595](https://github.com/fagemx/edda/issues/595) P0 shell precedence and stash
+   safety; [#596](https://github.com/fagemx/edda/issues/596) P1 backup ignore;
+   [#597](https://github.com/fagemx/edda/issues/597) P1 merge/cleanup authority;
+   [#598](https://github.com/fagemx/edda/issues/598) P1 gate-text contradiction.
+   Each issue cites the same frozen basis and review. No decision promotion or
+   ratification occurred; the merged tree was not reverted.
+
+Real names/receipt IDs not exposed by the historical carrier remain source
+references, not invented ledger IDs. An actual import must resolve distinct
+trusted principals before accepting the verified transition. The example
+demonstrates fan-out and provenance without laundering the earlier superseded
+pre-merge approval into the authoritative verdict.

--- a/docs/design/infra-contracts/freshness.md
+++ b/docs/design/infra-contracts/freshness.md
@@ -1,0 +1,82 @@
+# Freshness contract (GH-604)
+
+Status: unratified design, `signal.freshness=ledger-cadence-scoped-progress`,
+recorded 2026-09-04. No registry/reducer/pack writer ships in this design PR.
+
+## One definition for all consumers
+
+Writer registers append-only `source.registered` with schema_version,
+project_id, source, instance_id, generation, actor, expected_cadence_sec,
+stale_after_sec, dead_after_sec, effective_at. Cadence must be positive and
+`cadence <= stale_after < dead_after`. Defaults are 2× and 10× cadence;
+overrides are explicit, audited registrations. Latest active generation wins;
+updates do not erase earlier observations. `source.retired` ends expected
+activity and reports inactive, never fresh. Config can supply initial defaults
+but cannot silently override the ledger history.
+
+Registry scope is `(project_id, source, instance_id, generation)`. This avoids
+one active lane's heartbeat masking another dead lane. Consumers join only
+the current generation and use ledger acceptance timestamps, not arbitrary
+payload timestamps; future/skewed remote times are diagnostics, not evidence
+of freshness. Query takes an explicit UTC `as_of`; unknown registrations or
+missing/corrupt timestamps produce unknown, never fresh. Strict inequalities:
+
+| Source / active instance | Cadence | Fresh age | Stale age | Dead age |
+|---|---:|---:|---:|---:|
+| heartbeat / lane session | 30s | <=60s | >60s and <=300s | >300s |
+| digest / pending transcript job | 300s | <=600s | >600s and <=3000s | >3000s |
+| conductor / running phase attempt | 30s | <=60s | >60s and <=300s | >300s |
+| dispatch / active dispatch run | 30s | <=60s | >60s and <=300s | >300s |
+
+These are proposed initial defaults, not claims about current writer cadence.
+Enable a registration only when its writer can fulfill that cadence. Event-
+driven digest jobs register when work is pending and retire when caught up;
+idle sessions do not accumulate false deaths. Phase begin/done alone are not
+periodic: conductor uses progress heartbeat while running and terminal events
+retire that instance. Dispatch similarly joins its existing heartbeat with
+terminal outcome; completion event frequency is not its cadence.
+
+`source.observed` references a real durable event and observation class
+`heartbeat` or `progress`. Registration declares which class it expects.
+Empty/duplicate digest output does not count as progress: the transcript cursor
+must advance and the writer must report input/output counts. A healthy process
+heartbeat cannot hide a stuck progress source. If no qualifying observation
+exists, show `starting (none)` up to stale_after since registration, then stale
+or dead at the same boundaries; `starting` is never accepted by a fresh check.
+At a new generation, old timestamps cannot keep a restarted source fresh.
+
+## First consumption proof
+
+The first implementation wires the shared derived view into memory pack:
+
+```text
+sources: heartbeat/lane-2 fresh 18s ago · digest/job-9 DEAD 4h ago (cadence 5m)
+         conductor/phase-a stale 90s ago · dispatch/run-7 starting (none)
+```
+
+The line includes source/instance, age or none, state, and cadence when stale/
+dead. DEAD remains visible under pack truncation before healthy source detail;
+multiple dead instances are summarized with count and a query locator rather
+than silently dropped. Missing registration displays `unregistered` until
+rollout completes. Historical data without a cadence is unknown, not dead.
+Consumers expose the registration/event IDs and as_of for audit.
+
+GH-573 remains a separate fleet-watch consumer, **not merged into this issue**.
+It reads this reducer rather than recomputing heartbeat absence. Its existing
+behavior remains until the adapter lands; no alternate production thresholds
+are introduced here. Cost report GH-582 and status GH-567 follow the same
+view. Observation never grants recovery/reclaim/merge authority.
+
+Conductor `fresh` requires an active registered source with at least one
+qualifying observation whose derived state is fresh. Optional within_sec is
+a stricter age cap, combined with registry freshness using AND. Missing,
+unknown, starting, inactive, stale and dead fail with structured reason.
+Exactly 2× cadence passes, exactly 10× is stale, greater than 10× is dead.
+The check receives explicit source + instance; it cannot accidentally select
+the newest heartbeat from another run. This definition is shared with the
+[carrier schema](carrier.md), not duplicated in a runner.
+
+Implementation tests must cover threshold equality, restart generation,
+per-instance isolation, no first observation, retirement, future timestamps,
+empty digest progress, pack truncation and the same facts through fresh check
+and watch. This delivers death visibility, not only a timestamp writer.

--- a/docs/design/infra-contracts/loop.yaml
+++ b/docs/design/infra-contracts/loop.yaml
@@ -1,0 +1,12 @@
+name: loop-carrier-preview
+strategy_run_id: watch-run-2
+phases:
+  - id: tick
+    prompt: Observe the registered lane heartbeat for this bounded tick.
+    isolation: none
+    owns_objects: [source:heartbeat/lane-2]
+    check:
+      - type: fresh
+        source: heartbeat
+        instance: lane-2
+        within_sec: 60

--- a/docs/design/infra-contracts/research.yaml
+++ b/docs/design/infra-contracts/research.yaml
@@ -1,0 +1,15 @@
+name: research-carrier-preview
+strategy_run_id: review-587
+phases:
+  - id: review
+    prompt: Audit the frozen skill contract; record evidence with its original executor.
+    isolation: scratch
+    owns_objects: [finding:finding-587]
+    deliverable:
+      kind: finding
+      finding_id: finding-587
+      basis: {kind: git, sha: 580e98678fe6a39f57ad7a4dcbff74ecf47f2be4}
+    check:
+      - type: finding_verdict
+        finding_id: finding-587
+        basis: {kind: git, sha: 580e98678fe6a39f57ad7a4dcbff74ecf47f2be4}


### PR DESCRIPTION
## Problem and result
Research findings and writer freshness currently lack a shared carrier contract. This defines the finding lifecycle, cadence semantics and conductor delivery schema, including the real PR #587 post-merge audit mapped to four existing issues.

`edda conduct run <plan> --dry-run` validates typed carrier, isolation, run stamp, object claims and fresh/finding-verdict declarations. Normal execution rejects these preview-only promises before dispatch; legacy plans retain existing behavior. No finding/freshness/carrier runner is introduced.

Issue: #602, #603, #604
Closes #602
Closes #603
Closes #604

## Acceptance
- Ledger decisions finding.model, signal.freshness and conductor.carrier recorded after ask; all remain agent-authored/unratified.
- docs/design/infra-contracts contains all question answers, state matrix/transition rules, real #587 provenance, freshness threshold/dead-source pack examples, run-stamp receipt path and three runnable schema-preview fixtures.
- Actual implementation is split into #844, #846, #848 and #849 (fleet:pending).

## Validation
RAN: `cargo test -p edda-conductor` in the verifier lane after recovery of the interrupted suite. READ: the earlier CLI tests, dry runs, format, Markdown, staged-length, and clippy receipt (`evt_01m1nrm3r5hr170m4d613npm8m`). Exact-head CI remains required before review handoff.

## Review scope
Typed schema preview, runtime fail-closed parser guard, CLI dry-run integration and direct consumers; the three design issues' explicit acceptance; backwards compatibility and introduced security/data-loss regressions. Runtime implementations in the follow-up issues remain outside this PR.
