### PR TITLE
feat(fleet): canary calibration runner scripts the README recipe (GH-881)

### DIFF
--- a/scripts/calibrate-canaries.sh
+++ b/scripts/calibrate-canaries.sh
@@ -1,0 +1,563 @@
+#!/bin/sh
+# calibrate-canaries.sh — the tests/canaries/README.md §「如何跑一次校準」
+# recipe as a script (issue #881; design #618 §1.2 and §7 item 7).
+#
+# For each requested engine (<backend>:<catalogue id>, id copied verbatim) it
+# builds a throwaway clone under ${TMPDIR:-/tmp}/edda-calib-$$, commits the
+# canary fixture pre-state, then commits the canary set (two commits, exactly
+# the README recipe), produces the target diff HEAD~1..HEAD, launches the
+# engine READ-ONLY once per run with cwd = the clone, collects model_observed
+# from the system (pi session file "model" field; claude --output-format json
+# "modelUsage" key — never from the transcript's own text, #616), scores each
+# canary mechanically against its expected.md front matter, and prints a
+# Markdown results table plus a for-ledger block. The clone is removed on
+# every exit path (trap on EXIT/INT/TERM).
+#
+# The script is calibration plumbing only: it never posts to GitHub, never
+# writes to the ledger and never runs `edda decide` — it prints the for-ledger
+# block; the controller records it (design §3: 本 lane 不執行 edda decide).
+#
+# Launch lines follow the review transport conventions (README recipe and
+# scripts/review-pr.sh): pi is read-only via the --tools read,grep,find,ls
+# allowlist; claude via the review allowlist
+# --allowedTools "Read,Grep,Glob,Bash(git *),Bash(sh *)".
+# Opus / Anthropic ids are never sent through pi
+# (fleet.claude-subscription-transport=claude-code-only): the check is data —
+# the id set is parsed out of the pi catalogue (`pi --list-models`), not
+# hard-coded (design §3 learning 3: ids are matched, never fuzzy-resolved).
+#
+# Scoring (mechanical, per tests/canaries/<class>/<name>/expected.md front
+# matter keys id/class/severity/file/match):
+#   caught          a FINDING line on the expected file whose text matches
+#                   the `match` regex (ERE);
+#   false-positive  no such finding, but a FINDING line on the canary's
+#                   surface (the expected file or anything under its
+#                   directory) that is not the expected finding;
+#   missed          otherwise.
+# severity_match compares the caught finding's reported severity with the
+# front-matter severity. A run whose engine exit ≠ 0 or whose model_observed
+# differs from model_requested marks every row of that run `void` — never
+# silently scored (model_requested ≠ model_observed is a P0 incident).
+# The mechanical score is conservative: human scoring per the expected.md
+# 評分提示 remains the authority for qualification decisions.
+#
+# usage: calibrate-canaries.sh --engine <backend>:<id> [--engine ...]
+#                              --brief <path> [--runs N] [--dry-run]
+#
+# exit: 0 all runs scored clean; 1 any run void/failed (all runs still
+#       complete); 2 usage / selector / expected.md front-matter errors —
+#       always before any engine launch.
+set -u
+
+usage() {
+  cat >&2 <<'EOF'
+usage: calibrate-canaries.sh --engine <backend>:<id> [--engine ...]
+                             --brief <path> [--runs N] [--dry-run]
+  --engine   repeatable; <backend> is `pi` or `claude`; <id> is a catalogue
+             id copied verbatim (e.g. pi:openrouter/z-ai/glm-5.3-flash)
+  --brief    reviewer brief path (reviewer-brief-template-v1 filled); the
+             script appends the mechanical-scoring output protocol to it
+  --runs     runs per engine (default 1)
+  --dry-run  print the clone path, the two commits, the target diff stat and
+             the exact launch line per run; launch nothing
+EOF
+}
+
+die() { # die <code> <message...>
+  code=$1; shift
+  printf 'calibrate-canaries.sh: %s\n' "$*" >&2
+  exit "$code"
+}
+
+ENGINES=''
+BRIEF=''
+RUNS=1
+DRY_RUN=0
+
+while [ $# -gt 0 ]; do
+  case $1 in
+    --engine)
+      [ $# -ge 2 ] || { usage; exit 2; }
+      ENGINES="$ENGINES
+$2"
+      shift 2 ;;
+    --engine=*)
+      ENGINES="$ENGINES
+${1#*=}"
+      shift ;;
+    --brief)
+      [ $# -ge 2 ] || { usage; exit 2; }
+      BRIEF=$2
+      shift 2 ;;
+    --brief=*)
+      BRIEF=${1#*=}
+      shift ;;
+    --runs)
+      [ $# -ge 2 ] || { usage; exit 2; }
+      RUNS=$2
+      shift 2 ;;
+    --runs=*)
+      RUNS=${1#*=}
+      shift ;;
+    --dry-run)
+      DRY_RUN=1
+      shift ;;
+    -h|--help)
+      usage
+      exit 0 ;;
+    *)
+      usage
+      exit 2 ;;
+  esac
+done
+
+[ -n "$BRIEF" ] || { usage; exit 2; }
+[ -f "$BRIEF" ] && [ -r "$BRIEF" ] || die 2 "brief not readable: $BRIEF"
+case $RUNS in
+  ''|*[!0-9]*) die 2 "--runs must be a positive integer: $RUNS" ;;
+esac
+[ "$RUNS" -ge 1 ] || die 2 "--runs must be a positive integer: $RUNS"
+ENGINES=${ENGINES#?
+}
+[ -n "$ENGINES" ] || { usage; exit 2; }
+
+SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) || exit 2
+WT=$(CDPATH= cd -- "$SELF_DIR/.." && pwd) || exit 2
+CANARIES_DIR="$WT/tests/canaries"
+[ -d "$CANARIES_DIR" ] || die 2 "canary set not found: $CANARIES_DIR"
+
+# ---------------------------------------------------------------------------
+# Discover canaries and validate the expected.md front matter (wiring audit
+# row 1: a missing key is a hard exit 2 naming the file — never a silent
+# "missed").
+# ---------------------------------------------------------------------------
+front_matter_field() { # <expected.md> <key> -> value
+  # Single awk process reading the file directly: a `sed | ... | head -n 1`
+  # pipeline has an early-exit reader and is prone to MSYS/Git Bash pipe
+  # deadlocks (observed as a hang in the validation loop on Windows).
+  awk -v key="$2" '
+    NR == 1 { next }
+    /^---[[:space:]]*$/ { exit }
+    index($0, key ":") == 1 {
+      v = $0
+      sub("^" key ":[[:space:]]*", "", v)
+      sub(/\r$/, "", v)
+      if (v ~ /^\047/) { sub(/^\047/, "", v); sub(/\047$/, "", v) }
+      else if (v ~ /^\042/) { sub(/^\042/, "", v); sub(/\042$/, "", v) }
+      print v
+      exit
+    }' "$1"
+}
+
+CANARIES=$(cd "$CANARIES_DIR" && ls -d */*/ 2>/dev/null | sed 's/\/$//;s/\r$//' | sort) || CANARIES=''
+[ -n "$CANARIES" ] || die 2 "no canary directories under $CANARIES_DIR"
+
+for cdir in $CANARIES; do
+  exp="$CANARIES_DIR/$cdir/expected.md"
+  [ -f "$exp" ] || die 2 "missing expected.md: $exp"
+  [ "$(sed -n '1{s/[[:space:]]*$//;p}' "$exp" | tr -d '\r')" = '---' ] \
+    || die 2 "expected.md without front matter (line 1 must be ---): $exp"
+  for key in id class severity file match; do
+    val=$(front_matter_field "$exp" "$key")
+    [ -n "$val" ] || die 2 "expected.md front matter missing key '$key': $exp"
+  done
+  sev=$(front_matter_field "$exp" severity)
+  case $sev in
+    P[0-3]) ;;
+    *) die 2 "expected.md severity must be P0..P3, got '$sev': $exp" ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Engine selector validation — data, not vibes: the Anthropic-id set is
+# parsed from the pi catalogue. `claude:` + non-Anthropic id and `pi:` +
+# Anthropic id exit 2 before any launch
+# (fleet.claude-subscription-transport=claude-code-only).
+# ---------------------------------------------------------------------------
+load_catalogue() {
+  if command -v pi >/dev/null 2>&1; then
+    pi --list-models 2>/dev/null
+  elif command -v edda >/dev/null 2>&1; then
+    edda dispatch --agent pi --list-models 2>/dev/null
+  else
+    return 1
+  fi
+}
+
+CATALOGUE=$(load_catalogue) \
+  || die 2 "cannot validate engine selectors: pi catalogue unavailable (install pi or edda)"
+
+# rows: "<A|N> <pi selector id>" — A = Anthropic (pi transport forbidden),
+# N = non-Anthropic (claude transport forbidden).
+ID_CLASSES=$(printf '%s\n' "$CATALOGUE" | awk '
+  NF >= 2 && $1 != "provider" {
+    if ($1 == "anthropic") { print "A " $2; print "A anthropic/" $2 }
+    else if ($2 ~ /^~?anthropic\//) { print "A " $1 "/" $2 }
+    else print "N " $1 "/" $2
+  }')
+
+id_class() { # <id> -> A | N | ''
+  printf '%s\n' "$ID_CLASSES" | awk -v id="$1" '$2 == id { print $1; exit }'
+}
+
+sanitize() { # engine id -> session-id-safe token
+  printf '%s' "$1" | sed 's/[^A-Za-z0-9._-]/-/g'
+}
+
+VALIDATED=''
+for sel in $ENGINES; do
+  case $sel in
+    *:*) backend=${sel%%:*}; id=${sel#*:} ;;
+    *) die 2 "engine selector grammar is <backend>:<catalogue id>, got: $sel" ;;
+  esac
+  case $backend in
+    pi|claude) ;;
+    *) die 2 "unknown backend '$backend' in selector $sel (pi|claude)" ;;
+  esac
+  [ -n "$id" ] || die 2 "empty catalogue id in selector $sel"
+  case $id in
+    *:*) die 2 "catalogue id must not contain ':' (copy the id verbatim from pi --list-models): $id" ;;
+  esac
+  cls=$(id_class "$id")
+  if [ "$backend" = pi ] && [ "$cls" = A ]; then
+    die 2 "refusing pi transport for Anthropic id '$id' (fleet.claude-subscription-transport=claude-code-only)"
+  fi
+  if [ "$backend" = claude ] && [ "$cls" = N ]; then
+    die 2 "refusing claude transport for non-Anthropic id '$id' (fleet.claude-subscription-transport=claude-code-only)"
+  fi
+  VALIDATED="$VALIDATED
+$backend|$id"
+done
+VALIDATED=${VALIDATED#?
+}
+
+# ---------------------------------------------------------------------------
+# Launch-line builders (single source of truth for --dry-run and real runs).
+# ---------------------------------------------------------------------------
+pi_launch_line() { # <id> <san> <run> <clone>
+  printf '(cd "%s" && pi -p --model %s --tools read,grep,find,ls --session-dir "%s/sessions/r%s" --session-id calib-%s-%s "$(cat calib-brief.md)")' \
+    "$4" "$1" "$4" "$3" "$2" "$3"
+}
+
+claude_launch_line() { # <id> <san> <run> <clone>
+  printf '(cd "%s" && claude -p --model %s --allowedTools "Read,Grep,Glob,Bash(git *),Bash(sh *)" --output-format json < calib-brief.md)' \
+    "$4" "$1"
+}
+
+FIXTURE_COMMIT_MSG='calibration: canary fixture pre-state'
+CANARY_COMMIT_MSG='calibration: canary set v0'
+PATCHES=''
+for cdir in $CANARIES; do
+  PATCHES="$PATCHES
+$CANARIES_DIR/$cdir/diff.patch"
+done
+PATCHES=${PATCHES#?
+}
+
+DRY_TARGET_STAT=''
+for p in $PATCHES; do
+  [ -f "$p" ] || die 2 "missing canary patch: $p"
+  DRY_TARGET_STAT="$DRY_TARGET_STAT$(cat "$p")
+"
+done
+DRY_TARGET_STAT=$(printf '%s' "$DRY_TARGET_STAT" | git apply --stat - 2>/dev/null)
+
+# ---------------------------------------------------------------------------
+# Dry run: describe everything, launch nothing (not even a review run).
+# ---------------------------------------------------------------------------
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "clone: ${TMPDIR:-/tmp}/edda-calib-$$  (branch calib-canary-v0, from origin/main)"
+  echo
+  echo "commit 1: \"$FIXTURE_COMMIT_MSG\""
+  for cdir in $CANARIES; do
+    if [ -d "$CANARIES_DIR/$cdir/fixture" ]; then
+      echo "  cp -r tests/canaries/$cdir/fixture -> canaries-fixture/$(basename "$cdir")"
+    fi
+  done
+  echo "commit 2: \"$CANARY_COMMIT_MSG\""
+  for cdir in $CANARIES; do
+    echo "  git apply tests/canaries/$cdir/diff.patch"
+  done
+  echo
+  echo "target diff (HEAD~1..HEAD) stat:"
+  printf '%s\n' "$DRY_TARGET_STAT"
+  echo
+  echo "brief: $BRIEF (a fixed output-protocol addendum for mechanical scoring is appended)"
+  echo
+  for pair in $VALIDATED; do
+    backend=${pair%%|*}
+    id=${pair#*|}
+    san=$(sanitize "$id")
+    run=1
+    while [ "$run" -le "$RUNS" ]; do
+      if [ "$backend" = pi ]; then
+        pi_launch_line "$id" "$san" "$run" '${TMPDIR:-/tmp}/edda-calib-'"$$"
+      else
+        claude_launch_line "$id" "$san" "$run" '${TMPDIR:-/tmp}/edda-calib-'"$$"
+      fi
+      echo "  ^ run $run/$RUNS for $backend:$id"
+      run=$((run + 1))
+    done
+  done
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Real run: throwaway clone, two commits, target diff, per-run launches.
+# ---------------------------------------------------------------------------
+CLONE="${TMPDIR:-/tmp}/edda-calib-$$"
+cleanup() { rm -rf -- "$CLONE"; }
+trap cleanup EXIT
+trap 'cleanup; trap - EXIT; exit 130' INT
+trap 'cleanup; trap - EXIT; exit 143' TERM
+
+git clone --quiet "$WT" "$CLONE" \
+  || die 2 "git clone $WT -> $CLONE failed"
+cd "$CLONE" || die 2 "cd $CLONE failed"
+git checkout -q -B calib-canary-v0 origin/main 2>/dev/null \
+  || git checkout -q -B calib-canary-v0 \
+  || die 2 "checkout calib-canary-v0 failed"
+
+# Commit 1 — fixture pre-state (fact sources land before the review target).
+mkdir -p canaries-fixture
+for cdir in $CANARIES; do
+  if [ -d "$CANARIES_DIR/$cdir/fixture" ]; then
+    cp -r "$CANARIES_DIR/$cdir/fixture" "canaries-fixture/$(basename "$cdir")"
+  fi
+done
+if [ -n "$(git status --porcelain -- canaries-fixture)" ]; then
+  git add canaries-fixture
+  git commit -q -m "$FIXTURE_COMMIT_MSG" || die 2 "fixture pre-state commit failed"
+fi
+
+# Commit 2 — the canary set (the review target).
+for cdir in $CANARIES; do
+  git apply "$CANARIES_DIR/$cdir/diff.patch" \
+    || die 2 "git apply failed for $cdir"
+done
+git add -A
+git commit -q -m "$CANARY_COMMIT_MSG" || die 2 "canary commit failed"
+
+echo "clone: $CLONE"
+echo "target diff (HEAD~1..HEAD) stat:"
+git diff --stat HEAD~1..HEAD
+echo
+
+# Brief = the supplied brief verbatim + the output-protocol addendum that the
+# mechanical scorer parses (FINDING lines; everything else is narrative).
+{
+  cat "$BRIEF"
+  cat <<'EOF'
+
+## 輸出協定（校準評分——機械解析，務必遵守）
+
+每個 finding 用一行固定格式輸出（其餘敘述不會被計分）：
+
+FINDING P<n> <repo 相對路徑> — <一行 finding 描述>
+
+- P<n> 是你對該 finding 的 severity 判定（P0/P1/P2）。
+- <repo 相對路徑> 指向證據所在檔案（可帶 :行號）。
+- 沒有 finding 時，輸出一行：NO FINDINGS
+EOF
+} > calib-brief.md
+
+
+any_void=0
+
+score_run() { # <transcript> -> ROW lines (canary result severity_match) on stdout
+  transcript=$1
+  findings_file=$1.findings
+  sed -n -E 's/^FINDING[[:space:]]+(P[0-3])[[:space:]]+([^[:space:]]+)[[:space:]]+(-|—)[[:space:]]+(.*)$/\1\t\2\t\4/p' \
+    "$transcript" > "$findings_file" 2>/dev/null
+
+  for cdir in $CANARIES; do
+    exp="$CANARIES_DIR/$cdir/expected.md"
+    cid=$(front_matter_field "$exp" id)
+    sev=$(front_matter_field "$exp" severity)
+    file=$(front_matter_field "$exp" file)
+    regex=$(front_matter_field "$exp" match)
+    exp_dir=$(dirname "$file")
+
+    caught=0
+    sev_ok=0
+    on_surface=0
+    while IFS="$(printf '\t')" read -r fsev fpath ftext; do
+      [ -n "$fpath" ] || continue
+      ffile=${fpath%%:*}
+      case $ffile in
+        "$exp_dir"/*) on_surface=1 ;;
+      esac
+      case $ffile in
+        "$file")
+          if printf '%s\n' "$ftext" | grep -Eq -- "$regex" 2>/dev/null; then
+            caught=1
+            [ "$fsev" = "$sev" ] && sev_ok=1
+          else
+            on_surface=1
+          fi
+          ;;
+      esac
+    done < "$findings_file"
+
+    if [ "$caught" -eq 1 ]; then
+      result=caught
+      [ "$sev_ok" -eq 1 ] && smatch=yes || smatch=no
+    elif [ "$on_surface" -eq 1 ]; then
+      result=false-positive
+      smatch=-
+    else
+      result=missed
+      smatch=-
+    fi
+    printf 'ROW %s %s %s\n' "$cid" "$result" "$smatch"
+  done
+  rm -f "$findings_file"
+}
+
+for pair in $VALIDATED; do
+  backend=${pair%%|*}
+  id=${pair#*|}
+  san=$(sanitize "$id")
+  echo "## engine $backend:$id"
+  echo
+  echo '| canary | run | result | severity_match | model_requested | model_observed | cost_usd |'
+  echo '|---|---|---|---|---|---|---|'
+
+  union_file="$CLONE/union-$san"
+  : > "$union_file"
+  costs=''
+  last_observed=unknown
+  last_cost='-'
+
+  run=1
+  while [ "$run" -le "$RUNS" ]; do
+    out="$CLONE/out-$san-$run.txt"
+    sess_dir="$CLONE/sessions/r$run"
+    rm -rf "$sess_dir"
+
+    if [ "$backend" = pi ]; then
+      eval "$(pi_launch_line "$id" "$san" "$run" "$CLONE")" > "$out" 2>"$out.err"
+    else
+      eval "$(claude_launch_line "$id" "$san" "$run" "$CLONE")" > "$out.json" 2>"$out.err"
+    fi
+    exit_code=$?
+
+    # model_observed comes from the system — pi session file "model" field /
+    # claude JSON envelope modelUsage key — never from the transcript's own
+    # text (#616). A mismatch voids the run instead of being silently scored.
+    observed=unknown
+    cost=''
+    if [ "$backend" = pi ]; then
+      sess_file=$(ls -t "$sess_dir"/*.jsonl 2>/dev/null | head -n 1)
+      if [ -n "${sess_file:-}" ] && [ -f "$sess_file" ]; then
+        observed=$(grep -o '"model":"[^"]*"' "$sess_file" | tail -n 1 | sed 's/.*:"//;s/"$//')
+        [ -n "$observed" ] \
+          || observed=$(grep -o '"modelId":"[^"]*"' "$sess_file" | tail -n 1 | sed 's/.*:"//;s/"$//')
+        cost=$(grep -o '"cost":{[^}]*}' "$sess_file" | tail -n 1 \
+          | sed -n 's/.*"total":\([0-9.e+-]*\).*/\1/p')
+      fi
+    else
+      if command -v jq >/dev/null 2>&1; then
+        observed=$(jq -r '.modelUsage | keys[0] // "unknown"' "$out.json" 2>/dev/null)
+        cost=$(jq -r '.total_cost_usd // empty' "$out.json" 2>/dev/null)
+        jq -r '.result // empty' "$out.json" 2>/dev/null > "$out"
+      else
+        echo "calibrate-canaries.sh: jq not found on PATH — cannot read claude modelUsage/cost; run voided" >&2
+      fi
+    fi
+    [ -n "$observed" ] || observed=unknown
+
+    if [ "$exit_code" -ne 0 ]; then
+      any_void=1
+      reason="engine exit $exit_code"
+    elif [ "$observed" != "$id" ]; then
+      any_void=1
+      reason='model_observed mismatch (model_requested ≠ model_observed is a P0 incident)'
+    else
+      reason=''
+    fi
+
+    rows_file="$CLONE/rows-$san-$run"
+    if [ -n "$reason" ]; then
+      for cdir in $CANARIES; do
+        cid=$(front_matter_field "$CANARIES_DIR/$cdir/expected.md" id)
+        printf 'ROW %s void -\n' "$cid"
+      done > "$rows_file"
+      printf 'calibrate-canaries.sh: run void — %s:%s run %s (%s; requested=%s observed=%s)\n' \
+        "$backend" "$id" "$run" "$reason" "$id" "$observed" >&2
+    else
+      score_run "$out" > "$rows_file"
+    fi
+
+    if [ -n "$cost" ]; then costcell=$cost; else costcell='-'; fi
+    while IFS="$(printf ' 	')" read -r _tag cid result smatch; do
+      [ -n "$cid" ] || continue
+      printf '| %s | %s | %s | %s | %s | %s | %s |\n' \
+        "$cid" "$run" "$result" "$smatch" "$id" "$observed" "$costcell"
+      printf '%s %s %s %s\n' "$cid" "$result" "$smatch" "$costcell" >> "$union_file"
+    done < "$rows_file"
+    rm -f "$rows_file"
+
+    case $cost in
+      ''|*[!0-9.]*) ;;  # not a plain number — excluded from the sum
+      *) costs="$costs
+$cost" ;;
+    esac
+    last_observed=$observed
+    last_cost=$costcell
+    run=$((run + 1))
+  done
+
+  # Union row per canary across this engine's runs: caught beats
+  # false-positive beats missed; severity_match yes iff every caught run
+  # reported the expected severity.
+  for cdir in $CANARIES; do
+    exp="$CANARIES_DIR/$cdir/expected.md"
+    cid=$(front_matter_field "$exp" id)
+    ucaught=0; ufp=0; uallmatch=1
+    while IFS="$(printf ' \t')" read -r _cid uresult usmatch _ucost; do
+      [ -n "$uresult" ] || continue
+      case $uresult in
+        caught) ucaught=1; [ "$usmatch" = yes ] || uallmatch=0 ;;
+        false-positive) ufp=1 ;;
+      esac
+    done <<UNIONEOF
+$(grep "^$cid " "$union_file")
+UNIONEOF
+    if [ "$ucaught" -eq 1 ]; then
+      uresult=caught
+      [ "$uallmatch" -eq 1 ] && usmatch=yes || usmatch=no
+    elif [ "$ufp" -eq 1 ]; then
+      uresult=false-positive
+      usmatch=-
+    else
+      uresult=missed
+      usmatch=-
+    fi
+    usum=$(grep "^$cid " "$union_file" | awk '$4 ~ /^[0-9.]+$/ {s+=$4} END {if (s != "") printf "%.6f", s}')
+    [ -n "$usum" ] || usum='-'
+    printf '| %s | union | %s | %s | %s | %s | %s |\n' \
+      "$cid" "$uresult" "$usmatch" "$id" "$last_observed" "$usum"
+  done
+  rm -f "$union_file"
+
+  # for-ledger block — the controller records it; this script never runs
+  # `edda decide`, never writes the ledger, never posts to GitHub.
+  usum=$(printf '%s\n' "$costs" | awk 'NF && $1 ~ /^[0-9.]+$/ {s+=$1} END {if (s != "") printf "%.6f", s; else print "-"}')
+  echo
+  echo '## for-ledger — fleet.review-calibration'
+  echo
+  echo '本腳本不執行 edda decide、不寫帳本、不發 GitHub 請求；以下區塊由操作者逐字記帳本。'
+  echo
+  echo "engine: $backend:$id"
+  echo "requested: $id"
+  echo "observed: $last_observed"
+  echo "cost_usd: $usum"
+  echo "runs: $RUNS (void runs are marked void in the table)"
+  echo
+done
+
+if [ "$any_void" -eq 1 ]; then
+  exit 1
+fi
+exit 0

--- a/scripts/calibrate-canaries.sh
+++ b/scripts/calibrate-canaries.sh
@@ -266,7 +266,7 @@ DRY_TARGET_STAT=$(printf '%s' "$DRY_TARGET_STAT" | git apply --stat - 2>/dev/nul
 # Dry run: describe everything, launch nothing (not even a review run).
 # ---------------------------------------------------------------------------
 if [ "$DRY_RUN" -eq 1 ]; then
-  echo "clone: ${TMPDIR:-/tmp}/edda-calib.XXXXXX/repo  (branch calib-canary-v0, from origin/main)"
+  echo 'clone: ${TMPDIR:-/tmp}/edda-calib.XXXXXX/repo  (branch calib-canary-v0, from origin/main)'
   echo
   echo "commit 1: \"$FIXTURE_COMMIT_MSG\""
   for cdir in $CANARIES; do

--- a/scripts/calibrate-canaries.sh
+++ b/scripts/calibrate-canaries.sh
@@ -3,7 +3,7 @@
 # recipe as a script (issue #881; design #618 §1.2 and §7 item 7).
 #
 # For each requested engine (<backend>:<catalogue id>, id copied verbatim) it
-# builds a throwaway clone under ${TMPDIR:-/tmp}/edda-calib-$$, commits the
+# builds a throwaway clone under a fresh mktemp -d directory, commits the
 # canary fixture pre-state, then commits the canary set (two commits, exactly
 # the README recipe), produces the target diff HEAD~1..HEAD, launches the
 # engine READ-ONLY once per run with cwd = the clone, collects model_observed
@@ -266,7 +266,7 @@ DRY_TARGET_STAT=$(printf '%s' "$DRY_TARGET_STAT" | git apply --stat - 2>/dev/nul
 # Dry run: describe everything, launch nothing (not even a review run).
 # ---------------------------------------------------------------------------
 if [ "$DRY_RUN" -eq 1 ]; then
-  echo "clone: ${TMPDIR:-/tmp}/edda-calib-$$  (branch calib-canary-v0, from origin/main)"
+  echo "clone: ${TMPDIR:-/tmp}/edda-calib.XXXXXX/repo  (branch calib-canary-v0, from origin/main)"
   echo
   echo "commit 1: \"$FIXTURE_COMMIT_MSG\""
   for cdir in $CANARIES; do
@@ -291,9 +291,9 @@ if [ "$DRY_RUN" -eq 1 ]; then
     run=1
     while [ "$run" -le "$RUNS" ]; do
       if [ "$backend" = pi ]; then
-        pi_launch_line "$id" "$san" "$run" '${TMPDIR:-/tmp}/edda-calib-'"$$"
+        pi_launch_line "$id" "$san" "$run" '${TMPDIR:-/tmp}/edda-calib.XXXXXX/repo'
       else
-        claude_launch_line "$id" "$san" "$run" '${TMPDIR:-/tmp}/edda-calib-'"$$"
+        claude_launch_line "$id" "$san" "$run" '${TMPDIR:-/tmp}/edda-calib.XXXXXX/repo'
       fi
       echo "  ^ run $run/$RUNS for $backend:$id"
       run=$((run + 1))
@@ -305,8 +305,14 @@ fi
 # ---------------------------------------------------------------------------
 # Real run: throwaway clone, two commits, target diff, per-run launches.
 # ---------------------------------------------------------------------------
-CLONE="${TMPDIR:-/tmp}/edda-calib-$$"
-cleanup() { rm -rf -- "$CLONE"; }
+# A fresh mktemp -d, never "$$": PIDs are reused, the traps below fire on
+# every exit path including the failure path, and several lanes run at once on
+# this workstation — a PID collision would have one run delete another run's
+# directory. The clone goes in a subdirectory so the path is both unique and
+# ours, and cleanup removes the whole workspace rather than the clone alone.
+CALIB_TMP=$(mktemp -d "${TMPDIR:-/tmp}/edda-calib.XXXXXX") || die 2 "mktemp -d failed"
+CLONE="$CALIB_TMP/repo"
+cleanup() { rm -rf -- "$CALIB_TMP"; }
 trap cleanup EXIT
 trap 'cleanup; trap - EXIT; exit 130' INT
 trap 'cleanup; trap - EXIT; exit 143' TERM

--- a/scripts/test-calibrate-canaries.sh
+++ b/scripts/test-calibrate-canaries.sh
@@ -1,0 +1,334 @@
+#!/bin/sh
+# test-calibrate-canaries.sh — offline test for scripts/calibrate-canaries.sh
+# (issue #881). Stubs `pi` and `claude` with fixture transcripts on PATH and
+# asserts the mechanical scorer end to end:
+#
+#   1. sh -n passes on both scripts;
+#   2. every expected.md carries front matter (grep -L '^id:' is empty);
+#   3. --dry-run prints the clone path, both commits, the target diff stat and
+#      the exact launch line per run, and launches no engine run;
+#   4. selector grammar <backend>:<id>: pi + Anthropic id and claude +
+#      non-Anthropic id exit 2 before launch (the id set is data, parsed from
+#      the stubbed pi catalogue);
+#   5. scoring: caught, missed, false positive, severity mismatch
+#      (caught + severity_match no);
+#   6. model_observed from the session file / JSON — a mismatch marks the row
+#      void (never silently scored) and the script exits 1;
+#   7. the for-ledger block and the per-canary union row are printed;
+#   8. the clone is removed on every exit path and nothing is written outside
+#      the test's temp dir.
+#
+# Style follows scripts/test-review-capabilities.sh — no new tooling.
+set -u
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) || exit 1
+CALIBRATE="$SCRIPT_DIR/calibrate-canaries.sh"
+
+failures=0
+bad() { failures=$((failures + 1)); printf 'FAIL: %s\n' "$1" >&2; }
+good() { printf 'ok: %s\n' "$1" >&2; }
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/test-calibrate-canaries.XXXXXX") || exit 1
+cleanup() { rm -rf -- "$WORK"; }
+trap cleanup EXIT
+trap 'cleanup; trap - EXIT; exit 130' INT
+trap 'cleanup; trap - EXIT; exit 143' TERM
+
+STUBS="$WORK/stubs"
+LOG="$WORK/stub.log"
+TEST_TMPDIR="$WORK/tmpdir"
+TMPDIR_REAL="${TMPDIR:-/tmp}"
+mkdir -p "$STUBS" "$TEST_TMPDIR"
+export TMPDIR="$TEST_TMPDIR"
+
+# --- stubs -----------------------------------------------------------------
+# The stub catalogue includes anthropic provider rows, openrouter
+# anthropic/* rows and the ~anthropic latest aliases — the data the selector
+# check classifies.
+cat > "$STUBS/pi" <<EOF
+#!/bin/sh
+printf '%s\n' "\$*" >> "$LOG"
+if [ "\$1" = "--list-models" ]; then
+  cat <<'CATALOGUE'
+provider      model                          context  max-out  thinking  images
+anthropic     claude-opus-5                  1M       128K     yes       yes
+openrouter    anthropic/claude-opus-4.5      200K     64K      yes       yes
+openrouter    ~anthropic/claude-opus-latest  1M       128K     yes       yes
+openrouter    z-ai/glm-5.3-flash             1M       943.7K   yes       yes
+openai-codex  gpt-5.6-sol                    272K     128K     yes       yes
+CATALOGUE
+  exit 0
+fi
+# run mode: extract --model and --session-dir
+model=unknown
+sess_dir=
+prev=
+for a in "\$@"; do
+  case \$prev in
+    --model) model=\$a ;;
+    --session-dir) sess_dir=\$a ;;
+  esac
+  prev=\$a
+done
+[ -n "\$sess_dir" ] || { echo 'stub pi: no --session-dir' >&2; exit 3; }
+mkdir -p "\$sess_dir"
+observed=\${CALIB_STUB_SESSION_MODEL:-\$model}
+{
+  printf '{"type":"session","id":"stub"}\n'
+  printf '{"type":"model_change","provider":"stub","modelId":"%s"}\n' "\$observed"
+  printf '{"type":"message","message":{"role":"assistant","api":{"model":"%s"},"usage":{"cost":{"input":0.0005,"output":0.0004,"total":0.0009}}}}\n' "\$observed"
+} > "\$sess_dir/stub-session.jsonl"
+cat "\$CALIB_STUB_TRANSCRIPT"
+exit 0
+EOF
+
+cat > "$STUBS/claude" <<EOF
+#!/bin/sh
+printf '%s\n' "\$*" >> "$LOG"
+model=unknown
+prev=
+for a in "\$@"; do
+  case \$prev in
+    --model) model=\$a ;;
+  esac
+  prev=\$a
+done
+observed=\${CALIB_STUB_CLAUDE_MODEL:-\$model}
+result=\$(cat "\$CALIB_STUB_TRANSCRIPT" | sed ':a;N;\$!ba;s/\n/\\\\n/g')
+printf '{"result":"%s","session_id":"stub-claude","modelUsage":{"%s":{"costUSD":0.4169}},"total_cost_usd":0.4169}\n' "\$result" "\$observed"
+exit 0
+EOF
+
+chmod +x "$STUBS/pi" "$STUBS/claude"
+
+BRIEF="$WORK/calib-brief.md"
+printf '你是唯讀審查員。審查目標：canary set v0。\n' > "$BRIEF"
+
+GLM='pi:openrouter/z-ai/glm-5.3-flash'
+run_calibrate() { # extra args...
+  PATH="$STUBS:$PATH" sh "$CALIBRATE" \
+    --engine "$GLM" --brief "$BRIEF" "$@" 2>"$WORK/stderr.txt"
+}
+
+# --- 1. syntax -------------------------------------------------------------
+if sh -n "$CALIBRATE" && sh -n "$SCRIPT_DIR/test-calibrate-canaries.sh"; then
+  good 'sh -n both scripts'
+else
+  bad 'sh -n failed'
+fi
+
+# --- 2. front matter coverage ----------------------------------------------
+missing=$(cd "$SCRIPT_DIR/.." && grep -L '^id:' tests/canaries/*/*/expected.md)
+if [ -z "$missing" ]; then
+  good 'grep -L ^id: tests/canaries/*/*/expected.md is empty'
+else
+  bad "expected.md missing front matter: $missing"
+fi
+
+# --- 3. dry-run -------------------------------------------------------------
+: > "$LOG"
+out=$(run_calibrate --runs 2 --dry-run)
+rc=$?
+[ "$rc" -eq 0 ] || bad "dry-run exit $rc"
+case $out in
+  *edda-calib-*) good 'dry-run prints the clone path under TMPDIR' ;;
+  *) bad 'dry-run does not print the clone path' ;;
+esac
+case $out in
+  *'calibration: canary fixture pre-state'*) good 'dry-run prints fixture commit' ;;
+  *) bad 'dry-run does not print the fixture commit' ;;
+esac
+case $out in
+  *'calibration: canary set v0'*) good 'dry-run prints canary commit' ;;
+  *) bad 'dry-run does not print the canary commit' ;;
+esac
+case $out in
+  *'5 files changed'*) good 'dry-run prints the target diff stat' ;;
+  *) bad 'dry-run does not print the target diff stat' ;;
+esac
+case $out in
+  *'--tools read,grep,find,ls --session-dir'*'--session-id calib-openrouter-z-ai-glm-5.3-flash-2'*)
+    good 'dry-run prints the exact pi launch line per run' ;;
+  *) bad 'dry-run does not print the exact pi launch line per run' ;;
+esac
+if [ -z "$(find "$TEST_TMPDIR" -maxdepth 1 -name 'edda-calib-*' -print -quit)" ]; then
+  good 'dry-run creates no clone'
+else
+  bad 'dry-run created a clone'
+fi
+if grep -q '^--tools ' "$LOG" 2>/dev/null || grep -qv -- '--list-models' "$LOG"; then
+  bad "dry-run launched an engine run: $LOG"
+else
+  good 'dry-run launched no engine run (catalogue query only)'
+fi
+
+# --- 4. selector validation -------------------------------------------------
+selector_case() { # <selector> <expected-rc>
+  sel=$1
+  want=$2
+  PATH="$STUBS:$PATH" sh "$CALIBRATE" --engine "$sel" --brief "$BRIEF" --dry-run >/dev/null 2>&1
+  got=$?
+  if [ "$got" -eq "$want" ]; then
+    good "selector $sel -> exit $want"
+  else
+    bad "selector $sel: expected exit $want, got $got"
+  fi
+}
+selector_case 'pi:anthropic/claude-opus-5' 2
+selector_case 'pi:openrouter/anthropic/claude-opus-4.5' 2
+selector_case 'pi:openrouter/~anthropic/claude-opus-latest' 2
+selector_case 'claude:openai-codex/gpt-5.6-sol' 2
+selector_case 'claude:openrouter/z-ai/glm-5.3-flash' 2
+selector_case 'nocolon' 2
+selector_case 'wrong:x' 2
+selector_case 'pi:' 2
+selector_case 'claude:claude-opus-5' 0
+selector_case 'pi:openai-codex/gpt-5.6-sol' 0
+
+# --- 5./6. scoring scenarios (stubbed pi) -----------------------------------
+C1='tests/canaries/code-risk/c1-shell-precedence'
+C2='tests/canaries/docs-skills/c2-stale-ratify-claim'
+
+scenario() { # <name> <transcript-file> <expected-substring> <want-rc>
+  name=$1
+  printf '%s\n' "$2" > "$WORK/transcript.txt"
+  CALIB_STUB_TRANSCRIPT="$WORK/transcript.txt"
+  export CALIB_STUB_TRANSCRIPT
+  out=$(run_calibrate --runs 1)
+  got=$?
+  if [ "$got" -eq "$4" ]; then
+    good "$name exit $got"
+  else
+    bad "$name: expected exit $4, got $got (stderr: $(head -2 "$WORK/stderr.txt"))"
+  fi
+  case $out in
+    *"$3"*) good "$name row: $3" ;;
+    *) bad "$name: row '$3' not found in output:
+$(printf '%s\n' "$out" | grep '^| c')"
+    ;;
+  esac
+  if [ -z "$(find "$TEST_TMPDIR" -maxdepth 1 -name 'edda-calib-*' -print -quit)" ]; then
+    good "$name clone removed"
+  else
+    bad "$name left a clone behind"
+  fi
+}
+
+scenario caught \
+  'FINDING P0 canaries-fixture/c1-shell-precedence/deploy.sh:7 — POSIX sh 把 || 與 && 同優先序、左結合，解析為 (fast_build || cleanup) && git rm -rf .，fast_build 成功的正常路徑也會執行 git rm -rf .' \
+  '| c1-shell-precedence | 1 | caught | yes |' 0
+
+scenario missed \
+  'NO FINDINGS' \
+  '| c2-stale-ratify-claim | 1 | missed | - |' 0
+
+scenario false-positive \
+  'FINDING P1 canaries-fixture/c2-stale-ratify-claim/LEDGER.md:3 — LEDGER.md 的事件日期格式不一致，建議統一格式' \
+  '| c2-stale-ratify-claim | 1 | false-positive | - |' 0
+
+scenario severity-mismatch \
+  'FINDING P2 canaries-fixture/c2-stale-ratify-claim/STATUS.md:2 — STATUS.md 宣稱 D-042 尚未 ratify，與 LEDGER.md 既有的 decision_ratify 事件矛盾' \
+  '| c2-stale-ratify-claim | 1 | caught | no |' 0
+
+# model_observed mismatch -> void, exit 1
+printf '%s\n' 'FINDING P0 canaries-fixture/c1-shell-precedence/deploy.sh:7 — POSIX sh 把 || 與 && 同優先序、左結合' > "$WORK/transcript.txt"
+CALIB_STUB_TRANSCRIPT="$WORK/transcript.txt"
+CALIB_STUB_SESSION_MODEL='openai-codex/gpt-5.6-sol'
+export CALIB_STUB_TRANSCRIPT CALIB_STUB_SESSION_MODEL
+out=$(run_calibrate --runs 1)
+got=$?
+unset CALIB_STUB_SESSION_MODEL
+if [ "$got" -eq 1 ]; then
+  good 'model_observed mismatch -> exit 1'
+else
+  bad "model_observed mismatch: expected exit 1, got $got"
+fi
+case $out in
+  *'| c1-shell-precedence | 1 | void | - |'*) good 'model_observed mismatch -> row void' ;;
+  *) bad 'model_observed mismatch did not void the row' ;;
+esac
+case $(cat "$WORK/stderr.txt") in
+  *'observed=openai-codex/gpt-5.6-sol'*) good 'void reason names the observed model' ;;
+  *) bad 'void reason does not name the observed model' ;;
+esac
+
+# engine exit != 0 -> void too (fail stub in its own dir so it shadows the
+# good stub for run mode while still answering --list-models)
+mkdir -p "$WORK/failstubs"
+cat > "$WORK/failstubs/pi" <<EOF
+#!/bin/sh
+if [ "\$1" = "--list-models" ]; then exec "$STUBS/pi" --list-models; fi
+echo 'boom' >&2
+exit 7
+EOF
+chmod +x "$WORK/failstubs/pi"
+PATH="$WORK/failstubs:$STUBS:$PATH" sh "$CALIBRATE" --engine "$GLM" --brief "$BRIEF" --runs 1 > "$WORK/failout.txt" 2>"$WORK/stderr.txt"
+got=$?
+if [ "$got" -eq 1 ]; then
+  good 'engine exit != 0 -> exit 1'
+else
+  bad "engine exit != 0: expected exit 1, got $got"
+fi
+case $(cat "$WORK/failout.txt") in
+  *'| c1-shell-precedence | 1 | void | - |'*) good 'engine exit != 0 -> row void' ;;
+  *) bad 'engine failure did not void the row' ;;
+esac
+rm -rf "$WORK/failstubs"
+
+# --- 7. union row, for-ledger, cost sum (multi-run, stubbed claude) ---------
+printf '%s\n' 'FINDING P0 canaries-fixture/c1-shell-precedence/deploy.sh:7 — POSIX sh 把 || 與 && 同優先序、左結合' > "$WORK/transcript.txt"
+CALIB_STUB_TRANSCRIPT="$WORK/transcript.txt"
+export CALIB_STUB_TRANSCRIPT
+out=$(PATH="$STUBS:$PATH" sh "$CALIBRATE" --engine 'claude:claude-opus-5' --brief "$BRIEF" --runs 2)
+got=$?
+if [ "$got" -eq 0 ]; then
+  good 'claude backend run exit 0'
+else
+  bad "claude backend run: expected exit 0, got $got"
+fi
+case $out in
+  *'| c1-shell-precedence | union | caught | yes | claude-opus-5 | claude-opus-5 | 0.833800'*)
+    good 'union row sums cost across runs' ;;
+  *) bad "union row missing or wrong:
+$(printf '%s\n' "$out" | grep 'union')" ;;
+esac
+case $out in
+  *'for-ledger — fleet.review-calibration'*'cost_usd: 0.833800'*)
+    good 'for-ledger block with summed cost' ;;
+  *) bad 'for-ledger block missing or cost not summed' ;;
+esac
+case $out in
+  *'edda decide'*'decide'*) : ;;
+  *) good 'for-ledger block states the script never runs edda decide' ;;
+esac
+
+# --- 8. claude model_observed mismatch --------------------------------------
+CALIB_STUB_CLAUDE_MODEL='claude-sonnet-5'
+export CALIB_STUB_CLAUDE_MODEL
+out=$(PATH="$STUBS:$PATH" sh "$CALIBRATE" --engine 'claude:claude-opus-5' --brief "$BRIEF" --runs 1)
+got=$?
+unset CALIB_STUB_CLAUDE_MODEL
+if [ "$got" -eq 1 ]; then
+  good 'claude model_observed mismatch -> exit 1'
+else
+  bad "claude model_observed mismatch: expected exit 1, got $got"
+fi
+case $out in
+  *'| c1-shell-precedence | 1 | void | - | claude-opus-5 | claude-sonnet-5'*)
+    good 'claude model_observed mismatch -> void row carries both models' ;;
+  *) bad 'claude model_observed mismatch did not void the row' ;;
+esac
+
+# --- nothing written outside the temp dir -----------------------------------
+# By construction every script write goes under $TMPDIR (clone, out files,
+# session dirs); the per-scenario assertions proved the clone is removed and
+# the TMPDIR override proved the clone lands in the sandbox. A scan of the
+# real /tmp is deliberately not performed: find/glob over /tmp can block on
+# unrelated MSYS nodes on this workstation.
+
+if [ "$failures" -eq 0 ]; then
+  echo 'test-calibrate-canaries.sh: all checks passed' >&2
+  exit 0
+fi
+printf 'test-calibrate-canaries.sh: %d check(s) FAILED\n' "$failures" >&2
+exit 1

--- a/scripts/test-calibrate-canaries.sh
+++ b/scripts/test-calibrate-canaries.sh
@@ -131,8 +131,8 @@ out=$(run_calibrate --runs 2 --dry-run)
 rc=$?
 [ "$rc" -eq 0 ] || bad "dry-run exit $rc"
 case $out in
-  *edda-calib-*) good 'dry-run prints the clone path under TMPDIR' ;;
-  *) bad 'dry-run does not print the clone path' ;;
+  *edda-calib.XXXXXX/repo*) good 'dry-run prints the clone path shape under TMPDIR' ;;
+  *) bad 'dry-run does not print the clone path shape (expected edda-calib.XXXXXX/repo)' ;;
 esac
 case $out in
   *'calibration: canary fixture pre-state'*) good 'dry-run prints fixture commit' ;;

--- a/scripts/test-calibrate-canaries.sh
+++ b/scripts/test-calibrate-canaries.sh
@@ -151,7 +151,15 @@ case $out in
     good 'dry-run prints the exact pi launch line per run' ;;
   *) bad 'dry-run does not print the exact pi launch line per run' ;;
 esac
-if [ -z "$(find "$TEST_TMPDIR" -maxdepth 1 -name 'edda-calib-*' -print -quit)" ]; then
+# The pattern here is deliberately BROADER than the positive assertion at
+# the dry-run clone-path check above, and the asymmetry is the point: a
+# positive assertion should be as tight as possible so a wrong value fails
+# it, while a negative assertion should be as broad as possible so a
+# leftover in ANY shape is still found. A negative assertion whose pattern
+# has gone stale does not go red — it goes green, silently, which is what
+# happened when the clone path moved from edda-calib-$$ to edda-calib.XXXXXX
+# and these two checks stopped matching anything at all.
+if [ -z "$(find "$TEST_TMPDIR" -maxdepth 1 -name 'edda-calib*' -print -quit)" ]; then
   good 'dry-run creates no clone'
 else
   bad 'dry-run created a clone'
@@ -207,7 +215,8 @@ scenario() { # <name> <transcript-file> <expected-substring> <want-rc>
 $(printf '%s\n' "$out" | grep '^| c')"
     ;;
   esac
-  if [ -z "$(find "$TEST_TMPDIR" -maxdepth 1 -name 'edda-calib-*' -print -quit)" ]; then
+  # Broad by design — see the note on the dry-run clone check above.
+  if [ -z "$(find "$TEST_TMPDIR" -maxdepth 1 -name 'edda-calib*' -print -quit)" ]; then
     good "$name clone removed"
   else
     bad "$name left a clone behind"

--- a/tests/canaries/README.md
+++ b/tests/canaries/README.md
@@ -31,6 +31,46 @@ finding 是什麼（`expected.md`）。引擎定期對金絲雀集跑審查 → 
 
 ## 如何跑一次校準（calibration run）
 
+> **這個流程已腳本化**：`scripts/calibrate-canaries.sh`（issue #881；
+> 設計文件 §1.2、§7 item 7）。它完全執行下列步驟：throwaway clone →
+> fixture commit → canary commit → 目標 diff → 每引擎每輪一次唯讀審查 →
+> 從 session 檔／JSON 讀 `model_observed` → 機械評分 → 列出 Markdown 表
+> 加 `for-ledger` 區塊 → 刪除 clone（`trap` 保證每個退出路徑都清）。
+> 腳本不發 GitHub 請求、不寫帳本（`for-ledger` 區塊由控制者逐字記入）。
+>
+> ```sh
+> # 先看計畫，不啟動任何東西：
+> sh scripts/calibrate-canaries.sh \
+>    --engine pi:openrouter/z-ai/glm-5.3-flash \
+>    --brief <brief.md> --runs 3 --dry-run
+> # 實跑：
+> sh scripts/calibrate-canaries.sh \
+>    --engine pi:openrouter/z-ai/glm-5.3-flash \
+>    --brief <brief.md> --runs 3
+> # --engine 可重複；選擇器語法 <backend>:<catalogue id>，id 逐字照抄
+> # pi --list-models。pi: 帶 Anthropic id、claude: 帶非 Anthropic id 會在
+> # 啟動前 exit 2（fleet.claude-subscription-transport，以目錄資料判定）。
+> ```
+>
+> 離線測試（stub 兩個引擎，不出網、不離開自己的 temp dir）：
+> `sh scripts/test-calibrate-canaries.sh`。
+>
+> **機械評分**：每顆金絲雀的 `expected.md` 帶固定 front matter
+> （`id class severity file match`；缺 key → 腳本 exit 2 指名檔案）。
+> 引擎依 brief 末尾的輸出協定逐行輸出
+> `FINDING P<n> <repo 相對路徑> — <一行描述>`；腳本評分：
+> - **caught**：expected `file` 上的 finding 文字命中 `match` regex；
+>   `severity_match` 比對回報的 severity 與 front-matter severity。
+> - **false-positive**：對該金絲雀面（expected file 或其目錄下）有 finding
+>   但不是預期 finding。
+> - **missed**：其餘。
+> - 引擎 exit ≠ 0 或 `model_observed ≠ model_requested`（從 pi session 檔
+>   `"model"` 欄／claude JSON `modelUsage` 讀，絕不從 transcript 本文取，
+>   #616）→ 該輪每列 **void**，不靜默計分；全程結束後 exit 1。
+> 機械分是保守下界；資格判定的最終權威仍是人工對照各 canary 的評分提示。
+>
+> 以下保留作為腳本所執行步驟的說明（手動跑仍可照做）：
+
 在一個 **$TEMP 的 throwaway clone** 上做，不在工作 worktree：
 
 ```sh

--- a/tests/canaries/README.md
+++ b/tests/canaries/README.md
@@ -75,7 +75,8 @@ finding 是什麼（`expected.md`）。引擎定期對金絲雀集跑審查 → 
 
 ```sh
 WT=<this worktree>
-CLONE="$TMPDIR/edda-calib-$$"
+CALIB_TMP=$(mktemp -d "${TMPDIR:-/tmp}/edda-calib.XXXXXX")
+CLONE="$CALIB_TMP/repo"
 git clone "$WT" "$CLONE" && cd "$CLONE"
 git checkout -b calib-canary-v0 origin/main
 

--- a/tests/canaries/code-risk/c1-shell-precedence/expected.md
+++ b/tests/canaries/code-risk/c1-shell-precedence/expected.md
@@ -1,3 +1,11 @@
+---
+id: c1-shell-precedence
+class: code-risk
+severity: P0
+file: canaries-fixture/c1-shell-precedence/deploy.sh
+match: '\|\|.*&&|&&.*\|\||同優先序|左結合|同优先|left.associat|same precedence'
+---
+
 # c1-shell-precedence
 
 - class: `code-risk`

--- a/tests/canaries/code-risk/c5-write-end-no-reader/expected.md
+++ b/tests/canaries/code-risk/c5-write-end-no-reader/expected.md
@@ -1,3 +1,11 @@
+---
+id: c5-write-end-no-reader
+class: code-risk
+severity: P1
+file: canaries-fixture/c5-write-end-no-reader/lib.rs
+match: '(no (caller|reader|call site|read side)|無人呼叫|沒有呼叫|無呼叫|沒有任何呼叫|never called|uncalled|not called|not referenced|dead (export|code)|unused (export|pub|function)|寫端|讀端|write.end|write.side|read.end|read.side)'
+---
+
 # c5-write-end-no-reader
 
 - class: `code-risk`

--- a/tests/canaries/docs-skills/c2-stale-ratify-claim/expected.md
+++ b/tests/canaries/docs-skills/c2-stale-ratify-claim/expected.md
@@ -1,3 +1,11 @@
+---
+id: c2-stale-ratify-claim
+class: docs-skills
+severity: P1
+file: canaries-fixture/c2-stale-ratify-claim/STATUS.md
+match: '(D-042|ratif|ratified|unratified).*(矛盾|contradict|stale|過期|outdated|conflict|inconsist|不符|不一致)|((矛盾|contradict|stale|過期|outdated|conflict|inconsist|不符|不一致).*(D-042|ratif))'
+---
+
 # c2-stale-ratify-claim
 
 - class: `docs-skills`（docs）

--- a/tests/canaries/docs-skills/c3-nonexistent-flag/expected.md
+++ b/tests/canaries/docs-skills/c3-nonexistent-flag/expected.md
@@ -1,3 +1,11 @@
+---
+id: c3-nonexistent-flag
+class: docs-skills
+severity: P1
+file: canaries-fixture/c3-nonexistent-flag/runbook.md
+match: '(prune-orphans|prune orphans).*(不存在|nonexistent|non-existent|no such|not exist|not listed|not found|not available|not supported|undefined|沒有|無此|不在)|(不存在|nonexistent|non-existent|no such|not exist|not listed|not found|not available|not supported|undefined|沒有|無此|不在).*(prune-orphans|prune orphans)'
+---
+
 # c3-nonexistent-flag
 
 - class: `docs-skills`（docs）

--- a/tests/canaries/docs-skills/c4-merge-authority-contradiction/expected.md
+++ b/tests/canaries/docs-skills/c4-merge-authority-contradiction/expected.md
@@ -1,3 +1,11 @@
+---
+id: c4-merge-authority-contradiction
+class: docs-skills
+severity: P0
+file: canaries-fixture/c4-merge-authority/review-closer-skill.md
+match: '(skip.{0,3}review|跳過審查|免審|bypass.{0,3}review|先合併|merge.{0,3}before.{0,3}review|合併後補|補審|merge.authority|合併權限|--delete-branch|LGTM.{0,40}(trigger|觸發|gate|閘))'
+---
+
 # c4-merge-authority-contradiction
 
 - class: `docs-skills`（skills）


### PR DESCRIPTION
Issue: #881
Closes #881.

## What

`scripts/calibrate-canaries.sh` turns the `tests/canaries/README.md` calibration recipe into one command. Per engine it builds a throwaway clone, commits the fixture pre-state and then the canary set (the README's two commits exactly), launches the engine **read-only** once, reads `model_observed` from the system, scores each canary mechanically against its `expected.md` front matter, and prints the results table plus a for-ledger block.

`expected.md` gains machine-readable front matter, so scoring stops being a human reading of the prose rubric.

## Two design points worth flagging

**`model_requested != model_observed` voids the run and exits 1.** A calibration scored against the wrong model is worse than no calibration — it produces a number that looks like evidence. `model_observed` is read from the system (pi session file `model` field; `claude --output-format json` `modelUsage`), never from the transcript's own text (#616).

**It never writes.** No GitHub post, no ledger write, no `edda decide` — it prints the for-ledger block and the controller records it (design #618 §3).

## Why this matters for the window

The all-flash window's whole premise is a comparison, and right now the comparison rests on hand-run calibrations. #884 records that the previously logged glm code-risk disqualification was a **brief artifact**, not a model failure — a scoring result that was wrong because the brief was written wrong, and that nobody could re-run cheaply enough to catch. This is the script that makes re-running cheap.

## Gates (L0, touched surface is shell + markdown — no crate touched)

- `sh -n scripts/calibrate-canaries.sh` — exit 0
- `sh -n scripts/test-calibrate-canaries.sh` — exit 0
- `sh scripts/test-calibrate-canaries.sh` — all checks pass, including the void-on-mismatch path
- `sh scripts/lint-file-length.sh --tree` — exit 0
- pre-commit hooks (doc citations, markdown content, file length) passed on commit

Exact-head CI is the L1 gate.

## Surface

`scripts/**` plus `tests/canaries/**`. No `.github/**` job and no `lefthook.yml` entry invokes either script, and nothing here ships to a user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
