### PR TITLE
fix: publish dry-run watches the whole crates/ tree; capability probes accept comma-separated flag aliases

### DIFF
--- a/.github/workflows/publish-crates-check.yml
+++ b/.github/workflows/publish-crates-check.yml
@@ -8,7 +8,10 @@ on:
       - 'scripts/publish-crates*'
       - 'Cargo.toml'
       - 'Cargo.lock'
-      - 'crates/**/Cargo.toml'
+      # Whole crate tree, not just manifests: include_str! resources, build
+      # scripts, and packaged tests/READMEs also fail `cargo publish` at the
+      # tag, and a src-only change never ran this gate (GH-892, #891).
+      - 'crates/**'
       - 'rust-toolchain.toml'
 
 permissions:

--- a/scripts/fleet/reviewer-capabilities.ps1
+++ b/scripts/fleet/reviewer-capabilities.ps1
@@ -1,6 +1,7 @@
 # GH-702: keep builtin inventory and plan-mode write barrier aligned with
 # reviewer-capabilities.sh. Bash(...) permission patterns are not --tools
-# values on Claude Code 2.1.259.
+# values on Claude Code 2.1.259. Trailing class accepts ',' (GH-893): the
+# help text prints comma-separated aliases.
 $ReviewTools = 'Read,Grep,Glob,Bash'
 $ReviewDenied = 'Edit,Write,NotebookEdit,mcp__*'
 $ReviewPermissionMode = 'plan'
@@ -9,7 +10,7 @@ function Assert-ReviewCapabilities([string]$Transport = 'edda-dispatch') {
         $helpText = (& edda dispatch --help 2>&1) -join "`n"
         if ($LASTEXITCODE -ne 0) { throw 'review capability check: edda dispatch --help failed; refusing reviewer launch' }
         foreach ($flag in @('--tools', '--exclude-tools', '--permission-mode')) {
-            if ($helpText -notmatch ('(?m)(^|[\s,])' + [regex]::Escape($flag) + '([\s=]|$)')) {
+            if ($helpText -notmatch ('(?m)(^|[\s,])' + [regex]::Escape($flag) + '([\s=,]|$)')) {
                 throw "review capability check: edda dispatch lacks $flag; refusing reviewer launch (upgrade edda)"
             }
         }
@@ -17,7 +18,7 @@ function Assert-ReviewCapabilities([string]$Transport = 'edda-dispatch') {
     $helpText = (& claude --help 2>&1) -join "`n"
     if ($LASTEXITCODE -ne 0) { throw 'review capability check: claude --help failed; refusing reviewer launch' }
     foreach ($flag in @('--tools', '--disallowedTools', '--permission-mode')) {
-        if ($helpText -notmatch ('(?m)(^|[\s,])' + [regex]::Escape($flag) + '([\s=]|$)')) {
+        if ($helpText -notmatch ('(?m)(^|[\s,])' + [regex]::Escape($flag) + '([\s=,]|$)')) {
             throw "review capability check: claude lacks $flag; refusing reviewer launch (upgrade claude)"
         }
     }

--- a/scripts/reviewer-capabilities.sh
+++ b/scripts/reviewer-capabilities.sh
@@ -19,8 +19,11 @@ review_capabilities() { # edda-dispatch | claude-stdin; never starts a turn
       ;;
     *) echo 'review capability check: unknown transport' >&2; return 2 ;;
   esac
+  # Trailing class must accept ',' — claude 2.1.259 help prints comma-
+  # separated aliases ("--disallowedTools, --disallowed-tools <tools...>"),
+  # so a space/equals-only tail false-negatives the exact flag (GH-893).
   for review_flag in $review_required; do
-    if ! printf '%s\n' "$review_help" | grep -qE -- "(^|[[:space:],])$review_flag([[:space:]=]|$)"; then
+    if ! printf '%s\n' "$review_help" | grep -qE -- "(^|[[:space:],])$review_flag([[:space:]=,]|$)"; then
       echo "review capability check: edda dispatch lacks $review_flag; refusing reviewer launch (upgrade edda)" >&2
       return 2
     fi
@@ -28,7 +31,7 @@ review_capabilities() { # edda-dispatch | claude-stdin; never starts a turn
   # Dispatch delegates to this same backend, so verify BOTH binaries.
   review_help=$(claude --help 2>&1) || review_help=''
   for review_flag in --tools --disallowedTools --permission-mode; do
-    if ! printf '%s\n' "$review_help" | grep -qE -- "(^|[[:space:],])$review_flag([[:space:]=]|$)"; then
+    if ! printf '%s\n' "$review_help" | grep -qE -- "(^|[[:space:],])$review_flag([[:space:]=,]|$)"; then
       echo "review capability check: claude lacks $review_flag; refusing reviewer launch (upgrade claude)" >&2
       return 2
     fi

--- a/scripts/test-review-capabilities.sh
+++ b/scripts/test-review-capabilities.sh
@@ -51,7 +51,7 @@ EOF
 cat > "$tmp/bin/claude" <<'EOF'
 #!/bin/sh
 if [ "$*" = '--help' ]; then
- [ "$BACKEND" = old-claude ] || echo '--tools <tools> --disallowedTools <tools> --permission-mode <mode>'
+ [ "$BACKEND" = old-claude ] || echo '--tools <tools> --disallowedTools, --disallowed-tools <tools> --permission-mode <mode>'
  exit 0
 fi
 echo launch >> "$CALLS"
@@ -161,7 +161,7 @@ function edda {
 }
 function claude {
   if (($args -join ' ') -eq '--help') {
-    if ($env:BACKEND -ne 'old-claude') { '--tools <tools> --disallowedTools <tools> --permission-mode <mode>' }
+    if ($env:BACKEND -ne 'old-claude') { '--tools <tools> --disallowedTools, --disallowed-tools <tools> --permission-mode <mode>' }
     $global:LASTEXITCODE = 0; return
   }
   Add-Content $env:CALLS launch

--- a/scripts/test-review-posix-snapshot.sh
+++ b/scripts/test-review-posix-snapshot.sh
@@ -32,7 +32,7 @@ echo Linux
 EOF
 cat > "$tmp/bin/claude" <<'EOF'
 #!/bin/sh
-if [ "$*" = --help ]; then echo '--tools <tools> --disallowedTools <tools> --permission-mode <mode>'; fi
+if [ "$*" = --help ]; then echo '--tools <tools> --disallowedTools, --disallowed-tools <tools> --permission-mode <mode>'; fi
 EOF
 cat > "$tmp/bin/edda" <<'EOF'
 #!/bin/sh


### PR DESCRIPTION
Issue: #892

Issue: #893

Two follow-ups from the v0.5.0 release retrospective, one commit each.

1. GH-892 — .github/workflows/publish-crates-check.yml triggered only on manifests/scripts/workflow paths, so a src-only change (the out-of-crate include_str! regression fixed in #891) reached main without the workspace publish dry-run and surfaced at the v0.5.0 tag. The pull_request paths now watch the whole crates/ tree: include_str! resources, build scripts, and packaged tests/READMEs fail cargo publish the same way. The dry-run is incremental via rust-cache.

2. GH-893 — scripts/review-pr.sh exited rc=2 with "claude lacks --disallowedTools" on claude 2.1.259 because the help text prints comma-separated aliases ("--disallowedTools, --disallowed-tools <tools...>") and the probe's trailing character class only accepted space/equals. Both probes (scripts/reviewer-capabilities.sh and scripts/fleet/reviewer-capabilities.ps1) now accept ',' in the trailing class, and the three test fixtures mirror the real help format so the suite fails against the old regex.

Validation at head ed0c2c2 (frozen):
- RAN: the issue's exact failing path — sourcing scripts/reviewer-capabilities.sh and calling review_capabilities claude-stdin against real claude 2.1.259 now exits 0 (previously rc=2); negative control: a fake backend lacking the flag is still refused rc=2; sh scripts/test-review-capabilities.sh (POSIX + Windows generated lane canaries) and sh scripts/test-review-posix-snapshot.sh both pass with the updated fixtures; the old regex provably NO-MATCHes the new fixture text (the regression test bites); python yaml.safe_load on publish-crates-check.yml.
- READ: gh issue view 892/893 acceptance text; claude --help and edda dispatch --help real flag surfaces.
- Exact-head CI receipt to follow when the PR run completes.

Scope: one workflow paths list, two capability probes (one trailing character class each), three test fixture help strings. No product code. Adjacent: none — both routed findings are exactly these issues.