### PR TITLE
feat(fleet): brief dry-run validator — apply AUTHORED STEPS in a throwaway worktree at the pinned SHA before any lane launch

### DIFF
--- a/scripts/fleet/brief-validate.sh
+++ b/scripts/fleet/brief-validate.sh
@@ -1,0 +1,247 @@
+#!/bin/sh
+# brief-validate.sh — dry-run a lane brief's authored steps in a throwaway
+# worktree at the brief's pinned base SHA before any lane launch (GH-930).
+# The 09-05 flash wave STOPped five lanes on brief defects alone: authors
+# reasoned instead of measuring. This closes that hole mechanically.
+#
+# What it validates: the brief's authored span (between the exact lines
+# <<AUTHORED: BEGIN>> and <<AUTHORED: END>>), applied in order inside a
+# worktree at the facts block's `base full SHA` —
+#   - every concrete `edit({...})` must match exactly once, then mutates the
+#     tree the later steps see
+#   - a concrete `write({...})` lands its content verbatim; a bare-identifier
+#     content (a metavariable) is skipped with a note, never guessed
+#   - every step carrying an `output:` expectation is executed and compared:
+#     `empty stdout, exit 0`, an all-digits literal, or a text literal (the
+#     trailing period is stripped on both sides)
+#   - every concretely touched file then passes its per-type syntax gate:
+#     `sh -n` for *.sh, a PowerShell parser run for *.ps1, others skipped
+# All pass  → prints VALID and a `git diff --cached --stat` summary, writes
+#             the full expected diff to <brief>.expected.diff, exit 0
+# Any miss  → prints INVALID step=<n> with the verbatim output, exit 1, and
+#             writes no expected diff
+# Bad usage or a malformed brief → exit 2
+#
+# usage:
+#   sh scripts/fleet/brief-validate.sh <brief-path>
+set -eu
+
+usage() {
+    echo "usage: $0 <brief-path>" >&2
+    exit 2
+}
+
+[ $# -eq 1 ] || usage
+brief=$1
+[ -f "$brief" ] || { echo "brief-validate: no such brief: $brief" >&2; exit 2; }
+
+root=$(git rev-parse --show-toplevel)
+base=$(sed -n 's/^base full SHA: \([0-9a-f]\{40\}\).*$/\1/p' "$brief" | head -1)
+[ -n "$base" ] || {
+    echo "brief-validate: no 'base full SHA: <40-hex>' line in $brief" >&2
+    exit 2
+}
+
+tmp_span=$(mktemp "${TMPDIR:-/tmp}/brief-validate.span.XXXXXX")
+tmp_err=$(mktemp "${TMPDIR:-/tmp}/brief-validate.err.XXXXXX")
+tmp_old=$(mktemp "${TMPDIR:-/tmp}/brief-validate.old.XXXXXX")
+tmp_new=$(mktemp "${TMPDIR:-/tmp}/brief-validate.new.XXXXXX")
+tmp_json=$(mktemp "${TMPDIR:-/tmp}/brief-validate.json.XXXXXX")
+tmp_touched=$(mktemp "${TMPDIR:-/tmp}/brief-validate.touched.XXXXXX")
+wt=$(mktemp -d "${TMPDIR:-/tmp}/brief-validate.wt.XXXXXX")
+cleanup() {
+    rm -f "$tmp_span" "$tmp_err" "$tmp_old" "$tmp_new" "$tmp_json" "$tmp_touched"
+    git -C "$root" worktree remove --force "$wt" >/dev/null 2>&1 || :
+    git -C "$root" worktree prune >/dev/null 2>&1 || :
+}
+trap cleanup 0 HUP INT TERM
+
+# The authored span: everything between the two exact marker lines. Step and
+# expectation lines may carry presentation indent (the rendered brief indents
+# output lines). A step header is a dotted step number, then a space — both
+# `9.1 write(...)` and `10. git status` shapes.
+awk '
+    /^<<AUTHORED: BEGIN>>$/ { inspan = 1; next }
+    /^<<AUTHORED: END>>$/   { inspan = 0; next }
+    inspan && /^[ ]*output:[ ]?/ {
+        line = $0
+        sub(/^[ ]*output:[ ]?/, "", line)
+        print "EXPECT\t" line
+        next
+    }
+    inspan && /^[ ]*[0-9][0-9.]*[ ]/ {
+        num = $0
+        sub(/^[ ]*/, "", num)
+        sub(/[ \t].*$/, "", num)
+        line = $0
+        sub(/^[ ]*[0-9][0-9.]*[ ][ ]*/, "", line)
+        print "STEP\t" num "\t" line
+        next
+    }
+' "$brief" >"$tmp_span"
+
+if [ ! -s "$tmp_span" ]; then
+    echo "brief-validate: no <<AUTHORED: BEGIN>>/<<AUTHORED: END>> span with steps in $brief" >&2
+    exit 2
+fi
+
+git -C "$root" worktree add --detach "$wt" "$base" >/dev/null 2>&1 || {
+    echo "brief-validate: cannot create worktree at $base" >&2
+    exit 2
+}
+
+invalid() {  # invalid <step> <detail...> — verbatim evidence, exit 1, no diff
+    printf 'INVALID step=%s\n' "$1"
+    shift
+    printf '%s\n' "$*"
+    exit 1
+}
+
+cur_num=
+cur_body=
+cur_exp=
+
+emit_result() {
+    # flush on the next STEP or at the end of the span
+    :
+}
+
+flush_step() {
+    [ -n "$cur_num" ] || return 0
+    # a distinct name: the caller's read-loop `body` variable must survive
+    st_body=$cur_body
+    exp=${cur_exp%.}
+    case "$st_body" in
+        "write("*)
+            json=${st_body#"write("}
+            json=${json%)}
+            if ! printf '%s' "$json" | jq -e . >/dev/null 2>&1; then
+                echo "SKIP step=$cur_num (tool call is not concrete JSON)"
+                cur_num=
+                return 0
+            fi
+            path=$(printf '%s' "$json" | jq -r '.path // empty')
+            case "$path" in
+                ""|/*|*..*|*[!A-Za-z0-9._/-]*)
+                    invalid "$cur_num" "write path is not a plain repo-relative path: $path" ;;
+            esac
+            ctype=$(printf '%s' "$json" | jq -r '.content | type' 2>/dev/null || :)
+            if [ "$ctype" != "string" ]; then
+                echo "SKIP step=$cur_num (content is a metavariable, not a concrete string)"
+                cur_num=
+                return 0
+            fi
+            mkdir -p "$wt/$(dirname "$path")"
+            printf '%s' "$json" | jq -j '.content' >"$wt/$path"
+            printf '%s\t%s\n' "$cur_num" "$path" >>"$tmp_touched"
+            if [ -n "$exp" ]; then
+                # the launcher documents the write tool's success line without
+                # the byte count; that shape is what a brief must expect
+                [ "$exp" = "Successfully wrote bytes to $path" ] ||
+                    invalid "$cur_num" "expectation mismatch: want the write tool's success line for $path, brief says: $cur_exp"
+            fi
+            ;;
+        "edit("*)
+            json=${st_body#"edit("}
+            json=${json%)}
+            if ! printf '%s' "$json" | jq -e . >/dev/null 2>&1; then
+                invalid "$cur_num" "edit call is not concrete JSON: $st_body"
+            fi
+            path=$(printf '%s' "$json" | jq -r '.path // empty')
+            case "$path" in
+                ""|/*|*..*|*[!A-Za-z0-9._/-]*)
+                    invalid "$cur_num" "edit path is not a plain repo-relative path: $path" ;;
+            esac
+            [ -f "$wt/$path" ] || invalid "$cur_num" "edit target does not exist at $base: $path"
+            n=$(printf '%s' "$json" | jq '.edits | length')
+            i=0
+            while [ "$i" -lt "$n" ]; do
+                if ! printf '%s' "$json" | jq -e ".edits[$i].oldText | type == \"string\"" >/dev/null 2>&1; then
+                    invalid "$cur_num" "edit oldText is not a concrete string"
+                fi
+                if ! printf '%s' "$json" | jq -e ".edits[$i].newText | type == \"string\"" >/dev/null 2>&1; then
+                    invalid "$cur_num" "edit newText is not a concrete string"
+                fi
+                printf '%s' "$json" | jq -j ".edits[$i].oldText" >"$tmp_old"
+                printf '%s' "$json" | jq -j ".edits[$i].newText" >"$tmp_new"
+                count=$(jq -Rs --rawfile old "$tmp_old" 'split($old) | length - 1' <"$wt/$path")
+                if [ "$count" -ne 1 ]; then
+                    invalid "$cur_num" "oldText matches $count times in $path, want exactly 1: $(cat "$tmp_old")"
+                fi
+                jq -Rs --rawfile old "$tmp_old" --rawfile new "$tmp_new" \
+                    'split($old) | join($new)' <"$wt/$path" >"$tmp_json"
+                jq -j . "$tmp_json" >"$wt/$path"
+                i=$((i + 1))
+            done
+            printf '%s\t%s\n' "$cur_num" "$path" >>"$tmp_touched"
+            if [ -n "$exp" ]; then
+                [ "$exp" = "Successfully replaced $n block(s) in $path" ] ||
+                    invalid "$cur_num" "expectation mismatch: want the edit tool's success line for $path, brief says: $cur_exp"
+            fi
+            ;;
+        *)
+            # a command step: only validated when it carries an expectation
+            [ -n "$exp" ] || return 0
+            rc=0
+            out=$(cd "$wt" && sh -c "$st_body" 2>"$tmp_err") || rc=$?
+            if [ "$rc" -ne 0 ]; then
+                invalid "$cur_num" "exit=$rc output=$(cat "$tmp_err")$out"
+            fi
+            case "$exp" in
+                "empty stdout"*)
+                    [ -z "$out" ] || invalid "$cur_num" "want empty stdout, got: $out" ;;
+                *)
+                    [ "$out" = "$exp" ] || invalid "$cur_num" "want: $exp
+got: $out" ;;
+            esac
+            ;;
+    esac
+}
+
+while IFS="$(printf '\t')" read -r kind num body; do
+    case "$kind" in
+        STEP)
+            flush_step
+            cur_num=$num
+            cur_body=$body
+            cur_exp=
+            ;;
+        EXPECT)
+            if [ -n "$cur_exp" ]; then
+                cur_exp="$cur_exp
+$num"
+            else
+                cur_exp=$num
+            fi
+            ;;
+    esac
+done <"$tmp_span"
+flush_step
+
+# per-type syntax gates over every concretely touched file; a file edited by
+# several steps reports the step that last touched it
+tmp_gates=$(mktemp "${TMPDIR:-/tmp}/brief-validate.gates.XXXXXX")
+trap 'rm -f "$tmp_gates"; rm -f "$tmp_span" "$tmp_err" "$tmp_old" "$tmp_new" "$tmp_json" "$tmp_touched"; git -C "$root" worktree remove --force "$wt" >/dev/null 2>&1 || :; git -C "$root" worktree prune >/dev/null 2>&1 || :' 0 HUP INT TERM
+awk -F'\t' '{ line[$2] = $1 } END { for (f in line) print line[f] "\t" f }' \
+    "$tmp_touched" >"$tmp_gates"
+while IFS="$(printf '\t')" read -r st f; do
+    case "$f" in
+        *.sh)
+            if ! sh -n "$wt/$f" 2>"$tmp_err"; then
+                invalid "$st" "sh -n $f: $(cat "$tmp_err")"
+            fi
+            ;;
+        *.ps1)
+            if ! pwsh -NoProfile -Command "\$t=\$null; \$e=\$null; [void][System.Management.Automation.Language.Parser]::ParseFile('$wt/$f', [ref]\$t, [ref]\$e); if (\$e -and \$e.Count -gt 0) { \$e | ForEach-Object { [Console]::Error.WriteLine(\$_.Message) }; exit 1 }" 2>"$tmp_err"; then
+                invalid "$st" "pwsh parse $f: $(cat "$tmp_err")"
+            fi
+            ;;
+        *)
+            : ;;
+    esac
+done <"$tmp_gates"
+
+(cd "$wt" && git add -A && git diff --cached --stat)
+echo "VALID"
+git -C "$wt" diff --cached >"$brief.expected.diff"
+exit 0

--- a/scripts/fleet/brief-validate.sh
+++ b/scripts/fleet/brief-validate.sh
@@ -101,11 +101,6 @@ cur_num=
 cur_body=
 cur_exp=
 
-emit_result() {
-    # flush on the next STEP or at the end of the span
-    :
-}
-
 flush_step() {
     [ -n "$cur_num" ] || return 0
     # a distinct name: the caller's read-loop `body` variable must survive
@@ -237,7 +232,8 @@ while IFS="$(printf '\t')" read -r st f; do
             fi
             ;;
         *)
-            : ;;
+            echo "SKIP gate $f (no syntax gate for this file type)"
+            ;;
     esac
 done <"$tmp_gates"
 

--- a/scripts/fleet/next-issue.sh
+++ b/scripts/fleet/next-issue.sh
@@ -140,6 +140,11 @@ if [ "$dry" = 0 ] && grep -q '^<<AUTHORED STEPS>>$' "$brief_path"; then
     die "brief still contains <<AUTHORED STEPS>> — fill the authored middle in $brief_path, then rerun"
 fi
 
+if [ "$dry" = 0 ]; then
+    echo "== brief validate"
+    sh "$self_dir/brief-validate.sh" "$brief_path" ||
+        die "brief-validate INVALID — fix the failing step in the brief, then rerun"
+fi
 echo "== task"
 echo "cmd: $task_cmd"
 

--- a/scripts/fleet/test-brief-validate.sh
+++ b/scripts/fleet/test-brief-validate.sh
@@ -229,6 +229,8 @@ if [ "$run_suite" -eq 1 ]; then
         fail "brief-ok must write the expected diff beside the brief"
     grep -q '+line two edited' "$work/fixtures/brief-ok.md.expected.diff" ||
         fail "expected diff misses the applied edit: $(cat "$work/fixtures/brief-ok.md.expected.diff")"
+    grep -q 'SKIP gate new.txt' "$work/out/ok.txt" ||
+        fail "brief-ok must name the ungated file it skipped: $(cat "$work/out/ok.txt")"
     rm -f "$work/fixtures/brief-ok.md.expected.diff"
     echo "ok a valid brief validates with expected diff"
 

--- a/scripts/fleet/test-brief-validate.sh
+++ b/scripts/fleet/test-brief-validate.sh
@@ -1,0 +1,294 @@
+#!/bin/sh
+# Offline self-test for scripts/fleet/brief-validate.sh and the next-issue.sh
+# validate gate (GH-930). Stubs gh, edda and pwsh; jq, git and sh stay real.
+# Writes only under its temp dir. The validator operates on the repository of
+# its current working directory, so every fixture run happens with the cwd
+# set to a small fixture repo (three tracked files, one commit).
+#
+# Default suite: the validator itself — one VALID brief, five INVALID briefs
+# pinning the five brief-defect classes from the issue (absent runner,
+# whitespace the tree guarantees, numeric mismatch, orphan token left by an
+# edit, half-applied fix), and one structure error (missing markers).
+# --integration: only the next-issue.sh gate case — the gate must already be
+# inserted (delivery step 9.6); running it earlier always fails, because the
+# ungated loop dies at the <<AUTHORED STEPS>> marker check instead.
+#
+# usage:
+#   sh scripts/fleet/test-brief-validate.sh [--integration]
+set -eu
+
+cd "$(git rev-parse --show-toplevel)"
+ROOT=$(pwd)
+validator=scripts/fleet/brief-validate.sh
+next_issue=scripts/fleet/next-issue.sh
+
+mode=${1:-suite}
+case "$mode" in
+    suite) run_suite=1; run_integ=0 ;;
+    --integration) run_suite=0; run_integ=1 ;;
+    *) echo "usage: $0 [--integration]" >&2; exit 2 ;;
+esac
+
+sh -n "$validator" || {
+    echo "FAIL: sh -n $validator" >&2
+    exit 1
+}
+sh -n "$next_issue" || {
+    echo "FAIL: sh -n $next_issue" >&2
+    exit 1
+}
+sh -n "$0" || {
+    echo "FAIL: sh -n $0" >&2
+    exit 1
+}
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/test-brief-validate.XXXXXX")
+cleanup() {
+    rm -rf "$work"
+}
+trap cleanup 0 HUP INT TERM
+export TMPDIR="$work"
+
+mkdir -p "$work/bin" "$work/fixtures" "$work/scratch" "$work/lanes" "$work/out"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+# ── fixture repo ─────────────────────────────────────────────────────
+
+git init -q "$work/repo"
+git -C "$work/repo" config user.name t
+git -C "$work/repo" config user.email t@example.com
+printf 'alpha\n' >"$work/repo/seed.txt"
+printf 'state: old\n' >"$work/repo/note.md"
+printf 'state: old\n' >"$work/repo/todo.md"
+git -C "$work/repo" add -A
+git -C "$work/repo" commit -qm seed
+BASE=$(git -C "$work/repo" rev-parse HEAD)
+
+# ── fixture briefs ───────────────────────────────────────────────────
+
+facts="role: worker · lane: none · task id: none · issue: #0 ·
+base full SHA: __BASE__ ·
+scope paths: none ·"
+
+cat >"$work/fixtures/brief-ok.tmpl" <<EOF
+$facts
+<<AUTHORED: BEGIN>>
+9.1 write({"path":"new.txt","content":"line one\nline two\n"})
+    output: Successfully wrote bytes to new.txt.
+9.2 edit({"path":"new.txt","edits":[{"oldText":"line two","newText":"line two edited"}]})
+    output: Successfully replaced 1 block(s) in new.txt.
+9.3 grep -c -F line new.txt
+    output: 2.
+<<AUTHORED: END>>
+EOF
+
+cat >"$work/fixtures/brief-runner.tmpl" <<EOF
+$facts
+<<AUTHORED: BEGIN>>
+9.1 not-a-real-runner-880 --version
+    output: empty stdout, exit 0.
+<<AUTHORED: END>>
+EOF
+
+cat >"$work/fixtures/brief-space.tmpl" <<EOF
+$facts
+<<AUTHORED: BEGIN>>
+9.1 write({"path":"sp.txt","content":"x \n"})
+    output: Successfully wrote bytes to sp.txt.
+9.2 git add -- sp.txt && git diff --cached --check
+    output: empty stdout, exit 0.
+<<AUTHORED: END>>
+EOF
+
+cat >"$work/fixtures/brief-count.tmpl" <<EOF
+$facts
+<<AUTHORED: BEGIN>>
+9.1 write({"path":"n.txt","content":"needle\nneedle\n"})
+    output: Successfully wrote bytes to n.txt.
+9.2 grep -c -F needle n.txt
+    output: 1.
+<<AUTHORED: END>>
+EOF
+
+cat >"$work/fixtures/brief-orphan.tmpl" <<EOF
+$facts
+<<AUTHORED: BEGIN>>
+9.1 write({"path":"frag.sh","content":"if true\nthen\necho hi\nfi\n"})
+    output: Successfully wrote bytes to frag.sh.
+9.2 edit({"path":"frag.sh","edits":[{"oldText":"if true\nthen","newText":"# guard"}]})
+    output: Successfully replaced 1 block(s) in frag.sh.
+<<AUTHORED: END>>
+EOF
+
+cat >"$work/fixtures/brief-half.tmpl" <<EOF
+$facts
+<<AUTHORED: BEGIN>>
+9.1 edit({"path":"note.md","edits":[{"oldText":"state: old","newText":"state: new"}]})
+    output: Successfully replaced 1 block(s) in note.md.
+9.2 grep -q "state: new" note.md && grep -q "state: new" todo.md
+    output: empty stdout, exit 0.
+<<AUTHORED: END>>
+EOF
+
+# Missing markers: the validator must refuse with exit 2, never guess.
+cat >"$work/fixtures/brief-nomarkers.tmpl" <<EOF
+$facts
+9.1 write({"path":"new.txt","content":"x"})
+    output: Successfully wrote bytes to new.txt.
+EOF
+
+for t in ok runner space count orphan half nomarkers; do
+    sed "s/__BASE__/$BASE/" "$work/fixtures/brief-$t.tmpl" >"$work/fixtures/brief-$t.md"
+done
+
+# ── stubs (the validator itself needs none; next-issue.sh does) ──────
+
+cat >"$work/fixtures/issue-ok.json" <<'JSON'
+{"state":"OPEN","title":"feat(fleet): validate ok","labels":[{"name":"fleet:ready"}],"comments":[],
+ "body":"## Predicted surface\n\n`scripts/fleet/brief-validate.sh`.\n\n## doneWhen\n- item\n"}
+JSON
+cat >"$work/fixtures/pr-list-empty.json" <<'JSON'
+[]
+JSON
+cat >"$work/fixtures/issue-list-empty.json" <<'JSON'
+[]
+JSON
+
+: >"$work/gh-posted"
+: >"$work/gh-edits"
+: >"$work/pwsh-calls"
+: >"$work/edda-calls"
+
+cat >"$work/bin/gh" <<'STUB'
+#!/bin/sh
+jq_expr=
+prev=
+for a in "$@"; do
+    [ "$prev" = "--jq" ] && jq_expr=$a
+    prev=$a
+done
+resp=
+case "$1 $2" in
+    "issue list") resp=$(cat "$GH_FIXTURES/issue-list-empty.json") ;;
+    "pr list") resp=$(cat "$GH_FIXTURES/pr-list-empty.json") ;;
+esac
+case "$1 $2" in
+    "issue view")
+        resp=$(cat "$GH_FIXTURES/issue-ok.json") ;;
+    "issue edit")
+        echo "$*" >>"$GH_EDITS"
+        echo "edited"
+        exit 0 ;;
+    "issue comment")
+        { echo "---- comment ----"; cat; } >>"$GH_POSTED"
+        echo "commented"
+        exit 0 ;;
+    "label create")
+        echo "$*" >>"$GH_EDITS"
+        exit 0 ;;
+esac
+[ -n "$resp" ] || { echo "gh-stub: unexpected: $*" >&2; exit 1; }
+if [ -n "$jq_expr" ]; then
+    printf '%s' "$resp" | tr -d '\r' | jq -r "$jq_expr"
+else
+    printf '%s\n' "$resp"
+fi
+STUB
+chmod +x "$work/bin/gh"
+
+cat >"$work/bin/edda" <<'STUB'
+#!/bin/sh
+echo "$*" >>"$EDDA_CALLS"
+exit 0
+STUB
+chmod +x "$work/bin/edda"
+
+cat >"$work/bin/pwsh" <<'STUB'
+#!/bin/sh
+echo "pwsh-stub: $*" >>"$PWSH_CALLS"
+exit 0
+STUB
+chmod +x "$work/bin/pwsh"
+
+# ── default suite ────────────────────────────────────────────────────
+
+if [ "$run_suite" -eq 1 ]; then
+    # a. the valid brief: VALID + stat + .expected.diff beside the brief
+    (cd "$work/repo" && sh "$ROOT/scripts/fleet/brief-validate.sh" \
+        "$work/fixtures/brief-ok.md" >"$work/out/ok.txt" 2>&1) || \
+        fail "brief-ok must validate: $(cat "$work/out/ok.txt")"
+    grep -q '^VALID$' "$work/out/ok.txt" ||
+        fail "brief-ok misses the VALID line: $(cat "$work/out/ok.txt")"
+    grep -q 'new.txt' "$work/out/ok.txt" ||
+        fail "brief-ok stat must name new.txt: $(cat "$work/out/ok.txt")"
+    [ -f "$work/fixtures/brief-ok.md.expected.diff" ] ||
+        fail "brief-ok must write the expected diff beside the brief"
+    grep -q '+line two edited' "$work/fixtures/brief-ok.md.expected.diff" ||
+        fail "expected diff misses the applied edit: $(cat "$work/fixtures/brief-ok.md.expected.diff")"
+    rm -f "$work/fixtures/brief-ok.md.expected.diff"
+    echo "ok a valid brief validates with expected diff"
+
+    # b–f. the five defect classes: INVALID step=<n>, no expected diff
+    for t in runner:9.1 space:9.2 count:9.2 orphan:9.2 half:9.2; do
+        name=${t%%:*}
+        want=${t#*:}
+        set +e
+        (cd "$work/repo" && sh "$ROOT/scripts/fleet/brief-validate.sh" \
+            "$work/fixtures/brief-$name.md" >"$work/out/$name.txt" 2>&1)
+        rc=$?
+        set -e
+        [ "$rc" -eq 1 ] || fail "brief-$name exit $rc, want 1: $(cat "$work/out/$name.txt")"
+        grep -q "^INVALID step=$want" "$work/out/$name.txt" ||
+            fail "brief-$name must report INVALID step=$want: $(cat "$work/out/$name.txt")"
+        [ -f "$work/fixtures/brief-$name.md.expected.diff" ] &&
+            fail "brief-$name must not write an expected diff"
+        echo "ok $name rejected at step $want"
+    done
+
+    # g. structure error: missing markers → exit 2
+    set +e
+    (cd "$work/repo" && sh "$ROOT/scripts/fleet/brief-validate.sh" \
+        "$work/fixtures/brief-nomarkers.md" >"$work/out/nomarkers.txt" 2>&1)
+    rc=$?
+    set -e
+    [ "$rc" -eq 2 ] || fail "brief-nomarkers exit $rc, want 2: $(cat "$work/out/nomarkers.txt")"
+    grep -qi 'marker' "$work/out/nomarkers.txt" ||
+        fail "brief-nomarkers must name the missing marker: $(cat "$work/out/nomarkers.txt")"
+    echo "ok g missing markers refused"
+
+    echo "PASS: scripts/fleet/test-brief-validate.sh"
+    exit 0
+fi
+
+# ── integration: the gate sits in next-issue.sh before the launch ────
+
+if [ "$run_integ" -eq 1 ]; then
+    if ! grep -q 'brief-validate' "$next_issue"; then
+        fail "next-issue.sh carries no validate gate — insert it (step 9.6) before running --integration"
+    fi
+    cp "$work/fixtures/brief-runner.md" "$work/scratch/brief-gh886.md"
+    EDDA_FLEET_SCRATCH="$work/scratch" TEMP="$work/lanes" TMPDIR="$work" \
+        PATH="$work/bin:$PATH" \
+        GH_FIXTURES="$work/fixtures" GH_POSTED="$work/gh-posted" \
+        GH_EDITS="$work/gh-edits" PWSH_CALLS="$work/pwsh-calls" \
+        EDDA_CALLS="$work/edda-calls" \
+        sh "$next_issue" 886 docs/worker-9 >"$work/out/e.txt" 2>"$work/out/e.err" &&
+        fail "gated next-issue must exit 2" || rc=$?
+    [ "${rc:-0}" -eq 2 ] || fail "gated next-issue exit ${rc:-0}, want 2: $(cat "$work/out/e.err")"
+    grep -qi 'brief-validate\|INVALID' "$work/out/e.err" "$work/out/e.txt" ||
+        fail "gated refusal must name the validator: $(cat "$work/out/e.err")"
+    [ "$(ls -A "$work/scratch")" = "brief-gh886.md" ] ||
+        fail "gated next-issue changed the scratch dir: $(ls -A "$work/scratch")"
+    [ -s "$work/pwsh-calls" ] &&
+        fail "gated refusal must not launch: $(cat "$work/pwsh-calls")"
+    [ -s "$work/gh-edits" ] &&
+        fail "gated refusal must not touch labels or claims: $(cat "$work/gh-edits")"
+    [ -s "$work/edda-calls" ] &&
+        fail "gated refusal must not run task new: $(cat "$work/edda-calls")"
+    echo "PASS: scripts/fleet/test-brief-validate.sh"
+    exit 0
+fi


### PR DESCRIPTION
## Problem and change
scripts/fleet/brief-validate.sh applies a brief's authored span (between <<AUTHORED: BEGIN>> and <<AUTHORED: END>>) in a throwaway worktree at the brief's pinned base SHA before any lane launch: every concrete edit must match exactly once and mutates the tree later steps see, concrete writes land verbatim (metavariable writes are skipped with a note, never guessed), every expected-output step is executed and compared (empty-stdout, numeric, and literal forms), and touched .sh/.ps1 files pass a per-type syntax gate attributed to the step that last touched the file; ungated file types are skipped by name (SKIP gate <path>). All steps pass → VALID, a diff --stat summary, and the full expected diff beside the brief as .expected.diff; any mismatch → INVALID step=<n> with verbatim output and exit 1, no diff. scripts/fleet/next-issue.sh runs the validator after the authored-middle check and before any worktree, task, claim, or launch (skipped in --dry-run), exiting 2 on INVALID.

## Validation
### RAN
- sh scripts/fleet/test-brief-validate.sh — RED before the implementation (rc=1, `FAIL: sh -n scripts/fleet/brief-validate.sh`) and GREEN after (rc=0): PASS: scripts/fleet/test-brief-validate.sh — fixtures pin the issue's five brief-defect classes (absent runner, whitespace the tree guarantees, grep-count mismatch, orphan token left by an edit, half-applied fix) each at its failing step, plus one valid brief (asserting the SKIP gate line for the ungated .txt fixture) and a missing-markers structure refusal (exit 2)
- Round-1 review fix re-run @ c0148ed — RED with only the skip-naming assertion added (rc=1) and GREEN after the validator change (rc=0, 7 cases)
- sh scripts/fleet/test-brief-validate.sh --integration after the gate insertion — rc=0: PASS (next-issue.sh 886 exits 2 at the validate gate, scratch untouched, no launch, no claim, no task new)
- sh scripts/fleet/test-next-loop.sh after the gate insertion — rc=0: PASS: scripts/fleet/test-next-loop.sh
- sh scripts/fleet/test-brief-from-issue.sh — rc=0 (generator untouched); sh scripts/fleet/test-ready-queue-lint.sh — rc=0
- sh -n on scripts/fleet/brief-validate.sh and scripts/fleet/next-issue.sh — exit 0
- git diff --check before commit — empty

### READ
- Issue #930 doneWhen — every item delivered by this diff (validator, next-issue.sh gate before launch, five INVALID fixture classes + one VALID, red-then-green suite, throwaway worktree pinned at the brief's base SHA with trap cleanup and no ad-hoc CARGO_TARGET_DIR).

Closes #930
Issue: #930