### PR TITLE
fix(review): route source claims to pinned code

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -342,7 +342,8 @@ the workspace version at the reviewed base SHA:
 
 ```sh
 edda --version
-git show "$BASE:Cargo.toml" | sed -n '/^\[workspace.package\]/,/^\[/p' | grep '^version'
+BASE_SHA=$(gh pr view "$N" --json baseRefOid --jq .baseRefOid)
+git show "$BASE_SHA:Cargo.toml" | sed -n '/^\[workspace.package\]/,/^\[/p' | grep '^version'
 ```
 
 They identify the subject of a later measurement: the first is an installed

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -23,7 +23,7 @@ classes:
 
 # REVIEW.md — the executable review spec
 
-- Spec version: `review-spec-v1.3`
+- Spec version: `review-spec-v1.4`
 - Audience: anyone — human or engine — reviewing a pull request in this
   repository, and any script that builds a review brief.
 - Status: this file is the **single source of truth** for how a PR is reviewed
@@ -337,7 +337,17 @@ A docs-only head legitimately shows `Clippy`/`Test` as `skipping` while
 `CI Gate` passes (`ci.path-filter`). That is a correct run, not a broken one.
 
 
-Before claiming `RAN on this workstation`, confirm `edda --version` in the reviewed worktree prints the exact checked-out build identity (commit + date), or `unknown` when git metadata is unavailable.
+Before any CLI probe, record both the installed runtime (`edda --version`) and
+the workspace version at the reviewed base SHA:
+
+```sh
+edda --version
+git show "$BASE:Cargo.toml" | sed -n '/^\[workspace.package\]/,/^\[/p' | grep '^version'
+```
+
+They identify the subject of a later measurement: the first is an installed
+runtime claim and the second is a source claim. A mismatch is not a P0 by
+itself; route each claim through D1, including its required source fallback.
 
 **U7 — the round is complete before it is posted. P1.** Finish the whole scoped
 audit and batch every blocking P0/P1 before `Changes Requested`. A blocker
@@ -348,10 +358,22 @@ non-product cycles without useful progress and route the finding instead
 
 ### 5.1 docs
 
-**D1 — every command named must exist. P1.** Zero discretion (`brief-v1` §1):
-for every backticked CLI invocation the diff adds, probe it and report the exit
-code. You may not conclude anything about a command you did not probe, and "the
-document says it does X" is not a measurement.
+**D1 — claims name their measured subject. P1.** Zero discretion (`brief-v1`
+§1): classify every added factual command claim before measuring it.
+
+| Claim shape | Required subject and check |
+|---|---|
+| A user running a backticked command gets a result | The installed runtime. Probe the command and report its exit code. |
+| The repository or source at SHA `S` has a stated shape, with a repo-relative `path:line` citation | The source at `S`. Read it with `git show "$S:$path"` and report the cited lines. If the claim names no SHA, `S` is the reviewed head SHA. |
+
+A source claim may name a command as data; do not turn that citation into an
+installed-binary claim. Conversely, a runtime claim may not pass because a
+source file has a similar flag. The installed/runtime version mismatch recorded
+before the probes is never a P0 alone. It requires the source check for every
+source claim, and only that check can establish whether the citation is false.
+You may not conclude anything about a runtime command you did not probe or a
+source citation you did not read; "the document says it does X" is not a
+measurement.
 
 **Probe `git` with `-h`, never with `--help`.** On Windows `git <verb> --help`
 does not print to the terminal: it renders the HTML manual and opens it in the
@@ -370,6 +392,10 @@ names the command either names the issue that will implement it, or already
 states that non-zero exit itself** — a documented future verb and a cited
 failure are both allowed; an undocumented one is the `c3-nonexistent-flag`
 failure.
+
+For a source claim, use the cited line range after `git show`; a missing path,
+missing line, or absent stated shape is the P1. Do not use a failed installed
+probe as that finding. This is mechanical routing, not reviewer discretion.
 
 ```sh
 git diff "origin/$BASE..$SHA" | grep '^+' \
@@ -447,8 +473,8 @@ git diff "origin/$BASE..$SHA" -- '*SKILL.md' '.claude/**' 'skills/**' | grep '^+
   | grep -nEi 'merge|--delete-branch|self-review|skip (the )?review'
 ```
 
-**S2 — the skill's factual claims resolve.** Same measurement as D1 and D3,
-applied to every command and every `file:line` reference the skill asserts. P1
+**S2 — the skill's factual claims resolve.** Apply D1's claim routing and D3
+to every command and every `file:line` reference the skill asserts. P1
 per hit.
 
 **S3 — one source of truth. P1.** A skill that restates a rule owned by this
@@ -706,7 +732,7 @@ mechanical.
 | U5 | RAN | exit 0 on this worktree |
 | U6 | RAN | `gh pr checks 664` — `CI Gate pass`, clippy/test `skipping` |
 | U7 | canonical | `loop` items 1–2 and 6; procedural, no command |
-| D1 | RAN | `edda wave --help` → exit 2 (the #616 P1); `edda ask --help` → exit 0; run against this spec's own diff it caught `edda review --help` → exit 2, which is why the rule carries the documented-future-verb clause. The `git` arm was re-probed after #691: `git diff -h`, `git branch -h`, `git log -h` → exit 129 each, usage printed to the terminal, no browser window |
+| D1 | RAN | Runtime probes: `edda wave --help` → exit 2 (the #616 P1); `edda ask --help` → exit 0; this spec's own diff caught `edda review --help` → exit 2, so documented future verbs remain allowed. Source fallback: GH-693's preserved official 0.3 artifact cannot run `dispatch`, while `git show f9496030:crates/edda-cli/src/cmd_dispatch.rs` shows the cited flags; see `docs/evidence/gh693/`. The `git` arm was re-probed after #691: `git diff -h`, `git branch -h`, `git log -h` → exit 129 each, usage printed to the terminal, no browser window |
 | D2 | RAN | `edda ask fleet.review-engine`; and the scoping clause was measured — every decision this file cites resolves from the checkout, while the same `edda ask review.brief-source` from outside it prints `No results found.` |
 | D3 | RAN | 7 paths on a real docs range, 0 false positives after the trailing-argument strip |
 | D4 | RAN | 2 candidates on a real docs range, both carrying the authority caveat |
@@ -750,6 +776,9 @@ mechanical.
   `edda dispatch` ran. The fallback arm is pinned to the recorded
   `fleet.review-engine-model` read-only shape (§0 above) and the verdict
   header prints the `TRANSPORT=` receipt of the arm that actually ran.
+- `review-spec-v1.4` (2026-09-04, issue #693): D1 separates runtime claims
+  from SHA-pinned source claims. An installed-binary mismatch triggers the
+  source check; it cannot alone turn a correct source citation into a P0.
 
 Changing a rule here changes the line for every engine. Record the version in
 each verdict's `spec:` field so catch rates stay readable against the spec they

--- a/docs/evidence/gh693/README.md
+++ b/docs/evidence/gh693/README.md
@@ -46,4 +46,6 @@ Run `verify.ps1` with the official release ZIP. It verifies the archive digest,
 executes the official binary's version and missing-dispatch probes, and asserts
 that the full PR #684 source SHA contains every cited field. The script fails
 on any unexpected runtime result or missing source field; it does not print a
-hardcoded pass.
+hardcoded pass. It also creates a disposable Git fixture where local `main`
+advances after a recorded base commit, proving that `git show <base SHA>` reads
+the frozen base version rather than the mutable branch.

--- a/docs/evidence/gh693/README.md
+++ b/docs/evidence/gh693/README.md
@@ -1,0 +1,49 @@
+# GH-693 — D1 claim-subject evidence
+
+This evidence distinguishes the historical installed runtime from the source
+claim that it was incorrectly used to judge.
+
+## Historical runtime
+
+The preserved official Windows `edda 0.3.0` artifact has SHA-256:
+
+```text
+a303e1a5042c6a112c430920e1a7bd0257f3dccc1a7dc9a44909aeef4ae33214
+```
+
+The checked artifact reports `edda 0.3.0`, and its `edda dispatch --help`
+probe exits `2`: that release does not expose a `dispatch` command. This is the
+actual official artifact, not a rebuilt old workspace. The earlier development
+0.3 binary used during PR #684 instead listed eight pre-GH-574 dispatch flags.
+Those two observations differ and are not interchangeable.
+
+## Same-input regression
+
+The source side is PR #684 commit
+`f94960306377e01e5e395704bc0876ec1fb4257b`, whose document cites
+`crates/edda-cli/src/cmd_dispatch.rs` at lines 58, 64, 68, 77, 83, and 87. The historical command probe is a
+runtime observation; the citation is a source claim. Under the old D1 wording,
+the unavailable/stale runtime was sufficient to report a false P0 against that
+source claim. Under the GH-693 routing, the runtime result is recorded but the
+claim is checked from the cited source:
+
+```sh
+git show f94960306377e01e5e395704bc0876ec1fb4257b:crates/edda-cli/src/cmd_dispatch.rs
+```
+
+That source contains the six cited GH-574 options: `--permission-mode`,
+`--model`, `--thinking`, `--tools`, `--exclude-tools`, and `--session-dir`.
+The new rule therefore produces no P0 for the same source citation, while it
+would still report a P1 if those cited source lines were absent.
+
+The current workstation's installed `edda --version` is recorded separately
+when a review begins. It is diagnostic context and never substitutes for a
+SHA-pinned source read.
+
+## Reproduction
+
+Run `verify.ps1` with the official release ZIP. It verifies the archive digest,
+executes the official binary's version and missing-dispatch probes, and asserts
+that the full PR #684 source SHA contains every cited field. The script fails
+on any unexpected runtime result or missing source field; it does not print a
+hardcoded pass.

--- a/docs/evidence/gh693/verify.ps1
+++ b/docs/evidence/gh693/verify.ps1
@@ -1,0 +1,46 @@
+param(
+    [Parameter(Mandatory)]
+    [string]$Archive,
+
+    [string]$Repository = "C:\ai_agent\edda-wt-gh693-review-subject"
+)
+
+$expectedArchiveHash = "a303e1a5042c6a112c430920e1a7bd0257f3dccc1a7dc9a44909aeef4ae33214"
+$sourceSha = "f94960306377e01e5e395704bc0876ec1fb4257b"
+$sourcePath = "crates/edda-cli/src/cmd_dispatch.rs"
+$requiredFields = @(
+    "pub permission_mode: Option<String>",
+    "pub model: Option<String>",
+    "pub thinking: Option<String>",
+    "pub tools: Option<Vec<String>>",
+    "pub exclude_tools: Option<Vec<String>>",
+    "pub session_dir: Option<String>"
+)
+
+if ((Get-FileHash -LiteralPath $Archive -Algorithm SHA256).Hash.ToLowerInvariant() -ne $expectedArchiveHash) {
+    throw "official v0.3.0 archive hash did not match"
+}
+
+$unpacked = Join-Path ([System.IO.Path]::GetTempPath()) ("edda-gh693-" + [guid]::NewGuid())
+try {
+    Expand-Archive -LiteralPath $Archive -DestinationPath $unpacked -Force
+    $binary = Get-ChildItem -LiteralPath $unpacked -Recurse -Filter edda.exe | Select-Object -First 1 -ExpandProperty FullName
+    if (-not $binary) { throw "official archive contained no edda.exe" }
+
+    $version = & $binary --version
+    if ($LASTEXITCODE -ne 0 -or $version -ne "edda 0.3.0") { throw "unexpected official v0.3.0 version result" }
+
+    & $binary dispatch --help *> $null
+    if ($LASTEXITCODE -ne 2) { throw "official v0.3.0 dispatch probe did not exit 2" }
+
+    $source = git -C $Repository show "$sourceSha`:$sourcePath"
+    if ($LASTEXITCODE -ne 0) { throw "could not read PR #684 source at $sourceSha" }
+    $sourceText = $source -join "`n"
+    foreach ($field in $requiredFields) {
+        if ($sourceText -notmatch [regex]::Escape($field)) { throw "missing source field: $field" }
+    }
+} finally {
+    if (Test-Path -LiteralPath $unpacked) { Remove-Item -LiteralPath $unpacked -Recurse -Force }
+}
+
+Write-Output "GH-693 runtime and source claim routing verified"

--- a/docs/evidence/gh693/verify.ps1
+++ b/docs/evidence/gh693/verify.ps1
@@ -39,6 +39,22 @@ try {
     foreach ($field in $requiredFields) {
         if ($sourceText -notmatch [regex]::Escape($field)) { throw "missing source field: $field" }
     }
+
+    $fixture = Join-Path $unpacked "base-sha-fixture"
+    git init -q --initial-branch main $fixture
+    git -C $fixture config user.email "gh693@example.invalid"
+    git -C $fixture config user.name "GH-693 fixture"
+    Set-Content -LiteralPath (Join-Path $fixture "Cargo.toml") -Value "[workspace.package]`nversion = `"0.3.0`""
+    git -C $fixture add Cargo.toml
+    git -C $fixture commit -qm "base version"
+    $baseSha = git -C $fixture rev-parse HEAD
+    Set-Content -LiteralPath (Join-Path $fixture "Cargo.toml") -Value "[workspace.package]`nversion = `"0.4.0`""
+    git -C $fixture commit -am "advance local main" -q
+    $mutableBranchVersion = (git -C $fixture show "main:Cargo.toml") -join "`n"
+    $pinnedBaseVersion = (git -C $fixture show "$baseSha`:Cargo.toml") -join "`n"
+    if ($mutableBranchVersion -notmatch '0.4.0' -or $pinnedBaseVersion -notmatch '0.3.0') {
+        throw "full base SHA did not isolate the version read from local main"
+    }
 } finally {
     if (Test-Path -LiteralPath $unpacked) { Remove-Item -LiteralPath $unpacked -Recurse -Force }
 }


### PR DESCRIPTION
Issue: #693

Closes #693

D1 now distinguishes runtime claims from SHA-pinned source claims. Runtime claims still require an installed-binary probe; source claims with a `path:line` citation are verified with `git show` at the stated SHA (or the reviewed head). The installed `edda --version` and base workspace version are recorded before probes, and a version mismatch alone cannot become a P0.

`docs/evidence/gh693/verify.ps1` is a focused regression verifier. Against the official v0.3.0 Windows release asset, it verifies archive SHA-256 `a303e1a5042c6a112c430920e1a7bd0257f3dccc1a7dc9a44909aeef4ae33214`, confirms `edda 0.3.0`, confirms `edda dispatch --help` exits 2, and asserts that full PR #684 source SHA `f94960306377e01e5e395704bc0876ec1fb4257b` contains all six cited dispatch fields. The real official artifact and historic development-install eight-flag observation are documented separately.

Validation: executed `verify.ps1` successfully; `scripts/lint-markdown-content.sh`, `scripts/lint-doc-citations.sh --staged`, staged file-length ratchet, PowerShell parser validation for the verifier, `bash -n scripts/review-pr.sh`, and `git diff --check` passed. No Cargo gate applies to this documentation/evidence-only change.