### PR TITLE
fix(fleet): validate the machine/assignee identity shape in next-issue.sh before sh -c

### DIFF
--- a/scripts/fleet/next-issue.sh
+++ b/scripts/fleet/next-issue.sh
@@ -48,6 +48,14 @@ case "$machine" in
     */*) : ;;
     *) die "machine identity must be <machine>/<role>, got '$machine'" ;;
 esac
+# The identity is interpolated into the double-quoted sh -c task-new line
+# below, so every segment must be [A-Za-z0-9._-]+ — a quote, dollar, backtick,
+# backslash, or whitespace surviving this check would break out of that string.
+for machine_segment in "${machine%%/*}" "${machine#*/}"; do
+    case "$machine_segment" in
+        ''|*[!A-Za-z0-9._-]*) die "machine identity segments must match [A-Za-z0-9._-]+, got '$machine'" ;;
+    esac
+done
 
 self_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 root=$(CDPATH= cd -- "$self_dir/../.." && pwd)

--- a/scripts/fleet/test-next-loop.sh
+++ b/scripts/fleet/test-next-loop.sh
@@ -303,4 +303,20 @@ grep -q 'no pi arm yet' "$work/out/delegate.err" || fail "non-shadow refusal mus
 [ -s "$work/gh-posted" ] && fail "non-shadow refusal must post nothing"
 echo "ok 7 non-shadow delegation refusal"
 
+# ── 8. machine identity shape: a crafted identity never reaches sh -c ─
+
+printf '%s' "$HEAD1" >"$work/gh-head"
+for crafted in 'docs/worker-1" --evil "x' 'docs/'; do
+    : >"$work/edda-calls"
+    : >"$work/gh-edits"
+    run_loop sh "$next_issue" 886 "$crafted" >"$work/out/identity.txt" 2>"$work/out/identity.err" && \
+        fail "crafted identity '$crafted' must exit 2" || rc=$?
+    [ "${rc:-0}" -eq 2 ] || fail "identity refusal exit ${rc:-0}, want 2 for '$crafted'"
+    grep -q 'machine identity' "$work/out/identity.err" || \
+        fail "crafted identity '$crafted' must die at validation: $(cat "$work/out/identity.err")"
+    [ -s "$work/edda-calls" ] && fail "crafted identity '$crafted' reached task new: $(cat "$work/edda-calls")"
+    [ -s "$work/gh-edits" ] && fail "crafted identity '$crafted' touched labels: $(cat "$work/gh-edits")"
+done
+echo "ok 8 machine identity shape refusal"
+
 echo "PASS: scripts/fleet/test-next-loop.sh"


### PR DESCRIPTION
## Problem and change

`next-issue.sh` interpolates `--assignee "${machine#*/}"` into `sh -c "$task_cmd"` with only the `*/` shape validated, so a machine identity containing `"` survives into the `sh -c` string (GH-902, found by the glm shadow review of PR #899 Round 2 @ a55d64f). The identity is controller-supplied, so no privilege boundary was crossed — the remote input (issue title) is already sanitized.

The fix validates each segment of `<machine>/<role>` against `[A-Za-z0-9._-]+` right after the existing `*/` shape check, before anything else runs: a quote, dollar, backtick, backslash, or whitespace in either segment now exits 2 at argument parsing, before lint, render, task-new, claim, worktree, or launch.

## Validation

### RAN

- `sh scripts/fleet/test-next-loop.sh` at this head: ok 1 through ok 8, `PASS`, exit 0. New section 8 proves two crafted identities (`docs/worker-1" --evil "x`, `docs/`) exit 2 at validation, die with the identity message, and never reach `edda task new` or any label edit.
- Red-green proof: with only the test applied (fix reverted), the same suite exits 1 at `FAIL: crafted identity 'docs/worker-1" --evil "x' must die at validation:` — the unfixed script lets the crafted identity through to the AUTHORED STEPS refusal, so the new test discriminates.
- `sh -n scripts/fleet/next-issue.sh && sh -n scripts/fleet/test-next-loop.sh`: exit 0.
- `git diff --check`: clean. `git diff --cached --stat`: 2 files, +24.

### READ

- `scripts/fleet/next-issue.sh` in full at this head: the new loop sits between the `*/` shape check and `self_dir` resolution; no other path interpolates `$machine` into a shell string except `"${machine#*/}"` inside the now-guarded `task_cmd`.
- `scripts/fleet/test-next-loop.sh` harness shape: new section follows the house `run_loop ... && fail ... || rc=$?` pattern; `edda-calls`/`gh-edits` are reset per crafted case.

Issue: #902

Closes #902
9fd62b0932b3373b15f2526c8e2dfc588a5ae76f
