### PR TITLE
fix(fleet): issue-freshness gate precision — delivery via closing references, bare names resolve, proposals skipped

### DIFF
--- a/scripts/fleet/issue-freshness.sh
+++ b/scripts/fleet/issue-freshness.sh
@@ -43,6 +43,15 @@ cd "$(git rev-parse --show-toplevel)"
 sha=$(git rev-parse origin/main)
 body=$(gh issue view "$issue" --repo "$repo" --json body --jq .body | tr -d '\r')
 
+# Predicted-surface tokens are proposals for files that may not exist yet,
+# never references: the freshness scan reads the rest of the body only.
+body=$(printf '%s\n' "$body" | awk '
+    /^##[ \t]*Predicted surface[ \t]*$/ { skip = 1; next }
+    /^##[ \t]/ { skip = 0 }
+    skip { next }
+    { print }
+')
+
 fail=0
 fail_lines=
 
@@ -70,21 +79,46 @@ printf '%s\n' "$body" | awk -v RS='`' '
 while IFS= read -r tok; do
     [ -n "$tok" ] || continue
     case "$tok" in
-        */*) ;;
-        *.sh|*.ps1) ;;
+        */*)
+            # a slash token is only credible when its last segment names a
+            # file (carries a dot); `if/else` and friends WARN instead
+            case ${tok##*/} in
+                *.*)
+                    case "$tok" in
+                        *[!A-Za-z0-9._/-]*|-*|/|.|..|*/..*|../*)
+                            echo "WARN unparsed $tok"
+                            continue ;;
+                    esac
+                    if git cat-file -e "$sha:$tok" 2>/dev/null; then
+                        echo "PASS path $tok"
+                    else
+                        echo "FAIL path $tok missing at $sha"
+                        record_fail "FAIL path $tok missing at $sha"
+                    fi
+                    ;;
+                *)
+                    echo "WARN unparsed $tok"
+                    ;;
+            esac
+            ;;
+        *.*)
+            # bare filename: a repo-relative probe cannot see it, so resolve
+            # it against tracked paths and probe only on an exact single hit
+            case "$tok" in
+                *[!A-Za-z0-9._-]*)
+                    echo "WARN unparsed $tok"
+                    continue ;;
+            esac
+            resolved=$(git ls-files -- "*$tok" | head -n 1)
+            count=$(git ls-files -- "*$tok" | wc -l)
+            if [ "$count" -eq 1 ] && git cat-file -e "$sha:$resolved" 2>/dev/null; then
+                echo "PASS path $tok (resolved $resolved)"
+            else
+                echo "WARN bare name $tok does not resolve to exactly one tracked file"
+            fi
+            ;;
         *) continue ;;
     esac
-    case "$tok" in
-        *[!A-Za-z0-9._/-]*)
-            echo "WARN unparsed $tok"
-            continue ;;
-    esac
-    if git cat-file -e "$sha:$tok" 2>/dev/null; then
-        echo "PASS path $tok"
-    else
-        echo "FAIL path $tok missing at $sha"
-        record_fail "FAIL path $tok missing at $sha"
-    fi
 done <"$tmp"
 
 # 2. edda verbs: every `edda <verb>` mention must survive its own --help.
@@ -112,8 +146,15 @@ else
 fi
 
 # 4. delivered: any merged PR whose title/body/branch matches the issue.
-pr1=$(gh pr list --repo "$repo" --state merged --search "GH-$issue" --json number --jq '.[].number' || :)
-pr2=$(gh pr list --repo "$repo" --state merged --search "#$issue" --json number --jq '.[].number' || :)
+delivering() {
+    # a merged PR delivers this issue only when GitHub resolved a closing
+    # reference to it; mentions in title, body or branch do not count
+    gh pr list --repo "$repo" --state merged --search "$1" \
+        --json number,closingIssuesReferences \
+        --jq ".[] | select(any(.closingIssuesReferences[]?; .number == $issue)) | .number" || :
+}
+pr1=$(delivering "GH-$issue")
+pr2=$(delivering "#$issue")
 merged=$(printf '%s\n%s\n' "$pr1" "$pr2" | tr -d '\r' | sort -u | sed '/^$/d')
 if [ -n "$merged" ]; then
     spaced=$(printf '%s' "$merged" | tr '\n' ' ')

--- a/scripts/fleet/test-issue-freshness.sh
+++ b/scripts/fleet/test-issue-freshness.sh
@@ -70,8 +70,25 @@ cat >"$work/fixtures/issue-nodonewhen.json" <<'JSON'
 {"state":"OPEN","title":"feat(fleet): freshness no donewhen","labels":[{"name":"fleet:ready"}],"comments":[],
  "body":"## Predicted surface\n\nGate file `scripts/fleet/next-issue.sh` exists.\n"}
 JSON
+cat >"$work/fixtures/issue-barename.json" <<'JSON'
+{"state":"OPEN","title":"feat(fleet): freshness bare name","labels":[{"name":"fleet:ready"}],"comments":[],
+ "body":"Prose mentions bare `next-review.sh` here.\n\n## doneWhen\n- item\n"}
+JSON
+cat >"$work/fixtures/issue-concept.json" <<'JSON'
+{"state":"OPEN","title":"feat(fleet): freshness concept token","labels":[{"name":"fleet:ready"}],"comments":[],
+ "body":"## Predicted surface\n\nNew file `scripts/fleet/proposed-996.sh` lands here.\n\n## Details\n\nThe conflict cut `if/else` across hunks and `scripts/fleet/nope-996.sh` is referenced.\n\n## doneWhen\n- item\n"}
+JSON
+cat >"$work/fixtures/issue-mention.json" <<'JSON'
+{"state":"OPEN","title":"feat(fleet): freshness mention","labels":[{"name":"fleet:ready"}],"comments":[],
+ "body":"## doneWhen\n- `scripts/fleet/next-issue.sh`\n"}
+JSON
 cat >"$work/fixtures/pr-list-hit.json" <<'JSON'
-[{"number":746,"state":"MERGED","title":"x","body":"Closes #993"}]
+[{"number":746,"state":"MERGED","title":"x","body":"Closes #993",
+  "closingIssuesReferences":[{"number":993}]}]
+JSON
+cat >"$work/fixtures/pr-list-mention.json" <<'JSON'
+[{"number":555,"state":"MERGED","title":"x","body":"mentions #997",
+  "closingIssuesReferences":[]}]
 JSON
 cat >"$work/fixtures/pr-list-empty.json" <<'JSON'
 []
@@ -101,6 +118,7 @@ case "$1 $2" in
     "pr list")
         case "$*" in
             *993*) resp=$(cat "$GH_FIXTURES/pr-list-hit.json") ;;
+            *997*) resp=$(cat "$GH_FIXTURES/pr-list-mention.json") ;;
             *) resp=$(cat "$GH_FIXTURES/pr-list-empty.json") ;;
         esac ;;
 esac
@@ -111,6 +129,9 @@ case "$1 $2" in
             *\ 992\ *|*\ 992) resp=$(cat "$GH_FIXTURES/issue-badflag.json") ;;
             *\ 993\ *|*\ 993) resp=$(cat "$GH_FIXTURES/issue-stalepr.json") ;;
             *\ 994\ *|*\ 994) resp=$(cat "$GH_FIXTURES/issue-nodonewhen.json") ;;
+            *\ 995\ *|*\ 995) resp=$(cat "$GH_FIXTURES/issue-barename.json") ;;
+            *\ 996\ *|*\ 996) resp=$(cat "$GH_FIXTURES/issue-concept.json") ;;
+            *\ 997\ *|*\ 997) resp=$(cat "$GH_FIXTURES/issue-mention.json") ;;
             *) resp=$(cat "$GH_FIXTURES/issue-ok.json") ;;
         esac ;;
     "issue edit")
@@ -173,10 +194,10 @@ if [ "$run_suite" -eq 1 ]; then
     # a. valid issue: all checks PASS, exit 0
     run_gated sh "$freshness" 991 >"$work/out-a.txt" 2>"$work/err-a.txt" ||
         fail "issue 991 must pass: rc=$? err=$(cat "$work/err-a.txt")"
-    grep -q '^PASS path scripts/fleet/next-issue.sh$' "$work/out-a.txt" ||
-        fail "issue 991 misses the path PASS line: $(cat "$work/out-a.txt")"
-    grep -q '^PASS path scripts/fleet/brief-from-issue.sh$' "$work/out-a.txt" ||
-        fail "issue 991 misses the second path PASS line"
+    # 991's path-shaped tokens all live in its Predicted surface section —
+    # proposals are skipped, so the suite must see no path findings at all
+    grep -q '^PASS path' "$work/out-a.txt" &&
+        fail "issue 991 must skip Predicted-surface proposals: $(cat "$work/out-a.txt")"
     grep -q '^PASS edda ask$' "$work/out-a.txt" ||
         fail "issue 991 misses the edda PASS line"
     grep -q '^PASS doneWhen$' "$work/out-a.txt" ||
@@ -215,6 +236,35 @@ if [ "$run_suite" -eq 1 ]; then
     grep -q '^FAIL doneWhen' "$work/out-d.txt" ||
         fail "issue 994 misses the doneWhen FAIL line: $(cat "$work/out-d.txt")"
     echo "ok d missing doneWhen fails"
+
+    # e. bare filename resolves to exactly one tracked file
+    run_gated sh "$freshness" 995 >"$work/out-e.txt" 2>"$work/err-e.txt" ||
+        fail "issue 995 must pass: rc=$? err=$(cat "$work/err-e.txt")"
+    grep -q '^PASS path next-review.sh (resolved scripts/fleet/next-review.sh)$' "$work/out-e.txt" ||
+        fail "issue 995 misses the resolved bare-name PASS line: $(cat "$work/out-e.txt")"
+    echo "ok e bare name resolves"
+
+    # f. concept slash token WARNs, untracked file-like token FAILs,
+    #    Predicted-surface proposals are skipped entirely
+    run_gated sh "$freshness" 996 >"$work/out-f.txt" 2>"$work/err-f.txt" &&
+        fail "issue 996 must exit 1" || rc=$?
+    [ "${rc:-0}" -eq 1 ] || fail "issue 996 exit ${rc:-0}, want 1"
+    fails=$(grep -c '^FAIL' "$work/out-f.txt") || true
+    [ "$fails" -eq 1 ] || fail "issue 996 must print exactly one FAIL: $(cat "$work/out-f.txt")"
+    grep -q '^FAIL path scripts/fleet/nope-996.sh missing' "$work/out-f.txt" ||
+        fail "issue 996 must FAIL the untracked file-like token: $(cat "$work/out-f.txt")"
+    grep -q '^WARN unparsed if/else$' "$work/out-f.txt" ||
+        fail "issue 996 must WARN the concept token: $(cat "$work/out-f.txt")"
+    grep -q 'proposed-996' "$work/out-f.txt" &&
+        fail "issue 996 must skip Predicted-surface proposals: $(cat "$work/out-f.txt")"
+    echo "ok f concept warn, proposal skipped, untracked fails"
+
+    # g. merged PR that merely mentions the issue does not count as delivery
+    run_gated sh "$freshness" 997 >"$work/out-g.txt" 2>"$work/err-g.txt" ||
+        fail "issue 997 must pass: rc=$? err=$(cat "$work/err-g.txt")"
+    grep -q '^PASS not delivered$' "$work/out-g.txt" ||
+        fail "issue 997 must not treat a mention as delivery: $(cat "$work/out-g.txt")"
+    echo "ok g mention is not delivery"
 
     echo "PASS: scripts/fleet/test-issue-freshness.sh"
     exit 0


### PR DESCRIPTION
## Problem and change
Three false-FAIL classes in the day-old freshness gate blocked valid dispatches the moment it went live (evidence in #952): the delivery check counted any merged PR whose body mentions the issue number (#920 was labelled fleet:stale on the strength of three mentions); concept slash tokens (`if/else`) were probed as paths; bare filenames (`brief-from-issue.sh`) and Predicted-surface proposals (`scripts/fleet/brief-validate.sh` before it existed) failed the repo-relative probe. Now: a merged PR delivers only when GitHub's own `closingIssuesReferences` on it resolves the issue; Predicted-surface tokens are skipped entirely (proposals, not references); bare filenames resolve against tracked paths and probe only on an exact single hit; slash tokens whose last segment carries no dot WARN without blocking. Every former false-FAIL is now a WARN or a precise FAIL, and the gate no longer labels undelivered issues stale on mentions.

## Validation
### RAN
- sh scripts/fleet/test-issue-freshness.sh — RED with the new fixtures against the old gate (rc=1, `FAIL: issue 995 must pass`) and GREEN after (rc=0, 7 cases a–g): mention-only delivery now PASS (g), bare-name resolution PASS (e), concept WARN + proposal skip + precise FAIL (f), delivery-precision fixture carries closingIssuesReferences (c)
- sh scripts/fleet/test-issue-freshness.sh --integration — rc=0 (gate intact in next-issue.sh)
- sh scripts/fleet/test-next-loop.sh — rc=0; sh scripts/fleet/test-ready-queue-lint.sh — rc=0
- sh -n on both scripts — exit 0; git diff --check — clean
- Dogfood @ this head: `sh scripts/fleet/issue-freshness.sh 952` → rc=0 (was FAIL), `920` → rc=0 (was FAIL), both prints WARN-only

### READ
- Issue #952 doneWhen — every item delivered by this diff.

Closes #952
Issue: #952
