### PR TITLE
fix(fleet): capability canaries read DISPATCH_EXIT and report every case

### DIFF
--- a/scripts/test-review-capabilities.sh
+++ b/scripts/test-review-capabilities.sh
@@ -88,15 +88,22 @@ BACKEND=unguarded; export BACKEND
 printf ORIGINAL > "$CANARY"
 : > "$CALLS"
 printf brief > "$tmp/scratch/review-pr9998-r1-brief.md"
+failures=0
 sh "$tmp/unguarded-old-run.sh" > "$tmp/old-out" 2>&1 || old_rc=$?
 old_rc=${old_rc:-0}
-if [ "$(cat "$CANARY")" != TAMPERED ] || [ ! -s "$CALLS" ] || [ "$old_rc" -ne 0 ]; then
+# This control asks one thing: does an UNGUARDED dispatch reach the backend?
+# So it reads DISPATCH_EXIT from the receipt, not the runner's process exit.
+# Since GH-867 the process exit also folds in worktree and task teardown, and
+# this fixture's wt-review-pr9998 is a standalone `git init` repo rather than a
+# worktree registered against $ROOT, so `git worktree remove` fails here by
+# construction and FINAL_EXIT is always 2 — which made the control look dead
+# when it was working (GH-928).
+unguarded_dispatch_exit=$(sed -n 's/^DISPATCH_EXIT=//p' "$tmp/scratch/review-pr9998-r1.done" | head -1)
+if [ "$(cat "$CANARY")" != TAMPERED ] || [ ! -s "$CALLS" ] || [ "$unguarded_dispatch_exit" != 0 ]; then
   cat "$tmp/old-out" >&2 || true
-  echo 'FAIL unguarded baseline: old dispatch shape did not write owned canary' >&2
-  exit 1
+  echo "FAIL unguarded baseline: unguarded dispatch did not reach the backend (canary=$(cat "$CANARY") DISPATCH_EXIT=${unguarded_dispatch_exit:-absent} process_exit=$old_rc)" >&2
+  failures=$((failures + 1))
 fi
-
-failures=0
 for BACKEND in old modern old-claude fallback mutate; do
  export BACKEND
  printf ORIGINAL > "$CANARY"
@@ -128,16 +135,24 @@ for BACKEND in old modern old-claude fallback mutate; do
      echo 'FAIL mutate: tracked, untracked, or ignored source change was accepted' >&2; failures=$((failures + 1))
    fi ;;
  *)
-   if [ ! -s "$CALLS" ] || [ "$rc" -ne 0 ]; then
-     echo "FAIL $BACKEND: capable backend never launched"; failures=$((failures + 1))
+   # Same reading as the unguarded control above: "did the dispatch run" is
+   # DISPATCH_EXIT, not the process exit, which since GH-867 also carries
+   # teardown the fixture cannot satisfy (GH-928).
+   dispatch_exit=$(sed -n 's/^DISPATCH_EXIT=//p' "$tmp/scratch/review-pr9998-r1.done" | head -1)
+   if [ ! -s "$CALLS" ] || [ "$dispatch_exit" != 0 ]; then
+     echo "FAIL $BACKEND: capable backend never launched (DISPATCH_EXIT=${dispatch_exit:-absent} process_exit=$rc)"; failures=$((failures + 1))
    fi
    if ! grep -q '^TOOL_FLAGS=.*--permission-mode.*mcp__' "$tmp/scratch/review-pr9998-r1.done"; then
      echo "FAIL $BACKEND: no actual flags receipt"; failures=$((failures + 1))
    fi ;;
  esac
 done
-[ "$failures" -eq 0 ] || exit 1
-echo 'review capability canaries passed (unguarded baseline; old/modern dispatch and fallback; all source scopes)'
+# No early exit: the Windows block below must run even when a POSIX case
+# failed, so the operator sees every failing case in one run (GH-928). The
+# single gate is at the end of the file.
+if [ "$failures" -eq 0 ]; then
+  echo 'review capability canaries passed (unguarded baseline; old/modern dispatch and fallback; all source scopes)'
+fi
 
 # On Windows execute the generated PowerShell lane too. Functions stand in
 # for the two binaries; any non-help call with missing flags writes canary.
@@ -197,17 +212,23 @@ EOF
     pwsh -NoProfile -File "$(cygpath -w "$tmp/driver.ps1")" \
       -Lane "$(cygpath -w "$tmp/scratch/review-pr9998-r1-lane.ps1")" > "$tmp/win-out" 2>&1 || rc=$?
     if [ "$(tr -d '\r\n' < "$CANARY")" != ORIGINAL ]; then
-      echo "FAIL Windows $BACKEND: canary changed"; exit 1
+      echo "FAIL Windows $BACKEND: canary changed"; failures=$((failures + 1))
     fi
     case "$BACKEND" in
       old|old-claude)
-        if [ "$rc" -eq 0 ] || [ -s "$CALLS" ]; then cat "$tmp/win-out"; echo "FAIL Windows $BACKEND: not refused"; exit 1; fi ;;
+        if [ "$rc" -eq 0 ] || [ -s "$CALLS" ]; then cat "$tmp/win-out"; echo "FAIL Windows $BACKEND: not refused"; failures=$((failures + 1)); fi ;;
       mutate)
-        if [ ! -s "$CALLS" ] || [ "$rc" -eq 0 ] || ! grep -q '^WORKTREE_CHECK=failed' "$tmp/scratch/review-pr9998-r1.done"; then cat "$tmp/win-out"; echo 'FAIL Windows mutate: source change was accepted'; exit 1; fi ;;
+        if [ ! -s "$CALLS" ] || [ "$rc" -eq 0 ] || ! grep -q '^WORKTREE_CHECK=failed' "$tmp/scratch/review-pr9998-r1.done"; then cat "$tmp/win-out"; echo 'FAIL Windows mutate: source change was accepted'; failures=$((failures + 1)); fi ;;
       *)
-        if [ ! -s "$CALLS" ] || [ "$rc" -ne 0 ]; then cat "$tmp/win-out"; echo "FAIL Windows $BACKEND: no successful launch"; exit 1; fi
-        grep -q '^TOOL_FLAGS=.*--permission-mode.*mcp__' "$tmp/scratch/review-pr9998-r1.done" || exit 1 ;;
+        win_dispatch_exit=$(sed -n 's/^DISPATCH_EXIT=//p' "$tmp/scratch/review-pr9998-r1.done" | head -1)
+        if [ ! -s "$CALLS" ] || [ "$win_dispatch_exit" != 0 ]; then cat "$tmp/win-out"; echo "FAIL Windows $BACKEND: no successful launch (DISPATCH_EXIT=${win_dispatch_exit:-absent} process_exit=$rc)"; failures=$((failures + 1)); fi
+        grep -q '^TOOL_FLAGS=.*--permission-mode.*mcp__' "$tmp/scratch/review-pr9998-r1.done" || { echo "FAIL Windows $BACKEND: no actual flags receipt"; failures=$((failures + 1)); } ;;
     esac
   done
-  echo 'Windows generated lane canaries passed (old/modern transport and source-snapshot cases)'
+  if [ "$failures" -eq 0 ]; then
+    echo 'Windows generated lane canaries passed (old/modern transport and source-snapshot cases)'
+  fi
 fi
+
+# The one gate, after every case has had its say.
+[ "$failures" -eq 0 ] || exit 1


### PR DESCRIPTION
## Problem and change

`scripts/test-review-capabilities.sh` has exited 1 at its first case since #867 (bisected: `1bc2e57` green, `f675991` onward red), so neither summary line has been reached and every case after the first has gone unrun. Nothing noticed, because no CI job or hook runs this test.

The unguarded-baseline control was **not** broken. It works: the canary reads `TAMPERED`, a call is recorded, and the receipt says `DISPATCH_EXIT=0`. What broke is that five assertions read the runner's **process** exit to mean "did the dispatch run". Since #867 that exit is `FINAL_EXIT`, which also folds in worktree and task teardown — and this fixture's `wt-review-pr9998` is a standalone `git init` repo rather than a worktree registered against `$ROOT`, so teardown cannot succeed there and `FINAL_EXIT` is 2 on a perfectly good dispatch.

Two changes, both in the test:

1. Every "did the dispatch run" assertion reads `DISPATCH_EXIT` from `review-pr9998-r1.done` — the field #867 added to the receipt for exactly this distinction. Five sites: the unguarded control, the POSIX capable-backend case, and the Windows capable-backend case (the last two covering `modern` and `fallback` each). Their failure messages now print `DISPATCH_EXIT` and the process exit side by side, so the next reader does not have to re-derive which clause fired.
2. Every case records a failure and continues; the single `exit 1` gate moved to the end of the file.

**Change 2 is what found the other four.** Before it, the suite exited at the unguarded case and the four `modern` / `fallback` failures — POSIX and Windows — were invisible. They are the same defect, and they had been there since #867 too.

### Audit of the other exit-code assertions

The `mutate` cases at both blocks test `[ "$rc" -eq 0 ]` expecting a **non-zero** exit, which is correct under #867's semantics: a rejected source change *should* make the runner fail. The `old` / `old-claude` refusal cases likewise assert on the process exit of a run that never dispatched. Both are unchanged.

## Validation

### RAN at 872f7cec428549596c5093e35ea253f17a9e3fd3

- before round 1: exit 1, one `FAIL unguarded baseline`, **zero** `canaries passed` lines
- after round 1 (early exits removed, control fixed): exit 1 with **four** newly visible `FAIL` lines
- after round 2: **exit 0**, zero `FAIL` lines, both summary lines present
- `sh -n scripts/test-review-capabilities.sh` → exit 0
- `grep -c 'exit 1'` → 1 (the final gate only)
- `git diff --cached --name-only` → this file only

### READ

- the bisect and the preserved-fixture diagnosis in #928
- #867's `DISPATCH_EXIT` / `FINAL_EXIT` receipt fields in `scripts/review-pr.sh`

## Not in this PR

Putting this test behind a gate is #910 / #927. Until one of those lands it is still only run by hand — which is how five broken assertions survived a day on `main`.

Issue: #928
Closes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)
