### PR TITLE
fix(background): share current Haiku model selection

### DIFF
--- a/crates/edda-bridge-claude/src/bg_extract.rs
+++ b/crates/edda-bridge-claude/src/bg_extract.rs
@@ -11,15 +11,17 @@ use std::path::{Path, PathBuf};
 
 // ── Configuration ──
 
-pub(crate) const DEFAULT_MODEL: &str = "claude-3-5-haiku-20241022";
+/// Shared default retained for existing background companions.
+pub(crate) const DEFAULT_MODEL: &str = edda_core::background_model::DEFAULT_BACKGROUND_MODEL;
 pub(crate) const DEFAULT_MAX_TRANSCRIPT_CHARS: usize = 30_000;
 const DEFAULT_DAILY_BUDGET_USD: f64 = 0.50;
 const DEFAULT_CONFIDENCE_THRESHOLD: f64 = 0.7;
 const API_TIMEOUT_SECS: u64 = 30;
 
-// Haiku pricing (per token)
-pub(crate) const HAIKU_INPUT_COST_PER_TOKEN: f64 = 0.000_001; // $1 / 1M input tokens
-pub(crate) const HAIKU_OUTPUT_COST_PER_TOKEN: f64 = 0.000_005; // $5 / 1M output tokens
+// Claude Haiku 4.5 pricing (per token), current at GH-679 implementation:
+// https://platform.claude.com/docs/en/about-claude/pricing
+pub(crate) const HAIKU_INPUT_COST_PER_TOKEN: f64 = 0.000_001; // $1 / MTok
+pub(crate) const HAIKU_OUTPUT_COST_PER_TOKEN: f64 = 0.000_005; // $5 / MTok
 
 // ── Data Structures ──
 
@@ -272,15 +274,15 @@ pub fn extract_decisions(
     let prompt = build_extraction_prompt(&truncated, &vague);
 
     // Call LLM
-    let model = std::env::var("EDDA_BG_MODEL").unwrap_or_else(|_| DEFAULT_MODEL.to_string());
+    let model_override = crate::env_var("EDDA_BG_MODEL");
+    let model = edda_core::background_model::resolve_background_model(model_override.as_deref());
     let (response_text, input_tokens, output_tokens) =
         call_anthropic_sync(api_key, &model, &prompt)?;
 
     // Parse LLM output
     let decisions = parse_llm_decisions(&response_text);
 
-    let cost_usd = (input_tokens as f64 * HAIKU_INPUT_COST_PER_TOKEN)
-        + (output_tokens as f64 * HAIKU_OUTPUT_COST_PER_TOKEN);
+    let cost_usd = background_cost_usd(input_tokens, output_tokens);
 
     Ok(ExtractionResult {
         session_id: session_id.to_string(),
@@ -838,14 +840,7 @@ pub(crate) fn call_anthropic_sync(
     model: &str,
     prompt: &str,
 ) -> Result<(String, u64, u64)> {
-    let request = AnthropicRequest {
-        model: model.to_string(),
-        max_tokens: 2048,
-        messages: vec![ApiMessage {
-            role: "user".to_string(),
-            content: prompt.to_string(),
-        }],
-    };
+    let request = background_request(model, prompt);
 
     let body = serde_json::to_string(&request)?;
 
@@ -882,6 +877,22 @@ pub(crate) fn call_anthropic_sync(
     };
 
     Ok((text.to_string(), input_tokens, output_tokens))
+}
+
+fn background_request(model: &str, prompt: &str) -> AnthropicRequest {
+    AnthropicRequest {
+        model: model.to_string(),
+        max_tokens: 2048,
+        messages: vec![ApiMessage {
+            role: "user".to_string(),
+            content: prompt.to_string(),
+        }],
+    }
+}
+
+fn background_cost_usd(input_tokens: u64, output_tokens: u64) -> f64 {
+    (input_tokens as f64 * HAIKU_INPUT_COST_PER_TOKEN)
+        + (output_tokens as f64 * HAIKU_OUTPUT_COST_PER_TOKEN)
 }
 
 /// Parse LLM output as JSON array of decisions.

--- a/crates/edda-bridge-claude/src/bg_extract/tests.rs
+++ b/crates/edda-bridge-claude/src/bg_extract/tests.rs
@@ -1,6 +1,29 @@
 use super::*;
 
 #[test]
+fn background_request_uses_default_model_without_override() {
+    let model = edda_core::background_model::resolve_background_model(None);
+    let request = background_request(&model, "prompt");
+    assert_eq!(
+        request.model,
+        edda_core::background_model::DEFAULT_BACKGROUND_MODEL
+    );
+    assert_eq!(DEFAULT_MODEL, request.model);
+}
+
+#[test]
+fn background_request_uses_override_as_outgoing_model() {
+    let model = edda_core::background_model::resolve_background_model(Some("claude-test-model"));
+    let request = background_request(&model, "prompt");
+    assert_eq!(request.model, "claude-test-model");
+}
+
+#[test]
+fn background_cost_matches_haiku_4_5_standard_token_rates() {
+    assert_eq!(background_cost_usd(500_000, 100_000), 1.0);
+}
+
+#[test]
 fn test_parse_llm_output_valid_json() {
     let _store = crate::isolated_store();
     let input = r#"[

--- a/crates/edda-chronicle/src/synthesize.rs
+++ b/crates/edda-chronicle/src/synthesize.rs
@@ -58,14 +58,8 @@ async fn synthesize_with_llm(api_key: &str, input: SynthesisInput) -> Result<cra
 
     let prompt = build_prompt(&input);
 
-    let request = AnthropicRequest {
-        model: "claude-3-5-haiku-20241022".to_string(),
-        max_tokens: 1024,
-        messages: vec![Message {
-            role: "user".to_string(),
-            content: prompt,
-        }],
-    };
+    let model_override = std::env::var("EDDA_BG_MODEL").ok();
+    let request = background_request(model_override.as_deref(), prompt);
 
     let response = client
         .post("https://api.anthropic.com/v1/messages")
@@ -96,6 +90,17 @@ async fn synthesize_with_llm(api_key: &str, input: SynthesisInput) -> Result<cra
         .unwrap_or("");
 
     parse_llm_output(text)
+}
+
+fn background_request(model_override: Option<&str>, prompt: String) -> AnthropicRequest {
+    AnthropicRequest {
+        model: edda_core::background_model::resolve_background_model(model_override),
+        max_tokens: 1024,
+        messages: vec![Message {
+            role: "user".to_string(),
+            content: prompt,
+        }],
+    }
 }
 
 fn synthesize_with_template(input: SynthesisInput) -> Result<crate::RecapOutput> {
@@ -292,6 +297,21 @@ mod tests {
             commits: vec![],
             decisions: vec![],
         }
+    }
+
+    #[test]
+    fn background_request_uses_default_model_without_override() {
+        let request = background_request(None, "prompt".to_string());
+        assert_eq!(
+            request.model,
+            edda_core::background_model::DEFAULT_BACKGROUND_MODEL
+        );
+    }
+
+    #[test]
+    fn background_request_uses_override_as_outgoing_model() {
+        let request = background_request(Some("claude-test-model"), "prompt".to_string());
+        assert_eq!(request.model, "claude-test-model");
     }
 
     #[tokio::test]

--- a/crates/edda-core/src/background_model.rs
+++ b/crates/edda-core/src/background_model.rs
@@ -1,0 +1,39 @@
+//! Shared model selection for Edda's own background Anthropic requests.
+
+/// The current low-cost Anthropic model for Edda background work.
+pub const DEFAULT_BACKGROUND_MODEL: &str = "claude-haiku-4-5-20251001";
+
+/// Resolve the background model from an optional `EDDA_BG_MODEL` value.
+///
+/// The value is supplied by the caller so production code can read its normal
+/// environment while tests can exercise the same selection without mutating
+/// the process environment.
+#[must_use]
+pub fn resolve_background_model(override_value: Option<&str>) -> String {
+    override_value
+        .unwrap_or(DEFAULT_BACKGROUND_MODEL)
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_background_model, DEFAULT_BACKGROUND_MODEL};
+
+    #[test]
+    fn defaults_when_no_override_is_supplied() {
+        assert_eq!(resolve_background_model(None), DEFAULT_BACKGROUND_MODEL);
+    }
+
+    #[test]
+    fn preserves_the_override_as_the_request_model() {
+        assert_eq!(
+            resolve_background_model(Some("claude-test-model")),
+            "claude-test-model"
+        );
+    }
+
+    #[test]
+    fn preserves_an_empty_override_for_backwards_compatibility() {
+        assert_eq!(resolve_background_model(Some("")), "");
+    }
+}

--- a/crates/edda-core/src/lib.rs
+++ b/crates/edda-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod agent_phase;
 pub mod approval;
+pub mod background_model;
 pub mod bundle;
 pub mod canon;
 pub mod decision;


### PR DESCRIPTION
Issue: #679

Closes #679

Both outgoing background Anthropic request paths now use `edda_core::background_model` for the same default and `EDDA_BG_MODEL` override. The default is `claude-haiku-4-5-20251001`; its $1/MTok input and $5/MTok output rates are cited next to the extraction budget constants.

Regression coverage builds the actual outgoing request structs, immediately before serialization, for default and override selection at both sites. It does not inspect serialized bytes. The extraction test also pins the $1.00 cost for 500,000 input plus 100,000 output tokens. The tests avoid process-environment mutation.

Model and pricing sources checked 2026-09-04: https://docs.anthropic.com/en/docs/about-claude/model-deprecations and https://platform.claude.com/docs/en/about-claude/pricing.

Focused validation: `cargo fmt --all --check`; clippy for edda-core, edda-bridge-claude, and edda-chronicle with `--all-targets -- -D warnings`; tests edda-core (203), edda-bridge-claude (641), edda-chronicle (42); `scripts/lint-file-length.sh --tree`; `git diff --check`.

Negative-control evidence: the Chronicle override regression was run after temporarily restoring the retired inline literal. It failed by assertion with actual `claude-3-5-haiku-20241022` versus expected `claude-test-model` (exit 101), then the resolver was restored with the worktree clean at the unchanged head. See the PR evidence comment for the durable receipt.