### PR TITLE
docs(fleet): require released claim withdrawal

### DIFF
--- a/docs/evidence/gh682/queue-audit-2026-09-04.md
+++ b/docs/evidence/gh682/queue-audit-2026-09-04.md
@@ -23,10 +23,15 @@ after that label has been removed.
   (worker-2), #761 (docs/worker-1), #764 (docs/worker-1), #765
   (docs/worker-2), and #800 (4090/infra-controller). They were not changed.
   `lane:*` remains routing-only, including #761 and #764's `lane:4090`.
-- **1 open claim with unproven present ownership:** #690 has an older
-  `taking: 4090/lane-gh690` comment but no current `fleet:claimed` label. The
-  audit neither calls it released from age nor withdraws it; its owner must
-  reconcile it before a future dispatch.
+- **1 owner-confirmed live exception:** #690 has an older
+  `taking: 4090/lane-gh690` comment but no current `fleet:claimed` label.
+  Task 27's infra-controller confirmed the claim is live: its harness merged,
+  but the restricted-account build/test/push and fail-first credential/token
+  denial proof remain undelivered (issue comment
+  `IC_kwDORT1v6c8AAAABSYdvYw`, item 3). The owner explicitly retained
+  `fleet:pending`, and directed this audit not to add `fleet:claimed` or strike
+  the taking line. That pending-plus-live state is an owner-retained
+  discrepancy for follow-up, not evidence of a released claim.
 
 The separately known released-without-delivery claims #591, #634, #650, and
 #651 already contain explicit `RELEASED` withdrawals. They no longer match the

--- a/docs/evidence/gh682/queue-audit-2026-09-04.md
+++ b/docs/evidence/gh682/queue-audit-2026-09-04.md
@@ -1,0 +1,35 @@
+# GH682 queue audit — 2026-09-04
+
+This audit follows the actual reader in `scripts/fleet-claim-issue.sh`: fetch
+every repository issue comment, normalize CRLF, split it into lines, trim each
+line's leading whitespace, and select an issue when any resulting line starts
+with `taking:`. A separate `RELEASED` line does not suppress a selected line;
+a struck-through `~~taking: ...~~` line does not match.
+
+The GitHub REST scan returned **65** candidate issues. It is intentionally not
+limited to `fleet:claimed`, because the defect is a surviving `taking:` comment
+after that label has been removed.
+
+## Disposition
+
+- **56 closed issues:** #558, #564, #565, #574, #584, #585, #593, #599, #601,
+  #606, #608, #609, #617, #631, #633, #647, #649, #650, #661, #663, #665,
+  #666, #667, #669, #672, #678, #680, #701, #703, #704, #705, #706, #710,
+  #712, #714, #715, #729, #730, #731, #734, #741, #744, #747, #750, #751,
+  #757, #775, #776, #779, #783, #784, #789, #792, #797, #801, and #820.
+  Their claims are closed-issue history and were not rewritten.
+- **8 confirmed live open claims:** #671 (4090/worker-1), #682
+  (4090/economy-fleet-terra), #693 (4090/economy-fleet-terra), #746
+  (worker-2), #761 (docs/worker-1), #764 (docs/worker-1), #765
+  (docs/worker-2), and #800 (4090/infra-controller). They were not changed.
+  `lane:*` remains routing-only, including #761 and #764's `lane:4090`.
+- **1 open claim with unproven present ownership:** #690 has an older
+  `taking: 4090/lane-gh690` comment but no current `fleet:claimed` label. The
+  audit neither calls it released from age nor withdraws it; its owner must
+  reconcile it before a future dispatch.
+
+The separately known released-without-delivery claims #591, #634, #650, and
+#651 already contain explicit `RELEASED` withdrawals. They no longer match the
+active-line selector and were preserved. The only proven current label
+contradictions were `fleet:pending` plus `fleet:claimed` on #746 and #800;
+only `fleet:pending` was removed from those two issues.

--- a/docs/fleet/rules.md
+++ b/docs/fleet/rules.md
@@ -20,7 +20,7 @@
 - **R10 訊息**：真相先寫在 issue 或 PR，host 訊息只做門鈴；永不向人提問。
 - **R11 認證失效**：該運輸的 lane 停派，在 board 記一筆 `needs-operator: relogin <tool> on <machine>`，只記一次；不重試、不換帳號。來源：#593、#669。
 - **R12 核准的計畫步驟**：操作者已核准的設計稿步驟直接以 `fleet:ready` 開單。
-- **R13 交還**：交還必須附 R3 三證與 `git ls-remote` 結果；交還後 15 分鐘再查一次。若是**未交付即釋放**，必須將原 `taking:` 留言劃線並在同一則留言加 `RELEASED — this claim is withdrawn`，再移除與釋放事實矛盾的 `fleet:claimed`／機器 `lane:*` 標籤；已交付的 claim 是正確歷史，進行中的 claim 不得因時間推測為過期。完整規則見帳本 `fleet.cross-machine-claim`。來源：#650、#682。
+- **R13 交還**：交還必須附 R3 三證與 `git ls-remote` 結果；交還後 15 分鐘再查一次。若是**未交付即釋放**，必須**編輯、不得刪除**原認領留言：將原本的 `taking:` 行劃線，並在**同一則留言**加 `RELEASED — this claim is withdrawn`，再移除與釋放事實矛盾的 `fleet:claimed`／機器 `lane:*` 標籤。活認領的機器判準與 `scripts/fleet-claim-issue.sh` 相同：逐行去前導空白後，只有開頭仍是 `taking:` 的行算活；獨立的 `RELEASED` 行不會使原 `taking:` 行失效。已交付的 claim 是正確歷史，進行中的 claim 不得因時間推測為過期。完整規則見帳本 `fleet.cross-machine-claim`。來源：#650、#682。
 - **R14 每日預算**：管理者自身每日 5 美元；lane 照 brief。
 - **R15 認證失敗的機器判準**：一輪 agent 回合若 `Cost: $0.00`，一律當失敗處理，不論 exit code。理由：認證失敗的回合成本必為零，而 `edda dispatch` 目前回 exit 0（#669）。#669 落地後改以 exit code 為準，本條保留為交叉檢查。
 - **R16 存活面的已知污染**：`edda peers` 在 `cargo test -p edda-bridge-claude` 執行期間會出現非 UUID 形狀的假 session（測試 fixture 寫進真實 store，#646）。判存活時忽略 session id 不是 UUID 形狀的條目。心跳判活的視窗是 120 秒（`stale_secs()`），所以兩次查詢相隔超過該視窗可能得到不同答案 —— 這是時序，不是 store 分裂。

--- a/docs/fleet/rules.md
+++ b/docs/fleet/rules.md
@@ -8,7 +8,7 @@
 
 ## 操作者規則
 
-- **R1 認領**：起手前（R21）在 issue 留 `taking: <machine>/<role> at <ISO8601>` 留言**並**貼 `fleet:claimed` 標籤——留言加標籤合起來才是認領憑證；`lane:*` 標籤（`lane:feature`、`lane:4090`、`lane:docs`）只是路由／分類，永遠不是認領。先寫先贏；讀到別台的 taking 就不開工。來源：#784——本條的憑證形式 supersede `fleet.cross-machine-claim`（該決策只記 `taking: <machine> <lane>` 留言＋`lane:` 前綴機器標籤，是舊 carrier，不再是憑證）；跨機器「先查後開」的紀律本身仍出自 `fleet.cross-machine-claim`。
+- **R1 認領**：起手前（R21）在 issue 留 `taking: <machine>/<role> at <ISO8601>` 留言**並**貼 `fleet:claimed` 標籤——留言加標籤合起來才是認領憑證；`lane:*` 標籤（`lane:feature`、`lane:4090`、`lane:docs`）只是路由／分類，永遠不是認領。先寫先贏；讀到別台的 taking 就不開工。完整、可查的跨機器 carrier 與交還規則是帳本 `fleet.cross-machine-claim`；本條只保留操作者使用的憑證形式。來源：#784、#682。
 - **R2 重複產物**：同一 issue 有兩份產物，留 doneWhen 覆蓋較完整的那份；另一份關閉，可用部分搬過去。不因流程錯誤丟掉真工作。來源：#613 裁定、PR #670。
 - **R3 停止的定義**：三證齊備才算停 —— 排程任務非 `Running`、**沒有 `edda.exe` 仍持有該 lane 的 briefs 路徑**、lane log 有 `=== EXIT ===`。`Ready` 單獨不代表停（#650 被宣告交還時 lane 仍在寫）。只殺 wrapper 不算停。來源：#672、`fleet.lane-stop-4090`。
 - **R4 lane 類型**：diff 需要 cargo（Rust 原始碼、測試、fixture、`Cargo.*`，或 CI 會跑 cargo）就走 4090 build lane，否則走文書機。不看 issue 標題前綴。來源：#651。
@@ -20,7 +20,7 @@
 - **R10 訊息**：真相先寫在 issue 或 PR，host 訊息只做門鈴；永不向人提問。
 - **R11 認證失效**：該運輸的 lane 停派，在 board 記一筆 `needs-operator: relogin <tool> on <machine>`，只記一次；不重試、不換帳號。來源：#593、#669。
 - **R12 核准的計畫步驟**：操作者已核准的設計稿步驟直接以 `fleet:ready` 開單。
-- **R13 交還**：交還必須附 R3 三證與 `git ls-remote` 結果；交還後 15 分鐘再查一次。來源：#650。
+- **R13 交還**：交還必須附 R3 三證與 `git ls-remote` 結果；交還後 15 分鐘再查一次。若是**未交付即釋放**，必須將原 `taking:` 留言劃線並在同一則留言加 `RELEASED — this claim is withdrawn`，再移除與釋放事實矛盾的 `fleet:claimed`／機器 `lane:*` 標籤；已交付的 claim 是正確歷史，進行中的 claim 不得因時間推測為過期。完整規則見帳本 `fleet.cross-machine-claim`。來源：#650、#682。
 - **R14 每日預算**：管理者自身每日 5 美元；lane 照 brief。
 - **R15 認證失敗的機器判準**：一輪 agent 回合若 `Cost: $0.00`，一律當失敗處理，不論 exit code。理由：認證失敗的回合成本必為零，而 `edda dispatch` 目前回 exit 0（#669）。#669 落地後改以 exit code 為準，本條保留為交叉檢查。
 - **R16 存活面的已知污染**：`edda peers` 在 `cargo test -p edda-bridge-claude` 執行期間會出現非 UUID 形狀的假 session（測試 fixture 寫進真實 store，#646）。判存活時忽略 session id 不是 UUID 形狀的條目。心跳判活的視窗是 120 秒（`stale_secs()`），所以兩次查詢相隔超過該視窗可能得到不同答案 —— 這是時序，不是 store 分裂。

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -26,9 +26,9 @@
    ```
 2. **接單**：手動認領用 `sh scripts/fleet-claim-issue.sh <N> <machine>/<role>`（例如
    `4090/worker-1`、`docs/reviewer`）；`edda dispatch --issue <N> --machine <machine>/<role>`
-   也會在派發前做同一套認領。兩者都先查 PR 與完整 `taking:` 身分，再留 `taking:` 留言、加
-   `fleet:claimed`、移除 `fleet:ready`、指派 `@me`；不要另寫 lease 留言或另跑 `gh issue edit`。
-   `lane:*` 只供路由，不是認領憑證（#782）。
+   也會在派發前做同一套認領。認領、釋放與已交付歷史的正典是帳本
+   `fleet.cross-machine-claim`（`edda ask fleet.cross-machine-claim`）；本 runbook 不重述該協定。
+   實作入口、`--check` 的 exit code 與身分格式見 `docs/fleet/rules.md` R21（#782）。
 3. **派 lane**（開 worktree 後）：
    ```bash
    pwsh -NoProfile -File scripts/fleet/lane-launch.ps1 -Name <lane> -Brief <brief.md> -Cwd <worktree>
@@ -197,8 +197,7 @@ Brief 必含：assigned build lane、verification budget（L0 while iterating；
 | **lane 啟動走 Task Scheduler，不走 nohup／Start-Process**：Claude Code 的工具 shell 在 Windows Job Object 裡，nohup 的子程序仍隨 session 死。`Register-ScheduledTask` + `Start-ScheduledTask`（父程序是 svchost）；該環境 `HOME` 為空，lane wrapper 必須顯式設；`CARGO_TARGET_DIR` 只在 `-BuildLane` 指名四個允許 build lane 之一時設（不編譯的 session 沒有 build lane——`.claude/CLAUDE.md`、`verification.cost-discipline`；要編譯的必須給四擇一，launcher 拒絕其他名字）。`lane-launch.ps1` 不合成 build lane：`-BuildLane` 只收 `worker-1|worker-2|verifier|verifier-2`，設 `CARGO_TARGET_DIR`＝lane root（`$env:LOCALAPPDATA\fleet-workstation\lanes`，可用 `FLEET_LANE_ROOT` 改）\`<BuildLane>`；docs lane 不傳，wrapper 不設。`Get-ScheduledTaskInfo` 可輪詢，`Unregister-ScheduledTask` 清理。重派前先讀 worktree／branch／PR 狀態，不信任 live handle。**手續已脚本化**：用 `scripts/fleet/lane-launch.ps1` 註冊起 lane、`scripts/fleet/lane-status.ps1` 盯狀態（用法見 START HERE），不要再手寫 wrapper | `fleet.lane-launch`、`fleet.lane-dispatch` |
 | **停 lane 一律走 `scripts/fleet/lane-stop.ps1 -Name <lane>`**：`Stop-ScheduledTask` 與 `Unregister-ScheduledTask` 都只終止任務的 wrapper，**不殺它 spawn 的 process tree**（GH-672：被「停」的 lane 照樣 commit／push／開 PR，任務卻顯示 `State = Ready`）。`lane-stop.ps1` 停任務、殺整棵樹（wrapper 已死時依 `CommandLine` 比對 wrapper／brief 路徑抓孤兒）、驗證無殘留、回報實際終止了什麼，並補寫結束記錄（done-file + lane log 的 `=== EXIT ===` 行）——wrapper 本身也在 `finally` 寫同樣的結束記錄，所以正常結束、出錯、被停三種 endings 都有 EXIT。**殺完要驗共用 `.git/config`**：硬殺撞上 git 寫 config 會把它變成整片 NUL，主 checkout 加全部 worktree 同時失去 git；2026-09-02／03 各發生一次，而當時的 `.bak` 是**損毀後**才複製的，所以也是整片 NUL——備份不驗證等於沒有備份（GH-715）。殺完 `lane-stop.ps1` 驗證 config 仍可解析，壞了就從 `lane-launch.ps1` 開跑前存的**已驗證**備份還原（`scripts/fleet/git-config-guard.ps1`），還不回來就 exit 1；結束記錄一定先寫。沒有優雅關閉窗口：不帶 `/F` 的 `taskkill` 對沒有視窗的隱藏 console 程序無效（實測 exit 128、目標存活），加一段等待只會讓每次停 lane 多付秒數而擋不住任何損毀 | `fleet.lane-stop-4090` |
 | 一 issue ＝ 一單 phase plan ＝ 一 worktree ＝ 一 build lane；並行在 plan 之間；plan 裡不寫沒理由的 `depends_on`；並行 plan 不用 verdict gate | `cleanup.parallel-exec`、`cleanup.review-gate` |
-| 任何 session 開始一張 issue 前的起手守門（`--check`、認領憑證、拒絕條件）：見 `docs/fleet/rules.md` R21，本表不重述 | #784（R21；`fleet.cross-machine-claim` 的舊 carrier 已被取代） |
-| `edda dispatch --issue N --machine 4090/worker-1` 自動先查 PR／完整角色認領，再寫 `taking:`、將 `fleet:ready` 換成 `fleet:claimed` 並指派 `@me`；單獨查核用 `sh scripts/fleet-claim-issue.sh --check N 4090/worker-1`，唯讀，0 可接／1 已有人或 PR／2 使用或 GitHub 錯誤。裸機器名不接受；`lane:*` 僅供路由 | #782 |
+| 跨機器認領、釋放與已交付歷史：讀帳本 `fleet.cross-machine-claim`；起手守門的實作入口與拒絕條件見 `docs/fleet/rules.md` R21，本表不重述 | `fleet.cross-machine-claim`、#784（R21） |
 | build lane 只用 `worker-1|worker-2|verifier|verifier-2`；永不建 ad-hoc `CARGO_TARGET_DIR`；L1 與 verifier 設 `CARGO_INCREMENTAL=0` | `verification.cost-discipline` |
 | 操作者在場的小批量併行走 `/issue-pipeline`（in-session 子代理：開工先貼 `taking: <machine>/pipeline`、審查是 house review——審查者不修自己審的 PR、子代理隨 session 死，長時間無人值守改派 Task Scheduler lane）；一次最多兩張要編譯的單 | `fleet.parallel-modes=in-session-pipeline-when-operator-present-lanes-when-unattended` |
 | 審查釘 full SHA；**每次 push 使前一個判決失效**；一個 PR 一個審查者身分 | `fleet.review-protocol` |


### PR DESCRIPTION
Issue: #682

Makes `fleet.cross-machine-claim` the canonical source for the active `taking:` rule and release-versus-delivered distinction. A released, undelivered claim is withdrawn by editing—not deleting—its original comment: the original `taking:` line is struck through and `RELEASED — this claim is withdrawn` is added to that same comment. Active status matches `scripts/fleet-claim-issue.sh`: after leading whitespace is trimmed from each line, only a line beginning `taking:` is active.

The full queue audit is committed in `docs/evidence/gh682/queue-audit-2026-09-04.md`. It scans all repository issue comments with that predicate, not just `fleet:claimed` labels: 65 candidates, comprising 56 closed historical records, 8 confirmed live open claims, and #690 as an owner-confirmed live exception. No live or delivered claim was inferred stale from age. Existing released withdrawals #591, #634, #650, and #651 were preserved; only proven `fleet:pending` plus `fleet:claimed` conflicts on #746 and #800 were corrected.

Validation: documentation citation, Markdown-content, and file-length commit hooks passed, along with `git diff --check`. No Cargo gate applies to this docs-only change. Exact-head CI 33878218026 is green at f57a96371d495d37413df715a22247f52a065521; independent Sol Round 2 is LGTM (P0=0, P1=0).

Closes #682
