### PR TITLE
fix(fleet): review-l0 pre-push pass cannot run U1/C5/R3 without a PR number; oneline() truncates mid-character

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -277,7 +277,7 @@ lane brief allows. A file outside it is a lane-boundary violation.
 
 # review-spec:check U1
 ```sh
-gh pr diff "$N" --name-only
+if [ -n "${REVIEW_FILES:-}" ]; then cat "$REVIEW_FILES"; else gh pr diff "$N" --name-only; fi
 ```
 # review-spec:check-end
 
@@ -566,7 +566,8 @@ uncovered crate; never the whole workspace to reach one.
 
 # review-spec:check C5
 ```sh
-gh pr diff "$N" --name-only | grep '^crates/' | cut -d/ -f2 | sort -u \
+{ if [ -n "${REVIEW_FILES:-}" ]; then cat "$REVIEW_FILES"; else gh pr diff "$N" --name-only; fi; } \
+  | grep '^crates/' | cut -d/ -f2 | sort -u \
   | grep -Ev '^(edda-store|edda-ledger|edda-search-fts|edda-transcript|edda-bridge-claude|edda-conductor|edda-cli)$'
 ```
 # review-spec:check-end
@@ -610,7 +611,7 @@ git diff "origin/$BASE..$SHA" --unified=0 -- '*.sh' '*.bash' '*.ps1' '.github' \
 
 # review-spec:check R3
 ```sh
-for f in $(gh pr diff "$N" --name-only | grep -E '\.(sh|bash)$'); do
+for f in $(if [ -n "${REVIEW_FILES:-}" ]; then cat "$REVIEW_FILES"; else gh pr diff "$N" --name-only; fi | grep -E '\.(sh|bash)$'); do
   [ -f "$f" ] && { sh -n "$f"; echo "$f -> sh -n exit=$?"; }
 done
 ```

--- a/docs/guides/brief-template.md
+++ b/docs/guides/brief-template.md
@@ -210,7 +210,10 @@ issues the next brief. Success advances to the next numbered step.
     carry their reason and 需升級 rows escalate to the reviewer (REVIEW.md
     §6–§7); neither is a FAIL. This is the L0 self-check: the row commands
     are extracted from REVIEW.md at run time, so the lane is judged by the
-    rules its own tree states.
+    rules its own tree states. This no-PR-number pass cannot run U2, U3 and
+    U6 — they read the PR body and the PR's checks, which do not exist
+    pre-push — so those three rows stay N.A.(needs PR number), and a lane
+    must not read "every row PASS" as "every rule checked".
 21. git commit -m "docs(fleet): brief template for role and runtime composition" -m "Issue: #792"
     output: git commit summary, exit 0. Do not infer a PR-body link from it.
 22. git log -1 --format=%B | grep -Fx 'Issue: #792'

--- a/scripts/review-l0.sh
+++ b/scripts/review-l0.sh
@@ -27,10 +27,12 @@
 #            classifier's file list is the working tree against <base>
 #            (staged and unstaged work included) while the blocks diff the
 #            committed range — the pre-push shape of Example B step 20.
-#   [PR-number]  blocks referencing "$N" (U1, U2's first probe, U3, U6, C5,
-#            R3) run only when a PR number is passed; without one they report
-#            N.A.(needs PR number) instead of failing. Offline callers can
-#            fake the PR surface by putting a stub gh earlier in PATH —
+#   [PR-number]  blocks referencing "$N" (U2, U3, U6) run only when a PR
+#            number is passed; without one they report N.A.(needs PR number)
+#            instead of failing. U1, C5 and R3 enumerate the changed files
+#            from REVIEW_FILES (GH-922 d-004 option A), so the pre-push pass
+#            — no PR number — runs them too. Offline callers can still fake
+#            the PR surface by putting a stub gh earlier in PATH —
 #            scripts/test-review-l0.sh does exactly that.
 #   REVIEW_L0_SPEC  spec file to extract from (default REVIEW.md in the cwd —
 #            the checkout's own copy, so a lane self-checks the rules exactly
@@ -151,6 +153,13 @@ if [ "$ARG_SHA" = "HEAD" ]; then
 else
   git diff --name-only "${ARG_BASE}...${ARG_SHA}" > "$TMP/files" 2>/dev/null || exit 2
 fi
+# GH-922 (d-004 option A): the U1/C5/R3 blocks in REVIEW.md read their file
+# list from REVIEW_FILES when it is set and fall back to `gh pr diff "$N"
+# --name-only` otherwise. The runner always has the list it just computed, so
+# the pre-push pass (no PR number) can run those three rules; the gh command
+# stays once per rule, in REVIEW.md (review.spec-router-single-source).
+REVIEW_FILES="$TMP/files"
+export REVIEW_FILES
 
 CLASSES=$(sh "$TMP/classify.sh" < "$TMP/files") || {
   echo "review-l0.sh: the REVIEW.md classifier block failed" >&2
@@ -216,7 +225,13 @@ print_row() { # <rule> <class> <severity> <result> <evidence>
 }
 
 oneline() { # first line of stdin, pipes escaped for the table cell, capped
-  head -n 1 | sed 's/|/\\|/g' | cut -c1-160
+  # GH-922: `cut -c` is byte-based on this build; a long CJK evidence line
+  # would end in a partial UTF-8 sequence. The cap is a byte cap (LC_ALL=C)
+  # plus a back-off that strips a trailing partial multi-byte sequence, so
+  # the cell always decodes as valid UTF-8.
+  head -n 1 | sed 's/|/\\|/g' \
+    | LC_ALL=C cut -c1-160 \
+    | LC_ALL=C sed -E 's/[\xC0-\xFF][\x80-\xBF]*$//'
 }
 
 run_block() { # <rule> <class> <severity> <blocks-file line>
@@ -230,12 +245,18 @@ run_block() { # <rule> <class> <severity> <blocks-file line>
     return
   fi
   # Blocks referencing "$N" are PR-surface probes; without a number they
-  # cannot run and must say so rather than fail.
+  # cannot run and must say so rather than fail — unless the block reads its
+  # file list from REVIEW_FILES (GH-922 d-004 option A): there the "$N" lives
+  # only in the fallback branch, which REVIEW_FILES being set keeps unreached.
   case "$(cat "$TMP/block.sh")" in
     *'$N'*)
       if [ -z "$N" ]; then
-        print_row "$rule" "$2" "$3" 'N.A.(needs PR number)' '-'
-        return
+        if [ -n "${REVIEW_FILES:-}" ] && grep -q 'REVIEW_FILES' "$TMP/block.sh"; then
+          :
+        else
+          print_row "$rule" "$2" "$3" 'N.A.(needs PR number)' '-'
+          return
+        fi
       fi
       ;;
   esac

--- a/scripts/test-review-l0.sh
+++ b/scripts/test-review-l0.sh
@@ -2,7 +2,7 @@
 # test-review-l0.sh — GH-882: offline fixture for scripts/review-l0.sh.
 #
 # Builds a throwaway git repo (the fixture), stubs the PR surface (`gh`,
-# `edda`) on PATH, and runs the runner twice against the real REVIEW.md:
+# `edda`) on PATH, and runs the runner against the real REVIEW.md:
 #
 #   dirty fixture — the diff adds bad.sh carrying a destructive-command
 #     line (R1 hit; built via printf so the trigger literal never appears in
@@ -10,7 +10,12 @@
 #     rows FAIL, runner exit 1;
 #   clean fixture — the diff adds a valid good.sh → every run row is PASS
 #     (N.A. / 需升級 rows are the runner's own contract, never FAIL/ERROR),
-#     runner exit 0.
+#     runner exit 0;
+#   pre-push fixture (GH-922) — the dirty fixture run with NO PR number:
+#     U1/C5/R3 read the runner's file list and still run, R3 FAILs, while
+#     U2/U3/U6 stay N.A.(needs PR number);
+#   cjk fixture (GH-922) — an R1 evidence line far past the 160-byte cell
+#     cap; the capped cell must still decode as valid UTF-8.
 #
 # It also proves the unmarked-block contract from a temp-modified spec copy:
 # a fenced sh block without markers → `UNMARKED <first line>`, exit 3.
@@ -62,12 +67,18 @@ STUB
 chmod +x "$TMP/bin/gh" "$TMP/bin/edda"
 
 # ---- fixture repo -----------------------------------------------------------
-# <mode: dirty|clean> — base commit carries the repo-shaped stubs the blocks
-# need (lint / wiring scripts, a Cargo.toml with a version line); the branch
-# commit adds the fixture script that the rules then judge.
+# <mode: dirty|clean|cjk> — base commit carries the repo-shaped stubs the
+# blocks need (lint / wiring scripts, a Cargo.toml with a version line); the
+# branch commit adds the fixture script that the rules then judge. Each call
+# builds a fresh directory: re-using one would re-point its origin/main at
+# the branch head and collapse the diff the rules are meant to see.
+FIXSEQ=0
+FIXDIR=
 make_fixture() {
   mode=$1
-  fix="$TMP/$mode"
+  FIXSEQ=$((FIXSEQ + 1))
+  fix="$TMP/fix-$FIXSEQ"
+  FIXDIR="$fix"
   mkdir -p "$fix/scripts"
   git -C "$fix" init -q
   git -C "$fix" config user.email fixture@example.invalid
@@ -92,6 +103,14 @@ make_fixture() {
     } > "$fix/bad.sh"
     echo bad.sh > "$TMP/file-list"
     msg="feat(fleet): dirty fixture change"
+  elif [ "$mode" = cjk ]; then
+    # GH-922: one syntactically valid line whose Chinese comment pushes the
+    # R1 evidence well past the 160-byte cell cap (98 CJK chars = 294 bytes).
+    # The trigger literal is assembled at run time, as in the dirty fixture.
+    cjk=$(printf '中文字串證據行%.0s' 1 2 3 4 5 6 7 8 9 10 11 12 13 14)
+    printf '# %s rm -r%s /tmp/fixture-cjk\n' "$cjk" f > "$fix/cjk.sh"
+    echo cjk.sh > "$TMP/file-list"
+    msg="feat(fleet): cjk fixture change"
   else
     printf '#!/bin/sh\necho fixture-ok\n' > "$fix/good.sh"
     echo good.sh > "$TMP/file-list"
@@ -101,18 +120,20 @@ make_fixture() {
   git -C "$fix" commit -q -m "$msg"
 }
 
-run_l0() { # <fixture-dir> <spec> <out-file> — runner exit code via $?
+run_l0() { # <fixture-dir> <spec> <out-file> [PR-number] — runner exit code via $?
+  # With no PR-number argument the runner runs in the pre-push shape
+  # (GH-922): U1/C5/R3 must still run, from the runner's own file list.
   (cd "$1" \
     && PATH="$TMP/bin:$PATH" \
        GH_STUB_DIR="$TMP" \
        REVIEW_L0_SPEC="$2" \
-       sh "$RUNNER" origin/main HEAD 1) > "$3" 2>&1
+       sh "$RUNNER" origin/main HEAD ${4:-}) > "$3" 2>&1
 }
 
 # ---- 1. dirty fixture: R1 + R3 FAIL, exit 1 ---------------------------------
 make_fixture dirty
 rc=0
-run_l0 "$TMP/dirty" "$SPEC" "$TMP/dirty.out" || rc=$?
+run_l0 "$FIXDIR" "$SPEC" "$TMP/dirty.out" || rc=$?
 [ "$rc" -eq 1 ] || fail "dirty fixture: expected exit 1, got $rc"
 grep -Fq '| R1 | code-risk | P0 | FAIL' "$TMP/dirty.out" \
   || fail "dirty fixture: no FAIL row for R1"
@@ -123,7 +144,7 @@ echo "dirty fixture: R1 and R3 rows FAIL, runner exit 1 — OK"
 # ---- 2. clean fixture: no FAIL/ERROR rows, exit 0 ---------------------------
 make_fixture clean
 rc=0
-run_l0 "$TMP/clean" "$SPEC" "$TMP/clean.out" || rc=$?
+run_l0 "$FIXDIR" "$SPEC" "$TMP/clean.out" || rc=$?
 [ "$rc" -eq 0 ] || fail "clean fixture: expected exit 0, got $rc"
 if grep -E '\| (FAIL|ERROR)' "$TMP/clean.out"; then
   fail "clean fixture: FAIL/ERROR rows present"
@@ -152,10 +173,47 @@ awk '
   { print }
 ' "$SPEC" > "$TMP/unmarked-spec.md"
 rc=0
-run_l0 "$TMP/clean" "$TMP/unmarked-spec.md" "$TMP/unmarked.out" || rc=$?
+run_l0 "$FIXDIR" "$TMP/unmarked-spec.md" "$TMP/unmarked.out" || rc=$?
 [ "$rc" -eq 3 ] || fail "unmarked spec: expected exit 3, got $rc"
-grep -q '^UNMARKED gh pr diff' "$TMP/unmarked.out" \
+grep -q '^UNMARKED if \[ -n "${REVIEW_FILES:-}" \]' "$TMP/unmarked.out" \
   || fail "unmarked spec: no UNMARKED line"
 echo "unmarked spec: UNMARKED line printed, runner exit 3 — OK"
+
+# ---- 4. pre-push coverage: U1/C5/R3 run with no PR number (GH-922) ----------
+# The dirty fixture re-used with no PR argument: U1, C5 and R3 read the
+# runner's own file list (REVIEW_FILES) and must NOT report N.A.(needs PR
+# number); R3 still FAILs on bad.sh's syntax error. U2, U3 and U6 genuinely
+# need a PR and stay N.A. — the boundary d-004 fixes and the one it does not.
+make_fixture dirty
+rc=0
+run_l0 "$FIXDIR" "$SPEC" "$TMP/prepush.out" || rc=$?
+[ "$rc" -eq 1 ] || fail "pre-push fixture: expected exit 1, got $rc"
+for r in U1 C5 R3; do
+  grep -F "| $r |" "$TMP/prepush.out" >/dev/null \
+    || fail "pre-push fixture: no row for $r"
+  if grep -F "| $r |" "$TMP/prepush.out" | grep -Fq 'N.A.(needs PR number)'; then
+    fail "pre-push fixture: $r still N.A.(needs PR number)"
+  fi
+done
+grep -Fq '| R3 | code-risk | P0 | FAIL' "$TMP/prepush.out" \
+  || fail "pre-push fixture: R3 row not FAIL"
+for r in U2 U3 U6; do
+  grep -F "| $r |" "$TMP/prepush.out" | grep -Fq 'N.A.(needs PR number)' \
+    || fail "pre-push fixture: $r should stay N.A.(needs PR number)"
+done
+echo "pre-push fixture: U1/C5/R3 ran without a PR, R3 FAIL, U2/U3/U6 stay N.A. — OK"
+
+# ---- 5. CJK evidence cell: the cap never splits a multi-byte character ------
+# The evidence line is a long Chinese comment carrying an R1 hit; after the
+# 160-byte cap the cell must still decode as valid UTF-8 (iconv round-trip).
+make_fixture cjk
+rc=0
+run_l0 "$FIXDIR" "$SPEC" "$TMP/cjk.out" || rc=$?
+[ "$rc" -eq 1 ] || fail "cjk fixture: expected exit 1 (R1 hit), got $rc"
+grep -Fq '| R1 | code-risk | P0 | FAIL' "$TMP/cjk.out" \
+  || fail "cjk fixture: no FAIL row for R1"
+grep -F '| R1 |' "$TMP/cjk.out" | iconv -f UTF-8 -t UTF-8 >/dev/null \
+  || fail "cjk fixture: R1 evidence cell does not decode as valid UTF-8"
+echo "cjk fixture: R1 evidence cell survives the cap as valid UTF-8 — OK"
 
 echo "test-review-l0.sh: all fixture assertions held"


### PR DESCRIPTION
## Problem and change
#882's stated value is that the author runs the L0 pass before push, but measured at its own Example B command, 7 of 26 rows print `N.A.(needs PR number)` — including three P0s (U1 surface, U6 gates, R3 shell-parse), and R3 is the single most likely mechanical failure in a flash-built PR. Separately, `oneline()` capped evidence cells with `cut -c1-160`, which on a multi-byte-unaware build splits a CJK character in half.

Changes (d-004 option A plus C's correction, applied as ruled):

- `REVIEW.md` — the U1, C5 and R3 check blocks now read their file list from `$REVIEW_FILES` when that variable is set, falling back to `gh pr diff "$N" --name-only` when it is not. **`review.spec-router-single-source` implication, verbatim:** the `gh pr diff` command still appears exactly once per rule, in REVIEW.md, exactly where it appears today. No rule text moves into `review-l0.sh`, and the runner gains no copy of any check. What A adds is a fallback guard around the existing command, in the same block. U2, U3 and U6 are untouched and stay N.A. pre-push by design.
- `scripts/review-l0.sh` — exports `REVIEW_FILES="$TMP/files"` (the list it already computes) right after writing it; the runner's `$N` gate lets a block through when the block itself reads `REVIEW_FILES` and the variable is set, since `$N` then lives only in the unreached fallback branch. `oneline()` now caps by byte (`LC_ALL=C cut -c1-160`) and backs off a trailing partial multi-byte sequence, so a CJK evidence cell always decodes as valid UTF-8.
- `scripts/test-review-l0.sh` — two new fixtures: pre-push coverage (dirty fixture, no PR number: U1/C5/R3 run and R3 FAILs, U2/U3/U6 stay `N.A.(needs PR number)` — the boundary d-004 fixes and the one it does not) and a CJK evidence cell (a >160-byte Chinese R1 evidence line; the capped cell must round-trip through `iconv -f UTF-8 -t UTF-8`). Fixture dirs are now sequence-numbered so a repeated mode cannot re-point its own origin/main and collapse the diff.
- `docs/guides/brief-template.md` — Example B's L0 step now states which rules a no-PR-number pass cannot cover (U2, U3, U6) and why, so "every row PASS" is not read as "every rule checked".

Note on the base: this branch includes GH-884/#942 (review-spec-v1.5), which landed on main while this lane was in flight; the U1/C5/R3 block shapes d-004 ruled on are unchanged by it, and the pre-push rows below were measured against the v1.5 spec. The issue's class note (R22: authoritative round Opus, glm SHADOW) is executed under the operator's 2026-09-06 all-zcode instruction as a single authoritative zcode review with controller adjudication, recorded in the verdict.

## Validation
### RAN
- base_sha `b44679f559e555a9d858532c5fb01ab18ab5870f` (origin/main at lane start), delivery_sha `6f794ecb4f5cff3a825796b2f42986e236959206`.
- `sh scripts/test-review-l0.sh` → exit 0, five fixtures: dirty (R1+R3 FAIL, exit 1), clean (no FAIL/ERROR, exit 0), unmarked spec (UNMARKED line, exit 3), pre-push (U1/C5/R3 run without a PR, R3 FAIL, U2/U3/U6 stay N.A.), cjk (R1 evidence cell valid UTF-8 after the cap).
- `sh scripts/review-l0.sh origin/main HEAD` with no PR number on this lane's own diff — the live proof of d-004 (rows below copied verbatim); U1/C5/R3 carry no `needs PR number`, U2/U3/U6 still do:
  `| U1 | any | P0 | PASS | exit=0; REVIEW.md |`
  `| U2 | any | P1 | N.A.(needs PR number) | - |`
  `| U3 | any | P1 | N.A.(needs PR number) | - |`
  `| U6 | any | P0 | N.A.(needs PR number) | - |` (×2, both U6 blocks)
  `| C5 | code-plain | P1 | PASS | exit=1; (no output) |`
  `| R3 | code-risk | P0 | PASS | exit=0; scripts/review-l0.sh -> sh -n exit=0 |`
- Full L0 at the head: exit 0, no FAIL row; D5 需升級 row goes to the reviewer; R2 ran mechanically under review-spec-v1.5 (PASS).
- `sh scripts/lint-markdown-content.sh` and `sh scripts/lint-doc-citations.sh` → exit 0, no output.
- `sh -n` on both scripts → exit 0.
- `git push --porcelain -u origin fix/gh922-review-l0-pre-push-pass-cannot-run-u1-c5` → exit 0, no rejected ref; no force option used (R7).

### READ
- Issue #922 body — doneWhen 1–5 mapped to the RAN list above; doneWhen 5's iconv round-trip is the cjk fixture assertion.
- The controller rulings d-003/d-004 as stated in the issue's lane brief — d-004's option A + C implemented here; the option-A reason (shimming a fake gh would also intercept U2/U3/U6, which genuinely need the real gh) is why the fallback lives in the spec block instead of the runner's PATH.
- REVIEW.md v1.5 §5 rules U1/C5/R3 — read at the pinned SHA; the block edits are the only spec text changed.

Issue: #922
