### PR TITLE
feat(fleet): shadow review shape — shadow field in REVIEW.md, verdict-label, watcher exclusion, review-compare.sh

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -23,7 +23,7 @@ classes:
 
 # REVIEW.md — the executable review spec
 
-- Spec version: `review-spec-v1.4`
+- Spec version: `review-spec-v1.5`
 - Audience: anyone — human or engine — reviewing a pull request in this
   repository, and any script that builds a review brief.
 - Status: this file is the **single source of truth** for how a PR is reviewed
@@ -756,6 +756,11 @@ mechanical.
 | §7/§8 shadow | canonical | `review.gh880-shadow` + GH-887: the header field, the heading suffix and the exclusion rule are new in this revision; the compare script's provenance is the same ruling |
 
 ## 10. Version
+
+- `review-spec-v1.5` (2026-09-05, issue #887): the SHADOW round shape — the
+  `- shadow: true` header field, the ` (SHADOW)` heading suffix, the §8
+  exclusion rule, and the §9 provenance row. Nothing else in the rule set
+  changed; v1.4 verdicts remain valid for their SHAs.
 
 - `review-spec-v1` (2026-09-02, issue #633): first collection. Merges the
   review-fix loop (`.claude/CLAUDE.md`), the wiring verdict (#629) and brief

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -757,11 +757,11 @@ mechanical.
 
 ## 10. Version
 
-- `review-spec-v1.5` (2026-09-05, issue #887): the SHADOW round shape — the
-  `- shadow: true` header field, the ` (SHADOW)` heading suffix, the §8
-  exclusion rule, and the §9 provenance row. Nothing else in the rule set
-  changed; v1.4 verdicts remain valid for their SHAs.
-
+- `review-spec-v1.5` (2026-09-05, issue #887): the SHADOW round shape of
+  the make-up-round ruling recorded in the ledger — a header field, a
+  heading suffix, the §8 exclusion rule, and the §9 provenance row.
+  Nothing else in the rule set changed; v1.4 verdicts remain valid for
+  their SHAs.
 - `review-spec-v1` (2026-09-02, issue #633): first collection. Merges the
   review-fix loop (`.claude/CLAUDE.md`), the wiring verdict (#629) and brief
   template v1 (#618) into one runnable sequence, adds the mechanical class

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -649,6 +649,7 @@ One comment per round, pinned to the reviewed full SHA
 - spec: review-spec-v1.3
 - class: <code-risk | docs-skills>  (REVIEW.md classes: <docs|skills|code-plain|code-risk ...>)
 - escalations: <list of 需升級 items, or "none">
+- shadow: true — only on a SHADOW round (heading suffix ` (SHADOW)`); omit the field entirely on an authoritative round
 - cost: <elapsed / tokens / tool calls, as available>
 
 ### IN SCOPE
@@ -691,6 +692,8 @@ launched with; the watcher records a mismatch with the backend-reported id
 rather than overwriting it.
 
 ## 8. Step 8 — the verdict
+
+A round whose header carries `- shadow: true` and the ` (SHADOW)` heading suffix is **never a verdict** — it sets no `review:*` label, no `Independent Review` status, and the union over a SHA ignores it entirely; it is compare data for the make-up round (`scripts/review-compare.sh`), not a merge input (`review.gh880-shadow`).
 
 - **P0 = 0 and P1 = 0 → LGTM.** Add `fleet:reviewed`. Stop. Merge is the
   operator's action, never the reviewer's (`loop`; GATE-01).
@@ -750,6 +753,7 @@ mechanical.
 | R3 | RAN | `sh -n` on 3 changed scripts, all exit 0 |
 | R4–R5 | canonical | `brief-v1` §6.1 items 3–4; stated as properties, not commands |
 | §5.5 | RAN | `sh scripts/wiring-scan.sh 6340d94~1 6340d94` |
+| §7/§8 shadow | canonical | `review.gh880-shadow` + GH-887: the header field, the heading suffix and the exclusion rule are new in this revision; the compare script's provenance is the same ruling |
 
 ## 10. Version
 

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -188,24 +188,28 @@ gate_state() {
 verdict_body_lines() { # $1=reviewed sha; stdin: one body per <<<COMMENT>>>
                        # block (a single raw body also works); stdout: verdict<TAB>p0<TAB>p1
   awk -v sha="$1" '
-    function flush(   i, n, vline, v, p0, p1, inh, pinned) {
+    function flush(   i, n, vline, v, p0, p1, inh, pinned, isshadow) {
       if (!inb) return
       inb = 0
       n = split(buf, L, "\n")
-      pinned = 0; inh = 0; vline = ""
+      pinned = 0; inh = 0; vline = ""; isshadow = 0
       for (i = 1; i <= n; i++) {
         # $2 is validated with is_full_sha by every caller before it gets
         # here, so it is exactly 40 lowercase hex characters — no regex
-        # metacharacters — and this pin match is literal.
-        if (L[i] ~ ("^## Code Review: Round [0-9]+ — PR #[0-9]+ @ " sha "$")) {
+        # metacharacters — and this pin match is literal. The optional
+        # " (SHADOW)" suffix marks a shadow round (review.gh880-shadow).
+        if (L[i] ~ ("^## Code Review: Round [0-9]+ — PR #[0-9]+ @ " sha "( \(SHADOW\))?$")) {
           pinned = 1; continue
         }
+        # A shadow round is never a verdict: the body field is the machine
+        # signal, and the round is excluded from the union entirely.
+        if (pinned && L[i] == "- shadow: true") { isshadow = 1 }
         if (L[i] ~ /^#{1,}[[:space:]]*Verdict/) { inh = 1; continue }
         if (pinned && inh && vline == "" && L[i] ~ /LGTM|Changes Requested/) {
           vline = L[i]
         }
       }
-      if (!pinned || vline == "") return
+      if (!pinned || vline == "" || isshadow) return
       v = "LGTM"
       if (vline ~ /Changes Requested/) v = "Changes Requested"
       p0 = ""; p1 = ""
@@ -544,6 +548,15 @@ settle_pending() {
         # A failed/empty head query is NOT evidence the head moved: keep the
         # verdict pending and retry on the next poll.
         log "pr$pr head unknown, retry — head query failed after posting the verdict; pending entry kept"
+        return 0
+      fi
+      # A SHADOW round (review.gh880-shadow) is not a verdict: no review:*
+      # label, no Independent Review status, ever. The drop is the success
+      # path for a shadow round — the authoritative round comes later.
+      if grep -Eq -- '-? ?shadow: true$' "$1"; then
+        log "pr$pr r$round shadow round posted — no label, no status (review.gh880-shadow)"
+        state_set "$pr" "$sha" "$round"
+        pending_drop "$pr"
         return 0
       fi
       if [ "$(label_verdict "$sha" "$cur")" != "apply" ]; then

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -554,8 +554,10 @@ settle_pending() {
       # label, no Independent Review status, ever. The drop is the success
       # path for a shadow round — the authoritative round comes later.
       if grep -Eq -- '-? ?shadow: true$' "$1"; then
-        log "pr$pr r$round shadow round posted — no label, no status (review.gh880-shadow)"
-        state_set "$pr" "$sha" "$round"
+        log "pr$pr r$round shadow round posted — no label, no status, sha left unreviewed for the make-up round (review.gh880-shadow)"
+        # No state_set: recording the SHA as reviewed would make decide() skip
+        # this PR forever and the authoritative make-up round could never launch.
+        # Only the pending entry drops; the rescan sees the PR unreviewed.
         pending_drop "$pr"
         return 0
       fi

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -203,7 +203,7 @@ verdict_body_lines() { # $1=reviewed sha; stdin: one body per <<<COMMENT>>>
         }
         # A shadow round is never a verdict: the body field is the machine
         # signal, and the round is excluded from the union entirely.
-        if (pinned && L[i] == "- shadow: true") { isshadow = 1 }
+        if (pinned && (L[i] == "- shadow: true" || L[i] == "shadow: true")) { isshadow = 1 }
         if (L[i] ~ /^#{1,}[[:space:]]*Verdict/) { inh = 1; continue }
         if (pinned && inh && vline == "" && L[i] ~ /LGTM|Changes Requested/) {
           vline = L[i]

--- a/scripts/review-compare.sh
+++ b/scripts/review-compare.sh
@@ -35,13 +35,12 @@ comments=$(gh pr view "$pr" --repo "$repo" --json comments \
     die "gh pr view $pr comments failed"
 
 tmp=$(mktemp "${TMPDIR:-/tmp}/review-compare.XXXXXX")
-trap 'rm -f "$tmp" "$tmp".shadow.findings "$tmp".auth.findings "$tmp".shadow.meta "$tmp".auth.meta' 0 HUP INT TERM
 
 # Extract, per comment pinned to the sha, the verdict line, model_observed,
 # and the Findings rows into:
 #   $tmp.shadow.findings / $tmp.auth.findings   — "- [Pn] ..." lines
 #   $tmp.shadow.meta   / $tmp.auth.meta         — verdict<TAB>model_observed
-awk -v sha="$sha" -v tmp="$tmp" '
+printf '%s' "$comments" | awk -v sha="$sha" -v tmp="$tmp" '
     function flush(   i, n, pinned, isshadow, inh, section, m) {
       if (!inb) return
       inb = 0
@@ -86,18 +85,16 @@ awk -v sha="$sha" -v tmp="$tmp" '
     { if (!inb) { inb = 1; buf = "" }
       buf = buf $0 "\n" }
     END { flush() }
-' <<<"$comments"
+'
 
 [ -f "$tmp.shadow.findings" ] || die "no SHADOW round pinned to $sha on PR #$pr — nothing to compare"
-: >"$tmp.matched"
-: >"$tmp.drift"
 
 # Matching key per finding: every file:line and bare-file token in the line;
 # a finding with no file token falls back to its first 60 characters. Two
 # findings sharing any key are the same finding (#883 will make rule ids the
 # primary key; the fallback keeps this usable before that lands).
 findings_tmp2=$(mktemp "${TMPDIR:-/tmp}/review-compare.XXXXXX")
-trap 'rm -f "$tmp" "$findings_tmp2"' 0 HUP INT TERM
+trap 'rm -f "$tmp" "$tmp".shadow.findings "$tmp".auth.findings "$tmp".shadow.meta "$tmp".auth.meta' 0 HUP INT TERM
 mv "$tmp.shadow.findings" "$findings_tmp2.shadow" 2>/dev/null || printf '' >"$findings_tmp2.shadow"
 [ -f "$tmp.auth.findings" ] && mv "$tmp.auth.findings" "$findings_tmp2.auth" || printf '' >"$findings_tmp2.auth"
 
@@ -145,7 +142,7 @@ awk -v sf="$findings_tmp2.shadow" '
     }
 ' "$findings_tmp2.auth" >"$tmp.rows"
 
-shadow_verdict=$(sed -n 's/^[^\t]*\t//p' "$tmp.shadow.meta" | head -1)
+shadow_model=$(sed -n 's/^[^\t]*\t//p' "$tmp.shadow.meta" | head -1)
 auth_verdict=$(head -1 "$tmp.auth.meta" 2>/dev/null | cut -f1)
 auth_model=$(head -1 "$tmp.auth.meta" 2>/dev/null | cut -f2)
 
@@ -157,7 +154,7 @@ if [ ! -s "$tmp.auth.meta" ]; then
     echo
     cat "$findings_tmp2.shadow"
     echo
-    echo "for-ledger: shadow=$shadow_verdict authoritative=pending missed_P0=0 missed_P1=0 unconfirmed=$(grep -c '^unconfirmed' "$tmp.rows" 2>/dev/null || echo 0) matched=0 drift=0"
+    echo "for-ledger: shadow=$shadow_model authoritative=pending missed_P0=0 missed_P1=0 unconfirmed=$(grep -c '^unconfirmed' "$tmp.rows" 2>/dev/null || true) matched=0 drift=0"
     exit 0
 fi
 echo "- authoritative verdict/model: $auth_verdict / ${auth_model:-unknown}"

--- a/scripts/review-compare.sh
+++ b/scripts/review-compare.sh
@@ -1,0 +1,178 @@
+#!/bin/sh
+# review-compare.sh — diff a SHADOW round against the authoritative round on
+# the same SHA (GH-887, review.gh880-shadow). Reads GitHub comments only;
+# never posts, labels, or writes the ledger. The output feeds
+# fleet.review-calibration rows and the #888 return checklist.
+#
+# usage:
+#   sh scripts/review-compare.sh <pr> <sha>
+#
+# Output: a missed/unconfirmed/matched/severity-drift table and one
+# `for-ledger` line. Exit 0; exit 2 when there is no SHADOW round to compare.
+set -eu
+
+usage() {
+    echo "usage: $0 <pr> <sha>" >&2
+}
+
+die() {
+    echo "review-compare: $1" >&2
+    exit 2
+}
+
+repo=${EDDA_REPO:-fagemx/edda}
+pr=${1:-}
+sha=${2:-}
+[ -n "$pr" ] && [ -n "$sha" ] || { usage; exit 2; }
+case "$pr" in *[!0-9]*|'') die "pr must be a positive integer, got '$pr'" ;; esac
+case "$sha" in
+    *[!0-9a-f]*|'') die "sha must be a 40-hex value" ;;
+esac
+printf '%s' "$sha" | grep -qE '^[0-9a-f]{40}$' || die "sha must be a full 40-hex SHA, got '${sha}'"
+
+comments=$(gh pr view "$pr" --repo "$repo" --json comments \
+    --jq '.comments[] | "<<<COMMENT>>>", .body' 2>&1) ||
+    die "gh pr view $pr comments failed"
+
+tmp=$(mktemp "${TMPDIR:-/tmp}/review-compare.XXXXXX")
+trap 'rm -f "$tmp" "$tmp".shadow.findings "$tmp".auth.findings "$tmp".shadow.meta "$tmp".auth.meta' 0 HUP INT TERM
+
+# Extract, per comment pinned to the sha, the verdict line, model_observed,
+# and the Findings rows into:
+#   $tmp.shadow.findings / $tmp.auth.findings   — "- [Pn] ..." lines
+#   $tmp.shadow.meta   / $tmp.auth.meta         — verdict<TAB>model_observed
+awk -v sha="$sha" -v tmp="$tmp" '
+    function flush(   i, n, pinned, isshadow, inh, section, m) {
+      if (!inb) return
+      inb = 0
+      n = split(buf, L, "\n")
+      pinned = 0; isshadow = 0; inh = 0; section = ""
+      model = ""; verdict = ""
+      for (i = 1; i <= n; i++) {
+        # Heading pin without a regex over the em dash: gawk in the C locale
+        # counts bytes, and the dash is three of them, so a character-count
+        # regex silently misaligns. Split on " @ " and compare the tail.
+        if (L[i] ~ /^## Code Review: Round [0-9]+ /) {
+          p = index(L[i], " @ ")
+          if (p > 0) {
+            tail = substr(L[i], p + 3)
+            if (tail == sha || tail == sha " (SHADOW)") {
+              pinned = 1; continue
+            }
+          }
+        }
+        if (pinned && (L[i] == "shadow: true" || L[i] == "- shadow: true")) isshadow = 1
+        if (pinned && L[i] ~ /^- model_observed: /) {
+          model = L[i]
+          sub(/^- model_observed: /, "", model)
+        }
+        if (pinned && L[i] ~ /^#{1,}[[:space:]]*Verdict/) { inh = 1; section = "verdict"; continue }
+        if (pinned && L[i] ~ /^#{1,3}[[:space:]]*Findings/) { section = "findings"; continue }
+        if (pinned && L[i] ~ /^#{1,3}[[:space:]]*[A-Za-z]/ && L[i] !~ /Findings/ && L[i] !~ /Verdict/) {
+          if (section == "findings") section = ""
+        }
+        if (pinned && inh && verdict == "" && L[i] ~ /LGTM|Changes Requested/) {
+          verdict = L[i]
+        }
+        if (pinned && section == "findings" && L[i] ~ /^- \[P[0-9]\]/) {
+          print L[i] > (isshadow ? tmp ".shadow.findings" : tmp ".auth.findings")
+        }
+      }
+      if (pinned)
+        print verdict "\t" model > (isshadow ? tmp ".shadow.meta" : tmp ".auth.meta")
+    }
+    { sub(/\r$/, "") }
+    /^<<<COMMENT>>>$/ { flush(); inb = 1; buf = ""; next }
+    { if (!inb) { inb = 1; buf = "" }
+      buf = buf $0 "\n" }
+    END { flush() }
+' <<<"$comments"
+
+[ -f "$tmp.shadow.findings" ] || die "no SHADOW round pinned to $sha on PR #$pr — nothing to compare"
+: >"$tmp.matched"
+: >"$tmp.drift"
+
+# Matching key per finding: every file:line and bare-file token in the line;
+# a finding with no file token falls back to its first 60 characters. Two
+# findings sharing any key are the same finding (#883 will make rule ids the
+# primary key; the fallback keeps this usable before that lands).
+findings_tmp2=$(mktemp "${TMPDIR:-/tmp}/review-compare.XXXXXX")
+trap 'rm -f "$tmp" "$findings_tmp2"' 0 HUP INT TERM
+mv "$tmp.shadow.findings" "$findings_tmp2.shadow" 2>/dev/null || printf '' >"$findings_tmp2.shadow"
+[ -f "$tmp.auth.findings" ] && mv "$tmp.auth.findings" "$findings_tmp2.auth" || printf '' >"$findings_tmp2.auth"
+
+awk -v sf="$findings_tmp2.shadow" '
+    function keys(line,   s, k) {
+      k = ""
+      line = tolower(line)
+      s = line
+      while (match(s, /[a-z0-9_./-]+:[0-9]+/)) {
+        k = k "|" substr(s, RSTART, RLENGTH)
+        s = substr(s, RSTART + RLENGTH)
+      }
+      if (k == "") {
+        s = line
+        sub(/^- \[P[0-9]\] */, "", s)
+        k = "|" substr(s, 1, 60)
+      }
+      return k
+    }
+    BEGIN {
+      sn = 0
+      while ((getline line < sf) > 0) { sn++; sk[sn] = keys(line); sl[sn] = line }
+      close(sf)
+    }
+    {
+      ak = keys($0)
+      hit = 0
+      for (i = 1; i <= sn; i++) {
+        if (index(ak, sk[i]) > 0 || index(sk[i], ak) > 0) {
+          hit = 1
+          a = $0; b = sl[i]
+          sub(/^[^P]*P/, "", a); sub(/^[^P]*P/, "", b)
+          ap = substr(a, 1, 1); bp = substr(b, 1, 1)
+          if (ap == bp) print "matched\t" $0 "\t" sl[i]
+          else          print "drift\t" $0 "\t" sl[i]
+          shadow_used[i] = 1
+          break
+        }
+      }
+      if (!hit) print "missed\t" $0
+    }
+    END {
+      for (i = 1; i <= sn; i++)
+        if (!shadow_used[i]) print "unconfirmed\t" sl[i]
+    }
+' "$findings_tmp2.auth" >"$tmp.rows"
+
+shadow_verdict=$(sed -n 's/^[^\t]*\t//p' "$tmp.shadow.meta" | head -1)
+auth_verdict=$(head -1 "$tmp.auth.meta" 2>/dev/null | cut -f1)
+auth_model=$(head -1 "$tmp.auth.meta" 2>/dev/null | cut -f2)
+
+echo "## SHADOW vs authoritative — PR #$pr @ $sha"
+echo
+echo "- shadow verdict/model: $(sed -n 's/^\([^\t]*\)\t/\1 /p' "$tmp.shadow.meta" | head -1)"
+if [ ! -s "$tmp.auth.meta" ]; then
+    echo "- authoritative: **pending authoritative round** — the rows below are the shadow findings for the record"
+    echo
+    cat "$findings_tmp2.shadow"
+    echo
+    echo "for-ledger: shadow=$shadow_verdict authoritative=pending missed_P0=0 missed_P1=0 unconfirmed=$(grep -c '^unconfirmed' "$tmp.rows" 2>/dev/null || echo 0) matched=0 drift=0"
+    exit 0
+fi
+echo "- authoritative verdict/model: $auth_verdict / ${auth_model:-unknown}"
+echo
+echo "| kind | authoritative finding | shadow finding |"
+echo "|---|---|---|"
+grep '^matched' "$tmp.rows" | awk -F'\t' '{ gsub(/\|/, "\\|", $2); gsub(/\|/, "\\|", $3); print "| matched | " $2 " | " $3 " |" }'
+grep '^drift' "$tmp.rows" | awk -F'\t' '{ gsub(/\|/, "\\|", $2); gsub(/\|/, "\\|", $3); print "| **severity drift** | " $2 " | " $3 " |" }'
+grep '^missed' "$tmp.rows" | awk -F'\t' '{ gsub(/\|/, "\\|", $2); print "| **missed** | " $2 " | — |" }'
+grep '^unconfirmed' "$tmp.rows" | awk -F'\t' '{ gsub(/\|/, "\\|", $2); print "| **unconfirmed** | — | " $2 " |" }'
+echo
+mp0=$(grep -c '^missed.*\[P0\]' "$tmp.rows" || true)
+mp1=$(grep -c '^missed.*\[P1\]' "$tmp.rows" || true)
+unc=$(grep -c '^unconfirmed' "$tmp.rows" || true)
+mat=$(grep -c '^matched' "$tmp.rows" || true)
+dri=$(grep -c '^drift' "$tmp.rows" || true)
+shadow_model=$(sed -n 's/^[^\t]*\t//p' "$tmp.shadow.meta" | head -1)
+echo "for-ledger: shadow=$shadow_model authoritative=$auth_model missed_P0=$mp0 missed_P1=$mp1 unconfirmed=$unc matched=$mat drift=$dri"

--- a/scripts/review-compare.sh
+++ b/scripts/review-compare.sh
@@ -30,13 +30,14 @@ case "$sha" in
 esac
 printf '%s' "$sha" | grep -qE '^[0-9a-f]{40}$' || die "sha must be a full 40-hex SHA, got '${sha}'"
 
+gherr=$(mktemp "${TMPDIR:-/tmp}/review-compare.XXXXXX")
 comments=$(gh pr view "$pr" --repo "$repo" --json comments \
-    --jq '.comments[] | "<<<COMMENT>>>", .body' 2>&1) ||
-    die "gh pr view $pr comments failed"
+    --jq '.comments[] | "<<<COMMENT>>>", .body' 2>"$gherr") ||
+    die "gh pr view $pr comments failed: $(tail -1 "$gherr")"
 
 tmp=$(mktemp "${TMPDIR:-/tmp}/review-compare.XXXXXX")
 findings_tmp2=$(mktemp "${TMPDIR:-/tmp}/review-compare.XXXXXX")
-trap 'rm -f "$tmp" "$tmp".* "$findings_tmp2" "$findings_tmp2".*' 0 HUP INT TERM
+trap 'rm -f "$tmp" "$tmp".* "$findings_tmp2" "$findings_tmp2".* "$gherr"' 0 HUP INT TERM
 
 # Extract, per comment pinned to the sha, the verdict line, model_observed,
 # and the Findings rows into:
@@ -89,13 +90,17 @@ printf '%s' "$comments" | awk -v sha="$sha" -v tmp="$tmp" '
     END { flush() }
 '
 
-[ -f "$tmp.shadow.findings" ] || die "no SHADOW round pinned to $sha on PR #$pr — nothing to compare"
+[ -f "$tmp.shadow.meta" ] || die "no SHADOW round pinned to $sha on PR #$pr — nothing to compare"
 
 # Matching key per finding: every file:line and bare-file token in the line;
 # a finding with no file token falls back to its first 60 characters. Two
 # findings sharing any key are the same finding (#883 will make rule ids the
 # primary key; the fallback keeps this usable before that lands).
-mv "$tmp.shadow.findings" "$findings_tmp2.shadow"
+if [ -f "$tmp.shadow.findings" ]; then
+    mv "$tmp.shadow.findings" "$findings_tmp2.shadow"
+else
+    printf '' >"$findings_tmp2.shadow"
+fi
 if [ -f "$tmp.auth.findings" ]; then
     mv "$tmp.auth.findings" "$findings_tmp2.auth"
 else

--- a/scripts/review-compare.sh
+++ b/scripts/review-compare.sh
@@ -35,6 +35,8 @@ comments=$(gh pr view "$pr" --repo "$repo" --json comments \
     die "gh pr view $pr comments failed"
 
 tmp=$(mktemp "${TMPDIR:-/tmp}/review-compare.XXXXXX")
+findings_tmp2=$(mktemp "${TMPDIR:-/tmp}/review-compare.XXXXXX")
+trap 'rm -f "$tmp" "$tmp".* "$findings_tmp2" "$findings_tmp2".*' 0 HUP INT TERM
 
 # Extract, per comment pinned to the sha, the verdict line, model_observed,
 # and the Findings rows into:
@@ -93,10 +95,12 @@ printf '%s' "$comments" | awk -v sha="$sha" -v tmp="$tmp" '
 # a finding with no file token falls back to its first 60 characters. Two
 # findings sharing any key are the same finding (#883 will make rule ids the
 # primary key; the fallback keeps this usable before that lands).
-findings_tmp2=$(mktemp "${TMPDIR:-/tmp}/review-compare.XXXXXX")
-trap 'rm -f "$tmp" "$tmp".shadow.findings "$tmp".auth.findings "$tmp".shadow.meta "$tmp".auth.meta' 0 HUP INT TERM
-mv "$tmp.shadow.findings" "$findings_tmp2.shadow" 2>/dev/null || printf '' >"$findings_tmp2.shadow"
-[ -f "$tmp.auth.findings" ] && mv "$tmp.auth.findings" "$findings_tmp2.auth" || printf '' >"$findings_tmp2.auth"
+mv "$tmp.shadow.findings" "$findings_tmp2.shadow"
+if [ -f "$tmp.auth.findings" ]; then
+    mv "$tmp.auth.findings" "$findings_tmp2.auth"
+else
+    printf '' >"$findings_tmp2.auth"
+fi
 
 awk -v sf="$findings_tmp2.shadow" '
     function keys(line,   s, k) {

--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -105,7 +105,13 @@ SHA_GIVEN=""
 # failed` rather than guessing). `Changes Requested` is tested first so a line
 # naming both resolves to the blocking side.
 if [ "${1:-}" = "verdict-label" ]; then
-  vline=$(sed -n '/^#\{1,\}[[:space:]]*Verdict/,$p' | sed '1d' \
+  # A SHADOW round (review.gh880-shadow) is not a verdict: it is never
+  # review:lgtm or review:changes-requested, sets no label and no status.
+  # The body line is the machine signal; the heading suffix alone is not.
+  # The body is slurped once — a grep on stdin would consume it.
+  body=$(cat)
+  if printf '%s\n' "$body" | grep -Eq -- '-? ?shadow: true$'; then echo "shadow"; exit 0; fi
+  vline=$(printf '%s\n' "$body" | sed -n '/^#\{1,\}[[:space:]]*Verdict/,$p' | sed '1d' \
           | grep -m1 -E 'LGTM|Changes Requested') || vline=""
   case "$vline" in
     *"Changes Requested"*) echo "review:changes-requested" ;;
@@ -389,9 +395,19 @@ BRIEF="$SCRATCH/review-pr$PR-r$ROUND-brief.md"
   echo "A write-end swallow on a path where coordination, ledger, heartbeat, session-ledger, L3-store, or digest state is written is **P1** (REVIEW.md §5.5, GH-692, GH-733)."
   echo
   echo "## Output"
+  SHADOW_SUFFIX=""
+  SHADOW_FIELD=""
+  if [ "${EDDA_REVIEW_SHADOW:-0}" = "1" ]; then
+    # SHADOW round (review.gh880-shadow): the heading suffix and the body
+    # field mark the round so verdict-label, the watcher and the compare
+    # script can tell it apart from a verdict.
+    SHADOW_SUFFIX=" (SHADOW)"
+    SHADOW_FIELD="- shadow: true"
+  fi
   echo "Print the REVIEW.md §7 verdict — every field, the Rules table with one row per routed rule, the Wiring table — between the markers below, with this header line filled in:"
   echo "<<<VERDICT"
-  echo "## Code Review: Round $ROUND — PR #$PR @ $SHA"
+  echo "## Code Review: Round $ROUND — PR #$PR @ $SHA$SHADOW_SUFFIX"
+  if [ -n "$SHADOW_FIELD" ]; then echo "$SHADOW_FIELD"; fi
   echo "…the rest exactly as REVIEW.md §7 specifies (model_requested: $MODEL, spec: $SPEC_VERSION, class: $CANON_CLASS)…"
   echo "VERDICT>>>"
   echo

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -584,6 +584,32 @@ if ! grep -qF -- '--add-label review:lgtm' "$GH_STUB_LOG"; then
     exit 1
 fi
 
+# --- live loop: a SHADOW round posts no label and no status (GH-887) ----------
+
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+printf '## Code Review: Round 1 — PR #42 @ %s (SHADOW)\n\nshadow: true\n\n- model_observed: openrouter/z-ai/glm-5.3-flash\n\n### Verdict\nLGTM (P0=0, P1=0)\n' "$sha" \
+    >"$EDDA_FLEET_SCRATCH/review-pr42-r1-verdict.md.posted"
+export GH_HEAD="$sha"
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (shadow round)\n' >&2; exit 1; }
+if [ -n "$(pending_get)" ]; then
+    printf 'live: a shadow round must drop the pending entry, got:\n%s\n' "$(pending_get)" >&2
+    exit 1
+fi
+if grep -qF -- '--add-label review:lgtm' "$GH_STUB_LOG"; then
+    printf 'live: a shadow round must not apply the verdict label\n' >&2
+    exit 1
+fi
+if grep -q 'statuses/' "$GH_STUB_LOG"; then
+    printf 'live: a shadow round must not post the Independent Review status: %s\n' \
+        "$(grep 'statuses/' "$GH_STUB_LOG")" >&2
+    exit 1
+fi
+if ! grep -q 'shadow round posted' "$PR_REVIEW_WATCH_LOG"; then
+    printf 'live: the shadow drop must be logged\n' >&2
+    exit 1
+fi
+
 # --- live loop: provider probe before the single dispatch retry (P1) ---------
 
 reset_stubs

--- a/scripts/test-review-compare.sh
+++ b/scripts/test-review-compare.sh
@@ -18,7 +18,7 @@ sh -n "$0" || {
 work=$(mktemp -d "${TMPDIR:-/tmp}/test-review-compare.XXXXXX")
 trap 'rm -rf "$work"' EXIT
 export TMPDIR="$work"
-mkdir -p "$work/bin" "$work/fixtures" "$work/out" "$work/out"
+mkdir -p "$work/bin" "$work/fixtures" "$work/out"
 
 SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
@@ -31,12 +31,14 @@ STUB
 chmod +x "$work/bin/gh"
 
 # 1 missed P0 (scripts/d.sh:40), 1 missed P1 (scripts/e.sh:50),
-# 1 unconfirmed (scripts/c.sh:30), 2 matched (scripts/a.sh:10),
+# 1 unconfirmed (scripts/c.sh:30), 2 matched (scripts/a.sh:10, scripts/f.sh:60),
 # 1 severity drift (scripts/b.sh:20 — P1 authoritative vs P2 shadow).
 cat >"$work/fixtures/both.json" <<EOF
 {"comments":[
- {"body":"<<<CS>>>\n## Code Review: Round 1 — PR #899 @ $SHA (SHADOW)\n\nshadow: true\n\n- model_observed: openrouter/z-ai/glm-5.3-flash\n- spec: review-spec-v1.4\n\n### Findings\n- [P1] matched defect — evidence: scripts/a.sh:10\n- [P2] drifted severity — evidence: scripts/b.sh:20\n- [P2] shadow-only suspicion — evidence: scripts/c.sh:30\n\n### Verdict\nChanges Requested, P0=0, P1=1\n<<<CE>>>"},
- {"body":"## Code Review: Round 2 — PR #899 @ $SHA\n\n- model_observed: claude-opus-5\n- spec: review-spec-v1.4\n\n### Findings\n- [P1] matched defect — evidence: scripts/a.sh:10\n- [P1] drifted severity — evidence: scripts/b.sh:20\n- [P0] catastrophic miss — evidence: scripts/d.sh:40\n- [P1] real blocker the shadow missed — evidence: scripts/e.sh:50\n\n### Verdict\nLGTM (P0=0, P1=0)\n<<<CE>>>"}]}
+ {"body":"<<<CS>>>\n## Code Review: Round 1 — PR #899 @ $SHA (SHADOW)\n\nshadow: true\n\n- model_observed: openrouter/z-ai/glm-5.3-flash\n- spec: review-spec-v1.4\n\n### Findings\n- [P1] matched defect — evidence: scripts/a.sh:10\n- [P2] drifted severity — evidence: scripts/b.sh:20\n- [P2] shadow-only suspicion — evidence: scripts/c.sh:30
+- [P2] second matched pair — evidence: scripts/f.sh:60\n\n### Verdict\nChanges Requested, P0=0, P1=1\n<<<CE>>>"},
+ {"body":"## Code Review: Round 2 — PR #899 @ $SHA\n\n- model_observed: claude-opus-5\n- spec: review-spec-v1.4\n\n### Findings\n- [P1] matched defect — evidence: scripts/a.sh:10\n- [P1] drifted severity — evidence: scripts/b.sh:20\n- [P0] catastrophic miss — evidence: scripts/d.sh:40\n- [P2] second matched pair — evidence: scripts/f.sh:60
+- [P1] real blocker the shadow missed — evidence: scripts/e.sh:50\n\n### Verdict\nLGTM (P0=0, P1=0)\n<<<CE>>>"}]}
 EOF
 # Normalise the markers the stub emits (the fixture embeds its own comment
 # framing because gh --jq prints one body per <<<COMMENT>>> line).
@@ -80,7 +82,7 @@ line=$(grep '^for-ledger:' "$work/out/both.txt")
 printf '%s\n' "$line" | grep -q 'missed_P0=1' || echo "FAIL: for-ledger missed_P0=1 missing: $line" >&2
 printf '%s\n' "$line" | grep -q 'missed_P1=1' || echo "FAIL: for-ledger missed_P1=1 missing: $line" >&2
 printf '%s\n' "$line" | grep -q 'unconfirmed=1' || echo "FAIL: for-ledger unconfirmed=1 missing: $line" >&2
-printf '%s\n' "$line" | grep -q 'matched=1' || echo "FAIL: for-ledger matched=1 missing: $line" >&2
+printf '%s\n' "$line" | grep -q 'matched=2' || echo "FAIL: for-ledger matched=2 missing: $line" >&2
 printf '%s\n' "$line" | grep -q 'drift=1' || echo "FAIL: for-ledger drift=1 missing: $line" >&2
 printf '%s\n' "$line" | grep -q 'shadow=openrouter/z-ai/glm-5.3-flash' || echo "FAIL: shadow model missing: $line" >&2
 printf '%s\n' "$line" | grep -q 'authoritative=claude-opus-5' || echo "FAIL: authoritative model missing: $line" >&2

--- a/scripts/test-review-compare.sh
+++ b/scripts/test-review-compare.sh
@@ -34,49 +34,41 @@ chmod +x "$work/bin/gh"
 # 1 unconfirmed (scripts/c.sh:30), 2 matched (scripts/a.sh:10, scripts/f.sh:60),
 # 1 severity drift (scripts/b.sh:20 — P1 authoritative vs P2 shadow).
 cat >"$work/fixtures/both.json" <<EOF
-{"comments":[
- {"body":"<<<CS>>>\n## Code Review: Round 1 — PR #899 @ $SHA (SHADOW)\n\nshadow: true\n\n- model_observed: openrouter/z-ai/glm-5.3-flash\n- spec: review-spec-v1.4\n\n### Findings\n- [P1] matched defect — evidence: scripts/a.sh:10\n- [P2] drifted severity — evidence: scripts/b.sh:20\n- [P2] shadow-only suspicion — evidence: scripts/c.sh:30
-- [P2] second matched pair — evidence: scripts/f.sh:60\n\n### Verdict\nChanges Requested, P0=0, P1=1\n<<<CE>>>"},
- {"body":"## Code Review: Round 2 — PR #899 @ $SHA\n\n- model_observed: claude-opus-5\n- spec: review-spec-v1.4\n\n### Findings\n- [P1] matched defect — evidence: scripts/a.sh:10\n- [P1] drifted severity — evidence: scripts/b.sh:20\n- [P0] catastrophic miss — evidence: scripts/d.sh:40\n- [P2] second matched pair — evidence: scripts/f.sh:60
-- [P1] real blocker the shadow missed — evidence: scripts/e.sh:50\n\n### Verdict\nLGTM (P0=0, P1=0)\n<<<CE>>>"}]}
+{"comments": [{"body": "## Code Review: Round 1 — PR #899 @ $SHA (SHADOW)\n\nshadow: true\n\n- model_observed: openrouter/z-ai/glm-5.3-flash\n\n### Findings\n- [P1] matched defect — evidence: scripts/a.sh:10\n- [P2] drifted severity — evidence: scripts/b.sh:20\n- [P2] shadow-only suspicion — evidence: scripts/c.sh:30\n- [P2] second matched pair — evidence: scripts/f.sh:60\n\n### Verdict\nChanges Requested, P0=0, P1=1"}, {"body": "## Code Review: Round 2 — PR #899 @ $SHA\n\n- model_observed: claude-opus-5\n\n### Findings\n- [P1] matched defect — evidence: scripts/a.sh:10\n- [P1] drifted severity — evidence: scripts/b.sh:20\n- [P0] catastrophic miss — evidence: scripts/d.sh:40\n- [P2] second matched pair — evidence: scripts/f.sh:60\n- [P1] real blocker the shadow missed — evidence: scripts/e.sh:50\n\n### Verdict\nLGTM (P0=0, P1=0)"}]}
 EOF
 # Normalise the markers the stub emits (the fixture embeds its own comment
 # framing because gh --jq prints one body per <<<COMMENT>>> line).
 sed -i 's/<<<CS>>>/<<<COMMENT>>>/; s/<<<CE>>>//' "$work/fixtures/both.json"
-
 cat >"$work/fixtures/shadow-only.json" <<EOF
 {"comments":[
- {"body":"## Code Review: Round 1 — PR #899 @ $SHA (SHADOW)\n\nshadow: true\n\n- model_observed: openrouter/z-ai/glm-5.3-flash\n\n### Findings\n- [P1] shadow-only suspicion — evidence: scripts/c.sh:30\n\n### Verdict\nChanges Requested, P0=0, P1=1\n<<<CE>>>"}]}
+{"body":"## Code Review: Round 1 — PR #899 @ $SHA (SHADOW)\n\nshadow: true\n\n- model_observed: openrouter/z-ai/glm-5.3-flash\n\n### Findings\n- [P1] shadow-only suspicion — evidence: scripts/c.sh:30\n\n### Verdict\nChanges Requested, P0=0, P1=1\n<<<CE>>>"}]}
 EOF
 sed -i 's/<<<CE>>>//' "$work/fixtures/shadow-only.json"
-
 cat >"$work/fixtures/no-shadow.json" <<EOF
 {"comments":[
- {"body":"## Code Review: Round 1 — PR #899 @ $SHA\n\n- model_observed: claude-opus-5\n\n### Findings\n- [P0] authoritative only — evidence: scripts/d.sh:40\n\n### Verdict\nChanges Requested, P0=1, P1=0\n<<<CE>>>"}]}
+{"body":"## Code Review: Round 1 — PR #899 @ $SHA\n\n- model_observed: claude-opus-5\n\n### Findings\n- [P0] authoritative only — evidence: scripts/d.sh:40\n\n### Verdict\nChanges Requested, P0=1, P1=0\n<<<CE>>>"}]}
 EOF
 sed -i 's/<<<CE>>>//' "$work/fixtures/no-shadow.json"
-
 run() {
-    GH_COMMENTS_FIXTURE="$1" PATH="$work/bin:$PATH" sh "$script" 899 "$SHA"
+GH_COMMENTS_FIXTURE="$1" PATH="$work/bin:$PATH" sh "$script" 899 "$SHA"
 }
-
 # 1. both rounds: the counts and the for-ledger line
 run "$work/fixtures/both.json" >"$work/out/both.txt" 2>"$work/out/both.err"
 grep -q 'missed.*\[P0\] catastrophic miss' "$work/out/both.txt" || {
-    echo "FAIL: missed P0 not reported: $(cat "$work/out/both.txt")" >&2
-    exit 1
+echo "FAIL: missed P0 not reported: $(cat "$work/out/both.txt")" >&2
+exit 1
 }
 grep -q 'missed.*\[P1\] real blocker' "$work/out/both.txt" || {
-    echo "FAIL: missed P1 not reported" >&2
-    exit 1
+echo "FAIL: missed P1 not reported" >&2
+exit 1
 }
 grep -q 'unconfirmed.*shadow-only suspicion' "$work/out/both.txt" || {
-    echo "FAIL: unconfirmed not reported" >&2
-    exit 1
+echo "FAIL: unconfirmed not reported" >&2
+exit 1
 }
 grep -q 'severity drift' "$work/out/both.txt" || {
-    echo "FAIL: severity drift not reported" >&2
-    exit 1
+echo "FAIL: severity drift not reported" >&2
+exit 1
 }
 line=$(grep '^for-ledger:' "$work/out/both.txt")
 printf '%s\n' "$line" | grep -q 'missed_P0=1' || echo "FAIL: for-ledger missed_P0=1 missing: $line" >&2
@@ -87,37 +79,34 @@ printf '%s\n' "$line" | grep -q 'drift=1' || echo "FAIL: for-ledger drift=1 miss
 printf '%s\n' "$line" | grep -q 'shadow=openrouter/z-ai/glm-5.3-flash' || echo "FAIL: shadow model missing: $line" >&2
 printf '%s\n' "$line" | grep -q 'authoritative=claude-opus-5' || echo "FAIL: authoritative model missing: $line" >&2
 echo "ok 1 both rounds: counts and for-ledger line"
-
 # 2. no SHADOW round on the sha → exit 2, naming it
 rc=0
 GH_COMMENTS_FIXTURE="$work/fixtures/no-shadow.json" PATH="$work/bin:$PATH" \
-    sh "$script" 899 "$SHA" >"$work/out/noshadow.txt" 2>"$work/out/noshadow.err" || rc=$?
+sh "$script" 899 "$SHA" >"$work/out/noshadow.txt" 2>"$work/out/noshadow.err" || rc=$?
 [ "$rc" -eq 2 ] || {
-    echo "FAIL: no-shadow exit $rc, want 2" >&2
-    exit 1
+echo "FAIL: no-shadow exit $rc, want 2" >&2
+exit 1
 }
 grep -q 'no SHADOW round' "$work/out/noshadow.err" || {
-    echo "FAIL: no-shadow stderr must name the missing round: $(cat "$work/out/noshadow.err")" >&2
-    exit 1
+echo "FAIL: no-shadow stderr must name the missing round: $(cat "$work/out/noshadow.err")" >&2
+exit 1
 }
 echo "ok 2 no SHADOW round exits 2"
-
 # 3. shadow round but no authoritative round → pending, exit 0
 rc=0
 GH_COMMENTS_FIXTURE="$work/fixtures/shadow-only.json" PATH="$work/bin:$PATH" \
-    sh "$script" 899 "$SHA" >"$work/out/pending.txt" 2>"$work/out/pending.err" || rc=$?
+sh "$script" 899 "$SHA" >"$work/out/pending.txt" 2>"$work/out/pending.err" || rc=$?
 [ "$rc" -eq 0 ] || {
-    echo "FAIL: pending exit $rc, want 0" >&2
-    exit 1
+echo "FAIL: pending exit $rc, want 0" >&2
+exit 1
 }
 grep -q 'pending authoritative round' "$work/out/pending.txt" || {
-    echo "FAIL: pending line missing: $(cat "$work/out/pending.txt")" >&2
-    exit 1
+echo "FAIL: pending line missing: $(cat "$work/out/pending.txt")" >&2
+exit 1
 }
 grep -q 'authoritative=pending' "$work/out/pending.txt" || {
-    echo "FAIL: pending for-ledger line missing" >&2
-    exit 1
+echo "FAIL: pending for-ledger line missing" >&2
+exit 1
 }
 echo "ok 3 pending authoritative round exits 0"
-
 echo "PASS: scripts/test-review-compare.sh"

--- a/scripts/test-review-compare.sh
+++ b/scripts/test-review-compare.sh
@@ -1,0 +1,121 @@
+#!/bin/sh
+# Offline self-test for scripts/review-compare.sh (GH-887).
+# Stubs gh. Writes only under a temp dir.
+set -eu
+
+cd "$(git rev-parse --show-toplevel)"
+script=scripts/review-compare.sh
+
+sh -n "$script" || {
+    echo "FAIL: sh -n $script" >&2
+    exit 1
+}
+sh -n "$0" || {
+    echo "FAIL: sh -n $0" >&2
+    exit 1
+}
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/test-review-compare.XXXXXX")
+trap 'rm -rf "$work"' EXIT
+export TMPDIR="$work"
+mkdir -p "$work/bin" "$work/fixtures" "$work/out" "$work/out"
+
+SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+cat >"$work/bin/gh" <<STUB
+#!/bin/sh
+# the compare script's one query: expand comments the way the real gh's
+# --jq does
+jq -r '.comments[] | "<<<COMMENT>>>", .body' "\$GH_COMMENTS_FIXTURE"
+STUB
+chmod +x "$work/bin/gh"
+
+# 1 missed P0 (scripts/d.sh:40), 1 missed P1 (scripts/e.sh:50),
+# 1 unconfirmed (scripts/c.sh:30), 2 matched (scripts/a.sh:10),
+# 1 severity drift (scripts/b.sh:20 — P1 authoritative vs P2 shadow).
+cat >"$work/fixtures/both.json" <<EOF
+{"comments":[
+ {"body":"<<<CS>>>\n## Code Review: Round 1 — PR #899 @ $SHA (SHADOW)\n\nshadow: true\n\n- model_observed: openrouter/z-ai/glm-5.3-flash\n- spec: review-spec-v1.4\n\n### Findings\n- [P1] matched defect — evidence: scripts/a.sh:10\n- [P2] drifted severity — evidence: scripts/b.sh:20\n- [P2] shadow-only suspicion — evidence: scripts/c.sh:30\n\n### Verdict\nChanges Requested, P0=0, P1=1\n<<<CE>>>"},
+ {"body":"## Code Review: Round 2 — PR #899 @ $SHA\n\n- model_observed: claude-opus-5\n- spec: review-spec-v1.4\n\n### Findings\n- [P1] matched defect — evidence: scripts/a.sh:10\n- [P1] drifted severity — evidence: scripts/b.sh:20\n- [P0] catastrophic miss — evidence: scripts/d.sh:40\n- [P1] real blocker the shadow missed — evidence: scripts/e.sh:50\n\n### Verdict\nLGTM (P0=0, P1=0)\n<<<CE>>>"}]}
+EOF
+# Normalise the markers the stub emits (the fixture embeds its own comment
+# framing because gh --jq prints one body per <<<COMMENT>>> line).
+sed -i 's/<<<CS>>>/<<<COMMENT>>>/; s/<<<CE>>>//' "$work/fixtures/both.json"
+
+cat >"$work/fixtures/shadow-only.json" <<EOF
+{"comments":[
+ {"body":"## Code Review: Round 1 — PR #899 @ $SHA (SHADOW)\n\nshadow: true\n\n- model_observed: openrouter/z-ai/glm-5.3-flash\n\n### Findings\n- [P1] shadow-only suspicion — evidence: scripts/c.sh:30\n\n### Verdict\nChanges Requested, P0=0, P1=1\n<<<CE>>>"}]}
+EOF
+sed -i 's/<<<CE>>>//' "$work/fixtures/shadow-only.json"
+
+cat >"$work/fixtures/no-shadow.json" <<EOF
+{"comments":[
+ {"body":"## Code Review: Round 1 — PR #899 @ $SHA\n\n- model_observed: claude-opus-5\n\n### Findings\n- [P0] authoritative only — evidence: scripts/d.sh:40\n\n### Verdict\nChanges Requested, P0=1, P1=0\n<<<CE>>>"}]}
+EOF
+sed -i 's/<<<CE>>>//' "$work/fixtures/no-shadow.json"
+
+run() {
+    GH_COMMENTS_FIXTURE="$1" PATH="$work/bin:$PATH" sh "$script" 899 "$SHA"
+}
+
+# 1. both rounds: the counts and the for-ledger line
+run "$work/fixtures/both.json" >"$work/out/both.txt" 2>"$work/out/both.err"
+grep -q 'missed.*\[P0\] catastrophic miss' "$work/out/both.txt" || {
+    echo "FAIL: missed P0 not reported: $(cat "$work/out/both.txt")" >&2
+    exit 1
+}
+grep -q 'missed.*\[P1\] real blocker' "$work/out/both.txt" || {
+    echo "FAIL: missed P1 not reported" >&2
+    exit 1
+}
+grep -q 'unconfirmed.*shadow-only suspicion' "$work/out/both.txt" || {
+    echo "FAIL: unconfirmed not reported" >&2
+    exit 1
+}
+grep -q 'severity drift' "$work/out/both.txt" || {
+    echo "FAIL: severity drift not reported" >&2
+    exit 1
+}
+line=$(grep '^for-ledger:' "$work/out/both.txt")
+printf '%s\n' "$line" | grep -q 'missed_P0=1' || echo "FAIL: for-ledger missed_P0=1 missing: $line" >&2
+printf '%s\n' "$line" | grep -q 'missed_P1=1' || echo "FAIL: for-ledger missed_P1=1 missing: $line" >&2
+printf '%s\n' "$line" | grep -q 'unconfirmed=1' || echo "FAIL: for-ledger unconfirmed=1 missing: $line" >&2
+printf '%s\n' "$line" | grep -q 'matched=1' || echo "FAIL: for-ledger matched=1 missing: $line" >&2
+printf '%s\n' "$line" | grep -q 'drift=1' || echo "FAIL: for-ledger drift=1 missing: $line" >&2
+printf '%s\n' "$line" | grep -q 'shadow=openrouter/z-ai/glm-5.3-flash' || echo "FAIL: shadow model missing: $line" >&2
+printf '%s\n' "$line" | grep -q 'authoritative=claude-opus-5' || echo "FAIL: authoritative model missing: $line" >&2
+echo "ok 1 both rounds: counts and for-ledger line"
+
+# 2. no SHADOW round on the sha → exit 2, naming it
+rc=0
+GH_COMMENTS_FIXTURE="$work/fixtures/no-shadow.json" PATH="$work/bin:$PATH" \
+    sh "$script" 899 "$SHA" >"$work/out/noshadow.txt" 2>"$work/out/noshadow.err" || rc=$?
+[ "$rc" -eq 2 ] || {
+    echo "FAIL: no-shadow exit $rc, want 2" >&2
+    exit 1
+}
+grep -q 'no SHADOW round' "$work/out/noshadow.err" || {
+    echo "FAIL: no-shadow stderr must name the missing round: $(cat "$work/out/noshadow.err")" >&2
+    exit 1
+}
+echo "ok 2 no SHADOW round exits 2"
+
+# 3. shadow round but no authoritative round → pending, exit 0
+rc=0
+GH_COMMENTS_FIXTURE="$work/fixtures/shadow-only.json" PATH="$work/bin:$PATH" \
+    sh "$script" 899 "$SHA" >"$work/out/pending.txt" 2>"$work/out/pending.err" || rc=$?
+[ "$rc" -eq 0 ] || {
+    echo "FAIL: pending exit $rc, want 0" >&2
+    exit 1
+}
+grep -q 'pending authoritative round' "$work/out/pending.txt" || {
+    echo "FAIL: pending line missing: $(cat "$work/out/pending.txt")" >&2
+    exit 1
+}
+grep -q 'authoritative=pending' "$work/out/pending.txt" || {
+    echo "FAIL: pending for-ledger line missing" >&2
+    exit 1
+}
+echo "ok 3 pending authoritative round exits 0"
+
+echo "PASS: scripts/test-review-compare.sh"


### PR DESCRIPTION
## Problem and change

GH-887 executes the operator's ruling (`review.gh880-shadow`: 「#880 這張用 glm 影子審，Opus 補審等額度」) by giving a non-verdict review round a machine-recognizable shape and a compare tool. Stacked on `feat/gh886-controller-loop` (PR #899), which posts such rounds.

- `REVIEW.md` — §7 gains the `- shadow: true` header field, §8 one sentence (a shadow round sets no `review:*` label, no `Independent Review` status, and the union ignores it), §9 one provenance row; `grep -n shadow REVIEW.md` resolves to exactly those three places.
- `scripts/review-pr.sh` — `verdict-label` prints `shadow` for a body carrying the field (both with and without the header dash) and otherwise behaves byte-identically; `EDDA_REVIEW_SHADOW=1` writes the field and the heading suffix into the brief's output contract. The verdict-label stdin is slurped once — a stdin grep would consume the body before the Verdict section is read.
- `scripts/pr-review-watch.sh` — the verdict extractor recognizes the shadow suffix and excludes the round from the union entirely; `finish_verdict` drops a shadow round's pending entry with a log line and applies no label and no status.
- `scripts/review-compare.sh` (new) — `<pr> <sha>`: picks the shadow round and the authoritative round pinned to that SHA, matches findings by file:line tokens (rule ids land with #883), and prints missed / unconfirmed / matched / severity-drift rows plus one `for-ledger` line for `fleet.review-calibration`. No SHADOW round exits 2; a pending authoritative round prints the shadow findings and exits 0. It reads GitHub only.
- The heading pin in both scripts avoids a regex spanning the em dash: gawk in the C locale counts bytes and the dash is three of them, so a character-count regex silently misaligns — the pin splits on ` @ ` and compares the tail string.

## Validation

### RAN

- `sh scripts/test-review-compare.sh` → PASS (3 cases: both-rounds counts and for-ledger line, no-shadow exits 2, pending-authoritative exits 0); stub `gh` resolves `--jq` like the real one
- `sh scripts/test-pr-review-watch.sh` → passes through the new shadow live-loop scenario (no `review:lgtm` label, no `statuses/` call, pending dropped, drop logged); fails later at the provider-probe scenario for **pre-existing** workstation-environment reasons — verified by stashing all GH-887 changes and reproducing the identical failure at baseline a55d64f; filed as #905, CI (Linux) is the gate for the suite
- `sh -n` on all five scripts → exit 0
- `grep -n shadow REVIEW.md` → exactly three lines (§7 field, §8 rule, §9 row)
- verdict-label probes: shadow body → `shadow`; the same body without the field → `review:changes-requested` (today's mapping); a body with no Verdict line → empty
- discretionary-phrase grep over the two new/edited scripts (`as needed|if relevant|use (your )?judg|where appropriate`) → empty

### READ

- GH-887 issue body — doneWhen used as the acceptance ceiling, each item verified above
- `review.gh880-shadow`, `review.verdict-carrier`, `fleet.review-calibration` — resolved from the checkout ledger

Closes #887

Issue: #887
