### PR TITLE
docs(skills): track edda-release skill for the CI publication flow (GH-648)

### DIFF
--- a/.claude/skills/edda-release/SKILL.md
+++ b/.claude/skills/edda-release/SKILL.md
@@ -282,7 +282,7 @@ Use the decision table below, then resume at the earliest missing safe step.
 | Observed state | Action |
 |---|---|
 | No tag pushed, nothing published | Return to preflight |
-| `prepare-crates` reports `enabled=false` | BLOCKED until the operator configures `CARGO_REGISTRY_TOKEN`, then rerun failed jobs |
+| `prepare-crates` reports `enabled=false` | BLOCKED until the operator configures `CARGO_REGISTRY_TOKEN`, then rerun the whole run (`gh run rerun <id>` without `--failed` — nothing failed; downstream jobs were skipped) |
 | Tag pushed, run failed at `publish-crates` | Rerun failed jobs (`gh run rerun <id> --failed`); verified crates are NO-OP |
 | Run failed at `create-release` (parity) | Inspect registry with `verify --tag`; rerun only after the cause is gone |
 | Run failed at `create-release` (CHANGELOG section missing) | BLOCKED; repair means a new commit and tag — operator decision, never move the tag |

--- a/.claude/skills/edda-release/SKILL.md
+++ b/.claude/skills/edda-release/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: edda-release
+description: "Release Edda across crates.io, GitHub assets, install.sh, and Homebrew without channel drift"
+---
+
+# Edda Release
+
+You are Edda's release operator. A release is complete only when every install
+path advertised in `README.md` gives users the intended version and its
+release-critical commands. A GitHub Release alone is not success.
+
+Since GH-648 (PR #847) the repository automates crates.io publication inside
+`.github/workflows/release.yml`: pushing the `v<VERSION>` tag makes CI publish
+every workspace crate in dependency order, verify registry provenance against
+the tag SHA, and only then create the GitHub Release. Your job shifts from
+uploading crates to proving the release **before** the tag push and proving the
+public channels **after** CI is green.
+
+## Usage
+
+```text
+edda-release preflight <version>
+edda-release publish <version>
+edda-release verify <version>
+edda-release recover <version>
+```
+
+Parse `args` as an operation plus a bare semantic version such as `0.4.1`.
+Reject a leading `v` in the version argument; derive the tag as `v<version>`.
+
+- `preflight`: read-only release readiness and exact-SHA package proof
+- `publish`: run the preflight, push the tag, watch CI, then prove every
+  advertised channel
+- `verify`: read-only public consumer canaries and parity report
+- `recover`: inspect a partial release, then resume only missing safe steps
+
+If the operation or version is missing, ask for it. Never guess a version.
+
+## Non-negotiable invariant
+
+The public contract is the `README.md` Install section. At present it advertises
+four surfaces: `install.sh`, Homebrew, crates.io, and GitHub release assets.
+Treat any version or behavior mismatch among them as a release blocker.
+
+For crates.io, “published” means all publishable workspace crates at the exact
+version are visible, unyanked, carry the frozen tag SHA in
+`.cargo_vcs_info.json`, and a plain unversioned `cargo install edda` works.
+
+The crates.io-before-GitHub-Release ordering is enforced by CI: the
+`create-release` job runs `python3 scripts/publish-crates.py verify --tag` and
+fails unless every publishable crate exists unyanked at the tag version. Do not
+re-implement that gate manually — verify it ran.
+
+## Authority boundary
+
+- `preflight` and `verify` are read-only except for disposable build/canary
+  directories.
+- An explicit `publish <version>` request authorizes pushing the
+  `v<VERSION>` tag — which triggers CI publication to crates.io and the
+  release workflow — plus the follow-up public canaries.
+- It does not authorize yanking a crate, deleting or replacing a tag/release,
+  force-pushing, editing or creating repository secrets, copying credentials,
+  or merging a PR. Ask separately before any of those actions.
+- Never print or read credential contents. Check only whether the
+  `CARGO_REGISTRY_TOKEN` secret is configured and whether Cargo authentication
+  is available locally.
+
+## Common ground truth
+
+### Step 1: Read repository policy and distribution reality
+
+Read `AGENTS.md` and `.claude/CLAUDE.md` completely, then inspect the actual
+install promises and release automation:
+
+```bash
+rg -n "cargo install|brew install|releases|install.sh" README.md
+git status --short --branch
+git fetch origin main --tags
+git rev-parse HEAD
+git ls-remote --tags origin "refs/tags/v<VERSION>"
+gh release view "v<VERSION>" --repo fagemx/edda
+gh secret list --repo fagemx/edda
+```
+
+`gh secret list` must show `CARGO_REGISTRY_TOKEN`. Without that secret,
+`prepare-crates` skips crates publication **and** every downstream GitHub
+Release job while the workflow run still looks green — a silent no-op release.
+Treat an absent secret as BLOCKED before pushing anything.
+
+Preserve unrelated changes. Release from a clean commit on current `origin/main`
+unless the operator explicitly names another full SHA.
+
+### Step 2: Freeze version, SHA, docs, and verification evidence
+
+Require all workspace packages, `Cargo.lock`, `CHANGELOG.md`, and the CLI docs
+to describe the same version. `release.yml` extracts release notes from a
+CHANGELOG heading that starts exactly with `## [<VERSION>]` — a missing section
+fails `create-release` after publication and cannot be repaired without moving
+the tag, so it must exist before the push.
+
+```bash
+rg -n '^version = "' Cargo.toml          # workspace version == <VERSION>
+rg -n "^## \[<VERSION>\]" CHANGELOG.md    # release-notes section exists
+EDDA_BIN=<built-edda-binary> bash scripts/check-cli-docs.sh
+```
+
+- `check-cli-docs.sh` (GH-650/GH-795) is the CLI reference drift gate: it
+  verifies every verb and long flag in `docs/reference/cli.md` against the
+  built binary. The old `check_cli_reference.py` no longer exists.
+- Package-version parity against the tag is enforced mechanically by
+  `publish-crates.py plan` in Step 3, once the local tag exists.
+- Follow the L0/L1/L2 verification ladder in `.claude/CLAUDE.md`. Reuse a valid
+  L1 receipt and exact-head CI for the frozen full SHA. Do not rerun the full
+  workspace merely to feel safer; run only uncovered focused checks and state
+  why.
+
+### Step 3: Prove packaging, then create a local-only immutable release point
+
+Mirror the `publish-crates-check.yml` dry-run gate locally:
+
+```bash
+cargo package --workspace --locked --no-verify
+cargo publish --dry-run --workspace --locked
+```
+
+Optionally verify the local archives would carry the tag SHA (skill-local
+helper, kept only for this check):
+
+```bash
+python scripts/crates_release_plan.py \
+  --version <VERSION> --package-dir target/package --expected-sha <FULL_SHA>
+```
+
+Only after packaging is green, create an annotated tag locally. Do not push it,
+then run the plan gate — it requires HEAD to be the tag's exact commit on a
+clean tree, validates the tag shape, and prints the dependency-first publish
+order (`python` instead of `python3` on Windows):
+
+```bash
+git tag -a "v<VERSION>" <FULL_SHA> -m "Release v<VERSION>"
+git rev-list -n 1 "v<VERSION>"
+python3 scripts/publish-crates.py plan --tag "v<VERSION>"
+python3 scripts/publish-crates-test.py
+```
+
+Create a detached worktree from that tag for any local re-verification (for
+example `publish-crates.py verify` after CI, which requires HEAD == tag on a
+clean tree). Use the worktree's default `target/`; do not invent timestamped
+Cargo target lanes.
+
+```bash
+git worktree add --detach <TEMP_WORKTREE> "v<VERSION>"
+```
+
+`preflight` stops here and reports evidence. Remove only the exact disposable
+worktree after verifying its resolved path.
+
+## Operation: publish
+
+### Step 1: Push the tag — the single mutation point
+
+The tag push is what publishes crates.io. Everything before it (preflight) is
+the only chance to catch package defects; publication itself is irreversible.
+
+```bash
+git push origin "refs/tags/v<VERSION>"
+gh run list --workflow release.yml --branch "v<VERSION>" --limit 5
+gh run watch <RUN_ID> --exit-status
+```
+
+### Step 2: Verify every CI job did its job
+
+Require all five jobs green — a green run with skipped jobs is BLOCKED:
+
+| Job | Requirement |
+|---|---|
+| `prepare-crates` | `enabled=true` (secret present); tag/plan validation passed |
+| `publish-crates` | `SUCCESS: all <N> workspace versions verified` |
+| `create-release` | parity gate `verify --tag` passed; draft release created from the CHANGELOG section |
+| `build-release` | all five platform archives + `.sha256` uploaded to the draft |
+| `publish-release` | exact 10-asset set, no empty assets, checksums verified, native binary canary without credentials, release published `--latest` |
+
+Never repair a failed run by moving the tag.
+
+### Step 3: Prove the README Cargo path
+
+Use a fresh Cargo home and install root. Run exactly the public command without
+`--version`, `--git`, `--path`, or `--locked`:
+
+```text
+cargo install edda --root <FRESH_ROOT>
+<FRESH_ROOT>/bin/edda --version
+<FRESH_ROOT>/bin/edda dispatch --help
+<FRESH_ROOT>/bin/edda verdict --help
+```
+
+The version must equal `<VERSION>`. On Windows, retry once with `--jobs 1` only
+when rustc itself exits with an OS crash/resource signature such as
+`0xc0000005`. A Rust compiler diagnostic, test failure, missing native library,
+or wrong CLI behavior is a product failure and must not be relabeled flaky.
+
+Do not declare DONE until this unversioned install canary passes.
+
+### Step 4: Prove install.sh and Homebrew
+
+Run the one-line installer twice in disposable directories: once pinned
+(`--version v<VERSION>`) and once through its default “latest” path. Both
+binaries must report the same version and expose `dispatch` and `verdict`.
+
+After the release is published, generate the Homebrew formula from the release
+checksums:
+
+```bash
+./scripts/update-homebrew.sh <VERSION> <HOME_BREW_TAP_CHECKOUT>
+brew audit --strict fagemx/tap/edda
+brew reinstall fagemx/tap/edda
+edda --version
+edda dispatch --help
+edda verdict --help
+```
+
+Commit and push the tap formula only after its diff names the intended version
+and hashes. If no macOS/Linux Homebrew verifier is available, the release cannot
+claim full `DONE`; report `DONE_WITH_CONCERNS` with the missing public canary.
+
+### Step 5: Record the release receipt
+
+Pin every claim to the tag's full SHA. Use this exact output structure:
+
+```markdown
+## Edda Release v<VERSION>
+
+Status: DONE | DONE_WITH_CONCERNS | BLOCKED
+Tag SHA: <40-hex>
+
+| Surface | Evidence | Result |
+|---|---|---|
+| Workspace packages | <N>, version parity (plan ORDER) | PASS/FAIL |
+| Preflight package proof | dry-run publish + local provenance SHA | PASS/FAIL |
+| Release workflow | run URL, all 5 jobs green, none skipped | PASS/FAIL |
+| crates.io | <N> visible and unyanked | PASS/FAIL |
+| crates.io provenance | CI VERIFIED lines / verify --tag SHA match | PASS/FAIL |
+| cargo install edda | resolved version + critical help canaries | PASS/FAIL |
+| GitHub Release | isLatest, 10 assets, checksums, native canary | PASS/FAIL |
+| install.sh | pinned + latest version canaries | PASS/FAIL |
+| Homebrew | formula commit + install canary | PASS/FAIL/NOT RUN |
+
+Failures/retries: <exact command, classification, result>
+Remaining action: <none or one concrete next action>
+```
+
+## Operation: verify
+
+Run the public half of the workflow without changing remote state:
+
+1. From the tag worktree, `python3 scripts/publish-crates.py verify --tag
+   "v<VERSION>"` — read-only all-crate registry and provenance proof.
+2. Repeat the fresh unversioned Cargo canary.
+3. Inspect the exact GitHub Actions run (all five jobs, none skipped), release
+   assets, and checksums; require `isLatest=true`.
+4. Repeat pinned/latest `install.sh` and Homebrew canaries.
+5. Emit the release receipt. Do not say DONE when any README channel is stale.
+
+## Operation: recover
+
+First inventory immutable public state; do not repeat successful mutations.
+CI publication is idempotent — `publish-crates.py publish` prints `NO-OP` for
+every already-verified crate — so resuming is usually just rerunning failed
+jobs:
+
+```bash
+git ls-remote --tags origin "refs/tags/v<VERSION>"
+gh run list --workflow release.yml --branch "v<VERSION>" --limit 5
+gh run view <RUN_ID> --json jobs,conclusion
+gh release view "v<VERSION>" --repo fagemx/edda --json isDraft,isLatest,assets
+# from the detached tag worktree:
+python3 scripts/publish-crates.py verify --tag "v<VERSION>"
+```
+
+Use the decision table below, then resume at the earliest missing safe step.
+
+| Observed state | Action |
+|---|---|
+| No tag pushed, nothing published | Return to preflight |
+| `prepare-crates` reports `enabled=false` | BLOCKED until the operator configures `CARGO_REGISTRY_TOKEN`, then rerun failed jobs |
+| Tag pushed, run failed at `publish-crates` | Rerun failed jobs (`gh run rerun <id> --failed`); verified crates are NO-OP |
+| Run failed at `create-release` (parity) | Inspect registry with `verify --tag`; rerun only after the cause is gone |
+| Run failed at `create-release` (CHANGELOG section missing) | BLOCKED; repair means a new commit and tag — operator decision, never move the tag |
+| Run failed at `build-release`/`publish-release` | Rerun failed jobs; draft uploads are clobber-safe and re-verified |
+| Registry provenance differs from tag SHA | BLOCKED; do not yank or move tag without operator decision |
+| Public release exists but a channel is stale | Repair that channel without changing immutable crate/tag identity |
+
+Registry propagation is handled inside `publish-crates.py` (bounded retries and
+a 12 × 10 s per-crate poll), so a missing-crate failure there is real, not
+lag. After three failures with the same stable cause, stop and report
+`BLOCKED` with the exact attempts.
+
+## Anti-patterns
+
+1. **GitHub-only success**: assets existing does not satisfy `cargo install edda`.
+2. **Push tag, then hope**: preflight is the only gate before an irreversible
+   publication; CI publishes and verifies, but a bad package at the tag is
+   unfixable without a new release identity.
+3. **Skipped-jobs green run**: `prepare-crates` with no token skips publication
+   and the release silently; a green run means nothing unless every job ran.
+4. **Publish from a moving checkout**: publication happens in CI from the tag;
+   local re-verification only from the exact detached tag worktree.
+5. **Root crate only**: all publishable workspace crates must reach crates.io in
+   dependency order — enforced by `publish-crates.py` and the parity gate.
+6. **Local artifact trust**: verify downloaded registry provenance and public
+   install behavior, not only `target/release/edda`.
+7. **Retry laundering**: distinguish registry delay or rustc OS crash from a
+   deterministic product/compiler failure.
+8. **Credential improvisation**: never echo tokens or edit repository secrets
+   without explicit authorization.
+9. **Destructive recovery**: never yank, delete, recreate, or force-move public
+   release identity as an automatic recovery step.
+10. **Manual publication drift**: do not run `cargo publish` locally; CI owns
+    ordering, provenance, and verification. Local helpers only prove packaging
+    and verify public state.
+
+## References
+
+- crates.io publication mechanics: `references/crates-io.md`
+- release automation: `.github/workflows/release.yml` (five jobs, tag-triggered)
+- publication dry-run gate: `.github/workflows/publish-crates-check.yml`
+- publish plan/publish/verify script: `scripts/publish-crates.py` (+ its test
+  `scripts/publish-crates-test.py`)
+- consumer promises: `README.md`
+- Homebrew formula generator: `scripts/update-homebrew.sh`
+- CLI reference drift gate: `scripts/check-cli-docs.sh` (GH-650/GH-795)
+- verification ladder and build lanes: `.claude/CLAUDE.md`

--- a/.claude/skills/edda-release/references/crates-io.md
+++ b/.claude/skills/edda-release/references/crates-io.md
@@ -1,0 +1,151 @@
+# crates.io release protocol
+
+This reference contains the detailed mechanics behind the crates.io gate in
+`edda-release`. Read it before `publish` or `recover` touches anything.
+
+Since GH-648 (PR #847) crates.io publication is automated in CI by
+`scripts/publish-crates.py`, a tracked script tested on every relevant PR by
+`.github/workflows/publish-crates-check.yml`. The release operator no longer
+uploads crates manually; the operator proves readiness before the tag push and
+proves public state after CI.
+
+## Why the root crate is not enough
+
+The `edda` binary depends on path crates in the workspace. crates.io resolves
+those as registry dependencies, so each publishable internal dependency must be
+available before a dependant can be accepted. Publishing only `edda` either
+fails or leaves `cargo install edda` resolving an older release.
+
+The script derives the order from `cargo metadata --locked --no-deps`, which is
+the source of truth:
+
+- packages with `publish = false` / `publish = []` are excluded;
+- every workspace package version must equal the tag version;
+- normal and build path-dependency edges (including target/optional ones) must
+  precede their reader; unversioned dev edges are dropped by Cargo and ignored;
+- the `edda` CLI is forced last by construction, not alphabetically;
+- cycles or a crate depending on `edda` abort the plan.
+
+The CLI is also deliberately published last so that a plain
+`cargo install edda` immediately after the run cannot resolve a stale root.
+
+## The three modes
+
+All modes share the same entry gate: the tag must match `vMAJOR.MINOR.PATCH`,
+`HEAD` must be the tag's exact commit (full 40-hex SHA), and the tree must have
+no tracked modifications.
+
+```bash
+python3 scripts/publish-crates.py plan    --tag "v<VERSION>"   # validate + print ORDER
+python3 scripts/publish-crates.py publish --tag "v<VERSION>"   # CI only: upload loop
+python3 scripts/publish-crates.py verify  --tag "v<VERSION>"   # read-only all-crate proof
+```
+
+- `plan` — validation only; prints `ORDER: a -> b -> ...`. This is the
+  preflight ordering gate and runs locally.
+- `publish` — requires `CARGO_REGISTRY_TOKEN` in the environment; refuses to
+  run without it. For each package in order: skip (`NO-OP`) if the registry
+  already has a verified match, otherwise `cargo publish --locked --registry
+  crates-io -p <name>`, then poll registry verification (12 × 10 s). A timed-out
+  upload or an already-uploaded race is judged by registry evidence, not by
+  Cargo's error wording. After all uploads it rechecks every version to catch
+  yanks and stragglers. Idempotent and resumable by design.
+- `verify` — read-only: every package must pass registry verification.
+  This is the parity gate CI runs in `create-release` before any GitHub Release
+  exists, and the operator's local inventory tool in `verify`/`recover` (run it
+  from the detached tag worktree so the HEAD gate is satisfied).
+
+## What "verified" means
+
+For every publishable workspace crate the script requires, from the official
+registry:
+
+- the exact version endpoint exists (`crates.io/api/v1/crates/<name>/<version>`);
+- `yanked` is false and the returned identity matches name and version;
+- the downloaded `.crate` archive's SHA256 equals the registry checksum;
+- the archive contains `.cargo_vcs_info.json` whose `git.sha1` equals the
+  frozen tag SHA and whose `dirty` flag is false;
+- `path_in_vcs` matches the crate's real workspace-relative path.
+
+Archive members are read in memory; registry-controlled paths are never
+extracted to disk. Each verified crate prints `VERIFIED <name>@<version>
+source=<sha>`.
+
+## Local preflight proof
+
+Before the tag push, mirror CI's dry-run gate:
+
+```bash
+cargo package --workspace --locked --no-verify
+cargo publish --dry-run --workspace --locked
+```
+
+`--no-verify` is allowed only for packaging/dry-run preflight: it avoids
+rebuilding packaged crates whose new internal dependency versions do not exist
+on the registry yet. It is never allowed on a real `cargo publish` — and the
+operator does not run real publishes locally at all.
+
+Optionally, the skill-local helper `scripts/crates_release_plan.py` (shipped
+with this skill) can check that the
+local archives in `target/package` would carry the tag SHA:
+
+```bash
+python scripts/crates_release_plan.py \
+  --version <VERSION> --package-dir target/package --expected-sha <FULL_SHA>
+```
+
+That helper is legacy: its `--commands`/manual-upload modes are superseded by
+CI publication and must not be used to upload anything. Only its local
+`--package-dir` provenance check remains meaningful. The canonical ordering and
+registry mechanics live in the tracked `scripts/publish-crates.py`.
+
+## Authentication safety
+
+CI publishes with the repository secret `CARGO_REGISTRY_TOKEN`. If the secret
+is absent, `prepare-crates` skips publication **and** every downstream GitHub
+Release job while the run still reports green — treat that as BLOCKED, not as
+success. Check secret presence with `gh secret list --repo fagemx/edda`; only
+the operator may create or edit secrets.
+
+Locally, accept either Cargo's normal credential provider/configuration or a
+`CARGO_REGISTRY_TOKEN` already supplied by the operator environment. Check only
+presence and ownership:
+
+```bash
+cargo owner --list edda
+```
+
+Never display credential files or token values. Never copy a developer token to
+repository files, CI logs, or GitHub secrets without a separate explicit request.
+
+## Recovery
+
+crates.io versions cannot be overwritten, but the CI publication loop is
+idempotent: verified crates are `NO-OP`, missing crates are uploaded, and the
+final recheck proves the whole set. Recovery is therefore:
+
+1. Inventory with `verify --tag` from the tag worktree, plus
+   `gh run view <id> --json jobs` and `gh release view --json isDraft,isLatest,assets`.
+2. Rerun only the failed workflow jobs (`gh run rerun <id> --failed`).
+3. Draft-release reuse and clobber-safe asset uploads make build reruns safe;
+   `publish-release` re-verifies the exact 10-asset set and checksums before
+   flipping the release public.
+4. Re-run the all-crate `verify --tag` proof and the plain public install
+   canary after recovery.
+
+If an existing crate has the wrong source SHA, stop. Automatic yanking does not
+repair provenance and may break dependants or users.
+
+## Public canary classification
+
+| Failure | Classification | Response |
+|---|---|---|
+| crates.io 404 during the script's own poll | handled internally | bounded retries + 120 s per-crate poll; a final failure is real |
+| crates.io/API network errors | environment | bounded retry, keep release state unchanged |
+| Windows rustc exits `0xc0000005` | environment candidate | retry once with `--jobs 1` |
+| Cargo compiler diagnostic | product/package | stop and fix; do not call flaky |
+| `prepare-crates` enabled=false | missing secret | BLOCKED; operator configures the secret, then rerun |
+| Installed version is older | channel drift | stop; investigate channel before declaring DONE |
+| `dispatch` or `verdict` help missing | release contents wrong | stop; BLOCKED with exact evidence |
+| Downloaded package SHA differs | provenance violation | block and request operator decision |
+| CHANGELOG section missing at tag | source defect | BLOCKED; repair needs a new tag — operator decision, never move the tag |

--- a/.claude/skills/edda-release/scripts/crates_release_plan.py
+++ b/.claude/skills/edda-release/scripts/crates_release_plan.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Plan and verify Edda's dependency-ordered crates.io release.
+
+This helper is deliberately read-only. It never publishes, yanks, tags, or
+changes repository state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import re
+import subprocess
+import sys
+import tarfile
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+USER_AGENT = "edda-release-skill/1.0 (+https://github.com/fagemx/edda)"
+
+
+class ReleasePlanError(RuntimeError):
+    """A release invariant failed."""
+
+
+@dataclass(frozen=True)
+class Package:
+    name: str
+    version: str
+    dependencies: frozenset[str]
+
+
+def cargo_metadata(manifest_path: Path) -> dict[str, Any]:
+    completed = subprocess.run(
+        [
+            "cargo",
+            "metadata",
+            "--locked",
+            "--no-deps",
+            "--format-version",
+            "1",
+            "--manifest-path",
+            str(manifest_path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def publishable_packages(metadata: dict[str, Any]) -> dict[str, Package]:
+    workspace_ids = set(metadata["workspace_members"])
+    raw_packages = [
+        package
+        for package in metadata["packages"]
+        if package["id"] in workspace_ids and package.get("publish") != []
+    ]
+    names = {package["name"] for package in raw_packages}
+    if len(names) != len(raw_packages):
+        raise ReleasePlanError("publishable workspace crate names are not unique")
+
+    result: dict[str, Package] = {}
+    for package in raw_packages:
+        internal = frozenset(
+            dependency["name"]
+            for dependency in package.get("dependencies", [])
+            if dependency.get("path") is not None and dependency["name"] in names
+        )
+        result[package["name"]] = Package(
+            name=package["name"],
+            version=package["version"],
+            dependencies=internal,
+        )
+    if not result:
+        raise ReleasePlanError("no publishable workspace crates found")
+    return result
+
+
+def topological_levels(packages: dict[str, Package]) -> list[list[str]]:
+    remaining = {name: set(package.dependencies) for name, package in packages.items()}
+    levels: list[list[str]] = []
+    published: set[str] = set()
+
+    while remaining:
+        ready = sorted(
+            name for name, dependencies in remaining.items() if dependencies <= published
+        )
+        if not ready:
+            unresolved = ", ".join(
+                f"{name} -> {sorted(dependencies - published)}"
+                for name, dependencies in sorted(remaining.items())
+            )
+            raise ReleasePlanError(f"internal dependency cycle or missing node: {unresolved}")
+        levels.append(ready)
+        published.update(ready)
+        for name in ready:
+            del remaining[name]
+    return levels
+
+
+def require_version(packages: dict[str, Package], expected: str) -> None:
+    if re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", expected) is None:
+        raise ReleasePlanError("--version must be a bare MAJOR.MINOR.PATCH version")
+    mismatches = [
+        f"{package.name}={package.version}"
+        for package in packages.values()
+        if package.version != expected
+    ]
+    if mismatches:
+        raise ReleasePlanError(
+            f"workspace versions do not all equal {expected}: {', '.join(sorted(mismatches))}"
+        )
+
+
+def select_packages(packages: dict[str, Package], requested: list[str]) -> list[str]:
+    if not requested:
+        return sorted(packages)
+    unknown = sorted(set(requested) - set(packages))
+    if unknown:
+        raise ReleasePlanError(f"unknown or non-publishable crate(s): {', '.join(unknown)}")
+    return sorted(set(requested))
+
+
+def request_bytes(url: str, timeout: float) -> bytes:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return response.read()
+
+
+def registry_version(crate: str, version: str, timeout: float) -> dict[str, Any]:
+    url = f"https://crates.io/api/v1/crates/{crate}/{version}"
+    try:
+        payload = json.loads(request_bytes(url, timeout))
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return {"crate": crate, "version": version, "exists": False, "yanked": None}
+        raise ReleasePlanError(f"crates.io returned HTTP {error.code} for {crate}") from error
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as error:
+        raise ReleasePlanError(f"crates.io query failed for {crate}: {error}") from error
+
+    published = payload.get("version")
+    if not isinstance(published, dict):
+        raise ReleasePlanError(f"crates.io response for {crate} has no version object")
+    return {
+        "crate": crate,
+        "version": version,
+        "exists": True,
+        "yanked": published.get("yanked"),
+        "checksum": published.get("checksum"),
+    }
+
+
+def wait_for_registry(
+    crates: list[str],
+    version: str,
+    wait_seconds: float,
+    poll_seconds: float,
+    timeout: float,
+) -> list[dict[str, Any]]:
+    deadline = time.monotonic() + wait_seconds
+    last_error: ReleasePlanError | None = None
+    while True:
+        statuses: list[dict[str, Any]] = []
+        try:
+            statuses = [registry_version(crate, version, timeout) for crate in crates]
+            last_error = None
+        except ReleasePlanError as error:
+            last_error = error
+
+        if last_error is None and all(
+            status["exists"] and status["yanked"] is False for status in statuses
+        ):
+            return statuses
+        if time.monotonic() >= deadline:
+            if last_error is not None:
+                raise last_error
+            return statuses
+        time.sleep(min(poll_seconds, max(0.0, deadline - time.monotonic())))
+
+
+def vcs_sha_from_archive(archive: bytes, label: str) -> str:
+    try:
+        with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as crate:
+            members = [
+                member
+                for member in crate.getmembers()
+                if member.name.endswith("/.cargo_vcs_info.json")
+            ]
+            if len(members) != 1:
+                raise ReleasePlanError(
+                    f"{label} contains {len(members)} .cargo_vcs_info.json files"
+                )
+            extracted = crate.extractfile(members[0])
+            if extracted is None:
+                raise ReleasePlanError(f"cannot read provenance from {label}")
+            payload = json.load(extracted)
+    except (tarfile.TarError, json.JSONDecodeError) as error:
+        raise ReleasePlanError(f"cannot parse package provenance from {label}: {error}") from error
+
+    git = payload.get("git", {})
+    sha = git.get("sha1")
+    if not isinstance(sha, str):
+        raise ReleasePlanError(f"{label} has no git.sha1 provenance")
+    if git.get("dirty", False) is not False:
+        raise ReleasePlanError(f"{label} was packaged from a dirty worktree")
+    return sha.lower()
+
+
+def validate_expected_sha(value: str) -> str:
+    normalized = value.lower()
+    if len(normalized) != 40 or any(character not in "0123456789abcdef" for character in normalized):
+        raise ReleasePlanError("--expected-sha must be a full 40-hex commit SHA")
+    return normalized
+
+
+def local_package_provenance(
+    package_dir: Path, crates: list[str], version: str, expected_sha: str
+) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for crate in crates:
+        archive_path = package_dir / f"{crate}-{version}.crate"
+        if not archive_path.is_file():
+            raise ReleasePlanError(f"missing packaged archive: {archive_path}")
+        sha = vcs_sha_from_archive(archive_path.read_bytes(), str(archive_path))
+        if sha != expected_sha:
+            raise ReleasePlanError(
+                f"{archive_path.name} provenance {sha} does not match {expected_sha}"
+            )
+        result[crate] = sha
+    return result
+
+
+def published_package_provenance(
+    crates: list[str], version: str, expected_sha: str, timeout: float
+) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for crate in crates:
+        url = f"https://crates.io/api/v1/crates/{crate}/{version}/download"
+        try:
+            archive = request_bytes(url, timeout)
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as error:
+            raise ReleasePlanError(f"cannot download {crate} {version}: {error}") from error
+        sha = vcs_sha_from_archive(archive, f"{crate} {version} from crates.io")
+        if sha != expected_sha:
+            raise ReleasePlanError(
+                f"published {crate} provenance {sha} does not match {expected_sha}"
+            )
+        result[crate] = sha
+    return result
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--manifest-path", type=Path, default=Path("Cargo.toml"))
+    result.add_argument("--version", required=True, help="bare MAJOR.MINOR.PATCH version")
+    result.add_argument("--crate", action="append", default=[], dest="crates")
+    result.add_argument("--commands", action="store_true", help="print cargo publish commands")
+    result.add_argument("--json", action="store_true", dest="json_output")
+    result.add_argument("--check-crates-io", action="store_true")
+    result.add_argument(
+        "--allow-missing",
+        action="store_true",
+        help="inventory missing/yanked versions instead of failing (recovery only)",
+    )
+    result.add_argument(
+        "--wait-crates-io",
+        type=float,
+        metavar="SECONDS",
+        help="poll until selected crates exist and are unyanked",
+    )
+    result.add_argument("--poll-interval", type=float, default=5.0)
+    result.add_argument("--network-timeout", type=float, default=20.0)
+    result.add_argument("--package-dir", type=Path)
+    result.add_argument("--expected-sha")
+    result.add_argument("--check-published-provenance", action="store_true")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        metadata = cargo_metadata(args.manifest_path.resolve())
+        packages = publishable_packages(metadata)
+        require_version(packages, args.version)
+        levels = topological_levels(packages)
+        selected = select_packages(packages, args.crates)
+
+        if args.poll_interval <= 0:
+            raise ReleasePlanError("--poll-interval must be positive")
+        if args.network_timeout <= 0:
+            raise ReleasePlanError("--network-timeout must be positive")
+        if args.package_dir is not None and args.expected_sha is None:
+            raise ReleasePlanError("--package-dir requires --expected-sha")
+        if args.check_published_provenance and args.expected_sha is None:
+            raise ReleasePlanError("--check-published-provenance requires --expected-sha")
+        if args.allow_missing and args.check_published_provenance:
+            raise ReleasePlanError(
+                "--allow-missing cannot be combined with --check-published-provenance"
+            )
+        expected_sha = (
+            validate_expected_sha(args.expected_sha) if args.expected_sha is not None else None
+        )
+
+        registry: list[dict[str, Any]] | None = None
+        if args.wait_crates_io is not None:
+            if args.wait_crates_io < 0:
+                raise ReleasePlanError("--wait-crates-io must be non-negative")
+            registry = wait_for_registry(
+                selected,
+                args.version,
+                args.wait_crates_io,
+                args.poll_interval,
+                args.network_timeout,
+            )
+        elif args.check_crates_io or args.check_published_provenance:
+            registry = wait_for_registry(
+                selected, args.version, 0, args.poll_interval, args.network_timeout
+            )
+
+        if registry is not None:
+            unavailable = [
+                status["crate"]
+                for status in registry
+                if not status["exists"] or status["yanked"] is not False
+            ]
+            if unavailable and not args.allow_missing:
+                raise ReleasePlanError(
+                    f"crates.io exact version missing or yanked: {', '.join(unavailable)}"
+                )
+
+        local_provenance: dict[str, str] | None = None
+        if args.package_dir is not None and expected_sha is not None:
+            local_provenance = local_package_provenance(
+                args.package_dir.resolve(), selected, args.version, expected_sha
+            )
+
+        published_provenance: dict[str, str] | None = None
+        if args.check_published_provenance and expected_sha is not None:
+            published_provenance = published_package_provenance(
+                selected, args.version, expected_sha, args.network_timeout
+            )
+
+        output = {
+            "version": args.version,
+            "publishable_count": len(packages),
+            "selected_count": len(selected),
+            "selected": selected,
+            "levels": levels,
+            "registry": registry,
+            "local_provenance": local_provenance,
+            "published_provenance": published_provenance,
+        }
+
+        if args.json_output:
+            print(json.dumps(output, indent=2, sort_keys=True))
+        else:
+            print(f"publishable workspace crates: {len(packages)}")
+            for index, level in enumerate(levels):
+                print(f"L{index}: {', '.join(level)}")
+            if args.commands:
+                print("publish commands:")
+                for level in levels:
+                    for crate in level:
+                        if crate in selected:
+                            print(f"cargo publish -p {crate} --locked")
+            if registry is not None:
+                unavailable = [
+                    status["crate"]
+                    for status in registry
+                    if not status["exists"] or status["yanked"] is not False
+                ]
+                if unavailable:
+                    print(
+                        "crates.io inventory: "
+                        f"{len(registry) - len(unavailable)} ready, "
+                        f"{len(unavailable)} missing/yanked"
+                    )
+                else:
+                    print(f"crates.io exact-version parity: PASS ({len(registry)} checked)")
+            if local_provenance is not None:
+                print(f"local package provenance: PASS ({len(local_provenance)} checked)")
+            if published_provenance is not None:
+                print(f"published package provenance: PASS ({len(published_provenance)} checked)")
+        return 0
+    except (ReleasePlanError, subprocess.CalledProcessError) as error:
+        print(f"release preflight failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/edda-release/scripts/test_crates_release_plan.py
+++ b/.claude/skills/edda-release/scripts/test_crates_release_plan.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Focused tests for the read-only crates release planner."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import tarfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).with_name("crates_release_plan.py")
+SPEC = importlib.util.spec_from_file_location("crates_release_plan", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load {SCRIPT}")
+release_plan = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = release_plan
+SPEC.loader.exec_module(release_plan)
+
+
+def metadata_fixture() -> dict[str, object]:
+    package_id = "demo 1.2.3 (path+file:///demo)"
+    return {
+        "workspace_members": [package_id],
+        "packages": [
+            {
+                "id": package_id,
+                "name": "demo",
+                "version": "1.2.3",
+                "publish": None,
+                "dependencies": [],
+            }
+        ],
+    }
+
+
+def crate_archive(sha: str, *, dirty: bool = False) -> bytes:
+    output = io.BytesIO()
+    payload = json.dumps({"git": {"sha1": sha, "dirty": dirty}}).encode()
+    with tarfile.open(fileobj=output, mode="w:gz") as archive:
+        member = tarfile.TarInfo("demo-1.2.3/.cargo_vcs_info.json")
+        member.size = len(payload)
+        archive.addfile(member, io.BytesIO(payload))
+    return output.getvalue()
+
+
+class ReleasePlanTests(unittest.TestCase):
+    def test_topological_levels_are_dependency_first(self) -> None:
+        packages = {
+            "core": release_plan.Package("core", "1.2.3", frozenset()),
+            "middle": release_plan.Package("middle", "1.2.3", frozenset({"core"})),
+            "cli": release_plan.Package("cli", "1.2.3", frozenset({"middle"})),
+        }
+        self.assertEqual(
+            release_plan.topological_levels(packages),
+            [["core"], ["middle"], ["cli"]],
+        )
+
+    def test_topological_cycle_fails_closed(self) -> None:
+        packages = {
+            "a": release_plan.Package("a", "1.2.3", frozenset({"b"})),
+            "b": release_plan.Package("b", "1.2.3", frozenset({"a"})),
+        }
+        with self.assertRaises(release_plan.ReleasePlanError):
+            release_plan.topological_levels(packages)
+
+    def test_version_must_be_bare_semver(self) -> None:
+        packages = {"demo": release_plan.Package("demo", "1.2.3", frozenset())}
+        with self.assertRaises(release_plan.ReleasePlanError):
+            release_plan.require_version(packages, "v1.2.3")
+
+    def test_archive_provenance_rejects_dirty_package(self) -> None:
+        sha = "a" * 40
+        self.assertEqual(
+            release_plan.vcs_sha_from_archive(crate_archive(sha), "fixture"), sha
+        )
+        with self.assertRaises(release_plan.ReleasePlanError):
+            release_plan.vcs_sha_from_archive(
+                crate_archive(sha, dirty=True), "dirty fixture"
+            )
+
+    def test_recovery_inventory_allows_missing_registry_version(self) -> None:
+        status = [{"crate": "demo", "version": "1.2.3", "exists": False, "yanked": None}]
+        argv = [
+            str(SCRIPT),
+            "--version",
+            "1.2.3",
+            "--check-crates-io",
+            "--allow-missing",
+            "--json",
+        ]
+        with (
+            mock.patch.object(release_plan, "cargo_metadata", return_value=metadata_fixture()),
+            mock.patch.object(release_plan, "wait_for_registry", return_value=status),
+            mock.patch.object(release_plan.sys, "argv", argv),
+            redirect_stdout(io.StringIO()) as stdout,
+        ):
+            self.assertEqual(release_plan.main(), 0)
+        self.assertFalse(json.loads(stdout.getvalue())["registry"][0]["exists"])
+
+    def test_verify_rejects_missing_registry_version(self) -> None:
+        status = [{"crate": "demo", "version": "1.2.3", "exists": False, "yanked": None}]
+        argv = [str(SCRIPT), "--version", "1.2.3", "--check-crates-io"]
+        with (
+            mock.patch.object(release_plan, "cargo_metadata", return_value=metadata_fixture()),
+            mock.patch.object(release_plan, "wait_for_registry", return_value=status),
+            mock.patch.object(release_plan.sys, "argv", argv),
+            redirect_stderr(io.StringIO()) as stderr,
+        ):
+            self.assertEqual(release_plan.main(), 1)
+        self.assertIn("missing or yanked", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue: #648

Context: GH-648 / PR #847 (8885ce2) moved crates.io publication into release.yml (five tag-triggered jobs: prepare-crates, publish-crates, create-release, build-release, publish-release). The edda-release skill still described the pre-#847 flow — a manual per-crate cargo publish loop before the tag push — and referenced the deleted scripts/check_cli_reference.py. Following the old skill would bypass CI ordering and provenance verification.

This PR tracks the skill in the repository for the first time under .claude/skills/edda-release/ (house convention for tracked skills) and rewrites it to match the automated flow:

- preflight proves packaging before the irreversible mutation (plan gate after local tag, dry-run publish mirroring publish-crates-check.yml, CHANGELOG ## [version] section, CARGO_REGISTRY_TOKEN secret presence, check-cli-docs.sh CLI reference gate)
- publish pushes the tag, verifies all five CI jobs (a green run with skipped jobs is BLOCKED), then runs public canaries: unversioned cargo install edda, install.sh pinned+latest, Homebrew formula
- recover is CI-rerun based (publish-crates.py publish is idempotent; NO-OP for verified crates) with the token-absent skip and CHANGELOG-missing cases classified BLOCKED
- references/crates-io.md documents publish-crates.py plan/publish/verify semantics, provenance rules (sha1 == tag SHA, clean, path_in_vcs, registry checksum), and the canary classification table
- skill-local crates_release_plan.py is kept only for the local target/package provenance check; its upload modes are marked legacy — CI owns publication

Skill-internal helper paths are skill-relative (scripts/...) so the tracked copy and the local .agents mirror stay content-identical.

Validation at head bcb7a8e2 (frozen):
- RAN: python -m py_compile on both skill scripts; unittest test_crates_release_plan from the scripts directory (6 tests OK); publish-crates-test.py at repo scripts/ (8 tests OK); diff -r of .agents and .claude skill copies reports identical.
- RAN: pre-commit hooks on the commit (markdown content lint, staged file-length ratchet) passed.
- READ: release.yml, publish-crates.py, publish-crates-check.yml, install.sh, update-homebrew.sh, check-cli-docs.sh sources; CHANGELOG heading extraction semantics confirmed against the workflow awk.
- Exact-head CI receipt for this PR run to be posted when available. Docs/skill-only change: no Cargo gate applies locally; build lane n/a.

Scope: only .claude/skills/edda-release/**. No product code, workflow, or installer change. The new release.yml has not yet executed a real release (v0.4.0 predates #847); the first tagged release is the end-to-end validation of both the automation and this skill. Independent SHA-pinned review is required.
