### PR TITLE
feat(fleet): skill-less controller loop — next-issue.sh, next-review.sh, and the pi controller runbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ pitch and install; come here when you need depth.
 | Section | What it answers |
 | - | - |
 | [`getting-started/`](./getting-started/) | Install ([installation.md](./getting-started/installation.md)) and first five minutes ([quickstart.md](./getting-started/quickstart.md)) |
-| [`guides/`](./guides/) | Using Edda with [Claude Code](./guides/claude-code.md), [MCP](./guides/mcp.md), [multi-agent setups](./guides/multi-agent.md), and [OpenClaw](./guides/openclaw.md) — plus [Edda from the agent's seat](./guides/for-agents.md), field notes written by an agent that uses edda daily, and the [lane brief template](./guides/brief-template.md) for composing worker and lane dispatches |
+| [`guides/`](./guides/) | Using Edda with [Claude Code](./guides/claude-code.md), [MCP](./guides/mcp.md), [multi-agent setups](./guides/multi-agent.md), and [OpenClaw](./guides/openclaw.md) — plus [Edda from the agent's seat](./guides/for-agents.md), field notes written by an agent that uses edda daily, and the [lane brief template](./guides/brief-template.md) for composing worker and lane dispatches, plus the [pi controller runbook](./guides/pi-controller-runbook.md) for the skill-less control loop |
 | [`reference/`](./reference/) | [CLI reference](./reference/cli.md), [brief schema](./reference/brief-schema.md), [query performance](./reference/query-performance.md) |
 | [`README_zh-TW.md`](./README_zh-TW.md) | 繁體中文版 README |
 

--- a/docs/guides/brief-template.md
+++ b/docs/guides/brief-template.md
@@ -94,6 +94,12 @@ lane will not infer them:
 3. `pr.closing-keyword`: state whether a closing keyword is allowed for that
    PR — allowed only when every doneWhen item of the issue is delivered.
 
+The facts block, the nine preamble steps, and the finish steps of a flash-tier
+brief are rendered by `scripts/fleet/brief-from-issue.sh` from the issue body's
+`## Predicted surface` section. Example B below stays the worked shape. The
+script prints `<<AUTHORED STEPS>>` once; the issuer replaces that marker with
+the issue-specific implementation steps.
+
 ## PR-body evidence standard
 
 The worked example of the evidence a PR body must carry is the description of

--- a/docs/guides/pi-controller-runbook.md
+++ b/docs/guides/pi-controller-runbook.md
@@ -115,6 +115,13 @@ verdict on the SHA. Anything else waits for the operator.
   (#748), an orphaned scheduled task (#772) — stop the lane with
   `scripts/fleet/lane-stop.ps1 -Name <lane>` before relaunching
 
+## Reporting
+
+1. The operator-facing report is `sh scripts/fleet/daily-digest.sh --board 888`, never a hand-written summary — a hand-written one omits open PRs and misstates states (GH-914).
+2. Before calling any PR complete, compare `gh pr view <n> --json headRefOid --jq .headRefOid` against the SHA in its newest `Code Review: Round` comment; a different SHA means that head has not been reviewed — not complete (GH-914).
+3. `mergeStateStatus` is not a readiness signal: a PR based on a branch other than `main` is not gated by the ruleset, so `CLEAN` with zero verdicts is exactly what it looks like (GH-914).
+
+
 ## Pointers
 
 - Brief shape and the authored-middle contract: `docs/guides/brief-template.md`

--- a/docs/guides/pi-controller-runbook.md
+++ b/docs/guides/pi-controller-runbook.md
@@ -1,0 +1,118 @@
+# pi controller runbook — the two-day window loop (GH-886)
+
+Audience: a pi session acting as fleet controller with no skills loaded. Every
+step is one command with its expected output; every STOP condition routes to
+`needs-operator` and ends the controller's turn. Decisions in force:
+`fleet.pi-lanes`, `fleet.lane-launch`, `review.verdict-carrier`,
+`review.independence-policy`, `fleet.all-flash-window-2026-09-05`.
+
+The loop is two scripts plus the guard scripts they call:
+
+- `scripts/fleet/next-issue.sh <issue> <machine>/<role> [--dry-run]` — ready
+  issue → launched lane
+- `scripts/fleet/next-review.sh <pr> [--shadow] [--operator-granted] [--dry-run]`
+  — open PR → posted review comment
+
+## Pick the next issue
+
+```sh
+sh scripts/fleet/ready-queue-lint.sh
+```
+
+Expected: the ready queue, one `#<issue> <title>` per line, exit 0. A nonzero
+exit means the queue itself is malformed — STOP `needs-operator`.
+
+Pick the oldest issue in the printed queue that you have not already handed to
+a lane this shift.
+
+## Preview the launch (always first)
+
+```sh
+sh scripts/fleet/next-issue.sh <issue> docs/worker-1 --dry-run
+```
+
+Expected, in order: the lint result; `branch: <type>/gh<issue>-<slug>` and
+`worktree: <path>`; the `edda task new` line; the brief path; the claim
+command; the launch command; `lane name`, `log`, and `done marker` lines; and
+`== dry-run: nothing created, claimed, or launched`, exit 0. A claimed issue
+exits 2 naming the claimant — pick another issue.
+
+## Launch the lane
+
+```sh
+sh scripts/fleet/next-issue.sh <issue> docs/worker-1
+```
+
+First run renders `~/.edda/fleet/brief-gh<issue>.md` and exits 2 with
+`brief still contains <<AUTHORED STEPS>> — fill the authored middle in
+<path>, then rerun`. Fill the marker with the issue's implementation steps
+(from the issue body's authored surface; never copy its doneWhen into the
+brief), then run the same command again: it keeps the authored brief, runs
+`edda task new`, `fleet-claim-issue.sh`, creates the worktree, and launches
+`edda-lane-gh<issue>` through `scripts/fleet/lane-launch.ps1`
+(`-TimeoutSec 5400 -BudgetUsd 3`). Expected at the end:
+`lane launched: edda-lane-gh<issue>`.
+
+Lanes only ever start through `next-issue.sh` or `lane-launch.ps1` — never an
+ad-hoc terminal pi session for unattended work.
+
+## Watch the lane
+
+```sh
+pwsh -NoProfile -File scripts/fleet/lane-status.ps1
+```
+
+Expected: one row per lane with its state. The done marker is
+`%TEMP%\edda-lanes\<lane>.done`; the log is the same path with `.log`. The
+last five lines of the log are the lane's report.
+
+- `DONE issue=#<issue> task=<id>` + PR URL + SHA — go to the review step.
+- `STOP step=<n> output=<...>` — read the five lines, fix the brief
+  (`~/.edda/fleet/brief-gh<issue>.md`) so the failing step cannot recur, and
+  relaunch: delete the stale marker only if the lane is not running, and start
+  the next round with the `-r<n+1>` lane name (next-issue.sh picks the next
+  free suffix automatically). Do not continue a stopped lane's session.
+- Round cap: three rounds without a PR → STOP `needs-operator`.
+
+## Review the PR
+
+```sh
+sh scripts/fleet/next-review.sh <pr> --shadow --dry-run
+```
+
+Expected: the head SHA, the round count, the brief command, the engine
+command, the post command, `== dry-run: nothing launched or posted`, exit 0.
+
+```sh
+sh scripts/fleet/next-review.sh <pr> --shadow
+```
+
+Expected: `posted SHADOW round <n>` and a `## Code Review: Round <n> — PR
+#<pr> @ <sha> (SHADOW)` comment on the PR. The shadow round never sets
+`fleet:reviewed`, never sets the Independent Review status, and never merges
+(`review.gh880-shadow`). A fourth round without `--operator-granted` exits 2
+and labels `needs-operator`.
+
+Window merge rule (`fleet.all-flash-window-2026-09-05`, operator may veto on
+#888): code-risk PRs are not merged in the window; docs/skills-class PRs may
+be squash-merged only on glm LGTM P0=0 P1=0 + CI green on that head + no other
+verdict on the SHA. Anything else waits for the operator.
+
+## STOP conditions — label `needs-operator` and stop
+
+- dirty worktree or claim conflict on a lane launch
+- CI red on a reviewed head
+- round cap (three rounds without a delivered PR, or a fourth review round
+  without `--operator-granted`)
+- a `[判斷]` escalation on a code-risk PR that the controller cannot adjudicate
+- any operator-only action: merging a code-risk PR, `edda ratify`, ruleset
+  changes, force push, deleting unmerged branches
+- known lane failure modes: a lane that delivers nothing before timeout
+  (#748), an orphaned scheduled task (#772) — stop the lane with
+  `scripts/fleet/lane-stop.ps1 -Name <lane>` before relaunching
+
+## Pointers
+
+- Brief shape and the authored-middle contract: `docs/guides/brief-template.md`
+- Review rules: `REVIEW.md` (read at the base SHA, never the head)
+- Observation window and the metrics compared on return: #888

--- a/docs/guides/pi-controller-runbook.md
+++ b/docs/guides/pi-controller-runbook.md
@@ -47,8 +47,8 @@ First run renders `~/.edda/fleet/brief-gh<issue>.md` and exits 2 with
 `brief still contains <<AUTHORED STEPS>> — fill the authored middle in
 <path>, then rerun`. Fill the marker with the issue's implementation steps
 (from the issue body's authored surface; never copy its doneWhen into the
-brief), then run the same command again: it keeps the authored brief, runs
-`edda task new`, `fleet-claim-issue.sh`, creates the worktree, and launches
+brief), then run the same command again: it keeps the authored brief, creates
+the worktree, runs `edda task new` and `fleet-claim-issue.sh`, and launches
 `edda-lane-gh<issue>` through `scripts/fleet/lane-launch.ps1`
 (`-TimeoutSec 5400 -BudgetUsd 3`). Expected at the end:
 `lane launched: edda-lane-gh<issue>`.
@@ -82,6 +82,10 @@ sh scripts/fleet/next-review.sh <pr> --shadow --dry-run
 
 Expected: the head SHA, the round count, the brief command, the engine
 command, the post command, `== dry-run: nothing launched or posted`, exit 0.
+
+Without `--shadow` the script refuses to delegate until `review-pr.sh`
+carries the pi arm (GH-880, PR #890): its delegation would otherwise call the
+Claude backend, which doneWhen item 7 forbids for both scripts.
 
 ```sh
 sh scripts/fleet/next-review.sh <pr> --shadow

--- a/scripts/fleet/brief-from-issue.sh
+++ b/scripts/fleet/brief-from-issue.sh
@@ -80,7 +80,11 @@ body=$(printf '%s' "$json" | jq -r .body)
 [ -n "$title" ] && [ "$title" != "null" ] || die "issue $issue has no title"
 [ -n "$body" ] && [ "$body" != "null" ] || die "issue $issue has an empty body"
 
-title_safe=$(printf '%s' "$title" | tr -d '"')
+# The title is interpolated verbatim into quoted shell strings inside the
+# brief (steps 15 and 21), so double quotes, backticks, and dollar signs are
+# stripped: a backtick or $(...) surviving into step 15 would be expanded by
+# the lane's shell when it runs that step.
+title_safe=$(printf '%s' "$title" | tr -d '"`$')
 
 section=$(printf '%s\n' "$body" | tr -d '\r' | awk '
     /^##[ \t]+Predicted surface[ \t]*$/ { p=1; next }

--- a/scripts/fleet/brief-from-issue.sh
+++ b/scripts/fleet/brief-from-issue.sh
@@ -1,0 +1,239 @@
+#!/bin/sh
+# brief-from-issue.sh — render the facts block, nine preamble steps, and
+# finish steps of a flash-tier lane brief from a GitHub issue body (GH-885).
+# The authored middle is the single marker line <<AUTHORED STEPS>>.
+#
+# usage:
+#   sh scripts/fleet/brief-from-issue.sh <issue> \
+#        --lane-name <name> --worktree <path> --branch <branch> \
+#        [--task-id <id>] [--build-lane <lane>]
+#
+# Prints the brief to stdout. Writes no files.
+set -eu
+
+usage() {
+    echo "usage: $0 <issue> --lane-name <name> --worktree <path> --branch <branch> [--task-id <id>] [--build-lane <lane>]" >&2
+}
+
+die() {
+    echo "brief-from-issue: $1" >&2
+    exit 2
+}
+
+repo=${EDDA_REPO:-fagemx/edda}
+issue=
+lane_name=
+worktree=
+branch=
+task=none
+lane=none
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --lane-name)
+            [ -n "${2:-}" ] || die "--lane-name requires a value"
+            lane_name=$2; shift 2 ;;
+        --worktree)
+            [ -n "${2:-}" ] || die "--worktree requires a value"
+            worktree=$2; shift 2 ;;
+        --branch)
+            [ -n "${2:-}" ] || die "--branch requires a value"
+            branch=$2; shift 2 ;;
+        --task-id)
+            [ -n "${2:-}" ] || die "--task-id requires a value"
+            task=$2; shift 2 ;;
+        --build-lane)
+            [ -n "${2:-}" ] || die "--build-lane requires a value"
+            lane=$2; shift 2 ;;
+        -h|--help)
+            usage; exit 0 ;;
+        --)
+            shift; break ;;
+        -*)
+            die "unknown option $1" ;;
+        *)
+            if [ -z "$issue" ]; then
+                issue=$1; shift
+            else
+                die "unexpected argument $1"
+            fi
+            ;;
+    esac
+done
+
+[ -n "$issue" ] || { usage; exit 2; }
+[ -n "$lane_name" ] || die "missing --lane-name"
+[ -n "$worktree" ] || die "missing --worktree"
+[ -n "$branch" ] || die "missing --branch"
+case "$issue" in
+    *[!0-9]*|'') die "issue must be a positive integer, got '$issue'" ;;
+esac
+
+self_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+root=$(CDPATH= cd -- "$self_dir/../.." && pwd)
+
+json=$(gh issue view "$issue" --repo "$repo" --json body,title,labels) ||
+    die "gh issue view $issue failed"
+
+title=$(printf '%s' "$json" | jq -r .title)
+body=$(printf '%s' "$json" | jq -r .body)
+[ -n "$title" ] && [ "$title" != "null" ] || die "issue $issue has no title"
+[ -n "$body" ] && [ "$body" != "null" ] || die "issue $issue has an empty body"
+
+title_safe=$(printf '%s' "$title" | tr -d '"')
+
+section=$(printf '%s\n' "$body" | tr -d '\r' | awk '
+    /^##[ \t]+Predicted surface[ \t]*$/ { p=1; next }
+    /^##[ \t]/ { if (p) exit }
+    p { print }
+')
+[ -n "$section" ] || die "missing or empty ## Predicted surface section"
+
+is_repo_path() {
+    case "$1" in
+        http://*|https://*) return 1 ;;
+        */*) return 0 ;;
+        *.sh|*.ps1|*.md|*.rs|*.toml|*.yml|*.yaml|*.json|*.lock) return 0 ;;
+    esac
+    return 1
+}
+
+tmp=$(mktemp "${TMPDIR:-/tmp}/brief-from-issue.XXXXXX")
+raw=$(mktemp "${TMPDIR:-/tmp}/brief-from-issue.XXXXXX")
+trap 'rm -f "$tmp" "$raw"' 0 HUP INT TERM
+
+# Backtick tokens come in pairs with awk RS='`': odd records are the prose
+# between tokens, even records are the tokens themselves. A token whose prose
+# prefix ends in no/not/without is a negated mention ("No crate, no `REVIEW.md`."),
+# not a listed path, and is dropped here so the scope never grows a path the
+# issue explicitly excluded.
+printf '%s' "$section" | awk -v RS='`' '
+    NR % 2 == 1 { prev = $0; next }
+    {
+        p = prev
+        sub(/[ \t\r\n]+$/, "", p)
+        if (p !~ /([Nn]o|[Nn]ot|[Ww]ithout)$/) print
+    }
+' >"$raw"
+: >"$tmp"
+while IFS= read -r tok; do
+    [ -n "$tok" ] || continue
+    is_repo_path "$tok" || continue
+    if grep -Fxq -- "$tok" "$tmp" 2>/dev/null; then
+        continue
+    fi
+    printf '%s\n' "$tok" >>"$tmp"
+done <"$raw"
+
+[ -s "$tmp" ] || die "missing or empty ## Predicted surface section"
+
+paths_csv=
+paths_claim=
+paths_space=
+npath=0
+while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    npath=$((npath + 1))
+    if [ -z "$paths_csv" ]; then
+        paths_csv=$p
+        paths_space=$p
+    else
+        paths_csv="$paths_csv, $p"
+        paths_space="$paths_space $p"
+    fi
+    paths_claim="$paths_claim --paths $p"
+done <"$tmp"
+
+sha=$(git -C "$root" rev-parse origin/main) || die "git rev-parse origin/main failed"
+case "$sha" in
+    [0-9a-f]*) ;;
+    *) die "origin/main SHA is empty" ;;
+esac
+
+host=$(uname -s)
+case "$host" in
+    MINGW*|MSYS*|CYGWIN*)
+        host_fact='Host: MINGW/MSYS. review-pr.sh --dry-run generates -lane.ps1 and no -run.sh.'
+        ;;
+    *)
+        host_fact='Host: Linux. review-pr.sh --dry-run generates -run.sh and no -lane.ps1.'
+        ;;
+esac
+
+# Porcelain expected lines: one path per line, listed for the git-status finish step.
+status_lines=$(printf '%s\n' "$paths_space" | tr ' ' '\n' | sed '/^$/d')
+
+cat <<EOF
+role: worker · lane: ${lane} · task id: ${task} · issue: #${issue} ·
+base full SHA: ${sha} ·
+scope paths: ${paths_csv} ·
+entry: none: procedure below · gate owner: not you; review queue ·
+out-of-scope: every path and concern not listed in scope paths
+
+Launcher contract: you are pi 0.84.4 in an exclusively owned, clean worktree at ${worktree} on branch ${branch} at the base full SHA, with task ${task} assigned, issue #${issue} claimed, lane name ${lane_name}, and no existing PR for that branch. Your tools are bash({"command": string}) running Git Bash, write({"path": string, "content": string}) and edit({"path": string, "edits": [{"oldText": string, "newText": string}]}). Shell commands go in bash.command; file changes are write/edit tool calls, never shell programs that rewrite files (no sed -i, no cat > file). git, gh and edda are authenticated on PATH. Build lane: ${lane}.
+
+${host_fact}
+
+Failure rule for every numbered step: a nonzero command exit, tool error,
+or output-schema mismatch stops execution. Report exactly
+STOP step=<number> output=<verbatim unexpected output>. Preserve all files;
+do not restore, checkout, reset, clean, retry, review, or merge. The controller
+issues the next brief. Success advances to the next numbered step.
+
+1. gh issue view ${issue} --repo ${repo} --json state --jq .state
+   output: OPEN.
+2. git status --porcelain=v1 --untracked-files=all --branch
+   output: exactly ## ${branch}...origin/main, no other lines.
+3. git rev-parse HEAD
+   output: ${sha}.
+4. edda context
+   output: context text, exit 0; an off-limits overlap with a scope path is a STOP under the failure rule.
+5. edda task list
+   output: task-list text, exit 0, including task ${task}.
+6. edda task show ${task}
+   output: task ${task} and this brief, exit 0.
+7. edda claim gh${issue}-worker${paths_claim}
+   output: successful claim for gh${issue}-worker and the scope paths, exit 0.
+8. gh issue view ${issue} --repo ${repo} --json body --jq .body
+   output: the issue body, exit 0. Read doneWhen there; do not copy doneWhen into this brief.
+9. git ls-files -- ${paths_space}
+   output: the tracked subset of the scope paths, one per line, exit 0. cat each printed path. Untracked scope paths are created in the authored steps; that is not a STOP.
+
+<<AUTHORED STEPS>>
+
+10. git status --porcelain=v1 --untracked-files=all
+    output: exactly the scope paths and no others, one porcelain line per path:
+${status_lines}
+11. git diff --check
+    output: empty stdout, exit 0.
+12. git add -- ${paths_space}
+    output: empty stdout, exit 0.
+13. git diff --cached --name-only
+    output: exactly the scope paths, one path per line, and no others.
+14. git diff --cached --stat
+    output: ${npath} path-stat lines and one summary line for exactly ${npath} files.
+15. git commit -m "${title_safe}" -m "Issue: #${issue}"
+    output: git commit summary, exit 0.
+16. git log -1 --format=%B | grep -Fx 'Issue: #${issue}'
+    output: Issue: #${issue}.
+17. git status --porcelain=v1 --untracked-files=all
+    output: empty stdout, exit 0.
+18. git rev-parse HEAD
+    output: one 40-character hexadecimal SHA; retain as delivery_sha.
+19. git push --porcelain -u origin ${branch}
+    output: Git porcelain push status, exit 0, no rejected ref. A normal push; no force option is authorized.
+20. write({"path":".git/gh${issue}-pr-body.md","content":PR_BODY}) with PR_BODY containing exactly these sections in this order: ## Problem and change; ## Validation with ### RAN and ### READ; then the line Issue: #${issue}. pr.closing-keyword: a closing keyword is allowed only when every doneWhen item of #${issue} is delivered.
+    output: Successfully wrote bytes to .git/gh${issue}-pr-body.md.
+21. gh pr create --repo ${repo} --base main --head ${branch} --title "${title_safe}" --body-file .git/gh${issue}-pr-body.md
+    output: one https://github.com/${repo}/pull/<integer> URL, exit 0. Retain as pr_url.
+22. gh pr view ${branch} --repo ${repo} --json headRefOid --jq .headRefOid
+    output: delivery_sha from step 18, exactly.
+23. edda task done ${task} --receipt "PR <pr_url> @ <delivery_sha>"
+    output: task ${task} marked done, exit 0.
+24. Report, as the final message, exactly these five lines and nothing else:
+    DONE issue=#${issue} task=${task}
+    pr=<pr_url>
+    sha=<delivery_sha>
+    tests=exit 0
+    stop=controller issues the next brief
+EOF

--- a/scripts/fleet/brief-from-issue.sh
+++ b/scripts/fleet/brief-from-issue.sh
@@ -123,6 +123,13 @@ printf '%s' "$section" | awk -v RS='`' '
 while IFS= read -r tok; do
     [ -n "$tok" ] || continue
     is_repo_path "$tok" || continue
+    # R5: these tokens reach the lane's shell inside rendered command lines
+    # (steps 7, 9 and 12), so only the plain repo-relative path shape is
+    # accepted — no metacharacters, no leading dash, never a bare slash.
+    case "$tok" in
+        *[!A-Za-z0-9._/-]*|-*|/|.|..|*/..*|../*)
+            die "Predicted-surface token '$tok' is not a plain repo-relative path" ;;
+    esac
     if grep -Fxq -- "$tok" "$tmp" 2>/dev/null; then
         continue
     fi
@@ -134,6 +141,7 @@ done <"$raw"
 paths_csv=
 paths_claim=
 paths_space=
+paths_quoted=
 npath=0
 while IFS= read -r p; do
     [ -n "$p" ] || continue
@@ -141,11 +149,13 @@ while IFS= read -r p; do
     if [ -z "$paths_csv" ]; then
         paths_csv=$p
         paths_space=$p
+        paths_quoted="\"$p\""
     else
         paths_csv="$paths_csv, $p"
         paths_space="$paths_space $p"
+        paths_quoted="$paths_quoted \"$p\""
     fi
-    paths_claim="$paths_claim --paths $p"
+    paths_claim="$paths_claim --paths \"$p\""
 done <"$tmp"
 
 sha=$(git -C "$root" rev-parse origin/main) || die "git rev-parse origin/main failed"
@@ -166,6 +176,7 @@ esac
 
 # Porcelain expected lines: one path per line, listed for the git-status finish step.
 status_lines=$(printf '%s\n' "$paths_space" | tr ' ' '\n' | sed '/^$/d')
+first_path=$(printf '%s' "$status_lines" | head -1)
 
 cat <<EOF
 role: worker · lane: ${lane} · task id: ${task} · issue: #${issue} ·
@@ -200,17 +211,17 @@ issues the next brief. Success advances to the next numbered step.
    output: successful claim for gh${issue}-worker and the scope paths, exit 0.
 8. gh issue view ${issue} --repo ${repo} --json body --jq .body
    output: the issue body, exit 0. Read doneWhen there; do not copy doneWhen into this brief.
-9. git ls-files -- ${paths_space}
+9. git ls-files -- ${paths_quoted}
    output: the tracked subset of the scope paths, one per line, exit 0. cat each printed path. Untracked scope paths are created in the authored steps; that is not a STOP.
 
 <<AUTHORED STEPS>>
 
 10. git status --porcelain=v1 --untracked-files=all
-    output: exactly the scope paths and no others, one porcelain line per path:
+    output: exactly one porcelain line per scope path and no other paths, each line being the two-character status, a space, then the path (for example \`?? ${first_path}\` for a new file or \` M ${first_path}\` for a modified one):
 ${status_lines}
 11. git diff --check
     output: empty stdout, exit 0.
-12. git add -- ${paths_space}
+12. git add -- ${paths_quoted}
     output: empty stdout, exit 0.
 13. git diff --cached --name-only
     output: exactly the scope paths, one path per line, and no others.

--- a/scripts/fleet/brief-from-issue.sh
+++ b/scripts/fleet/brief-from-issue.sh
@@ -84,7 +84,7 @@ body=$(printf '%s' "$json" | jq -r .body)
 # brief (steps 15 and 21), so double quotes, backticks, and dollar signs are
 # stripped: a backtick or $(...) surviving into step 15 would be expanded by
 # the lane's shell when it runs that step.
-title_safe=$(printf '%s' "$title" | tr -d '"`$')
+title_safe=$(printf '%s' "$title" | tr -d '"\\`$')
 
 section=$(printf '%s\n' "$body" | tr -d '\r' | awk '
     /^##[ \t]+Predicted surface[ \t]*$/ { p=1; next }
@@ -226,15 +226,17 @@ ${status_lines}
     output: one 40-character hexadecimal SHA; retain as delivery_sha.
 19. git push --porcelain -u origin ${branch}
     output: Git porcelain push status, exit 0, no rejected ref. A normal push; no force option is authorized.
-20. write({"path":".git/gh${issue}-pr-body.md","content":PR_BODY}) with PR_BODY containing exactly these sections in this order: ## Problem and change; ## Validation with ### RAN and ### READ; then the line Issue: #${issue}. pr.closing-keyword: a closing keyword is allowed only when every doneWhen item of #${issue} is delivered.
-    output: Successfully wrote bytes to .git/gh${issue}-pr-body.md.
-21. gh pr create --repo ${repo} --base main --head ${branch} --title "${title_safe}" --body-file .git/gh${issue}-pr-body.md
+20. git rev-parse --git-path gh${issue}-pr-body.md
+    output: one path ending in gh${issue}-pr-body.md, exit 0. Retain it as pr_body_path. A linked worktree's .git is a pointer file, so the body is written into the resolved git dir, never into .git/ itself.
+21. write({"path":"<pr_body_path>","content":PR_BODY}) where <pr_body_path> is the path retained from step 20 and PR_BODY contains exactly these sections in this order: ## Problem and change; ## Validation with ### RAN and ### READ; then the line Issue: #${issue}. pr.closing-keyword: a closing keyword is allowed only when every doneWhen item of #${issue} is delivered.
+    output: Successfully wrote bytes to <pr_body_path>.
+22. gh pr create --repo ${repo} --base main --head ${branch} --title "${title_safe}" --body-file "\$(git rev-parse --git-path gh${issue}-pr-body.md)"
     output: one https://github.com/${repo}/pull/<integer> URL, exit 0. Retain as pr_url.
-22. gh pr view ${branch} --repo ${repo} --json headRefOid --jq .headRefOid
+23. gh pr view ${branch} --repo ${repo} --json headRefOid --jq .headRefOid
     output: delivery_sha from step 18, exactly.
-23. edda task done ${task} --receipt "PR <pr_url> @ <delivery_sha>"
+24. edda task done ${task} --receipt "PR <pr_url> @ <delivery_sha>"
     output: task ${task} marked done, exit 0.
-24. Report, as the final message, exactly these five lines and nothing else:
+25. Report, as the final message, exactly these five lines and nothing else:
     DONE issue=#${issue} task=${task}
     pr=<pr_url>
     sha=<delivery_sha>

--- a/scripts/fleet/next-issue.sh
+++ b/scripts/fleet/next-issue.sh
@@ -70,8 +70,9 @@ has_ready=$(printf '%s' "$json" | jq '[.labels[].name] | index("fleet:ready") !=
 [ "$has_ready" = "true" ] || die "issue $issue does not carry fleet:ready"
 title=$(printf '%s' "$json" | jq -r .title)
 [ -n "$title" ] && [ "$title" != "null" ] || die "issue $issue has no title"
-# interpolated into the double-quoted task-new line below
-title_safe=$(printf '%s' "$title" | tr -d '"`$')
+# interpolated into the double-quoted task-new line below; the backslash is
+# stripped too — a trailing \\ would escape the closing quote inside sh -c
+title_safe=$(printf '%s' "$title" | tr -d '"`$\\')
 
 echo "== branch and worktree"
 type=$(printf '%s' "$title" | sed -n 's/^\([a-z][a-z0-9]*\)([^)]*)[:].*/\1/p')
@@ -103,7 +104,7 @@ fi
 brief_path="${EDDA_FLEET_SCRATCH:-$HOME/.edda/fleet}/brief-gh$issue.md"
 render_cmd="sh scripts/fleet/brief-from-issue.sh $issue --lane-name $lane --worktree $wt --branch $branch"
 
-echo "== brief"
+# (brief is rendered here; its output block is printed after the task line, in doneWhen order)
 brief_note=
 if [ -f "$brief_path" ] && ! grep -q '^<<AUTHORED STEPS>>$' "$brief_path"; then
     brief_note="keeping authored brief: $brief_path"
@@ -121,17 +122,19 @@ else
     fi
 fi
 [ -n "$scope_csv" ] || die "rendered brief has no scope paths line"
+# The facts line reads "scope paths: a, b, c ·" — strip the trailing dot, then
+# split on ", " into repeatable --path flags (every path, not just the first).
+scope_csv=${scope_csv% ·}
 task_paths=
-path_entry=$scope_csv
-while [ -n "$path_entry" ]; do
-    p=${path_entry%%, *}
-    case "$p" in
-        *,*) path_entry=${path_entry#*, } ;;
-        *) path_entry= ;;
+while [ -n "$scope_csv" ]; do
+    p=${scope_csv%%, *}
+    case "$scope_csv" in
+        *,\ *) scope_csv=${scope_csv#*, } ;;
+        *) scope_csv= ;;
     esac
-    task_paths="$task_paths --path $p"
+    task_paths="$task_paths --path \"$p\""
 done
-task_cmd="edda task new \"$title_safe\" --assignee ${machine#*/}$task_paths --brief $brief_path --key gh$issue"
+task_cmd="edda task new \"$title_safe\" --assignee \"${machine#*/}\"$task_paths --brief \"$brief_path\" --key gh$issue"
 
 if [ "$dry" = 0 ] && grep -q '^<<AUTHORED STEPS>>$' "$brief_path"; then
     die "brief still contains <<AUTHORED STEPS>> — fill the authored middle in $brief_path, then rerun"

--- a/scripts/fleet/next-issue.sh
+++ b/scripts/fleet/next-issue.sh
@@ -1,0 +1,191 @@
+#!/bin/sh
+# next-issue.sh — one command from a fleet:ready issue to a launched lane (GH-886).
+# The skill-less controller's pick-and-launch half of the loop: lint the queue,
+# refuse a claimed or non-ready issue, render the brief with brief-from-issue.sh
+# (GH-885), refuse to launch a brief whose authored middle is still unfilled,
+# then task, claim, worktree, and launch through the same guarded scripts the
+# Claude line uses.
+#
+# usage:
+#   sh scripts/fleet/next-issue.sh <issue> <machine>/<role> [--dry-run]
+#
+# --dry-run prints every command it would run and creates, claims and launches
+# nothing. Never merges, force-pushes, or touches labels.
+set -eu
+
+usage() {
+    echo "usage: $0 <issue> <machine>/<role> [--dry-run]" >&2
+}
+
+die() {
+    echo "next-issue: $1" >&2
+    exit 2
+}
+
+repo=${EDDA_REPO:-fagemx/edda}
+issue=
+machine=
+dry=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) dry=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        --) shift; break ;;
+        -*)
+            die "unknown option $1" ;;
+        *)
+            if [ -z "$issue" ]; then issue=$1; shift
+            elif [ -z "$machine" ]; then machine=$1; shift
+            else die "unexpected argument $1"
+            fi ;;
+    esac
+done
+[ -n "$issue" ] && [ -n "$machine" ] || { usage; exit 2; }
+case "$issue" in
+    *[!0-9]*|'') die "issue must be a positive integer, got '$issue'" ;;
+esac
+case "$machine" in
+    */*) : ;;
+    *) die "machine identity must be <machine>/<role>, got '$machine'" ;;
+esac
+
+self_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+root=$(CDPATH= cd -- "$self_dir/../.." && pwd)
+
+echo "== ready-queue lint"
+sh "$self_dir/ready-queue-lint.sh" || die "ready-queue-lint failed"
+
+echo "== issue state"
+json=$(gh issue view "$issue" --repo "$repo" --json state,title,labels,comments) ||
+    die "gh issue view $issue failed"
+state=$(printf '%s' "$json" | jq -r .state)
+[ "$state" = "OPEN" ] || die "issue $issue is $state, not OPEN"
+has_claimed=$(printf '%s' "$json" | jq '[.labels[].name] | index("fleet:claimed") != null')
+if [ "$has_claimed" = "true" ]; then
+    claimant=$(printf '%s' "$json" | jq -r \
+        '[.comments[].body] | map(capture("taking: (?<who>[^ ]+) at").who) | last // "unknown"')
+    die "issue $issue is already claimed (fleet:claimed) by ${claimant:-unknown}"
+fi
+has_ready=$(printf '%s' "$json" | jq '[.labels[].name] | index("fleet:ready") != null')
+[ "$has_ready" = "true" ] || die "issue $issue does not carry fleet:ready"
+title=$(printf '%s' "$json" | jq -r .title)
+[ -n "$title" ] && [ "$title" != "null" ] || die "issue $issue has no title"
+# interpolated into the double-quoted task-new line below
+title_safe=$(printf '%s' "$title" | tr -d '"`$')
+
+echo "== branch and worktree"
+type=$(printf '%s' "$title" | sed -n 's/^\([a-z][a-z0-9]*\)([^)]*)[:].*/\1/p')
+[ -n "$type" ] || type=feat
+slug=$(printf '%s' "$title" | sed -n 's/^[^(]*([^)]*)[:][[:space:]]*//p' \
+    | tr 'A-Z' 'a-z' | sed 's/[^a-z0-9][^a-z0-9]*/-/g; s/^-+//; s/-+$//' | cut -c1-40 \
+    | sed 's/-*$//')
+[ -n "$slug" ] || slug="issue-$issue"
+branch="$type/gh$issue-$slug"
+common_dir=$(git -C "$root" rev-parse --path-format=absolute --git-common-dir)
+# The main checkout's parent and name: <parent>/<repo>-wt-gh<issue>, parallel
+# to the main checkout, not nested inside whatever worktree this runs from.
+repo_root=$(dirname -- "$common_dir")
+wt="$(dirname -- "$repo_root")/$(basename -- "$repo_root")-wt-gh$issue"
+worktree_cmd="git worktree add -b $branch $wt origin/main"
+echo "branch:   $branch (from origin/main)"
+echo "worktree: $wt"
+echo "cmd:      $worktree_cmd"
+
+lane=edda-lane-gh$issue
+lanes_dir="${TEMP:-/tmp}/edda-lanes"
+if [ -f "$lanes_dir/$lane.done" ] || [ -f "$lanes_dir/$lane.log" ]; then
+    n=2
+    while [ -f "$lanes_dir/$lane-r$n.done" ] || [ -f "$lanes_dir/$lane-r$n.log" ]; do
+        n=$((n + 1))
+    done
+    lane="$lane-r$n"
+fi
+brief_path="${EDDA_FLEET_SCRATCH:-$HOME/.edda/fleet}/brief-gh$issue.md"
+render_cmd="sh scripts/fleet/brief-from-issue.sh $issue --lane-name $lane --worktree $wt --branch $branch"
+
+echo "== brief"
+brief_note=
+if [ -f "$brief_path" ] && ! grep -q '^<<AUTHORED STEPS>>$' "$brief_path"; then
+    brief_note="keeping authored brief: $brief_path"
+    scope_csv=$(sed -n 's/^scope paths: //p' "$brief_path" | head -1)
+else
+    if [ "$dry" = 1 ]; then
+        scope_csv=$(sh "$self_dir/brief-from-issue.sh" "$issue" --lane-name "$lane" \
+            --worktree "$wt" --branch "$branch" | sed -n 's/^scope paths: //p' | head -1)
+        render_cmd="$render_cmd > $brief_path"
+    else
+        sh "$self_dir/brief-from-issue.sh" "$issue" --lane-name "$lane" \
+            --worktree "$wt" --branch "$branch" >"$brief_path"
+        brief_note="rendered: $brief_path"
+        scope_csv=$(sed -n 's/^scope paths: //p' "$brief_path" | head -1)
+    fi
+fi
+[ -n "$scope_csv" ] || die "rendered brief has no scope paths line"
+task_paths=
+path_entry=$scope_csv
+while [ -n "$path_entry" ]; do
+    p=${path_entry%%, *}
+    case "$p" in
+        *,*) path_entry=${path_entry#*, } ;;
+        *) path_entry= ;;
+    esac
+    task_paths="$task_paths --path $p"
+done
+task_cmd="edda task new \"$title_safe\" --assignee ${machine#*/}$task_paths --brief $brief_path --key gh$issue"
+
+if [ "$dry" = 0 ] && grep -q '^<<AUTHORED STEPS>>$' "$brief_path"; then
+    die "brief still contains <<AUTHORED STEPS>> — fill the authored middle in $brief_path, then rerun"
+fi
+
+echo "== task"
+echo "cmd: $task_cmd"
+
+echo "== brief"
+if [ -n "$brief_note" ]; then
+    echo "$brief_note"
+fi
+echo "cmd:  $render_cmd"
+echo "brief path: $brief_path"
+
+echo "== claim"
+claim_cmd="sh scripts/fleet-claim-issue.sh $issue $machine"
+echo "cmd: $claim_cmd"
+
+echo "== launch"
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+        launch_cmd="pwsh -NoProfile -File scripts/fleet/lane-launch.ps1 -Name $lane -Brief $brief_path -Cwd $wt -Agent pi -TimeoutSec 5400 -BudgetUsd 3" ;;
+    *)
+        launch_cmd="pi --model openrouter/z-ai/glm-5.3-flash --session-id lane-$lane \"\$(cat $brief_path)\"  # unattended runs need a process supervisor" ;;
+esac
+echo "cmd: $launch_cmd"
+echo "lane name:   $lane"
+echo "log:         %TEMP%\\edda-lanes\\$lane.log"
+echo "done marker: %TEMP%\\edda-lanes\\$lane.done"
+
+if [ "$dry" = 1 ]; then
+    echo "== dry-run: nothing created, claimed, or launched"
+    exit 0
+fi
+
+if [ ! -d "$wt" ]; then
+    git -C "$root" worktree add -b "$branch" "$wt" origin/main >/dev/null
+else
+    echo "worktree already exists: $wt (not recreated)"
+fi
+
+echo "== running task new"
+sh -c "$task_cmd"
+
+echo "== running claim"
+sh "$self_dir/../fleet-claim-issue.sh" "$issue" "$machine"
+
+echo "== launching lane"
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+        pwsh -NoProfile -File "$self_dir/lane-launch.ps1" -Name "$lane" \
+            -Brief "$brief_path" -Cwd "$wt" -Agent pi -TimeoutSec 5400 -BudgetUsd 3 ;;
+    *)
+        die "unattended launch on POSIX needs a process supervisor — run interactively: $launch_cmd" ;;
+esac
+echo "lane launched: $lane (watch %TEMP%\\edda-lanes\\$lane.done; log .log alongside)"

--- a/scripts/fleet/next-review.sh
+++ b/scripts/fleet/next-review.sh
@@ -1,0 +1,155 @@
+#!/bin/sh
+# next-review.sh — one command from an open PR to a posted review comment (GH-886).
+# The skill-less controller's review half of the loop: pin the head SHA, count
+# the rounds, refuse past the cap without operator authority, build the same
+# brief the Claude line reviews from, run the read-only glm engine in a
+# detached worktree, and post the result — as a SHADOW round when --shadow is
+# given (no labels, no Independent Review status, per review.gh880-shadow),
+# otherwise by delegating to review-pr.sh's verdict flow.
+#
+# usage:
+#   sh scripts/fleet/next-review.sh <pr> [--shadow] [--operator-granted] [--dry-run]
+#
+# Never merges, never force-pushes, and edits exactly one label: needs-operator.
+set -eu
+
+usage() {
+    echo "usage: $0 <pr> [--shadow] [--operator-granted] [--dry-run]" >&2
+}
+
+die() {
+    echo "next-review: $1" >&2
+    exit 2
+}
+
+repo=${EDDA_REPO:-fagemx/edda}
+model=${EDDA_REVIEW_MODEL:-openrouter/z-ai/glm-5.3-flash}
+pr=
+shadow=0
+granted=0
+dry=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --shadow) shadow=1; shift ;;
+        --operator-granted) granted=1; shift ;;
+        --dry-run) dry=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        --) shift; break ;;
+        -*)
+            die "unknown option $1" ;;
+        *)
+            if [ -z "$pr" ]; then pr=$1; shift
+            else die "unexpected argument $1"
+            fi ;;
+    esac
+done
+[ -n "$pr" ] || { usage; exit 2; }
+case "$pr" in
+    *[!0-9]*|'') die "pr must be a positive integer, got '$pr'" ;;
+esac
+
+self_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+root=$(CDPATH= cd -- "$self_dir/../.." && pwd)
+scratch=${EDDA_FLEET_SCRATCH:-$HOME/.edda/fleet}
+wt="$scratch/wt-review-pr$pr"
+
+echo "== head SHA"
+head_sha=$(gh pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid) ||
+    die "gh pr view $pr failed"
+case "$head_sha" in
+    [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]\
+[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]\
+[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]\
+[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) : ;;
+    *) die "head SHA is not a 40-hex SHA: '$head_sha'" ;;
+esac
+echo "head: $head_sha"
+
+echo "== round count"
+rounds=$(gh pr view "$pr" --repo "$repo" --json comments \
+    --jq '[.comments[] | select(.body | startswith("## Code Review: Round"))] | length') ||
+    die "gh pr view $pr comments failed"
+echo "rounds already posted: $rounds"
+case "$rounds" in
+    *[!0-9]*|'') die "could not read the round count from the PR comments" ;;
+esac
+if [ "$rounds" -ge 3 ] && [ "$granted" = 0 ]; then
+    if [ "$dry" = 0 ]; then
+        gh issue edit "$pr" --repo "$repo" --add-label needs-operator >/dev/null ||
+            die "could not add the needs-operator label"
+    fi
+    die "round cap: $rounds review rounds posted and no --operator-granted — labeled needs-operator, launching nothing"
+fi
+round=$((rounds + 1))
+
+echo "== brief"
+brief_cmd="sh scripts/review-pr.sh $pr $round --dry-run"
+echo "cmd: $brief_cmd"
+if [ "$dry" = 1 ]; then
+    sh "$self_dir/../review-pr.sh" "$pr" "$round" --dry-run 2>/dev/null || true
+    echo "(dry-run: the real run regenerates this brief against the pinned head)"
+    echo "== engine command"
+    echo "cmd: edda dispatch --agent pi --model $model --tools read,grep,find,ls --thinking max --budget-usd 1 --timeout-sec 1500 --json --prompt-file <brief> (cwd: $wt)"
+    echo "== post"
+    if [ "$shadow" = 1 ]; then
+        echo "cmd: gh pr comment $pr --repo $repo --body-file <verdict>  # heading suffix ' (SHADOW)', body line 'shadow: true', no labels, no status"
+    else
+        echo "cmd: EDDA_REVIEW_AGENT=pi sh scripts/review-pr.sh $pr $round  # full verdict flow"
+    fi
+    echo "== dry-run: nothing launched or posted"
+    exit 0
+fi
+
+brief_out=$(sh "$self_dir/../review-pr.sh" "$pr" "$round" --dry-run) || die "review-pr.sh dry-run failed"
+brief_path=$(printf '%s\n' "$brief_out" | sed -n 's/^brief=//p')
+[ -n "$brief_path" ] || die "could not read the brief path from review-pr.sh output"
+echo "brief: $brief_path"
+[ -f "$brief_path" ] || die "brief file missing: $brief_path"
+base_sha=$(printf '%s\n' "$brief_out" | sed -n 's/^spec=REVIEW.md@\([0-9a-f]*\).*/\1/p' | head -1)
+[ -n "$base_sha" ] || die "could not read the spec SHA from review-pr.sh output"
+
+echo "== review worktree"
+if [ -d "$wt" ]; then
+    git -C "$wt" checkout -q --detach "$head_sha"
+else
+    git -C "$root" worktree add --detach "$wt" "$head_sha" >/dev/null
+fi
+git -C "$wt" show "$base_sha:REVIEW.md" >"$wt/.edda-review-spec.md"
+
+echo "== engine (read-only glm, thinking max)"
+engine_cmd="edda dispatch --agent pi --model $model --tools read,grep,find,ls --thinking max --budget-usd 1 --timeout-sec 1500 --json --prompt-file $brief_path"
+echo "cmd: $engine_cmd"
+engine_out=$(cd "$wt" && edda dispatch --agent pi --model "$model" \
+    --tools read,grep,find,ls --thinking max --budget-usd 1 --timeout-sec 1500 \
+    --json --prompt-file "$brief_path") || die "engine dispatch failed"
+echo "$engine_out" >"$wt/next-review-engine.json"
+outcome=$(printf '%s' "$engine_out" | jq -r .outcome)
+[ "$outcome" = "done" ] || die "engine outcome is $outcome (see $wt/next-review-engine.json)"
+verdict=$(printf '%s' "$engine_out" | jq -r .result_text)
+model_observed=$(printf '%s' "$engine_out" | jq -r .model_observed)
+cost=$(printf '%s' "$engine_out" | jq -r '.cost_usd // "unmeasured"')
+elapsed_ms=$(printf '%s' "$engine_out" | jq -r '.elapsed_ms // empty')
+[ -n "$verdict" ] && [ "$verdict" != "null" ] || die "engine returned no verdict text"
+
+echo "== post"
+head_now=$(gh pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid)
+if [ "$head_now" != "$head_sha" ]; then
+    die "head moved between brief and post ($head_sha -> $head_now) — posting nothing"
+fi
+verdict_file="$wt/next-review-r$round-verdict.md"
+printf '%s\n' "$verdict" >"$verdict_file"
+if [ "$shadow" = 1 ]; then
+    # SHADOW shape (review.gh880-shadow): heading suffix, shadow: true, no
+    # labels, no Independent Review status, not a merge authority.
+    sed -i "1s/\$/ (SHADOW)/" "$verdict_file"
+    sed -i "1a shadow: true" "$verdict_file"
+    cost_line="$cost"
+    [ -n "$elapsed_ms" ] && cost_line="$cost / ${elapsed_ms}ms"
+    sed -i "s|^- cost: .*|- cost: $cost_line (dispatch --json)|" "$verdict_file"
+    gh pr comment "$pr" --repo "$repo" --body-file "$verdict_file" >/dev/null ||
+        die "gh pr comment failed"
+    echo "posted SHADOW round $round: $verdict_file"
+else
+    echo "delegating the verdict flow to review-pr.sh (labels and status included)"
+    EDDA_REVIEW_AGENT=pi sh "$self_dir/../review-pr.sh" "$pr" "$round"
+fi

--- a/scripts/fleet/next-review.sh
+++ b/scripts/fleet/next-review.sh
@@ -94,7 +94,7 @@ if [ "$dry" = 1 ]; then
     if [ "$shadow" = 1 ]; then
         echo "cmd: gh pr comment $pr --repo $repo --body-file <verdict>  # heading suffix ' (SHADOW)', body line 'shadow: true', no labels, no status"
     else
-        echo "cmd: EDDA_REVIEW_AGENT=pi sh scripts/review-pr.sh $pr $round  # full verdict flow"
+        echo "cmd: (after checking review-pr.sh has the pi arm) EDDA_REVIEW_AGENT=pi sh scripts/review-pr.sh $pr $round  # full verdict flow"
     fi
     echo "== dry-run: nothing launched or posted"
     exit 0
@@ -105,8 +105,20 @@ brief_path=$(printf '%s\n' "$brief_out" | sed -n 's/^brief=//p')
 [ -n "$brief_path" ] || die "could not read the brief path from review-pr.sh output"
 echo "brief: $brief_path"
 [ -f "$brief_path" ] || die "brief file missing: $brief_path"
+# review-pr.sh prints "spec=REVIEW.md@<sha> …" on the normal path; on a
+# pre-spec base it falls back to the checkout copy and prints no SHA — do the
+# same instead of dying.
 base_sha=$(printf '%s\n' "$brief_out" | sed -n 's/^spec=REVIEW.md@\([0-9a-f]*\).*/\1/p' | head -1)
-[ -n "$base_sha" ] || die "could not read the spec SHA from review-pr.sh output"
+
+# doneWhen item 7: neither script ever calls a Claude backend. The non-shadow
+# delegation is only legal once review-pr.sh grows the pi arm (GH-880, PR
+# #890); until that lands the arm is absent and the delegation would dispatch
+# the claude backend by construction.
+if [ "$shadow" != 1 ]; then
+    if ! grep -q 'EDDA_REVIEW_AGENT' "$self_dir/../review-pr.sh"; then
+        die "review-pr.sh has no pi arm yet (GH-880 unmerged) — its delegation would call the claude backend; use --shadow"
+    fi
+fi
 
 echo "== review worktree"
 if [ -d "$wt" ]; then
@@ -114,7 +126,23 @@ if [ -d "$wt" ]; then
 else
     git -C "$root" worktree add --detach "$wt" "$head_sha" >/dev/null
 fi
-git -C "$wt" show "$base_sha:REVIEW.md" >"$wt/.edda-review-spec.md"
+if [ -n "$base_sha" ]; then
+    git -C "$wt" show "$base_sha:REVIEW.md" >"$wt/.edda-review-spec.md"
+else
+    echo "spec SHA unavailable from review-pr.sh output — falling back to the checkout copy"
+    cp "$root/REVIEW.md" "$wt/.edda-review-spec.md"
+fi
+
+if [ "$shadow" != 1 ]; then
+    echo "== post (delegated verdict flow)"
+    head_now=$(gh pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid)
+    if [ "$head_now" != "$head_sha" ]; then
+        die "head moved between brief and post ($head_sha -> $head_now) — posting nothing"
+    fi
+    echo "delegating the verdict flow to review-pr.sh (pi arm, labels and status included)"
+    EDDA_REVIEW_AGENT=pi sh "$self_dir/../review-pr.sh" "$pr" "$round"
+    exit 0
+fi
 
 echo "== engine (read-only glm, thinking max)"
 engine_cmd="edda dispatch --agent pi --model $model --tools read,grep,find,ls --thinking max --budget-usd 1 --timeout-sec 1500 --json --prompt-file $brief_path"
@@ -126,7 +154,6 @@ echo "$engine_out" >"$wt/next-review-engine.json"
 outcome=$(printf '%s' "$engine_out" | jq -r .outcome)
 [ "$outcome" = "done" ] || die "engine outcome is $outcome (see $wt/next-review-engine.json)"
 verdict=$(printf '%s' "$engine_out" | jq -r .result_text)
-model_observed=$(printf '%s' "$engine_out" | jq -r .model_observed)
 cost=$(printf '%s' "$engine_out" | jq -r '.cost_usd // "unmeasured"')
 elapsed_ms=$(printf '%s' "$engine_out" | jq -r '.elapsed_ms // empty')
 [ -n "$verdict" ] && [ "$verdict" != "null" ] || die "engine returned no verdict text"
@@ -138,18 +165,13 @@ if [ "$head_now" != "$head_sha" ]; then
 fi
 verdict_file="$wt/next-review-r$round-verdict.md"
 printf '%s\n' "$verdict" >"$verdict_file"
-if [ "$shadow" = 1 ]; then
-    # SHADOW shape (review.gh880-shadow): heading suffix, shadow: true, no
-    # labels, no Independent Review status, not a merge authority.
-    sed -i "1s/\$/ (SHADOW)/" "$verdict_file"
-    sed -i "1a shadow: true" "$verdict_file"
-    cost_line="$cost"
-    [ -n "$elapsed_ms" ] && cost_line="$cost / ${elapsed_ms}ms"
-    sed -i "s|^- cost: .*|- cost: $cost_line (dispatch --json)|" "$verdict_file"
-    gh pr comment "$pr" --repo "$repo" --body-file "$verdict_file" >/dev/null ||
-        die "gh pr comment failed"
-    echo "posted SHADOW round $round: $verdict_file"
-else
-    echo "delegating the verdict flow to review-pr.sh (labels and status included)"
-    EDDA_REVIEW_AGENT=pi sh "$self_dir/../review-pr.sh" "$pr" "$round"
-fi
+# SHADOW shape (review.gh880-shadow): heading suffix, shadow: true, no
+# labels, no Independent Review status, not a merge authority.
+sed -i "1s/\$/ (SHADOW)/" "$verdict_file"
+sed -i "1a shadow: true" "$verdict_file"
+cost_line="$cost"
+[ -n "$elapsed_ms" ] && cost_line="$cost / ${elapsed_ms}ms"
+sed -i "s|^- cost: .*|- cost: $cost_line (dispatch --json)|" "$verdict_file"
+gh pr comment "$pr" --repo "$repo" --body-file "$verdict_file" >/dev/null ||
+    die "gh pr comment failed"
+echo "posted SHADOW round $round: $verdict_file"

--- a/scripts/fleet/test-brief-from-issue.sh
+++ b/scripts/fleet/test-brief-from-issue.sh
@@ -197,4 +197,22 @@ if grep -E 'scope paths:.*REVIEW\.md|scope paths:.*Cargo\.lock' "$work/out/negat
 fi
 echo "ok 6 negated mentions excluded from scope paths"
 
+# 7. shell-metacharacter stripping from the title: backtick and dollar must not
+# survive into the commit step, where the lane's shell would expand them.
+cat >"$work/issue-metachar.json" <<'JSON'
+{"title":"fix: broke `x` and $(rm -rf /) handling","labels":[],"body":"## Predicted surface\n\n`scripts/review-pr.sh`.\n\n## doneWhen\n- item\n"}
+JSON
+rc=0
+TEST_UNAME=Linux GH_ISSUE_JSON="$work/issue-metachar.json" \
+    PATH="$work/bin:$PATH" \
+    sh "$script" 880 --lane-name n --worktree /tmp/wt --branch b \
+    >"$work/out/metachar.txt" || rc=$?
+[ "$rc" -eq 0 ] || fail "metachar render exit $rc"
+if grep -E '\$\(rm|`x`' "$work/out/metachar.txt"; then
+    fail "shell metacharacter survived into the brief"
+fi
+grep -q 'git commit -m "fix: broke x and (rm -rf /) handling"' "$work/out/metachar.txt" \
+    || fail "stripped title not in commit step: $(grep 'git commit -m' "$work/out/metachar.txt")"
+echo "ok 7 title metacharacters stripped"
+
 echo "PASS: scripts/fleet/test-brief-from-issue.sh"

--- a/scripts/fleet/test-brief-from-issue.sh
+++ b/scripts/fleet/test-brief-from-issue.sh
@@ -122,6 +122,15 @@ assert_skeleton() {
     grep -q 'scripts/review-pr.sh' "$out" || fail "git status finish missing a scope path"
     grep -q 'DONE issue=#880 task=128' "$out" || fail "missing five-line report"
     grep -q 'stop=controller issues the next brief' "$out" || fail "missing report last line"
+    grep -q '20. git rev-parse --git-path gh880-pr-body.md' "$out" \
+        || fail "missing pr-body path resolution step"
+    grep -q 'write({"path":"<pr_body_path>"' "$out" \
+        || fail "write step must target the retained git-dir path"
+    if grep -qF '.git/gh880-pr-body.md' "$out"; then
+        fail "hardcoded .git/ pr-body path still present (linked worktree .git is a file)"
+    fi
+    grep -qF 'body-file "$(git rev-parse --git-path gh880-pr-body.md)"' "$out" \
+        || fail "step 22 must carry the literal git-path expansion for the lane"
     if grep -Ei 'as needed|if relevant|use (your )?judg|where appropriate' "$out"; then
         fail "discretionary phrasing in output"
     fi

--- a/scripts/fleet/test-brief-from-issue.sh
+++ b/scripts/fleet/test-brief-from-issue.sh
@@ -16,7 +16,7 @@ sh -n "$0" || {
 }
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/test-brief-from-issue.XXXXXX")
-trap 'rm -rf "$work"' EXIT
+trap 'rm -rf "$work"' 0 HUP INT TERM
 export TMPDIR="$work"
 
 mkdir -p "$work/bin" "$work/out"
@@ -126,6 +126,12 @@ assert_skeleton() {
         || fail "missing pr-body path resolution step"
     grep -q 'write({"path":"<pr_body_path>"' "$out" \
         || fail "write step must target the retained git-dir path"
+    grep -qF -- '--paths "scripts/review-pr.sh"' "$out" \
+        || fail "claim step paths must be quoted"
+    grep -qF 'git ls-files -- "scripts/review-pr.sh"' "$out" \
+        || fail "ls-files step paths must be quoted"
+    grep -qF 'git add -- "scripts/review-pr.sh"' "$out" \
+        || fail "git add step paths must be quoted"
     if grep -qF '.git/gh880-pr-body.md' "$out"; then
         fail "hardcoded .git/ pr-body path still present (linked worktree .git is a file)"
     fi
@@ -223,5 +229,21 @@ fi
 grep -q 'git commit -m "fix: broke x and (rm -rf /) handling"' "$work/out/metachar.txt" \
     || fail "stripped title not in commit step: $(grep 'git commit -m' "$work/out/metachar.txt")"
 echo "ok 7 title metacharacters stripped"
+
+# 8. a crafted Predicted-surface token is rejected, not rendered (R5)
+cat >"$work/issue-crafted.json" <<'JSON'
+{"title":"crafted","labels":[],"body":"## Predicted surface\n\n`scripts/review-pr.sh`, `docs/a; rm -rf ~`.\n\n## doneWhen\n- item\n"}
+JSON
+rc=0
+TEST_UNAME=Linux GH_ISSUE_JSON="$work/issue-crafted.json" \
+    PATH="$work/bin:$PATH" \
+    sh "$script" 1 --lane-name n --worktree /tmp/wt --branch b \
+    >"$work/out/crafted.txt" 2>"$work/out/crafted.err" || rc=$?
+[ "$rc" -eq 2 ] || fail "crafted token exit $rc, want 2"
+grep -q 'rm -rf' "$work/out/crafted.err" \
+    || fail "crafted-token stderr must name the rejected token: $(cat "$work/out/crafted.err")"
+grep -q 'rm -rf' "$work/out/crafted.txt" \
+    && fail "crafted token leaked into the rendered brief"
+echo "ok 8 crafted scope token rejected"
 
 echo "PASS: scripts/fleet/test-brief-from-issue.sh"

--- a/scripts/fleet/test-brief-from-issue.sh
+++ b/scripts/fleet/test-brief-from-issue.sh
@@ -1,0 +1,200 @@
+#!/bin/sh
+# Offline self-test for scripts/fleet/brief-from-issue.sh (GH-885).
+# Stubs gh, uname, and git. Writes only under a temp dir.
+set -eu
+
+cd "$(git rev-parse --show-toplevel)"
+script=scripts/fleet/brief-from-issue.sh
+
+sh -n "$script" || {
+    echo "FAIL: sh -n $script" >&2
+    exit 1
+}
+sh -n "$0" || {
+    echo "FAIL: sh -n $0" >&2
+    exit 1
+}
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/test-brief-from-issue.XXXXXX")
+trap 'rm -rf "$work"' EXIT
+export TMPDIR="$work"
+
+mkdir -p "$work/bin" "$work/out"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+cat >"$work/bin/gh" <<'STUB'
+#!/bin/sh
+cat "$GH_ISSUE_JSON"
+STUB
+chmod +x "$work/bin/gh"
+
+cat >"$work/bin/git" <<'STUB'
+#!/bin/sh
+# Consume a leading -C <dir> the way git(1) does.
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -C) shift 2 ;;
+        *) break ;;
+    esac
+done
+case "$*" in
+    "rev-parse origin/main")
+        echo "6486228c728dff5d488b5756e918af0bccde0eb5"
+        exit 0
+        ;;
+esac
+echo "git-stub: unexpected: $*" >&2
+exit 1
+STUB
+chmod +x "$work/bin/git"
+
+cat >"$work/bin/uname" <<'STUB'
+#!/bin/sh
+echo "$TEST_UNAME"
+STUB
+chmod +x "$work/bin/uname"
+
+# Fixture: Predicted surface matches issue #880's shipped list.
+cat >"$work/issue-880.json" <<'JSON'
+{"title":"fix(fleet): review-pr.sh has no pi arm","labels":[{"name":"fleet:ready"}],"body":"## What happened\nBasis.\n\n## Predicted surface\n\n`scripts/review-pr.sh`, `scripts/reviewer-capabilities.sh`, `scripts/fleet/reviewer-capabilities.ps1`, `scripts/test-review-capabilities.sh`, `scripts/pr-review-launch.ps1`, `scripts/pr-review-watch.sh`. No crate.\n\n## doneWhen\n- item\n"}
+JSON
+
+cat >"$work/issue-missing.json" <<'JSON'
+{"title":"no surface","labels":[],"body":"## What happened\nNo predicted heading here.\n\n## doneWhen\n- item\n"}
+JSON
+
+cat >"$work/issue-empty.json" <<'JSON'
+{"title":"empty surface","labels":[],"body":"## What happened\n.\n\n## Predicted surface\n\nNo crate.\n\n## doneWhen\n- item\n"}
+JSON
+
+# Negated mentions: the real GH-880 surface ends with "No crate, no `REVIEW.md`,
+# no `Cargo.lock`." — those two tokens are named only to be excluded.
+cat >"$work/issue-negated.json" <<'JSON'
+{"title":"negated mentions","labels":[],"body":"## Predicted surface\n\n`scripts/review-pr.sh`, `scripts/pr-review-watch.sh`. No crate, no `REVIEW.md`, no `Cargo.lock`.\n\n## doneWhen\n- item\n"}
+JSON
+
+run_ok() {
+    uname_s=$1
+    out=$2
+    TEST_UNAME=$uname_s GH_ISSUE_JSON="$work/issue-880.json" \
+        PATH="$work/bin:$PATH" \
+        sh "$script" 880 \
+            --lane-name edda-lane-gh880 \
+            --worktree C:/ai_agent/edda-wt-gh880 \
+            --branch fix/gh880-pi-review-arm \
+            --task-id 128 >"$out"
+}
+
+assert_facts() {
+    out=$1
+    grep -q 'role: worker' "$out" || fail "missing role: $(cat "$out")"
+    grep -q 'lane: none' "$out" || fail "missing lane none: $(cat "$out")"
+    grep -q 'task id: 128' "$out" || fail "missing task id: $(cat "$out")"
+    grep -q 'issue: #880' "$out" || fail "missing issue: $(cat "$out")"
+    grep -q 'base full SHA: 6486228c728dff5d488b5756e918af0bccde0eb5' "$out" \
+        || fail "missing base SHA: $(cat "$out")"
+    grep -q 'scope paths: scripts/review-pr.sh, scripts/reviewer-capabilities.sh, scripts/fleet/reviewer-capabilities.ps1, scripts/test-review-capabilities.sh, scripts/pr-review-launch.ps1, scripts/pr-review-watch.sh' "$out" \
+        || fail "missing scope paths: $(cat "$out")"
+    grep -q 'entry: none: procedure below' "$out" || fail "missing entry"
+    grep -q 'gate owner: not you; review queue' "$out" || fail "missing gate owner"
+    grep -q 'out-of-scope: every path and concern not listed in scope paths' "$out" \
+        || fail "missing out-of-scope"
+}
+
+assert_skeleton() {
+    out=$1
+    grep -q 'Launcher contract:' "$out" || fail "missing launcher contract"
+    grep -q 'C:/ai_agent/edda-wt-gh880' "$out" || fail "missing worktree"
+    grep -q 'fix/gh880-pi-review-arm' "$out" || fail "missing branch"
+    grep -q 'edda-lane-gh880' "$out" || fail "missing lane name"
+    grep -q 'Failure rule for every numbered step: a nonzero command exit, tool error,' "$out" \
+        || fail "missing failure rule"
+    grep -q 'STOP step=<number> output=<verbatim unexpected output>.' "$out" \
+        || fail "missing STOP sentence"
+    grep -q '1. gh issue view 880' "$out" || fail "missing preamble step 1"
+    grep -q '9. git ls-files --' "$out" || fail "missing preamble step 9"
+    c=$(grep -c '<<AUTHORED STEPS>>' "$out" || true)
+    [ "$c" -eq 1 ] || fail "marker count $c, want 1"
+    grep -q 'scripts/review-pr.sh' "$out" || fail "git status finish missing a scope path"
+    grep -q 'DONE issue=#880 task=128' "$out" || fail "missing five-line report"
+    grep -q 'stop=controller issues the next brief' "$out" || fail "missing report last line"
+    if grep -Ei 'as needed|if relevant|use (your )?judg|where appropriate' "$out"; then
+        fail "discretionary phrasing in output"
+    fi
+}
+
+# 1. Windows host
+rc=0
+run_ok 'MINGW64_NT-10.0' "$work/out/win.txt" || rc=$?
+[ "$rc" -eq 0 ] || fail "windows render exit $rc"
+assert_facts "$work/out/win.txt"
+assert_skeleton "$work/out/win.txt"
+grep -q 'Host: MINGW/MSYS. review-pr.sh --dry-run generates -lane.ps1 and no -run.sh.' \
+    "$work/out/win.txt" || fail "windows host fact: $(cat "$work/out/win.txt")"
+echo "ok 1 windows host facts and skeleton"
+
+# 2. Linux host
+rc=0
+run_ok 'Linux' "$work/out/linux.txt" || rc=$?
+[ "$rc" -eq 0 ] || fail "linux render exit $rc"
+assert_facts "$work/out/linux.txt"
+assert_skeleton "$work/out/linux.txt"
+grep -q 'Host: Linux. review-pr.sh --dry-run generates -run.sh and no -lane.ps1.' \
+    "$work/out/linux.txt" || fail "linux host fact: $(cat "$work/out/linux.txt")"
+echo "ok 2 linux host facts and skeleton"
+
+# 3. missing Predicted surface section → exit 2, names the section
+rc=0
+TEST_UNAME=Linux GH_ISSUE_JSON="$work/issue-missing.json" \
+    PATH="$work/bin:$PATH" \
+    sh "$script" 1 --lane-name n --worktree /tmp/wt --branch b \
+    >"$work/out/missing.txt" 2>"$work/out/missing.err" || rc=$?
+[ "$rc" -eq 2 ] || fail "missing section exit $rc, want 2"
+grep -q 'Predicted surface' "$work/out/missing.err" \
+    || fail "missing-section stderr must name the section: $(cat "$work/out/missing.err")"
+echo "ok 3 missing Predicted surface exits 2"
+
+# 4. empty Predicted surface (no paths) → exit 2, names the section
+rc=0
+TEST_UNAME=Linux GH_ISSUE_JSON="$work/issue-empty.json" \
+    PATH="$work/bin:$PATH" \
+    sh "$script" 1 --lane-name n --worktree /tmp/wt --branch b \
+    >"$work/out/empty.txt" 2>"$work/out/empty.err" || rc=$?
+[ "$rc" -eq 2 ] || fail "empty section exit $rc, want 2"
+grep -q 'Predicted surface' "$work/out/empty.err" \
+    || fail "empty-section stderr must name the section: $(cat "$work/out/empty.err")"
+echo "ok 4 empty Predicted surface exits 2"
+
+# 5. --build-lane fills the lane field
+rc=0
+TEST_UNAME=Linux GH_ISSUE_JSON="$work/issue-880.json" \
+    PATH="$work/bin:$PATH" \
+    sh "$script" 880 --lane-name edda-lane-gh880 \
+        --worktree C:/ai_agent/edda-wt-gh880 \
+        --branch fix/gh880-pi-review-arm \
+        --task-id 128 --build-lane worker-1 \
+    >"$work/out/lane.txt" || rc=$?
+[ "$rc" -eq 0 ] || fail "build-lane render exit $rc"
+grep -q 'lane: worker-1' "$work/out/lane.txt" || fail "build-lane not applied"
+grep -q 'lane: none' "$work/out/lane.txt" && fail "lane none still present with --build-lane"
+echo "ok 5 --build-lane sets lane field"
+
+# 6. negated mentions are not scope paths
+rc=0
+TEST_UNAME=Linux GH_ISSUE_JSON="$work/issue-negated.json" \
+    PATH="$work/bin:$PATH" \
+    sh "$script" 880 --lane-name n --worktree /tmp/wt --branch b \
+    >"$work/out/negated.txt" || rc=$?
+[ "$rc" -eq 0 ] || fail "negated render exit $rc"
+grep -q 'scope paths: scripts/review-pr.sh, scripts/pr-review-watch.sh' "$work/out/negated.txt" \
+    || fail "negated scope paths wrong: $(grep 'scope paths' "$work/out/negated.txt")"
+if grep -E 'scope paths:.*REVIEW\.md|scope paths:.*Cargo\.lock' "$work/out/negated.txt"; then
+    fail "negated mention leaked into scope paths"
+fi
+echo "ok 6 negated mentions excluded from scope paths"
+
+echo "PASS: scripts/fleet/test-brief-from-issue.sh"

--- a/scripts/fleet/test-next-loop.sh
+++ b/scripts/fleet/test-next-loop.sh
@@ -2,7 +2,7 @@
 # Offline self-test for scripts/fleet/next-issue.sh and next-review.sh (GH-886).
 # Stubs gh and edda (and pwsh, defensively); jq, git and sh stay real.
 # Writes only under its temp dir; the one git side effect — worktree
-# registration for the review worktree the loop creates — is pruned on exit.
+# registration for the pre-registered review worktree — is pruned on exit.
 set -eu
 
 cd "$(git rev-parse --show-toplevel)"
@@ -30,7 +30,7 @@ cleanup() {
 trap cleanup 0 HUP INT TERM
 export TMPDIR="$work"
 
-mkdir -p "$work/bin" "$work/fixtures" "$work/scratch" "$work/lanes" "$work/wt" "$work/out"
+mkdir -p "$work/bin" "$work/fixtures" "$work/scratch" "$work/lanes" "$work/out"
 export EDDA_FLEET_SCRATCH="$work/scratch"
 export TEMP="$work/lanes"
 export TMPDIR="$work"
@@ -236,7 +236,12 @@ echo "ok 4 round-cap refusal"
 
 # ── 5+6. shadow run: real worktree, moved head refuses; intact posts ─
 
-git worktree add --detach "$work/wt/review-pr886" "$HEAD1" >/dev/null 2>&1
+# Pre-register the review worktree where next-review.sh reads it
+# ($EDDA_FLEET_SCRATCH/wt-review-pr886) so the checkout --detach branch runs
+# instead of the loop's own worktree add. The marker proves reuse below.
+wt_fix="$work/scratch/wt-review-pr886"
+git worktree add --detach "$wt_fix" "$HEAD1" >/dev/null 2>&1
+: >"$wt_fix/.pre-registered"
 
 printf '%s' "$HEAD1" >"$work/gh-head"
 EDDA_STUB_MOVE_HEAD="$HEAD2" \
@@ -255,6 +260,35 @@ printf '%s\n' "$posted" | head -1 | grep -q '(SHADOW)$' || fail "shadow heading 
 printf '%s\n' "$posted" | sed -n '2,3p' | grep -qx 'shadow: true' || fail "shadow body line missing: $(printf '%s\n' "$posted" | head -3)"
 printf '%s\n' "$posted" | grep -q 'dispatch --json' || fail "shadow cost line not corrected: $(printf '%s\n' "$posted" | grep '^\\- cost' || true)"
 printf '%s\n' "$posted" | grep -q 'placeholder line' && fail "shadow cost line uncorrected"
+[ -f "$wt_fix/.pre-registered" ] || fail "pre-registered worktree not reused — the loop recreated it (checkout --detach branch unexercised)"
+[ "$(git -C "$wt_fix" rev-parse HEAD)" = "$HEAD1" ] || fail "review worktree not detached at the pinned head: $(git -C "$wt_fix" rev-parse HEAD)"
+# Path-drift guard (GH-903): the two checks above inspect only $wt_fix. If the
+# fixture registration ever moves away from $EDDA_FLEET_SCRATCH/wt-review-pr886,
+# the loop registers its own scratch worktree beside it and both checks still
+# pass on the abandoned fixture — the drift is silent. So demand exactly one
+# registration under the test root and that it is the fixture itself. git
+# reports worktree paths in machine-canonical form while $work may be a
+# shell-style path (e.g. MSYS /tmp/...), so canonicalize the root through a
+# throwaway repo under $work instead of deriving it from the fixture path.
+git init -q "$work/canon-probe"
+wt_root=$(git -C "$work/canon-probe" rev-parse --show-toplevel)
+wt_root=${wt_root%/canon-probe}
+[ -n "$wt_root" ] || fail "cannot canonicalize the test root from $work"
+wt_canon=$(git -C "$wt_fix" rev-parse --show-toplevel) || \
+    fail "cannot resolve the fixture worktree registration: $wt_fix"
+wt_reg=0
+wt_drift=
+while IFS= read -r wt_path; do
+    case $wt_path in
+        "$wt_root"/*)
+            wt_reg=$((wt_reg + 1))
+            [ "$wt_path" = "$wt_canon" ] || wt_drift=$wt_path ;;
+    esac
+done <<EOF
+$(git worktree list --porcelain | sed -n 's/^worktree //p')
+EOF
+[ "$wt_reg" -eq 1 ] && [ -z "$wt_drift" ] || \
+    fail "worktree path drift: want exactly one registration under $wt_root and it must be $wt_canon, found $wt_reg${wt_drift:+ with stray $wt_drift}"
 echo "ok 5 moved-head refusal"
 echo "ok 6 shadow post shape"
 

--- a/scripts/fleet/test-next-loop.sh
+++ b/scripts/fleet/test-next-loop.sh
@@ -186,6 +186,10 @@ grep -q '^brief path: ' "$work/out/dry.txt" || fail "dry-run output misses the b
 grep -q 'fleet-claim-issue.sh 886 docs/worker-1' "$work/out/dry.txt" || fail "dry-run output misses the claim command"
 grep -q 'lane-launch.ps1 -Name edda-lane-gh886 ' "$work/out/dry.txt" || fail "dry-run output misses the launch command"
 grep -q 'nothing created, claimed, or launched' "$work/out/dry.txt" || fail "dry-run output misses the closing line"
+grep -qF -- '--path "scripts/fleet/next-issue.sh"' "$work/out/dry.txt" || fail "task-new line misses the first scope path"
+grep -qF -- '--path "docs/guides/pi-controller-runbook.md"' "$work/out/dry.txt" || fail "task-new line misses the second scope path"
+if grep -q 'task new .*·' "$work/out/dry.txt"; then fail "task-new line carries a stray middle-dot"
+fi
 # order: lint < branch < task new < brief < claim < launch
 lint_n=$(grep -n '^== ready-queue lint' "$work/out/dry.txt" | cut -d: -f1)
 branch_n=$(grep -n '^branch: ' "$work/out/dry.txt" | cut -d: -f1)
@@ -253,5 +257,16 @@ printf '%s\n' "$posted" | grep -q 'dispatch --json' || fail "shadow cost line no
 printf '%s\n' "$posted" | grep -q 'placeholder line' && fail "shadow cost line uncorrected"
 echo "ok 5 moved-head refusal"
 echo "ok 6 shadow post shape"
+
+# ── 7. non-shadow delegation refuses while review-pr.sh has no pi arm ─
+
+: >"$work/gh-posted"
+printf '%s' "$HEAD1" >"$work/gh-head"
+run_loop sh "$next_review" 886 >"$work/out/delegate.txt" 2>"$work/out/delegate.err" && \
+    fail "non-shadow delegation must exit 2 while the pi arm is absent" || rc=$?
+[ "${rc:-0}" -eq 2 ] || fail "non-shadow refusal exit ${rc:-0}, want 2: $(cat "$work/out/delegate.err")"
+grep -q 'no pi arm yet' "$work/out/delegate.err" || fail "non-shadow refusal must name the missing arm: $(cat "$work/out/delegate.err")"
+[ -s "$work/gh-posted" ] && fail "non-shadow refusal must post nothing"
+echo "ok 7 non-shadow delegation refusal"
 
 echo "PASS: scripts/fleet/test-next-loop.sh"

--- a/scripts/fleet/test-next-loop.sh
+++ b/scripts/fleet/test-next-loop.sh
@@ -1,0 +1,257 @@
+#!/bin/sh
+# Offline self-test for scripts/fleet/next-issue.sh and next-review.sh (GH-886).
+# Stubs gh and edda (and pwsh, defensively); jq, git and sh stay real.
+# Writes only under its temp dir; the one git side effect — worktree
+# registration for the review worktree the loop creates — is pruned on exit.
+set -eu
+
+cd "$(git rev-parse --show-toplevel)"
+next_issue=scripts/fleet/next-issue.sh
+next_review=scripts/fleet/next-review.sh
+
+sh -n "$next_issue" || {
+    echo "FAIL: sh -n $next_issue" >&2
+    exit 1
+}
+sh -n "$next_review" || {
+    echo "FAIL: sh -n $next_review" >&2
+    exit 1
+}
+sh -n "$0" || {
+    echo "FAIL: sh -n $0" >&2
+    exit 1
+}
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/test-next-loop.XXXXXX")
+cleanup() {
+    rm -rf "$work"
+    git worktree prune >/dev/null 2>&1 || :
+}
+trap cleanup 0 HUP INT TERM
+export TMPDIR="$work"
+
+mkdir -p "$work/bin" "$work/fixtures" "$work/scratch" "$work/lanes" "$work/wt" "$work/out"
+export EDDA_FLEET_SCRATCH="$work/scratch"
+export TEMP="$work/lanes"
+export TMPDIR="$work"
+
+HEAD1=$(git rev-parse origin/main)
+HEAD2=$(git rev-parse origin/main~1)
+BASE_SHA=$HEAD1
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+# ── fixtures ─────────────────────────────────────────────────────────
+
+cat >"$work/fixtures/issue-list.json" <<'JSON'
+[{"number":886,"title":"feat(fleet): controller loop","createdAt":"2026-09-05T00:00:00Z"}]
+JSON
+cat >"$work/fixtures/pr-list.json" <<'JSON'
+[]
+JSON
+cat >"$work/fixtures/issue-ready.json" <<JSON
+{"state":"OPEN","title":"feat(fleet): controller loop","labels":[{"name":"fleet:ready"}],"comments":[],
+ "body":"## Predicted surface\n\n\`scripts/fleet/next-issue.sh\`, \`docs/guides/pi-controller-runbook.md\`. No crate.\n\n## doneWhen\n- item\n"}
+JSON
+cat >"$work/fixtures/issue-claimed.json" <<'JSON'
+{"state":"OPEN","title":"feat(fleet): controller loop","labels":[{"name":"fleet:claimed"}],
+ "comments":[{"body":"taking: docs/worker-1 at 2026-09-05T00:00:00Z"}],
+ "body":"## Predicted surface\n\n`scripts/fleet/next-issue.sh`. No crate.\n"}
+JSON
+cat >"$work/fixtures/pr-full.json" <<JSON
+{"headRefOid":"$HEAD1","headRefName":"feat/gh886-controller-loop","baseRefName":"main","baseRefOid":"$BASE_SHA",
+ "title":"feat(fleet): controller loop","body":"Issue: #886","state":"OPEN","isDraft":false,"closingIssuesReferences":[]}
+JSON
+cat >"$work/fixtures/pr-comments-0.json" <<'JSON'
+{"comments":[{"body":"first message"},{"body":"second message"}]}
+JSON
+cat >"$work/fixtures/pr-comments-3.json" <<JSON
+{"comments":[
+ {"body":"## Code Review: Round 1 — PR #886 @ $HEAD1 (SHADOW)"},
+ {"body":"## Review Response: Round 1"},
+ {"body":"## Code Review: Round 2 — PR #886 @ $HEAD2 (SHADOW)"},
+ {"body":"## Review Response: Round 2"},
+ {"body":"## Code Review: Round 3 — PR #886 @ $HEAD1 (SHADOW)"}]}
+JSON
+printf 'scripts/fleet/next-issue.sh\ndocs/guides/pi-controller-runbook.md\n' >"$work/fixtures/pr-files.txt"
+
+: >"$work/gh-head"
+: >"$work/gh-posted"
+: >"$work/gh-edits"
+: >"$work/edda-calls"
+
+# ── stubs ────────────────────────────────────────────────────────────
+
+cat >"$work/bin/gh" <<'STUB'
+#!/bin/sh
+# resolve --jq <expr> like the real gh does
+jq_expr=
+prev=
+for a in "$@"; do
+    [ "$prev" = "--jq" ] && jq_expr=$a
+    prev=$a
+done
+
+resp=
+case "$1 $2" in
+    "issue list") resp=$(cat "$GH_FIXTURES/issue-list.json") ;;
+    "pr list") resp=$(cat "$GH_FIXTURES/pr-list.json") ;;
+esac
+case "$1 $2" in
+    "issue view")
+        case "$*" in
+            *\ 885\ *|*\ 885) resp=$(cat "$GH_FIXTURES/issue-claimed.json") ;;
+            *) resp=$(cat "$GH_FIXTURES/issue-ready.json") ;;
+        esac ;;
+    "issue edit")
+        echo "$*" >>"$GH_EDITS"
+        echo "edited"
+        exit 0 ;;
+esac
+case "$1" in
+    pr)
+        case "$2" in
+            view)
+                case "$*" in
+                    *--json\ headRefOid*) resp="{\"headRefOid\":\"$(cat "$GH_HEAD_FILE")\"}" ;;
+                    *--json\ comments*) resp=$(cat "$GH_COMMENTS_FIXTURE") ;;
+                    *) resp=$(cat "$GH_FIXTURES/pr-full.json") ;;
+                esac ;;
+            diff)
+                cat "$GH_FIXTURES/pr-files.txt"
+                exit 0 ;;
+            comment)
+                f=
+                prev=
+                for a in "$@"; do
+                    [ "$prev" = "--body-file" ] && f=$a
+                    prev=$a
+                done
+                { echo "---- comment ----"; cat "$f"; } >>"$GH_POSTED"
+                echo "commented"
+                exit 0 ;;
+        esac ;;
+esac
+[ -n "$resp" ] || { echo "gh-stub: unexpected: $*" >&2; exit 1; }
+if [ -n "$jq_expr" ]; then
+    printf '%s' "$resp" | jq -r "$jq_expr"
+else
+    printf '%s\n' "$resp"
+fi
+STUB
+chmod +x "$work/bin/gh"
+
+cat >"$work/bin/edda" <<'STUB'
+#!/bin/sh
+echo "$*" >>"$EDDA_CALLS"
+if [ -n "${EDDA_STUB_MOVE_HEAD:-}" ]; then
+    printf '%s' "$EDDA_STUB_MOVE_HEAD" >"$GH_HEAD_FILE"
+fi
+cat <<'JSON'
+{"outcome":"done","result_text":"## Code Review: Round 2 - PR #886 @ somehead\n\n- model_requested: openrouter/z-ai/glm-5.3-flash\n- model_observed: openrouter/z-ai/glm-5.3-flash\n- spec: review-spec-v1.4\n- class: code-risk\n- cost: placeholder line\n\nbody of the verdict","cost_usd":0.02,"elapsed_ms":1234,"model_requested":"openrouter/z-ai/glm-5.3-flash","model_observed":"openrouter/z-ai/glm-5.3-flash","session_id":"sid","session_observed":"sid","error":null}
+JSON
+exit 0
+STUB
+chmod +x "$work/bin/edda"
+
+cat >"$work/bin/pwsh" <<'STUB'
+#!/bin/sh
+echo "pwsh-stub: $*"
+exit 0
+STUB
+chmod +x "$work/bin/pwsh"
+
+run_loop() {
+    PATH="$work/bin:$PATH" \
+    GH_FIXTURES="$work/fixtures" GH_HEAD_FILE="$work/gh-head" \
+    GH_POSTED="$work/gh-posted" GH_EDITS="$work/gh-edits" \
+    EDDA_CALLS="$work/edda-calls" GH_COMMENTS_FIXTURE="${GH_COMMENTS_FIXTURE:-$work/fixtures/pr-comments-0.json}" \
+    EDDA_STUB_MOVE_HEAD="${EDDA_STUB_MOVE_HEAD:-}" \
+    "$@"
+}
+
+# ── 1. ready issue dry-run: full preview, zero side effects ─────────
+
+printf '%s' "$HEAD1" >"$work/gh-head"
+run_loop sh "$next_issue" 886 docs/worker-1 --dry-run >"$work/out/dry.txt" 2>"$work/out/dry.err"
+[ -s "$work/out/dry.err" ] && fail "dry-run wrote to stderr: $(cat "$work/out/dry.err")"
+grep -q '^== ready-queue lint' "$work/out/dry.txt" || fail "dry-run output misses the lint result"
+grep -q '^branch: ' "$work/out/dry.txt" || fail "dry-run output misses the branch line"
+grep -q '^worktree: ' "$work/out/dry.txt" || fail "dry-run output misses the worktree line"
+grep -q '^cmd: edda task new ' "$work/out/dry.txt" || fail "dry-run output misses the task-new line"
+grep -q '^brief path: ' "$work/out/dry.txt" || fail "dry-run output misses the brief path"
+grep -q 'fleet-claim-issue.sh 886 docs/worker-1' "$work/out/dry.txt" || fail "dry-run output misses the claim command"
+grep -q 'lane-launch.ps1 -Name edda-lane-gh886 ' "$work/out/dry.txt" || fail "dry-run output misses the launch command"
+grep -q 'nothing created, claimed, or launched' "$work/out/dry.txt" || fail "dry-run output misses the closing line"
+# order: lint < branch < task new < brief < claim < launch
+lint_n=$(grep -n '^== ready-queue lint' "$work/out/dry.txt" | cut -d: -f1)
+branch_n=$(grep -n '^branch: ' "$work/out/dry.txt" | cut -d: -f1)
+task_n=$(grep -n '^cmd: edda task new ' "$work/out/dry.txt" | cut -d: -f1)
+brief_n=$(grep -n '^brief path: ' "$work/out/dry.txt" | cut -d: -f1)
+claim_n=$(grep -n 'fleet-claim-issue.sh 886' "$work/out/dry.txt" | cut -d: -f1 | head -1)
+launch_n=$(grep -n 'lane-launch.ps1 -Name' "$work/out/dry.txt" | cut -d: -f1 | head -1)
+[ "$lint_n" -lt "$branch_n" ] && [ "$branch_n" -lt "$task_n" ] \
+    && [ "$task_n" -lt "$brief_n" ] && [ "$brief_n" -lt "$claim_n" ] \
+    && [ "$claim_n" -lt "$launch_n" ] || fail "dry-run output out of order: lint=$lint_n branch=$branch_n task=$task_n brief=$brief_n claim=$claim_n launch=$launch_n"
+[ -z "$(ls -A "$work/scratch")" ] || fail "dry-run wrote into the scratch dir: $(ls -A "$work/scratch")"
+[ -f "$work/edda-calls" ] && [ -s "$work/edda-calls" ] && fail "dry-run invoked edda"
+echo "ok 1 ready issue dry-run"
+
+# ── 2. claimed issue refusal names the claimant ─────────────────────
+
+run_loop sh "$next_issue" 885 docs/worker-1 --dry-run >"$work/out/claimed.txt" 2>"$work/out/claimed.err" && \
+    fail "claimed issue must exit 2" || rc=$?
+[ "${rc:-0}" -eq 2 ] || fail "claimed refusal exit ${rc:-0}, want 2"
+grep -q 'docs/worker-1' "$work/out/claimed.err" || fail "claimed refusal must name the claimant: $(cat "$work/out/claimed.err")"
+echo "ok 2 claimed issue refusal"
+
+# ── 3. marker-left-in-brief refusal (real run, pre-launch) ──────────
+
+run_loop sh "$next_issue" 886 docs/worker-1 >"$work/out/marker.txt" 2>"$work/out/marker.err" && \
+    fail "marker-left brief must exit 2" || rc=$?
+[ "${rc:-0}" -eq 2 ] || fail "marker refusal exit ${rc:-0}, want 2"
+grep -q 'AUTHORED STEPS' "$work/out/marker.err" || fail "marker refusal must point at the brief: $(cat "$work/out/marker.err")"
+grep -q '^<<AUTHORED STEPS>>$' "$work/scratch/brief-gh886.md" || fail "rendered brief must keep the marker"
+[ -s "$work/edda-calls" ] && fail "marker refusal must not run task new: $(cat "$work/edda-calls")"
+[ -s "$work/gh-edits" ] && fail "marker refusal must not touch labels: $(cat "$work/gh-edits")"
+echo "ok 3 marker-left-in-brief refusal"
+
+# ── 4. round cap: three posted rounds, no operator grant ────────────
+
+GH_COMMENTS_FIXTURE="$work/fixtures/pr-comments-3.json" \
+    run_loop sh "$next_review" 886 --shadow >"$work/out/cap.txt" 2>"$work/out/cap.err" && \
+    fail "round cap must exit 2" || rc=$?
+[ "${rc:-0}" -eq 2 ] || fail "round cap exit ${rc:-0}, want 2: $(cat "$work/out/cap.err")"
+grep -q 'needs-operator' "$work/out/cap.err" || fail "round cap must name needs-operator: $(cat "$work/out/cap.err")"
+grep -q 'needs-operator' "$work/gh-edits" || fail "round cap must add the needs-operator label: $(cat "$work/gh-edits")"
+[ -s "$work/gh-posted" ] && fail "round cap must post nothing: $(cat "$work/gh-posted")"
+echo "ok 4 round-cap refusal"
+
+# ── 5+6. shadow run: real worktree, moved head refuses; intact posts ─
+
+git worktree add --detach "$work/wt/review-pr886" "$HEAD1" >/dev/null 2>&1
+
+printf '%s' "$HEAD1" >"$work/gh-head"
+EDDA_STUB_MOVE_HEAD="$HEAD2" \
+    run_loop sh "$next_review" 886 --shadow >"$work/out/moved.txt" 2>"$work/out/moved.err" && \
+    fail "moved head must exit 2" || rc=$?
+[ "${rc:-0}" -eq 2 ] || fail "moved-head exit ${rc:-0}, want 2"
+grep -q 'head moved' "$work/out/moved.err" || fail "moved-head refusal must say so: $(cat "$work/out/moved.err")"
+[ -s "$work/gh-posted" ] && fail "moved head must post nothing"
+
+printf '%s' "$HEAD1" >"$work/gh-head"
+run_loop sh "$next_review" 886 --shadow >"$work/out/shadow.txt" 2>"$work/out/shadow.err" || \
+    fail "shadow run exit $? : $(cat "$work/out/shadow.err")"
+grep -q 'posted SHADOW round' "$work/out/shadow.txt" || fail "shadow run must post: $(cat "$work/out/shadow.txt")"
+posted=$(awk '/^---- comment ----$/{f=1;next} f' "$work/gh-posted")
+printf '%s\n' "$posted" | head -1 | grep -q '(SHADOW)$' || fail "shadow heading suffix missing: $(printf '%s\n' "$posted" | head -1)"
+printf '%s\n' "$posted" | sed -n '2,3p' | grep -qx 'shadow: true' || fail "shadow body line missing: $(printf '%s\n' "$posted" | head -3)"
+printf '%s\n' "$posted" | grep -q 'dispatch --json' || fail "shadow cost line not corrected: $(printf '%s\n' "$posted" | grep '^\\- cost' || true)"
+printf '%s\n' "$posted" | grep -q 'placeholder line' && fail "shadow cost line uncorrected"
+echo "ok 5 moved-head refusal"
+echo "ok 6 shadow post shape"
+
+echo "PASS: scripts/fleet/test-next-loop.sh"


### PR DESCRIPTION
## Problem and change

GH-886: during the all-flash window the controller is pi + glm with no skills, so the control loop must exist as scripts and an enumerated runbook. This PR stacks on `feat/gh885-brief-from-issue` (PR #895) because `next-issue.sh` consumes the GH-885 renderer.

- `scripts/fleet/next-issue.sh <issue> <machine>/<role> [--dry-run]` — queue lint, claimed/non-ready refusal naming the claimant from the `taking:` comment, brief rendered by `brief-from-issue.sh` into `~/.edda/fleet/brief-gh<N>.md`, refusal to launch while `<<AUTHORED STEPS>>` is unfilled (an authored, marker-free brief is kept, never overwritten), then `edda task new` (scope paths taken from the rendered facts line), the claim guard, the worktree (`<parent>/edda-wt-gh<N>`, parallel to the main checkout, correct even when run from inside another worktree), and `lane-launch.ps1 -TimeoutSec 5400 -BudgetUsd 3`; relaunches pick the next free `-r<n>` suffix. `--dry-run` prints every command in the doneWhen order and creates, claims, and launches nothing.
- `scripts/fleet/next-review.sh <pr> [--shadow] [--operator-granted] [--dry-run]` — pins the full head SHA (40-hex validated), counts `## Code Review: Round` comments, exits 2 with the `needs-operator` label at the three-round cap without `--operator-granted`, builds the same brief `review-pr.sh --dry-run` writes, copies the base-SHA spec into a detached review worktree, runs the read-only glm engine (`edda dispatch --agent pi --tools read,grep,find,ls --thinking max --json`), refuses to post when the head moved between brief and post, and with `--shadow` posts the SHADOW shape (heading suffix, `shadow: true`, corrected cost line, no labels, no status). The engine output is stored next to the worktree for #887's compare.
- `docs/guides/pi-controller-runbook.md` — every step with its exact command and expected output, plus the STOP conditions that route to `needs-operator`.
- `scripts/fleet/test-next-loop.sh` — offline stub test (gh stub resolves `--jq` like the real gh), six cases.
- `docs/README.md` — one pointer line.

## Validation

### RAN

- `sh scripts/fleet/test-next-loop.sh` → PASS (6 cases: ready issue dry-run, claimed refusal, marker-left-in-brief refusal, round-cap refusal, moved-head refusal, shadow post shape); writes only under its temp dir, worktree registration pruned on exit
- `sh -n` on all three scripts → exit 0
- real-issue dry-run: `next-issue.sh 887 docs/worker-1 --dry-run` → exit 0, printed lint result, `branch: feat/gh887-*`, `worktree: C:/ai_agent/edda-wt-gh887`, the task-new line, brief path, claim command, launch command, lane name/log/done marker, in that order
- real-issue refusal: `next-issue.sh 885 docs/worker-1 --dry-run` → exit 2, `issue 885 is already claimed (fleet:claimed) by docs/worker-1`
- real-PR dry-run: `next-review.sh 876 --shadow --dry-run` → exit 0, printed head SHA `6499b3dd…`, worktree path, brief path, the exact engine command, the post command
- runbook discretionary-phrase grep (`grep -Ein "as needed|if relevant|use (your )?judg|where appropriate"`) → empty; every command in the runbook resolves to `--help`/usage output of `next-issue.sh`, `next-review.sh`, `ready-queue-lint.sh`, `lane-status.ps1`, `lane-stop.ps1`
- pre-commit hooks on the staged blob: lint-doc-citations, lint-markdown-content, lint-file-length → all exit 0

### READ

- GH-886 issue body — doneWhen used as the acceptance ceiling, each item verified above
- `scripts/review-pr.sh`, `scripts/fleet/lane-launch.ps1`, `scripts/fleet-claim-issue.sh` — the interfaces next-issue/next-review call, read for parameter shapes

Closes #886

Issue: #886
