### PR TITLE
feat(fleet): issue freshness gate — next-issue.sh re-derives applicability at dispatch time

### DIFF
--- a/scripts/fleet/issue-freshness.sh
+++ b/scripts/fleet/issue-freshness.sh
@@ -1,0 +1,135 @@
+#!/bin/sh
+# issue-freshness.sh — re-derive an issue's applicability at dispatch time
+# (GH-931). Issues are opened faster than anyone re-reads them, so every
+# dispatch re-checks the body against today's tree instead of trusting the
+# day it was written. Checks, one PASS/FAIL/WARN line each:
+#   1. every path-shaped backtick token in the body exists at the pinned
+#      origin/main SHA (git cat-file -e); negated mentions ("no `X`") are
+#      skipped, unparseable tokens WARN without blocking
+#   2. every `edda <verb>` referenced in the body has a working --help
+#   3. the body carries a non-empty doneWhen section
+#   4. no merged PR already delivers the issue (search GH-<n> and #<n>)
+# Any FAIL: label the issue fleet:stale, comment the FAIL list, exit 1.
+# All PASS (WARN allowed): exit 0.
+#
+# usage:
+#   sh scripts/fleet/issue-freshness.sh <issue-number>
+set -eu
+
+usage() {
+    echo "usage: $0 <issue-number>" >&2
+    exit 2
+}
+
+repo=${EDDA_REPO:-fagemx/edda}
+issue=
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help) usage ;;
+        --) shift; break ;;
+        -*) usage ;;
+        *)
+            if [ -z "$issue" ]; then issue=$1; shift
+            else usage
+            fi ;;
+    esac
+done
+[ -n "$issue" ] || usage
+case "$issue" in
+    *[!0-9]*|'') usage ;;
+esac
+
+cd "$(git rev-parse --show-toplevel)"
+sha=$(git rev-parse origin/main)
+body=$(gh issue view "$issue" --repo "$repo" --json body --jq .body | tr -d '\r')
+
+fail=0
+fail_lines=
+
+record_fail() {
+    fail=1
+    fail_lines="$fail_lines$1
+"
+}
+
+# 1. path tokens: split on backticks; even records are the tokens, and the
+# prose record before each one decides whether the mention is negated. A
+# token counts as path-shaped when it contains a slash or ends in .sh/.ps1;
+# anything weirder WARNs without blocking.
+tmp=$(mktemp "${TMPDIR:-/tmp}/issue-freshness.XXXXXX")
+trap 'rm -f "$tmp"' 0 HUP INT TERM
+printf '%s\n' "$body" | awk -v RS='`' '
+    NR % 2 == 1 { prev = $0; next }
+    {
+        p = prev
+        sub(/[ \t\r\n]+$/, "", p)
+        if (p ~ /([Nn]o|[Nn]ot|[Ww]ithout)$/) next
+        print
+    }
+' >"$tmp"
+while IFS= read -r tok; do
+    [ -n "$tok" ] || continue
+    case "$tok" in
+        */*) ;;
+        *.sh|*.ps1) ;;
+        *) continue ;;
+    esac
+    case "$tok" in
+        *[!A-Za-z0-9._/-]*)
+            echo "WARN unparsed $tok"
+            continue ;;
+    esac
+    if git cat-file -e "$sha:$tok" 2>/dev/null; then
+        echo "PASS path $tok"
+    else
+        echo "FAIL path $tok missing at $sha"
+        record_fail "FAIL path $tok missing at $sha"
+    fi
+done <"$tmp"
+
+# 2. edda verbs: every `edda <verb>` mention must survive its own --help.
+verbs=$(printf '%s\n' "$body" | grep -oE '`edda [a-z][a-z0-9-]*' | sed 's/^`edda //' | sort -u)
+for verb in $verbs; do
+    if edda "$verb" --help >/dev/null 2>&1; then
+        echo "PASS edda $verb"
+    else
+        echo "FAIL edda $verb --help exited nonzero"
+        record_fail "FAIL edda $verb --help exited nonzero"
+    fi
+done
+
+# 3. doneWhen: present and non-empty (blank lines do not count as content).
+section=$(printf '%s\n' "$body" | awk '
+    /^##[ \t]*doneWhen[ \t]*$/ { p = 1; next }
+    /^##[ \t]/ { p = 0 }
+    p { print }
+')
+if [ -z "$(printf '%s' "$section" | tr -d '[:space:]')" ]; then
+    echo "FAIL doneWhen missing or empty"
+    record_fail "FAIL doneWhen missing or empty"
+else
+    echo "PASS doneWhen"
+fi
+
+# 4. delivered: any merged PR whose title/body/branch matches the issue.
+pr1=$(gh pr list --repo "$repo" --state merged --search "GH-$issue" --json number --jq '.[].number' || :)
+pr2=$(gh pr list --repo "$repo" --state merged --search "#$issue" --json number --jq '.[].number' || :)
+merged=$(printf '%s\n%s\n' "$pr1" "$pr2" | tr -d '\r' | sort -u | sed '/^$/d')
+if [ -n "$merged" ]; then
+    spaced=$(printf '%s' "$merged" | tr '\n' ' ')
+    echo "FAIL delivered by merged PR(s): $spaced"
+    record_fail "FAIL delivered by merged PR(s): $spaced"
+else
+    echo "PASS not delivered"
+fi
+
+if [ "$fail" -eq 1 ]; then
+    gh label create fleet:stale --repo "$repo" >/dev/null 2>&1 || :
+    gh issue edit "$issue" --repo "$repo" --add-label fleet:stale >/dev/null
+    {
+        printf 'fleet:stale — freshness gate FAILED at %s:\n' "$sha"
+        printf '%s\n' "$fail_lines"
+    } | gh issue comment "$issue" --repo "$repo" --body-file - >/dev/null
+    exit 1
+fi
+exit 0

--- a/scripts/fleet/next-issue.sh
+++ b/scripts/fleet/next-issue.sh
@@ -68,6 +68,11 @@ if [ "$has_claimed" = "true" ]; then
 fi
 has_ready=$(printf '%s' "$json" | jq '[.labels[].name] | index("fleet:ready") != null')
 [ "$has_ready" = "true" ] || die "issue $issue does not carry fleet:ready"
+if [ "$dry" = 0 ]; then
+    echo "== issue freshness"
+    sh "$self_dir/issue-freshness.sh" "$issue" ||
+        die "issue $issue failed the freshness gate (labelled fleet:stale) — not dispatching"
+fi
 title=$(printf '%s' "$json" | jq -r .title)
 [ -n "$title" ] && [ "$title" != "null" ] || die "issue $issue has no title"
 # interpolated into the double-quoted task-new line below; the backslash is

--- a/scripts/fleet/test-issue-freshness.sh
+++ b/scripts/fleet/test-issue-freshness.sh
@@ -1,0 +1,243 @@
+#!/bin/sh
+# Offline self-test for scripts/fleet/issue-freshness.sh and the next-issue.sh
+# freshness gate (GH-931). Stubs gh and edda (and pwsh, defensively); jq, git
+# and sh stay real. Writes only under its temp dir.
+#
+# Default suite: the gate script itself (exit codes, findings, stale-marking).
+# --integration: only the next-issue.sh gate case — the gate must already be
+# inserted (delivery step 9.6); running it earlier always fails, because the
+# ungated loop dies at the <<AUTHORED STEPS>> marker check instead.
+#
+# usage:
+#   sh scripts/fleet/test-issue-freshness.sh [--integration]
+set -eu
+
+cd "$(git rev-parse --show-toplevel)"
+freshness=scripts/fleet/issue-freshness.sh
+next_issue=scripts/fleet/next-issue.sh
+
+mode=${1:-suite}
+case "$mode" in
+    suite) run_suite=1; run_integ=0 ;;
+    --integration) run_suite=0; run_integ=1 ;;
+    *) echo "usage: $0 [--integration]" >&2; exit 2 ;;
+esac
+
+sh -n "$freshness" || {
+    echo "FAIL: sh -n $freshness" >&2
+    exit 1
+}
+sh -n "$next_issue" || {
+    echo "FAIL: sh -n $next_issue" >&2
+    exit 1
+}
+sh -n "$0" || {
+    echo "FAIL: sh -n $0" >&2
+    exit 1
+}
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/test-issue-freshness.XXXXXX")
+cleanup() {
+    rm -rf "$work"
+}
+trap cleanup 0 HUP INT TERM
+export TMPDIR="$work"
+
+mkdir -p "$work/bin" "$work/fixtures" "$work/scratch" "$work/lanes"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+# ── fixtures ─────────────────────────────────────────────────────────
+
+# Paths referenced here must exist on origin/main: issue-freshness.sh probes
+# git cat-file -e against the pinned remote head, not the working tree.
+cat >"$work/fixtures/issue-ok.json" <<'JSON'
+{"state":"OPEN","title":"feat(fleet): freshness ok","labels":[{"name":"fleet:ready"}],"comments":[],
+ "body":"## Predicted surface\n\nGate file `scripts/fleet/next-issue.sh` and helper `scripts/fleet/brief-from-issue.sh` exist.\n\n## doneWhen\n- `edda ask` resolves\n"}
+JSON
+cat >"$work/fixtures/issue-badflag.json" <<'JSON'
+{"state":"OPEN","title":"feat(fleet): freshness bad flag","labels":[{"name":"fleet:ready"}],"comments":[],
+ "body":"## Predicted surface\n\nGate file `scripts/fleet/next-issue.sh` exists.\n\n## doneWhen\n- `edda bogusverb-xyz` works\n"}
+JSON
+cat >"$work/fixtures/issue-stalepr.json" <<'JSON'
+{"state":"OPEN","title":"feat(fleet): freshness stale pr","labels":[{"name":"fleet:ready"}],"comments":[],
+ "body":"## Predicted surface\n\nGate file `scripts/fleet/next-issue.sh` exists.\n\n## doneWhen\n- `edda ask` resolves\n"}
+JSON
+cat >"$work/fixtures/issue-nodonewhen.json" <<'JSON'
+{"state":"OPEN","title":"feat(fleet): freshness no donewhen","labels":[{"name":"fleet:ready"}],"comments":[],
+ "body":"## Predicted surface\n\nGate file `scripts/fleet/next-issue.sh` exists.\n"}
+JSON
+cat >"$work/fixtures/pr-list-hit.json" <<'JSON'
+[{"number":746,"state":"MERGED","title":"x","body":"Closes #993"}]
+JSON
+cat >"$work/fixtures/pr-list-empty.json" <<'JSON'
+[]
+JSON
+cat >"$work/fixtures/issue-list-empty.json" <<'JSON'
+[]
+JSON
+
+: >"$work/gh-posted"
+: >"$work/gh-edits"
+: >"$work/pwsh-calls"
+
+# ── stubs ────────────────────────────────────────────────────────────
+
+cat >"$work/bin/gh" <<'STUB'
+#!/bin/sh
+jq_expr=
+prev=
+for a in "$@"; do
+    [ "$prev" = "--jq" ] && jq_expr=$a
+    prev=$a
+done
+
+resp=
+case "$1 $2" in
+    "issue list") resp=$(cat "$GH_FIXTURES/issue-list-empty.json") ;;
+    "pr list")
+        case "$*" in
+            *993*) resp=$(cat "$GH_FIXTURES/pr-list-hit.json") ;;
+            *) resp=$(cat "$GH_FIXTURES/pr-list-empty.json") ;;
+        esac ;;
+esac
+case "$1 $2" in
+    "issue view")
+        case "$*" in
+            *\ 991\ *|*\ 991) resp=$(cat "$GH_FIXTURES/issue-ok.json") ;;
+            *\ 992\ *|*\ 992) resp=$(cat "$GH_FIXTURES/issue-badflag.json") ;;
+            *\ 993\ *|*\ 993) resp=$(cat "$GH_FIXTURES/issue-stalepr.json") ;;
+            *\ 994\ *|*\ 994) resp=$(cat "$GH_FIXTURES/issue-nodonewhen.json") ;;
+            *) resp=$(cat "$GH_FIXTURES/issue-ok.json") ;;
+        esac ;;
+    "issue edit")
+        echo "$*" >>"$GH_EDITS"
+        echo "edited"
+        exit 0 ;;
+    "issue comment")
+        body=
+        prev=
+        for a in "$@"; do
+            [ "$prev" = "--body" ] && body=$a
+            prev=$a
+        done
+        if [ -z "$body" ]; then
+            body=$(cat)
+        fi
+        { echo "---- comment ----"; printf '%s\n' "$body"; } >>"$GH_POSTED"
+        echo "commented"
+        exit 0 ;;
+    "label create")
+        echo "$*" >>"$GH_EDITS"
+        echo "created"
+        exit 0 ;;
+esac
+[ -n "$resp" ] || { echo "gh-stub: unexpected: $*" >&2; exit 1; }
+if [ -n "$jq_expr" ]; then
+    printf '%s' "$resp" | tr -d '\r' | jq -r "$jq_expr"
+else
+    printf '%s\n' "$resp"
+fi
+STUB
+chmod +x "$work/bin/gh"
+
+cat >"$work/bin/edda" <<'STUB'
+#!/bin/sh
+case "$*" in
+    *bogusverb*) exit 1 ;;
+esac
+exit 0
+STUB
+chmod +x "$work/bin/edda"
+
+cat >"$work/bin/pwsh" <<'STUB'
+#!/bin/sh
+echo "pwsh-stub: $*" >>"$PWSH_CALLS"
+exit 0
+STUB
+chmod +x "$work/bin/pwsh"
+
+run_gated() {
+    PATH="$work/bin:$PATH" \
+    GH_FIXTURES="$work/fixtures" GH_POSTED="$work/gh-posted" \
+    GH_EDITS="$work/gh-edits" PWSH_CALLS="$work/pwsh-calls" \
+    "$@"
+}
+
+# ── default suite: the gate script itself ────────────────────────────
+
+if [ "$run_suite" -eq 1 ]; then
+    # a. valid issue: all checks PASS, exit 0
+    run_gated sh "$freshness" 991 >"$work/out-a.txt" 2>"$work/err-a.txt" ||
+        fail "issue 991 must pass: rc=$? err=$(cat "$work/err-a.txt")"
+    grep -q '^PASS path scripts/fleet/next-issue.sh$' "$work/out-a.txt" ||
+        fail "issue 991 misses the path PASS line: $(cat "$work/out-a.txt")"
+    grep -q '^PASS path scripts/fleet/brief-from-issue.sh$' "$work/out-a.txt" ||
+        fail "issue 991 misses the second path PASS line"
+    grep -q '^PASS edda ask$' "$work/out-a.txt" ||
+        fail "issue 991 misses the edda PASS line"
+    grep -q '^PASS doneWhen$' "$work/out-a.txt" ||
+        fail "issue 991 misses the doneWhen PASS line"
+    grep -q '^PASS not delivered$' "$work/out-a.txt" ||
+        fail "issue 991 misses the delivered PASS line"
+    grep -q '^FAIL' "$work/out-a.txt" &&
+        fail "issue 991 must print no FAIL lines: $(cat "$work/out-a.txt")"
+    echo "ok a valid issue passes"
+
+    # b. nonexistent edda flag: FAIL, fleet:stale label + comment naming it
+    run_gated sh "$freshness" 992 >"$work/out-b.txt" 2>"$work/err-b.txt" &&
+        fail "issue 992 must exit 1" || rc=$?
+    [ "${rc:-0}" -eq 1 ] || fail "issue 992 exit ${rc:-0}, want 1"
+    grep -q '^FAIL edda bogusverb-xyz' "$work/out-b.txt" ||
+        fail "issue 992 misses the bogusverb FAIL line: $(cat "$work/out-b.txt")"
+    grep -q 'fleet:stale' "$work/gh-edits" ||
+        fail "issue 992 must add the fleet:stale label: $(cat "$work/gh-edits")"
+    grep -q 'bogusverb-xyz' "$work/gh-posted" ||
+        fail "issue 992 comment must name the FAIL item: $(cat "$work/gh-posted")"
+    echo "ok b bad flag fails and marks stale"
+
+    # c. delivered by a merged PR: FAIL naming the PR
+    : >"$work/gh-edits"
+    run_gated sh "$freshness" 993 >"$work/out-c.txt" 2>"$work/err-c.txt" &&
+        fail "issue 993 must exit 1" || rc=$?
+    [ "${rc:-0}" -eq 1 ] || fail "issue 993 exit ${rc:-0}, want 1"
+    grep -q '746' "$work/out-c.txt" ||
+        fail "issue 993 must name merged PR 746: $(cat "$work/out-c.txt")"
+    echo "ok c merged-PR delivery fails"
+
+    # d. missing doneWhen: FAIL
+    run_gated sh "$freshness" 994 >"$work/out-d.txt" 2>"$work/err-d.txt" &&
+        fail "issue 994 must exit 1" || rc=$?
+    [ "${rc:-0}" -eq 1 ] || fail "issue 994 exit ${rc:-0}, want 1"
+    grep -q '^FAIL doneWhen' "$work/out-d.txt" ||
+        fail "issue 994 misses the doneWhen FAIL line: $(cat "$work/out-d.txt")"
+    echo "ok d missing doneWhen fails"
+
+    echo "PASS: scripts/fleet/test-issue-freshness.sh"
+    exit 0
+fi
+
+# ── integration: the gate sits in next-issue.sh ahead of everything ──
+
+if [ "$run_integ" -eq 1 ]; then
+    if ! grep -q 'issue-freshness' "$next_issue"; then
+        fail "next-issue.sh carries no freshness gate — insert it (step 9.6) before running --integration"
+    fi
+    EDDA_FLEET_SCRATCH="$work/scratch" TEMP="$work/lanes" TMPDIR="$work" \
+        run_gated sh "$next_issue" 992 docs/worker-9 >"$work/out-e.txt" 2>"$work/err-e.txt" &&
+        fail "gated next-issue must exit 2 for 992" || rc=$?
+    [ "${rc:-0}" -eq 2 ] || fail "gated next-issue exit ${rc:-0}, want 2"
+    grep -qi 'freshness' "$work/err-e.txt" ||
+        fail "gated refusal must name freshness: $(cat "$work/err-e.txt")"
+    [ -z "$(ls -A "$work/scratch")" ] ||
+        fail "gated next-issue wrote into the scratch dir: $(ls -A "$work/scratch")"
+    grep -q 'fleet:stale' "$work/gh-edits" ||
+        fail "gated refusal must label fleet:stale: $(cat "$work/gh-edits")"
+    [ -s "$work/pwsh-calls" ] &&
+        fail "gated refusal must not launch: $(cat "$work/pwsh-calls")"
+    echo "PASS: scripts/fleet/test-issue-freshness.sh"
+    exit 0
+fi


### PR DESCRIPTION
## Problem and change
scripts/fleet/issue-freshness.sh re-derives issue applicability at dispatch time: path tokens probed at the pinned origin/main SHA with git cat-file -e (negated mentions skipped, unparseable tokens WARN), referenced edda subcommands probed with --help, doneWhen presence, and merged-PR delivery via `gh pr list --state merged --search`. On any FAIL it labels the issue fleet:stale, comments the FAIL list, and exits 1; scripts/fleet/next-issue.sh runs it after the fleet:ready check and before any brief render, worktree, task, claim, or launch (skipped in --dry-run, which never touches labels).

## Validation
### RAN
- sh scripts/fleet/test-issue-freshness.sh — RED before the implementation (rc=1, `FAIL: sh -n scripts/fleet/issue-freshness.sh`) and GREEN after (rc=0): PASS: scripts/fleet/test-issue-freshness.sh
- sh scripts/fleet/test-issue-freshness.sh --integration after the gate insertion — rc=0: PASS: scripts/fleet/test-issue-freshness.sh (next-issue.sh 992 exits 2 at the freshness gate, scratch empty, fleet:stale labeled, no launch)
- sh scripts/fleet/test-next-loop.sh after the gate insertion — rc=0: PASS: scripts/fleet/test-next-loop.sh
- sh scripts/fleet/test-brief-from-issue.sh — rc=0; sh scripts/fleet/test-ready-queue-lint.sh — rc=0
- sh -n on scripts/fleet/issue-freshness.sh and scripts/fleet/next-issue.sh — exit 0
- git diff --check before commit — empty

### READ
- Issue #931 doneWhen — every item delivered by this diff (gate script, next-issue.sh gate, fleet:stale marking with FAIL-list comment, fixtures for the #925-style bad flag and #746-style merged-PR classes plus a valid issue and a missing-doneWhen issue, red-then-green suite).

Closes #931
Issue: #931
