### PR TITLE
fix(fleet): pin the lane worktree-prep command in rendered briefs — step 2 expects ...origin/main but lane-prepare.ps1 creates branches with no upstream

### DIFF
--- a/docs/guides/brief-template.md
+++ b/docs/guides/brief-template.md
@@ -161,7 +161,7 @@ issues the next brief. Success advances to the next numbered step.
 1. gh issue view 792 --repo fagemx/edda --json state --jq .state
    output: `OPEN`.
 2. git status --porcelain=v1 --untracked-files=all --branch
-   output: exactly ## codex/gh792-brief-template, no other lines.
+   output: exactly ## codex/gh792-brief-template...origin/main, no other lines.
 3. git rev-parse HEAD
    output: fb6ab1b503c3abb8502b3964678977aa23d316c4 (the base full SHA).
 4. edda context

--- a/scripts/fleet/brief-from-issue.sh
+++ b/scripts/fleet/brief-from-issue.sh
@@ -205,7 +205,7 @@ scope paths: ${paths_csv} ·
 entry: none: procedure below · gate owner: not you; review queue ·
 out-of-scope: every path and concern not listed in scope paths
 
-Launcher contract: you are pi 0.84.4 in an exclusively owned, clean worktree at ${worktree} on branch ${branch} at the base full SHA, with task ${task} assigned, issue #${issue} claimed, lane name ${lane_name}, and no existing PR for that branch. Your tools are bash({"command": string}) running Git Bash, write({"path": string, "content": string}) and edit({"path": string, "edits": [{"oldText": string, "newText": string}]}). Shell commands go in bash.command; file changes are write/edit tool calls, never shell programs that rewrite files (no sed -i, no cat > file). git, gh and edda are authenticated on PATH. Build lane: ${lane}.
+Launcher contract: you are pi 0.84.4 in an exclusively owned, clean worktree at ${worktree} on branch ${branch} at the base full SHA, with task ${task} assigned, issue #${issue} claimed, lane name ${lane_name}, and no existing PR for that branch. The one sanctioned prep command that produced this worktree is git worktree add -b ${branch} ${worktree} origin/main — a prep from any other start point cannot satisfy step 2. Your tools are bash({"command": string}) running Git Bash, write({"path": string, "content": string}) and edit({"path": string, "edits": [{"oldText": string, "newText": string}]}). Shell commands go in bash.command; file changes are write/edit tool calls, never shell programs that rewrite files (no sed -i, no cat > file). git, gh and edda are authenticated on PATH. Build lane: ${lane}.
 
 ${host_fact}
 

--- a/scripts/fleet/lane-prepare.ps1
+++ b/scripts/fleet/lane-prepare.ps1
@@ -60,6 +60,14 @@ if ($BuildLane -and $allowedBuildLanes -notcontains $BuildLane) {
   Fail "-BuildLane '$BuildLane' is not an allowed build lane (verification.cost-discipline allows only: $($allowedBuildLanes -join ', '))"
 }
 
+# GH-897: the rendered brief's step 2 expects the '## <branch>...origin/main'
+# tracking line, and git sets that upstream only when the branch starts from
+# a remote-tracking refname — a raw SHA start point silently skips it. So the
+# sanctioned lane prep starts from an origin/* ref, never a resolved SHA.
+if ($StartRef -notmatch '^origin/') {
+  Fail "start ref '$StartRef' is not a remote-tracking ref: git sets the branch tracking line ('## <branch>...origin/main' in the rendered brief's step 2) only from an origin/* refname, never from a raw SHA"
+}
+
 # The FIXED lane worktree path (lane-launch.ps1 and lane-warm.ps1 derive the
 # same path; do not change one without the other).
 function Get-LaneWorktreePath([string]$MainRepo, [string]$Lane) {
@@ -228,10 +236,10 @@ $baseSha = & git -C $MainRepo rev-parse --verify "$StartRef^{commit}"
 if ($LASTEXITCODE -ne 0 -or -not $baseSha) { Fail "start ref '$StartRef' does not resolve after fetch" }
 
 if (Test-Path -LiteralPath $WtPath) {
-  & git -C $WtPath checkout -b $Branch $baseSha 2>$null
+  & git -C $WtPath checkout -b $Branch $StartRef 2>$null
   if ($LASTEXITCODE -ne 0) { Fail "git checkout -b $Branch failed in '$WtPath'" }
 } else {
-  & git -C $MainRepo worktree add -b $Branch $WtPath $baseSha 2>$null
+  & git -C $MainRepo worktree add -b $Branch $WtPath $StartRef 2>$null
   if ($LASTEXITCODE -ne 0) { Fail "git worktree add -b $Branch $WtPath failed" }
 }
 

--- a/scripts/fleet/test-brief-from-issue.sh
+++ b/scripts/fleet/test-brief-from-issue.sh
@@ -287,4 +287,21 @@ grep -q '24. edda task done 128' "$work/out/withtask.txt" \
     || fail "rail step 24 missing with --task-id"
 echo "ok 9 omitted --task-id renders rail-free steps (both modes)"
 
+# 10. the rendered contract pins the one sanctioned prep command (GH-897):
+#     step 2 keeps the tracking-suffix expectation and the launcher contract
+#     names the refname form that produces it.
+rc=0
+TEST_UNAME=Linux GH_ISSUE_JSON="$work/issue-880.json" \
+    PATH="$work/bin:$PATH" \
+    sh "$script" 880 --lane-name edda-lane-gh880 \
+        --worktree C:/ai_agent/edda-wt-gh880 \
+        --branch fix/gh880-pi-review-arm \
+    >"$work/out/prep.txt" || rc=$?
+[ "$rc" -eq 0 ] || fail "prep render exit $rc"
+grep -qF 'exactly ## fix/gh880-pi-review-arm...origin/main, no other lines.' "$work/out/prep.txt" \
+    || fail "step 2 does not pin the tracking-suffix form"
+grep -qF "git worktree add -b fix/gh880-pi-review-arm C:/ai_agent/edda-wt-gh880 origin/main" "$work/out/prep.txt" \
+    || fail "launcher contract does not name the sanctioned prep command"
+echo "ok 10 sanctioned prep command pinned in the rendered brief"
+
 echo "PASS: scripts/fleet/test-brief-from-issue.sh"

--- a/scripts/fleet/test-lane-helpers.sh
+++ b/scripts/fleet/test-lane-helpers.sh
@@ -188,6 +188,19 @@ git -C "$repo" worktree list --porcelain | grep -F "$(cygpath -m "$lane")" >/dev
   || fail "prepare: worktree not registered with the repo"
 ok "prepare creates fixed worktree $lanewin on a new branch from origin/main"
 
+# GH-897: the new branch must carry the auto-upstream line so the rendered
+# brief's step 2 (## <branch>...origin/main) matches what the prep produces.
+up=$(git -C "$lane" rev-parse --abbrev-ref --symbolic-full-name "@{upstream}" 2>/dev/null || true)
+[ "$up" = "origin/main" ] || fail "prepare: branch codex/gh100-a tracks '$up', want origin/main — the rendered brief's step 2 would STOP"
+ok "prepare sets the tracking line the rendered brief step 2 expects"
+
+# GH-897: a raw-SHA start point cannot set the tracking line — refuse it.
+sha=$(git -C "$repo" rev-parse origin/main)
+expect_fail "prepare raw-SHA start ref" "remote-tracking" \
+  prepare -BuildLane worker-2 -Branch codex/gh109-sha -Repo "$repo" -StartRef "$sha"
+[ ! -e "$(wt_posix "$repo" worker-2)" ] || fail "refused raw-SHA prepare created a worktree"
+ok "prepare refuses a non-tracking start ref instead of an untracked branch"
+
 expect_ok "prepare idempotent same branch" prepare -BuildLane worker-1 -Branch codex/gh100-a -Repo "$repo"
 [ "$(git -C "$lane" symbolic-ref --quiet HEAD)" = "refs/heads/codex/gh100-a" ] \
   || fail "idempotent prepare moved the worktree"


### PR DESCRIPTION
## Problem and change

Two legitimate lane prep paths disagreed on whether a rendered brief's step 2 passes (GH-897, found by the glm shadow review of PR #895 Round 1 @ 6ba187d): `next-issue.sh` creates branches name-based from `origin/main` (auto-upstream fires, step 2's `## <branch>...origin/main` matches), while `lane-prepare.ps1` resolved the start ref to a raw SHA before `git worktree add -b` / `checkout -b` — a SHA start point silently skips git's auto-upstream, so the lane branch prints `## <branch>` and the lane STOPs at step 2. `docs/guides/brief-template.md` Example B's step 2 expected a third form (no tracking suffix at all).

The fix pins one sanctioned prep: `git worktree add -b <branch> <path> origin/main` — a remote-tracking refname start point, which is what auto-sets the tracking line.

- `lane-prepare.ps1`: a non-`origin/*` `-StartRef` is now refused loudly at argument validation (both create paths pass the refname through instead of the resolved SHA; `base=` still prints the pinned start SHA for the record).
- `brief-from-issue.sh`: the rendered launcher contract now names the sanctioned prep command verbatim, so the contract and step 2 can no longer drift apart.
- `docs/guides/brief-template.md`: Example B step 2 aligned to the renderer's tracking-suffix form.

## Validation

### RAN

- Red-green, `scripts/fleet/test-brief-from-issue.sh`: with only the test applied (fix reverted), exit 1 at `FAIL: launcher contract does not name the sanctioned prep command`; at this head, ok 1 through ok 10, `PASS`, exit 0. New section 10 pins step 2's tracking-suffix form and the named prep command.
- Red-green, `scripts/fleet/test-lane-helpers.sh`: with only the tests applied, exit 1 at `FAIL (after case 1): prepare: branch codex/gh100-a tracks '', want origin/main` — the issue's exact defect reproduced; at this head, `PASS: lane helper self-test (30 cases)`, exit 0. New cases: the prepared branch carries `origin/main` upstream, and a raw-SHA `-StartRef` is refused with `remote-tracking` named, creating no worktree.
- `sh -n scripts/fleet/brief-from-issue.sh && sh -n scripts/fleet/test-brief-from-issue.sh && sh -n scripts/fleet/test-lane-helpers.sh`: exit 0 (lane-prepare.ps1 is exercised by the 30-case suite, which is its parse and behavior check).
- `git diff --check`: clean. `git diff --stat`: 5 files, +42/−4.

### READ

- No caller passes `-StartRef` anywhere in `scripts/` or `docs/` (grep at this head): the new refusal has no existing caller to break, and the default `origin/main` is exactly the sanctioned form.
- The existing-wt switch path and the create path both now take `$StartRef`; `base=$baseSha` output unchanged, so downstream consumers of the printed facts still get the pinned SHA.

Issue: #897

Closes #897
198e7e59efdce37258e4e54efcecf21ad5b8b43a
