### PR TITLE
feat(fleet): add persistent lane helpers

### DIFF
--- a/.claude/skills/parallel-wave/SKILL.md
+++ b/.claude/skills/parallel-wave/SKILL.md
@@ -46,9 +46,10 @@ against the crate map. Pairwise intersect:
   and refuses to switch until the previous branch's local tip matches the
   remote tip. It never force-checks out or removes a worktree, branch, or
   source.
-- Set `CARGO_TARGET_DIR=<lane-root>/<lane>` for that lane's entire lifetime.
-  Never an ad-hoc build dir — that is the 194 GB failure. Worker lanes use
-  incremental compilation; verifier lanes use `CARGO_INCREMENTAL=0`.
+- Use the canonical environment policy in [`.claude/CLAUDE.md` Build
+  lanes](../../CLAUDE.md#build-lanes); `lane-warm.ps1 -PrintEnv` is the helper
+  contract consumed by `lane-launch.ps1`. Do not duplicate that policy in wave
+  plans or worktree prompts.
 - Worktree prompts must name the prepared fixed worktree and current branch:
   do NOT `checkout main`, pull, create branches, remove branches, or create a
   second worktree. The controller prepares the next branch only after the lane

--- a/.claude/skills/parallel-wave/SKILL.md
+++ b/.claude/skills/parallel-wave/SKILL.md
@@ -39,12 +39,20 @@ against the crate map. Pairwise intersect:
 
 ## Layer 2 — in-flight containment
 
-- Worktree per bundle: `git worktree add <root>-wt-ghNNN -b <branch> origin/main`.
-- Fixed lane pool only (`worker-1`, `worker-2`, `verifier`): set
-  `CARGO_TARGET_DIR=<lane-root>/<lane>` for the whole lane lifetime. Never an
-  ad-hoc build dir — that is the 194 GB failure.
-- Worktree prompts must say: already on branch X, do NOT `checkout main`, do
-  NOT pull, do NOT create branches (checkout of main fails in a worktree anyway).
+- Each active bundle has one lane-bound fixed worktree. The fixed pool is
+  `worker-1`, `worker-2`, `verifier`, and `verifier-2`, at
+  `<root>-wt-<lane>`; use `scripts/fleet/lane-prepare.ps1` to create it or
+  switch to a new branch from `origin/main`. It refuses a busy or dirty lane,
+  and refuses to switch until the previous branch's local tip matches the
+  remote tip. It never force-checks out or removes a worktree, branch, or
+  source.
+- Set `CARGO_TARGET_DIR=<lane-root>/<lane>` for that lane's entire lifetime.
+  Never an ad-hoc build dir — that is the 194 GB failure. Worker lanes use
+  incremental compilation; verifier lanes use `CARGO_INCREMENTAL=0`.
+- Worktree prompts must name the prepared fixed worktree and current branch:
+  do NOT `checkout main`, pull, create branches, remove branches, or create a
+  second worktree. The controller prepares the next branch only after the lane
+  is idle and its prior branch has been pushed.
 - No verdict gates in parallel plans (`cleanup.review-gate=pr-not-verdict-gate`;
   gates assume an attached controller — wave1 timed out 2 of 3). This also makes
   the GH-543 worktree-ledger trap inapplicable.

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -108,8 +108,8 @@
     # 首次準備或切到下一張 issue：固定路徑，不建 per-issue worktree
     pwsh -NoProfile -File scripts/fleet/lane-prepare.ps1 -BuildLane <worker-1|worker-2|verifier|verifier-2> -Branch <branch> -Repo C:/ai_agent/edda
    edda claim "ghNNN" --paths "crates/<crate>/src/*"
-   edda conduct run <plan.yaml> --agent pi --cwd C:/ai_agent/edda-wt-ghNNN      # 多 phase
-   edda dispatch --agent pi --prompt-file brief.md --cwd C:/ai_agent/edda-wt-ghNNN --budget-usd 5   # 單輪
+   edda conduct run <plan.yaml> --agent pi --cwd C:/ai_agent/edda-wt-<lane>      # 多 phase
+   edda dispatch --agent pi --prompt-file brief.md --cwd C:/ai_agent/edda-wt-<lane> --budget-usd 5   # 單輪
    ```
     plan YAML 放 scratchpad 或 `.tmp/plans/`，不進 repo。lane worktree 固定為
     `C:\ai_agent\edda-wt-<worker-1|worker-2|verifier|verifier-2>`；prepare 只在閒置、乾淨

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -103,15 +103,19 @@
    `edda claim check`（#576，2026-09-02 已合進 main）把這步變成機器判——**但要用從 main 重建的二進位**：
    PATH 上的 `edda.exe` 可能比 #576 舊，`edda claim --help` 沒列出 `check` 就是舊的（它會把 `check` 當成 claim 的 label）。
    重建：`cargo install --path crates/edda-cli --force`，再 `edda claim --help` 確認。
-3. **每張一個 plan、一個 worktree、一條 lane**：
+3. **每張一個 plan、每條 lane 一個固定 worktree**：
    ```bash
-   git worktree add C:/ai_agent/edda-wt-ghNNN -b <branch> origin/main
+    # 首次準備或切到下一張 issue：固定路徑，不建 per-issue worktree
+    pwsh -NoProfile -File scripts/fleet/lane-prepare.ps1 -BuildLane <worker-1|worker-2|verifier|verifier-2> -Branch <branch> -Repo C:/ai_agent/edda
    edda claim "ghNNN" --paths "crates/<crate>/src/*"
    edda conduct run <plan.yaml> --agent pi --cwd C:/ai_agent/edda-wt-ghNNN      # 多 phase
    edda dispatch --agent pi --prompt-file brief.md --cwd C:/ai_agent/edda-wt-ghNNN --budget-usd 5   # 單輪
    ```
-   plan YAML 放 scratchpad 或 `.tmp/plans/`，不進 repo。Rust lane 設 `CARGO_TARGET_DIR` 為
-   `$env:LOCALAPPDATA\fleet-workstation\lanes\worker-1|worker-2`（verifier 用 `verifier|verifier-2`）。
+    plan YAML 放 scratchpad 或 `.tmp/plans/`，不進 repo。lane worktree 固定為
+    `C:\ai_agent\edda-wt-<worker-1|worker-2|verifier|verifier-2>`；prepare 只在閒置、乾淨
+    worktree 且舊分支的 local tip 等於 `origin/<branch>` 時切換，絕不 force checkout、刪 branch 或刪 source。
+    Rust lane 設 `CARGO_TARGET_DIR` 為
+    `$env:LOCALAPPDATA\fleet-workstation\lanes\worker-1|worker-2|verifier|verifier-2`。
    lane 的**啟動方式**用 `scripts/fleet/lane-launch.ps1`（見 START HERE；Task Scheduler，不是 nohup，規則見 §六）。
 4. **PR 一開就派審（自動，不用人手）**：本機 watcher（`scripts/pr-review-watch.sh`，由
    `scripts/pr-review-launch.ps1` 註冊成隱藏排程任務 `edda-pr-review-watcher`）每 60 秒掃 open PR：
@@ -151,8 +155,10 @@ conventional commit 格式；`SKIP_CLIPPY=1` 跳過 clippy 並自動在訊息尾
 CI 只在 PR 與 push 到 main 時跑，feature branch 靠 PR 的 CI Gate。
 
 1. 在指定 worktree 與分支上做 brief 說的那一件事——不 checkout main、不 pull、不開別的分支。
-2. L0 閘（`cargo fmt --all --check`；`cargo clippy -p <crate> --all-targets -- -D warnings`；`cargo test -p <crate>`），
-   凍結 SHA 前跑一次 L1（`CARGO_INCREMENTAL=0`，workspace 全套），記 gate receipt（SHA、閘、toolchain、lane、結果）。
+2. L0 閘（`cargo fmt --all --check`；`cargo clippy -p <crate> --all-targets -- -D warnings`；`cargo test -p <crate>`）。
+   凍結 SHA 的 L1 是 exact-head CI；Windows CI 未覆蓋的 touched crate 由 verifier lane 以
+   `CARGO_INCREMENTAL=0` 跑一次 `cargo test -p <crate>`（C5 selector），並記 gate receipt
+   （SHA、CI run、toolchain、lane、結果）。不要以本機 workspace 全套代替 L1。
 3. `git push -u origin <branch>`、開 PR、**停**。不合併、不刪分支、不刪 worktree。
 
 Brief 必含：assigned build lane、verification budget（L0 while iterating；L1 once per frozen SHA）、cleanup authority（build cache 可清；worktree／branch／source 不刪）。

--- a/scripts/fleet/lane-launch.ps1
+++ b/scripts/fleet/lane-launch.ps1
@@ -7,10 +7,11 @@
 # that sets UTF-8 encodings, HOME and GIT_CONFIG_PARAMETERS explicitly (empty
 # or hostile in the task environment), then runs `edda dispatch`.
 #
-# CARGO_TARGET_DIR is set ONLY when -BuildLane names one of the four ratified
-# build lanes (see below): a session that compiles nothing has no build lane
-# (.claude/CLAUDE.md, verification.cost-discipline), while a compiling session
-# must be given one of the four — the launcher refuses any other name.
+# CARGO env is set in the wrapper ONLY when -BuildLane names one of the four
+# ratified build lanes (see below): a session that compiles nothing has no
+# build lane (.claude/CLAUDE.md, verification.cost-discipline), while a
+# compiling session must be given one of the four — the launcher refuses any
+# other name.
 #
 # Every artifact the launcher writes lives under -LogDir (resolved to an
 # absolute path before anything is written or embedded — the task runs from a
@@ -26,11 +27,15 @@
 #
 # -BuildLane is optional and accepts exactly the ratified build lanes
 # worker-1|worker-2|verifier|verifier-2 (verification.cost-discipline); when
-# given, the wrapper sets CARGO_TARGET_DIR to <lane root>\<BuildLane> (lane
-# root = $env:LOCALAPPDATA\fleet-workstation\lanes unless FLEET_LANE_ROOT is
-# set). When omitted, the wrapper sets NO CARGO_TARGET_DIR at all — the
-# launcher never synthesizes a build lane; docs lanes compile nothing and
-# pass none.
+# given, the wrapper gets the lane env contract — CARGO_TARGET_DIR set to the
+# FIXED lane dir <lane root>\<BuildLane> (lane root =
+# $env:LOCALAPPDATA\fleet-workstation\lanes unless FLEET_LANE_ROOT is set),
+# CARGO_INCREMENTAL (1 worker / 0 verifier) and the CI-matching
+# CARGO_PROFILE_{DEV,TEST}_DEBUG=line-tables-only trim (GH-626). That contract
+# has one owner — lane-warm.ps1 Get-LaneBuildEnv, exposed via -PrintEnv — and
+# the launcher consumes it instead of duplicating a drifting literal. When
+# omitted, the wrapper sets NO CARGO env at all — the launcher never
+# synthesizes a build lane; docs lanes compile nothing and pass none.
 #
 # Prints, one line each: the .git/config backup verdict (GH-715), then task
 # name, state, wrapper path, log path, done path.
@@ -136,7 +141,20 @@ $LogDir = (Resolve-Path -LiteralPath $LogDir).Path
 if (-not $SessionId) { $SessionId = "lane-$Name" }
 if ($BuildLane) {
   $laneRoot = if ($env:FLEET_LANE_ROOT) { $env:FLEET_LANE_ROOT } else { "$env:LOCALAPPDATA\fleet-workstation\lanes" }
-  $CargoTargetDir = Join-Path $laneRoot $BuildLane
+  # GH-626: the lane env contract lives in lane-warm.ps1 (-PrintEnv), the same
+  # source lane-warm builds with — the wrapper cannot drift from prepare/warm.
+  # In-process call: 'exit 0/1' in a child script returns here with
+  # $LASTEXITCODE set (verified), so no extra pwsh process is needed.
+  $helperOut = @(& (Join-Path $PSScriptRoot 'lane-warm.ps1') -BuildLane $BuildLane -LaneRoot $laneRoot -PrintEnv)
+  if ($LASTEXITCODE -ne 0) { Fail "lane-warm.ps1 -PrintEnv failed for build lane '$BuildLane'" }
+  $laneEnv = [ordered]@{}
+  foreach ($line in $helperOut) {
+    if ($line -match '^([A-Z][A-Z0-9_]+)=(.*)$') { $laneEnv[$Matches[1]] = $Matches[2] }
+  }
+  if (-not $laneEnv.Contains('CARGO_TARGET_DIR')) {
+    Fail "lane-warm.ps1 -PrintEnv reported no CARGO_TARGET_DIR for build lane '$BuildLane'"
+  }
+  $laneEnvText = ($laneEnv.Keys | ForEach-Object { ('{0} = {1}' -f "`$env:$_", (PsQuote $laneEnv[$_])) }) -join "`r`n"
 }
 $Log = Join-Path $LogDir "$Name.log"
 $Done = Join-Path $LogDir "$Name.done"
@@ -162,7 +180,7 @@ $OutputEncoding = [System.Text.UTF8Encoding]::new($false)
 $env:HOME = $env:USERPROFILE
 # keep `git --help` from opening a browser inside the hidden task
 $env:GIT_CONFIG_PARAMETERS = "'help.format=man'"
-$env:CARGO_TARGET_DIR = __CARGO__
+__LANEENV__
 Set-Location -LiteralPath __CWD__
 $code = $null
 try {
@@ -201,9 +219,9 @@ if ($DryRun) {
   "dry-run real command line (verbatim, as a real lane would run it):"
   "  edda $argLine"
   if ($BuildLane) {
-    $wrapperText = $wrapperText.Replace('__CARGO__', (PsQuote $CargoTargetDir))
+    $wrapperText = $wrapperText.Replace('__LANEENV__', $laneEnvText)
   } else {
-    $wrapperText = $wrapperText -replace '(?m)^.*__CARGO__.*\r?\n', ''
+    $wrapperText = $wrapperText -replace '(?m)^.*__LANEENV__.*\r?\n', ''
   }
   $wrapperText.Replace('__CWD__', (PsQuote $Cwd)).Replace('__LOG__', (PsQuote $Log)).Replace('__RUN__', $runDry).Replace('__DONE__', (PsQuote $Done)) |
     Set-Content -LiteralPath $Wrapper -Encoding utf8
@@ -260,9 +278,9 @@ if ($BudgetUsd -gt 0) { $argLine += " --budget-usd $BudgetUsd" }
 $runReal = "& edda $argLine 2>&1 | Tee-Object -FilePath $(PsQuote $Log) -Append"
 
 if ($BuildLane) {
-  $wrapperText = $wrapperText.Replace('__CARGO__', (PsQuote $CargoTargetDir))
+  $wrapperText = $wrapperText.Replace('__LANEENV__', $laneEnvText)
 } else {
-  $wrapperText = $wrapperText -replace '(?m)^.*__CARGO__.*\r?\n', ''
+  $wrapperText = $wrapperText -replace '(?m)^.*__LANEENV__.*\r?\n', ''
 }
 $wrapperText.Replace('__CWD__', (PsQuote $Cwd)).Replace('__LOG__', (PsQuote $Log)).Replace('__RUN__', $runReal).Replace('__DONE__', (PsQuote $Done)) |
   Set-Content -LiteralPath $Wrapper -Encoding utf8

--- a/scripts/fleet/lane-prepare.ps1
+++ b/scripts/fleet/lane-prepare.ps1
@@ -1,0 +1,223 @@
+# lane-prepare.ps1 — prepare the lane-bound persistent worktree for one of the
+# four ratified build lanes (GH-626).
+#
+# One lane owns ONE worktree at a FIXED path for its whole lifetime:
+#
+#   <main-repo-parent>\<repo-name>-wt-<build-lane>
+#
+# (main checkout C:\ai_agent\edda -> C:\ai_agent\edda-wt-worker-1). The path
+# never changes per issue, so cargo fingerprints survive branch switches and
+# only touched crates recompile (#613 measured: warm lane, branch switched on
+# the same path, ~1s to first compile). Per issue this script switches that
+# worktree to a NEW branch cut from origin/main, gated on:
+#
+#   * the lane's scheduled task is not Running on the worktree (busy gate),
+#   * the worktree is clean (`git status --porcelain` empty; dirty gate),
+#   * the CURRENT branch is pushed — verified by comparing the local tip to
+#     refs/remotes/origin/<branch>; an upstream configuration alone is NOT
+#     accepted (unpushed gate).
+#
+# The script NEVER deletes a branch, a worktree, or source files, and NEVER
+# force-checks-out: every refusal is a loud exit 1 that leaves state untouched.
+# Re-running with the same branch while the worktree sits on it (clean) is an
+# idempotent no-op.
+#
+# Scope note: this script fixes the WORKTREE path only. CARGO_TARGET_DIR
+# (<lane root>\<lane>; lane root = $env:LOCALAPPDATA\fleet-workstation\lanes,
+# overridable by FLEET_LANE_ROOT) is set by the lane wrapper (lane-launch.ps1)
+# and by lane-warm.ps1's Get-LaneBuildEnv. Both helpers derive the worktree
+# path with the identical formula above; lane-warm.ps1 refuses a lane worktree
+# it did not prepare, so the two cannot drift.
+#
+# usage:
+#   pwsh -NoProfile -File scripts/fleet/lane-prepare.ps1 -BuildLane <lane> `
+#        -Branch <new-branch> -Repo <main checkout> [-StartRef origin/main] [-DryRun]
+#
+# -DryRun runs every read-only gate, prints the exact commands a real run
+# would execute, and mutates nothing (no fetch — fetch moves refs).
+#
+# Prints on success: lane=, worktree=, branch=, base= (pinned start SHA).
+# Exit 0 = prepared (or already prepared); 1 = refused / error, nothing changed.
+param(
+  [Parameter(Mandatory = $true)][string]$BuildLane,
+  [Parameter(Mandatory = $true)][string]$Branch,
+  [Parameter(Mandatory = $true)][string]$Repo,
+  [string]$StartRef = 'origin/main',
+  [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Fail([string]$Msg) {
+  [Console]::Error.WriteLine("lane-prepare: $Msg")
+  exit 1
+}
+
+# --- shared helpers (kept in sync with lane-warm.ps1) -----------------------
+
+$allowedBuildLanes = @('worker-1', 'worker-2', 'verifier', 'verifier-2')
+if ($BuildLane -and $allowedBuildLanes -notcontains $BuildLane) {
+  Fail "-BuildLane '$BuildLane' is not an allowed build lane (verification.cost-discipline allows only: $($allowedBuildLanes -join ', '))"
+}
+
+# The FIXED lane worktree path (lane-launch.ps1 and lane-warm.ps1 derive the
+# same path; do not change one without the other).
+function Get-LaneWorktreePath([string]$MainRepo, [string]$Lane) {
+  $parent = Split-Path -Parent $MainRepo
+  $name = Split-Path -Leaf $MainRepo
+  return Join-Path $parent ($name + '-wt-' + $Lane)
+}
+
+# Compare git/Task Scheduler paths robustly: git prints worktree paths with
+# forward slashes, Join-Path produces backslashes; normalize both.
+function ConvertTo-NormPath([string]$p) {
+  return ($p -replace '/', '\').TrimEnd('\').ToLowerInvariant()
+}
+
+function Test-WtRegistered([string]$MainRepo, [string]$WtPath) {
+  $want = ConvertTo-NormPath $WtPath
+  foreach ($line in @(& git -C $MainRepo worktree list --porcelain)) {
+    if ($line -like 'worktree *' -and ((ConvertTo-NormPath $line.Substring('worktree '.Length)) -eq $want)) {
+      return $true
+    }
+  }
+  return $false
+}
+
+# Busy gate: any scheduled task named edda-lane-* in State = Running whose
+# action WorkingDirectory is the lane worktree (lane-launch.ps1 registers the
+# task with that WorkingDirectory). A stopped, registered task is a finished
+# lane, not a busy one. Windows-only by design — the fleet runs on Windows.
+function Test-LaneTaskBusy([string]$WtPath) {
+  $want = ConvertTo-NormPath $WtPath
+  foreach ($t in @(Get-ScheduledTask -TaskName 'edda-lane-*' -ErrorAction SilentlyContinue)) {
+    if ($t.State -ne 'Running') { continue }
+    foreach ($a in $t.Actions) {
+      $wd = if ($a.WorkingDirectory) { $a.WorkingDirectory.TrimEnd('\') } else { '' }
+      if ($wd -and ((ConvertTo-NormPath $wd) -eq $want)) { return $true }
+    }
+  }
+  return $false
+}
+
+function Get-WtBranch([string]$WtPath) {
+  # Empty output = detached HEAD (nothing to verify as pushed).
+  return (& git -C $WtPath symbolic-ref --quiet HEAD 2>$null)
+}
+
+# The unpushed gate: the local tip must MATCH THE REMOTE TIP
+# (refs/remotes/origin/<branch> exists and points at the same commit). A
+# configured upstream alone proves nothing — branch.<name>.remote can point
+# anywhere while local commits remain unpushed (measured trap, GH-626 tests).
+function Test-BranchPushed([string]$WtPath, [string]$Branch) {
+  $remoteRef = "refs/remotes/origin/$Branch"
+  $remoteTip = & git -C $WtPath rev-parse --verify --quiet "$remoteRef^{commit}"
+  if (-not $remoteTip) { return $false }
+  $localTip = & git -C $WtPath rev-parse --verify "refs/heads/$Branch^{commit}"
+  return ($remoteTip -eq $localTip)
+}
+
+# --- resolve the main repo (works from the main checkout or any worktree) ---
+
+& git -C $Repo rev-parse --git-dir >$null 2>$null
+if ($LASTEXITCODE -ne 0) { Fail "-Repo '$Repo' is not a git repository" }
+$commonDir = (& git -C $Repo rev-parse --path-format=absolute --git-common-dir).Trim()
+$MainRepo = Split-Path -Parent $commonDir
+if (-not (Test-Path -LiteralPath $MainRepo)) { Fail "main repo '$MainRepo' (from $Repo) does not exist" }
+
+# Branch-name validation: git's own ref rules (rejects ../, leading '-', ~^:,
+# etc.); no whitespace, no deletion, no force anywhere in this script.
+& git -C $MainRepo check-ref-format --branch $Branch >$null 2>$null
+if ($LASTEXITCODE -ne 0) { Fail "-Branch '$Branch' is not a valid branch name (git check-ref-format)" }
+
+$WtPath = Get-LaneWorktreePath $MainRepo $BuildLane
+
+# --- 1. busy gate ------------------------------------------------------------
+
+if (Test-LaneTaskBusy $WtPath) {
+  Fail "lane '$BuildLane' is busy: a running edda-lane-* task is bound to '$WtPath'; stop it with scripts/fleet/lane-stop.ps1 first"
+}
+
+# --- 2. branch already exists ------------------------------------------------
+
+$branchExists = (& git -C $MainRepo show-ref --verify --quiet "refs/heads/$Branch")
+if ($LASTEXITCODE -eq 0) {
+  # Only acceptable shape: the lane worktree itself is on that branch and
+  # clean — a re-prepare of the same issue. Anything else is refused loudly:
+  # branches are never reused, moved, or deleted here.
+  if (-not (Test-Path -LiteralPath $WtPath -PathType Container)) {
+    Fail "branch '$Branch' already exists but the lane worktree '$WtPath' is missing; refusing to reuse the branch — pick a new branch name (branches are never deleted here)"
+  }
+  if (-not (Test-WtRegistered $MainRepo $WtPath)) {
+    Fail "'$WtPath' exists but is not a registered worktree of '$MainRepo'; refusing to touch it"
+  }
+  $dirty = (& git -C $WtPath status --porcelain)
+  if ($dirty) { Fail "lane worktree '$WtPath' is dirty:`n$dirty"; }
+  $cur = Get-WtBranch $WtPath
+  if ($cur -ne "refs/heads/$Branch") {
+    Fail "branch '$Branch' already exists and is checked out elsewhere; refusing (branches are never deleted or force-moved)"
+  }
+  $msg = "already prepared: lane=$BuildLane worktree=$WtPath branch=$Branch (clean, no-op)"
+  if ($DryRun) { "dry-run: $msg" } else { $msg }
+  exit 0
+}
+
+# --- 3. existing lane worktree: shape, clean, unpushed gates -----------------
+
+if (Test-Path -LiteralPath $WtPath) {
+  if (-not (Test-Path -LiteralPath $WtPath -PathType Container)) {
+    Fail "'$WtPath' exists and is not a directory; refusing to overwrite"
+  }
+  if (-not (Test-WtRegistered $MainRepo $WtPath)) {
+    Fail "'$WtPath' exists but is not a registered worktree of '$MainRepo'; refusing to touch it (remove the collision by hand if it is yours)"
+  }
+  $dirty = (& git -C $WtPath status --porcelain)
+  if ($dirty) { Fail "lane worktree '$WtPath' is dirty:`n$dirty" }
+
+  $cur = Get-WtBranch $WtPath
+  if ($cur) {
+    $curBranch = $cur -replace '^refs/heads/', ''
+    if (-not (Test-BranchPushed $WtPath $curBranch)) {
+      $remoteState = if (& git -C $WtPath rev-parse --verify --quiet "refs/remotes/origin/$curBranch^{commit}") { 'differs from' } else { 'is missing from' }
+      Fail "branch '$curBranch' ($(& git -C $WtPath rev-parse --short HEAD)) is not pushed: the remote tip $remoteState refs/remotes/origin/$curBranch. A configured upstream alone is not sufficient; push the branch before switching the lane worktree"
+    }
+  }
+  # detached HEAD is safe to switch away from: the worktree is clean and no
+  # branch ref is involved.
+}
+
+# --- 4. dry-run: report the exact commands, change nothing -------------------
+
+if ($DryRun) {
+  $baseSha = & git -C $MainRepo rev-parse --verify --quiet "$StartRef^{commit}"
+  if (-not $baseSha) { Fail "start ref '$StartRef' does not resolve (dry-run does not fetch; run a real prepare or fetch first)" }
+  "dry-run: no changes made"
+  "dry-run: would fetch: git -C $MainRepo fetch origin"
+  if (Test-Path -LiteralPath $WtPath) {
+    "dry-run: would switch: git -C $WtPath checkout -b $Branch $StartRef"
+  } else {
+    "dry-run: would create worktree: git -C $MainRepo worktree add -b $Branch $WtPath $StartRef"
+  }
+  "dry-run: worktree=$WtPath branch=$Branch start=$StartRef"
+  exit 0
+}
+
+# --- 5. fetch + create/switch ------------------------------------------------
+
+& git -C $MainRepo fetch origin 2>$null
+if ($LASTEXITCODE -ne 0) { Fail "git fetch origin failed in '$MainRepo'" }
+$baseSha = & git -C $MainRepo rev-parse --verify "$StartRef^{commit}"
+if ($LASTEXITCODE -ne 0 -or -not $baseSha) { Fail "start ref '$StartRef' does not resolve after fetch" }
+
+if (Test-Path -LiteralPath $WtPath) {
+  & git -C $WtPath checkout -b $Branch $baseSha 2>$null
+  if ($LASTEXITCODE -ne 0) { Fail "git checkout -b $Branch failed in '$WtPath'" }
+} else {
+  & git -C $MainRepo worktree add -b $Branch $WtPath $baseSha 2>$null
+  if ($LASTEXITCODE -ne 0) { Fail "git worktree add -b $Branch $WtPath failed" }
+}
+
+"lane=$BuildLane"
+"worktree=$WtPath"
+"branch=$Branch"
+"base=$baseSha"

--- a/scripts/fleet/lane-prepare.ps1
+++ b/scripts/fleet/lane-prepare.ps1
@@ -90,7 +90,13 @@ function Test-WtRegistered([string]$MainRepo, [string]$WtPath) {
 # lane, not a busy one. Windows-only by design — the fleet runs on Windows.
 function Test-LaneTaskBusy([string]$WtPath) {
   $want = ConvertTo-NormPath $WtPath
-  foreach ($t in @(Get-ScheduledTask -TaskName 'edda-lane-*' -ErrorAction SilentlyContinue)) {
+  try {
+    # An empty result proves no matching tasks; a failed query proves nothing.
+    $tasks = @(Get-ScheduledTask -TaskName 'edda-lane-*' -ErrorAction Stop)
+  } catch {
+    Fail "cannot query Task Scheduler for lane activity: $($_.Exception.Message); refusing to switch a lane whose idle state cannot be proven"
+  }
+  foreach ($t in $tasks) {
     if ($t.State -ne 'Running') { continue }
     foreach ($a in $t.Actions) {
       $wd = if ($a.WorkingDirectory) { $a.WorkingDirectory.TrimEnd('\') } else { '' }
@@ -101,8 +107,20 @@ function Test-LaneTaskBusy([string]$WtPath) {
 }
 
 function Get-WtBranch([string]$WtPath) {
-  # Empty output = detached HEAD (nothing to verify as pushed).
+  # Empty output = detached HEAD; its commit gets a separate durability gate.
   return (& git -C $WtPath symbolic-ref --quiet HEAD 2>$null)
+}
+
+# A detached worktree is safe to switch only when its current commit is still
+# reachable from origin's remote-tracking refs. Cleanliness alone does not
+# protect a unique detached commit from becoming reflog-only after checkout.
+function Test-DetachedHeadDurable([string]$WtPath) {
+  $head = (& git -C $WtPath rev-parse --verify 'HEAD^{commit}').Trim()
+  if ($LASTEXITCODE -ne 0 -or -not $head) {
+    Fail "cannot resolve detached HEAD in '$WtPath'; refusing to switch it"
+  }
+  $remoteRefs = @(& git -C $WtPath for-each-ref --contains $head --format='%(refname)' 'refs/remotes/origin/')
+  return (@($remoteRefs | Where-Object { $_ }).Count -gt 0)
 }
 
 # The unpushed gate: the local tip must MATCH THE REMOTE TIP
@@ -181,9 +199,9 @@ if (Test-Path -LiteralPath $WtPath) {
       $remoteState = if (& git -C $WtPath rev-parse --verify --quiet "refs/remotes/origin/$curBranch^{commit}") { 'differs from' } else { 'is missing from' }
       Fail "branch '$curBranch' ($(& git -C $WtPath rev-parse --short HEAD)) is not pushed: the remote tip $remoteState refs/remotes/origin/$curBranch. A configured upstream alone is not sufficient; push the branch before switching the lane worktree"
     }
+  } elseif (-not (Test-DetachedHeadDurable $WtPath)) {
+    Fail "detached HEAD $(& git -C $WtPath rev-parse --short HEAD) is not reachable from an origin remote-tracking ref; attach and push it before switching the lane worktree"
   }
-  # detached HEAD is safe to switch away from: the worktree is clean and no
-  # branch ref is involved.
 }
 
 # --- 4. dry-run: report the exact commands, change nothing -------------------

--- a/scripts/fleet/lane-warm.ps1
+++ b/scripts/fleet/lane-warm.ps1
@@ -1,0 +1,250 @@
+# lane-warm.ps1 — post-merge warmer for idle lane worktrees (GH-626).
+#
+# After a main merge, the controller warms each IDLE lane so the next issue
+# starts with a hot target dir (#613 measured: warm lane ≈1s to first compile
+# vs 30-84s cold). Warm means, strictly:
+#
+#   * the lane worktree was prepared by lane-prepare.ps1 (fixed path
+#     <main-repo-parent>\<repo>-wt-<lane>; warm never creates it),
+#   * no edda-lane-* task is Running on it (busy gate),
+#   * the worktree is clean and its branch is pushed or detached (the same
+#     unpushed gate as lane-prepare: the remote TIP must match; an upstream
+#     configuration alone is not accepted),
+#   * rust-lld.exe is available in the active toolchain sysroot — the shipped
+#     .cargo/config.toml pins it as the MSVC linker (GH-810), so a missing
+#     rust-lld would only surface as a mid-build linker error. Fail fast
+#     instead. No linker path is ever set or guessed here; the repo config
+#     ships it.
+#
+# Then it checks out the merged main tip (detached — no branch is created or
+# moved) and runs `cargo build --workspace --all-targets` — build only, never
+# tests — with the lane env from Get-LaneBuildEnv. The target dir is always
+# the FIXED lane dir <lane-root>\<lane>, never a per-SHA directory. Trimming
+# is deliberately not part of warm: stale `incremental` sessions are reclaimed
+# by age per .claude/CLAUDE.md (Build lanes), and #613 measured trimming buys
+# nothing.
+#
+# usage:
+#   pwsh -NoProfile -File scripts/fleet/lane-warm.ps1 -BuildLane <lane> `
+#        -Repo <main checkout> [-MainRef origin/main] [-LaneRoot <dir>] `
+#        (-Warm | -DryRun | -PrintEnv)
+#
+# Exactly one mode is required: -PrintEnv (print the wrapper env, no repo
+# needed), -DryRun (all read-only gates + exact commands, zero side effects —
+# no fetch, no checkout, no cargo), or -Warm (the explicit requested warm).
+#
+# The lifecycle hook (a scheduled post-merge warmer) is intentionally NOT
+# registered here: the controller invokes this script per idle lane after a
+# merge, per the operator authorization on GH-626 — no hidden service without
+# need.
+param(
+  [Parameter(Mandatory = $true)][string]$BuildLane,
+  [string]$Repo = '',
+  [string]$MainRef = 'origin/main',
+  [string]$LaneRoot = '',
+  [switch]$PrintEnv,
+  [switch]$DryRun,
+  [switch]$Warm
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Fail([string]$Msg) {
+  [Console]::Error.WriteLine("lane-warm: $Msg")
+  exit 1
+}
+
+# --- shared helpers (kept in sync with lane-prepare.ps1) ---------------------
+
+$allowedBuildLanes = @('worker-1', 'worker-2', 'verifier', 'verifier-2')
+if ($BuildLane -and $allowedBuildLanes -notcontains $BuildLane) {
+  Fail "-BuildLane '$BuildLane' is not an allowed build lane (verification.cost-discipline allows only: $($allowedBuildLanes -join ', '))"
+}
+
+# The FIXED lane worktree path (identical formula to lane-prepare.ps1, which
+# is the only thing allowed to create it).
+function Get-LaneWorktreePath([string]$MainRepo, [string]$Lane) {
+  $parent = Split-Path -Parent $MainRepo
+  $name = Split-Path -Leaf $MainRepo
+  return Join-Path $parent ($name + '-wt-' + $Lane)
+}
+
+# Compare git/Task Scheduler paths robustly: git prints worktree paths with
+# forward slashes, Join-Path produces backslashes; normalize both.
+function ConvertTo-NormPath([string]$p) {
+  return ($p -replace '/', '\').TrimEnd('\').ToLowerInvariant()
+}
+
+function Test-WtRegistered([string]$MainRepo, [string]$WtPath) {
+  $want = ConvertTo-NormPath $WtPath
+  foreach ($line in @(& git -C $MainRepo worktree list --porcelain)) {
+    if ($line -like 'worktree *' -and ((ConvertTo-NormPath $line.Substring('worktree '.Length)) -eq $want)) {
+      return $true
+    }
+  }
+  return $false
+}
+
+function Test-LaneTaskBusy([string]$WtPath) {
+  $want = ConvertTo-NormPath $WtPath
+  foreach ($t in @(Get-ScheduledTask -TaskName 'edda-lane-*' -ErrorAction SilentlyContinue)) {
+    if ($t.State -ne 'Running') { continue }
+    foreach ($a in $t.Actions) {
+      $wd = if ($a.WorkingDirectory) { $a.WorkingDirectory.TrimEnd('\') } else { '' }
+      if ($wd -and ((ConvertTo-NormPath $wd) -eq $want)) { return $true }
+    }
+  }
+  return $false
+}
+
+function Get-WtBranch([string]$WtPath) {
+  return (& git -C $WtPath symbolic-ref --quiet HEAD 2>$null)
+}
+
+function Test-BranchPushed([string]$WtPath, [string]$Branch) {
+  $remoteTip = & git -C $WtPath rev-parse --verify --quiet "refs/remotes/origin/$Branch^{commit}"
+  if (-not $remoteTip) { return $false }
+  $localTip = & git -C $WtPath rev-parse --verify "refs/heads/$Branch^{commit}"
+  return ($remoteTip -eq $localTip)
+}
+
+# The lane build env — the single source of truth for what a lane wrapper must
+# set. Exposed via -PrintEnv for the lane-launch.ps1 integration (parent
+# handoff on GH-626): CARGO_INCREMENTAL=1 for worker lanes (focused -p builds),
+# 0 for verifier lanes (the C5 run), and the CI-matching debug trim. The
+# linker is deliberately absent: shipped .cargo/config.toml pins rust-lld.exe
+# for x86_64-pc-windows-msvc, and no machine-specific path is duplicated.
+function Get-LaneBuildEnv([string]$Lane, [string]$Root) {
+  $incremental = if ($Lane -like 'verifier*') { '0' } else { '1' }
+  return [ordered]@{
+    'CARGO_TARGET_DIR'         = (Join-Path $Root $Lane)
+    'CARGO_INCREMENTAL'        = $incremental
+    'CARGO_PROFILE_DEV_DEBUG'  = 'line-tables-only'
+    'CARGO_PROFILE_TEST_DEBUG' = 'line-tables-only'
+  }
+}
+
+# Lane root precedence: explicit -LaneRoot > FLEET_LANE_ROOT > the default
+# under LOCALAPPDATA (same default as lane-launch.ps1). Quoted throughout —
+# a bare assignment of that path is a PowerShell parser error.
+function Resolve-LaneRoot([string]$ExplicitRoot) {
+  if ($ExplicitRoot) { return $ExplicitRoot }
+  if ($env:FLEET_LANE_ROOT) { return $env:FLEET_LANE_ROOT }
+  return (Join-Path $env:LOCALAPPDATA 'fleet-workstation\lanes')
+}
+
+# rust-lld availability, exactly as the shipped .cargo/config.toml resolves
+# it: a bare linker name inside the toolchain's target bin directory.
+function Get-RustLldState() {
+  try {
+    $sysroot = (& rustc --print sysroot 2>$null)
+    if (-not $sysroot -or $LASTEXITCODE -ne 0) { return 'absent (rustc not runnable)' }
+    $lld = Join-Path ([string]$sysroot) 'lib\rustlib\x86_64-pc-windows-msvc\bin\rust-lld.exe'
+    if (Test-Path -LiteralPath $lld -PathType Leaf) { return "present ($lld)" }
+    return "absent (expected $lld)"
+  } catch {
+    return 'absent (rustc not runnable)'
+  }
+}
+
+# --- mode selection -----------------------------------------------------------
+
+$modes = @()
+if ($PrintEnv) { $modes += 'PrintEnv' }
+if ($DryRun) { $modes += 'DryRun' }
+if ($Warm) { $modes += 'Warm' }
+if ($modes.Count -ne 1) {
+  Fail "exactly one of -PrintEnv, -DryRun, -Warm is required (got: $(if ($modes) { $modes -join ', ' } else { 'none' }))"
+}
+
+# --- -PrintEnv: expose the wrapper env for the lane-launch integration -------
+
+if ($PrintEnv) {
+  $root = Resolve-LaneRoot $LaneRoot
+  $env0 = Get-LaneBuildEnv $BuildLane $root
+  "# lane wrapper env for -BuildLane $BuildLane (lane-launch.ps1 integration, GH-626)"
+  foreach ($k in $env0.Keys) { "$k=$($env0[$k])" }
+  "# linker: not set here — shipped .cargo/config.toml pins rust-lld.exe for x86_64-pc-windows-msvc"
+  exit 0
+}
+
+# --- -DryRun / -Warm: the lane worktree must already be prepared --------------
+
+if (-not $Repo) { Fail "-Repo is required for -DryRun and -Warm" }
+& git -C $Repo rev-parse --git-dir >$null 2>$null
+if ($LASTEXITCODE -ne 0) { Fail "-Repo '$Repo' is not a git repository" }
+$commonDir = (& git -C $Repo rev-parse --path-format=absolute --git-common-dir).Trim()
+$MainRepo = Split-Path -Parent $commonDir
+
+$WtPath = Get-LaneWorktreePath $MainRepo $BuildLane
+if (-not (Test-Path -LiteralPath $WtPath -PathType Container)) {
+  Fail "lane worktree '$WtPath' does not exist; run scripts/fleet/lane-prepare.ps1 -BuildLane $BuildLane first (warm never creates worktrees)"
+}
+if (-not (Test-WtRegistered $MainRepo $WtPath)) { Fail "'$WtPath' is not a registered worktree of '$MainRepo'; refusing" }
+
+$reasons = @()
+if (Test-LaneTaskBusy $WtPath) { $reasons += "busy: a running edda-lane-* task is bound to '$WtPath'" }
+$dirty = (& git -C $WtPath status --porcelain)
+if ($dirty) { $reasons += "dirty worktree:`n$dirty" }
+$cur = Get-WtBranch $WtPath
+$pushed = $true
+if ($cur) {
+  $curBranch = $cur -replace '^refs/heads/', ''
+  $pushed = Test-BranchPushed $WtPath $curBranch
+  if (-not $pushed) {
+    $remoteState = if (& git -C $WtPath rev-parse --verify --quiet "refs/remotes/origin/$curBranch^{commit}") { 'differs from' } else { 'is missing from' }
+    $reasons += "branch '$curBranch' is not pushed: the remote tip $remoteState refs/remotes/origin/$curBranch; an upstream configuration alone is not sufficient"
+  }
+}
+$rustLld = Get-RustLldState
+
+if ($reasons.Count -gt 0) {
+  $msg = "warm refused for lane '$BuildLane' on '$WtPath': $($reasons -join '; ')"
+  if ($DryRun) { [Console]::Error.WriteLine("lane-warm: dry-run: would refuse: $msg"); exit 1 }
+  Fail $msg
+}
+
+if ($rustLld -like 'absent*') {
+  $msg = "rust-lld.exe is $rustLld — the shipped .cargo/config.toml pins it as the MSVC linker, so the build would fail; update the toolchain (GH-810)"
+  if ($DryRun) { [Console]::Error.WriteLine("lane-warm: dry-run: would refuse: $msg"); exit 1 }
+  Fail $msg
+}
+
+$laneRoot = Resolve-LaneRoot $LaneRoot
+$buildEnv = Get-LaneBuildEnv $BuildLane $laneRoot
+
+if ($DryRun) {
+  "warm: dry-run, no changes made"
+  "warm: worktree=$WtPath"
+  foreach ($k in $buildEnv.Keys) { "warm: $k=$($buildEnv[$k])" }
+  "warm: linker=from shipped .cargo/config.toml (rust-lld.exe); rustlld=$rustLld"
+  "warm: would fetch: git -C $MainRepo fetch origin"
+  "warm: would checkout: git -C $WtPath checkout --detach $MainRef"
+  "warm: would run (cwd=$WtPath): cargo build --workspace --all-targets"
+  exit 0
+}
+
+# --- the explicit requested warm ----------------------------------------------
+
+& git -C $MainRepo fetch origin 2>$null
+if ($LASTEXITCODE -ne 0) { Fail "git fetch origin failed in '$MainRepo'" }
+$mainSha = & git -C $MainRepo rev-parse --verify "$MainRef^{commit}"
+if ($LASTEXITCODE -ne 0 -or -not $mainSha) { Fail "main ref '$MainRef' does not resolve after fetch" }
+
+& git -C $WtPath checkout --detach $mainSha 2>$null
+if ($LASTEXITCODE -ne 0) { Fail "git checkout --detach $mainSha failed in '$WtPath'" }
+
+foreach ($k in $buildEnv.Keys) { Set-Item -Path "env:$k" -Value $buildEnv[$k] }
+
+Push-Location -LiteralPath $WtPath
+try {
+  $start = Get-Date
+  & cargo build --workspace --all-targets 2>&1 | ForEach-Object { "$_" } | Write-Output
+  $code = $LASTEXITCODE
+  $seconds = [math]::Round(((Get-Date) - $start).TotalSeconds, 1)
+  "warm: lane=$BuildLane worktree=$WtPath main=$mainSha"
+  "warm: cargo exit=$code duration=${seconds}s target_dir=$($buildEnv['CARGO_TARGET_DIR'])"
+  exit $code
+} finally {
+  Pop-Location
+}

--- a/scripts/fleet/lane-warm.ps1
+++ b/scripts/fleet/lane-warm.ps1
@@ -87,7 +87,13 @@ function Test-WtRegistered([string]$MainRepo, [string]$WtPath) {
 
 function Test-LaneTaskBusy([string]$WtPath) {
   $want = ConvertTo-NormPath $WtPath
-  foreach ($t in @(Get-ScheduledTask -TaskName 'edda-lane-*' -ErrorAction SilentlyContinue)) {
+  try {
+    # An empty result proves no matching tasks; a failed query proves nothing.
+    $tasks = @(Get-ScheduledTask -TaskName 'edda-lane-*' -ErrorAction Stop)
+  } catch {
+    Fail "cannot query Task Scheduler for lane activity: $($_.Exception.Message); refusing to warm a lane whose idle state cannot be proven"
+  }
+  foreach ($t in $tasks) {
     if ($t.State -ne 'Running') { continue }
     foreach ($a in $t.Actions) {
       $wd = if ($a.WorkingDirectory) { $a.WorkingDirectory.TrimEnd('\') } else { '' }
@@ -99,6 +105,18 @@ function Test-LaneTaskBusy([string]$WtPath) {
 
 function Get-WtBranch([string]$WtPath) {
   return (& git -C $WtPath symbolic-ref --quiet HEAD 2>$null)
+}
+
+# Warm will detach at main, so an existing detached commit must first be
+# reachable from origin. Otherwise checkout would strand unique work in a
+# reflog even though the worktree is clean.
+function Test-DetachedHeadDurable([string]$WtPath) {
+  $head = (& git -C $WtPath rev-parse --verify 'HEAD^{commit}').Trim()
+  if ($LASTEXITCODE -ne 0 -or -not $head) {
+    Fail "cannot resolve detached HEAD in '$WtPath'; refusing to warm it"
+  }
+  $remoteRefs = @(& git -C $WtPath for-each-ref --contains $head --format='%(refname)' 'refs/remotes/origin/')
+  return (@($remoteRefs | Where-Object { $_ }).Count -gt 0)
 }
 
 function Test-BranchPushed([string]$WtPath, [string]$Branch) {
@@ -195,6 +213,8 @@ if ($cur) {
     $remoteState = if (& git -C $WtPath rev-parse --verify --quiet "refs/remotes/origin/$curBranch^{commit}") { 'differs from' } else { 'is missing from' }
     $reasons += "branch '$curBranch' is not pushed: the remote tip $remoteState refs/remotes/origin/$curBranch; an upstream configuration alone is not sufficient"
   }
+} elseif (-not (Test-DetachedHeadDurable $WtPath)) {
+  $reasons += "detached HEAD $(& git -C $WtPath rev-parse --short HEAD) is not reachable from an origin remote-tracking ref; attach and push it before warming"
 }
 $rustLld = Get-RustLldState
 

--- a/scripts/fleet/test-lane-helpers.sh
+++ b/scripts/fleet/test-lane-helpers.sh
@@ -1,0 +1,426 @@
+#!/bin/sh
+# Self-test for scripts/fleet/lane-prepare.ps1 and scripts/fleet/lane-warm.ps1
+# (GH-626). Offline fixtures only: throwaway repos with a local bare "origin",
+# a temp FLEET_LANE_ROOT, stub rustc/cargo on PATH (no real Cargo run), and one
+# real scheduled task (the established pattern of scripts/test-git-config-guard.sh)
+# to prove the busy gate against a genuinely Running edda-lane-* task.
+#
+# Contract pinned here:
+#   * prepare creates the FIXED lane worktree path
+#     <main-repo-parent>\<repo>-wt-<lane> and a new branch from origin/main,
+#     and is idempotent for the same branch,
+#   * prepare refuses: dirty worktree, unpushed previous branch (upstream
+#     configuration alone is not accepted — the remote TIP must match), a
+#     running lane task bound to the worktree, an existing branch, a path
+#     collision, a bad lane/branch name — always loudly, never force-checkout,
+#     never deletion,
+#   * warm refuses: worktree not prepared, dirty, unpushed, busy, rust-lld
+#     absent from the active toolchain — and never starts cargo in those cases,
+#   * warm -DryRun and prepare -DryRun have ZERO side effects (no fetch, no
+#     refs, no checkout, no cargo) and print the exact commands,
+#   * env contract: CARGO_TARGET_DIR=<lane-root>\<lane> (fixed lane dir, never
+#     per-SHA), CARGO_INCREMENTAL=1 for workers / 0 for verifiers,
+#     CARGO_PROFILE_DEV_DEBUG and CARGO_PROFILE_TEST_DEBUG = line-tables-only;
+#     the linker comes from the shipped .cargo/config.toml, never a guessed
+#     machine path,
+#   * lane-warm -PrintEnv exposes the same env for the lane-launch integration;
+#     lane-launch -DryRun proves the wrapper actually carries it (with
+#     -BuildLane: the full contract; without: no CARGO_* env at all),
+#
+# Style follows scripts/test-git-config-guard.sh — no new tooling.
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
+PREPARE="$root/scripts/fleet/lane-prepare.ps1"
+WARM="$root/scripts/fleet/lane-warm.ps1"
+
+command -v pwsh >/dev/null 2>&1 || { echo "SKIP: pwsh not on PATH"; exit 0; }
+command -v git >/dev/null 2>&1 || { echo "SKIP: git not on PATH"; exit 0; }
+
+tmp=$(mktemp -d)
+BUSY_TASK='edda-lane-busytest'
+
+cleanup() {
+  pwsh -NoProfile -NonInteractive -Command "
+    Stop-ScheduledTask -TaskName '$BUSY_TASK' -ErrorAction SilentlyContinue
+    Unregister-ScheduledTask -TaskName '$BUSY_TASK' -Confirm:\$false -ErrorAction SilentlyContinue
+    foreach (\$n in @('gh626envcheck', 'gh626noenv')) {
+      Unregister-ScheduledTask -TaskName ('edda-lane-' + \$n) -Confirm:\$false -ErrorAction SilentlyContinue
+    }
+    foreach (\$h in @(Get-CimInstance Win32_Process | Where-Object { \$_.CommandLine -and \$_.CommandLine.Contains('lane-helper-busy.ps1') })) {
+      & taskkill /PID \$h.ProcessId /T /F 2>\$null | Out-Null
+    }
+  " >/dev/null 2>&1 || true
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+case_number=0
+fail() { echo "FAIL (after case $case_number): $*" >&2; exit 1; }
+ok() { case_number=$((case_number + 1)); echo "ok $case_number - $*"; }
+
+prepare() { pwsh -NoProfile -NonInteractive -File "$PREPARE" "$@"; }
+warm()    { pwsh -NoProfile -NonInteractive -File "$WARM" "$@"; }
+
+# A throwaway repo with one commit on main, pushed to a local bare origin.
+new_repo() {
+  name=$1
+  origin="$tmp/$name-origin.git"
+  repo="$tmp/$name"
+  git init -q --bare "$origin"
+  git init -q "$repo"
+  git -C "$repo" config user.email t@example.com
+  git -C "$repo" config user.name tester
+  git -C "$repo" config commit.gpgsign false
+  echo hello >"$repo/f.txt"
+  git -C "$repo" add f.txt
+  git -C "$repo" commit -qm init
+  git -C "$repo" branch -M main 2>/dev/null || true
+  git -C "$repo" remote add origin "$origin"
+  git -C "$repo" push -q origin main
+  printf '%s' "$repo"
+}
+
+# The FIXED lane worktree path the helpers must derive (POSIX form for git,
+# Windows form for output comparison).
+wt_posix() { printf '%s' "$1-wt-$2"; }
+wt_win()   { cygpath -m "$1-wt-$2"; }
+
+refs_snapshot() { git -C "$1" for-each-ref | sed 's/ $//'; }
+
+# Register a genuinely Running scheduled task whose WorkingDirectory is the
+# given directory — the shape lane-launch.ps1 produces for a live lane.
+register_busy_task() {
+  wdir=$(cygpath -w "$1")
+  taskscript="$tmp/lane-helper-busy.ps1"
+  printf 'Start-Sleep -Seconds 180\n' >"$taskscript"
+  wscript=$(cygpath -w "$taskscript")
+  pwsh -NoProfile -NonInteractive -Command "
+    \$action = New-ScheduledTaskAction -Execute (Get-Command pwsh.exe).Source \`
+      -Argument \"-NoProfile -NonInteractive -File $wscript\" -WorkingDirectory '$wdir'
+    \$settings = New-ScheduledTaskSettingsSet \`
+      -ExecutionTimeLimit (New-TimeSpan -Seconds 120) \`
+      -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
+    Unregister-ScheduledTask -TaskName '$BUSY_TASK' -Confirm:\$false -ErrorAction SilentlyContinue
+    Register-ScheduledTask -TaskName '$BUSY_TASK' -Action \$action -Settings \$settings -RunLevel Limited | Out-Null
+    Start-ScheduledTask -TaskName '$BUSY_TASK'
+    Start-Sleep -Seconds 2
+    (Get-ScheduledTask -TaskName '$BUSY_TASK').State
+  "
+}
+
+# Stub toolchain: rustc prints a fake sysroot; cargo records its argv and the
+# build env into $FIXTURE_RECORD and exits 0. present=yes|no controls whether
+# the fake sysroot contains rust-lld.exe.
+make_stub_bin() {
+  dir=$1; present=$2
+  mkdir -p "$dir"
+  sysroot="$tmp/stub-sysroot-$present"
+  rm -rf "$sysroot"; mkdir -p "$sysroot"
+  if [ "$present" = yes ]; then
+    mkdir -p "$sysroot/lib/rustlib/x86_64-pc-windows-msvc/bin"
+    : >"$sysroot/lib/rustlib/x86_64-pc-windows-msvc/bin/rust-lld.exe"
+  fi
+  wsysroot=$(cygpath -w "$sysroot")
+  printf '@echo off\r\necho %s\r\n' "$wsysroot" >"$dir/rustc.cmd"
+  {
+    printf '@echo off\r\n'
+    printf 'if not "%%FIXTURE_RECORD%%"=="" (\r\n'
+    printf '  echo cargo %%* >> "%%FIXTURE_RECORD%%"\r\n'
+    printf '  echo TDIR=%%CARGO_TARGET_DIR%% INCR=%%CARGO_INCREMENTAL%% DEV=%%CARGO_PROFILE_DEV_DEBUG%% TEST=%%CARGO_PROFILE_TEST_DEBUG%% >> "%%FIXTURE_RECORD%%"\r\n'
+    printf ')\r\n'
+    printf 'exit /b 0\r\n'
+  } >"$dir/cargo.cmd"
+}
+
+expect_ok() {
+  desc=$1; shift
+  if ! out=$("$@" 2>&1); then fail "$desc: expected success :: $out"; fi
+}
+
+expect_fail() {
+  desc=$1; want=$2; shift 2
+  if out=$("$@" 2>&1); then fail "$desc: expected failure, got success :: $out"; fi
+  case "$out" in
+    *"$want"*) : ;;
+    *) fail "$desc: output missing '$want' :: $out" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# lane-prepare.ps1
+
+repo=$(new_repo prep1)
+lane=$(wt_posix "$repo" worker-1)
+lanewin=$(wt_win "$repo" worker-1)
+
+expect_ok "prepare happy path" prepare -BuildLane worker-1 -Branch codex/gh100-a -Repo "$repo"
+[ -e "$lane/.git" ] || fail "prepare: lane worktree not created at $lane"
+cur=$(git -C "$lane" symbolic-ref --quiet HEAD)
+[ "$cur" = "refs/heads/codex/gh100-a" ] || fail "prepare: branch is $cur, expected refs/heads/codex/gh100-a"
+base=$(git -C "$repo" rev-parse origin/main)
+[ "$(git -C "$lane" rev-parse HEAD)" = "$base" ] || fail "prepare: tip is not origin/main"
+git -C "$repo" worktree list --porcelain | grep -F "$(cygpath -m "$lane")" >/dev/null \
+  || fail "prepare: worktree not registered with the repo"
+ok "prepare creates fixed worktree $lanewin on a new branch from origin/main"
+
+expect_ok "prepare idempotent same branch" prepare -BuildLane worker-1 -Branch codex/gh100-a -Repo "$repo"
+[ "$(git -C "$lane" symbolic-ref --quiet HEAD)" = "refs/heads/codex/gh100-a" ] \
+  || fail "idempotent prepare moved the worktree"
+ok "prepare re-run on the same branch is a no-op"
+
+# Previous branch with an extra commit, upstream CONFIGURED but remote tip absent.
+git -C "$lane" commit -q --allow-empty -m extra
+git -C "$lane" branch -u origin/main codex/gh100-a
+before_head=$(git -C "$lane" rev-parse HEAD)
+expect_fail "prepare unpushed" "remote tip" prepare -BuildLane worker-1 -Branch codex/gh101-b -Repo "$repo"
+[ "$(git -C "$lane" rev-parse HEAD)" = "$before_head" ] || fail "refused prepare still moved HEAD"
+ok "prepare refuses to switch away from an unpushed branch (upstream config not trusted)"
+
+git -C "$lane" push -q origin codex/gh100-a
+expect_ok "prepare switch after push" prepare -BuildLane worker-1 -Branch codex/gh101-b -Repo "$repo"
+[ "$(git -C "$lane" symbolic-ref --quiet HEAD)" = "refs/heads/codex/gh101-b" ] \
+  || fail "prepare did not switch to the new branch"
+ok "prepare switches the fixed worktree once the previous branch is pushed"
+
+echo dirty >"$lane/dirty.txt"
+expect_fail "prepare dirty" "dirty" prepare -BuildLane worker-1 -Branch codex/gh102-c -Repo "$repo"
+[ "$(git -C "$lane" symbolic-ref --quiet HEAD)" = "refs/heads/codex/gh101-b" ] \
+  || fail "refused dirty prepare moved HEAD"
+rm "$lane/dirty.txt"
+ok "prepare refuses a dirty lane worktree"
+
+git -C "$lane" push -q origin codex/gh101-b
+
+expect_fail "prepare existing branch" "already exists" prepare -BuildLane worker-1 -Branch main -Repo "$repo"
+ok "prepare refuses an existing branch instead of reusing or deleting it"
+
+# A branch that already exists with NO lane worktree must be refused too:
+# branches are never reused, moved, or deleted.
+git -C "$repo" branch codex/gh108-nowt
+expect_fail "prepare existing branch missing worktree" "already exists but the lane worktree" \
+  prepare -BuildLane verifier -Branch codex/gh108-nowt -Repo "$repo"
+[ ! -d "$(wt_posix "$repo" verifier)" ] || fail "prepare created a worktree for an existing branch"
+ok "prepare refuses an existing branch whose lane worktree does not exist"
+
+# Genuine collision: a FILE at the exact FIXED lane worktree path. (The
+# original fixture used a sibling '<lane>-collision' path, which collides with
+# nothing — every gate passed and prepare actually switched branches, so the
+# case proved nothing: RED 2026-09-04, test setup fixed, guard unchanged.)
+crepo=$(new_repo prep2)
+printf x >"$(wt_posix "$crepo" verifier-2)"
+expect_fail "prepare collision" "not a directory" prepare -BuildLane verifier-2 -Branch codex/gh103-d -Repo "$crepo"
+[ "$(cat "$(wt_posix "$crepo" verifier-2)")" = "x" ] || fail "prepare overwrote the colliding file"
+[ ! -d "$(wt_posix "$crepo" verifier-2)" ] || fail "prepare replaced the colliding file with a worktree"
+ok "prepare refuses a file at the fixed lane worktree path (no overwrite)"
+
+expect_fail "prepare bad lane" "allowed" prepare -BuildLane worker-3 -Branch codex/x -Repo "$repo"
+expect_fail "prepare bad branch" "ref" prepare -BuildLane worker-1 -Branch '../evil' -Repo "$repo"
+ok "prepare validates lane and branch names"
+
+# Busy gate: a genuinely Running task bound to the lane worktree path.
+git -C "$repo" worktree add -q -b codex/gh104-busy "$(wt_posix "$repo" worker-2)" origin/main
+state=$(register_busy_task "$(wt_posix "$repo" worker-2)")
+[ "$state" = "Running" ] || fail "busy fixture task did not reach Running (state=$state)"
+expect_fail "prepare busy" "busy" prepare -BuildLane worker-2 -Branch codex/gh105-e -Repo "$repo"
+[ "$(git -C "$(wt_posix "$repo" worker-2)" symbolic-ref --quiet HEAD)" = "refs/heads/codex/gh104-busy" ] \
+  || fail "busy refusal still switched the worktree"
+ok "prepare refuses a lane whose scheduled task is Running on the worktree"
+
+# Dry-run: exact commands, zero side effects — both arms. A fresh lane (no
+# worktree) prints `worktree add`; a prepared lane prints `checkout -b`. (The
+# original case asserted the checkout arm against a fresh lane, whose dry-run
+# correctly prints worktree add — a second latent assertion bug, never reached
+# before the collision case was fixed.)
+before_refs=$(refs_snapshot "$repo")
+before_wts=$(git -C "$repo" worktree list --porcelain)
+expect_ok "prepare dry-run fresh" prepare -BuildLane verifier -Branch codex/gh106-f -Repo "$repo" -DryRun
+out=$(prepare -BuildLane verifier -Branch codex/gh106-f -Repo "$repo" -DryRun 2>&1)
+case "$out" in *worktree\ add*) : ;; *) fail "dry-run does not show the worktree add command :: $out" ;; esac
+[ ! -d "$(wt_posix "$repo" verifier)" ] || fail "dry-run created the worktree"
+[ "$(refs_snapshot "$repo")" = "$before_refs" ] || fail "dry-run mutated refs"
+[ "$(git -C "$repo" worktree list --porcelain)" = "$before_wts" ] || fail "dry-run registered a worktree"
+ok "prepare -DryRun (fresh lane) prints the exact worktree-add command and mutates nothing"
+
+expect_ok "prepare fixture switch" prepare -BuildLane verifier -Branch codex/gh106-f -Repo "$repo"
+[ "$(git -C "$(wt_posix "$repo" verifier)" symbolic-ref --quiet HEAD)" = "refs/heads/codex/gh106-f" ] \
+  || fail "fixture: verifier worktree not on codex/gh106-f"
+git -C "$(wt_posix "$repo" verifier)" push -q origin codex/gh106-f  # fixture: the unpushed gate must not fire
+before_refs=$(refs_snapshot "$repo")
+out=$(prepare -BuildLane verifier -Branch codex/gh109-h -Repo "$repo" -DryRun 2>&1)
+case "$out" in *"checkout -b"*) : ;; *) fail "dry-run does not show the checkout command :: $out" ;; esac
+[ "$(refs_snapshot "$repo")" = "$before_refs" ] || fail "dry-run mutated refs"
+[ "$(git -C "$(wt_posix "$repo" verifier)" symbolic-ref --quiet HEAD)" = "refs/heads/codex/gh106-f" ] \
+  || fail "dry-run switched the prepared lane worktree"
+ok "prepare -DryRun (prepared lane) prints the exact checkout command and mutates nothing"
+
+echo dirty >"$(wt_posix "$repo" worker-1)/dirty.txt"
+before_refs=$(refs_snapshot "$repo")
+expect_fail "prepare dry-run dirty" "dirty" prepare -BuildLane worker-1 -Branch codex/gh107-g -Repo "$repo" -DryRun
+[ "$(refs_snapshot "$repo")" = "$before_refs" ] || fail "dry-run refusal mutated refs"
+rm "$(wt_posix "$repo" worker-1)/dirty.txt"
+ok "prepare -DryRun on a dirty lane reports the refusal and mutates nothing"
+
+# ---------------------------------------------------------------------------
+# lane-warm.ps1
+
+wrepo=$(new_repo warm1)
+wwt=$(wt_posix "$wrepo" worker-1)
+expect_fail "warm unprepared" "lane-prepare" warm -BuildLane worker-1 -Repo "$wrepo" -Warm
+ok "warm refuses a lane whose worktree was never prepared"
+
+expect_ok "warm fixture prepare" prepare -BuildLane worker-1 -Branch codex/gh200-a -Repo "$wrepo"
+git -C "$wwt" commit -q --allow-empty -m unpushed
+stub="$tmp/stubbin"
+record="$tmp/cargo-record.txt"; : >"$record"
+make_stub_bin "$stub" yes
+# POSIX `env` cannot exec a shell function (three latent `env warm ...`
+# failures, never reached in the previous session), so env-var prefixes are
+# bracketed exports around the function calls instead. PATH carries the stub
+# toolchain: without it -Warm resolves the REAL cargo and starts a full
+# workspace build inside the test (the timeout of the previous session); the
+# stub records argv + env and exits 0 — no real Cargo run.
+old_path=$PATH
+export PATH="$stub:$PATH"
+export FIXTURE_RECORD="$(cygpath -w "$record")"
+
+expect_fail "warm unpushed" "remote tip" warm -BuildLane worker-1 -Repo "$wrepo" -Warm
+[ ! -s "$record" ] || fail "refused warm still invoked cargo"
+ok "warm refuses an unpushed branch and never starts cargo"
+
+git -C "$wwt" reset -q --hard origin/main  # fixture repair: back to the pushed tip
+git -C "$wwt" push -q origin codex/gh200-a
+wlaneroot=$(cygpath -w "$tmp/lanes")
+export FLEET_LANE_ROOT="$wlaneroot"
+
+out=$(warm -BuildLane worker-1 -Repo "$wrepo" -DryRun 2>&1)
+case "$out" in
+  *"cargo build --workspace --all-targets"*) : ;;
+  *) fail "warm dry-run does not show the exact build command :: $out" ;;
+esac
+case "$out" in
+  *"CARGO_TARGET_DIR=$wlaneroot\\worker-1"*) : ;;
+  *) fail "warm dry-run CARGO_TARGET_DIR is not the fixed lane dir :: $out" ;;
+esac
+case "$out" in
+  *"CARGO_INCREMENTAL=1"*) : ;;
+  *) fail "warm dry-run does not set CARGO_INCREMENTAL=1 for a worker :: $out" ;;
+esac
+case "$out" in
+  *"line-tables-only"*) : ;;
+  *) fail "warm dry-run does not report line-tables-only :: $out" ;;
+esac
+case "$out" in
+  *"rust-lld"*) : ;;
+  *) fail "warm dry-run does not report the shipped rust-lld linker :: $out" ;;
+esac
+[ ! -s "$record" ] || fail "warm dry-run invoked cargo"
+[ "$(git -C "$wwt" symbolic-ref --quiet HEAD)" = "refs/heads/codex/gh200-a" ] \
+  || fail "warm dry-run checked out"
+ok "warm -DryRun reports exact command, fixed lane dir, env; zero side effects"
+
+# default lane root: FLEET_LANE_ROOT must be unset for these two
+unset FLEET_LANE_ROOT
+# fixture: warm never creates worktrees, so the verifier-2 dry-run needs one
+expect_ok "warm fixture prepare verifier-2" prepare -BuildLane verifier-2 -Branch codex/gh201-b -Repo "$wrepo"
+git -C "$(wt_posix "$wrepo" verifier-2)" push -q origin codex/gh201-b
+out=$(warm -BuildLane verifier-2 -Repo "$wrepo" -DryRun 2>&1)
+case "$out" in
+  *"CARGO_INCREMENTAL=0"*) : ;;
+  *) fail "verifier lane should warm with CARGO_INCREMENTAL=0 :: $out" ;;
+esac
+ok "warm sets CARGO_INCREMENTAL=0 for verifier lanes"
+
+out=$(warm -BuildLane worker-1 -Repo "$wrepo" -DryRun 2>&1)
+case "$out" in
+  *"$LOCALAPPDATA\\fleet-workstation\\lanes\\worker-1"*) : ;;
+  *) fail "default lane root is not LOCALAPPDATA fleet-workstation lanes :: $out" ;;
+esac
+ok "warm defaults the lane root to LOCALAPPDATA\fleet-workstation\lanes"
+export FLEET_LANE_ROOT="$wlaneroot"
+
+expect_ok "warm happy path" warm -BuildLane worker-1 -Repo "$wrepo" -Warm
+recorded=$(cat "$record")
+case "$recorded" in
+  *"cargo build --workspace --all-targets"*) : ;;
+  *) fail "warm did not run cargo build --workspace --all-targets :: $recorded" ;;
+esac
+case "$recorded" in
+  *"--all-targets test"*|*"cargo test"*) fail "warm ran tests :: $recorded" ;;
+  *) : ;;
+esac
+case "$recorded" in
+  *"TDIR=$wlaneroot\\worker-1 INCR=1 DEV=line-tables-only TEST=line-tables-only"*) : ;;
+  *) fail "warm passed the wrong env to cargo :: $recorded" ;;
+esac
+main_sha=$(git -C "$wrepo" rev-parse origin/main)
+[ "$(git -C "$wwt" rev-parse HEAD)" = "$main_sha" ] || fail "warm did not check out the merged main tip"
+[ -z "$(git -C "$wwt" symbolic-ref -q HEAD)" ] || fail "warm left the worktree on a branch"
+ok "warm checks out merged main and runs cargo build --workspace --all-targets with the lane env"
+
+expect_fail "warm busy" "busy" warm -BuildLane worker-2 -Repo "$repo" -Warm
+ok "warm refuses a lane whose scheduled task is Running"
+
+# rust-lld absent from the active toolchain: fail fast, before any checkout/build.
+absent_stub="$tmp/stubbin-absent"; : >"$record"
+make_stub_bin "$absent_stub" no
+before_head=$(git -C "$wwt" rev-parse HEAD)
+export PATH="$absent_stub:$PATH"
+expect_fail "warm rustlld absent" "rust-lld" warm -BuildLane worker-1 -Repo "$wrepo" -Warm
+export PATH="$stub:$PATH"
+[ ! -s "$record" ] || fail "rust-lld absent warm still invoked cargo"
+[ "$(git -C "$wwt" rev-parse HEAD)" = "$before_head" ] || fail "rust-lld absent warm still checked out"
+ok "warm fails fast when rust-lld.exe is absent from the toolchain sysroot"
+
+out=$(warm -BuildLane worker-1 -PrintEnv 2>&1)  # FLEET_LANE_ROOT still exported
+case "$out" in
+  *"CARGO_TARGET_DIR=$wlaneroot\\worker-1"*) : ;;
+  *) fail "PrintEnv CARGO_TARGET_DIR wrong :: $out" ;;
+esac
+case "$out" in
+  *"CARGO_INCREMENTAL=1"*) : ;;
+  *) fail "PrintEnv worker incremental wrong :: $out" ;;
+esac
+out=$(warm -BuildLane verifier-2 -PrintEnv 2>&1)
+case "$out" in
+  *"CARGO_INCREMENTAL=0"*) : ;;
+  *) fail "PrintEnv verifier incremental wrong :: $out" ;;
+esac
+ok "lane-warm -PrintEnv exposes the wrapper env for the lane-launch integration"
+
+expect_fail "warm mode ambiguity" "exactly one" warm -BuildLane worker-1 -Repo "$wrepo" -PrintEnv -DryRun
+expect_fail "warm no mode" "exactly one" warm -BuildLane worker-1 -Repo "$wrepo"
+ok "warm requires exactly one of -PrintEnv / -DryRun / -Warm"
+
+# restore the caller environment before the launch section
+unset FIXTURE_RECORD FLEET_LANE_ROOT
+export PATH="$old_path"
+
+# ---------------------------------------------------------------------------
+# lane-launch.ps1 wrapper env integration (GH-626): the wrapper must receive
+# the lane env contract from lane-warm -PrintEnv — one owner, no duplicated
+# literal — and must set NO CARGO_* env at all without a build lane.
+launch() { pwsh -NoProfile -NonInteractive -File "$root/scripts/fleet/lane-launch.ps1" "$@"; }
+llog="$tmp/launch-logs"; mkdir -p "$llog"
+
+expect_ok "launch dry-run with build lane" launch -Name gh626envcheck -Cwd "$repo" \
+  -BuildLane worker-1 -LogDir "$llog" -TimeoutSec 60 -DryRun
+lw="$llog/gh626envcheck.dryrun-wrapper.ps1"
+[ -f "$lw" ] || fail "launch dry-run produced no wrapper"
+grep -F "\$env:CARGO_TARGET_DIR = " "$lw" | grep -F "worker-1" >/dev/null \
+  || fail "launch wrapper CARGO_TARGET_DIR is not the fixed lane dir"
+grep -F "\$env:CARGO_INCREMENTAL = '1'" "$lw" >/dev/null \
+  || fail "launch wrapper missing CARGO_INCREMENTAL=1 for a worker lane"
+n=$(grep -cF 'line-tables-only' "$lw" || true)
+[ "$n" -ge 2 ] || fail "launch wrapper missing line-tables-only dev/test trim (found $n)"
+ok "lane-launch -BuildLane wrapper carries the lane env contract from lane-warm -PrintEnv"
+
+expect_ok "launch dry-run without build lane" launch -Name gh626noenv -Cwd "$repo" \
+  -LogDir "$llog" -TimeoutSec 60 -DryRun
+if grep -q 'CARGO_' "$llog/gh626noenv.dryrun-wrapper.ps1"; then
+  fail "launch wrapper set CARGO_* env without a build lane"
+fi
+ok "lane-launch without -BuildLane sets no CARGO env (docs lanes compile nothing)"
+
+echo "1..$case_number"
+echo "PASS: lane helper self-test ($case_number cases)"

--- a/scripts/fleet/test-lane-helpers.sh
+++ b/scripts/fleet/test-lane-helpers.sh
@@ -11,11 +11,12 @@
 #     and is idempotent for the same branch,
 #   * prepare refuses: dirty worktree, unpushed previous branch (upstream
 #     configuration alone is not accepted — the remote TIP must match), a
-#     running lane task bound to the worktree, an existing branch, a path
-#     collision, a bad lane/branch name — always loudly, never force-checkout,
-#     never deletion,
-#   * warm refuses: worktree not prepared, dirty, unpushed, busy, rust-lld
-#     absent from the active toolchain — and never starts cargo in those cases,
+#     running or unreadable lane task state, an unpublished detached commit,
+#     an existing branch, a path collision, a bad lane/branch name — always
+#     loudly, never force-checkout, never deletion,
+#   * warm refuses: worktree not prepared, dirty, unpushed, unpublished
+#     detached work, busy or unreadable Task Scheduler state, rust-lld absent
+#     from the active toolchain — and never starts cargo in those cases,
 #   * warm -DryRun and prepare -DryRun have ZERO side effects (no fetch, no
 #     refs, no checkout, no cargo) and print the exact commands,
 #   * env contract: CARGO_TARGET_DIR=<lane-root>\<lane> (fixed lane dir, never
@@ -147,6 +148,29 @@ expect_fail() {
   esac
 }
 
+# Run a helper under a deliberately failing Task Scheduler query. A function
+# defined in the pwsh caller shadows the cmdlet in the child script scope, so
+# this covers the actual fail-closed catch rather than a textual mock.
+scheduler_fail_prepare() {
+  repo_win=$(cygpath -w "$1")
+  prepare_win=$(cygpath -w "$PREPARE")
+  pwsh -NoProfile -NonInteractive -Command "
+    function Get-ScheduledTask { [CmdletBinding()] param([string]\$TaskName); throw 'fixture scheduler query failed' }
+    & '$prepare_win' -BuildLane worker-1 -Branch codex/scheduler-fail -Repo '$repo_win' -DryRun
+    exit \$LASTEXITCODE
+  "
+}
+
+scheduler_fail_warm() {
+  repo_win=$(cygpath -w "$1")
+  warm_win=$(cygpath -w "$WARM")
+  pwsh -NoProfile -NonInteractive -Command "
+    function Get-ScheduledTask { [CmdletBinding()] param([string]\$TaskName); throw 'fixture scheduler query failed' }
+    & '$warm_win' -BuildLane worker-1 -Repo '$repo_win' -DryRun
+    exit \$LASTEXITCODE
+  "
+}
+
 # ---------------------------------------------------------------------------
 # lane-prepare.ps1
 
@@ -260,6 +284,33 @@ expect_fail "prepare dry-run dirty" "dirty" prepare -BuildLane worker-1 -Branch 
 [ "$(refs_snapshot "$repo")" = "$before_refs" ] || fail "dry-run refusal mutated refs"
 rm "$(wt_posix "$repo" worker-1)/dirty.txt"
 ok "prepare -DryRun on a dirty lane reports the refusal and mutates nothing"
+
+# A clean detached HEAD still needs a durable remote ref. The warmer normally
+# creates detached main checkouts, but a unique commit in that state must not
+# be stranded in a reflog by prepare or warm.
+detrepo=$(new_repo detached)
+detlane=$(wt_posix "$detrepo" worker-1)
+git -C "$detrepo" worktree add -q --detach "$detlane" origin/main
+echo detached >"$detlane/f.txt"
+git -C "$detlane" add f.txt
+git -C "$detlane" commit -qm detached-unique
+dethead=$(git -C "$detlane" rev-parse HEAD)
+expect_fail "prepare detached unique" "not reachable" \
+  prepare -BuildLane worker-1 -Branch codex/detached-next -Repo "$detrepo" -DryRun
+expect_fail "warm detached unique" "not reachable" warm -BuildLane worker-1 -Repo "$detrepo" -DryRun
+[ "$(git -C "$detlane" rev-parse HEAD)" = "$dethead" ] || fail "detached refusal moved HEAD"
+[ "$(git -C "$detrepo" for-each-ref --contains "$dethead" --format='%(refname)' refs/remotes/origin/)" = "" ] \
+  || fail "detached fixture accidentally gained a remote containing ref"
+ok "prepare and warm refuse a clean detached commit without an origin ref"
+
+# A scheduler query failure cannot be treated as an empty task list. These
+# helpers must fail before a dry-run could report a switch or warm command.
+srepo=$(new_repo scheduler)
+expect_fail "prepare scheduler query failure" "cannot query Task Scheduler" scheduler_fail_prepare "$srepo"
+expect_ok "scheduler warm fixture prepare" prepare -BuildLane worker-1 -Branch codex/scheduler-base -Repo "$srepo"
+git -C "$(wt_posix "$srepo" worker-1)" push -q origin codex/scheduler-base
+expect_fail "warm scheduler query failure" "cannot query Task Scheduler" scheduler_fail_warm "$srepo"
+ok "prepare and warm fail closed when Task Scheduler cannot be queried"
 
 # ---------------------------------------------------------------------------
 # lane-warm.ps1


### PR DESCRIPTION
Issue: #626
Closes: #626

Implements persistent fixed lane worktree preparation, a guarded post-merge
warmer, and the lane wrapper environment contract. The helpers refuse busy,
dirty, unpushed, or colliding lane state; dry-runs make no changes. The
runbook and parallel-wave guidance now use the four fixed lanes and the
L0/exact-head-CI/C5 ladder.

Evidence: the native Git Bash helper suite passed all 25 cases. The current
RTX 4090 receipt is at
`C:\ai_agent\fleet-workstation\evidence\gh626\HANDOFF.md`: crate-cold
(dependency-warm) `edda-conductor` build 10.631 s, warm 1.474 s, and
same-path branch switch 1.542 s. A safety-layer block prevented a full
lane-cache reset, so this draft does not claim a fresh full-cold measurement
or linker-only timing.

Pending: exact-head CI, independent SOL source audit, and acceptance review.
This draft remains open; GitHub applies the close directive only if its PR is
accepted and merged.
