### PR TITLE
fix(postmortem): command_failure keying, segment command word matching, and separate show counter (GH-813)

### DIFF
--- a/crates/edda-bridge-claude/src/dispatch/tools.rs
+++ b/crates/edda-bridge-claude/src/dispatch/tools.rs
@@ -312,9 +312,11 @@ pub(super) fn evaluate_learned_rules(
 
     let result = edda_postmortem::hooks::evaluate_rules(&rules_store, &hook_ctx);
 
-    // Record hits so matched rules get their TTL reset
+    // Record shows for matched rules. PreToolUse matches on every Bash call
+    // must NOT reset the rule's TTL (GH-813) — shows are counted instead of
+    // hits, so noise rules still decay on schedule.
     if !result.matched_rule_ids.is_empty() {
-        edda_postmortem::hooks::record_matched_hits(&mut rules_store, &result.matched_rule_ids);
+        edda_postmortem::hooks::record_matched_shows(&mut rules_store, &result.matched_rule_ids);
         let _ = rules_store.save_project(project_id);
     }
 

--- a/crates/edda-cli/src/cmd_rules.rs
+++ b/crates/edda-cli/src/cmd_rules.rs
@@ -60,10 +60,10 @@ pub fn execute(cmd: RulesCmd, repo_root: &Path) -> anyhow::Result<()> {
                 }
             } else {
                 println!(
-                    "{:<12} {:<10} {:<12} {:<5} TRIGGER → ACTION",
-                    "STATUS", "CATEGORY", "HITS", "TTL"
+                    "{:<24} {:<12} {:<10} {:<5} {:<5} {:<5} TRIGGER → ACTION",
+                    "ID", "STATUS", "CATEGORY", "HITS", "SHOWS", "TTL"
                 );
-                println!("{}", "-".repeat(70));
+                println!("{}", "-".repeat(88));
                 for rule in &rules {
                     let revoked = rule
                         .revoked_reason
@@ -71,10 +71,12 @@ pub fn execute(cmd: RulesCmd, repo_root: &Path) -> anyhow::Result<()> {
                         .map(|r| format!("  [revoked: {r}]"))
                         .unwrap_or_default();
                     println!(
-                        "{:<12} {:<10} {:<12} {:<5} {} → {}{}",
+                        "{:<24} {:<12} {:<10} {:<5} {:<5} {:<5} {} → {}{}",
+                        rule.id,
                         rule.status,
                         rule.category,
                         rule.hits,
+                        rule.shows,
                         rule.ttl_days,
                         rule.trigger,
                         rule.action,
@@ -144,4 +146,150 @@ pub fn execute(cmd: RulesCmd, repo_root: &Path) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::isolated_store;
+    use edda_postmortem::{RuleCategory, RuleStatus, RulesStore};
+
+    /// Seed a project rules store with one live and one dead rule, pointed
+    /// at the isolated store root. Returns the live rule's ID.
+    fn seed_store(repo_root: &Path) -> String {
+        let project_id = edda_store::project_id(repo_root);
+        let mut store = RulesStore::default();
+        let live_id = store.propose_rule(
+            "command_failure:npm".to_string(),
+            "Check npm install output".to_string(),
+            None,
+            RuleCategory::Workflow,
+            "test-session".to_string(),
+            None,
+        );
+        let dead_id = store.propose_rule(
+            "command_failure:legacy".to_string(),
+            "Legacy rule".to_string(),
+            None,
+            RuleCategory::Workflow,
+            "test-session".to_string(),
+            None,
+        );
+        assert!(store.revoke_rule(&dead_id, "seed revoke".to_string()));
+        store
+            .save(&RulesStore::project_rules_path(&project_id))
+            .expect("seed rules.json");
+        live_id
+    }
+
+    fn load_store(repo_root: &Path) -> RulesStore {
+        RulesStore::load_project(&edda_store::project_id(repo_root))
+    }
+
+    #[test]
+    fn revoke_marks_rule_dead_with_reason() {
+        let _store = isolated_store();
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        let live_id = seed_store(repo.path());
+
+        execute(
+            RulesCmd::Revoke {
+                id: live_id.clone(),
+                reason: "operator revocation".to_string(),
+            },
+            repo.path(),
+        )
+        .expect("revoke should succeed");
+
+        let store = load_store(repo.path());
+        let rule = store.get(&live_id).expect("rule still present");
+        assert_eq!(rule.status, RuleStatus::Dead);
+        assert_eq!(rule.revoked_reason.as_deref(), Some("operator revocation"));
+    }
+
+    #[test]
+    fn revoke_unknown_id_errors() {
+        let _store = isolated_store();
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        seed_store(repo.path());
+
+        let result = execute(
+            RulesCmd::Revoke {
+                id: "rule_does_not_exist".to_string(),
+                reason: "nope".to_string(),
+            },
+            repo.path(),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn list_reports_rules_without_error() {
+        let _store = isolated_store();
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        let live_id = seed_store(repo.path());
+
+        // Human-readable listing (exercises the ID/SHOWS columns)...
+        execute(
+            RulesCmd::List {
+                all: true,
+                json: false,
+            },
+            repo.path(),
+        )
+        .expect("list should succeed");
+        // ...and JSON listing.
+        execute(
+            RulesCmd::List {
+                all: false,
+                json: true,
+            },
+            repo.path(),
+        )
+        .expect("json list should succeed");
+
+        // The store itself is untouched by listing.
+        let store = load_store(repo.path());
+        assert!(store.get(&live_id).is_some());
+    }
+
+    #[test]
+    fn list_empty_store_is_ok() {
+        let _store = isolated_store();
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        execute(
+            RulesCmd::List {
+                all: false,
+                json: false,
+            },
+            repo.path(),
+        )
+        .expect("list on empty store should succeed");
+    }
+
+    #[test]
+    fn gc_removes_only_dead_rules() {
+        let _store = isolated_store();
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        let live_id = seed_store(repo.path());
+
+        execute(RulesCmd::Gc, repo.path()).expect("gc should succeed");
+
+        let store = load_store(repo.path());
+        assert_eq!(store.rules.len(), 1, "only the dead rule is removed");
+        assert_eq!(store.rules[0].id, live_id);
+        assert_eq!(store.rules[0].status, RuleStatus::Proposed);
+    }
+
+    #[test]
+    fn decay_persists_after_execution() {
+        let _store = isolated_store();
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        seed_store(repo.path());
+
+        execute(RulesCmd::Decay, repo.path()).expect("decay should succeed");
+
+        let store = load_store(repo.path());
+        assert!(store.last_decay_run.is_some(), "decay run recorded");
+    }
 }

--- a/crates/edda-cli/src/cmd_rules.rs
+++ b/crates/edda-cli/src/cmd_rules.rs
@@ -25,6 +25,14 @@ pub enum RulesCmd {
     Stats,
     /// Garbage-collect dead rules
     Gc,
+    /// Revoke a rule by ID (marks it Dead with a reason)
+    Revoke {
+        /// Rule ID (rule_*)
+        id: String,
+        /// Why the rule is being revoked
+        #[arg(long)]
+        reason: String,
+    },
 }
 
 pub fn execute(cmd: RulesCmd, repo_root: &Path) -> anyhow::Result<()> {
@@ -57,14 +65,20 @@ pub fn execute(cmd: RulesCmd, repo_root: &Path) -> anyhow::Result<()> {
                 );
                 println!("{}", "-".repeat(70));
                 for rule in &rules {
+                    let revoked = rule
+                        .revoked_reason
+                        .as_deref()
+                        .map(|r| format!("  [revoked: {r}]"))
+                        .unwrap_or_default();
                     println!(
-                        "{:<12} {:<10} {:<12} {:<5} {} → {}",
+                        "{:<12} {:<10} {:<12} {:<5} {} → {}{}",
                         rule.status,
                         rule.category,
                         rule.hits,
                         rule.ttl_days,
                         rule.trigger,
                         rule.action,
+                        revoked,
                     );
                 }
                 println!("\n{} rules shown.", rules.len());
@@ -116,6 +130,16 @@ pub fn execute(cmd: RulesCmd, repo_root: &Path) -> anyhow::Result<()> {
             let removed = store.gc_dead_rules();
             store.save_project(&project_id)?;
             println!("Removed {removed} dead rules.");
+        }
+
+        RulesCmd::Revoke { id, reason } => {
+            let mut store = edda_postmortem::RulesStore::load_project(&project_id);
+            if store.revoke_rule(&id, reason.clone()) {
+                store.save_project(&project_id)?;
+                println!("Rule {id} revoked: {reason}");
+            } else {
+                anyhow::bail!("Rule not found: {id}");
+            }
         }
     }
 

--- a/crates/edda-postmortem/src/analyzer.rs
+++ b/crates/edda-postmortem/src/analyzer.rs
@@ -142,7 +142,9 @@ fn analyze_failures(
         .iter()
         .filter(|cmd| crate::rules::is_trackable_command(cmd))
     {
-        let short_cmd = cmd.split_whitespace().next().unwrap_or(cmd);
+        let Some(short_cmd) = crate::rules::command_word(cmd) else {
+            continue;
+        };
         rule_proposals.push(RuleProposal {
             trigger: format!("command_failure:{short_cmd}"),
             action: format!("Verify {short_cmd} is available and configured before running"),
@@ -371,6 +373,21 @@ mod tests {
         // rules that fired on every Bash call).
         assert_eq!(result.rule_proposals.len(), 1);
         assert_eq!(result.rule_proposals[0].trigger, "command_failure:npm");
+    }
+
+    #[test]
+    fn failed_command_normalizes_quoted_command_triggers() {
+        let trigger = trigger_with(vec![TriggerReason::SessionFailures]);
+        let mut input = base_input();
+        input.failed_commands = vec![r#""python" -V"#.to_string()];
+
+        let result = analyze(&trigger, &input);
+        assert_eq!(result.rule_proposals.len(), 1);
+        assert_eq!(result.rule_proposals[0].trigger, "command_failure:python");
+        assert_eq!(
+            result.rule_proposals[0].action,
+            "Verify python is available and configured before running"
+        );
     }
 
     #[test]

--- a/crates/edda-postmortem/src/analyzer.rs
+++ b/crates/edda-postmortem/src/analyzer.rs
@@ -132,8 +132,16 @@ fn analyze_failures(
         });
     }
 
-    // Rule proposal: if specific commands keep failing, suggest a pre-check
-    for cmd in &input.failed_commands {
+    // Rule proposal: if specific commands keep failing, suggest a pre-check.
+    // Filter out compound commands, variable assignments, and shell
+    // builtins/keywords/common utilities: their failures are environmental
+    // noise, not a missing-tool signal, and such rules previously fired on
+    // every Bash call (GH-813).
+    for cmd in input
+        .failed_commands
+        .iter()
+        .filter(|cmd| crate::rules::is_trackable_command(cmd))
+    {
         let short_cmd = cmd.split_whitespace().next().unwrap_or(cmd);
         rule_proposals.push(RuleProposal {
             trigger: format!("command_failure:{short_cmd}"),
@@ -335,6 +343,34 @@ mod tests {
             .iter()
             .any(|l| l.severity == LessonSeverity::High));
         assert!(!result.rule_proposals.is_empty());
+    }
+
+    #[test]
+    fn failed_command_filters_builtins_compound_and_assignments() {
+        let trigger = trigger_with(vec![TriggerReason::SessionFailures]);
+        let mut input = base_input();
+        input.outcome = "error_stuck".to_string();
+        input.tool_failures = 6;
+        input.failed_commands = vec![
+            "cd /tmp && npm test".to_string(),
+            "echo hi; ls -la".to_string(),
+            "git status | head".to_string(),
+            "FOO=bar npm test".to_string(),
+            "cd /tmp".to_string(),
+            "echo missing-file".to_string(),
+            "grep pattern".to_string(),
+            "for f in *; do echo $f; done".to_string(),
+            "   ".to_string(),
+            "".to_string(),
+            "npm test".to_string(),
+        ];
+
+        let result = analyze(&trigger, &input);
+        // Only the trackable real command survives the filter (GH-813:
+        // builtins/keywords/assignments/compound commands produced noise
+        // rules that fired on every Bash call).
+        assert_eq!(result.rule_proposals.len(), 1);
+        assert_eq!(result.rule_proposals[0].trigger, "command_failure:npm");
     }
 
     #[test]

--- a/crates/edda-postmortem/src/hooks.rs
+++ b/crates/edda-postmortem/src/hooks.rs
@@ -165,9 +165,9 @@ fn matches_trigger(trigger: &str, ctx: &HookContext) -> bool {
             return false;
         }
         return ctx.command.as_deref().is_some_and(|current| {
-            current
-                .split([';', '&', '|', '\n'])
-                .any(|segment| crate::rules::command_word(segment) == Some(cmd))
+            crate::rules::split_command_segments(current)
+                .iter()
+                .any(|segment| crate::rules::command_word(segment).as_deref() == Some(cmd))
         });
     }
 
@@ -390,6 +390,33 @@ mod tests {
             command: Some("echo python; grep python file.txt".to_string()),
         };
         assert_eq!(evaluate_rules(&store, &ctx).rules_matched, 0);
+    }
+
+    #[test]
+    fn command_failure_does_not_match_quoted_segment_content() {
+        let store = make_store(vec![active_rule(
+            "command_failure:python",
+            "Verify python is available",
+            RuleCategory::Workflow,
+        )]);
+
+        // GH-813: `python` inside a quoted argument is not a segment's
+        // command word — the only segment runs `printf` → no match.
+        let ctx = HookContext {
+            hook_event: "PreToolUse".to_string(),
+            tool_name: "Bash".to_string(),
+            files_touched: vec![],
+            cwd: "/project".to_string(),
+            command: Some("printf '%s' 'skip; python -V'".to_string()),
+        };
+        assert_eq!(evaluate_rules(&store, &ctx).rules_matched, 0);
+
+        // Quoted command word still keys: `"python" x.py` runs python.
+        let quoted_ctx = HookContext {
+            command: Some("\"python\" x.py".to_string()),
+            ..ctx
+        };
+        assert_eq!(evaluate_rules(&store, &quoted_ctx).rules_matched, 1);
     }
 
     #[test]

--- a/crates/edda-postmortem/src/hooks.rs
+++ b/crates/edda-postmortem/src/hooks.rs
@@ -112,6 +112,14 @@ pub fn record_matched_hits(store: &mut RulesStore, matched_ids: &[String]) {
     }
 }
 
+/// Record shows for matched rules: increments the show counter WITHOUT
+/// updating `last_hit`, promoting Proposed rules, or reactivating Dormant/
+/// Settled ones (GH-813: PreToolUse matches on every Bash call must not
+/// reset the rule's decay TTL).
+pub fn record_matched_shows(store: &mut RulesStore, matched_ids: &[String]) {
+    store.record_matched_shows(matched_ids);
+}
+
 /// Format enforcement results as a warning message for the user.
 pub fn format_warnings(result: &EvaluationResult) -> Option<String> {
     if result.enforcements.is_empty() {
@@ -140,32 +148,26 @@ fn matches_trigger(trigger: &str, ctx: &HookContext) -> bool {
     }
 
     if let Some(cmd) = trigger.strip_prefix("command_failure:") {
-        // Match only when the incoming Bash command actually contains the
-        // previously failed command token. Matching every Bash call floods
-        // hooks with irrelevant warnings AND record_hit() keeps resetting the
-        // rule's TTL, so noise rules never decay — a self-feeding loop.
+        // First-token keying (GH-813): match only when the previously failed
+        // command is the command word of a segment of the incoming Bash
+        // command (split on `;`, `&&`, `||`, `|`, newline). Matching every
+        // Bash call — or any whole-word occurrence — flooded hooks with
+        // irrelevant warnings AND record_hit() kept resetting the rule's
+        // TTL, so noise rules never decayed — a self-feeding loop.
         // No command available → no match (silence over noise).
         if ctx.tool_name != "Bash" {
             return false;
         }
         let cmd = cmd.trim();
-        if cmd.is_empty() {
+        if !crate::rules::is_trackable_command(cmd) {
+            // Builtins/keywords/assignments never match, even if a legacy
+            // store still holds such a rule; the decay cycle revokes it.
             return false;
         }
-        // Simple tokens (e.g., "ls", "python") match as whole words so they
-        // don't hit substrings like "tools"; complex tokens (e.g., "WS=$(cat")
-        // fall back to substring containment.
-        let is_simple_token = cmd
-            .chars()
-            .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '.');
         return ctx.command.as_deref().is_some_and(|current| {
-            if is_simple_token {
-                current
-                    .split(|c: char| !(c.is_alphanumeric() || c == '_' || c == '-' || c == '.'))
-                    .any(|word| word == cmd)
-            } else {
-                current.contains(cmd)
-            }
+            current
+                .split([';', '&', '|', '\n'])
+                .any(|segment| crate::rules::command_word(segment) == Some(cmd))
         });
     }
 
@@ -200,6 +202,8 @@ mod tests {
             status: RuleStatus::Active,
             source_session: "test".to_string(),
             source_event: None,
+            shows: 0,
+            revoked_reason: None,
             category,
         }
     }
@@ -318,6 +322,133 @@ mod tests {
             ..hit_ctx
         };
         assert_eq!(evaluate_rules(&store, &write_ctx).rules_matched, 0);
+    }
+
+    #[test]
+    fn command_failure_keys_on_first_token_of_segments() {
+        let store = make_store(vec![active_rule(
+            "command_failure:python",
+            "Verify python is available",
+            RuleCategory::Workflow,
+        )]);
+
+        let ctx = HookContext {
+            hook_event: "PreToolUse".to_string(),
+            tool_name: "Bash".to_string(),
+            files_touched: vec![],
+            cwd: "/project".to_string(),
+            command: Some("python scripts/run.py".to_string()),
+        };
+        assert_eq!(evaluate_rules(&store, &ctx).rules_matched, 1);
+
+        // GH-813: `echo python` runs `echo`, not `python` — the failed
+        // command only keys when it is the command word of a segment.
+        let echo_ctx = HookContext {
+            command: Some("echo python".to_string()),
+            ..ctx.clone()
+        };
+        assert_eq!(evaluate_rules(&store, &echo_ctx).rules_matched, 0);
+
+        // Segment splitting on `&&`, `;`, `|`, and newline: the next
+        // segment's command word keys again.
+        let seg_ctx = HookContext {
+            command: Some("cd /tmp && python scripts/run.py".to_string()),
+            ..ctx.clone()
+        };
+        assert_eq!(evaluate_rules(&store, &seg_ctx).rules_matched, 1);
+
+        let pipe_ctx = HookContext {
+            command: Some("cat data.txt | python -\nprint('x')".to_string()),
+            ..ctx.clone()
+        };
+        assert_eq!(evaluate_rules(&store, &pipe_ctx).rules_matched, 1);
+
+        // Leading environment variable assignments are skipped, so the
+        // command word after them keys.
+        let env_ctx = HookContext {
+            command: Some("FOO=1 BAR=2 python scripts/run.py".to_string()),
+            ..ctx.clone()
+        };
+        assert_eq!(evaluate_rules(&store, &env_ctx).rules_matched, 1);
+    }
+
+    #[test]
+    fn command_failure_does_not_match_when_cmd_is_argument() {
+        let store = make_store(vec![active_rule(
+            "command_failure:python",
+            "Verify python is available",
+            RuleCategory::Workflow,
+        )]);
+
+        // GH-813: `python` appears only as an argument, never as a segment's
+        // command word → no match.
+        let ctx = HookContext {
+            hook_event: "PreToolUse".to_string(),
+            tool_name: "Bash".to_string(),
+            files_touched: vec![],
+            cwd: "/project".to_string(),
+            command: Some("echo python; grep python file.txt".to_string()),
+        };
+        assert_eq!(evaluate_rules(&store, &ctx).rules_matched, 0);
+    }
+
+    #[test]
+    fn command_failure_builtin_rules_never_match() {
+        // Legacy stores may still hold rules for builtins/keywords/common
+        // utilities (GH-813: echo 1789, cd 1618 hits). They must not match.
+        let store = make_store(vec![
+            active_rule("command_failure:cd", "no", RuleCategory::Workflow),
+            active_rule("command_failure:echo", "no", RuleCategory::Workflow),
+            active_rule("command_failure:ls", "no", RuleCategory::Workflow),
+            active_rule("command_failure:grep", "no", RuleCategory::Workflow),
+        ]);
+        let ctx = HookContext {
+            hook_event: "PreToolUse".to_string(),
+            tool_name: "Bash".to_string(),
+            files_touched: vec![],
+            cwd: "/project".to_string(),
+            command: Some("cd /tmp; echo hi; ls -la | grep foo".to_string()),
+        };
+        assert_eq!(evaluate_rules(&store, &ctx).rules_matched, 0);
+    }
+
+    #[test]
+    fn command_failure_exact_command_word_matches_segment() {
+        let store = make_store(vec![active_rule(
+            "command_failure:git",
+            "Check git config",
+            RuleCategory::Workflow,
+        )]);
+        let ctx = HookContext {
+            hook_event: "PreToolUse".to_string(),
+            tool_name: "Bash".to_string(),
+            files_touched: vec![],
+            cwd: "/project".to_string(),
+            command: Some("cd /tmp; echo hi; git status".to_string()),
+        };
+        let result = evaluate_rules(&store, &ctx);
+        assert_eq!(result.rules_matched, 1);
+        assert_eq!(result.matched_rule_ids[0], "rule_test_command_failure_git");
+    }
+
+    #[test]
+    fn record_matched_shows_does_not_reset_ttl_or_status() {
+        let mut store = make_store(vec![active_rule(
+            "command_failure:python",
+            "Verify python is available",
+            RuleCategory::Workflow,
+        )]);
+        let last_hit = store.rules[0].last_hit.clone();
+        let hits = store.rules[0].hits;
+        let id = store.rules[0].id.clone();
+
+        record_matched_shows(&mut store, &["rule_missing".to_string(), id]);
+
+        let rule = &store.rules[0];
+        assert_eq!(rule.shows, 1);
+        assert_eq!(rule.hits, hits);
+        assert_eq!(rule.last_hit, last_hit);
+        assert_eq!(rule.status, RuleStatus::Active);
     }
 
     #[test]

--- a/crates/edda-postmortem/src/rules.rs
+++ b/crates/edda-postmortem/src/rules.rs
@@ -459,16 +459,101 @@ pub struct StoreStats {
 /// environmental noise rather than a missing-tool signal. They must never
 /// become learned-rule command triggers (GH-813: echo 1789 / cd 1618 hits).
 pub const DISALLOWED_TRIGGER_WORDS: &[&str] = &[
-    "cd", "echo", "ls", "pwd", "set", "for", "if", "while", "do", "done", "export", "test",
-    "printf", "cat", "sed", "grep", "head", "tail", "wc", "find", "true", "false",
+    "alias",
+    "bg",
+    "bind",
+    "break",
+    "builtin",
+    "caller",
+    "case",
+    "cd",
+    "command",
+    "compgen",
+    "complete",
+    "compopt",
+    "continue",
+    "coproc",
+    "declare",
+    "dirs",
+    "disown",
+    "do",
+    "done",
+    "echo",
+    "elif",
+    "else",
+    "enable",
+    "esac",
+    "eval",
+    "exec",
+    "exit",
+    "export",
+    "fc",
+    "fg",
+    "fi",
+    "for",
+    "function",
+    "getopts",
+    "hash",
+    "help",
+    "history",
+    "if",
+    "in",
+    "jobs",
+    "kill",
+    "let",
+    "local",
+    "logout",
+    "mapfile",
+    "popd",
+    "printf",
+    "pushd",
+    "pwd",
+    "read",
+    "readarray",
+    "readonly",
+    "return",
+    "select",
+    "set",
+    "shift",
+    "shopt",
+    "source",
+    "suspend",
+    "test",
+    "then",
+    "time",
+    "times",
+    "trap",
+    "true",
+    "type",
+    "typeset",
+    "ulimit",
+    "umask",
+    "unalias",
+    "unset",
+    "until",
+    "wait",
+    "while",
+    "cat",
+    "sed",
+    "grep",
+    "head",
+    "tail",
+    "wc",
+    "find",
+    "ls",
+    "false",
 ];
 
-/// True when a bare token is a variable assignment (`NAME=value`).
+/// True when a bare token is a variable assignment: `NAME=value` or the
+/// bash append form `NAME+=value`. The name before `=` / `+=` must be a
+/// valid shell identifier (ASCII alpha/underscore, then ASCII alphanum or
+/// underscore).
 pub fn is_var_assignment(token: &str) -> bool {
     let Some(eq) = token.find('=') else {
         return false;
     };
     let name = &token[..eq];
+    let name = name.strip_suffix('+').unwrap_or(name);
     !name.is_empty()
         && name
             .chars()
@@ -477,45 +562,141 @@ pub fn is_var_assignment(token: &str) -> bool {
         && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
-/// Command word of a command segment: trim, skip leading `VAR=val`
-/// environment assignments, return the first token. Returns None when the
-/// segment contains no command (empty or a bare assignment).
-pub fn command_word(segment: &str) -> Option<&str> {
-    let mut rest = segment.trim();
-    while let Some((first, tail)) = rest.split_once(char::is_whitespace) {
-        if !is_var_assignment(first) {
-            break;
+/// Split a shell command into segments on `;`, `&`, `|`, and newline.
+///
+/// Quote-aware: delimiters inside single quotes, double quotes, or after a
+/// backslash escape do not split. For example
+/// `printf '%s' 'skip; python -V'` is ONE segment whose command word is
+/// `printf`.
+pub fn split_command_segments(cmd: &str) -> Vec<&str> {
+    let mut segments = Vec::new();
+    let mut start = 0usize;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+    for (i, ch) in cmd.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
         }
-        rest = tail.trim_start();
+        match ch {
+            '\\' => escaped = true,
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            ';' | '&' | '|' | '\n' if !in_single && !in_double => {
+                segments.push(&cmd[start..i]);
+                start = i + ch.len_utf8();
+            }
+            _ => {}
+        }
     }
-    let word = rest.split_whitespace().next()?;
-    if is_var_assignment(word) {
-        return None;
+    segments.push(&cmd[start..]);
+    segments
+}
+
+/// Tokenize a command segment into unquoted words.
+///
+/// Splits on unquoted whitespace; single and double quotes group characters
+/// into one word and are stripped (so `'python'` yields `python`); a
+/// backslash outside single quotes escapes the next character (so
+/// `git\ commit` is one word). Inside double quotes only `\`, `"`, `$`, and
+/// backtick drop the backslash, matching shell quoting rules closely enough
+/// for command-word extraction.
+fn unquoted_words(segment: &str) -> Vec<String> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    let mut in_word = false;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+    for ch in segment.chars() {
+        if escaped {
+            // Outside quotes any escaped character is literal; inside double
+            // quotes only a few escapes drop the backslash.
+            if !in_double || matches!(ch, '\\' | '"' | '$' | '`') {
+                current.push(ch);
+            } else {
+                current.push('\\');
+                current.push(ch);
+            }
+            escaped = false;
+            continue;
+        }
+        match ch {
+            '\\' if !in_single => {
+                escaped = true;
+                in_word = true;
+            }
+            '\'' if !in_double => {
+                in_single = !in_single;
+                in_word = true;
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+                in_word = true;
+            }
+            c if c.is_whitespace() && !in_single && !in_double => {
+                if in_word {
+                    words.push(std::mem::take(&mut current));
+                    in_word = false;
+                }
+            }
+            c => {
+                current.push(c);
+                in_word = true;
+            }
+        }
     }
-    Some(word)
+    if in_word {
+        words.push(current);
+    }
+    words
+}
+
+/// Quote-aware command word of a command segment.
+///
+/// Tokenizes `segment` into words while respecting quotes and backslash
+/// escapes, skips leading variable assignments (including quoted values
+/// like `FOO='hello world'`), and returns the first non-assignment word,
+/// unquoted (e.g. `python` for `'python'` or `"python"`). Returns None when
+/// the segment is empty or consists only of assignments.
+pub fn command_word(segment: &str) -> Option<String> {
+    let mut words = unquoted_words(segment);
+    while words.first().is_some_and(|w| is_var_assignment(w)) {
+        words.remove(0);
+    }
+    words.into_iter().next()
 }
 
 /// True when a command may become a learned-rule command trigger.
 ///
 /// Rejects empty/whitespace commands, compound commands (`;`, `&&`, `||`,
-/// `|`, newline), commands starting with variable assignments, and shell
-/// builtins/keywords/common utilities (GH-813).
+/// `|`, newline), commands whose leading word is a variable assignment
+/// (`FOO=bar npm test` keeps its assignment prefix out of learned
+/// triggers), and shell builtins/keywords/common utilities (GH-813). The
+/// leading word is taken quote-aware, so `"echo" hi` is also rejected.
 pub fn is_trackable_command(cmd: &str) -> bool {
     let cmd = cmd.trim();
     if cmd.is_empty() || cmd.contains([';', '|', '&', '\n']) {
         return false;
     }
-    let Some(word) = cmd.split_whitespace().next() else {
-        return false;
-    };
-    !is_var_assignment(word) && !DISALLOWED_TRIGGER_WORDS.contains(&word)
+    match unquoted_words(cmd).first() {
+        Some(word) if !is_var_assignment(word) => {
+            !DISALLOWED_TRIGGER_WORDS.contains(&word.as_str())
+        }
+        _ => false,
+    }
 }
 
 /// True when a stored rule trigger is disallowed and should be reclaimed by
-/// the decay cycle. Superset of `!is_trackable_command`: any `=` in the
-/// trigger (assignment fragments) is also reclaimed (GH-813).
+/// the decay cycle. ONLY `command_failure:` triggers can be disallowed
+/// command triggers: `file_churn:<path>` (paths may contain `=`),
+/// `multi_agent_start`, and free-text triggers are never revoked by the
+/// decay cycle (GH-813).
 pub fn is_disallowed_trigger(trigger: &str) -> bool {
-    let cmd = trigger.strip_prefix("command_failure:").unwrap_or(trigger);
+    let Some(cmd) = trigger.strip_prefix("command_failure:") else {
+        return false;
+    };
     cmd.contains('=') || !is_trackable_command(cmd)
 }
 
@@ -540,266 +721,6 @@ fn file_sha256(path: &str) -> Option<String> {
     Some(hex::encode(hash))
 }
 
+#[path = "rules_tests.rs"]
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn make_rule(trigger: &str, action: &str, status: RuleStatus) -> Rule {
-        Rule {
-            id: new_rule_id(),
-            trigger: trigger.to_string(),
-            action: action.to_string(),
-            anchor_file: None,
-            anchor_hash: None,
-            created: now_rfc3339(),
-            last_hit: now_rfc3339(),
-            hits: 2,
-            ttl_days: DEFAULT_TTL_DAYS,
-            superseded_by: None,
-            status,
-            source_session: "test-session".to_string(),
-            source_event: None,
-            shows: 0,
-            revoked_reason: None,
-            category: RuleCategory::PreCommit,
-        }
-    }
-
-    fn rfc3339_days_ago(days: i64) -> String {
-        (OffsetDateTime::now_utc() - time::Duration::days(days))
-            .format(&time::format_description::well_known::Rfc3339)
-            .expect("RFC3339 formatting should not fail")
-    }
-
-    #[test]
-    fn new_store_is_empty() {
-        let store = RulesStore::default();
-        assert!(store.rules.is_empty());
-        assert!(store.active_rules().is_empty());
-    }
-
-    #[test]
-    fn propose_creates_proposed_rule() {
-        let mut store = RulesStore::default();
-        let id = store.propose_rule(
-            "test failure".into(),
-            "run tests before commit".into(),
-            None,
-            RuleCategory::PreCommit,
-            "s1".into(),
-            None,
-        );
-        assert!(!id.is_empty());
-        let rule = store.get(&id).unwrap();
-        assert_eq!(rule.status, RuleStatus::Proposed);
-        assert_eq!(rule.hits, 1);
-    }
-
-    #[test]
-    fn duplicate_proposal_confirms_existing() {
-        let mut store = RulesStore::default();
-        let id1 = store.propose_rule(
-            "test failure".into(),
-            "run tests before commit".into(),
-            None,
-            RuleCategory::PreCommit,
-            "s1".into(),
-            None,
-        );
-        let id2 = store.propose_rule(
-            "test failure".into(),
-            "run tests before commit".into(),
-            None,
-            RuleCategory::PreCommit,
-            "s2".into(),
-            None,
-        );
-        // Same rule ID returned (confirmation, not new rule)
-        assert_eq!(id1, id2);
-        let rule = store.get(&id1).unwrap();
-        assert_eq!(rule.hits, 2);
-        // 2 hits -> promoted to Active
-        assert_eq!(rule.status, RuleStatus::Active);
-    }
-
-    #[test]
-    fn contradiction_supersedes_old_rule() {
-        let mut store = RulesStore::default();
-        let id1 = store.propose_rule(
-            "test failure".into(),
-            "run tests before commit".into(),
-            None,
-            RuleCategory::PreCommit,
-            "s1".into(),
-            None,
-        );
-        // Same trigger, different action
-        let id2 = store.propose_rule(
-            "test failure".into(),
-            "run linter before commit".into(),
-            None,
-            RuleCategory::PreCommit,
-            "s2".into(),
-            None,
-        );
-        assert_ne!(id1, id2);
-        let old = store.get(&id1).unwrap();
-        assert_eq!(old.status, RuleStatus::Superseded);
-        assert_eq!(old.superseded_by.as_deref(), Some(id2.as_str()));
-    }
-
-    #[test]
-    fn record_hit_resets_ttl() {
-        let mut rule = make_rule("trigger", "action", RuleStatus::Active);
-        let before = rule.last_hit.clone();
-        std::thread::sleep(std::time::Duration::from_millis(10));
-        rule.record_hit();
-        assert_ne!(rule.last_hit, before);
-        assert_eq!(rule.hits, 3);
-    }
-
-    #[test]
-    fn dormant_reactivates_on_hit() {
-        let mut rule = make_rule("trigger", "action", RuleStatus::Dormant);
-        rule.record_hit();
-        assert_eq!(rule.status, RuleStatus::Active);
-    }
-
-    #[test]
-    fn active_window_cap_enforced() {
-        let mut store = RulesStore::default();
-        // Create 20 active rules
-        for i in 0..20 {
-            let mut rule = make_rule(
-                &format!("trigger_{i}"),
-                &format!("action_{i}"),
-                RuleStatus::Active,
-            );
-            rule.hits = 20 - i;
-            store.rules.push(rule);
-        }
-        store.run_decay_cycle();
-        let active_count = store.active_rules().len();
-        assert!(
-            active_count <= MAX_ACTIVE_RULES,
-            "active_count={active_count} exceeds cap={MAX_ACTIVE_RULES}"
-        );
-    }
-
-    #[test]
-    fn gc_removes_dead_rules() {
-        let mut store = RulesStore::default();
-        store.rules.push(make_rule("a", "b", RuleStatus::Active));
-        store.rules.push(make_rule("c", "d", RuleStatus::Dead));
-        store
-            .rules
-            .push(make_rule("e", "f", RuleStatus::Superseded));
-        let removed = store.gc_dead_rules();
-        assert_eq!(removed, 1);
-        assert_eq!(store.rules.len(), 2);
-    }
-
-    #[test]
-    fn record_shown_never_resets_ttl_or_promotes() {
-        // Proposed rule shown 100 times: still Proposed, hits untouched.
-        let mut proposed = make_rule("trigger", "action", RuleStatus::Proposed);
-        for _ in 0..100 {
-            proposed.record_shown();
-        }
-        assert_eq!(proposed.shows, 100);
-        assert_eq!(proposed.hits, 2);
-        assert_eq!(proposed.status, RuleStatus::Proposed);
-
-        // Active rule whose TTL already elapsed still decays on schedule:
-        // shows never refresh last_hit (GH-813).
-        let mut active = make_rule("trigger", "action", RuleStatus::Active);
-        active.last_hit = rfc3339_days_ago(31);
-        let last_hit = active.last_hit.clone();
-        for _ in 0..100 {
-            active.record_shown();
-        }
-        active.apply_time_decay();
-        assert_eq!(active.shows, 100);
-        assert_eq!(active.status, RuleStatus::Dormant);
-        assert_eq!(active.last_hit, last_hit);
-    }
-
-    #[test]
-    fn revoke_marks_dead_with_reason() {
-        let mut store = RulesStore::default();
-        store.rules.push(make_rule("a", "b", RuleStatus::Active));
-        let id = store.rules[0].id.clone();
-        assert!(store.revoke_rule(&id, "superseded by policy".to_string()));
-        let rule = store.get(&id).unwrap();
-        assert_eq!(rule.status, RuleStatus::Dead);
-        assert_eq!(rule.revoked_reason.as_deref(), Some("superseded by policy"));
-        assert!(!store.revoke_rule("rule_missing", "x".to_string()));
-    }
-
-    #[test]
-    fn decay_cycle_reclaims_disallowed_command_triggers() {
-        let mut store = RulesStore::default();
-        for trigger in [
-            "command_failure:cd",
-            "command_failure:echo",
-            "command_failure:ls",
-            "command_failure:FOO=1",
-            "command_failure:a && b",
-            "cd /tmp && echo hi",
-            "command_failure:npm",
-        ] {
-            store
-                .rules
-                .push(make_rule(trigger, "action", RuleStatus::Active));
-        }
-        store.run_decay_cycle();
-        for rule in &store.rules {
-            if rule.trigger == "command_failure:npm" {
-                assert!(rule.is_alive(), "npm rule should survive: {}", rule.trigger);
-                assert_eq!(rule.revoked_reason, None);
-            } else {
-                assert_eq!(rule.status, RuleStatus::Dead, "{}", rule.trigger);
-                assert_eq!(
-                    rule.revoked_reason.as_deref(),
-                    Some("disallowed command trigger (builtin/keyword/assignment)")
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn store_round_trip() {
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("rules.json");
-
-        let mut store = RulesStore::default();
-        store.propose_rule(
-            "trigger".into(),
-            "action".into(),
-            None,
-            RuleCategory::Workflow,
-            "s1".into(),
-            None,
-        );
-        store.save(&path).unwrap();
-
-        let loaded = RulesStore::load(&path);
-        assert_eq!(loaded.rules.len(), 1);
-        assert_eq!(loaded.rules[0].trigger, "trigger");
-    }
-
-    #[test]
-    fn stats_counts_correctly() {
-        let mut store = RulesStore::default();
-        store.rules.push(make_rule("a", "b", RuleStatus::Active));
-        store.rules.push(make_rule("c", "d", RuleStatus::Proposed));
-        store.rules.push(make_rule("e", "f", RuleStatus::Dormant));
-        store.rules.push(make_rule("g", "h", RuleStatus::Dead));
-        let stats = store.stats();
-        assert_eq!(stats.total, 4);
-        assert_eq!(stats.active, 1);
-        assert_eq!(stats.proposed, 1);
-        assert_eq!(stats.dormant, 1);
-        assert_eq!(stats.dead, 1);
-    }
-}
+mod tests;

--- a/crates/edda-postmortem/src/rules.rs
+++ b/crates/edda-postmortem/src/rules.rs
@@ -112,6 +112,15 @@ pub struct Rule {
     pub source_session: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_event: Option<String>,
+    /// Times this rule's enforcement was shown to a user (e.g. PreToolUse
+    /// matches). Unlike `hits`, shows never update `last_hit`, never promote
+    /// Proposed -> Active, and never reactivate Dormant/Settled rules
+    /// (GH-813: hit-on-every-Bash-call kept noise rules alive forever).
+    #[serde(default)]
+    pub shows: u64,
+    /// Why this rule was revoked (only set when revoked via `revoke`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revoked_reason: Option<String>,
     pub category: RuleCategory,
 }
 
@@ -138,6 +147,21 @@ impl Rule {
         if matches!(self.status, RuleStatus::Dormant | RuleStatus::Settled) {
             self.status = RuleStatus::Active;
         }
+    }
+
+    /// Record that this rule's enforcement was shown to the user.
+    ///
+    /// Increments the show counter only: `last_hit` is NOT updated, Proposed
+    /// rules are NOT promoted, and Dormant/Settled rules are NOT reactivated
+    /// (GH-813: shows are pure statistics and must not reset the TTL).
+    pub fn record_shown(&mut self) {
+        self.shows += 1;
+    }
+
+    /// Revoke this rule: mark it Dead with a reason.
+    pub fn revoke(&mut self, reason: String) {
+        self.status = RuleStatus::Dead;
+        self.revoked_reason = Some(reason);
     }
 
     /// Compute days since last hit.
@@ -283,6 +307,8 @@ impl RulesStore {
             status: RuleStatus::Proposed,
             source_session,
             source_event,
+            shows: 0,
+            revoked_reason: None,
             category,
         };
 
@@ -296,6 +322,15 @@ impl RulesStore {
     /// 2. Anchor decay: check if anchored file changed
     /// 3. Enforce active window cap (~15)
     pub fn run_decay_cycle(&mut self) {
+        // 0. Reclaim disallowed command triggers (GH-813): shell
+        // builtins/keywords/common utilities and variable assignments never
+        // make meaningful learned rules — revoke them outright.
+        for rule in &mut self.rules {
+            if rule.is_alive() && is_disallowed_trigger(&rule.trigger) {
+                rule.revoke("disallowed command trigger (builtin/keyword/assignment)".to_string());
+            }
+        }
+
         // 1. Time decay
         for rule in &mut self.rules {
             rule.apply_time_decay();
@@ -340,6 +375,27 @@ impl RulesStore {
         }
 
         self.last_decay_run = Some(now_rfc3339());
+    }
+
+    /// Record shows for matched rules. Unlike `record_matched_hits`, this
+    /// never resets the TTL or reactivates decayed rules (GH-813).
+    pub fn record_matched_shows(&mut self, matched_ids: &[String]) {
+        for id in matched_ids {
+            if let Some(rule) = self.get_mut(id) {
+                rule.record_shown();
+            }
+        }
+    }
+
+    /// Revoke a rule by ID. Returns false when the ID is unknown.
+    pub fn revoke_rule(&mut self, id: &str, reason: String) -> bool {
+        match self.get_mut(id) {
+            Some(rule) => {
+                rule.revoke(reason);
+                true
+            }
+            None => false,
+        }
     }
 
     /// Garbage-collect dead rules (remove from store entirely).
@@ -399,6 +455,70 @@ pub struct StoreStats {
 
 // -- Helpers --
 
+/// Shell builtins, keywords, and ubiquitous utilities whose failures are
+/// environmental noise rather than a missing-tool signal. They must never
+/// become learned-rule command triggers (GH-813: echo 1789 / cd 1618 hits).
+pub const DISALLOWED_TRIGGER_WORDS: &[&str] = &[
+    "cd", "echo", "ls", "pwd", "set", "for", "if", "while", "do", "done", "export", "test",
+    "printf", "cat", "sed", "grep", "head", "tail", "wc", "find", "true", "false",
+];
+
+/// True when a bare token is a variable assignment (`NAME=value`).
+pub fn is_var_assignment(token: &str) -> bool {
+    let Some(eq) = token.find('=') else {
+        return false;
+    };
+    let name = &token[..eq];
+    !name.is_empty()
+        && name
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Command word of a command segment: trim, skip leading `VAR=val`
+/// environment assignments, return the first token. Returns None when the
+/// segment contains no command (empty or a bare assignment).
+pub fn command_word(segment: &str) -> Option<&str> {
+    let mut rest = segment.trim();
+    while let Some((first, tail)) = rest.split_once(char::is_whitespace) {
+        if !is_var_assignment(first) {
+            break;
+        }
+        rest = tail.trim_start();
+    }
+    let word = rest.split_whitespace().next()?;
+    if is_var_assignment(word) {
+        return None;
+    }
+    Some(word)
+}
+
+/// True when a command may become a learned-rule command trigger.
+///
+/// Rejects empty/whitespace commands, compound commands (`;`, `&&`, `||`,
+/// `|`, newline), commands starting with variable assignments, and shell
+/// builtins/keywords/common utilities (GH-813).
+pub fn is_trackable_command(cmd: &str) -> bool {
+    let cmd = cmd.trim();
+    if cmd.is_empty() || cmd.contains([';', '|', '&', '\n']) {
+        return false;
+    }
+    let Some(word) = cmd.split_whitespace().next() else {
+        return false;
+    };
+    !is_var_assignment(word) && !DISALLOWED_TRIGGER_WORDS.contains(&word)
+}
+
+/// True when a stored rule trigger is disallowed and should be reclaimed by
+/// the decay cycle. Superset of `!is_trackable_command`: any `=` in the
+/// trigger (assignment fragments) is also reclaimed (GH-813).
+pub fn is_disallowed_trigger(trigger: &str) -> bool {
+    let cmd = trigger.strip_prefix("command_failure:").unwrap_or(trigger);
+    cmd.contains('=') || !is_trackable_command(cmd)
+}
+
 fn new_rule_id() -> String {
     format!("rule_{}", ulid::Ulid::new().to_string().to_lowercase())
 }
@@ -439,8 +559,16 @@ mod tests {
             status,
             source_session: "test-session".to_string(),
             source_event: None,
+            shows: 0,
+            revoked_reason: None,
             category: RuleCategory::PreCommit,
         }
+    }
+
+    fn rfc3339_days_ago(days: i64) -> String {
+        (OffsetDateTime::now_utc() - time::Duration::days(days))
+            .format(&time::format_description::well_known::Rfc3339)
+            .expect("RFC3339 formatting should not fail")
     }
 
     #[test]
@@ -569,6 +697,74 @@ mod tests {
         let removed = store.gc_dead_rules();
         assert_eq!(removed, 1);
         assert_eq!(store.rules.len(), 2);
+    }
+
+    #[test]
+    fn record_shown_never_resets_ttl_or_promotes() {
+        // Proposed rule shown 100 times: still Proposed, hits untouched.
+        let mut proposed = make_rule("trigger", "action", RuleStatus::Proposed);
+        for _ in 0..100 {
+            proposed.record_shown();
+        }
+        assert_eq!(proposed.shows, 100);
+        assert_eq!(proposed.hits, 2);
+        assert_eq!(proposed.status, RuleStatus::Proposed);
+
+        // Active rule whose TTL already elapsed still decays on schedule:
+        // shows never refresh last_hit (GH-813).
+        let mut active = make_rule("trigger", "action", RuleStatus::Active);
+        active.last_hit = rfc3339_days_ago(31);
+        let last_hit = active.last_hit.clone();
+        for _ in 0..100 {
+            active.record_shown();
+        }
+        active.apply_time_decay();
+        assert_eq!(active.shows, 100);
+        assert_eq!(active.status, RuleStatus::Dormant);
+        assert_eq!(active.last_hit, last_hit);
+    }
+
+    #[test]
+    fn revoke_marks_dead_with_reason() {
+        let mut store = RulesStore::default();
+        store.rules.push(make_rule("a", "b", RuleStatus::Active));
+        let id = store.rules[0].id.clone();
+        assert!(store.revoke_rule(&id, "superseded by policy".to_string()));
+        let rule = store.get(&id).unwrap();
+        assert_eq!(rule.status, RuleStatus::Dead);
+        assert_eq!(rule.revoked_reason.as_deref(), Some("superseded by policy"));
+        assert!(!store.revoke_rule("rule_missing", "x".to_string()));
+    }
+
+    #[test]
+    fn decay_cycle_reclaims_disallowed_command_triggers() {
+        let mut store = RulesStore::default();
+        for trigger in [
+            "command_failure:cd",
+            "command_failure:echo",
+            "command_failure:ls",
+            "command_failure:FOO=1",
+            "command_failure:a && b",
+            "cd /tmp && echo hi",
+            "command_failure:npm",
+        ] {
+            store
+                .rules
+                .push(make_rule(trigger, "action", RuleStatus::Active));
+        }
+        store.run_decay_cycle();
+        for rule in &store.rules {
+            if rule.trigger == "command_failure:npm" {
+                assert!(rule.is_alive(), "npm rule should survive: {}", rule.trigger);
+                assert_eq!(rule.revoked_reason, None);
+            } else {
+                assert_eq!(rule.status, RuleStatus::Dead, "{}", rule.trigger);
+                assert_eq!(
+                    rule.revoked_reason.as_deref(),
+                    Some("disallowed command trigger (builtin/keyword/assignment)")
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/edda-postmortem/src/rules.rs
+++ b/crates/edda-postmortem/src/rules.rs
@@ -580,7 +580,7 @@ pub fn split_command_segments(cmd: &str) -> Vec<&str> {
             continue;
         }
         match ch {
-            '\\' => escaped = true,
+            '\\' if !in_single => escaped = true,
             '\'' if !in_double => in_single = !in_single,
             '"' if !in_single => in_double = !in_double,
             ';' | '&' | '|' | '\n' if !in_single && !in_double => {

--- a/crates/edda-postmortem/src/rules_tests.rs
+++ b/crates/edda-postmortem/src/rules_tests.rs
@@ -348,3 +348,22 @@ fn stats_counts_correctly() {
     assert_eq!(stats.dormant, 1);
     assert_eq!(stats.dead, 1);
 }
+
+#[test]
+fn split_command_segments_backslash_in_single_quotes_is_literal() {
+    let cmd = r"printf '%s\n' 'a\'; python -V";
+    let segments = split_command_segments(cmd);
+    assert_eq!(segments.len(), 2);
+    assert_eq!(segments[0], r"printf '%s\n' 'a\'");
+    assert_eq!(segments[1], " python -V");
+    assert_eq!(command_word(segments[1]), Some("python".into()));
+}
+
+#[test]
+fn trackable_and_command_word_with_quoted_command() {
+    assert!(is_trackable_command(r#""python" -V"#));
+    assert_eq!(command_word(r#""python" -V"#), Some("python".into()));
+    assert!(!is_trackable_command(r#""echo" hi"#));
+    assert!(!is_trackable_command("FOO=bar npm test"));
+    assert_eq!(command_word("FOO=bar npm test"), Some("npm".into()));
+}

--- a/crates/edda-postmortem/src/rules_tests.rs
+++ b/crates/edda-postmortem/src/rules_tests.rs
@@ -1,0 +1,350 @@
+use super::*;
+
+fn make_rule(trigger: &str, action: &str, status: RuleStatus) -> Rule {
+    Rule {
+        id: new_rule_id(),
+        trigger: trigger.to_string(),
+        action: action.to_string(),
+        anchor_file: None,
+        anchor_hash: None,
+        created: now_rfc3339(),
+        last_hit: now_rfc3339(),
+        hits: 2,
+        ttl_days: DEFAULT_TTL_DAYS,
+        superseded_by: None,
+        status,
+        source_session: "test-session".to_string(),
+        source_event: None,
+        shows: 0,
+        revoked_reason: None,
+        category: RuleCategory::PreCommit,
+    }
+}
+
+fn rfc3339_days_ago(days: i64) -> String {
+    (OffsetDateTime::now_utc() - time::Duration::days(days))
+        .format(&time::format_description::well_known::Rfc3339)
+        .expect("RFC3339 formatting should not fail")
+}
+
+#[test]
+fn new_store_is_empty() {
+    let store = RulesStore::default();
+    assert!(store.rules.is_empty());
+    assert!(store.active_rules().is_empty());
+}
+
+#[test]
+fn propose_creates_proposed_rule() {
+    let mut store = RulesStore::default();
+    let id = store.propose_rule(
+        "test failure".into(),
+        "run tests before commit".into(),
+        None,
+        RuleCategory::PreCommit,
+        "s1".into(),
+        None,
+    );
+    assert!(!id.is_empty());
+    let rule = store.get(&id).unwrap();
+    assert_eq!(rule.status, RuleStatus::Proposed);
+    assert_eq!(rule.hits, 1);
+}
+
+#[test]
+fn duplicate_proposal_confirms_existing() {
+    let mut store = RulesStore::default();
+    let id1 = store.propose_rule(
+        "test failure".into(),
+        "run tests before commit".into(),
+        None,
+        RuleCategory::PreCommit,
+        "s1".into(),
+        None,
+    );
+    let id2 = store.propose_rule(
+        "test failure".into(),
+        "run tests before commit".into(),
+        None,
+        RuleCategory::PreCommit,
+        "s2".into(),
+        None,
+    );
+    // Same rule ID returned (confirmation, not new rule)
+    assert_eq!(id1, id2);
+    let rule = store.get(&id1).unwrap();
+    assert_eq!(rule.hits, 2);
+    // 2 hits -> promoted to Active
+    assert_eq!(rule.status, RuleStatus::Active);
+}
+
+#[test]
+fn contradiction_supersedes_old_rule() {
+    let mut store = RulesStore::default();
+    let id1 = store.propose_rule(
+        "test failure".into(),
+        "run tests before commit".into(),
+        None,
+        RuleCategory::PreCommit,
+        "s1".into(),
+        None,
+    );
+    // Same trigger, different action
+    let id2 = store.propose_rule(
+        "test failure".into(),
+        "run linter before commit".into(),
+        None,
+        RuleCategory::PreCommit,
+        "s2".into(),
+        None,
+    );
+    assert_ne!(id1, id2);
+    let old = store.get(&id1).unwrap();
+    assert_eq!(old.status, RuleStatus::Superseded);
+    assert_eq!(old.superseded_by.as_deref(), Some(id2.as_str()));
+}
+
+#[test]
+fn record_hit_resets_ttl() {
+    let mut rule = make_rule("trigger", "action", RuleStatus::Active);
+    let before = rule.last_hit.clone();
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    rule.record_hit();
+    assert_ne!(rule.last_hit, before);
+    assert_eq!(rule.hits, 3);
+}
+
+#[test]
+fn dormant_reactivates_on_hit() {
+    let mut rule = make_rule("trigger", "action", RuleStatus::Dormant);
+    rule.record_hit();
+    assert_eq!(rule.status, RuleStatus::Active);
+}
+
+#[test]
+fn active_window_cap_enforced() {
+    let mut store = RulesStore::default();
+    // Create 20 active rules
+    for i in 0..20 {
+        let mut rule = make_rule(
+            &format!("trigger_{i}"),
+            &format!("action_{i}"),
+            RuleStatus::Active,
+        );
+        rule.hits = 20 - i;
+        store.rules.push(rule);
+    }
+    store.run_decay_cycle();
+    let active_count = store.active_rules().len();
+    assert!(
+        active_count <= MAX_ACTIVE_RULES,
+        "active_count={active_count} exceeds cap={MAX_ACTIVE_RULES}"
+    );
+}
+
+#[test]
+fn gc_removes_dead_rules() {
+    let mut store = RulesStore::default();
+    store.rules.push(make_rule("a", "b", RuleStatus::Active));
+    store.rules.push(make_rule("c", "d", RuleStatus::Dead));
+    store
+        .rules
+        .push(make_rule("e", "f", RuleStatus::Superseded));
+    let removed = store.gc_dead_rules();
+    assert_eq!(removed, 1);
+    assert_eq!(store.rules.len(), 2);
+}
+
+#[test]
+fn record_shown_never_resets_ttl_or_promotes() {
+    // Proposed rule shown 100 times: still Proposed, hits untouched.
+    let mut proposed = make_rule("trigger", "action", RuleStatus::Proposed);
+    for _ in 0..100 {
+        proposed.record_shown();
+    }
+    assert_eq!(proposed.shows, 100);
+    assert_eq!(proposed.hits, 2);
+    assert_eq!(proposed.status, RuleStatus::Proposed);
+
+    // Active rule whose TTL already elapsed still decays on schedule:
+    // shows never refresh last_hit (GH-813).
+    let mut active = make_rule("trigger", "action", RuleStatus::Active);
+    active.last_hit = rfc3339_days_ago(31);
+    let last_hit = active.last_hit.clone();
+    for _ in 0..100 {
+        active.record_shown();
+    }
+    active.apply_time_decay();
+    assert_eq!(active.shows, 100);
+    assert_eq!(active.status, RuleStatus::Dormant);
+    assert_eq!(active.last_hit, last_hit);
+}
+
+#[test]
+fn revoke_marks_dead_with_reason() {
+    let mut store = RulesStore::default();
+    store.rules.push(make_rule("a", "b", RuleStatus::Active));
+    let id = store.rules[0].id.clone();
+    assert!(store.revoke_rule(&id, "superseded by policy".to_string()));
+    let rule = store.get(&id).unwrap();
+    assert_eq!(rule.status, RuleStatus::Dead);
+    assert_eq!(rule.revoked_reason.as_deref(), Some("superseded by policy"));
+    assert!(!store.revoke_rule("rule_missing", "x".to_string()));
+}
+
+#[test]
+fn decay_cycle_reclaims_disallowed_command_triggers() {
+    let mut store = RulesStore::default();
+    for trigger in [
+        "command_failure:cd",
+        "command_failure:echo",
+        "command_failure:ls",
+        "command_failure:FOO=1",
+        "command_failure:a && b",
+        "command_failure:npm",
+    ] {
+        store
+            .rules
+            .push(make_rule(trigger, "action", RuleStatus::Active));
+    }
+    store.run_decay_cycle();
+    for rule in &store.rules {
+        if rule.trigger == "command_failure:npm" {
+            assert!(rule.is_alive(), "npm rule should survive: {}", rule.trigger);
+            assert_eq!(rule.revoked_reason, None);
+        } else {
+            assert_eq!(rule.status, RuleStatus::Dead, "{}", rule.trigger);
+            assert_eq!(
+                rule.revoked_reason.as_deref(),
+                Some("disallowed command trigger (builtin/keyword/assignment)")
+            );
+        }
+    }
+}
+
+#[test]
+fn is_var_assignment_recognizes_append_form() {
+    assert!(is_var_assignment("FOO=1"));
+    assert!(is_var_assignment("FOO+=1"));
+    assert!(is_var_assignment("_x=y"));
+    assert!(is_var_assignment("PATH+=/usr/bin"));
+    assert!(!is_var_assignment("1FOO=y"));
+    assert!(!is_var_assignment("+=y"));
+    assert!(!is_var_assignment("plain"));
+    assert!(!is_var_assignment(""));
+}
+
+#[test]
+fn split_command_segments_is_quote_aware() {
+    // Delimiters inside quotes do not split: ONE segment.
+    assert_eq!(
+        split_command_segments("printf '%s' 'skip; python -V'"),
+        vec!["printf '%s' 'skip; python -V'"]
+    );
+    assert_eq!(
+        split_command_segments("echo \"a && b\""),
+        vec!["echo \"a && b\""]
+    );
+    // Unquoted delimiters split. `&&` yields an empty segment between
+    // the two ampersands; empty segments have no command word.
+    assert_eq!(
+        split_command_segments("cd /tmp && python x.py"),
+        vec!["cd /tmp ", "", " python x.py"]
+    );
+    assert_eq!(
+        split_command_segments("a;b|c&d\ne"),
+        vec!["a", "b", "c", "d", "e"]
+    );
+    // Backslash-escaped delimiter does not split.
+    assert_eq!(split_command_segments("echo a\\;b"), vec!["echo a\\;b"]);
+    // Empty input still yields one empty segment.
+    assert_eq!(split_command_segments(""), vec![""]);
+}
+
+#[test]
+fn command_word_is_quote_aware() {
+    // Quoted command word is unquoted.
+    assert_eq!(command_word("'python' x.py").as_deref(), Some("python"));
+    assert_eq!(command_word("\"python\" x.py").as_deref(), Some("python"));
+    // Quoted value with spaces: the whole thing is one assignment word.
+    assert_eq!(
+        command_word("FOO='hello world' bar").as_deref(),
+        Some("bar")
+    );
+    assert_eq!(
+        command_word("BAR=\"a b c\" git status").as_deref(),
+        Some("git")
+    );
+    // Append-assignment form is skipped.
+    assert_eq!(command_word("PATH+=/x python").as_deref(), Some("python"));
+    // Quoted segment never changes the command word.
+    assert_eq!(
+        command_word("printf '%s' 'skip; python -V'").as_deref(),
+        Some("printf")
+    );
+    // Only assignments → None.
+    assert_eq!(command_word("FOO=1"), None);
+    assert_eq!(command_word(""), None);
+    assert_eq!(command_word("   "), None);
+}
+#[test]
+fn decay_cycle_never_revokes_non_command_failure_triggers() {
+    // Only `command_failure:` triggers can be disallowed command
+    // triggers. File paths may contain `=`; free-text and special
+    // triggers must never be touched by the reclaim pass (GH-813).
+    let mut store = RulesStore::default();
+    for trigger in [
+        "file_churn:config/foo=bar.toml",
+        "multi_agent_start",
+        "cd /tmp && echo hi",
+        "build failure in CI",
+    ] {
+        store
+            .rules
+            .push(make_rule(trigger, "action", RuleStatus::Active));
+    }
+    store.run_decay_cycle();
+    for rule in &store.rules {
+        assert!(
+            rule.is_alive(),
+            "non-command_failure trigger wrongly revoked: {}",
+            rule.trigger
+        );
+    }
+}
+
+#[test]
+fn store_round_trip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("rules.json");
+
+    let mut store = RulesStore::default();
+    store.propose_rule(
+        "trigger".into(),
+        "action".into(),
+        None,
+        RuleCategory::Workflow,
+        "s1".into(),
+        None,
+    );
+    store.save(&path).unwrap();
+
+    let loaded = RulesStore::load(&path);
+    assert_eq!(loaded.rules.len(), 1);
+    assert_eq!(loaded.rules[0].trigger, "trigger");
+}
+
+#[test]
+fn stats_counts_correctly() {
+    let mut store = RulesStore::default();
+    store.rules.push(make_rule("a", "b", RuleStatus::Active));
+    store.rules.push(make_rule("c", "d", RuleStatus::Proposed));
+    store.rules.push(make_rule("e", "f", RuleStatus::Dormant));
+    store.rules.push(make_rule("g", "h", RuleStatus::Dead));
+    let stats = store.stats();
+    assert_eq!(stats.total, 4);
+    assert_eq!(stats.active, 1);
+    assert_eq!(stats.proposed, 1);
+    assert_eq!(stats.dormant, 1);
+    assert_eq!(stats.dead, 1);
+}


### PR DESCRIPTION
Closes #813
Issue: #813

## Summary
Fixes command_failure learned rules firing on every Bash call and resetting TTL on PreToolUse:
1. **Keying**: Filter `failed_commands` in `analyze_failures` to reject compound commands (`;`, `&&`, `||`, `|`, `\n`), variable assignments (`NAME=...` and `NAME+=...`), and shell builtins/keywords (`cd`, `echo`, `ls`, `pwd`, `set`, `for`, `if`, `while`, `do`, `done`, `export`, `test`, `printf`, `cat`, `sed`, `grep`, `head`, `tail`, `wc`, `find`, `true`, `false`, etc.). Normalized command trigger keying via `command_word` handles quoted commands like `"\"python\" -V"`.
2. **Matching**: In `matches_trigger`, `command_failure:<cmd>` matches only when `<cmd>` is the command word of a segment of the incoming Bash command (splitting quote-aware on `;`, `&`, `|`, `\n`, with backslash inside single quotes treated as literal), skipping leading environment assignments. Disallowed command words (builtins/keywords) never match.
3. **Hit Semantics**: Split PreToolUse recording from failure hits: added `record_shown()` on `Rule` which increments `shows` without updating `last_hit` and without promoting or reactivating rules. PreToolUse in `edda-bridge-claude` now calls `record_matched_shows`.
4. **Operator Revocation & Reclaim**: Added `edda rules revoke <id> --reason "<reason>"` which marks a live rule as Dead with `revoked_reason`. `edda rules list` displays ID column and revocation reasons. `run_decay_cycle` automatically reclaims existing rules with disallowed command triggers as Dead, strictly scoped to `command_failure:`.
