### PR TITLE
feat(fleet): add shadow-review compare script (GH-887 slice A)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -758,7 +758,7 @@ mechanical.
 | R3 | RAN | `sh -n` on 3 changed scripts, all exit 0 |
 | R4–R5 | canonical | `brief-v1` §6.1 items 3–4; stated as properties, not commands |
 | §5.5 | RAN | `sh scripts/wiring-scan.sh 6340d94~1 6340d94` |
-| §8 shadow rule | canonical | operator ruling 2026-09-05 (`review.gh880-shadow`, issue #887): a ` (SHADOW)` round is never a verdict, sets no label and no `Independent Review` status; `sh scripts/review-compare.sh <pr> <sha>` diffs it against the authoritative round on the same SHA |
+| §8 shadow rule | canonical | operator ruling 2026-09-05 (`review.gh880-shadow` = `glm-shadow-round-opus-makeup-when-quota`, issue #887): a ` (SHADOW)` round is never a verdict, sets no label and no `Independent Review` status; `sh scripts/review-compare.sh <pr> <sha>` diffs it against the authoritative round on the same SHA |
 
 ## 10. Version
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -649,7 +649,7 @@ One comment per round, pinned to the reviewed full SHA
 - spec: review-spec-v1.3
 - class: <code-risk | docs-skills>  (REVIEW.md classes: <docs|skills|code-plain|code-risk ...>)
 - escalations: <list of 需升級 items, or "none">
-- shadow: true|false  (true: the heading is `## Code Review: Round <N> (SHADOW) — PR #<n> @ <full 40-hex SHA>`; a SHADOW round is never a verdict — §8)
+- shadow: true|false  (documentation for a SHADOW round: true requires the heading suffix ` (SHADOW)` — `## Code Review: Round <N> (SHADOW) — PR #<n> @ <full 40-hex SHA>`; the suffix is the only marker, this field never substitutes for it; a SHADOW round is never a verdict — §8)
 - cost: <elapsed / tokens / tool calls, as available>
 
 ### IN SCOPE
@@ -704,9 +704,10 @@ rather than overwriting it.
 - Every push invalidates this verdict (`loop` item 5). A draft/ready flip, a
   label, or a status change is not a push and reruns nothing (`ladder`, L3).
 - **A round posted as SHADOW is never a verdict.** A §7 comment whose heading
-  carries the ` (SHADOW)` suffix and whose header sets `- shadow: true` sets
-  no `review:*` label and no `Independent Review` status — the union rule
-  below ignores it. It is calibration evidence, not a gate:
+  carries the ` (SHADOW)` suffix — the only SHADOW marker; the `- shadow:
+  true` header field is documentation that accompanies it, never a
+  substitute — sets no `review:*` label and no `Independent Review` status —
+  the union rule below ignores it. It is calibration evidence, not a gate:
   `scripts/review-compare.sh <pr> <sha>` diffs its findings against the
   authoritative round (the latest §7 round on that SHA without the suffix)
   and prints one `for-ledger` line for the calibration ledger (issue #887).
@@ -718,7 +719,10 @@ strongest durable local carrier; do not invent a PR.
 The watcher also posts the merge gate's commit status: context
 `Independent Review`, pinned to the reviewed SHA in §7's heading. Its state
 is the union of every §7 verdict comment on that SHA plus the round just
-posted: `success` only when at least one verdict is `LGTM (P0=0, P1=0)` and
+posted — a SHADOW round (heading with the ` (SHADOW)` suffix) is never a
+verdict and never enters this state; that exclusion is part of this rule,
+not a side effect of the watcher's pin regex — `success` only when at least
+one verdict is `LGTM (P0=0, P1=0)` and
 no verdict on that SHA is anything else; any standing non-qualifying verdict
 is `failure`; no verdict at all is `error`. A later LGTM therefore does not
 override an earlier Changes Requested on the same SHA (GH-742).

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -649,6 +649,7 @@ One comment per round, pinned to the reviewed full SHA
 - spec: review-spec-v1.3
 - class: <code-risk | docs-skills>  (REVIEW.md classes: <docs|skills|code-plain|code-risk ...>)
 - escalations: <list of 需升級 items, or "none">
+- shadow: true|false  (true: the heading is `## Code Review: Round <N> (SHADOW) — PR #<n> @ <full 40-hex SHA>`; a SHADOW round is never a verdict — §8)
 - cost: <elapsed / tokens / tool calls, as available>
 
 ### IN SCOPE
@@ -702,6 +703,13 @@ rather than overwriting it.
 - An LGTM with a non-empty `escalations:` field is provisional (§6.4).
 - Every push invalidates this verdict (`loop` item 5). A draft/ready flip, a
   label, or a status change is not a push and reruns nothing (`ladder`, L3).
+- **A round posted as SHADOW is never a verdict.** A §7 comment whose heading
+  carries the ` (SHADOW)` suffix and whose header sets `- shadow: true` sets
+  no `review:*` label and no `Independent Review` status — the union rule
+  below ignores it. It is calibration evidence, not a gate:
+  `scripts/review-compare.sh <pr> <sha>` diffs its findings against the
+  authoritative round (the latest §7 round on that SHA without the suffix)
+  and prints one `for-ledger` line for the calibration ledger (issue #887).
 
 Internal verifier reports, task receipts and CI do not replace this comment
 (`loop`). For a local-only delivery with no PR, record the same fields in the
@@ -750,6 +758,7 @@ mechanical.
 | R3 | RAN | `sh -n` on 3 changed scripts, all exit 0 |
 | R4–R5 | canonical | `brief-v1` §6.1 items 3–4; stated as properties, not commands |
 | §5.5 | RAN | `sh scripts/wiring-scan.sh 6340d94~1 6340d94` |
+| §8 shadow rule | canonical | operator ruling 2026-09-05 (`review.gh880-shadow`, issue #887): a ` (SHADOW)` round is never a verdict, sets no label and no `Independent Review` status; `sh scripts/review-compare.sh <pr> <sha>` diffs it against the authoritative round on the same SHA |
 
 ## 10. Version
 

--- a/scripts/review-compare.sh
+++ b/scripts/review-compare.sh
@@ -1,0 +1,244 @@
+#!/bin/sh
+# review-compare.sh — diff the SHADOW review round against the authoritative
+# review round on the same SHA (issue #887; operator ruling recorded as
+# decision `review.gh880-shadow`).
+#
+# usage: review-compare.sh <pr> <sha>
+#   <pr>   PR number
+#   <sha>  the reviewed full 40-hex SHA both rounds are pinned to
+#
+# Environment:
+#   EDDA_REPO              owner/repo            (default fagemx/edda)
+#   EDDA_COMPARE_FIXTURE   read the comment stream from this file instead of
+#                          GitHub (offline tests). The file holds the exact
+#                          stream `gh pr view <pr> --json comments --jq
+#                          '.comments[] | "<<<COMMENT>>>", .body'` prints:
+#                          one <<<COMMENT>>> line before each raw comment
+#                          body, oldest comment first.
+#
+# This script READS GitHub comments only. It never posts, never labels, and
+# never writes the ledger; its only output is stdout — the compare table and
+# one `for-ledger` line that the controller records as a
+# `fleet.review-calibration` row (REVIEW.md §8).
+#
+# Round selection (REVIEW.md §7/§8): among the §7 comments whose heading is
+# `## Code Review: Round <N> — PR #<pr> @ <sha>` — pinned to BOTH the given
+# PR number and the given SHA — the SHADOW round is the last one marked
+# ` (SHADOW)` in the heading (or carrying `- shadow: true` in its header),
+# and the authoritative round is the last one without that mark. "Last" is
+# last in the comment stream, which GitHub returns oldest-first.
+#
+# Findings are the `- [P0|P1|P2] ...` lines of the `### Findings` section.
+# Two findings match by rule id (`[U3]`, `[D2]`, ... — #883) when both carry
+# one, else by the first `file:line` token in the line, else by the finding
+# text itself. The first occurrence of a key wins within one round.
+# Classification:
+#   missed          in the authoritative round only (counted by severity)
+#   unconfirmed     in the SHADOW round only
+#   matched         in both rounds, same severity
+#   severity drift  in both rounds, different severity
+#
+# model_observed is read from each round's `- model_observed:` header field;
+# a round that reported none is printed as `unverified`, never invented.
+#
+# Exit codes: 0 = compared, or pending authoritative round (printed, never a
+# silent zero — no counts and no for-ledger line in the pending case);
+# 2 = usage error, unreadable fixture, or no SHADOW round pinned to that SHA;
+# 3 = the GitHub comments fetch failed.
+set -u
+
+REPO=${EDDA_REPO:-fagemx/edda}
+
+usage() { echo "usage: review-compare.sh <pr> <sha>" >&2; }
+
+is_full_sha() {
+  printf '%s\n' "${1:-}" | grep -Eq '^[0-9a-f]{40}$'
+}
+
+[ $# -eq 2 ] || { usage; exit 2; }
+PR=$1
+SHA=$2
+case "$PR" in
+  ''|*[!0-9]*) echo "review-compare.sh: <pr> must be a number, got '$PR'" >&2; exit 2 ;;
+esac
+is_full_sha "$SHA" || {
+  echo "review-compare.sh: $SHA is not a full lowercase 40-hex SHA" >&2
+  exit 2
+}
+
+if [ -n "${EDDA_COMPARE_FIXTURE:-}" ]; then
+  [ -r "$EDDA_COMPARE_FIXTURE" ] || {
+    echo "review-compare.sh: fixture $EDDA_COMPARE_FIXTURE is not readable" >&2
+    exit 2
+  }
+  stream=$(cat "$EDDA_COMPARE_FIXTURE")
+else
+  stream=$(gh pr view "$PR" --repo "$REPO" --json comments \
+    --jq '.comments[] | "<<<COMMENT>>>", .body' 2>&1)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "review-compare.sh: gh comments fetch failed (exit $rc): $stream" >&2
+    exit 3
+  fi
+fi
+
+# The pin regex is built from two validated values: <pr> is digits only and
+# <sha> is exactly 40 lowercase hex characters (REVIEW.md R5), so neither can
+# carry regex metacharacters and both match literally (same reasoning as
+# pr-review-watch.sh verdict_body_lines).
+printf '%s\n' "$stream" | awk -v pr="$PR" -v sha="$SHA" '
+  BEGIN { pinre = "^## Code Review: Round [0-9]+( \\(SHADOW\\))? — PR #" pr " @ " sha "$" }
+
+  function trim(s) {
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", s)
+    return s
+  }
+
+  function flush_comment() {
+    if (!inb) return
+    inb = 0
+    ncom++
+    parse_comment(ncom, buf)
+    buf = ""
+  }
+
+  function store_finding(c, line,   sev, key, disp, rest, ei, dup) {
+    sev = "P?"
+    if (match(line, /\[P[0-2]\]/)) sev = substr(line, RSTART + 1, RLENGTH - 2)
+    key = ""
+    if (match(line, /\[(U|D|S|C|R)[0-9]+(\.[0-9]+)?\]/)) {
+      key = substr(line, RSTART + 1, RLENGTH - 2)
+    } else if (match(line, "[A-Za-z0-9_./~-]+:[0-9]+")) {
+      key = substr(line, RSTART, RLENGTH)
+    }
+    if (key == "") {
+      # No rule id and no file:line: fall back to the finding text itself.
+      rest = line
+      sub(/^- \[P[0-2]\][[:space:]]*/, "", rest)
+      ei = index(rest, " — evidence:")
+      if (ei > 0) rest = substr(rest, 1, ei - 1)
+      gsub(/[[:space:]]+/, " ", rest)
+      rest = trim(rest)
+      if (rest == "") rest = trim(line)
+      key = rest
+      disp = (length(key) > 48) ? substr(key, 1, 45) "..." : key
+    } else {
+      disp = key
+    }
+    dup = c SUBSEP key
+    if (dup in seenkey) return        # first occurrence wins within a round
+    seenkey[dup] = 1
+    fcnt[c]++
+    fsev[c, fcnt[c]] = sev
+    fkey[c, fcnt[c]] = key
+    fdisp[c, fcnt[c]] = disp
+  }
+
+  function parse_comment(c, body,   i, n, L, line, pinned, inhdr, inf,
+                         issh, rline, model) {
+    n = split(body, L, "\n")
+    pinned = 0; inhdr = 1; inf = 0; issh = 0; rline = ""; model = ""
+    for (i = 1; i <= n; i++) {
+      line = L[i]
+      if (!pinned && line ~ pinre) {
+        pinned = 1
+        rline = line
+        if (index(line, "(SHADOW)") > 0) issh = 1
+        continue
+      }
+      if (line ~ /^#{3}[[:space:]]/) {
+        inhdr = 0
+        inf = (line ~ /^#{3}[[:space:]]*Findings([[:space:]]|$)/) ? 1 : 0
+        continue
+      }
+      if (inhdr && line ~ /^- model_observed:/) {
+        model = trim(substr(line, length("- model_observed:") + 1))
+        continue
+      }
+      if (inhdr && line ~ /^- shadow:[[:space:]]*true([[:space:]]|$)/) {
+        issh = 1
+        continue
+      }
+      if (inf && line ~ /^- \[P[0-2]\]/) store_finding(c, line)
+    }
+    if (!pinned) return
+    pinnedc[c] = 1
+    isshadow[c] = issh
+    modelobs[c] = model
+    match(rline, /Round [0-9]+/)
+    roundnum[c] = substr(rline, RSTART + 6, RLENGTH - 6)
+  }
+
+  { sub(/\r$/, "") }
+  /^<<<COMMENT>>>$/ { flush_comment(); inb = 1; buf = ""; next }
+  { if (!inb) { inb = 1; buf = "" }
+    buf = buf $0 "\n" }
+  END {
+    flush_comment()
+    sc = 0; ac = 0
+    for (c = 1; c <= ncom; c++) {
+      if (!pinnedc[c]) continue
+      if (isshadow[c]) sc = c; else ac = c   # last wins: stream is oldest-first
+    }
+    if (sc == 0) {
+      print "review-compare.sh: no SHADOW round pinned to PR " pr " @ " sha > "/dev/stderr"
+      exit 2
+    }
+    sm = (modelobs[sc] != "") ? modelobs[sc] : "unverified"
+    slabel = "Round " roundnum[sc] " (SHADOW)"
+    if (ac == 0) {
+      printf "shadow-review compare — PR %s @ %s\n", pr, sha
+      printf "shadow round: %s (model_observed: %s)\n", slabel, sm
+      print "pending authoritative round — no non-SHADOW §7 comment on this PR is pinned to this SHA"
+      if (fcnt[sc] + 0 == 0) {
+        print "(no findings in the SHADOW round)"
+      } else {
+        print ""
+        print "| finding | shadow |"
+        print "|---|---|"
+        for (i = 1; i <= fcnt[sc]; i++)
+          printf "| %s | %s |\n", fdisp[sc, i], fsev[sc, i]
+      }
+      exit 0
+    }
+    am = (modelobs[ac] != "") ? modelobs[ac] : "unverified"
+    for (i = 1; i <= fcnt[sc]; i++) shmap[fkey[sc, i]] = fsev[sc, i]
+    for (i = 1; i <= fcnt[ac]; i++) authmap[fkey[ac, i]] = fsev[ac, i]
+    printf "shadow-review compare — PR %s @ %s\n", pr, sha
+    printf "shadow round: %s (model_observed: %s)\n", slabel, sm
+    printf "authoritative round: Round %s (model_observed: %s)\n", roundnum[ac], am
+    print ""
+    print "| class | finding | shadow | authoritative |"
+    print "|---|---|---|---|"
+    mp0 = 0; mp1 = 0; unc = 0; mat = 0; drf = 0; any = 0
+    for (i = 1; i <= fcnt[ac]; i++) {   # missed: authoritative findings the shadow round lacks
+      k = fkey[ac, i]; sev = fsev[ac, i]
+      if (k in shmap) continue
+      any = 1
+      if (sev == "P0") mp0++; else if (sev == "P1") mp1++
+      printf "| missed | %s | — | %s |\n", fdisp[ac, i], sev
+    }
+    for (i = 1; i <= fcnt[sc]; i++) {   # unconfirmed: shadow-only findings
+      k = fkey[sc, i]
+      if (k in authmap) continue         # already matched or drifted below
+      any = 1; unc++
+      printf "| unconfirmed | %s | %s | — |\n", fdisp[sc, i], fsev[sc, i]
+    }
+    for (i = 1; i <= fcnt[ac]; i++) {   # matched and severity drift
+      k = fkey[ac, i]; sev = fsev[ac, i]; any = 1
+      if (!(k in shmap)) continue
+      if (shmap[k] == sev) {
+        mat++
+        printf "| matched | %s | %s | %s |\n", fdisp[ac, i], shmap[k], sev
+      } else {
+        drf++
+        printf "| severity drift | %s | %s | %s |\n", fdisp[ac, i], shmap[k], sev
+      }
+    }
+    if (!any) print "(no findings on either round)"
+    printf "\ncounts: missed_P0=%d missed_P1=%d unconfirmed=%d matched=%d drift=%d\n", mp0, mp1, unc, mat, drf
+    printf "for-ledger: shadow=%s authoritative=%s missed_P0=%d missed_P1=%d unconfirmed=%d matched=%d drift=%d\n", sm, am, mp0, mp1, unc, mat, drf
+    exit 0
+  }
+'
+exit $?

--- a/scripts/review-compare.sh
+++ b/scripts/review-compare.sh
@@ -24,8 +24,9 @@
 # Round selection (REVIEW.md §7/§8): among the §7 comments whose heading is
 # `## Code Review: Round <N> — PR #<pr> @ <sha>` — pinned to BOTH the given
 # PR number and the given SHA — the SHADOW round is the last one marked
-# ` (SHADOW)` in the heading (or carrying `- shadow: true` in its header),
-# and the authoritative round is the last one without that mark. "Last" is
+# ` (SHADOW)` in the heading, and the authoritative round is the last one
+# without that mark. The `- shadow: true` header field is documentation that
+# accompanies the suffix; it never marks a round on its own. "Last" is
 # last in the comment stream, which GitHub returns oldest-first.
 #
 # Findings are the `- [P0|P1|P2] ...` lines of the `### Findings` section.
@@ -153,10 +154,6 @@ printf '%s\n' "$stream" | awk -v pr="$PR" -v sha="$SHA" '
       }
       if (inhdr && line ~ /^- model_observed:/) {
         model = trim(substr(line, length("- model_observed:") + 1))
-        continue
-      }
-      if (inhdr && line ~ /^- shadow:[[:space:]]*true([[:space:]]|$)/) {
-        issh = 1
         continue
       }
       if (inf && line ~ /^- \[P[0-2]\]/) store_finding(c, line)

--- a/scripts/review-compare.sh
+++ b/scripts/review-compare.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # review-compare.sh — diff the SHADOW review round against the authoritative
 # review round on the same SHA (issue #887; operator ruling recorded as
-# decision `review.gh880-shadow`).
+# decision `review.gh880-shadow` = `glm-shadow-round-opus-makeup-when-quota`).
 #
 # usage: review-compare.sh <pr> <sha>
 #   <pr>   PR number

--- a/scripts/test-review-compare.sh
+++ b/scripts/test-review-compare.sh
@@ -155,6 +155,27 @@ EDDA_COMPARE_FIXTURE="$F2" sh "$COMPARE" 887 "$SHA" >"$out" 2>&1 || rc=$?
 expect_rc "no-shadow: exit" 2 "$rc"
 expect_has "no-shadow: message" "no SHADOW round pinned to PR 887 @ $SHA" "$out"
 
+# --- fixture 4: `- shadow: true` with a plain heading is NOT a SHADOW round ---
+# The ` (SHADOW)` heading suffix is the only marker (REVIEW.md §7); the
+# header field is documentation that accompanies the suffix and never
+# substitutes for it. A plain-heading round carrying the field is therefore
+# an authoritative round — the same shape the watcher (which never reads the
+# field) pins as a verdict, so both readers agree.
+F4="$tmp/field-only.txt"
+cat >"$F4" <<'EOF'
+<<<COMMENT>>>
+## Code Review: Round 2 — PR #887 @ 0123456789abcdef0123456789abcdef01234567
+
+- model_observed: claude-opus-5
+- shadow: true
+
+### Findings
+- [P1] [D2] ledger claim stale — evidence: REVIEW.md:88
+
+### Verdict
+Changes Requested, P0=0, P1=1 — plain heading: authoritative, field is documentation only
+EOF
+
 # --- scenario 3: no authoritative round — pending, exit 0, never a silent zero -
 out="$tmp/s3.out"
 rc=0
@@ -165,6 +186,14 @@ expect_has "pending: finding with rule id" "| U1 | P0 |" "$out"
 expect_has "pending: finding by text" "| doneWhen item has no code behind it | P1 |" "$out"
 expect_lacks "pending: no for-ledger line" "for-ledger:" "$out"
 expect_lacks "pending: no counts line" "counts:" "$out"
+
+# --- scenario 4: the field alone never marks SHADOW (REVIEW.md §7) ------------
+out="$tmp/s4.out"
+rc=0
+EDDA_COMPARE_FIXTURE="$F4" sh "$COMPARE" 887 "$SHA" >"$out" 2>&1 || rc=$?
+expect_rc "field-only: exit" 2 "$rc"
+expect_has "field-only: message" "no SHADOW round pinned to PR 887 @ $SHA" "$out"
+expect_lacks "field-only: not detected as shadow" "shadow round:" "$out"
 
 # --- usage and SHA validation (REVIEW.md R5) ----------------------------------
 rc=0; sh "$COMPARE" >/dev/null 2>&1 || rc=$?

--- a/scripts/test-review-compare.sh
+++ b/scripts/test-review-compare.sh
@@ -1,0 +1,181 @@
+#!/bin/sh
+# Offline fixtures for review-compare.sh (issue #887): the compare table and
+# the for-ledger line on a shadow/authoritative round pair (one missed P0,
+# one missed P1, one unconfirmed, two matches, one severity drift), the
+# no-SHADOW exit, and the pending-authoritative exit. Everything is offline:
+# comments come from EDDA_COMPARE_FIXTURE files holding the exact stream
+# `gh pr view <pr> --json comments --jq '.comments[] | "<<<COMMENT>>>", .body'`
+# prints, so no gh, no network, and no state outside the temp dir.
+# Style follows scripts/test-pr-review-watch.sh — no new tooling.
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' 0 HUP INT TERM
+
+COMPARE="$root/scripts/review-compare.sh"
+SHA=0123456789abcdef0123456789abcdef01234567
+OTHER=ffffffffffffffffffffffffffffffffffffffff
+
+# --- helpers ------------------------------------------------------------------
+expect_rc() { # name expected_rc actual_rc
+    if [ "$2" = "$3" ]; then :; else
+        printf '%s: expected exit %s, got %s\n' "$1" "$2" "$3" >&2
+        return 1
+    fi
+}
+expect_has() { # name needle file
+    if grep -Fq -- "$2" "$3"; then :; else
+        printf '%s: output missing: %s\n' "$1" "$2" >&2
+        return 1
+    fi
+}
+expect_lacks() { # name needle file
+    if grep -Fq -- "$2" "$3"; then
+        printf '%s: output must not contain: %s\n' "$1" "$2" >&2
+        return 1
+    fi
+}
+
+# --- fixture 1: shadow + two authoritative rounds + an unpinned decoy ---------
+# Stream order is chronological, so "latest" is the last match: the decoy
+# (other SHA) and the Round 1 authoritative comment must both be ignored.
+F1="$tmp/mixed-stream.txt"
+cat >"$F1" <<'EOF'
+<<<COMMENT>>>
+## Code Review: Round 1 — PR #887 @ ffffffffffffffffffffffffffffffffffffffff
+
+- model_observed: decoy-engine
+
+### Findings
+- [P0] [U1] decoy finding — evidence: README.md:3
+
+### Verdict
+Changes Requested, P0=1, P1=0 — decoy on another SHA
+<<<COMMENT>>>
+## Code Review: Round 1 — PR #887 @ 0123456789abcdef0123456789abcdef01234567
+
+- model_observed: old-engine
+
+### Findings
+- [P2] [D1] stale old claim — evidence: README.md:9
+
+### Verdict
+Changes Requested, P0=0, P1=0 — superseded authoritative round
+<<<COMMENT>>>
+## Code Review: Round 2 (SHADOW) — PR #887 @ 0123456789abcdef0123456789abcdef01234567
+
+- model_requested: glm-5.3-flash
+- model_observed: glm-5.3-flash
+- shadow: true
+
+### Findings
+- [P1] [R3] changed script does not parse — evidence: scripts/x.sh:12
+- [P1] [R1] destructive command without an enumerated trigger — evidence: scripts/y.sh:9
+- [P2] [D5] wording — evidence: REVIEW.md:100
+- [P1] wiring slot unfilled — evidence: docs/fleet/rules.md:7
+
+### Verdict
+Changes Requested, P0=0, P1=2 — shadow round, not a verdict
+<<<COMMENT>>>
+## Code Review: Round 3 — PR #887 @ 0123456789abcdef0123456789abcdef01234567
+
+- model_observed: claude-opus-5
+
+### Findings
+- [P0] [U1] out-of-surface file — evidence: crates/edda-core/src/types.rs:42
+- [P1] [D2] ledger claim stale — evidence: REVIEW.md:88
+- [P1] [R3] changed script does not parse — evidence: scripts/x.sh:12
+- [P2] [D5] wording — evidence: REVIEW.md:100
+- [P0] [R1] destructive command without an enumerated trigger — evidence: scripts/y.sh:9
+
+### Verdict
+Changes Requested, P0=2, P1=1 — authoritative round
+EOF
+
+# --- fixture 2: authoritative rounds only — no SHADOW round -------------------
+F2="$tmp/no-shadow.txt"
+cat >"$F2" <<'EOF'
+<<<COMMENT>>>
+## Code Review: Round 1 — PR #887 @ 0123456789abcdef0123456789abcdef01234567
+
+- model_observed: claude-opus-5
+
+### Findings
+- [P1] [U3] missing Issue line — evidence: PR body
+
+### Verdict
+Changes Requested, P0=0, P1=1 — authoritative only
+EOF
+
+# --- fixture 3: SHADOW round only — pending authoritative ---------------------
+F3="$tmp/pending.txt"
+cat >"$F3" <<'EOF'
+<<<COMMENT>>>
+## Code Review: Round 2 (SHADOW) — PR #887 @ 0123456789abcdef0123456789abcdef01234567
+
+- model_observed: glm-5.3-flash
+- shadow: true
+
+### Findings
+- [P0] [U1] out-of-surface file — evidence: crates/edda-core/src/types.rs:42
+- [P1] doneWhen item has no code behind it
+
+### Verdict
+Changes Requested, P0=1, P1=1 — shadow round, not a verdict
+EOF
+
+# --- scenario 1: mixed rounds — the compare table + for-ledger line -----------
+out="$tmp/s1.out"
+rc=0
+EDDA_COMPARE_FIXTURE="$F1" sh "$COMPARE" 887 "$SHA" >"$out" 2>&1 || rc=$?
+expect_rc "mixed: exit" 0 "$rc"
+expect_has "mixed: header" "shadow-review compare — PR 887 @ $SHA" "$out"
+expect_has "mixed: shadow round" "shadow round: Round 2 (SHADOW) (model_observed: glm-5.3-flash)" "$out"
+expect_has "mixed: latest authoritative" "authoritative round: Round 3 (model_observed: claude-opus-5)" "$out"
+expect_has "mixed: missed P0 row"   "| missed | U1 | — | P0 |" "$out"
+expect_has "mixed: missed P1 row"   "| missed | D2 | — | P1 |" "$out"
+expect_has "mixed: unconfirmed row" "| unconfirmed | docs/fleet/rules.md:7 | P1 | — |" "$out"
+expect_has "mixed: matched row 1"   "| matched | R3 | P1 | P1 |" "$out"
+expect_has "mixed: matched row 2"   "| matched | D5 | P2 | P2 |" "$out"
+expect_has "mixed: drift row"       "| severity drift | R1 | P1 | P0 |" "$out"
+expect_has "mixed: counts" \
+  "counts: missed_P0=1 missed_P1=1 unconfirmed=1 matched=2 drift=1" "$out"
+expect_has "mixed: for-ledger" \
+  "for-ledger: shadow=glm-5.3-flash authoritative=claude-opus-5 missed_P0=1 missed_P1=1 unconfirmed=1 matched=2 drift=1" "$out"
+expect_lacks "mixed: other-SHA decoy absent" "decoy" "$out"
+expect_lacks "mixed: other-SHA finding absent" "README.md:3" "$out"
+expect_lacks "mixed: superseded round absent" "old-engine" "$out"
+expect_lacks "mixed: superseded finding absent" "README.md:9" "$out"
+
+# --- scenario 2: no SHADOW round pinned to the SHA — exit 2 with a message ----
+out="$tmp/s2.out"
+rc=0
+EDDA_COMPARE_FIXTURE="$F2" sh "$COMPARE" 887 "$SHA" >"$out" 2>&1 || rc=$?
+expect_rc "no-shadow: exit" 2 "$rc"
+expect_has "no-shadow: message" "no SHADOW round pinned to PR 887 @ $SHA" "$out"
+
+# --- scenario 3: no authoritative round — pending, exit 0, never a silent zero -
+out="$tmp/s3.out"
+rc=0
+EDDA_COMPARE_FIXTURE="$F3" sh "$COMPARE" 887 "$SHA" >"$out" 2>&1 || rc=$?
+expect_rc "pending: exit" 0 "$rc"
+expect_has "pending: marker" "pending authoritative round" "$out"
+expect_has "pending: finding with rule id" "| U1 | P0 |" "$out"
+expect_has "pending: finding by text" "| doneWhen item has no code behind it | P1 |" "$out"
+expect_lacks "pending: no for-ledger line" "for-ledger:" "$out"
+expect_lacks "pending: no counts line" "counts:" "$out"
+
+# --- usage and SHA validation (REVIEW.md R5) ----------------------------------
+rc=0; sh "$COMPARE" >/dev/null 2>&1 || rc=$?
+expect_rc "usage: no args exits 2" 2 "$rc"
+rc=0; EDDA_COMPARE_FIXTURE="$F1" sh "$COMPARE" 887 0123456789abcdef >/dev/null 2>&1 || rc=$?
+expect_rc "usage: short sha exits 2" 2 "$rc"
+rc=0; EDDA_COMPARE_FIXTURE="$F1" sh "$COMPARE" not-a-number "$SHA" >/dev/null 2>&1 || rc=$?
+expect_rc "usage: non-numeric pr exits 2" 2 "$rc"
+
+# --- both new scripts parse ----------------------------------------------------
+sh -n "$COMPARE"
+sh -n "$root/scripts/test-review-compare.sh"
+
+printf 'review-compare fixtures passed\n'


### PR DESCRIPTION
## Summary
- Slice A of #887 on current `main`: `REVIEW.md` shadow round shape plus `scripts/review-compare.sh` and offline fixtures.
- Does **not** edit `scripts/review-pr.sh` or `scripts/pr-review-watch.sh` (open PRs #890 and #872 write those files). Remaining #887 doneWhen stays on the issue.
- Competing PR #906 (later `taking: docs/worker-1`) is a full-surface stack on #899 that does edit those scripts and uses `Closes #887`. 4090 claimed first (`taking: 4090/worker-3`). This PR is the mergeable slice that avoids that overlap.

Issue: #887

## Test plan
- [ ] `sh -n scripts/review-compare.sh scripts/test-review-compare.sh`
- [ ] `sh scripts/test-review-compare.sh`
- [ ] `grep -n shadow REVIEW.md` lists exactly the three §7/§8/§9 places
- [ ] Independent Review (pi glm-5.3-flash `--thinking max`, read-only) LGTM
- [ ] CI Gate green