### PR TITLE
feat(skills): give controllers a ready-batch selection procedure

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -383,6 +383,11 @@ When edda detects multiple agents, it injects peer information into your context
 
 Ignoring these rules causes merge conflicts and duplicated work.
 
+**Fleet standing authorization:** a `fleet:ready` label is the operator's
+signature — the controller selects the batch itself (fleet-orchestrate's
+ready-batch selection procedure) without asking the operator for issue
+numbers; the operator intervenes at promote and adjudication.
+
 ### PR review-fix loop
 
 **How to review is `REVIEW.md` at the repo root — run it top to bottom.** It is

--- a/.claude/skills/fleet-orchestrate/SKILL.md
+++ b/.claude/skills/fleet-orchestrate/SKILL.md
@@ -29,16 +29,20 @@ when changing or validating review policy.
    authority, and stop conditions. “Keep going” does not expand scope.
 2. Inspect repository instructions, current revision, dirty state, active
    peers, claims, decisions, issue/PR state, and available durable carriers.
-3. Maintain two logical rails: read-only review/discovery and write-enabled
+3. Select this batch before any dispatch: run the ready-batch selection
+   procedure below and hand its table to `/parallel-wave`. `fleet:ready` is
+   the operator's authorization — the controller picks the batch itself and
+   never stops to ask the operator for issue numbers.
+4. Maintain two logical rails: read-only review/discovery and write-enabled
    delivery. A verified finding may cross rails; a suspicion may not.
-4. Build a dependency and file-overlap graph. Parallelize only independent
+5. Build a dependency and file-overlap graph. Parallelize only independent
    ready bundles; serialize the same code chain. Set worker WIP no higher than
    verifier capacity.
-5. Keep one controller, independent workers, and a read-only verifier. From
+6. Keep one controller, independent workers, and a read-only verifier. From
    two concurrent workers onward, reserve a verifier seat.
-6. Record tasks, claims, rulings, and acceptance criteria in the durable truth
+7. Record tasks, claims, rulings, and acceptance criteria in the durable truth
    layer before ringing host messaging as a doorbell.
-7. Gate every cross-machine dispatch mechanically (GH-656): before a lane
+8. Gate every cross-machine dispatch mechanically (GH-656): before a lane
    starts an issue, its claim is written by exactly one command —
    `scripts/fleet-claim-issue.sh <issue> <machine>/<role>` (e.g.
    `4090/worker-1`, `docs/reviewer`), which leaves the `taking:` comment
@@ -48,10 +52,54 @@ when changing or validating review policy.
    writes no claim and does not substitute for the script. The token is
    an explicit `<machine>/<role>` value from the brief, never a hostname
    guess.
-8. Give self-contained briefs (including assigned build lane, verification
+9. Give self-contained briefs (including assigned build lane, verification
    budget, and cleanup authority), monitor compressed state, adjudicate
    conflicts, and close only against immutable full SHAs with proportional
    evidence.
+
+## Ready-batch selection (select this batch)
+
+`fleet:ready` is the operator's signature: promoting an issue to ready already
+authorized it. When the operator says "run ready work today"（「今天開始跑」）, the
+controller runs this procedure and produces the batch itself — it never stops
+to ask for issue numbers. This step **selects**; the actual claim write is the
+single command in sequence step 8 (`scripts/fleet-claim-issue.sh`, #783) —
+selection does not claim.
+
+Run it verbatim:
+
+1. **Query candidates** — the machine check is the filter of record (GH-665);
+   never a raw label listing as the only filter. The second query adds
+   routing fields:
+
+   ```bash
+   sh scripts/fleet/ready-queue-lint.sh    # pickable ready issues, oldest first
+   gh issue list --label fleet:ready --state open --json number,title,createdAt,labels
+   ```
+
+2. **Exclude**, recording each issue's reason for the output table:
+   - (a) another machine already holds it: a `taking:` comment or a `lane:*`
+     label naming a different workstation (`fleet.cross-machine-claim`). The
+     same workstation (`docs` vs `docs/pipeline`) is **not** "another
+     machine".
+   - (b) already in flight: an open PR
+     (`gh pr list --search "head:gh<n>"`), **or** a remote branch
+     (`git ls-remote --heads origin "gh<n>*" "*gh<n>*"`) — pushed-but-unopened
+     branches are invisible to `gh pr list`.
+   - (c) labeled `needs-operator`.
+
+3. **Route** by predicted write surface: anything touching `crates/**`,
+   `.github/workflows/**`, `scripts/**`, or `Cargo.*` needs a build lane →
+   the 4090-shaped machine. Pure `docs/**`, `*.md`, or `.claude/skills/**`
+   work stays on this docs machine.
+
+4. **Sort** oldest `createdAt` first, unless an issue is blocked-by another
+   selected issue — blocked items keep their dependency order and stay
+   unassigned until their blocker dispatches.
+
+5. **Output** one table — selected / excluded with reason — and hand it to
+   `/parallel-wave` as its Layer-1 input. Do not restate REVIEW.md tables
+   here; review routing lives in the review charter.
 
 ## Non-negotiable invariants
 

--- a/.claude/skills/fleet-orchestrate/SKILL.md
+++ b/.claude/skills/fleet-orchestrate/SKILL.md
@@ -74,7 +74,7 @@ Run it verbatim:
 
    ```bash
    sh scripts/fleet/ready-queue-lint.sh    # pickable ready issues, oldest first
-   gh issue list --label fleet:ready --state open --json number,title,createdAt,labels
+   gh issue list --label fleet:ready --state open --json number,title,createdAt,labels,comments,body
    ```
 
 2. **Exclude**, recording each issue's reason for the output table:
@@ -83,8 +83,8 @@ Run it verbatim:
      same workstation (`docs` vs `docs/pipeline`) is **not** "another
      machine".
    - (b) already in flight: an open PR
-     (`gh pr list --search "head:gh<n>"`), **or** a remote branch
-     (`git ls-remote --heads origin "gh<n>*" "*gh<n>*"`) — pushed-but-unopened
+     (`gh pr list --state open --search "<n>"`), **or** a remote branch
+     (`git ls-remote --heads origin "*gh<n>*" "*<n>*"`) — pushed-but-unopened
      branches are invisible to `gh pr list`.
    - (c) labeled `needs-operator`.
 

--- a/.claude/skills/fleet-orchestrate/SKILL.md
+++ b/.claude/skills/fleet-orchestrate/SKILL.md
@@ -70,11 +70,15 @@ Run it verbatim:
 
 1. **Query candidates** — the machine check is the filter of record (GH-665);
    never a raw label listing as the only filter. The second query adds
-   routing fields:
+   routing fields; the third reads each candidate in full — the body and
+   comments carry the predicted write surface, `blocked-by` edges, and other
+   machines' `taking:` claims, so the rules below are applied from fetched
+   data, never from titles alone:
 
    ```bash
    sh scripts/fleet/ready-queue-lint.sh    # pickable ready issues, oldest first
-   gh issue list --label fleet:ready --state open --json number,title,createdAt,labels,comments,body
+   gh issue list --label fleet:ready --state open --json number,title,createdAt,labels
+   gh issue view <n> --json body,comments,labels,title,createdAt   # per candidate <n>
    ```
 
 2. **Exclude**, recording each issue's reason for the output table:
@@ -82,9 +86,11 @@ Run it verbatim:
      label naming a different workstation (`fleet.cross-machine-claim`). The
      same workstation (`docs` vs `docs/pipeline`) is **not** "another
      machine".
-   - (b) already in flight: an open PR
-     (`gh pr list --state open --search "<n>"`), **or** a remote branch
-     (`git ls-remote --heads origin "*gh<n>*" "*<n>*"`) — pushed-but-unopened
+   - (b) already in flight: an open PR — list open `headRefName`s
+     (`gh pr list --state open --json headRefName`) and treat any branch
+     name containing `gh<n>` as in flight (the repo's convention is
+     `<type>/gh<n>-…`; a `head:gh<n>` search misses it) — **or** a remote
+     branch (`git ls-remote --heads origin "*gh<n>*"`) — pushed-but-unopened
      branches are invisible to `gh pr list`.
    - (c) labeled `needs-operator`.
 

--- a/.claude/skills/fleet-worker/SKILL.md
+++ b/.claude/skills/fleet-worker/SKILL.md
@@ -16,6 +16,8 @@ description: Use when running one lane of the Fleet execution loop — pick a si
 ## 一圈流程
 
 1. **領單**（claim 協議；**先讀後寫**）：
+   （有控制者在場時，brief 會直接指定本圈的 issue——那是 fleet-orchestrate ready-batch
+   selection 的產出；下面的 `--oldest` 撿單是沒有控制者的單機路徑。兩者都以 `fleet:ready` 為操作者授權。）
    - 找最老 ready 單：`sh scripts/fleet/ready-queue-lint.sh --oldest`——只回傳最老且**尚未交付**的 ready 單。腳本用合併 PR 機器檢查（GH-665）剔除已交付仍掛 `fleet:ready` 的單，不做記憶判斷；gh 失敗會 fail closed，絕不把壞掉的查詢誤判成「隊列空」。
    - 無單 → **idle 退避**，回報「隊列空」並結束。絕不自己發明工作。
    - **先讀，不寫**——三個拒領理由，任一成立 → 放棄，領下一張：

--- a/.claude/skills/parallel-wave/SKILL.md
+++ b/.claude/skills/parallel-wave/SKILL.md
@@ -21,6 +21,12 @@ invariant, API/schema order). Plan YAMLs live outside the repo (scratchpad or
 
 ## Layer 1 — static judgment (before dispatch)
 
+Layer 1's input **is** the select-this-batch table from fleet-orchestrate's
+ready-batch selection procedure — a batch never appears from nowhere. That
+table already applied the exclusion checklist (cross-machine claims, in-flight
+PRs/remote branches, `needs-operator`); this layer starts from its selected
+rows and does not repeat those checks.
+
 Ready-queue intake is a machine check, not memory (GH-665): source candidate
 issues from `scripts/fleet/ready-queue-lint.sh`, never a raw
 `gh issue list --label fleet:ready` — the script excludes open issues whose

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -24,8 +24,10 @@
    git status                              # 乾淨、on branch main
    git rev-list --count HEAD..origin/main  # 0 = 沒落後
    ```
-2. **接單**：`sh scripts/fleet-claim-issue.sh <N> <machine>/<role>`（例如 `4090/worker-1`、`docs/reviewer`），
-   該腳本會留下 `taking:` 留言並原子化切換標籤與 assignee。不使用手動 lease 留言（決策 `fleet.cross-machine-claim`、#783）。
+2. **接單**：`sh scripts/fleet-claim-issue.sh <N> <machine>/<role>`（例如 `4090/worker-1`、`docs/reviewer`）——
+   認領寫入只有這一個指令，它留 `taking:` 留言＋`lane:<machine>` 標籤；不手寫 lease 留言
+   （決策 `fleet.cross-machine-claim`、#783）。過渡步（#782 併入前保留；併入後刪除）：script exit 0 後跑
+   `gh issue edit <N> --add-label fleet:claimed --remove-label fleet:ready --add-assignee @me`——腳本目前不翻這兩個標籤。
 3. **派 lane**（開 worktree 後）：
    ```bash
    pwsh -NoProfile -File scripts/fleet/lane-launch.ps1 -Name <lane> -Brief <brief.md> -Cwd <worktree>

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -24,8 +24,8 @@
    git status                              # 乾淨、on branch main
    git rev-list --count HEAD..origin/main  # 0 = 沒落後
    ```
-2. **接單**：`gh issue edit <N> --add-label fleet:claimed --remove-label fleet:ready --add-assignee @me`，
-   並在 issue 留 lease 留言。
+2. **接單**：`sh scripts/fleet-claim-issue.sh <N> <machine>/<role>`（例如 `4090/worker-1`、`docs/reviewer`），
+   該腳本會留下 `taking:` 留言並原子化切換標籤與 assignee。不使用手動 lease 留言（決策 `fleet.cross-machine-claim`、#783）。
 3. **派 lane**（開 worktree 後）：
    ```bash
    pwsh -NoProfile -File scripts/fleet/lane-launch.ps1 -Name <lane> -Brief <brief.md> -Cwd <worktree>

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -98,7 +98,10 @@
 1. **開場**：在 `C:\ai_agent\edda` 開 Claude Code。pack 自動列出決策、peers、任務。說：
    「`/fleet-orchestrate` 今天跑 ready 的單」。控制者先做 fleet-orchestrate 的 controller sequence
    第 1–2 步：定目標、排除、證據門檻、開單與合併授權、停止條件；看 revision、dirty state、peers、claims、issue/PR 狀態。
-2. **判併行**：`/parallel-wave`——每張 ready issue 推 predicted write surface，兩兩交集：
+   **Standing 授權（不必逐批請示）**：`fleet:ready` 標籤就是操作者的簽名——控制者接著自己跑
+   fleet-orchestrate 的 ready-batch selection 程序選出這一批、產出選/排表，不回頭問編號；
+   操作者的介入點是 promote 與裁決，不是每批打字給編號（程序正典在 fleet-orchestrate，這裡不重述）。
+2. **判併行**：`/parallel-wave`——輸入就是上一步選單程序的選/排表；每張選中的 ready issue 推 predicted write surface，兩兩交集：
    disjoint → 一起派；同檔不同符號 → 兩邊 brief 寫 FORBIDDEN 符號清單；同符號 → 串成一條；scope 太糊 → 退回佇列。
    `edda claim check`（#576，2026-09-02 已合進 main）把這步變成機器判——**但要用從 main 重建的二進位**：
    PATH 上的 `edda.exe` 可能比 #576 舊，`edda claim --help` 沒列出 `check` 就是舊的（它會把 `check` 當成 claim 的 label）。


### PR DESCRIPTION
## Summary
- Controllers get a copy-pasteable ready-batch selection procedure: `ready-queue-lint.sh` + exclusions (other machine, open PR or remote `ghN` branch, `needs-operator`) + write-surface routing + oldest-first sort.
- Output is a selected/excluded table handed to `/parallel-wave` (Layer 1 no longer invents its input).
- Standing authorization: `fleet:ready` is the operator signature; the controller does not ask for issue numbers. One sentence in CLAUDE.md and runbook §三; procedure stays in fleet-orchestrate.
- Claim write remains the #783 script; selection does not claim.

Closes #667
Issue: #667

## 今天開始跑 — first-reply sketch (regression)
Operator: 「今天開始跑」
- Old FAIL: 「給我 issue 編號，我就開始寫 brief」
- New PASS: first action is `sh scripts/fleet/ready-queue-lint.sh` + the label query, then the select/exclude table, then `/parallel-wave`. No question asking for numbers.

## Changes
- `.claude/skills/fleet-orchestrate/SKILL.md`
- `.claude/skills/parallel-wave/SKILL.md`
- `.claude/skills/fleet-worker/SKILL.md` (pointer only)
- `docs/guides/operator-runbook.md`
- `.claude/CLAUDE.md`

## Verification
- `sh scripts/lint-markdown-content.sh` exit 0
- UTF-8, no BOM
- Docs/skills-only: no local Cargo

## Wiring (REVIEW.md §5.5)
| 新面 | Writer & shape | Reader | Failure signal | Layer reach |
|---|---|---|---|---|
| no new surfaces | skill/runbook prose; queue reader remains `ready-queue-lint.sh` | controller / parallel-wave | empty table → idle | docs/skills |
