### PR TITLE
docs(cli): dispatch networked Codex via edda, not the plugin sandbox

### DIFF
--- a/crates/edda-cli/src/skills/coord-orchestrate.md
+++ b/crates/edda-cli/src/skills/coord-orchestrate.md
@@ -36,6 +36,16 @@ The whole formation — you included — produces delivery candidates and
 proves what was done and how it was verified; sign-off belongs to whoever
 holds merge authority outside the formation, unless explicitly delegated.
 
+## How to launch networked roles
+
+When a dispatched role must reach the network — a reviewer posting a verdict
+to a PR with `gh`, an implementer pushing a branch — launch it with
+`edda dispatch --agent codex` (GH-565): the codex backend sets no sandbox or
+approval flags, so the user's global Codex configuration is inherited
+unchanged. Do not use the Claude Code codex plugin for that role; it defaults
+to a `read-only` sandbox that overrides `~/.codex/config.toml`, and a
+read-only sandbox has no network access, so every outbound call fails.
+
 ## Review scope contract
 
 Before every review, freeze `IN SCOPE`: changed behavior/paths, directly

--- a/crates/edda-conductor/src/agent/codex_app_server.rs
+++ b/crates/edda-conductor/src/agent/codex_app_server.rs
@@ -22,6 +22,13 @@ pub struct CodexTurnOutcome {
 impl CodexAppServer {
     pub async fn spawn(bin: &Path) -> Result<Self> {
         let mut command = Command::new(bin);
+        // No sandbox or approval flags are set here on purpose (GH-565): the
+        // app-server inherits the user's global Codex configuration
+        // (~/.codex/config.toml) unchanged, which is what lets networked
+        // roles — a reviewer posting a PR comment with `gh`, an implementer
+        // pushing a branch — work. Do not add a read-only default: the
+        // Claude Code codex plugin's hardcoded `sandbox: "read-only"` is
+        // exactly the failure this deliberate inheritance avoids.
         command.arg("app-server");
         Self::spawn_with_command(command).await
     }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -698,6 +698,14 @@ edda dispatch --agent <AGENT> --prompt-file <FILE> [OPTIONS]
 | `--machine LABEL` | Machine label for the cross-machine claim guard (also via `EDDA_MACHINE`; requires `--issue`) |
 | `--json` | Print exactly one JSON object to stdout instead of text lines |
 
+A `codex` agent that must reach the network — posting a PR comment with
+`gh`, pushing a branch — should be launched through
+`edda dispatch --agent codex` (GH-565): the backend sets no sandbox or
+approval flags, so the user's global Codex configuration is inherited
+unchanged. The Claude Code codex plugin is not a substitute for that role;
+it defaults to a `read-only` sandbox that overrides `~/.codex/config.toml`,
+and a read-only sandbox has no network access.
+
 With `--json` the object has the shape
 `{"outcome":"done\|crash\|timeout\|max_turns\|budget_exceeded\|claim_refused", "result_text":string\|null, "cost_usd":number\|null, "session_id":string, "error":string\|null, "model_requested":string, "model_observed":string, "session_observed":string}`.
 When refused by the cross-machine claim guard (`outcome` is `"claim_refused"`), a reduced shape is emitted:

--- a/scripts/file-length-ceilings.txt
+++ b/scripts/file-length-ceilings.txt
@@ -20,7 +20,7 @@ crates/edda-cli/src/cmd_gc.rs 1117
 crates/edda-cli/src/cmd_plan.rs 1022
 crates/edda-cli/src/cmd_prs/merge_gate.rs 1295
 crates/edda-cli/src/main.rs 1460
-crates/edda-conductor/src/agent/codex_app_server.rs 1061
+crates/edda-conductor/src/agent/codex_app_server.rs 1068
 crates/edda-conductor/src/agent/codex_rpc.rs 1378
 crates/edda-conductor/src/agent/pi_rpc.rs 1480
 crates/edda-conductor/src/runner/gate.rs 1020


### PR DESCRIPTION
## Summary
Fixes Issue #565 by documenting that a Codex agent which must reach the network (post a PR comment, push a branch) is launched with `edda dispatch --agent codex`, not the Claude Code codex plugin. The plugin hardcodes `sandbox: "read-only"` and overrides `~/.codex/config.toml`. Edda's adapter deliberately sets no sandbox/approval flags so the user's config is inherited.

Issue: #565
Closes #565

## Changes
- `coord-orchestrate.md`: how to launch networked roles.
- `docs/reference/cli.md`: same fact next to `edda dispatch`.
- `codex_app_server.rs`: comment on `spawn` — no sandbox flags is intentional (GH-565).
- `scripts/file-length-ceilings.txt`: ratchet for the 7-line comment.

## Verification & doneWhen
- [x] Dispatch guidance names `edda dispatch --agent codex` and the plugin's read-only override
- [x] Adapter comment: inheritance is deliberate
- [x] No behavior change; pre-commit fmt/clippy on `edda` and `edda-conductor` green
- [x] `sh scripts/lint-markdown-content.sh` passes

Frozen SHA: `0264b56c7859ff83cfa54f62160a17e4ff398489`
