### PR TITLE
fix(fleet): brief-from-issue renders failing steps 6/24 when --task-id is omitted (task=none)

### DIFF
--- a/scripts/fleet/brief-from-issue.sh
+++ b/scripts/fleet/brief-from-issue.sh
@@ -178,6 +178,26 @@ esac
 status_lines=$(printf '%s\n' "$paths_space" | tr ' ' '\n' | sed '/^$/d')
 first_path=$(printf '%s' "$status_lines" | head -1)
 
+# GH-898: --task-id is optional. With no rail task, fixed steps 6 and 24 would
+# render `edda task show none` and `edda task done none`, which must fail —
+# the lane stops at step 6 on a valid render. Rail-free forms render instead
+# and step 24's receipt becomes a session note.
+if [ "$task" = "none" ]; then
+    step5="5. edda task list
+   output: task-list text, exit 0."
+    step6="6. git rev-parse --is-inside-work-tree
+   output: true."
+    step24="24. edda note 'GH${issue} delivered: PR <pr_url> @ <delivery_sha>; lane tests green.' --tag session
+    output: Wrote NOTE <event-id>, exit 0."
+else
+    step5="5. edda task list
+   output: task-list text, exit 0, including task ${task}."
+    step6="6. edda task show ${task}
+   output: task ${task} and this brief, exit 0."
+    step24="24. edda task done ${task} --receipt \"PR <pr_url> @ <delivery_sha>\"
+    output: task ${task} marked done, exit 0."
+fi
+
 cat <<EOF
 role: worker · lane: ${lane} · task id: ${task} · issue: #${issue} ·
 base full SHA: ${sha} ·
@@ -203,10 +223,8 @@ issues the next brief. Success advances to the next numbered step.
    output: ${sha}.
 4. edda context
    output: context text, exit 0; an off-limits overlap with a scope path is a STOP under the failure rule.
-5. edda task list
-   output: task-list text, exit 0, including task ${task}.
-6. edda task show ${task}
-   output: task ${task} and this brief, exit 0.
+${step5}
+${step6}
 7. edda claim gh${issue}-worker${paths_claim}
    output: successful claim for gh${issue}-worker and the scope paths, exit 0.
 8. gh issue view ${issue} --repo ${repo} --json body --jq .body
@@ -245,8 +263,7 @@ ${status_lines}
     output: one https://github.com/${repo}/pull/<integer> URL, exit 0. Retain as pr_url.
 23. gh pr view ${branch} --repo ${repo} --json headRefOid --jq .headRefOid
     output: delivery_sha from step 18, exactly.
-24. edda task done ${task} --receipt "PR <pr_url> @ <delivery_sha>"
-    output: task ${task} marked done, exit 0.
+${step24}
 25. Report, as the final message, exactly these five lines and nothing else:
     DONE issue=#${issue} task=${task}
     pr=<pr_url>

--- a/scripts/fleet/test-brief-from-issue.sh
+++ b/scripts/fleet/test-brief-from-issue.sh
@@ -246,4 +246,45 @@ grep -q 'rm -rf' "$work/out/crafted.txt" \
     && fail "crafted token leaked into the rendered brief"
 echo "ok 8 crafted scope token rejected"
 
+# 9. omitted --task-id renders without the task-rail steps (GH-898): the
+#    fixed steps 6 and 24 must never name task none, and both invocation
+#    modes are proven.
+rc=0
+TEST_UNAME=Linux GH_ISSUE_JSON="$work/issue-880.json" \
+    PATH="$work/bin:$PATH" \
+    sh "$script" 880 --lane-name edda-lane-gh880 \
+        --worktree C:/ai_agent/edda-wt-gh880 \
+        --branch fix/gh880-pi-review-arm \
+    >"$work/out/notask.txt" || rc=$?
+[ "$rc" -eq 0 ] || fail "no-task-id render exit $rc"
+if grep -q 'edda task show none' "$work/out/notask.txt"; then
+    fail "step 6 renders edda task show none — the lane stops there (GH-898)"
+fi
+if grep -q 'task done none' "$work/out/notask.txt"; then
+    fail "step 24 renders edda task done none — the receipt cannot succeed (GH-898)"
+fi
+if grep -q 'including task none' "$work/out/notask.txt"; then
+    fail "step 5 expects task none on the rail (GH-898)"
+fi
+grep -q '6. git rev-parse --is-inside-work-tree' "$work/out/notask.txt" \
+    || fail "rail-free step 6 missing"
+grep -q '24. edda note ' "$work/out/notask.txt" \
+    || fail "rail-free step 24 missing"
+grep -q 'DONE issue=#880 task=none' "$work/out/notask.txt" \
+    || fail "task=none report line missing"
+rc=0
+TEST_UNAME=Linux GH_ISSUE_JSON="$work/issue-880.json" \
+    PATH="$work/bin:$PATH" \
+    sh "$script" 880 --lane-name edda-lane-gh880 \
+        --worktree C:/ai_agent/edda-wt-gh880 \
+        --branch fix/gh880-pi-review-arm \
+        --task-id 128 \
+    >"$work/out/withtask.txt" || rc=$?
+[ "$rc" -eq 0 ] || fail "with-task-id render exit $rc"
+grep -q '6. edda task show 128' "$work/out/withtask.txt" \
+    || fail "rail step 6 missing with --task-id"
+grep -q '24. edda task done 128' "$work/out/withtask.txt" \
+    || fail "rail step 24 missing with --task-id"
+echo "ok 9 omitted --task-id renders rail-free steps (both modes)"
+
 echo "PASS: scripts/fleet/test-brief-from-issue.sh"


### PR DESCRIPTION
## Problem and change

`--task-id` is optional in `brief-from-issue.sh` and defaults to `none`, but the rendered brief still carries the rail steps `6. edda task show none` and `24. edda task done none`, which must fail — the lane stops at step 6 on a valid render (GH-898, found by the glm shadow review of PR #895 Round 2 @ f38e9f8).

Design (fixed by the dispatcher, not left to the caller): omitting `--task-id` keeps rendering — `next-issue.sh` must render before the rail task exists — but steps 5, 6 and 24 take a rail-free form when `task=none`. Step 5 drops the "including task none" expectation, step 6 becomes `git rev-parse --is-inside-work-tree`, and step 24's receipt becomes an `edda note` session note; the step-25 report then truthfully reads `task=none`. The `--task-id` form renders exactly as before.

## Validation

### RAN

- `sh scripts/fleet/test-brief-from-issue.sh` at this head: ok 1 through ok 9, `PASS`, exit 0. New section 9 proves both invocation modes: omitted `--task-id` renders no `edda task show none`, no `task done none`, no `including task none`, and carries the rail-free step 6 and `edda note` step 24 with `DONE issue=#880 task=none`; `--task-id 128` still renders `6. edda task show 128` and `24. edda task done 128`.
- Red-green proof: with only the test applied (renderer fix reverted), the suite exits 1 at `FAIL: step 6 renders edda task show none — the lane stops there (GH-898)` — the new test discriminates against the shipped renderer.
- `sh -n scripts/fleet/brief-from-issue.sh && sh -n scripts/fleet/test-brief-from-issue.sh`: exit 0.
- `git diff --check`: clean. `git diff --stat`: 2 files, +64/−6.

### READ

- `scripts/fleet/brief-from-issue.sh` at this head: the `task=none` branch assigns the three step strings before the heredoc; `${step5}`/`${step6}`/`${step24}` expand inside the unquoted heredoc, and the assignment-time expansion of `${issue}`/`${task}` keeps the heredoc-time expansion a no-op. The `--task-id` branch reproduces the shipped step text byte-for-byte (section 9's positive assertions pin it).

Issue: #898

Closes #898
c3e71915e2f449ea358af1f68a8918f81462fb13
