### PR TITLE
fix(openclaw): redact durable bridge event data

### DIFF
--- a/crates/edda-bridge-openclaw/Cargo.toml
+++ b/crates/edda-bridge-openclaw/Cargo.toml
@@ -22,6 +22,7 @@ serde_json.workspace = true
 time.workspace = true
 
 [dev-dependencies]
+edda-store = { path = "../edda-store", version = "0.5.0", features = ["test-support"] }
 tempfile.workspace = true
 
 [lints]

--- a/crates/edda-bridge-openclaw/src/parse.rs
+++ b/crates/edda-bridge-openclaw/src/parse.rs
@@ -74,7 +74,10 @@ pub(crate) fn append_to_session_ledger(
         "event_data": &envelope.event_data,
     });
 
-    let line = serde_json::to_string(&record)?;
+    // Hook event data can contain tool arguments and outputs. Scrub the entire
+    // serialized record before opening the durable ledger so no raw secret
+    // reaches disk through any string-valued field.
+    let (line, _) = edda_core::secret_guard::redact(&serde_json::to_string(&record)?);
     let mut file = fs::OpenOptions::new()
         .create(true)
         .append(true)
@@ -166,6 +169,42 @@ mod tests {
 
         let content = fs::read_to_string(&ledger_path).unwrap();
         assert!(content.contains("before_agent_start"));
+
+        let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+    }
+
+    #[test]
+    fn append_session_ledger_redacts_tool_payload_before_durable_write() {
+        let _store = edda_store::test_support::isolated_store_root().unwrap();
+        let pid = "test_oc_ledger_redaction";
+        let _ = edda_store::ensure_dirs(pid);
+        let sentinel = "AKIAIOSFODNN7EXAMPLE";
+        let envelope = OpenClawEnvelope {
+            hook_event_name: "after_tool_call".into(),
+            session_id: "redact-s1".into(),
+            session_key: "agent:main:redact-s1".into(),
+            agent_id: "main".into(),
+            workspace_dir: "/tmp".into(),
+            session_file: None,
+            event_data: serde_json::json!({
+                "tool_name": "bash",
+                "tool_input": {"command": format!("echo {sentinel}")},
+                "tool_output": {"token": sentinel},
+            }),
+        };
+
+        append_to_session_ledger(pid, "redact-s1", &envelope).unwrap();
+
+        let ledger_path = edda_store::project_dir(pid)
+            .join("ledger")
+            .join("redact-s1.jsonl");
+        let content = fs::read_to_string(&ledger_path).unwrap();
+        assert!(
+            !content.contains(sentinel),
+            "raw sentinel must never reach disk"
+        );
+        assert!(content.contains("[REDACTED:aws_access_key_id]"));
+        assert!(content.contains("after_tool_call"));
 
         let _ = fs::remove_dir_all(edda_store::project_dir(pid));
     }


### PR DESCRIPTION
Issue: #870

## Scope
- Fixes the reproducible OpenClaw durable-ledger redaction gap: serialize then apply the existing secret guard before the JSONL file is opened/written.
- Adds an isolated-store regression using only the public AWS example sentinel.
- Does **not** change SDK/ACP/PR873 harness or shared Claude/store/derive/pack behavior.
- Re-pins dev-dependency `edda-store` to workspace `0.5.0` to match current base.

## Adjudication and evidence
- Frozen head: `42df0b5c7bc59201f870ee178c61581bf1121491` (clean tree; the delta over the Round-2-gated head `1f1836dccb7a1436fd25b1cfa71e70d1e5abeaa7` is the empty review-gate commit `42df0b5` — `git diff` between the two is empty, so source, manifests, `Cargo.lock`, and the toolchain pin are byte-identical). This line supersedes a previously cited build SHA (`1f1836d5e7a9…`) that was mis-pinned and unresolvable.
- Focused Windows C5 gate at `42df0b5c7bc59201f870ee178c61581bf1121491`: `cargo test -p edda-bridge-openclaw` — 33 passed, 0 failed, 0 ignored, exit 0 — on the verifier lane (`CARGO_INCREMENTAL=0`, fixed `CARGO_TARGET_DIR`), rustc 1.98.1, host x86_64-pc-windows-msvc. Test binary SHA-256 `322cd6b001ddbc682b6da5408b1bd0008d1e4bd16463cd8f26c03f8e37798530` (warm-lane fingerprint reuse of the byte-identical tree; not relinked, mtime unchanged). Receipt: `briefs/infra-20260904/probe-869-870-build-review-refresh.json` (full log: `probe-869-870-test-review-refresh.log`).
- Exact-head CI: the applicable source-gate runs for the identical tree are `33939734068 @ 1f1836dc…` — Format, Clippy ×3 OS, Test ubuntu+macOS full workspace, Test windows 7-crate subset, MSRV 1.91.0 — all pass; publish dry-run `33939734052` pass. At the current head `42df0b5c…`, exact-head CI run `33943123913` was in flight at receipt time and publication dry-run `33943123896` passed; this verifier does not rerun CI.
- Frozen PR873 harness run (Round-1 binary at `6499b3dd`, whose `parse.rs` is byte-identical to this head): OpenClaw redaction now PASS. Hermes and OpenClaw heartbeat findings remain harness fixture-mapping false failures: `inject_for` rewrites the lifecycle check's `session.start` into the injection event, bypassing their native start handlers.
- Required PR873-owner surface (not changed here): apply `inject_for` only for injection checks; heartbeat must dispatch `VENDORS[vendor].events['session.start']`.

## Gates
- `cargo test -p edda-bridge-openclaw` @ `42df0b5c7bc59201f870ee178c61581bf1121491` — 33 passed, 0 failed (verifier lane; receipt `probe-869-870-build-review-refresh.json`, log `probe-869-870-test-review-refresh.log`)
- Exact-head CI @ `1f1836dcc…` (identical tree, READ-reused) — runs `33939734068` (Format, Clippy ×3 OS, Tests, MSRV) and `33939734052` (publish dry-run); at `42df0b5c…` run `33943123913` in flight at receipt time, publication dry-run `33943123896` pass
- Pre-rebase local gates (hermes 22-pass source validation, clippy, fmt, lint-file-length) were recorded at `6499b3dd` (Round 1 receipt) and are superseded by the exact-head CI runs above.

Heartbeat conformance remains deferred to the PR873 harness mapping. No claim of five-bridge PASS while that harness mapping remains unfixed.
