### PR TITLE
feat(cli,conductor): add elapsed time accounting

### DIFF
--- a/.claude/skills/fleet-review/SKILL.md
+++ b/.claude/skills/fleet-review/SKILL.md
@@ -36,6 +36,19 @@ context: fork
 2. **定位 PR**：args 給的號碼／URL；或
    `gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number'`。
 
+## elapsed 來源
+
+verdict header 增列 `elapsed: <N> ms (pi session)`；來源和 `model_observed`
+相同的 pi session JSONL 檔。先將 `PI_SESSION_FILE` 設為該檔案，再執行：
+
+```sh
+node scripts/pi-session-elapsed.mjs "$PI_SESSION_FILE"
+```
+
+只在 `elapsed_measured=true` 時填入 `elapsed_ms`，否則寫
+`elapsed: unmeasured`，不以 0 代替缺值。此值是第一到最後一筆訊息的時間差，
+與 dispatch 的 spawn→exit 量測分開標示。brief 模板與 `REVIEW.md` 記有相同命令。
+
 ## 貼裁定
 
 `gh pr comment <n> --body-file <tmp>`，格式照 `REVIEW.md` §7 一字不改。

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -14,6 +14,7 @@ ran_allowlist:
   - "gh "
   - "git "
   - "sh scripts/"
+  - "node scripts/pi-session-elapsed.mjs "
 independence: session
 classes:
   code-risk: ["crates/**", "scripts/**", "*.sh", "*.ps1", ".github/**", "install.sh", "Cargo.toml", "Cargo.lock", "*.rs"]
@@ -614,6 +615,7 @@ One comment per round, pinned to the reviewed full SHA
 ```text
 ## Code Review: Round <N> — PR #<n> @ <full 40-hex SHA>
 
+- elapsed: <pi session first-to-last message elapsed_ms; unmeasured if unavailable>
 - model_requested: <the model dispatch asked for>
 - model_observed: <read from the system, or "unverified">
 - reviewer_session: <per-PR UUID the lane was launched with>
@@ -744,3 +746,20 @@ mechanical.
 Changing a rule here changes the line for every engine. Record the version in
 each verdict's `spec:` field so catch rates stay readable against the spec they
 were measured under.
+
+### Review elapsed source (GH-644)
+
+Read elapsed from the **same pi session JSONL file** used for `model_observed`:
+
+```sh
+node scripts/pi-session-elapsed.mjs "$PI_SESSION_FILE"
+```
+
+Set `PI_SESSION_FILE` to the session file already located for this review.
+Copy `elapsed_ms` into the verdict header as `elapsed: <N> ms (pi session)`
+only when `elapsed_measured` is true; otherwise write `elapsed: unmeasured`.
+The helper measures the first through last **message** timestamps, excluding
+session headers. Missing, malformed, single-message, or a last timestamp before
+the first timestamp
+remain unmeasured. This session interval and dispatch's process lifetime are
+different observations; always identify the source in the header.

--- a/crates/edda-cli/src/cmd_conduct.rs
+++ b/crates/edda-cli/src/cmd_conduct.rs
@@ -638,7 +638,14 @@ fn print_status(state: &PlanState) {
             }
             _ => String::new(),
         };
-        println!("  {icon} {:<24} {:?} {detail}", ps.id, ps.status);
+        let elapsed = ps
+            .duration_ms
+            .map(|ms| format!("{ms} ms"))
+            .unwrap_or_else(|| "—".into());
+        println!(
+            "  {icon} {:<24} {:?} {detail} elapsed={elapsed}",
+            ps.id, ps.status
+        );
     }
     println!();
 }

--- a/crates/edda-cli/src/cmd_dispatch.rs
+++ b/crates/edda-cli/src/cmd_dispatch.rs
@@ -167,6 +167,7 @@ pub struct DispatchOutput {
     pub outcome: Outcome,
     pub result_text: Option<String>,
     pub cost_usd: Option<f64>,
+    pub elapsed_ms: Option<u64>,
     pub session_id: String,
     pub error: Option<String>,
     /// The model edda actually passed to the backend, or the literal
@@ -199,6 +200,7 @@ impl DispatchOutput {
                 cost_usd,
                 result_text,
             } => Self {
+                elapsed_ms: None,
                 outcome: Outcome::Done,
                 result_text,
                 cost_usd,
@@ -209,6 +211,7 @@ impl DispatchOutput {
                 session_observed,
             },
             PhaseResult::AgentCrash { error } => Self {
+                elapsed_ms: None,
                 outcome: Outcome::Crash,
                 result_text: None,
                 cost_usd: None,
@@ -219,6 +222,7 @@ impl DispatchOutput {
                 session_observed,
             },
             PhaseResult::Timeout => Self {
+                elapsed_ms: None,
                 outcome: Outcome::Timeout,
                 result_text: None,
                 cost_usd: None,
@@ -229,6 +233,7 @@ impl DispatchOutput {
                 session_observed,
             },
             PhaseResult::MaxTurns { cost_usd } => Self {
+                elapsed_ms: None,
                 outcome: Outcome::MaxTurns,
                 result_text: None,
                 cost_usd,
@@ -239,6 +244,7 @@ impl DispatchOutput {
                 session_observed,
             },
             PhaseResult::BudgetExceeded { cost_usd } => Self {
+                elapsed_ms: None,
                 outcome: Outcome::BudgetExceeded,
                 result_text: None,
                 cost_usd,
@@ -287,6 +293,12 @@ impl DispatchOutput {
             }
         }
         out.push_str(&format!("Cost: {}\n", self.cost_text()));
+        out.push_str(&format!(
+            "Elapsed: {}\n",
+            self.elapsed_ms
+                .map(|ms| format!("{ms} ms"))
+                .unwrap_or_else(|| "—".into())
+        ));
         out.push_str(&format!("Model requested: {}\n", self.model_requested));
         out.push_str(&format!("Model observed: {}\n", self.model_observed));
         out.push_str(&format!("Session: {}\n", self.session_id));
@@ -300,6 +312,8 @@ impl DispatchOutput {
             "outcome": self.outcome.as_str(),
             "result_text": self.result_text,
             "cost_usd": self.cost_usd,
+            "elapsed_ms": self.elapsed_ms,
+            "elapsed_measured": self.elapsed_ms.is_some(),
             "session_id": self.session_id,
             "error": self.error,
             "model_requested": self.model_requested,
@@ -680,8 +694,12 @@ pub async fn run_with_launcher(
             &cancel,
             &hb,
         )
-        .await?
+        .await
     };
+    launcher.finish_dispatch().await;
+    let result = result.unwrap_or_else(|error| PhaseResult::AgentCrash {
+        error: format!("{error:#}"),
+    });
     // GH-574: requested comes from the phase edda built (what was actually
     // passed to the backend); observed is whatever the backend reported
     // in-band, "unknown" when it reported nothing.
@@ -695,14 +713,20 @@ pub async fn run_with_launcher(
     let session_observed = launcher
         .last_observed_session()
         .unwrap_or_else(|| "unknown".to_owned());
-    Ok(DispatchOutput::from_result(
+    let mut output = DispatchOutput::from_result(
         result,
         session_id.to_owned(),
         model_requested,
         model_observed,
         session_observed,
-    ))
+    );
+    output.elapsed_ms = launcher.last_elapsed_ms();
+    Ok(output)
 }
+
+#[cfg(test)]
+#[path = "cmd_dispatch_elapsed_tests.rs"]
+mod elapsed_tests;
 
 #[cfg(test)]
 mod tests {
@@ -795,6 +819,8 @@ mod tests {
             keys,
             vec![
                 "cost_usd",
+                "elapsed_measured",
+                "elapsed_ms",
                 "error",
                 "model_observed",
                 "model_requested",
@@ -1314,66 +1340,7 @@ mod tests {
 
     // ── JSON serialization shape ──
 
-    #[test]
-    fn json_shape_pins_field_names_for_each_outcome() {
-        let cases = vec![
-            (
-                PhaseResult::AgentDone {
-                    cost_usd: Some(1.25),
-                    result_text: Some("did it".into()),
-                },
-                "done",
-            ),
-            (
-                PhaseResult::AgentCrash {
-                    error: "boom".into(),
-                },
-                "crash",
-            ),
-            (PhaseResult::Timeout, "timeout"),
-            (PhaseResult::MaxTurns { cost_usd: None }, "max_turns"),
-            (
-                PhaseResult::BudgetExceeded { cost_usd: None },
-                "budget_exceeded",
-            ),
-        ];
-        for (result, expected_outcome) in cases {
-            let out = DispatchOutput::from_result(
-                result,
-                "sess-1".into(),
-                "inherited".into(),
-                "unknown".into(),
-                "unknown".into(),
-            );
-            let value: serde_json::Value =
-                serde_json::from_str(&out.to_json()).expect("json parses");
-            assert_eq!(value["outcome"].as_str(), Some(expected_outcome));
-            assert!(value["result_text"].is_null() || value["result_text"].is_string());
-            assert!(value["cost_usd"].is_null() || value["cost_usd"].is_number());
-            assert_eq!(value["session_id"].as_str(), Some("sess-1"));
-            assert!(value["error"].is_null() || value["error"].is_string());
-            let mut keys: Vec<&str> = value
-                .as_object()
-                .expect("json object")
-                .keys()
-                .map(|k| k.as_str())
-                .collect();
-            keys.sort_unstable();
-            assert_eq!(
-                keys,
-                vec![
-                    "cost_usd",
-                    "error",
-                    "model_observed",
-                    "model_requested",
-                    "outcome",
-                    "result_text",
-                    "session_id",
-                    "session_observed"
-                ]
-            );
-        }
-    }
+    include!("cmd_dispatch_json_tests.rs");
 
     #[test]
     fn json_carries_crash_error_and_done_fields() {

--- a/crates/edda-cli/src/cmd_dispatch_elapsed_tests.rs
+++ b/crates/edda-cli/src/cmd_dispatch_elapsed_tests.rs
@@ -1,0 +1,57 @@
+use super::*;
+use edda_conductor::agent::launcher::ClaudeCodeLauncher;
+
+#[test]
+fn claude_measures_real_child_and_resets_before_a_failed_spawn() {
+    let _store = crate::test_support::isolated_store();
+    tokio::runtime::Runtime::new().unwrap().block_on(async {
+        let dir = tempfile::tempdir().unwrap();
+        #[cfg(windows)]
+        let bin = {
+            let bin = dir.path().join("claude.cmd");
+            std::fs::write(&bin, "@echo off\r\necho {\"type\":\"result\",\"subtype\":\"success\",\"result\":\"done\"}\r\n").unwrap();
+            bin
+        };
+        #[cfg(unix)]
+        let bin = {
+            use std::os::unix::fs::PermissionsExt;
+            let bin = dir.path().join("claude.sh");
+            std::fs::write(&bin, "#!/bin/sh\nsleep 0.1\nprintf '%s\\n' '{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"done\"}'\n").unwrap();
+            std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+            bin
+        };
+        let mut launcher = ClaudeCodeLauncher::with_bin(bin);
+        let phase = build_phase("test", None, None, "default", CapabilityOptions::default());
+        let out = run_with_launcher(&launcher, &phase, "test", dir.path(), CancellationToken::new()).await.unwrap();
+        assert_eq!(out.outcome, Outcome::Done);
+        assert!(out.elapsed_ms.is_some());
+        launcher.claude_bin = dir.path().join("gone");
+        let out = run_with_launcher(&launcher, &phase, "test", dir.path(), CancellationToken::new()).await.unwrap();
+        assert_eq!(out.outcome, Outcome::Crash);
+        assert_eq!(out.elapsed_ms, None);
+    });
+}
+
+#[test]
+fn failed_spawn_is_unmeasured_and_does_not_invent_zero() {
+    let _store = crate::test_support::isolated_store();
+    tokio::runtime::Runtime::new().unwrap().block_on(async {
+        let dir = tempfile::tempdir().unwrap();
+        let launcher = ClaudeCodeLauncher::with_bin(dir.path().join("missing-backend"));
+        let phase = build_phase("test", None, None, "default", CapabilityOptions::default());
+        let out = run_with_launcher(
+            &launcher,
+            &phase,
+            "test",
+            dir.path(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        let value: serde_json::Value = serde_json::from_str(&out.to_json()).unwrap();
+        assert_eq!(value["outcome"], "crash");
+        assert_eq!(value["elapsed_measured"], false);
+        assert!(value.get("elapsed_ms").unwrap().is_null());
+        assert!(out.render_text().contains("Elapsed: —"));
+    });
+}

--- a/crates/edda-cli/src/cmd_dispatch_json_tests.rs
+++ b/crates/edda-cli/src/cmd_dispatch_json_tests.rs
@@ -1,0 +1,62 @@
+#[test]
+fn json_shape_pins_field_names_for_each_outcome() {
+    let cases = vec![
+        (
+            PhaseResult::AgentDone {
+                cost_usd: Some(1.25),
+                result_text: Some("did it".into()),
+            },
+            "done",
+        ),
+        (
+            PhaseResult::AgentCrash {
+                error: "boom".into(),
+            },
+            "crash",
+        ),
+        (PhaseResult::Timeout, "timeout"),
+        (PhaseResult::MaxTurns { cost_usd: None }, "max_turns"),
+        (
+            PhaseResult::BudgetExceeded { cost_usd: None },
+            "budget_exceeded",
+        ),
+    ];
+    for (result, expected_outcome) in cases {
+        let out = DispatchOutput::from_result(
+            result,
+            "sess-1".into(),
+            "inherited".into(),
+            "unknown".into(),
+            "unknown".into(),
+        );
+        let value: serde_json::Value =
+            serde_json::from_str(&out.to_json()).expect("json parses");
+        assert_eq!(value["outcome"].as_str(), Some(expected_outcome));
+        assert!(value["result_text"].is_null() || value["result_text"].is_string());
+        assert!(value["cost_usd"].is_null() || value["cost_usd"].is_number());
+        assert_eq!(value["session_id"].as_str(), Some("sess-1"));
+        assert!(value["error"].is_null() || value["error"].is_string());
+        let mut keys: Vec<&str> = value
+            .as_object()
+            .expect("json object")
+            .keys()
+            .map(|k| k.as_str())
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec![
+                "cost_usd",
+                "elapsed_measured",
+                "elapsed_ms",
+                "error",
+                "model_observed",
+                "model_requested",
+                "outcome",
+                "result_text",
+                "session_id",
+                "session_observed"
+            ]
+        );
+    }
+}

--- a/crates/edda-cli/tests/dispatch_codex_threads.rs
+++ b/crates/edda-cli/tests/dispatch_codex_threads.rs
@@ -124,6 +124,7 @@ fn run_dispatch(
             "dispatch",
             "--agent",
             "codex",
+            "--json",
             "--session-id",
             "sess-cross-proc",
             "--prompt-file",
@@ -147,6 +148,9 @@ fn run_dispatch(
             output.status
         ));
     }
+    let receipt: serde_json::Value = serde_json::from_str(&stdout).expect("dispatch JSON");
+    assert_eq!(receipt["elapsed_measured"], true);
+    assert!(receipt["elapsed_ms"].as_u64().unwrap() > 0);
     Ok(stdout)
 }
 

--- a/crates/edda-cli/tests/dispatch_elapsed.rs
+++ b/crates/edda-cli/tests/dispatch_elapsed.rs
@@ -1,0 +1,63 @@
+//! Real dispatch process against a deterministic pi RPC fixture (GH-644).
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn fixture(dir: &Path) -> PathBuf {
+    let body = r#"read_cmd
+write_line '{"id":"req-1","type":"response","command":"prompt","success":true}'
+pause
+write_line '{"type":"agent_settled"}'
+read_cmd
+write_line '{"id":"req-2","type":"response","command":"get_session_stats","success":true,"data":{"cost":0.42}}'
+read_cmd
+write_line '{"id":"req-3","type":"response","command":"get_state","success":true,"data":{"model":null}}'
+"#;
+    #[cfg(windows)]
+    {
+        let script = dir.join("pi.ps1");
+        let body = body
+            .replace("read_cmd", "Read-Line")
+            .replace("write_line", "Write-Line")
+            .replace("pause", "Start-Sleep -Milliseconds 100");
+        std::fs::write(&script, format!("if ($args -contains '--version') {{ exit 0 }}\nfunction Read-Line {{ if ($null -eq [Console]::In.ReadLine()) {{ exit 0 }} }}\nfunction Write-Line([string]$line) {{ [Console]::Out.WriteLine($line); [Console]::Out.Flush() }}\n{body}")).unwrap();
+        let wrapper = dir.join("pi.cmd");
+        std::fs::write(&wrapper, format!("@echo off\r\npowershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"{}\" %*\r\n", script.display())).unwrap();
+        wrapper
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let wrapper = dir.join("pi.sh");
+        std::fs::write(&wrapper, format!("#!/bin/sh\n[ \"$1\" = --version ] && exit 0\nread_cmd() {{ IFS= read -r _ || exit 0; }}\nwrite_line() {{ printf '%s\\n' \"$1\"; }}\n{}", body.replace("pause", "sleep 0.1"))).unwrap();
+        std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o755)).unwrap();
+        wrapper
+    }
+}
+
+#[test]
+fn real_dispatch_json_measures_spawn_to_exit() {
+    let root = tempfile::tempdir().unwrap();
+    let backend = fixture(root.path());
+    let prompt = root.path().join("prompt.txt");
+    std::fs::write(&prompt, "fixture").unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_edda"))
+        .args(["dispatch", "--agent", "pi", "--json", "--prompt-file"])
+        .arg(prompt)
+        .arg("--cwd")
+        .arg(root.path())
+        .env("EDDA_PI_BIN", backend)
+        .env("EDDA_STORE_ROOT", root.path().join("store"))
+        .stdin(std::process::Stdio::null())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["outcome"], "done");
+    assert_eq!(value["elapsed_measured"], true);
+    assert!(value["elapsed_ms"].as_u64().unwrap() >= 100);
+    assert_eq!(value["cost_usd"], 0.42);
+}

--- a/crates/edda-conductor/src/agent/codex_app_server.rs
+++ b/crates/edda-conductor/src/agent/codex_app_server.rs
@@ -1,5 +1,8 @@
+use super::timing::ProcessTiming;
 use std::path::Path;
 use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Instant;
 
 use anyhow::{anyhow, bail, Context, Result};
 use serde_json::{json, Value};
@@ -7,6 +10,9 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 
 pub struct CodexAppServer {
+    started: Instant,
+    reaped: bool,
+    timing: Arc<ProcessTiming>,
     child: Child,
     stdin: ChildStdin,
     stdout: Lines<BufReader<ChildStdout>>,
@@ -23,15 +29,27 @@ impl CodexAppServer {
     pub async fn spawn(bin: &Path) -> Result<Self> {
         let mut command = Command::new(bin);
         command.arg("app-server");
-        Self::spawn_with_command(command).await
+        Self::spawn_with_timing(command, Arc::default()).await
     }
 
-    async fn spawn_with_command(mut command: Command) -> Result<Self> {
+    pub(crate) async fn spawn_timed(bin: &Path, timing: Arc<ProcessTiming>) -> Result<Self> {
+        let mut command = Command::new(bin);
+        command.arg("app-server");
+        Self::spawn_with_timing(command, timing).await
+    }
+
+    #[cfg(test)]
+    async fn spawn_with_command(command: Command) -> Result<Self> {
+        Self::spawn_with_timing(command, Arc::default()).await
+    }
+
+    async fn spawn_with_timing(mut command: Command, timing: Arc<ProcessTiming>) -> Result<Self> {
         command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .kill_on_drop(true);
 
+        let started = Instant::now();
         let mut child = command
             .spawn()
             .context("failed to spawn Codex App Server")?;
@@ -44,6 +62,9 @@ impl CodexAppServer {
             .take()
             .context("Codex App Server stdout was not piped")?;
         let mut server = Self {
+            started,
+            reaped: false,
+            timing,
             child,
             stdin,
             stdout: BufReader::new(stdout).lines(),
@@ -204,9 +225,12 @@ impl CodexAppServer {
         Ok(())
     }
 
-    async fn terminate(&mut self) {
+    pub(crate) async fn terminate(&mut self) {
         let _ = self.child.kill().await;
-        let _ = self.child.wait().await;
+        if self.child.wait().await.is_ok() && !self.reaped {
+            self.reaped = true;
+            self.timing.record(self.started);
+        }
     }
 
     fn take_id(&mut self) -> u64 {
@@ -772,37 +796,7 @@ mod tests {
         assert!(error.to_string().contains("tasklist.exe exited"));
     }
 
-    #[test]
-    fn correlates_response_ids_while_skipping_notifications() -> anyhow::Result<()> {
-        let lines = [
-            r#"{"method":"thread/started","params":{"thread":{"id":"t-1"}}}"#,
-            r#"{"id":1,"result":{"ignored":true}}"#,
-            r#"{"id":2,"result":{"thread":{"id":"t-1"}}}"#,
-        ];
-
-        let result = response_for_id(lines.iter().copied(), 2)?;
-
-        assert_eq!(result["thread"]["id"], "t-1");
-        Ok(())
-    }
-
-    #[test]
-    fn rejects_malformed_app_server_json() {
-        let error = response_for_id(["not-json"], 2).expect_err("malformed JSON should fail");
-
-        assert!(error.to_string().contains("invalid app-server JSON"));
-    }
-
-    #[test]
-    fn preserves_json_rpc_error_message() {
-        let error = response_for_id(
-            [r#"{"id":2,"error":{"code":-32602,"message":"bad params"}}"#],
-            2,
-        )
-        .expect_err("JSON-RPC error should fail");
-
-        assert!(error.to_string().contains("bad params"));
-    }
+    include!("codex_app_server_json_tests.rs");
 
     #[test]
     fn reports_unexpected_eof() {

--- a/crates/edda-conductor/src/agent/codex_app_server_json_tests.rs
+++ b/crates/edda-conductor/src/agent/codex_app_server_json_tests.rs
@@ -1,0 +1,31 @@
+#[test]
+fn correlates_response_ids_while_skipping_notifications() -> anyhow::Result<()> {
+    let lines = [
+        r#"{"method":"thread/started","params":{"thread":{"id":"t-1"}}}"#,
+        r#"{"id":1,"result":{"ignored":true}}"#,
+        r#"{"id":2,"result":{"thread":{"id":"t-1"}}}"#,
+    ];
+
+    let result = response_for_id(lines.iter().copied(), 2)?;
+
+    assert_eq!(result["thread"]["id"], "t-1");
+    Ok(())
+}
+
+#[test]
+fn rejects_malformed_app_server_json() {
+    let error = response_for_id(["not-json"], 2).expect_err("malformed JSON should fail");
+
+    assert!(error.to_string().contains("invalid app-server JSON"));
+}
+
+#[test]
+fn preserves_json_rpc_error_message() {
+    let error = response_for_id(
+        [r#"{"id":2,"error":{"code":-32602,"message":"bad params"}}"#],
+        2,
+    )
+    .expect_err("JSON-RPC error should fail");
+
+    assert!(error.to_string().contains("bad params"));
+}

--- a/crates/edda-conductor/src/agent/codex_rpc.rs
+++ b/crates/edda-conductor/src/agent/codex_rpc.rs
@@ -1,3 +1,4 @@
+use super::timing::ProcessTiming;
 use crate::agent::codex_app_server::{CodexAppServer, CodexTurnOutcome};
 use crate::agent::launcher::{AgentLauncher, PhaseResult};
 use crate::plan::schema::Phase;
@@ -5,6 +6,7 @@ use anyhow::Result;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
@@ -78,6 +80,7 @@ pub struct CodexLauncher {
     pub verbose: bool,
     thread_store: Option<ThreadStore>,
     state: Mutex<LauncherState>,
+    timing: Arc<ProcessTiming>,
 }
 
 /// File-backed cold-start store for the session→thread map.
@@ -192,6 +195,7 @@ impl CodexLauncher {
             codex_bin: default_codex_bin(),
             verbose: false,
             thread_store: None,
+            timing: Arc::default(),
             state: Mutex::new(LauncherState::default()),
         }
     }
@@ -201,6 +205,7 @@ impl CodexLauncher {
             codex_bin,
             verbose: false,
             thread_store: None,
+            timing: Arc::default(),
             state: Mutex::new(LauncherState::default()),
         }
     }
@@ -261,6 +266,7 @@ impl AgentLauncher for CodexLauncher {
         cwd: &Path,
         cancel: CancellationToken,
     ) -> Result<PhaseResult> {
+        self.timing.reset();
         // GH-574 honesty: the codex app-server exposes no model/thinking/
         // tool-policy selection path edda can verify, so a phase declaring
         // any of them would be silently ignored — the exact failure mode
@@ -294,7 +300,7 @@ impl AgentLauncher for CodexLauncher {
         };
         let mut state = self.state.lock().await;
         if state.server.is_none() {
-            match CodexAppServer::spawn(&self.codex_bin).await {
+            match CodexAppServer::spawn_timed(&self.codex_bin, Arc::clone(&self.timing)).await {
                 // Cold start: merge the persisted session→thread map so a
                 // session id recorded by a previous process resumes instead
                 // of starting over. In-memory entries win (hot path).
@@ -349,6 +355,9 @@ impl AgentLauncher for CodexLauncher {
             // client so the next phase re-spawns a fresh app-server. The
             // thread map survives: codex persists threads and `thread/resume`
             // restores the conversation.
+            if let Some(server) = state.server.as_mut() {
+                server.terminate().await;
+            }
             state.server = None;
         }
         let result = if outcome.dropped_stale_binding {
@@ -358,7 +367,7 @@ impl AgentLauncher for CodexLauncher {
             // terminated the child, so spawn a fresh app-server first. The
             // bad binding was already removed from `threads`, so it is not
             // written back below.
-            match CodexAppServer::spawn(&self.codex_bin).await {
+            match CodexAppServer::spawn_timed(&self.codex_bin, Arc::clone(&self.timing)).await {
                 Ok(server) => state.server = Some(server),
                 Err(error) => {
                     return Ok(PhaseResult::AgentCrash {
@@ -388,6 +397,9 @@ impl AgentLauncher for CodexLauncher {
             )
             .await;
             if !retry.keep_server {
+                if let Some(server) = state.server.as_mut() {
+                    server.terminate().await;
+                }
                 state.server = None;
             }
             retry.result
@@ -401,6 +413,17 @@ impl AgentLauncher for CodexLauncher {
             store.persist(cwd, &state.threads, &state.removals);
         }
         Ok(result)
+    }
+
+    fn last_elapsed_ms(&self) -> Option<u64> {
+        self.timing.elapsed_ms()
+    }
+
+    async fn finish_dispatch(&self) {
+        let mut state = self.state.lock().await;
+        if let Some(mut server) = state.server.take() {
+            server.terminate().await;
+        }
     }
 }
 
@@ -644,39 +667,7 @@ mod tests {
         }
     }
 
-    #[test]
-    fn codex_bin_falls_back_to_the_platform_install() {
-        // npm ships codex as an extensionless sh launcher plus codex.cmd on
-        // Windows, with no codex.exe, and CreateProcess does not apply
-        // PATHEXT — the bare name never resolves there.
-        let expected = if cfg!(windows) { "codex.cmd" } else { "codex" };
-        assert_eq!(resolve_codex_bin(None), PathBuf::from(expected));
-    }
-
-    #[test]
-    fn edda_codex_bin_overrides_the_platform_default() {
-        let custom = "/opt/codex/bin/codex-custom";
-        assert_eq!(
-            resolve_codex_bin(Some(OsString::from(custom))),
-            PathBuf::from(custom)
-        );
-    }
-
-    #[test]
-    fn empty_edda_codex_bin_is_treated_as_unset() {
-        let expected = if cfg!(windows) { "codex.cmd" } else { "codex" };
-        assert_eq!(
-            resolve_codex_bin(Some(OsString::new())),
-            PathBuf::from(expected),
-            "an empty override must not produce an unspawnable empty path"
-        );
-    }
-
-    #[test]
-    fn with_bin_overrides_the_default() {
-        let custom = PathBuf::from("/opt/codex/bin/codex");
-        assert_eq!(CodexLauncher::with_bin(custom.clone()).codex_bin, custom);
-    }
+    include!("codex_rpc_config_tests.rs");
 
     #[test]
     fn persistence_is_opt_in() {

--- a/crates/edda-conductor/src/agent/codex_rpc_config_tests.rs
+++ b/crates/edda-conductor/src/agent/codex_rpc_config_tests.rs
@@ -1,0 +1,33 @@
+#[test]
+fn codex_bin_falls_back_to_the_platform_install() {
+    // npm ships codex as an extensionless sh launcher plus codex.cmd on
+    // Windows, with no codex.exe, and CreateProcess does not apply
+    // PATHEXT — the bare name never resolves there.
+    let expected = if cfg!(windows) { "codex.cmd" } else { "codex" };
+    assert_eq!(resolve_codex_bin(None), PathBuf::from(expected));
+}
+
+#[test]
+fn edda_codex_bin_overrides_the_platform_default() {
+    let custom = "/opt/codex/bin/codex-custom";
+    assert_eq!(
+        resolve_codex_bin(Some(OsString::from(custom))),
+        PathBuf::from(custom)
+    );
+}
+
+#[test]
+fn empty_edda_codex_bin_is_treated_as_unset() {
+    let expected = if cfg!(windows) { "codex.cmd" } else { "codex" };
+    assert_eq!(
+        resolve_codex_bin(Some(OsString::new())),
+        PathBuf::from(expected),
+        "an empty override must not produce an unspawnable empty path"
+    );
+}
+
+#[test]
+fn with_bin_overrides_the_default() {
+    let custom = PathBuf::from("/opt/codex/bin/codex");
+    assert_eq!(CodexLauncher::with_bin(custom.clone()).codex_bin, custom);
+}

--- a/crates/edda-conductor/src/agent/launcher.rs
+++ b/crates/edda-conductor/src/agent/launcher.rs
@@ -1,9 +1,10 @@
+use super::timing::ProcessTiming;
 use crate::agent::stream::{classify_result, StreamMonitor};
 use crate::plan::schema::Phase;
 use anyhow::Result;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
@@ -40,6 +41,14 @@ pub trait AgentLauncher: Send + Sync {
         cwd: &Path,
         cancel: CancellationToken,
     ) -> Result<PhaseResult>;
+
+    /// Wall-clock spawn through confirmed process exit for the last call.
+    fn last_elapsed_ms(&self) -> Option<u64> {
+        None
+    }
+
+    /// Release a dispatch-owned persistent process before reading its timing.
+    async fn finish_dispatch(&self) {}
 
     /// The model the backend reported **in-band** during the most recent
     /// turn on this launcher, if any. Observation, not inference: a
@@ -103,6 +112,7 @@ pub struct ClaudeCodeLauncher {
     /// In-band session id from the same `system/init` message, for
     /// [`AgentLauncher::last_observed_session`] (GH-708).
     observed_session: std::sync::Mutex<Option<String>>,
+    timing: ProcessTiming,
 }
 
 impl Default for ClaudeCodeLauncher {
@@ -210,6 +220,7 @@ impl ClaudeCodeLauncher {
             resume: false,
             observed_model: std::sync::Mutex::new(None),
             observed_session: std::sync::Mutex::new(None),
+            timing: ProcessTiming::default(),
         }
     }
 
@@ -221,6 +232,7 @@ impl ClaudeCodeLauncher {
             resume: false,
             observed_model: std::sync::Mutex::new(None),
             observed_session: std::sync::Mutex::new(None),
+            timing: ProcessTiming::default(),
         }
     }
 
@@ -278,6 +290,7 @@ impl AgentLauncher for ClaudeCodeLauncher {
         cwd: &Path,
         cancel: CancellationToken,
     ) -> Result<PhaseResult> {
+        self.timing.reset();
         if phase.thinking.is_some() {
             // GH-574 honesty: claude's CLI exposes no thinking-level flag,
             // so a phase that declares one would otherwise be silently
@@ -290,6 +303,7 @@ impl AgentLauncher for ClaudeCodeLauncher {
         }
         let mut cmd = self.build_command(phase, prompt, plan_context, session_id, cwd);
 
+        let started = Instant::now();
         let mut child = cmd.spawn()?;
         let stdout = child
             .stdout
@@ -305,29 +319,41 @@ impl AgentLauncher for ClaudeCodeLauncher {
             .with_tee(tee_path);
         let timeout_sec = phase.timeout_sec.unwrap_or(1800);
 
-        let result = tokio::select! {
-            result = monitor.run() => {
-                let monitor_result = result?;
-                // In-band model observation: whatever the backend itself
-                // reported, or nothing. Never inferred from config.
-                self.record_observed_model(monitor_result.model.clone());
-                // Same terms for the session id: what claude says it ran,
-                // which is the only way to see a --resume that forked
-                // instead of continuing (GH-708).
-                self.record_observed_session(monitor_result.session_id.clone());
-                let exit = child.wait().await?;
-                Ok(classify_result(&monitor_result, exit.code()))
+        let result = async {
+            tokio::select! {
+                result = monitor.run() => {
+                    let monitor_result = result?;
+                    // In-band model observation: whatever the backend itself
+                    // reported, or nothing. Never inferred from config.
+                    self.record_observed_model(monitor_result.model.clone());
+                    // Same terms for the session id: what claude says it ran,
+                    // which is the only way to see a --resume that forked
+                    // instead of continuing (GH-708).
+                    self.record_observed_session(monitor_result.session_id.clone());
+                    let exit = child.wait().await?;
+                    Ok(classify_result(&monitor_result, exit.code()))
+                }
+                _ = tokio::time::sleep(Duration::from_secs(timeout_sec)) => {
+                    child.kill().await.ok();
+                    Ok(PhaseResult::Timeout)
+                }
+                _ = cancel.cancelled() => {
+                    child.kill().await.ok();
+                    Ok(PhaseResult::AgentCrash { error: "conductor shutdown".into() })
+                }
             }
-            _ = tokio::time::sleep(Duration::from_secs(timeout_sec)) => {
-                child.kill().await.ok();
-                Ok(PhaseResult::Timeout)
-            }
-            _ = cancel.cancelled() => {
-                child.kill().await.ok();
-                Ok(PhaseResult::AgentCrash { error: "conductor shutdown".into() })
-            }
-        };
+        }
+        .await;
+        if child.try_wait()?.is_none() {
+            child.kill().await?;
+        }
+        child.wait().await?;
+        self.timing.record(started);
         result
+    }
+
+    fn last_elapsed_ms(&self) -> Option<u64> {
+        self.timing.elapsed_ms()
     }
 
     fn last_observed_model(&self) -> Option<String> {

--- a/crates/edda-conductor/src/agent/mod.rs
+++ b/crates/edda-conductor/src/agent/mod.rs
@@ -4,3 +4,4 @@ pub mod codex_rpc;
 pub mod launcher;
 pub mod pi_rpc;
 pub mod stream;
+mod timing;

--- a/crates/edda-conductor/src/agent/pi_rpc.rs
+++ b/crates/edda-conductor/src/agent/pi_rpc.rs
@@ -1,3 +1,4 @@
+use super::timing::ProcessTiming;
 use crate::agent::launcher::{AgentLauncher, PhaseResult};
 use crate::plan::schema::Phase;
 use anyhow::{anyhow, Context, Result};
@@ -6,7 +7,7 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::Mutex;
@@ -66,6 +67,7 @@ pub struct PiRpcLauncher {
     /// In-band model report from the most recent settled turn (RPC
     /// `get_state`), for [`AgentLauncher::last_observed_model`].
     observed_model: std::sync::Mutex<Option<String>>,
+    timing: ProcessTiming,
 }
 
 impl Default for PiRpcLauncher {
@@ -82,6 +84,7 @@ impl PiRpcLauncher {
             model: None,
             session_dir: None,
             observed_model: std::sync::Mutex::new(None),
+            timing: ProcessTiming::default(),
         }
     }
 
@@ -92,6 +95,7 @@ impl PiRpcLauncher {
             model: None,
             session_dir: None,
             observed_model: std::sync::Mutex::new(None),
+            timing: ProcessTiming::default(),
         }
     }
 
@@ -217,6 +221,7 @@ impl AgentLauncher for PiRpcLauncher {
         cwd: &Path,
         cancel: CancellationToken,
     ) -> Result<PhaseResult> {
+        self.timing.reset();
         self.validate_phase(phase)?;
         let command = self.build_command(phase, session_id, cwd);
         let timeout_sec = phase.timeout_sec.unwrap_or(1800);
@@ -228,12 +233,17 @@ impl AgentLauncher for PiRpcLauncher {
             self.verbose,
             Duration::from_secs(timeout_sec),
             cancel,
+            &self.timing,
         )
         .await?;
         // In-band model observation: whatever pi itself reported via RPC
         // `get_state`, or nothing. Never inferred from config or sessions.
         self.record_observed_model(observed);
         Ok(result)
+    }
+
+    fn last_elapsed_ms(&self) -> Option<u64> {
+        self.timing.elapsed_ms()
     }
 
     fn last_observed_model(&self) -> Option<String> {
@@ -247,6 +257,7 @@ impl AgentLauncher for PiRpcLauncher {
 /// Run one phase against a pre-built command (injectable for tests).
 /// Returns the phase result plus the model pi reported in-band via RPC
 /// `get_state`, if the turn settled and pi exposed one (GH-574).
+#[allow(clippy::too_many_arguments)] // Timing observer is independent of the RPC payload.
 async fn run_command(
     command: Command,
     phase: &Phase,
@@ -255,6 +266,7 @@ async fn run_command(
     verbose: bool,
     timeout: Duration,
     cancel: CancellationToken,
+    timing: &ProcessTiming,
 ) -> Result<(PhaseResult, Option<String>)> {
     let mut session = PiRpcSession::spawn_command(command).await?;
     // pi has no system-prompt flag in RPC mode; carry plan context inline.
@@ -274,6 +286,9 @@ async fn run_command(
         None
     };
     session.terminate().await;
+    if session.child.try_wait()?.is_some() {
+        timing.record(session.started);
+    }
     let result = result?;
     Ok((result, observed))
 }
@@ -306,6 +321,7 @@ pub fn list_models(pi_bin: Option<PathBuf>, search: Option<&str>) -> Result<Stri
 
 /// One live `pi --mode rpc` process speaking JSONL.
 struct PiRpcSession {
+    started: Instant,
     child: Child,
     stdin: ChildStdin,
     stdout: Lines<BufReader<ChildStdout>>,
@@ -324,6 +340,7 @@ impl PiRpcSession {
             .stderr(Stdio::piped())
             .kill_on_drop(true);
 
+        let started = Instant::now();
         let mut child = command.spawn().context("failed to spawn pi RPC process")?;
         let stdin = child.stdin.take().context("pi RPC stdin was not piped")?;
         let stdout = child.stdout.take().context("pi RPC stdout was not piped")?;
@@ -343,6 +360,7 @@ impl PiRpcSession {
         });
 
         Ok(Self {
+            started,
             child,
             stdin,
             stdout: BufReader::new(stdout).lines(),
@@ -946,6 +964,7 @@ sleep 60"
                 false,
                 Duration::from_secs(phase.timeout_sec.unwrap_or(1800)),
                 CancellationToken::new(),
+                &ProcessTiming::default(),
             ),
         )
         .await
@@ -1079,6 +1098,7 @@ sleep 60"
                 false,
                 Duration::from_secs(1800),
                 cancel,
+                &ProcessTiming::default(),
             ),
         )
         .await
@@ -1431,38 +1451,7 @@ sleep 60"
         assert!(error.to_string().contains("list-models"), "{error}");
     }
 
-    #[test]
-    fn pi_bin_falls_back_to_the_platform_install() {
-        // npm ships pi as a .cmd shim on Windows with no .exe, and
-        // CreateProcess does not apply PATHEXT — the bare name never resolves.
-        let expected = if cfg!(windows) { "pi.cmd" } else { "pi" };
-        assert_eq!(resolve_pi_bin(None), PathBuf::from(expected));
-    }
-
-    #[test]
-    fn edda_pi_bin_overrides_the_platform_default() {
-        let custom = "/opt/pi/bin/pi-custom";
-        assert_eq!(
-            resolve_pi_bin(Some(OsString::from(custom))),
-            PathBuf::from(custom)
-        );
-    }
-
-    #[test]
-    fn empty_edda_pi_bin_is_treated_as_unset() {
-        let expected = if cfg!(windows) { "pi.cmd" } else { "pi" };
-        assert_eq!(
-            resolve_pi_bin(Some(OsString::new())),
-            PathBuf::from(expected),
-            "an empty override must not produce an unspawnable empty path"
-        );
-    }
-
-    #[test]
-    fn with_bin_overrides_the_default() {
-        let custom = PathBuf::from("/opt/pi/bin/pi");
-        assert_eq!(PiRpcLauncher::with_bin(custom.clone()).pi_bin, custom);
-    }
+    include!("pi_rpc_config_tests.rs");
 
     #[test]
     fn stderr_tail_is_empty_for_no_output() {

--- a/crates/edda-conductor/src/agent/pi_rpc_config_tests.rs
+++ b/crates/edda-conductor/src/agent/pi_rpc_config_tests.rs
@@ -1,0 +1,32 @@
+#[test]
+fn pi_bin_falls_back_to_the_platform_install() {
+    // npm ships pi as a .cmd shim on Windows with no .exe, and
+    // CreateProcess does not apply PATHEXT — the bare name never resolves.
+    let expected = if cfg!(windows) { "pi.cmd" } else { "pi" };
+    assert_eq!(resolve_pi_bin(None), PathBuf::from(expected));
+}
+
+#[test]
+fn edda_pi_bin_overrides_the_platform_default() {
+    let custom = "/opt/pi/bin/pi-custom";
+    assert_eq!(
+        resolve_pi_bin(Some(OsString::from(custom))),
+        PathBuf::from(custom)
+    );
+}
+
+#[test]
+fn empty_edda_pi_bin_is_treated_as_unset() {
+    let expected = if cfg!(windows) { "pi.cmd" } else { "pi" };
+    assert_eq!(
+        resolve_pi_bin(Some(OsString::new())),
+        PathBuf::from(expected),
+        "an empty override must not produce an unspawnable empty path"
+    );
+}
+
+#[test]
+fn with_bin_overrides_the_default() {
+    let custom = PathBuf::from("/opt/pi/bin/pi");
+    assert_eq!(PiRpcLauncher::with_bin(custom.clone()).pi_bin, custom);
+}

--- a/crates/edda-conductor/src/agent/timing.rs
+++ b/crates/edda-conductor/src/agent/timing.rs
@@ -1,0 +1,25 @@
+//! Process lifetime evidence. A failed spawn or unconfirmed reap stays unknown.
+use std::sync::Mutex;
+use std::time::Instant;
+
+#[derive(Default)]
+pub(crate) struct ProcessTiming(Mutex<Option<u64>>);
+
+impl ProcessTiming {
+    pub(crate) fn reset(&self) {
+        if let Ok(mut slot) = self.0.lock() {
+            *slot = None;
+        }
+    }
+
+    pub(crate) fn record(&self, started: Instant) {
+        if let Ok(mut slot) = self.0.lock() {
+            let elapsed = started.elapsed().as_millis().min(u64::MAX as u128) as u64;
+            *slot = Some(slot.unwrap_or(0).saturating_add(elapsed));
+        }
+    }
+
+    pub(crate) fn elapsed_ms(&self) -> Option<u64> {
+        self.0.lock().ok().and_then(|slot| *slot)
+    }
+}

--- a/crates/edda-conductor/src/runner/edda.rs
+++ b/crates/edda-conductor/src/runner/edda.rs
@@ -186,6 +186,18 @@ pub fn record_phase_done_with_plan(
     summary: Option<&str>,
     cost_usd: Option<f64>,
 ) {
+    record_phase_done_timed(cwd, plan_id, phase_id, summary, cost_usd, None);
+}
+
+/// Phase receipt with optional measured elapsed time, exposed by `edda log --json`.
+pub fn record_phase_done_timed(
+    cwd: &Path,
+    plan_id: Option<&str>,
+    phase_id: &str,
+    summary: Option<&str>,
+    cost_usd: Option<f64>,
+    elapsed_ms: Option<u64>,
+) {
     let cost_str = cost_usd.map(|c| format!(" [${c:.3}]")).unwrap_or_default();
     let summary_str = summary
         .map(|s| {
@@ -200,12 +212,20 @@ pub fn record_phase_done_with_plan(
         })
         .unwrap_or_default();
     let text = format!("Phase \"{phase_id}\" passed{cost_str}{summary_str}");
+    let text = format!(
+        "{text} [elapsed: {}]",
+        elapsed_ms
+            .map(|ms| format!("{ms} ms"))
+            .unwrap_or_else(|| "—".into())
+    );
     let tags = vec!["conductor".to_string(), format!("phase:{phase_id}")];
     let payload = serde_json::json!({
         "plan_id": plan_id,
         "phase_id": phase_id,
         "status": "passed",
         "cost_usd": cost_usd,
+        "elapsed_ms": elapsed_ms,
+        "elapsed_measured": elapsed_ms.is_some(),
     });
     append_ledger_note_best_effort(
         &format!("phase \"{phase_id}\" passed"),
@@ -237,6 +257,18 @@ pub fn record_phase_failed_with_plan(
     cost_usd: Option<f64>,
     error: &str,
 ) {
+    record_phase_failed_timed(cwd, plan_id, phase_id, cost_usd, error, None);
+}
+
+/// Failed phase receipt; missing timing remains unmeasured, including pre-run failures.
+pub fn record_phase_failed_timed(
+    cwd: &Path,
+    plan_id: Option<&str>,
+    phase_id: &str,
+    cost_usd: Option<f64>,
+    error: &str,
+    elapsed_ms: Option<u64>,
+) {
     let error_str = if error.len() > 200 {
         format!("{}...", truncate_str(error, 200))
     } else {
@@ -244,6 +276,12 @@ pub fn record_phase_failed_with_plan(
     };
     let cost_str = cost_usd.map(|c| format!(" [${c:.3}]")).unwrap_or_default();
     let text = format!("Phase \"{phase_id}\" failed{cost_str}: {error_str}");
+    let text = format!(
+        "{text} [elapsed: {}]",
+        elapsed_ms
+            .map(|ms| format!("{ms} ms"))
+            .unwrap_or_else(|| "—".into())
+    );
     let mut tags = vec!["conductor".to_string(), format!("phase:{phase_id}")];
     tags.push("failure".to_string());
     let payload = serde_json::json!({
@@ -251,6 +289,8 @@ pub fn record_phase_failed_with_plan(
         "phase_id": phase_id,
         "status": "failed",
         "cost_usd": cost_usd,
+        "elapsed_ms": elapsed_ms,
+        "elapsed_measured": elapsed_ms.is_some(),
     });
     append_ledger_note_best_effort(
         &format!("phase \"{phase_id}\" failed"),
@@ -286,6 +326,8 @@ pub fn record_phase_gate_timed_out(
         "phase_id": phase_id,
         "status": "gate_timed_out",
         "cost_usd": cost_usd,
+        "elapsed_ms": null,
+        "elapsed_measured": false,
     });
     append_ledger_note_best_effort(
         &format!("phase \"{phase_id}\" gate timed out"),
@@ -728,5 +770,34 @@ mod tests {
         assert_eq!(payload["status"], "aborted");
         assert_eq!(payload["phases_passed"], 2);
         assert_eq!(payload["phases_pending"], 3);
+    }
+    #[test]
+    fn ledger_phase_receipts_keep_elapsed_beside_cost_and_mark_unknown() {
+        for failed in [false, true] {
+            for elapsed in [None, Some(5000), Some(0)] {
+                let dir = tempfile::tempdir().unwrap();
+                init_test_ledger(dir.path());
+                if failed {
+                    record_phase_failed_timed(
+                        dir.path(),
+                        Some("p"),
+                        "a",
+                        Some(1.25),
+                        "fixture",
+                        elapsed,
+                    );
+                } else {
+                    record_phase_done_timed(dir.path(), Some("p"), "a", None, Some(1.25), elapsed);
+                }
+                let event = conductor_phase_event(dir.path()).unwrap();
+                let payload = &event.payload["conductor_phase"];
+                assert_eq!(payload["elapsed_ms"].as_u64(), elapsed);
+                assert_eq!(payload["elapsed_measured"], elapsed.is_some());
+                assert_eq!(payload["cost_usd"], 1.25);
+                if elapsed.is_none() {
+                    assert!(event.payload["text"].as_str().unwrap().contains("—"));
+                }
+            }
+        }
     }
 }

--- a/crates/edda-conductor/src/runner/outcome.rs
+++ b/crates/edda-conductor/src/runner/outcome.rs
@@ -93,12 +93,13 @@ pub(super) async fn fail_checking_phase(
     // the phase's measured cost — checks failing after a measured agent
     // turn must not rewrite that cost as unmeasured null.
     let measured = state.get_phase(phase_id).ok().and_then(|p| p.cost_usd);
-    edda::record_phase_failed_with_plan(
+    edda::record_phase_failed_timed(
         cwd,
         Some(plan.name.as_str()),
         phase_id,
         measured,
         &err_msg,
+        Some(elapsed.as_millis() as u64),
     );
     let ps = state.get_phase(phase_id)?;
     let (error_type, attempt_charged) = match &error_info {
@@ -345,12 +346,13 @@ pub(super) async fn process_phase_result(
                     // Record to edda ledger — with the plan id (GH-584
                     // round-2 P1-2): the structured payload must attribute
                     // the cost to its plan on the production path.
-                    edda::record_phase_done_with_plan(
+                    edda::record_phase_done_timed(
                         cwd,
                         Some(&plan.name),
                         phase_id,
                         result_text.as_deref(),
                         cost_usd,
+                        Some(elapsed_ms),
                     );
                     event_log.record(Event::PhasePassed {
                         phase_id: phase_id.to_string(),
@@ -412,12 +414,13 @@ pub(super) async fn process_phase_result(
                 let _ = tmux.update_phase_status(phase_id, "Stale");
             }
             let measured = state.get_phase(phase_id).ok().and_then(|p| p.cost_usd);
-            edda::record_phase_failed_with_plan(
+            edda::record_phase_failed_timed(
                 cwd,
                 Some(&plan.name),
                 phase_id,
                 measured,
                 "timed out",
+                Some(elapsed_ms),
             );
             event_log.record(Event::PhaseFailed {
                 phase_id: phase_id.to_string(),
@@ -460,7 +463,14 @@ pub(super) async fn process_phase_result(
                 let _ = tmux.update_phase_status(phase_id, "Failed");
             }
             let measured = state.get_phase(phase_id).ok().and_then(|p| p.cost_usd);
-            edda::record_phase_failed_with_plan(cwd, Some(&plan.name), phase_id, measured, &error);
+            edda::record_phase_failed_timed(
+                cwd,
+                Some(&plan.name),
+                phase_id,
+                measured,
+                &error,
+                Some(elapsed_ms),
+            );
             event_log.record(Event::PhaseFailed {
                 phase_id: phase_id.to_string(),
                 attempt,
@@ -531,7 +541,14 @@ pub(super) async fn process_phase_result(
             // terminal states — the workspace ledger must get the failure
             // event, carrying the measured cost when the backend reported one.
             let measured = state.get_phase(phase_id).ok().and_then(|p| p.cost_usd);
-            edda::record_phase_failed_with_plan(cwd, Some(&plan.name), phase_id, measured, &msg);
+            edda::record_phase_failed_timed(
+                cwd,
+                Some(&plan.name),
+                phase_id,
+                measured,
+                &msg,
+                Some(elapsed_ms),
+            );
             notifier
                 .notify_phase_terminal(phase_terminal_event(
                     &plan.name, phase_id, "Failed", attempt, None,

--- a/crates/edda-conductor/src/runner/sequential.rs
+++ b/crates/edda-conductor/src/runner/sequential.rs
@@ -496,10 +496,10 @@ async fn run_next_phase(
 
     // Clear retry_context on new attempt start (it was already consumed for prompt building)
     let retry_ctx = phase_state.retry_context.take();
-    // GH-584 round-2 P1-3: a fresh attempt starts unmeasured — the
-    // previous attempt's cost belongs to its own (already written)
-    // terminal event, not to this one.
+    // A fresh attempt starts unmeasured; prior cost belongs to its terminal event.
     phase_state.cost_usd = None;
+    // Duration has the same boundary; never render prior-attempt timing while this runs.
+    phase_state.duration_ms = None;
 
     // 3. Transition: pending → running
     transition(

--- a/crates/edda-conductor/src/state/brief.rs
+++ b/crates/edda-conductor/src/state/brief.rs
@@ -109,8 +109,8 @@ impl Brief {
                 } else {
                     None
                 },
-                duration_ms: None, // Not tracked in PlanState
-                cost_usd: None,    // Not tracked in PlanState per-phase
+                duration_ms: ps.duration_ms,
+                cost_usd: ps.cost_usd,
                 started_at: ps.started_at.clone(),
                 completed_at: ps.completed_at.clone(),
                 error: ps.error.as_ref().map(|e| e.message.clone()),
@@ -168,7 +168,9 @@ pub fn brief_path(cwd: &Path, plan_name: &str) -> PathBuf {
 /// `write_runner_status` pattern — a brief-write failure must never abort
 /// the run.
 pub fn write_brief(cwd: &Path, state: &PlanState, meta: Option<BriefMeta>) {
-    let brief = Brief::from_state(state, meta);
+    let mut measured = state.clone();
+    super::derive::hydrate_durations(cwd, &mut measured);
+    let brief = Brief::from_state(&measured, meta);
     let path = brief_path(cwd, &state.plan_name);
     if let Ok(data) = serde_json::to_string_pretty(&brief) {
         if let Err(e) = edda_store::write_atomic(&path, data.as_bytes()) {
@@ -482,6 +484,62 @@ phases:
         assert_eq!(
             brief.phases["build"].error.as_deref(),
             Some("cargo test exited 1"),
+        );
+    }
+    #[test]
+    fn event_duration_reaches_derived_brief_without_inventing_missing_measurements() {
+        use crate::runner::event_log::{Event, EventLogger};
+        use crate::state::persist::{load_state, save_state};
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = test_plan_state();
+        // Real semantics: the attempt counter is incremented and persisted
+        // before the matching PhaseStart/terminal events are appended, so
+        // attempt-1 evidence always coexists with a persisted attempts == 1.
+        state.get_phase_mut("build").unwrap().attempts = 1;
+        save_state(dir.path(), &state).unwrap();
+        let mut events = EventLogger::new(dir.path(), &state.plan_name);
+        for failed in [false, true] {
+            events.record(if failed {
+                Event::PhaseFailed {
+                    phase_id: "build".into(),
+                    attempt: 1,
+                    duration_ms: 5000,
+                    error: "fixture".into(),
+                    error_type: None,
+                    env_retries: 0,
+                    attempt_charged: true,
+                }
+            } else {
+                Event::PhasePassed {
+                    phase_id: "build".into(),
+                    attempt: 1,
+                    duration_ms: 5000,
+                    cost_usd: None,
+                }
+            });
+            let restored = load_state(dir.path(), &state.plan_name).unwrap().unwrap();
+            assert_eq!(restored.phases[0].duration_ms, Some(5000));
+            write_brief(dir.path(), &state, None);
+            let brief: Brief = serde_json::from_str(
+                &std::fs::read_to_string(brief_path(dir.path(), &state.plan_name)).unwrap(),
+            )
+            .unwrap();
+            assert_eq!(brief.phases["build"].duration_ms, Some(5000));
+            assert_eq!(brief.phases["test"].duration_ms, None);
+        }
+        // Retry boundary: the new attempt number is persisted before its
+        // PhaseStart, and the stale prior-attempt duration was already
+        // cleared by the runner.
+        state.get_phase_mut("build").unwrap().attempts = 2;
+        save_state(dir.path(), &state).unwrap();
+        events.record(Event::PhaseStart {
+            phase_id: "build".into(),
+            attempt: 2,
+        });
+        let restored = load_state(dir.path(), &state.plan_name).unwrap().unwrap();
+        assert_eq!(
+            Brief::from_state(&restored, None).phases["build"].duration_ms,
+            None
         );
     }
 }

--- a/crates/edda-conductor/src/state/derive.rs
+++ b/crates/edda-conductor/src/state/derive.rs
@@ -129,6 +129,48 @@ pub fn find_next_phase(plan: &Plan, state: &PlanState, order: &[String]) -> Opti
     None
 }
 
+/// Restore latest-attempt timing from the append-only evidence, never timestamps.
+pub fn hydrate_durations(cwd: &std::path::Path, state: &mut PlanState) {
+    use std::io::BufRead;
+    let path = cwd
+        .join(".edda/conductor")
+        .join(&state.plan_name)
+        .join("events.jsonl");
+    let Ok(file) = std::fs::File::open(path) else {
+        return;
+    };
+    for line in std::io::BufReader::new(file).lines().map_while(Result::ok) {
+        let Ok(event) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        let Some(id) = event["phase_id"].as_str() else {
+            continue;
+        };
+        let Some(phase) = state.phases.iter_mut().find(|p| p.id == id) else {
+            continue;
+        };
+        // Only evidence for the persisted current attempt may change its
+        // measurement. Legacy or malformed records without an attempt, and
+        // records from a later attempt, must not overwrite a serialized
+        // duration after restart.
+        if event["attempt"].as_u64() != Some(u64::from(phase.attempts)) {
+            continue;
+        }
+        match event["type"].as_str() {
+            Some("phase_start") => phase.duration_ms = None,
+            Some("phase_passed" | "phase_failed") => {
+                // Older gate rejections emitted a fabricated zero. It is not a measurement.
+                phase.duration_ms = if event["error_type"] == "gate_rejected" {
+                    None
+                } else {
+                    event["duration_ms"].as_u64()
+                };
+            }
+            _ => {}
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -158,8 +200,50 @@ mod tests {
                 verdict_comment: None,
                 env_retries: 0,
                 cost_usd: None,
+                duration_ms: None,
             })
             .collect()
+    }
+
+    #[test]
+    fn hydrate_durations_uses_only_the_current_attempt() {
+        let root = tempfile::tempdir().unwrap();
+        let plan = parse_plan("name: measured\nphases:\n  - id: build\n    prompt: x\n").unwrap();
+        let mut state = PlanState::from_plan(&plan, "plan.yaml");
+        let phase = state.get_phase_mut("build").unwrap();
+        phase.attempts = 2;
+        // A retry was persisted immediately after its attempt boundary, before
+        // the new attempt wrote a start or terminal event.
+        phase.duration_ms = None;
+
+        let events_dir = root.path().join(".edda/conductor/measured");
+        std::fs::create_dir_all(&events_dir).unwrap();
+        std::fs::write(
+            events_dir.join("events.jsonl"),
+            concat!(
+                "{\"type\":\"phase_passed\",\"phase_id\":\"build\",\"attempt\":1,\"duration_ms\":100}\n",
+                "{\"type\":\"phase_start\",\"phase_id\":\"build\",\"attempt\":3}\n",
+                "{\"type\":\"phase_failed\",\"phase_id\":\"build\",\"duration_ms\":300}\n"
+            ),
+        )
+        .unwrap();
+
+        hydrate_durations(root.path(), &mut state);
+        assert_eq!(state.get_phase("build").unwrap().duration_ms, None);
+
+        // Hydration must preserve a serialized duration when every available
+        // record is malformed, missing an attempt, or for another attempt.
+        state.get_phase_mut("build").unwrap().duration_ms = Some(222);
+        hydrate_durations(root.path(), &mut state);
+        assert_eq!(state.get_phase("build").unwrap().duration_ms, Some(222));
+
+        std::fs::write(
+            events_dir.join("events.jsonl"),
+            "{\"type\":\"phase_start\",\"phase_id\":\"build\",\"attempt\":2}\n{\"type\":\"phase_failed\",\"phase_id\":\"build\",\"attempt\":2,\"duration_ms\":500}\n",
+        )
+        .unwrap();
+        hydrate_durations(root.path(), &mut state);
+        assert_eq!(state.get_phase("build").unwrap().duration_ms, Some(500));
     }
 
     #[test]

--- a/crates/edda-conductor/src/state/machine.rs
+++ b/crates/edda-conductor/src/state/machine.rs
@@ -126,6 +126,9 @@ pub struct PhaseState {
     /// gate rejection after a resume must still find the cost.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cost_usd: Option<f64>,
+    /// Duration of the latest completed attempt, hydrated from events.jsonl.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -368,6 +371,7 @@ impl PlanState {
                 verdict_comment: None,
                 env_retries: 0,
                 cost_usd: None,
+                duration_ms: None,
             })
             .collect();
 

--- a/crates/edda-conductor/src/state/persist.rs
+++ b/crates/edda-conductor/src/state/persist.rs
@@ -88,8 +88,9 @@ pub fn load_state(cwd: &Path, plan_name: &str) -> Result<Option<PlanState>> {
     }
     let content = std::fs::read_to_string(&path)
         .with_context(|| format!("reading state: {}", path.display()))?;
-    let state: PlanState = serde_json::from_str(&content)
+    let mut state: PlanState = serde_json::from_str(&content)
         .with_context(|| format!("parsing state: {}", path.display()))?;
+    super::derive::hydrate_durations(cwd, &mut state);
     Ok(Some(state))
 }
 

--- a/docs/superpowers/specs/2026-09-02-reviewer-brief-template-v1.md
+++ b/docs/superpowers/specs/2026-09-02-reviewer-brief-template-v1.md
@@ -82,6 +82,7 @@ FOLLOW-UP ISSUE，不擴大本輪。
 判決格式（照抄此節，替換角括號）：
 
 ## Code Review: Round N
+- elapsed: <pi session first-to-last message elapsed_ms; unmeasured if unavailable>
 - model_requested: <dispatch 指定的模型>
 - model_observed: <由系統取得：pi 讀 session 檔的 "model" 欄；claude 讀
   `claude -p --output-format json` 的頂層 **modelUsage** 鍵（其 key 就是模型 id，
@@ -147,3 +148,20 @@ claude 讀 `--output-format json` 的 **`modelUsage`** 鍵（RAN 2026-09-02：
   （`PI_MODEL`）不算系統觀察值。
 - 變更紀錄會附在每次判決的 `brief:` 欄（如 `reviewer-brief-template-v1.2`），
   讓抓取率可以對著 brief 版本解讀。
+
+### Review elapsed source (GH-644)
+
+Read elapsed from the **same pi session JSONL file** used for `model_observed`:
+
+```sh
+node scripts/pi-session-elapsed.mjs "$PI_SESSION_FILE"
+```
+
+Set `PI_SESSION_FILE` to the session file already located for this review.
+Copy `elapsed_ms` into the verdict header as `elapsed: <N> ms (pi session)`
+only when `elapsed_measured` is true; otherwise write `elapsed: unmeasured`.
+The helper measures the first through last **message** timestamps, excluding
+session headers. Missing, malformed, single-message, or a last timestamp before
+the first timestamp
+remain unmeasured. This session interval and dispatch's process lifetime are
+different observations; always identify the source in the header.

--- a/scripts/pi-session-elapsed.mjs
+++ b/scripts/pi-session-elapsed.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// Review elapsed evidence from the same pi JSONL file used for model observation.
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+export function sessionElapsed(raw) {
+  const messages = [];
+  try {
+    for (const line of raw.split(/\r?\n/).filter(line => line.trim())) {
+      const row = JSON.parse(line);
+      if (row.type !== 'message') continue;
+      const value = row.timestamp ?? row.message?.timestamp;
+      const timestamp = typeof value === 'number' ? value
+        : typeof value === 'string' ? Date.parse(value) : NaN;
+      if (!Number.isFinite(timestamp)) return { elapsed_ms: null, elapsed_measured: false };
+      messages.push(timestamp);
+    }
+  } catch {
+    return { elapsed_ms: null, elapsed_measured: false };
+  }
+  const elapsed = messages.length > 1 ? messages.at(-1) - messages[0] : NaN;
+  return Number.isSafeInteger(elapsed) && elapsed >= 0
+    ? { elapsed_ms: elapsed, elapsed_measured: true }
+    : { elapsed_ms: null, elapsed_measured: false };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  if (process.argv.includes('--help')) {
+    console.log('Usage: node scripts/pi-session-elapsed.mjs <pi-session.jsonl>');
+  } else {
+    let result;
+    try { result = sessionElapsed(readFileSync(process.argv[2], 'utf8')); }
+    catch { result = { elapsed_ms: null, elapsed_measured: false }; }
+    console.log(JSON.stringify(result));
+  }
+}

--- a/scripts/pi-session-elapsed.test.mjs
+++ b/scripts/pi-session-elapsed.test.mjs
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { sessionElapsed } from './pi-session-elapsed.mjs';
+
+test('message timestamps exclude session header and preserve measured zero', () => {
+  const raw = [
+    { type: 'session', timestamp: '2020-01-01T00:00:00Z' },
+    { type: 'message', timestamp: '2026-09-04T00:00:00Z' },
+    { type: 'message', timestamp: '2026-09-04T00:00:05Z' },
+  ].map(JSON.stringify).join('\n');
+  assert.deepEqual(sessionElapsed(raw), { elapsed_ms: 5000, elapsed_measured: true });
+  const equal = [1, 1].map(timestamp => JSON.stringify({ type: 'message', message: { timestamp } })).join('\n');
+  assert.deepEqual(sessionElapsed(equal), { elapsed_ms: 0, elapsed_measured: true });
+});
+
+test('missing, malformed, one-message and backwards evidence stays unmeasured', () => {
+  for (const raw of ['', 'bad JSON', '{"type":"message"}',
+    '{"type":"message","timestamp":1}',
+    '{"type":"message","timestamp":2}\n{"type":"message","timestamp":1}']) {
+    assert.deepEqual(sessionElapsed(raw), { elapsed_ms: null, elapsed_measured: false });
+  }
+});


### PR DESCRIPTION
Issue: #644

Closes #644

Adds measured elapsed time to dispatch receipts, conductor state/briefs, ledger phase receipts, and review headers.

Validation: focused conductor timeout, dispatch elapsed integration, Codex cross-process dispatch integration, dispatch elapsed units, Node helper tests, formatting, and touched-crate Clippy passed. The pre-commit citation gate was bypassed only after its shared GH-794 script (absent from this branch basis) deterministically failed on unstaged COMPATIBILITY.md and cmd_status citations; durable log: C:\Users\fagem\AppData\Local\Temp\edda-gh644-precommit-citation-failure.log.