### PR TITLE
feat(fleet): brief-from-issue renders the invariant brief skeleton from the issue body

### DIFF
--- a/docs/guides/brief-template.md
+++ b/docs/guides/brief-template.md
@@ -94,6 +94,12 @@ lane will not infer them:
 3. `pr.closing-keyword`: state whether a closing keyword is allowed for that
    PR — allowed only when every doneWhen item of the issue is delivered.
 
+The facts block, the nine preamble steps, and the finish steps of a flash-tier
+brief are rendered by `scripts/fleet/brief-from-issue.sh` from the issue body's
+`## Predicted surface` section. Example B below stays the worked shape. The
+script prints `<<AUTHORED STEPS>>` once; the issuer replaces that marker with
+the issue-specific implementation steps.
+
 ## PR-body evidence standard
 
 The worked example of the evidence a PR body must carry is the description of

--- a/scripts/fleet/brief-from-issue.sh
+++ b/scripts/fleet/brief-from-issue.sh
@@ -80,7 +80,11 @@ body=$(printf '%s' "$json" | jq -r .body)
 [ -n "$title" ] && [ "$title" != "null" ] || die "issue $issue has no title"
 [ -n "$body" ] && [ "$body" != "null" ] || die "issue $issue has an empty body"
 
-title_safe=$(printf '%s' "$title" | tr -d '"')
+# The title is interpolated verbatim into quoted shell strings inside the
+# brief (steps 15 and 21), so double quotes, backticks, and dollar signs are
+# stripped: a backtick or $(...) surviving into step 15 would be expanded by
+# the lane's shell when it runs that step.
+title_safe=$(printf '%s' "$title" | tr -d '"`$')
 
 section=$(printf '%s\n' "$body" | tr -d '\r' | awk '
     /^##[ \t]+Predicted surface[ \t]*$/ { p=1; next }

--- a/scripts/fleet/brief-from-issue.sh
+++ b/scripts/fleet/brief-from-issue.sh
@@ -1,0 +1,239 @@
+#!/bin/sh
+# brief-from-issue.sh — render the facts block, nine preamble steps, and
+# finish steps of a flash-tier lane brief from a GitHub issue body (GH-885).
+# The authored middle is the single marker line <<AUTHORED STEPS>>.
+#
+# usage:
+#   sh scripts/fleet/brief-from-issue.sh <issue> \
+#        --lane-name <name> --worktree <path> --branch <branch> \
+#        [--task-id <id>] [--build-lane <lane>]
+#
+# Prints the brief to stdout. Writes no files.
+set -eu
+
+usage() {
+    echo "usage: $0 <issue> --lane-name <name> --worktree <path> --branch <branch> [--task-id <id>] [--build-lane <lane>]" >&2
+}
+
+die() {
+    echo "brief-from-issue: $1" >&2
+    exit 2
+}
+
+repo=${EDDA_REPO:-fagemx/edda}
+issue=
+lane_name=
+worktree=
+branch=
+task=none
+lane=none
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --lane-name)
+            [ -n "${2:-}" ] || die "--lane-name requires a value"
+            lane_name=$2; shift 2 ;;
+        --worktree)
+            [ -n "${2:-}" ] || die "--worktree requires a value"
+            worktree=$2; shift 2 ;;
+        --branch)
+            [ -n "${2:-}" ] || die "--branch requires a value"
+            branch=$2; shift 2 ;;
+        --task-id)
+            [ -n "${2:-}" ] || die "--task-id requires a value"
+            task=$2; shift 2 ;;
+        --build-lane)
+            [ -n "${2:-}" ] || die "--build-lane requires a value"
+            lane=$2; shift 2 ;;
+        -h|--help)
+            usage; exit 0 ;;
+        --)
+            shift; break ;;
+        -*)
+            die "unknown option $1" ;;
+        *)
+            if [ -z "$issue" ]; then
+                issue=$1; shift
+            else
+                die "unexpected argument $1"
+            fi
+            ;;
+    esac
+done
+
+[ -n "$issue" ] || { usage; exit 2; }
+[ -n "$lane_name" ] || die "missing --lane-name"
+[ -n "$worktree" ] || die "missing --worktree"
+[ -n "$branch" ] || die "missing --branch"
+case "$issue" in
+    *[!0-9]*|'') die "issue must be a positive integer, got '$issue'" ;;
+esac
+
+self_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+root=$(CDPATH= cd -- "$self_dir/../.." && pwd)
+
+json=$(gh issue view "$issue" --repo "$repo" --json body,title,labels) ||
+    die "gh issue view $issue failed"
+
+title=$(printf '%s' "$json" | jq -r .title)
+body=$(printf '%s' "$json" | jq -r .body)
+[ -n "$title" ] && [ "$title" != "null" ] || die "issue $issue has no title"
+[ -n "$body" ] && [ "$body" != "null" ] || die "issue $issue has an empty body"
+
+title_safe=$(printf '%s' "$title" | tr -d '"')
+
+section=$(printf '%s\n' "$body" | tr -d '\r' | awk '
+    /^##[ \t]+Predicted surface[ \t]*$/ { p=1; next }
+    /^##[ \t]/ { if (p) exit }
+    p { print }
+')
+[ -n "$section" ] || die "missing or empty ## Predicted surface section"
+
+is_repo_path() {
+    case "$1" in
+        http://*|https://*) return 1 ;;
+        */*) return 0 ;;
+        *.sh|*.ps1|*.md|*.rs|*.toml|*.yml|*.yaml|*.json|*.lock) return 0 ;;
+    esac
+    return 1
+}
+
+tmp=$(mktemp "${TMPDIR:-/tmp}/brief-from-issue.XXXXXX")
+raw=$(mktemp "${TMPDIR:-/tmp}/brief-from-issue.XXXXXX")
+trap 'rm -f "$tmp" "$raw"' 0 HUP INT TERM
+
+# Backtick tokens come in pairs with awk RS='`': odd records are the prose
+# between tokens, even records are the tokens themselves. A token whose prose
+# prefix ends in no/not/without is a negated mention ("No crate, no `REVIEW.md`."),
+# not a listed path, and is dropped here so the scope never grows a path the
+# issue explicitly excluded.
+printf '%s' "$section" | awk -v RS='`' '
+    NR % 2 == 1 { prev = $0; next }
+    {
+        p = prev
+        sub(/[ \t\r\n]+$/, "", p)
+        if (p !~ /([Nn]o|[Nn]ot|[Ww]ithout)$/) print
+    }
+' >"$raw"
+: >"$tmp"
+while IFS= read -r tok; do
+    [ -n "$tok" ] || continue
+    is_repo_path "$tok" || continue
+    if grep -Fxq -- "$tok" "$tmp" 2>/dev/null; then
+        continue
+    fi
+    printf '%s\n' "$tok" >>"$tmp"
+done <"$raw"
+
+[ -s "$tmp" ] || die "missing or empty ## Predicted surface section"
+
+paths_csv=
+paths_claim=
+paths_space=
+npath=0
+while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    npath=$((npath + 1))
+    if [ -z "$paths_csv" ]; then
+        paths_csv=$p
+        paths_space=$p
+    else
+        paths_csv="$paths_csv, $p"
+        paths_space="$paths_space $p"
+    fi
+    paths_claim="$paths_claim --paths $p"
+done <"$tmp"
+
+sha=$(git -C "$root" rev-parse origin/main) || die "git rev-parse origin/main failed"
+case "$sha" in
+    [0-9a-f]*) ;;
+    *) die "origin/main SHA is empty" ;;
+esac
+
+host=$(uname -s)
+case "$host" in
+    MINGW*|MSYS*|CYGWIN*)
+        host_fact='Host: MINGW/MSYS. review-pr.sh --dry-run generates -lane.ps1 and no -run.sh.'
+        ;;
+    *)
+        host_fact='Host: Linux. review-pr.sh --dry-run generates -run.sh and no -lane.ps1.'
+        ;;
+esac
+
+# Porcelain expected lines: one path per line, listed for the git-status finish step.
+status_lines=$(printf '%s\n' "$paths_space" | tr ' ' '\n' | sed '/^$/d')
+
+cat <<EOF
+role: worker · lane: ${lane} · task id: ${task} · issue: #${issue} ·
+base full SHA: ${sha} ·
+scope paths: ${paths_csv} ·
+entry: none: procedure below · gate owner: not you; review queue ·
+out-of-scope: every path and concern not listed in scope paths
+
+Launcher contract: you are pi 0.84.4 in an exclusively owned, clean worktree at ${worktree} on branch ${branch} at the base full SHA, with task ${task} assigned, issue #${issue} claimed, lane name ${lane_name}, and no existing PR for that branch. Your tools are bash({"command": string}) running Git Bash, write({"path": string, "content": string}) and edit({"path": string, "edits": [{"oldText": string, "newText": string}]}). Shell commands go in bash.command; file changes are write/edit tool calls, never shell programs that rewrite files (no sed -i, no cat > file). git, gh and edda are authenticated on PATH. Build lane: ${lane}.
+
+${host_fact}
+
+Failure rule for every numbered step: a nonzero command exit, tool error,
+or output-schema mismatch stops execution. Report exactly
+STOP step=<number> output=<verbatim unexpected output>. Preserve all files;
+do not restore, checkout, reset, clean, retry, review, or merge. The controller
+issues the next brief. Success advances to the next numbered step.
+
+1. gh issue view ${issue} --repo ${repo} --json state --jq .state
+   output: OPEN.
+2. git status --porcelain=v1 --untracked-files=all --branch
+   output: exactly ## ${branch}...origin/main, no other lines.
+3. git rev-parse HEAD
+   output: ${sha}.
+4. edda context
+   output: context text, exit 0; an off-limits overlap with a scope path is a STOP under the failure rule.
+5. edda task list
+   output: task-list text, exit 0, including task ${task}.
+6. edda task show ${task}
+   output: task ${task} and this brief, exit 0.
+7. edda claim gh${issue}-worker${paths_claim}
+   output: successful claim for gh${issue}-worker and the scope paths, exit 0.
+8. gh issue view ${issue} --repo ${repo} --json body --jq .body
+   output: the issue body, exit 0. Read doneWhen there; do not copy doneWhen into this brief.
+9. git ls-files -- ${paths_space}
+   output: the tracked subset of the scope paths, one per line, exit 0. cat each printed path. Untracked scope paths are created in the authored steps; that is not a STOP.
+
+<<AUTHORED STEPS>>
+
+10. git status --porcelain=v1 --untracked-files=all
+    output: exactly the scope paths and no others, one porcelain line per path:
+${status_lines}
+11. git diff --check
+    output: empty stdout, exit 0.
+12. git add -- ${paths_space}
+    output: empty stdout, exit 0.
+13. git diff --cached --name-only
+    output: exactly the scope paths, one path per line, and no others.
+14. git diff --cached --stat
+    output: ${npath} path-stat lines and one summary line for exactly ${npath} files.
+15. git commit -m "${title_safe}" -m "Issue: #${issue}"
+    output: git commit summary, exit 0.
+16. git log -1 --format=%B | grep -Fx 'Issue: #${issue}'
+    output: Issue: #${issue}.
+17. git status --porcelain=v1 --untracked-files=all
+    output: empty stdout, exit 0.
+18. git rev-parse HEAD
+    output: one 40-character hexadecimal SHA; retain as delivery_sha.
+19. git push --porcelain -u origin ${branch}
+    output: Git porcelain push status, exit 0, no rejected ref. A normal push; no force option is authorized.
+20. write({"path":".git/gh${issue}-pr-body.md","content":PR_BODY}) with PR_BODY containing exactly these sections in this order: ## Problem and change; ## Validation with ### RAN and ### READ; then the line Issue: #${issue}. pr.closing-keyword: a closing keyword is allowed only when every doneWhen item of #${issue} is delivered.
+    output: Successfully wrote bytes to .git/gh${issue}-pr-body.md.
+21. gh pr create --repo ${repo} --base main --head ${branch} --title "${title_safe}" --body-file .git/gh${issue}-pr-body.md
+    output: one https://github.com/${repo}/pull/<integer> URL, exit 0. Retain as pr_url.
+22. gh pr view ${branch} --repo ${repo} --json headRefOid --jq .headRefOid
+    output: delivery_sha from step 18, exactly.
+23. edda task done ${task} --receipt "PR <pr_url> @ <delivery_sha>"
+    output: task ${task} marked done, exit 0.
+24. Report, as the final message, exactly these five lines and nothing else:
+    DONE issue=#${issue} task=${task}
+    pr=<pr_url>
+    sha=<delivery_sha>
+    tests=exit 0
+    stop=controller issues the next brief
+EOF

--- a/scripts/fleet/brief-from-issue.sh
+++ b/scripts/fleet/brief-from-issue.sh
@@ -123,6 +123,13 @@ printf '%s' "$section" | awk -v RS='`' '
 while IFS= read -r tok; do
     [ -n "$tok" ] || continue
     is_repo_path "$tok" || continue
+    # R5: these tokens reach the lane's shell inside rendered command lines
+    # (steps 7, 9 and 12), so only the plain repo-relative path shape is
+    # accepted — no metacharacters, no leading dash, never a bare slash.
+    case "$tok" in
+        *[!A-Za-z0-9._/-]*|-*|/|.|..|*/..*|../*)
+            die "Predicted-surface token '$tok' is not a plain repo-relative path" ;;
+    esac
     if grep -Fxq -- "$tok" "$tmp" 2>/dev/null; then
         continue
     fi
@@ -134,6 +141,7 @@ done <"$raw"
 paths_csv=
 paths_claim=
 paths_space=
+paths_quoted=
 npath=0
 while IFS= read -r p; do
     [ -n "$p" ] || continue
@@ -141,11 +149,13 @@ while IFS= read -r p; do
     if [ -z "$paths_csv" ]; then
         paths_csv=$p
         paths_space=$p
+        paths_quoted="\"$p\""
     else
         paths_csv="$paths_csv, $p"
         paths_space="$paths_space $p"
+        paths_quoted="$paths_quoted \"$p\""
     fi
-    paths_claim="$paths_claim --paths $p"
+    paths_claim="$paths_claim --paths \"$p\""
 done <"$tmp"
 
 sha=$(git -C "$root" rev-parse origin/main) || die "git rev-parse origin/main failed"
@@ -166,6 +176,7 @@ esac
 
 # Porcelain expected lines: one path per line, listed for the git-status finish step.
 status_lines=$(printf '%s\n' "$paths_space" | tr ' ' '\n' | sed '/^$/d')
+first_path=$(printf '%s' "$status_lines" | head -1)
 
 cat <<EOF
 role: worker · lane: ${lane} · task id: ${task} · issue: #${issue} ·
@@ -200,17 +211,17 @@ issues the next brief. Success advances to the next numbered step.
    output: successful claim for gh${issue}-worker and the scope paths, exit 0.
 8. gh issue view ${issue} --repo ${repo} --json body --jq .body
    output: the issue body, exit 0. Read doneWhen there; do not copy doneWhen into this brief.
-9. git ls-files -- ${paths_space}
+9. git ls-files -- ${paths_quoted}
    output: the tracked subset of the scope paths, one per line, exit 0. cat each printed path. Untracked scope paths are created in the authored steps; that is not a STOP.
 
 <<AUTHORED STEPS>>
 
 10. git status --porcelain=v1 --untracked-files=all
-    output: exactly the scope paths and no others, one porcelain line per path:
+    output: exactly one porcelain line per scope path and no other paths, each line being the two-character status, a space, then the path (for example \`?? ${first_path}\` for a new file or \` M ${first_path}\` for a modified one):
 ${status_lines}
 11. git diff --check
     output: empty stdout, exit 0.
-12. git add -- ${paths_space}
+12. git add -- ${paths_quoted}
     output: empty stdout, exit 0.
 13. git diff --cached --name-only
     output: exactly the scope paths, one path per line, and no others.

--- a/scripts/fleet/brief-from-issue.sh
+++ b/scripts/fleet/brief-from-issue.sh
@@ -84,7 +84,7 @@ body=$(printf '%s' "$json" | jq -r .body)
 # brief (steps 15 and 21), so double quotes, backticks, and dollar signs are
 # stripped: a backtick or $(...) surviving into step 15 would be expanded by
 # the lane's shell when it runs that step.
-title_safe=$(printf '%s' "$title" | tr -d '"`$')
+title_safe=$(printf '%s' "$title" | tr -d '"\\`$')
 
 section=$(printf '%s\n' "$body" | tr -d '\r' | awk '
     /^##[ \t]+Predicted surface[ \t]*$/ { p=1; next }
@@ -226,15 +226,17 @@ ${status_lines}
     output: one 40-character hexadecimal SHA; retain as delivery_sha.
 19. git push --porcelain -u origin ${branch}
     output: Git porcelain push status, exit 0, no rejected ref. A normal push; no force option is authorized.
-20. write({"path":".git/gh${issue}-pr-body.md","content":PR_BODY}) with PR_BODY containing exactly these sections in this order: ## Problem and change; ## Validation with ### RAN and ### READ; then the line Issue: #${issue}. pr.closing-keyword: a closing keyword is allowed only when every doneWhen item of #${issue} is delivered.
-    output: Successfully wrote bytes to .git/gh${issue}-pr-body.md.
-21. gh pr create --repo ${repo} --base main --head ${branch} --title "${title_safe}" --body-file .git/gh${issue}-pr-body.md
+20. git rev-parse --git-path gh${issue}-pr-body.md
+    output: one path ending in gh${issue}-pr-body.md, exit 0. Retain it as pr_body_path. A linked worktree's .git is a pointer file, so the body is written into the resolved git dir, never into .git/ itself.
+21. write({"path":"<pr_body_path>","content":PR_BODY}) where <pr_body_path> is the path retained from step 20 and PR_BODY contains exactly these sections in this order: ## Problem and change; ## Validation with ### RAN and ### READ; then the line Issue: #${issue}. pr.closing-keyword: a closing keyword is allowed only when every doneWhen item of #${issue} is delivered.
+    output: Successfully wrote bytes to <pr_body_path>.
+22. gh pr create --repo ${repo} --base main --head ${branch} --title "${title_safe}" --body-file "\$(git rev-parse --git-path gh${issue}-pr-body.md)"
     output: one https://github.com/${repo}/pull/<integer> URL, exit 0. Retain as pr_url.
-22. gh pr view ${branch} --repo ${repo} --json headRefOid --jq .headRefOid
+23. gh pr view ${branch} --repo ${repo} --json headRefOid --jq .headRefOid
     output: delivery_sha from step 18, exactly.
-23. edda task done ${task} --receipt "PR <pr_url> @ <delivery_sha>"
+24. edda task done ${task} --receipt "PR <pr_url> @ <delivery_sha>"
     output: task ${task} marked done, exit 0.
-24. Report, as the final message, exactly these five lines and nothing else:
+25. Report, as the final message, exactly these five lines and nothing else:
     DONE issue=#${issue} task=${task}
     pr=<pr_url>
     sha=<delivery_sha>

--- a/scripts/fleet/test-brief-from-issue.sh
+++ b/scripts/fleet/test-brief-from-issue.sh
@@ -197,4 +197,22 @@ if grep -E 'scope paths:.*REVIEW\.md|scope paths:.*Cargo\.lock' "$work/out/negat
 fi
 echo "ok 6 negated mentions excluded from scope paths"
 
+# 7. shell-metacharacter stripping from the title: backtick and dollar must not
+# survive into the commit step, where the lane's shell would expand them.
+cat >"$work/issue-metachar.json" <<'JSON'
+{"title":"fix: broke `x` and $(rm -rf /) handling","labels":[],"body":"## Predicted surface\n\n`scripts/review-pr.sh`.\n\n## doneWhen\n- item\n"}
+JSON
+rc=0
+TEST_UNAME=Linux GH_ISSUE_JSON="$work/issue-metachar.json" \
+    PATH="$work/bin:$PATH" \
+    sh "$script" 880 --lane-name n --worktree /tmp/wt --branch b \
+    >"$work/out/metachar.txt" || rc=$?
+[ "$rc" -eq 0 ] || fail "metachar render exit $rc"
+if grep -E '\$\(rm|`x`' "$work/out/metachar.txt"; then
+    fail "shell metacharacter survived into the brief"
+fi
+grep -q 'git commit -m "fix: broke x and (rm -rf /) handling"' "$work/out/metachar.txt" \
+    || fail "stripped title not in commit step: $(grep 'git commit -m' "$work/out/metachar.txt")"
+echo "ok 7 title metacharacters stripped"
+
 echo "PASS: scripts/fleet/test-brief-from-issue.sh"

--- a/scripts/fleet/test-brief-from-issue.sh
+++ b/scripts/fleet/test-brief-from-issue.sh
@@ -122,6 +122,15 @@ assert_skeleton() {
     grep -q 'scripts/review-pr.sh' "$out" || fail "git status finish missing a scope path"
     grep -q 'DONE issue=#880 task=128' "$out" || fail "missing five-line report"
     grep -q 'stop=controller issues the next brief' "$out" || fail "missing report last line"
+    grep -q '20. git rev-parse --git-path gh880-pr-body.md' "$out" \
+        || fail "missing pr-body path resolution step"
+    grep -q 'write({"path":"<pr_body_path>"' "$out" \
+        || fail "write step must target the retained git-dir path"
+    if grep -qF '.git/gh880-pr-body.md' "$out"; then
+        fail "hardcoded .git/ pr-body path still present (linked worktree .git is a file)"
+    fi
+    grep -qF 'body-file "$(git rev-parse --git-path gh880-pr-body.md)"' "$out" \
+        || fail "step 22 must carry the literal git-path expansion for the lane"
     if grep -Ei 'as needed|if relevant|use (your )?judg|where appropriate' "$out"; then
         fail "discretionary phrasing in output"
     fi

--- a/scripts/fleet/test-brief-from-issue.sh
+++ b/scripts/fleet/test-brief-from-issue.sh
@@ -16,7 +16,7 @@ sh -n "$0" || {
 }
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/test-brief-from-issue.XXXXXX")
-trap 'rm -rf "$work"' EXIT
+trap 'rm -rf "$work"' 0 HUP INT TERM
 export TMPDIR="$work"
 
 mkdir -p "$work/bin" "$work/out"
@@ -126,6 +126,12 @@ assert_skeleton() {
         || fail "missing pr-body path resolution step"
     grep -q 'write({"path":"<pr_body_path>"' "$out" \
         || fail "write step must target the retained git-dir path"
+    grep -qF -- '--paths "scripts/review-pr.sh"' "$out" \
+        || fail "claim step paths must be quoted"
+    grep -qF 'git ls-files -- "scripts/review-pr.sh"' "$out" \
+        || fail "ls-files step paths must be quoted"
+    grep -qF 'git add -- "scripts/review-pr.sh"' "$out" \
+        || fail "git add step paths must be quoted"
     if grep -qF '.git/gh880-pr-body.md' "$out"; then
         fail "hardcoded .git/ pr-body path still present (linked worktree .git is a file)"
     fi
@@ -223,5 +229,21 @@ fi
 grep -q 'git commit -m "fix: broke x and (rm -rf /) handling"' "$work/out/metachar.txt" \
     || fail "stripped title not in commit step: $(grep 'git commit -m' "$work/out/metachar.txt")"
 echo "ok 7 title metacharacters stripped"
+
+# 8. a crafted Predicted-surface token is rejected, not rendered (R5)
+cat >"$work/issue-crafted.json" <<'JSON'
+{"title":"crafted","labels":[],"body":"## Predicted surface\n\n`scripts/review-pr.sh`, `docs/a; rm -rf ~`.\n\n## doneWhen\n- item\n"}
+JSON
+rc=0
+TEST_UNAME=Linux GH_ISSUE_JSON="$work/issue-crafted.json" \
+    PATH="$work/bin:$PATH" \
+    sh "$script" 1 --lane-name n --worktree /tmp/wt --branch b \
+    >"$work/out/crafted.txt" 2>"$work/out/crafted.err" || rc=$?
+[ "$rc" -eq 2 ] || fail "crafted token exit $rc, want 2"
+grep -q 'rm -rf' "$work/out/crafted.err" \
+    || fail "crafted-token stderr must name the rejected token: $(cat "$work/out/crafted.err")"
+grep -q 'rm -rf' "$work/out/crafted.txt" \
+    && fail "crafted token leaked into the rendered brief"
+echo "ok 8 crafted scope token rejected"
 
 echo "PASS: scripts/fleet/test-brief-from-issue.sh"

--- a/scripts/fleet/test-brief-from-issue.sh
+++ b/scripts/fleet/test-brief-from-issue.sh
@@ -1,0 +1,200 @@
+#!/bin/sh
+# Offline self-test for scripts/fleet/brief-from-issue.sh (GH-885).
+# Stubs gh, uname, and git. Writes only under a temp dir.
+set -eu
+
+cd "$(git rev-parse --show-toplevel)"
+script=scripts/fleet/brief-from-issue.sh
+
+sh -n "$script" || {
+    echo "FAIL: sh -n $script" >&2
+    exit 1
+}
+sh -n "$0" || {
+    echo "FAIL: sh -n $0" >&2
+    exit 1
+}
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/test-brief-from-issue.XXXXXX")
+trap 'rm -rf "$work"' EXIT
+export TMPDIR="$work"
+
+mkdir -p "$work/bin" "$work/out"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+cat >"$work/bin/gh" <<'STUB'
+#!/bin/sh
+cat "$GH_ISSUE_JSON"
+STUB
+chmod +x "$work/bin/gh"
+
+cat >"$work/bin/git" <<'STUB'
+#!/bin/sh
+# Consume a leading -C <dir> the way git(1) does.
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -C) shift 2 ;;
+        *) break ;;
+    esac
+done
+case "$*" in
+    "rev-parse origin/main")
+        echo "6486228c728dff5d488b5756e918af0bccde0eb5"
+        exit 0
+        ;;
+esac
+echo "git-stub: unexpected: $*" >&2
+exit 1
+STUB
+chmod +x "$work/bin/git"
+
+cat >"$work/bin/uname" <<'STUB'
+#!/bin/sh
+echo "$TEST_UNAME"
+STUB
+chmod +x "$work/bin/uname"
+
+# Fixture: Predicted surface matches issue #880's shipped list.
+cat >"$work/issue-880.json" <<'JSON'
+{"title":"fix(fleet): review-pr.sh has no pi arm","labels":[{"name":"fleet:ready"}],"body":"## What happened\nBasis.\n\n## Predicted surface\n\n`scripts/review-pr.sh`, `scripts/reviewer-capabilities.sh`, `scripts/fleet/reviewer-capabilities.ps1`, `scripts/test-review-capabilities.sh`, `scripts/pr-review-launch.ps1`, `scripts/pr-review-watch.sh`. No crate.\n\n## doneWhen\n- item\n"}
+JSON
+
+cat >"$work/issue-missing.json" <<'JSON'
+{"title":"no surface","labels":[],"body":"## What happened\nNo predicted heading here.\n\n## doneWhen\n- item\n"}
+JSON
+
+cat >"$work/issue-empty.json" <<'JSON'
+{"title":"empty surface","labels":[],"body":"## What happened\n.\n\n## Predicted surface\n\nNo crate.\n\n## doneWhen\n- item\n"}
+JSON
+
+# Negated mentions: the real GH-880 surface ends with "No crate, no `REVIEW.md`,
+# no `Cargo.lock`." — those two tokens are named only to be excluded.
+cat >"$work/issue-negated.json" <<'JSON'
+{"title":"negated mentions","labels":[],"body":"## Predicted surface\n\n`scripts/review-pr.sh`, `scripts/pr-review-watch.sh`. No crate, no `REVIEW.md`, no `Cargo.lock`.\n\n## doneWhen\n- item\n"}
+JSON
+
+run_ok() {
+    uname_s=$1
+    out=$2
+    TEST_UNAME=$uname_s GH_ISSUE_JSON="$work/issue-880.json" \
+        PATH="$work/bin:$PATH" \
+        sh "$script" 880 \
+            --lane-name edda-lane-gh880 \
+            --worktree C:/ai_agent/edda-wt-gh880 \
+            --branch fix/gh880-pi-review-arm \
+            --task-id 128 >"$out"
+}
+
+assert_facts() {
+    out=$1
+    grep -q 'role: worker' "$out" || fail "missing role: $(cat "$out")"
+    grep -q 'lane: none' "$out" || fail "missing lane none: $(cat "$out")"
+    grep -q 'task id: 128' "$out" || fail "missing task id: $(cat "$out")"
+    grep -q 'issue: #880' "$out" || fail "missing issue: $(cat "$out")"
+    grep -q 'base full SHA: 6486228c728dff5d488b5756e918af0bccde0eb5' "$out" \
+        || fail "missing base SHA: $(cat "$out")"
+    grep -q 'scope paths: scripts/review-pr.sh, scripts/reviewer-capabilities.sh, scripts/fleet/reviewer-capabilities.ps1, scripts/test-review-capabilities.sh, scripts/pr-review-launch.ps1, scripts/pr-review-watch.sh' "$out" \
+        || fail "missing scope paths: $(cat "$out")"
+    grep -q 'entry: none: procedure below' "$out" || fail "missing entry"
+    grep -q 'gate owner: not you; review queue' "$out" || fail "missing gate owner"
+    grep -q 'out-of-scope: every path and concern not listed in scope paths' "$out" \
+        || fail "missing out-of-scope"
+}
+
+assert_skeleton() {
+    out=$1
+    grep -q 'Launcher contract:' "$out" || fail "missing launcher contract"
+    grep -q 'C:/ai_agent/edda-wt-gh880' "$out" || fail "missing worktree"
+    grep -q 'fix/gh880-pi-review-arm' "$out" || fail "missing branch"
+    grep -q 'edda-lane-gh880' "$out" || fail "missing lane name"
+    grep -q 'Failure rule for every numbered step: a nonzero command exit, tool error,' "$out" \
+        || fail "missing failure rule"
+    grep -q 'STOP step=<number> output=<verbatim unexpected output>.' "$out" \
+        || fail "missing STOP sentence"
+    grep -q '1. gh issue view 880' "$out" || fail "missing preamble step 1"
+    grep -q '9. git ls-files --' "$out" || fail "missing preamble step 9"
+    c=$(grep -c '<<AUTHORED STEPS>>' "$out" || true)
+    [ "$c" -eq 1 ] || fail "marker count $c, want 1"
+    grep -q 'scripts/review-pr.sh' "$out" || fail "git status finish missing a scope path"
+    grep -q 'DONE issue=#880 task=128' "$out" || fail "missing five-line report"
+    grep -q 'stop=controller issues the next brief' "$out" || fail "missing report last line"
+    if grep -Ei 'as needed|if relevant|use (your )?judg|where appropriate' "$out"; then
+        fail "discretionary phrasing in output"
+    fi
+}
+
+# 1. Windows host
+rc=0
+run_ok 'MINGW64_NT-10.0' "$work/out/win.txt" || rc=$?
+[ "$rc" -eq 0 ] || fail "windows render exit $rc"
+assert_facts "$work/out/win.txt"
+assert_skeleton "$work/out/win.txt"
+grep -q 'Host: MINGW/MSYS. review-pr.sh --dry-run generates -lane.ps1 and no -run.sh.' \
+    "$work/out/win.txt" || fail "windows host fact: $(cat "$work/out/win.txt")"
+echo "ok 1 windows host facts and skeleton"
+
+# 2. Linux host
+rc=0
+run_ok 'Linux' "$work/out/linux.txt" || rc=$?
+[ "$rc" -eq 0 ] || fail "linux render exit $rc"
+assert_facts "$work/out/linux.txt"
+assert_skeleton "$work/out/linux.txt"
+grep -q 'Host: Linux. review-pr.sh --dry-run generates -run.sh and no -lane.ps1.' \
+    "$work/out/linux.txt" || fail "linux host fact: $(cat "$work/out/linux.txt")"
+echo "ok 2 linux host facts and skeleton"
+
+# 3. missing Predicted surface section → exit 2, names the section
+rc=0
+TEST_UNAME=Linux GH_ISSUE_JSON="$work/issue-missing.json" \
+    PATH="$work/bin:$PATH" \
+    sh "$script" 1 --lane-name n --worktree /tmp/wt --branch b \
+    >"$work/out/missing.txt" 2>"$work/out/missing.err" || rc=$?
+[ "$rc" -eq 2 ] || fail "missing section exit $rc, want 2"
+grep -q 'Predicted surface' "$work/out/missing.err" \
+    || fail "missing-section stderr must name the section: $(cat "$work/out/missing.err")"
+echo "ok 3 missing Predicted surface exits 2"
+
+# 4. empty Predicted surface (no paths) → exit 2, names the section
+rc=0
+TEST_UNAME=Linux GH_ISSUE_JSON="$work/issue-empty.json" \
+    PATH="$work/bin:$PATH" \
+    sh "$script" 1 --lane-name n --worktree /tmp/wt --branch b \
+    >"$work/out/empty.txt" 2>"$work/out/empty.err" || rc=$?
+[ "$rc" -eq 2 ] || fail "empty section exit $rc, want 2"
+grep -q 'Predicted surface' "$work/out/empty.err" \
+    || fail "empty-section stderr must name the section: $(cat "$work/out/empty.err")"
+echo "ok 4 empty Predicted surface exits 2"
+
+# 5. --build-lane fills the lane field
+rc=0
+TEST_UNAME=Linux GH_ISSUE_JSON="$work/issue-880.json" \
+    PATH="$work/bin:$PATH" \
+    sh "$script" 880 --lane-name edda-lane-gh880 \
+        --worktree C:/ai_agent/edda-wt-gh880 \
+        --branch fix/gh880-pi-review-arm \
+        --task-id 128 --build-lane worker-1 \
+    >"$work/out/lane.txt" || rc=$?
+[ "$rc" -eq 0 ] || fail "build-lane render exit $rc"
+grep -q 'lane: worker-1' "$work/out/lane.txt" || fail "build-lane not applied"
+grep -q 'lane: none' "$work/out/lane.txt" && fail "lane none still present with --build-lane"
+echo "ok 5 --build-lane sets lane field"
+
+# 6. negated mentions are not scope paths
+rc=0
+TEST_UNAME=Linux GH_ISSUE_JSON="$work/issue-negated.json" \
+    PATH="$work/bin:$PATH" \
+    sh "$script" 880 --lane-name n --worktree /tmp/wt --branch b \
+    >"$work/out/negated.txt" || rc=$?
+[ "$rc" -eq 0 ] || fail "negated render exit $rc"
+grep -q 'scope paths: scripts/review-pr.sh, scripts/pr-review-watch.sh' "$work/out/negated.txt" \
+    || fail "negated scope paths wrong: $(grep 'scope paths' "$work/out/negated.txt")"
+if grep -E 'scope paths:.*REVIEW\.md|scope paths:.*Cargo\.lock' "$work/out/negated.txt"; then
+    fail "negated mention leaked into scope paths"
+fi
+echo "ok 6 negated mentions excluded from scope paths"
+
+echo "PASS: scripts/fleet/test-brief-from-issue.sh"


### PR DESCRIPTION
## Problem and change

GH-885: during the all-flash window there is no Claude controller, and a 40-step flash-tier brief typed from a blank page is the one artifact a pi controller cannot yet author. This adds `scripts/fleet/brief-from-issue.sh`, which renders the invariant parts of a brief from the issue body:

- the nine-field facts block (role, lane, task id, issue, base full SHA, scope paths, entry, gate owner, out-of-scope) — scope paths come from the issue's `## Predicted surface` section;
- the fixed nine preamble steps with the issue's paths and numbers substituted;
- the finish steps ending in the five-line report, with the `git status` step listing exactly the scope paths;
- host facts rendered from `uname` (MINGW/MSYS vs Linux), not guessed — the #880 round-1 STOP was a hand-written wrong host assumption;
- the authored middle left as the single `<<AUTHORED STEPS>>` marker for the issuer.

Two review-driven hardenings, both test-proven: a backtick token negated in prose ("No crate, no \`REVIEW.md\`, no \`Cargo.lock\`." in #880's own surface) is excluded from scope paths, and shell metacharacters (double quotes, backticks, dollar signs) are stripped from the title so nothing survives into the quoted shell strings of steps 15 and 21 for the lane's shell to expand. A missing or empty `## Predicted surface` section exits 2 naming the section; the script never invents a path. `docs/guides/brief-template.md` gains one paragraph pointing at the renderer; Example B is unchanged.

## Validation

### RAN

- `sh scripts/fleet/test-brief-from-issue.sh` → PASS (7 cases: windows host, linux host, missing section exits 2, empty section exits 2, `--build-lane`, negated mentions excluded, title metacharacters stripped); writes only under its temp dir
- `sh -n scripts/fleet/brief-from-issue.sh` and `sh -n scripts/fleet/test-brief-from-issue.sh` → exit 0
- `sh scripts/fleet/brief-from-issue.sh 880 --lane-name edda-lane-gh880 --worktree C:/ai_agent/edda-wt-gh880 --branch fix/gh880-pi-review-arm --task-id 128` → exit 0; all nine facts fields in template order with none empty; `scope paths: scripts/review-pr.sh, scripts/fleet/reviewer-capabilities.ps1, scripts/reviewer-capabilities.sh, scripts/test-review-capabilities.sh, scripts/pr-review-launch.ps1, scripts/pr-review-watch.sh`; `<<AUTHORED STEPS>>` exactly once; discretionary-phrase grep (`grep -Ei "as needed|if relevant|use (your )?judg|where appropriate"`) empty; five-line report last
- pre-commit hooks on both staged blobs: lint-doc-citations, lint-markdown-content, lint-file-length → all exit 0

### READ

- `docs/guides/brief-template.md` — facts block shape (lines 39–57), procedure shape (lines 75–96), Example B (lines 130–217), all unchanged by this diff at head 6ba187d
- GH-885 issue body — doneWhen used as the acceptance ceiling, each item verified against the code and the test above

Closes #885

Issue: #885
