### PR TITLE
fix(fleet): verdict publication posts the report only, heading first; watcher rejects transcript dumps and skips non-open PRs

### DIFF
--- a/scripts/fleet/next-review.sh
+++ b/scripts/fleet/next-review.sh
@@ -165,13 +165,24 @@ if [ "$head_now" != "$head_sha" ]; then
 fi
 verdict_file="$wt/next-review-r$round-verdict.md"
 printf '%s\n' "$verdict" >"$verdict_file"
+# R23 (#917): publish the report only, heading first. Everything before the
+# first `## Code Review: Round` line (the engine's own narration, #867's
+# transcript-dump shape) is discarded into a separate posting file; the raw
+# verdict file is kept untouched beside it. No heading line: post nothing,
+# fail loudly, name the PR and the file.
+first_heading=$(grep -nE '^## Code Review: Round [0-9]+ — PR #[0-9]+ @ [0-9a-f]{40}( \(SHADOW\))?$' \
+    "$verdict_file" | sed -n '1s/:.*//p')
+[ -n "$first_heading" ] ||
+    die "verdict for PR #$pr has no '## Code Review: Round' heading line — posted nothing (raw verdict kept at $verdict_file)"
+posted_file="$wt/next-review-r$round-verdict.posted.md"
+tail -n +"$first_heading" "$verdict_file" >"$posted_file"
 # SHADOW shape (review.gh880-shadow): heading suffix, shadow: true, no
 # labels, no Independent Review status, not a merge authority.
-sed -i "1s/\$/ (SHADOW)/" "$verdict_file"
-sed -i "1a shadow: true" "$verdict_file"
+sed -i "1s/\$/ (SHADOW)/" "$posted_file"
+sed -i "1a shadow: true" "$posted_file"
 cost_line="$cost"
 [ -n "$elapsed_ms" ] && cost_line="$cost / ${elapsed_ms}ms"
-sed -i "s|^- cost: .*|- cost: $cost_line (dispatch --json)|" "$verdict_file"
-gh pr comment "$pr" --repo "$repo" --body-file "$verdict_file" >/dev/null ||
+sed -i "s|^- cost: .*|- cost: $cost_line (dispatch --json)|" "$posted_file"
+gh pr comment "$pr" --repo "$repo" --body-file "$posted_file" >/dev/null ||
     die "gh pr comment failed"
-echo "posted SHADOW round $round: $verdict_file"
+echo "posted SHADOW round $round: $posted_file"

--- a/scripts/fleet/test-next-loop.sh
+++ b/scripts/fleet/test-next-loop.sh
@@ -150,12 +150,41 @@ echo "$*" >>"$EDDA_CALLS"
 if [ -n "${EDDA_STUB_MOVE_HEAD:-}" ]; then
     printf '%s' "$EDDA_STUB_MOVE_HEAD" >"$GH_HEAD_FILE"
 fi
+# R23 (#917): verdict fixtures carry a real §7 heading. EDDA_STUB_RESULT_FILE
+# substitutes the whole dispatch envelope (built with jq below).
+if [ -n "${EDDA_STUB_RESULT_FILE:-}" ]; then
+    cat "$EDDA_STUB_RESULT_FILE"
+    exit 0
+fi
 cat <<'JSON'
-{"outcome":"done","result_text":"## Code Review: Round 2 - PR #886 @ somehead\n\n- model_requested: openrouter/z-ai/glm-5.3-flash\n- model_observed: openrouter/z-ai/glm-5.3-flash\n- spec: review-spec-v1.4\n- class: code-risk\n- cost: placeholder line\n\nbody of the verdict","cost_usd":0.02,"elapsed_ms":1234,"model_requested":"openrouter/z-ai/glm-5.3-flash","model_observed":"openrouter/z-ai/glm-5.3-flash","session_id":"sid","session_observed":"sid","error":null}
+{"outcome":"done","result_text":"## Code Review: Round 2 — PR #886 @ aabbccdd11223344556677889900aabbccddeeff\n\n- model_requested: openrouter/z-ai/glm-5.3-flash\n- model_observed: openrouter/z-ai/glm-5.3-flash\n- spec: review-spec-v1.4\n- class: code-risk\n- cost: placeholder line\n\nbody of the verdict","cost_usd":0.02,"elapsed_ms":1234,"model_requested":"openrouter/z-ai/glm-5.3-flash","model_observed":"openrouter/z-ai/glm-5.3-flash","session_id":"sid","session_observed":"sid","error":null}
 JSON
 exit 0
 STUB
 chmod +x "$work/bin/edda"
+
+# Verdict fixtures for the R23 publication cases: the same envelope with the
+# engine's narration before the heading (#867's transcript-dump shape), and
+# one with no heading line at all.
+verdict_envelope() { # $1=result text file -> dispatch envelope JSON on stdout
+    jq -n --rawfile v "$1" \
+        '{outcome:"done",result_text:$v,cost_usd:0.02,elapsed_ms:1234,model_requested:"openrouter/z-ai/glm-5.3-flash",model_observed:"openrouter/z-ai/glm-5.3-flash",session_id:"sid",session_observed:"sid",error:null}'
+}
+{
+    printf 'I will start by loading the project guide.\n'
+    printf 'Rerunning with a backslash-free harness.\n'
+    for i in 1 2 3 4 5 6 7 8 9 10; do printf 'narration line %s\n' "$i"; done
+    printf -- '---\n'
+    printf '## Code Review: Round 2 — PR #886 @ aabbccdd11223344556677889900aabbccddeeff\n\n'
+    printf -- '- model_requested: openrouter/z-ai/glm-5.3-flash\n- cost: placeholder line\n\nbody of the verdict\n'
+} >"$work/fixtures/verdict-narration.txt"
+verdict_envelope "$work/fixtures/verdict-narration.txt" >"$work/fixtures/verdict-narration.json"
+{
+    printf 'I will start by loading the project guide.\n'
+    for i in 1 2 3; do printf 'narration line %s\n' "$i"; done
+    printf 'no verdict was produced\n'
+} >"$work/fixtures/verdict-noheading.txt"
+verdict_envelope "$work/fixtures/verdict-noheading.txt" >"$work/fixtures/verdict-noheading.json"
 
 cat >"$work/bin/pwsh" <<'STUB'
 #!/bin/sh
@@ -318,5 +347,32 @@ for crafted in 'docs/worker-1" --evil "x' 'docs/'; do
     [ -s "$work/gh-edits" ] && fail "crafted identity '$crafted' touched labels: $(cat "$work/gh-edits")"
 done
 echo "ok 8 machine identity shape refusal"
+
+# ── 9. R23 publication: narration before the heading is trimmed ─────
+
+: >"$work/gh-posted"
+printf '%s' "$HEAD1" >"$work/gh-head"
+EDDA_STUB_RESULT_FILE="$work/fixtures/verdict-narration.json" \
+    run_loop sh "$next_review" 886 --shadow >"$work/out/trim.txt" 2>"$work/out/trim.err" || \
+    fail "narration trim run exit $? : $(cat "$work/out/trim.err")"
+grep -q 'posted SHADOW round' "$work/out/trim.txt" || fail "trim run must post: $(cat "$work/out/trim.txt")"
+posted=$(awk '/^---- comment ----$/{f=1;next} f' "$work/gh-posted")
+printf '%s\n' "$posted" | head -1 | grep -q '^## Code Review: Round' || \
+    fail "posted body must begin with the heading: $(printf '%s\n' "$posted" | head -1)"
+printf '%s\n' "$posted" | grep -q 'narration line' && fail "narration leaked into the posted verdict"
+printf '%s\n' "$posted" | grep -qF 'I will start by loading' && fail "engine preamble leaked into the posted verdict"
+echo "ok 9 R23 publication trims narration"
+
+# ── 10. R23 publication: a verdict with no heading posts nothing ────
+
+: >"$work/gh-posted"
+printf '%s' "$HEAD1" >"$work/gh-head"
+EDDA_STUB_RESULT_FILE="$work/fixtures/verdict-noheading.json" \
+    run_loop sh "$next_review" 886 --shadow >"$work/out/nohead.txt" 2>"$work/out/nohead.err" && \
+    fail "headingless verdict must exit non-zero" || rc=$?
+[ "${rc:-0}" -eq 2 ] || fail "headingless verdict exit ${rc:-0}, want 2: $(cat "$work/out/nohead.err")"
+grep -q 'PR #886' "$work/out/nohead.err" || fail "refusal must name the PR: $(cat "$work/out/nohead.err")"
+[ -s "$work/gh-posted" ] && fail "headingless verdict must post nothing: $(cat "$work/gh-posted")"
+echo "ok 10 R23 publication refuses a headingless verdict"
 
 echo "PASS: scripts/fleet/test-next-loop.sh"

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -268,8 +268,13 @@ collect_verdicts() { # $1=pr $2=reviewed sha — every verdict comment pinned to
   # must withhold the status, never let the union rule run on this round's
   # verdict file alone (see post_review_status).
   is_full_sha "$2" || { log "pr$1 collect-verdicts: $2 is not a full lowercase 40-hex SHA"; return 3; }
-  comments=$(gh pr view "$1" --repo "$REPO" --json comments \
-    --jq '.comments[] | "<<<COMMENT \(.id)>>>" , .body' 2>&1)
+  # REST issues comments, not `gh pr view --json comments`: the GraphQL shape
+  # carries only node ids (base64), while the malformed-notice contract needs
+  # the numeric comment id humans can resolve. --paginate keeps the full
+  # comment list (a 30-comment default page would hide older verdicts from
+  # the union); jq runs per page and pages split between comments.
+  comments=$(gh api --paginate "repos/$REPO/issues/$1/comments" \
+    --jq '.[] | "<<<COMMENT \(.id)>>>" , .body' 2>&1)
   rc=$?
   if [ "$rc" -ne 0 ]; then
     log "pr$1 comments fetch failed (gh exit $rc): $comments"

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -3,6 +3,10 @@
 # has not been reviewed yet, launch the read-only reviewer (scripts/review-pr.sh),
 # post `review: started on <sha>` as an acknowledgement (retried, bounded), then
 # post the SHA-pinned verdict when the reviewer finishes and set review:* labels.
+# R23 (#917): a verdict comment is the report only, §7 heading first — the
+# watcher never launches or acks on a non-open PR, treats a comment carrying
+# the heading anywhere but line 1 as a malformed transcript dump (one notice,
+# no status, no label), and posts its own receipts to the log, not the comment.
 #
 # usage: pr-review-watch.sh [--once] [--dry-run]
 #        pr-review-watch.sh decide                 (offline helper; TSV on stdin)
@@ -191,27 +195,50 @@ gate_state() {
 # `### Verdict` heading carries the verdict and its P0/P1 counts (the same
 # line scripts/review-pr.sh verdict-label reads). Missing counts are passed
 # through as empty fields — the union rule treats them as non-zero.
-verdict_body_lines() { # $1=reviewed sha; stdin: one body per <<<COMMENT>>>
-                       # block (a single raw body also works); stdout: verdict<TAB>p0<TAB>p1
+verdict_body_lines() { # $1=reviewed sha; stdin: one body per <<<COMMENT>>> block
+                       # (a single raw body also works); stdout: verdict<TAB>p0<TAB>p1,
+                       # plus one `<<<MALFORMED <comment id>>>` record per malformed comment
   awk -v sha="$1" '
-    function flush(   i, n, vline, v, p0, p1, inh, pinned) {
+    BEGIN {
+      # The R23 heading shape (rules.md R23), with the SHADOW suffix accepted
+      # in both recorded positions (REVIEW.md §7/§8: after Round <N>; #917
+      # trim contract: line end). Built from 40 single-char classes so the
+      # match never depends on awk interval-expression support.
+      h = ""
+      for (i = 0; i < 40; i++) h = h "[0-9a-f]"
+      heading = "^## Code Review: Round [0-9]+( \\(SHADOW\\))? — PR #[0-9]+ @ " h "( \\(SHADOW\\))?$"
+    }
+    function flush(   i, n, vline, v, p0, p1, inh, first) {
       if (!inb) return
       inb = 0
       n = split(buf, L, "\n")
-      pinned = 0; inh = 0; vline = ""
-      for (i = 1; i <= n; i++) {
-        # $2 is validated with is_full_sha by every caller before it gets
-        # here, so it is exactly 40 lowercase hex characters — no regex
-        # metacharacters — and this pin match is literal.
-        if (L[i] ~ ("^## Code Review: Round [0-9]+ — PR #[0-9]+ @ " sha "$")) {
-          pinned = 1; continue
+      # R23 (#917): a verdict comment BEGINS with the §7 heading. A comment
+      # carrying the heading anywhere else is a transcript dump (#867): it is
+      # no verdict at all — no status, no label, no round. The caller posts
+      # the one-shot malformed notice from the <<<MALFORMED>>> record.
+      first = L[1]
+      if (first !~ heading) {
+        for (i = 1; i <= n; i++) {
+          if (L[i] ~ heading) {
+            if (cid != "") print "<<<MALFORMED " cid ">>>"
+            return
+          }
         }
+        return
+      }
+      # $2 is validated with is_full_sha by every caller before it gets
+      # here, so it is exactly 40 lowercase hex characters — no regex
+      # metacharacters — and this pin match is literal. No ` (SHADOW)`
+      # allowance here: a SHADOW verdict never enters the union (REVIEW.md §8).
+      if (first !~ ("^## Code Review: Round [0-9]+ — PR #[0-9]+ @ " sha "$")) return
+      inh = 0; vline = ""
+      for (i = 2; i <= n; i++) {
         if (L[i] ~ /^#{1,}[[:space:]]*Verdict/) { inh = 1; continue }
-        if (pinned && inh && vline == "" && L[i] ~ /LGTM|Changes Requested/) {
+        if (inh && vline == "" && L[i] ~ /LGTM|Changes Requested/) {
           vline = L[i]
         }
       }
-      if (!pinned || vline == "") return
+      if (vline == "") return
       v = "LGTM"
       if (vline ~ /Changes Requested/) v = "Changes Requested"
       p0 = ""; p1 = ""
@@ -220,27 +247,40 @@ verdict_body_lines() { # $1=reviewed sha; stdin: one body per <<<COMMENT>>>
       print v "\t" p0 "\t" p1
     }
     { sub(/\r$/, "") }
-    /^<<<COMMENT>>>$/ { flush(); inb = 1; buf = ""; next }
-    { if (!inb) { inb = 1; buf = "" }
+    /^<<<COMMENT>>>$/ { flush(); inb = 1; buf = ""; cid = ""; next }
+    /^<<<COMMENT [0-9]+>>>$/ {
+      flush(); inb = 1; buf = ""
+      cid = $0; sub(/^<<<COMMENT /, "", cid); sub(/>>>$/, "", cid)
+      next
+    }
+    { if (!inb) { inb = 1; buf = ""; cid = "" }
       buf = buf $0 "\n" }
     END { flush() }
   '
 }
 
 collect_verdicts() { # $1=pr $2=reviewed sha — every verdict comment pinned to that sha
-  # Return codes: 0 = ok (verdict lines on stdout, possibly none); 3 = the
-  # comments fetch failed. An unreadable comment list is NOT "no prior
-  # verdicts" — callers must withhold the status, never let the union rule
-  # run on this round's verdict file alone (see post_review_status).
+  # Return codes: 0 = ok (verdict lines on stdout, possibly none); 4 = ok,
+  # but at least one malformed verdict comment was seen (its `<<<MALFORMED
+  # <comment id>>>` records are on stdout; the caller posts the one-shot
+  # notice and withholds the status for that poll); 3 = the comments fetch
+  # failed. An unreadable comment list is NOT "no prior verdicts" — callers
+  # must withhold the status, never let the union rule run on this round's
+  # verdict file alone (see post_review_status).
   is_full_sha "$2" || { log "pr$1 collect-verdicts: $2 is not a full lowercase 40-hex SHA"; return 3; }
   comments=$(gh pr view "$1" --repo "$REPO" --json comments \
-    --jq '.comments[] | "<<<COMMENT>>>", .body' 2>&1)
+    --jq '.comments[] | "<<<COMMENT \(.id)>>>" , .body' 2>&1)
   rc=$?
   if [ "$rc" -ne 0 ]; then
     log "pr$1 comments fetch failed (gh exit $rc): $comments"
     return 3
   fi
-  printf '%s\n' "$comments" | verdict_body_lines "$2"
+  out=$(printf '%s\n' "$comments" | verdict_body_lines "$2")
+  printf '%s\n' "$out"
+  case "$out" in
+    *"<<<MALFORMED"*) return 4 ;;
+    *) return 0 ;;
+  esac
 }
 # /D8-debt
 
@@ -258,11 +298,21 @@ ack_drop() { # $1=pr
 }
 
 ack_try() { # $1=pr $2=sha $3=attempts — one attempt.
-  # exit 0 = posted (pending entry cleared); 1 = failed, retries remain;
-  # 2 = failed after the bound. The entry is a durable record: after the bound
-  # it is only marked "post-failed" once review:post-failed is APPLIED; if the
-  # label call fails too, the entry stays for the next poll (no silent
-  # terminal state).
+  # exit 0 = posted (or the PR is no longer open — entry dropped, nothing to
+  # ack); 1 = failed, retries remain; 2 = failed after the bound. The entry
+  # is a durable record: after the bound it is only marked "post-failed" once
+  # review:post-failed is APPLIED; if the label call fails too, the entry
+  # stays for the next poll (no silent terminal state).
+  # R23 follow-on (#917): `review: started` never lands on a merged or
+  # closed PR (#867 posted it twice on an already-merged PR). A state read
+  # that fails counts as NOT open — a watcher that cannot read the state
+  # never acks.
+  st=$(gh pr view "$1" --repo "$REPO" --json state --jq .state 2>/dev/null)
+  if [ "$st" != "OPEN" ]; then
+    log "pr$1 ack skipped: state is '${st:-unreadable}', not OPEN — posting nothing, ack entry dropped"
+    ack_drop "$1"
+    return 0
+  fi
   if printf 'review: started on %s\n' "$2" \
       | gh pr comment "$1" --repo "$REPO" --body-file - >/dev/null 2>&1; then
     ack_drop "$1"
@@ -515,11 +565,36 @@ post_review_status() { # $1=pr $2=reviewed sha $3=verdict file
   [ -n "$p1" ] || p1="?"
   comments=$(collect_verdicts "$1" "$2")
   rc=$?
-  if [ "$rc" -ne 0 ]; then
+  if [ "$rc" -ne 0 ] && [ "$rc" -ne 4 ]; then
     log "pr$1 comments unreadable (gh exit $rc); status withheld, will retry next poll"
     return 3
   fi
-  state=$(printf '%s\n%s\n' "$comments" "$(verdict_body_lines "$2" < "$3")" | gate_state)
+  # R23 (#917): a transcript-dump verdict (heading anywhere but line 1) is no
+  # verdict — it contributes nothing to the union. The watcher posts one
+  # notice per comment id (marker file in $SCRATCH, the same one-shot
+  # mechanism as $STATUSOK) and withholds the status for any poll in which a
+  # NEW notice goes out — the per-PR failure signal; the next poll proceeds
+  # with the malformed comment permanently excluded.
+  new_notice=0
+  seen=
+  for cid in $(printf '%s\n' "$comments" | sed -n 's/^<<<MALFORMED \([0-9]\{1,\}\)>>>/\1/p'); do
+    seen="$seen $cid"
+    marker="$SCRATCH/review-pr$1-malformed-$cid.noticed"
+    if [ -f "$marker" ]; then continue; fi
+    if gh pr comment "$1" --repo "$REPO" --body "review: malformed verdict comment $cid" >/dev/null 2>&1; then
+      : > "$marker"
+      log "pr$1 malformed verdict comment $cid: notice posted; it contributes no verdict"
+    else
+      log "pr$1 malformed notice for comment $cid failed to post; will retry next poll"
+    fi
+    new_notice=1
+  done
+  if [ "$new_notice" = "1" ]; then
+    log "pr$1 status withheld this poll: new malformed verdict notice(s):$seen"
+    return 3
+  fi
+  prior=$(printf '%s\n' "$comments" | awk -F'\t' '$1 == "LGTM" || $1 == "Changes Requested"')
+  state=$(printf '%s\n%s\n' "$prior" "$(verdict_body_lines "$2" < "$3")" | gate_state)
   gh api "repos/$REPO/statuses/$2" \
     -f state="$state" -f context="Independent Review" \
     -f description="$v P0=$p0 P1=$p1" >/dev/null
@@ -690,17 +765,18 @@ settle_pending() {
         [ -n "$tool_flags" ] || tool_flags='unknown — no TOOL_FLAGS receipt'
         [ -n "$tree_check" ] || tree_check='unknown — no WORKTREE_CHECK receipt'
         COMMENT="$SCRATCH/review-pr$pr-r$round-comment.md"
-        {
-          echo "> **Round $round review** — automatic watcher (\`scripts/pr-review-watch.sh\`): transport \`$tdesc\`, tool flags \`$tool_flags\`, worktree check \`$tree_check\`, model \`$REQ\` (observed \`$OBSERVED\`), reviewer_session $(reviewer_session_desc "$DONE" "$SIDO"), $costline, detached worktree at \`$sha\`. Reviewed head SHA: \`$sha\`."
-          echo
-          cat "$VERDICT"
-        } > "$COMMENT"
+        # R23 (#917): the posted comment IS the report — the §7 carrier
+        # verbatim, heading first, no watcher narration before it. The
+        # transport/tool/worktree/session receipts this header used to carry
+        # move to the log line below; the round guard above already proved
+        # the carrier begins with the SHA-pinned heading.
+        cp "$VERDICT" "$COMMENT"
         if [ "$DRY" = "1" ]; then
           echo "dry-run: would post $COMMENT to PR #$pr and set a review:* label"
           continue
         fi
         if gh pr comment "$pr" --repo "$REPO" --body-file "$COMMENT" >/dev/null 2>&1; then
-          log "pr$pr r$round posted verdict comment"
+          log "pr$pr r$round posted verdict comment (transport $tdesc, tool flags $tool_flags, worktree check $tree_check, model $REQ observed $OBSERVED, reviewer_session $(reviewer_session_desc "$DONE" "$SIDO"), $costline, detached worktree at $sha)"
           mv "$VERDICT" "$POSTED"
           pending_update "$pr" "$round" "$sha" "$attempts" "$launched" 0
           finish_verdict "$POSTED"
@@ -774,6 +850,16 @@ scan_open_prs() {
     [ "${verb:-}" = "REVIEW" ] || continue
     [ -n "${pr:-}" ] || continue
     pending_has "$pr" && continue
+
+    # R23 follow-on (#917): never start a round on a PR that is not open
+    # (#867 launched a review on an already-merged PR and acked it twice).
+    # A state read that fails counts as NOT open — a watcher that cannot
+    # read the state never launches.
+    st=$(gh pr view "$pr" --repo "$REPO" --json state --jq .state 2>/dev/null)
+    if [ "$st" != "OPEN" ]; then
+      log "pr$pr skipped: state is '${st:-unreadable}', not OPEN — no launch, no review: started, no status"
+      continue
+    fi
 
     prev=$(state_field "$pr" 2)
     round=$(state_field "$pr" 3)

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -77,7 +77,59 @@ case "$1" in
     exit 0
     ;;
   api)
-    [ -n "${GH_FAIL_STATUS:-}" ] && exit 1
+    case "$*" in
+      *"/statuses/"*)
+        [ -n "${GH_FAIL_STATUS:-}" ] && exit 1
+        exit 0
+        ;;
+      *"comments"*)
+        # collect_verdicts reads REST issues comments (numeric ids). The
+        # GH_COMMENTS_FILE fixture stores the jq-output shape (sentinel + raw
+        # bodies); re-encode it as the REST array so the real --jq filter in
+        # collect_verdicts runs against the stub, ids included.
+        [ -n "${GH_FAIL_COMMENTS:-}" ] && exit 1
+        [ -z "${GH_COMMENTS_FILE:-}" ] && exit 0
+        # resolve the caller's --jq operand (this stub header has no global loop)
+        jq_expr=
+        prev=
+        for a in "$@"; do
+            [ "$prev" = "--jq" ] && jq_expr=$a
+            prev=$a
+        done
+        json=$(awk '
+          /^<<<COMMENT>>>$/ { n++; id[n] = 1; next }
+          /^<<<COMMENT [0-9]+>>>$/ {
+            n++
+            id[n] = $0
+            sub(/^<<<COMMENT /, "", id[n])
+            sub(/>>>$/, "", id[n])
+            next
+          }
+          {
+            if (n == 0) next
+            esc = $0
+            gsub(/\\/, "\\\\", esc)
+            gsub(/"/, "\\\"", esc)
+            body[n] = body[n] (body[n] == "" ? "" : "\\n") esc
+          }
+          END {
+            printf "["
+            for (i = 1; i <= n; i++) {
+              printf "%s{\"id\":%s,\"body\":\"%s\"}", (i > 1 ? "," : ""), id[i], body[i]
+            }
+            printf "]\n"
+          }
+        ' "$GH_COMMENTS_FILE")
+        # the stub IS gh: apply the caller's --jq itself, exactly like the
+        # real endpoint's --jq would run against this array
+        if [ -n "$jq_expr" ]; then
+            printf '%s' "$json" | jq -r "$jq_expr"
+        else
+            printf '%s\n' "$json"
+        fi
+        exit 0
+        ;;
+    esac
     exit 0
     ;;
   label) exit 0 ;;

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -66,7 +66,8 @@ case "$1" in
             exit 0
             ;;
           *state*)
-            echo "OPEN"
+            [ -n "${GH_FAIL_STATE:-}" ] && exit 1
+            if [ -n "${GH_STATE:-}" ]; then echo "$GH_STATE"; else echo "OPEN"; fi
             exit 0
             ;;
         esac
@@ -384,8 +385,10 @@ expect_gate_state 'an unknown verdict word is failure' 'failure' 'Needs Discussi
 # GH_PR_LIST_FILE, which also stores jq output rather than raw JSON.
 
 verdict_comment() { # $1=round $2=sha $3=verdict line — the shape the watcher posts
-    printf '<<<COMMENT>>>\n> **Round %s review** — automatic watcher, reviewed head SHA: `%s`.\n\n## Code Review: Round %s — PR #42 @ %s\n\n### Verdict\n%s\n' \
-        "$1" "$2" "$1" "$2" "$3"
+    # R23 (#917): the posted comment IS the report — the §7 heading is the
+    # first line, no watcher banner before it.
+    printf '<<<COMMENT>>>\n## Code Review: Round %s — PR #42 @ %s\n\n### Verdict\n%s\n' \
+        "$1" "$2" "$3"
 }
 
 expect_collect() {
@@ -664,14 +667,24 @@ if [ "$(printf '%s' "$(pending_get)" | cut -f4)" != "1" ]; then
     exit 1
 fi
 
-# --- live loop: the verdict header names the transport that actually ran (P1) --
+# --- live loop: the receipts the verdict header used to carry (GH-708, R23) ----
 # Round 2 P1-1: the header used to hardcode `edda dispatch --agent claude` even
-# when the oversized-brief claude-stdin fallback was the arm that ran. The
-# header must print the TRANSPORT= receipt from .done, verbatim, or say
-# "unknown" when the receipt is missing — never the transport we wish had run.
+# when the oversized-brief claude-stdin fallback was the arm that ran. R23
+# (#917) moves the receipts out of the PR comment entirely: the comment IS the
+# §7 report, heading first, and the transport receipt lands in the watcher log
+# — verbatim, or "unknown" when the receipt is missing, never the transport we
+# wish had run.
 
 header_comment_path() {
     sed -n 's/.*--body-file //p' "$GH_STUB_LOG" | tail -1
+}
+
+comment_head_is_heading() { # $1=comment file — R23: the heading is line 1
+    head -1 "$1" | grep -q '^## Code Review: Round [0-9]* — PR #42 @ '
+}
+
+last_receipt_line() { # the receipts of the MOST RECENT posted verdict comment
+    grep 'posted verdict comment' "$PR_REVIEW_WATCH_LOG" | tail -1
 }
 
 verdict_log_fixture() {
@@ -704,8 +717,12 @@ verdict_log_fixture
 run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (header: dispatch arm)\n' >&2; exit 1; }
 cfile=$(header_comment_path)
 [ -n "$cfile" ] || { printf 'live: a settled verdict should post a comment\n' >&2; exit 1; }
-grep -qF 'transport `edda dispatch --agent claude`' "$cfile" || {
-    printf 'live: header must name the edda-dispatch receipt, got header:\n%s\n' "$(head -1 "$cfile")" >&2
+comment_head_is_heading "$cfile" || {
+    printf 'live: R23 — the posted comment must begin with the §7 heading, got:\n%s\n' "$(head -1 "$cfile")" >&2
+    exit 1
+}
+last_receipt_line | grep -qF 'transport edda dispatch --agent claude,' || {
+    printf 'live: the log must name the edda-dispatch receipt, got:\n%s\n' "$(tail -3 "$PR_REVIEW_WATCH_LOG")" >&2
     exit 1
 }
 
@@ -715,12 +732,16 @@ printf 'TRANSPORT=claude-stdin\nDISPATCH_EXIT=0\n' >"$EDDA_FLEET_SCRATCH/review-
 verdict_log_fixture
 run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (header: fallback arm)\n' >&2; exit 1; }
 cfile=$(header_comment_path)
-grep -qF 'transport `claude -p via stdin (oversized-brief fallback)`' "$cfile" || {
-    printf 'live: header must name the claude-stdin fallback receipt, got header:\n%s\n' "$(head -1 "$cfile")" >&2
+comment_head_is_heading "$cfile" || {
+    printf 'live: R23 — the posted comment must begin with the §7 heading, got:\n%s\n' "$(head -1 "$cfile")" >&2
     exit 1
 }
-if grep -qF 'edda dispatch --agent claude' "$cfile"; then
-    printf 'live: header must not claim edda dispatch when the claude-stdin fallback ran, got header:\n%s\n' "$(head -1 "$cfile")" >&2
+last_receipt_line | grep -qF 'transport claude -p via stdin (oversized-brief fallback),' || {
+    printf 'live: the log must name the claude-stdin fallback receipt, got:\n%s\n' "$(tail -3 "$PR_REVIEW_WATCH_LOG")" >&2
+    exit 1
+}
+if last_receipt_line | grep -qF 'transport edda dispatch --agent claude,'; then
+    printf 'live: the log must not claim edda dispatch when the claude-stdin fallback ran\n' >&2
     exit 1
 fi
 
@@ -730,18 +751,22 @@ printf 'DISPATCH_EXIT=0\n' >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
 verdict_log_fixture
 run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (header: missing receipt)\n' >&2; exit 1; }
 cfile=$(header_comment_path)
-grep -qF 'transport `unknown — no TRANSPORT receipt in .done`' "$cfile" || {
-    printf 'live: a missing TRANSPORT receipt must render as unknown, not a guessed transport, got header:\n%s\n' "$(head -1 "$cfile")" >&2
+comment_head_is_heading "$cfile" || {
+    printf 'live: R23 — the posted comment must begin with the §7 heading, got:\n%s\n' "$(head -1 "$cfile")" >&2
+    exit 1
+}
+last_receipt_line | grep -qF 'transport unknown — no TRANSPORT receipt in .done,' || {
+    printf 'live: a missing TRANSPORT receipt must log as unknown, not a guessed transport, got:\n%s\n' "$(tail -3 "$PR_REVIEW_WATCH_LOG")" >&2
     exit 1
 }
 export GH_HEAD="$sha"
 
-# --- live loop: the header names the reviewer conversation (GH-708) ------------
+# --- live loop: the log names the reviewer conversation (GH-708, R23) ----------
 # The per-PR reviewer session is what makes round 2+ a delta review, so the
-# verdict header carries it. Two independent facts are compared, never merged:
+# watcher log carries it. Two independent facts are compared, never merged:
 # SESSION=/SESSION_MODE= are what review-pr.sh LAUNCHED with, and the log's
 # `Session:` line is what the backend REPORTED. A disagreement means the resume
-# forked into a fresh conversation, and the header must say so.
+# forked into a fresh conversation, and the log must say so.
 
 reset_stubs
 pending_set 42 1 "$sha" 0 0
@@ -750,8 +775,12 @@ printf 'TRANSPORT=edda-dispatch\nSESSION=11111111-2222-4333-8444-555555555555\nS
 verdict_log_fixture
 run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (header: session)\n' >&2; exit 1; }
 cfile=$(header_comment_path)
-grep -qF 'reviewer_session `11111111-2222-4333-8444-555555555555` (resumed)' "$cfile" || {
-    printf 'live: header must name the resumed reviewer conversation, got header:\n%s\n' "$(head -1 "$cfile")" >&2
+comment_head_is_heading "$cfile" || {
+    printf 'live: R23 — the posted comment must begin with the §7 heading, got:\n%s\n' "$(head -1 "$cfile")" >&2
+    exit 1
+}
+last_receipt_line | grep -qF 'reviewer_session `11111111-2222-4333-8444-555555555555` (resumed)' || {
+    printf 'live: the log must name the resumed reviewer conversation, got:\n%s\n' "$(last_receipt_line)" >&2
     exit 1
 }
 
@@ -764,8 +793,12 @@ verdict_log_fixture
 FIXTURE_SESSION_OBSERVED=
 run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (header: session mismatch)\n' >&2; exit 1; }
 cfile=$(header_comment_path)
-grep -qF 'BACKEND REPORTED `99999999-8888-4777-8666-555555555555`' "$cfile" || {
-    printf 'live: a resume that ran in a different conversation must be reported, not hidden, got header:\n%s\n' "$(head -1 "$cfile")" >&2
+comment_head_is_heading "$cfile" || {
+    printf 'live: R23 — the posted comment must begin with the §7 heading, got:\n%s\n' "$(head -1 "$cfile")" >&2
+    exit 1
+}
+last_receipt_line | grep -qF 'BACKEND REPORTED `99999999-8888-4777-8666-555555555555`' || {
+    printf 'live: a resume that ran in a different conversation must be reported, not hidden, got:\n%s\n' "$(tail -3 "$PR_REVIEW_WATCH_LOG")" >&2
     exit 1
 }
 
@@ -780,12 +813,16 @@ verdict_log_fixture
 FIXTURE_NO_SESSION_OBSERVED=0
 run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (header: no observation)\n' >&2; exit 1; }
 cfile=$(header_comment_path)
-grep -qF 'reviewer_session `11111111-2222-4333-8444-555555555555` (resumed)' "$cfile" || {
-    printf 'live: a reviewer that observed no session must render the launched id plainly, got header:\n%s\n' "$(head -1 "$cfile")" >&2
+comment_head_is_heading "$cfile" || {
+    printf 'live: R23 — the posted comment must begin with the §7 heading, got:\n%s\n' "$(head -1 "$cfile")" >&2
     exit 1
 }
-if grep -qF 'BACKEND REPORTED' "$cfile"; then
-    printf 'live: no observation is not a mismatch — the header must not claim one, got header:\n%s\n' "$(head -1 "$cfile")" >&2
+grep -qF 'reviewer_session `11111111-2222-4333-8444-555555555555` (resumed)' "$PR_REVIEW_WATCH_LOG" || {
+    printf 'live: a reviewer that observed no session must render the launched id plainly, got:\n%s\n' "$(tail -3 "$PR_REVIEW_WATCH_LOG")" >&2
+    exit 1
+}
+if last_receipt_line | grep -qF 'BACKEND REPORTED'; then
+    printf 'live: no observation is not a mismatch — the log must not claim one\n' >&2
     exit 1
 fi
 
@@ -795,8 +832,12 @@ printf 'TRANSPORT=edda-dispatch\nDISPATCH_EXIT=0\n' >"$EDDA_FLEET_SCRATCH/review
 verdict_log_fixture
 run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (header: no session receipt)\n' >&2; exit 1; }
 cfile=$(header_comment_path)
-grep -qF 'mode unknown — no SESSION_MODE receipt in .done' "$cfile" || {
-    printf 'live: a missing SESSION_MODE receipt must render as unknown, got header:\n%s\n' "$(head -1 "$cfile")" >&2
+comment_head_is_heading "$cfile" || {
+    printf 'live: R23 — the posted comment must begin with the §7 heading, got:\n%s\n' "$(head -1 "$cfile")" >&2
+    exit 1
+}
+last_receipt_line | grep -qF 'mode unknown — no SESSION_MODE receipt in .done' || {
+    printf 'live: a missing SESSION_MODE receipt must log as unknown, got:\n%s\n' "$(tail -3 "$PR_REVIEW_WATCH_LOG")" >&2
     exit 1
 }
 unset GH_HEAD
@@ -972,6 +1013,132 @@ if ! grep -qF -- '--add-label review:lgtm' "$GH_STUB_LOG"; then
     printf 'live: the label should be applied after the comments recover\n' >&2
     exit 1
 fi
+
+# --- R23 (#917): verdict shape and non-open PRs --------------------------------
+# 1. the happy path is unchanged: a §7 carrier (heading first) posts the
+#    comment, writes the status, and applies the label
+# 2. #867's transcript dump (heading mid-body) is no verdict: no status, no
+#    label, exactly one malformed notice, and the round does not settle this
+#    poll (the per-PR failure signal)
+# 3. the same dump on the next poll: no second notice; the union runs on this
+#    round's LGTM alone and the round settles
+# 4. a non-open PR is never launched and never acked (MERGED, CLOSED, and an
+#    unreadable state all count as not open)
+
+r23_dump_fixture() { # $1=comment id $2=sha — #867's shape: narration, ---, heading mid-body
+    {
+        printf '<<<COMMENT %s>>>\n' "$1"
+        for i in 1 2 3 4 5 6 7 8 9 10 11 12; do printf 'reviewer narration line %s\n' "$i"; done
+        printf -- '---\n'
+        printf '## Code Review: Round 1 — PR #42 @ %s\n\n### Verdict\nLGTM (P0=0, P1=0)\n' "$2"
+    } >"$tmp/comments-pr42-r23-dump"
+}
+
+r23_done_receipt() {
+    printf 'TRANSPORT=edda-dispatch\nDISPATCH_EXIT=0\nFINAL_EXIT=0\nWORKTREE_CHECK=unchanged\nWORKTREE_CLEANUP=removed\nTASK_CLEANUP=not-applicable\nTERMINAL_RECEIPT=complete\n' \
+        >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
+}
+
+# case 1 — heading-first LGTM: the unchanged happy path
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+r23_done_receipt
+verdict_log_fixture
+export GH_HEAD="$sha"
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (r23 case 1)\n' >&2; exit 1; }
+grep -qF -- '-f state=success' "$GH_STUB_LOG" || {
+    printf 'live: r23 case 1 — a heading-first LGTM must write the status\n' >&2; exit 1
+}
+grep -qF -- '--add-label review:lgtm' "$GH_STUB_LOG" || {
+    printf 'live: r23 case 1 — a heading-first LGTM must apply the label\n' >&2; exit 1
+}
+unset GH_HEAD
+
+# case 2 — the transcript dump contributes nothing and draws exactly one notice
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+r23_done_receipt
+verdict_log_fixture
+r23_dump_fixture 7777001 "$sha"
+export GH_HEAD="$sha"
+export GH_COMMENTS_FILE="$tmp/comments-pr42-r23-dump"
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (r23 case 2)\n' >&2; exit 1; }
+[ "$(statuses_calls)" = "0" ] || {
+    printf 'live: r23 case 2 — a transcript dump must not let a status post, got %s calls\n' \
+        "$(statuses_calls)" >&2; exit 1
+}
+if grep -qF -- '--add-label review:lgtm' "$GH_STUB_LOG"; then
+    printf 'live: r23 case 2 — a transcript dump must not let the label apply\n' >&2; exit 1
+fi
+[ "$(grep -cF 'review: malformed verdict comment 7777001' "$GH_STUB_LOG")" = "1" ] || {
+    printf 'live: r23 case 2 — exactly one malformed notice expected, got:\n%s\n' \
+        "$(grep -F 'malformed verdict comment' "$GH_STUB_LOG")" >&2; exit 1
+}
+[ "$(printf '%s' "$(pending_get)" | cut -f6)" = "1" ] || {
+    printf 'live: r23 case 2 — the round must not settle this poll (postfail bump), got:\n%s\n' \
+        "$(pending_get)" >&2; exit 1
+}
+
+# case 3 — the next poll: notice not repeated, the union proceeds, the round settles
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (r23 case 3)\n' >&2; exit 1; }
+[ "$(grep -cF 'review: malformed verdict comment 7777001' "$GH_STUB_LOG")" = "1" ] || {
+    printf 'live: r23 case 3 — the malformed notice must not repeat\n' >&2; exit 1
+}
+grep -qF -- '-f state=success' "$GH_STUB_LOG" || {
+    printf 'live: r23 case 3 — the union (this LGTM alone) must succeed on the retry\n' >&2; exit 1
+}
+[ -z "$(pending_get)" ] || {
+    printf 'live: r23 case 3 — the round should settle once the status lands, got:\n%s\n' \
+        "$(pending_get)" >&2; exit 1
+}
+unset GH_HEAD GH_COMMENTS_FILE
+
+# case 4 — a non-open PR: no launch, no ack, no status
+for r23_state in MERGED CLOSED; do
+    reset_stubs
+    printf '42\t%s\t\t2026-09-02T00:00:00Z\n' "$sha" >"$tmp/pr-list-r23"
+    GH_PR_LIST_FILE="$tmp/pr-list-r23" GH_STATE="$r23_state" \
+        run_watch_once >/dev/null 2>&1 || {
+        printf 'live: watcher cycle failed (r23 case 4: %s)\n' "$r23_state" >&2; exit 1
+    }
+    [ -s "$REVIEW_STUB_LOG" ] && {
+        printf 'live: r23 case 4 — a %s PR must not be launched, got:\n%s\n' \
+            "$r23_state" "$(cat "$REVIEW_STUB_LOG")" >&2; exit 1
+    }
+    grep -qF 'review: started on' "$GH_STUB_LOG" && {
+        printf 'live: r23 case 4 — a %s PR must not be acked\n' "$r23_state" >&2; exit 1
+    }
+    grep -qF "pr42 skipped: state is '$r23_state', not OPEN" "$PR_REVIEW_WATCH_LOG" || {
+        printf 'live: r23 case 4 — the skip must be logged with the state, got:\n%s\n' \
+            "$(tail -3 "$PR_REVIEW_WATCH_LOG")" >&2; exit 1
+    }
+done
+reset_stubs
+# an unreadable state counts as not open — no launch either
+printf '42\t%s\t\t2026-09-02T00:00:00Z\n' "$sha" >"$tmp/pr-list-r23"
+GH_PR_LIST_FILE="$tmp/pr-list-r23" GH_FAIL_STATE=1 \
+    run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (r23 case 4: unreadable state)\n' >&2; exit 1; }
+[ -s "$REVIEW_STUB_LOG" ] && {
+    printf 'live: r23 case 4 — an unreadable state must not launch, got:\n%s\n' \
+        "$(cat "$REVIEW_STUB_LOG")" >&2; exit 1
+}
+grep -qF "pr42 skipped: state is 'unreadable', not OPEN" "$PR_REVIEW_WATCH_LOG" || {
+    printf 'live: r23 case 4 — an unreadable state must be logged as a skip, got:\n%s\n' \
+        "$(tail -3 "$PR_REVIEW_WATCH_LOG")" >&2; exit 1
+}
+# the ack retry path: a non-open PR is never acked and its entry is dropped
+for r23_state in MERGED CLOSED; do
+    reset_stubs
+    printf '42\t%s\t0\t\n' "$sha" >"$EDDA_FLEET_SCRATCH/review-acks.tsv"
+    GH_STATE="$r23_state" expect_ack "ack skipped on a $r23_state PR" 0 42 "$sha" 0
+    [ -z "$(ack_state)" ] || {
+        printf 'live: r23 case 4 — the ack entry must be dropped for a %s PR, got:\n%s\n' \
+            "$r23_state" "$(ack_state)" >&2; exit 1
+    }
+    grep -qF 'review: started on' "$GH_STUB_LOG" && {
+        printf 'live: r23 case 4 — a %s PR must not be acked\n' "$r23_state" >&2; exit 1
+    }
+done
 
 # --- offline guarantee: the real watcher log was never touched -----------------
 size_after=0


### PR DESCRIPTION
## Problem and change

#867's verdict comment was a transcript dump — the reviewer's own narration for
twelve lines, then the complete `## Code Review: Round` report mid-body. The
watcher matched the heading as a *line*, so the dump still set
`Independent Review=success`, and the PR merged; every parser that treats the
comment as the unit saw no verdict at all. Nothing checked the shape of what
gets published, and nothing stopped the watcher from launching (and acking,
twice) a review on a PR that had already merged.

Changes, per the issue's doneWhen and controller ruling d-005:

- `scripts/fleet/next-review.sh` — the SHADOW publish step now trims the
  verdict to the first `## Code Review: Round <N> — PR #<n> @ <40-hex>` line
  (SHADOW suffix accepted at line end) before the shape edits; with no heading
  line it posts nothing, names the PR and the raw verdict file on stderr, and
  exits non-zero (`die`). The raw verdict file is kept untouched beside the
  trimmed posting file.
- `scripts/pr-review-watch.sh` — a comment is a verdict only when its **first
  line** is the R23 heading. A comment carrying the heading anywhere else is
  malformed: it contributes nothing to the `Independent Review` union, and the
  watcher posts exactly one `review: malformed verdict comment <id>` per
  comment id (marker file in `$SCRATCH`, the same one-shot mechanism as the
  status marker) and withholds the status for that poll — the per-PR failure
  signal; the next poll proceeds with the dump permanently excluded. The
  watcher's own posted comment is the §7 carrier verbatim, heading first: the
  transport/tool/worktree/session receipts the old banner carried moved to the
  watcher log line (the carrier's own §7 header already carries
  model/session/cost). The watcher also checks `gh pr view --json state`
  before launching **and** before acking, and skips anything not `OPEN` — an
  unreadable state counts as not open, so a watcher that cannot read the state
  never launches or acks (distinct skip line in the log).
- `scripts/test-pr-review-watch.sh` — the `verdict_comment` fixture now models
  the new posted shape (heading first); the GH-708 receipt assertions moved
  from the comment header to the watcher log (`last_receipt_line`), with the
  posted comment asserted to begin with the §7 heading; new R23 cases:
  heading-first happy path, #867 dump (no status, no label, exactly one
  notice, postfail bump), notice-not-repeated + union succeeds on the retry,
  and MERGED/CLOSED/unreadable state refusing launch and ack (entry dropped).
- `scripts/fleet/test-next-loop.sh` — the edda stub now emits a real §7
  heading (em-dash + 40-hex) and accepts a fixture envelope; new cases:
  narration before the heading is trimmed from the posted body, and a
  headingless verdict posts nothing and exits 2 naming the PR.

Not touched, per d-005: `scripts/review-pr.sh` (assembles, does not post;
owned by open PR #890) and `scripts/fleet/manager-tick.sh` (not on main).
This issue owns the R23 shape rule; #919 asserts it with its own test rather
than re-implementing it (`review.verdict-shape-owner`).

## Validation

### RAN

- `sh scripts/test-pr-review-watch.sh` — exit 0, `pr-review-watch fixtures passed` (includes the new R23 cases and the reworked GH-708 block).
- `sh scripts/fleet/test-next-loop.sh` — exit 0, ok 1–9 including the two new R23 publication cases.
- `sh -n` on all four changed scripts — exit 0.
- `sh scripts/review-l0.sh origin/main HEAD` — exit 0; classes=code-risk; U4/U5/C2/C3/C4/R1/WIRING PASS; U1/U2/U3/U6/C5/R3 N.A.(needs PR number); R2 需升級 (adjudicated in the review round below).
- `git diff --check` — empty.
- Known-red, pre-existing, environmental: `sh scripts/test-review-pr.sh` fails D11 (`nohup process died immediately`) **identically on the pristine base SHA** (verified by stash) — MSYS nohup process-spawn behavior on this Windows box; `scripts/review-pr.sh` and its suite are not in this diff. Routed as a follow-up candidate, not a regression of this change.

### READ

- Exact-head CI on this PR's head (Format / Clippy ×3 / Test Linux+macOS / Test Windows subset / MSRV) — fleet script tests are not yet a CI gate (that is #910), so CI here proves the Cargo workspace still builds green with the scripts unchanged, and the script suites above are the load-bearing local evidence.
- Base integration: diff is scripts-only; no crate, `Cargo.*`, or toolchain change.

Issue: #917
