### PR TITLE
fix(edda-conductor): preserve cost measured-ness in brief.json (GH-571)

### DIFF
--- a/crates/edda-conductor/src/state/brief.rs
+++ b/crates/edda-conductor/src/state/brief.rs
@@ -25,7 +25,11 @@ pub struct Brief {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_phase: Option<String>,
     pub completed_phases: usize,
-    pub cost: BriefCost,
+    /// GH-571: cost is only published when the backend measured usage. An
+    /// unmeasured plan (cost_measured == false) emits no "cost" key at all,
+    /// mirroring demo/runtime-edda.js which drops unmeasured cost claims.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost: Option<BriefCost>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifacts: Vec<String>,
 }
@@ -74,10 +78,13 @@ pub struct BriefPhase {
     pub reason: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct BriefCost {
-    pub total_usd: f64,
+    /// GH-571: None means unmeasured (no usage reported), not a genuine $0.00.
+    /// A measured zero round-trips as Some(0.0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_usd: Option<f64>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub by_phase: HashMap<String, f64>,
 }
@@ -130,9 +137,15 @@ impl Brief {
             }
         }
 
-        let cost = BriefCost {
-            total_usd: state.total_cost_usd,
-            by_phase: HashMap::new(), // Per-phase cost not tracked in PlanState
+        // GH-571: preserve measured-ness — unmeasured plans publish no cost
+        // claim, while a measured zero stays a genuine Some(0.0).
+        let cost = if state.cost_measured {
+            Some(BriefCost {
+                total_usd: Some(state.total_cost_usd),
+                by_phase: HashMap::new(), // Per-phase cost not tracked in PlanState
+            })
+        } else {
+            None
         };
 
         Brief {
@@ -287,13 +300,13 @@ phases:
     #[test]
     fn from_state_cost_aggregation() {
         let mut state = test_plan_state();
-        state.total_cost_usd = 1.23;
+        state.record_cost(1.23);
 
         let brief = Brief::from_state(&state, None);
 
-        assert!((brief.cost.total_usd - 1.23).abs() < f64::EPSILON);
+        assert_eq!(brief.cost.as_ref().unwrap().total_usd, Some(1.23));
         // by_phase is empty because PlanState doesn't track per-phase cost
-        assert!(brief.cost.by_phase.is_empty());
+        assert!(brief.cost.as_ref().unwrap().by_phase.is_empty());
     }
 
     #[test]
@@ -341,6 +354,7 @@ phases:
             None,
         )
         .unwrap();
+        state.record_cost(0.0);
         let brief = Brief::from_state(
             &state,
             Some(BriefMeta {
@@ -395,7 +409,7 @@ phases:
             }),
         )
         .unwrap();
-        state.total_cost_usd = 0.42;
+        state.record_cost(0.42);
 
         let brief = Brief::from_state(
             &state,
@@ -415,12 +429,117 @@ phases:
         assert_eq!(restored.plan.total_phases, brief.plan.total_phases);
         assert_eq!(restored.completed_phases, brief.completed_phases);
         assert_eq!(restored.current_phase, brief.current_phase);
-        assert!((restored.cost.total_usd - brief.cost.total_usd).abs() < f64::EPSILON);
+        assert_eq!(restored.cost, brief.cost);
         assert_eq!(restored.phases.len(), brief.phases.len());
         assert_eq!(
             restored.meta.as_ref().unwrap().board_type,
             brief.meta.as_ref().unwrap().board_type,
         );
+    }
+
+    #[test]
+    fn from_state_unmeasured_cost() {
+        let state = test_plan_state();
+        assert!(!state.cost_measured);
+
+        let brief = Brief::from_state(&state, None);
+
+        assert!(brief.cost.is_none(), "unmeasured plan must publish no cost");
+        let json = serde_json::to_string_pretty(&brief).unwrap();
+        assert!(!json.contains("\"cost\""), "no cost key in JSON: {json}");
+    }
+
+    #[test]
+    fn from_state_measured_zero_cost() {
+        let mut state = test_plan_state();
+        state.record_cost(0.0);
+
+        let brief = Brief::from_state(&state, None);
+
+        let cost = brief.cost.as_ref().unwrap();
+        assert_eq!(cost.total_usd, Some(0.0));
+        let json = serde_json::to_string_pretty(&brief).unwrap();
+        assert!(json.contains("\"totalUsd\": 0.0"), "JSON: {json}");
+    }
+
+    #[test]
+    fn from_state_measured_nonzero_cost() {
+        let mut state = test_plan_state();
+        state.record_cost(1.23);
+
+        let brief = Brief::from_state(&state, None);
+
+        let cost = brief.cost.as_ref().unwrap();
+        assert_eq!(cost.total_usd, Some(1.23));
+        let json = serde_json::to_string_pretty(&brief).unwrap();
+        assert!(json.contains("\"totalUsd\": 1.23"), "JSON: {json}");
+    }
+
+    #[test]
+    fn brief_roundtrip_unmeasured() {
+        let state = test_plan_state();
+        let brief = Brief::from_state(&state, None);
+        assert!(brief.cost.is_none());
+
+        let json = serde_json::to_string_pretty(&brief).unwrap();
+        let restored: Brief = serde_json::from_str(&json).unwrap();
+        assert!(restored.cost.is_none());
+    }
+
+    #[test]
+    fn brief_deserialization_compatibility() {
+        // Missing "cost" → None
+        let restored: Brief = serde_json::from_str(
+            r#"{
+                "plan": {"name": "test", "totalPhases": 0},
+                "phases": {},
+                "completedPhases": 0,
+                "artifacts": []
+            }"#,
+        )
+        .unwrap();
+        assert!(restored.cost.is_none(), "missing cost deserializes as None");
+
+        // "cost": {} → Some(BriefCost { total_usd: None, .. })
+        let restored: Brief = serde_json::from_str(
+            r#"{
+                "plan": {"name": "test", "totalPhases": 0},
+                "phases": {},
+                "completedPhases": 0,
+                "artifacts": [],
+                "cost": {}
+            }"#,
+        )
+        .unwrap();
+        let cost = restored.cost.as_ref().unwrap();
+        assert_eq!(cost.total_usd, None);
+        assert!(cost.by_phase.is_empty());
+
+        // "cost": {"totalUsd": 0.0} → measured zero
+        let restored: Brief = serde_json::from_str(
+            r#"{
+                "plan": {"name": "test", "totalPhases": 0},
+                "phases": {},
+                "completedPhases": 0,
+                "artifacts": [],
+                "cost": {"totalUsd": 0.0}
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(restored.cost.as_ref().unwrap().total_usd, Some(0.0));
+
+        // "cost": {"totalUsd": 1.50} → measured nonzero
+        let restored: Brief = serde_json::from_str(
+            r#"{
+                "plan": {"name": "test", "totalPhases": 0},
+                "phases": {},
+                "completedPhases": 0,
+                "artifacts": [],
+                "cost": {"totalUsd": 1.50}
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(restored.cost.as_ref().unwrap().total_usd, Some(1.50));
     }
 
     #[test]

--- a/docs/reference/brief-schema.md
+++ b/docs/reference/brief-schema.md
@@ -229,6 +229,8 @@ The edda brief uses karvi's scoped board format (`meta` + `controls` + `log` ske
 }
 ```
 
+> **Note**: The `cost` field is optional and omitted when execution is unmeasured (`cost_measured == false`); see Field Reference below.
+
 ### Field Reference
 
 | Field | Type | Source | Update Frequency |
@@ -252,10 +254,13 @@ The edda brief uses karvi's scoped board format (`meta` + `controls` + `log` ske
 | `phases.{id}.reason` | string | PhaseSkipped.reason | On skip |
 | `currentPhase` | string | Latest PhaseStart.phase_id | Per PhaseStart |
 | `completedPhases` | number | Count of Passed + Skipped | Per pass/skip |
-| `cost.total_usd` | number | PlanCompleted.total_cost_usd | On plan complete |
-| `cost.by_phase.{id}` | number | PhasePassed.cost_usd | Per pass |
+| `cost` | object (optional) | Aggregated phase/plan costs | Omitted when unmeasured (`cost_measured == false`) |
+| `cost.total_usd` | number (optional) | PlanCompleted.total_cost_usd | On plan complete when measured; omitted when unmeasured |
+| `cost.by_phase.{id}` | number | PhasePassed.cost_usd | Per pass, when measured |
 | `artifacts` | string[] | Agent output (parsed) | Per pass |
 | `log[]` | array | All events | Per event |
+
+**Cost measured-ness**: When running without cost measurement (`cost_measured == false`), the `cost` field is omitted from `brief.json` to distinguish unmeasured execution from a measured zero ($0.00). When cost measurement is active, measured zero is preserved as `"total_usd": 0.0`.
 
 ### Phase Status Values
 
@@ -326,7 +331,7 @@ How each `events.jsonl` event translates to a brief PATCH:
 | `PhasePassed { phase_id, attempt, duration_ms, cost_usd }` | `{ phases: { [phase_id]: { status: "passed", attempts: attempt, duration_ms, cost_usd, completedAt: ts } }, completedPhases: N, cost: { by_phase: { [phase_id]: cost_usd } } }` |
 | `PhaseFailed { phase_id, attempt, duration_ms, error }` | `{ phases: { [phase_id]: { status: "failed", attempts: attempt, error } } }` |
 | `PhaseSkipped { phase_id, reason }` | `{ phases: { [phase_id]: { status: "skipped", reason } }, completedPhases: N }` |
-| `PlanCompleted { phases_passed, total_cost_usd }` | `{ cost: { total_usd: total_cost_usd } }` |
+| `PlanCompleted { phases_passed, total_cost_usd }` | `{ cost: { total_usd: total_cost_usd } }` — populated when cost is measured; omitted when unmeasured (`total_cost_usd` null) |
 | `PlanAborted { phases_passed, phases_pending }` | No brief update — task status changes instead |
 
 **Note**: `completedPhases` counts phases with status `"passed"` or `"skipped"`.


### PR DESCRIPTION
Closes #571
Issue: #571

### Summary of Changes

1. In `crates/edda-conductor/src/state/brief.rs`:
- Model `BriefCost.total_usd` as `Option<f64>` with `#[serde(default, skip_serializing_if = "Option::is_none")]` instead of a bare `f64`.
- Model `Brief.cost` as `Option<BriefCost>` with `#[serde(default, skip_serializing_if = "Option::is_none")]`.
- Derive `PartialEq` on `BriefCost` to support roundtrip and test equality.
- Update `Brief::from_state` to populate `cost` only when `state.cost_measured == true`:
  - Unmeasured state (`!state.cost_measured`) emits no `cost` claim at all (parity with `demo/runtime-edda.js`).
  - Genuine measured zero (`state.cost_measured && state.total_cost_usd == 0.0`) emits `"cost": { "totalUsd": 0.0 }`.
  - Measured nonzero total emits `"cost": { "totalUsd": <val> }`.
- Update existing tests (`from_state_cost_aggregation`, `brief_roundtrip`, `brief_json_camel_case`) to align with `record_cost` and `Option` cost modeling.
- Add 5 new unit tests covering:
  - `from_state_unmeasured_cost`: verifies no `cost` object in JSON when unmeasured.
  - `from_state_measured_zero_cost`: verifies `totalUsd: 0.0` preserved when measured zero.
  - `from_state_measured_nonzero_cost`: verifies nonzero value preserved.
  - `brief_roundtrip_unmeasured`: verifies `cost: None` round-trips.
  - `brief_deserialization_compatibility`: tests missing cost, `cost: {}`, `totalUsd: 0.0`, and `totalUsd: 1.50`.

2. In `docs/reference/brief-schema.md`:
- Document `cost` and `cost.total_usd` as optional, omitted when unmeasured (`cost_measured == false`).
- Document event translation for `PlanCompleted` reflecting cost measured-ness.
- Document cost measured-ness model distinguishing unmeasured state from measured zero ($0.00).

### Gates & Verification

- `cargo test -p edda-conductor --lib state::brief` -> 14 passed, 0 failed
- `cargo fmt --all --check` -> PASS
- `cargo clippy --workspace --all-targets` -> PASS
- `sh scripts/lint-markdown-content.sh` -> PASS
- `node demo/tests/test_runtime_edda.js` -> 21 passed, 0 failed (all 21 test functions)
- File length: `crates/edda-conductor/src/state/brief.rs` at 664 lines (< 1000 ratchet limit)
