### PR TITLE
fix(fleet): pr-review-watch.sh writes Independent Review only when the verdict engine is authoritative for the PR surface (rules.md R22); SHADOW otherwise

### DIFF
--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -605,6 +605,64 @@ post_review_status() { # $1=pr $2=reviewed sha $3=verdict file
     -f description="$v P0=$p0 P1=$p1" >/dev/null
 }
 
+# ---- rules.md R22 executor: engine x surface decides status/label -----------
+
+# Path table — SOURCE OF TRUTH: docs/fleet/rules.md R22 (anti-drift test:
+# scripts/test-pr-review-watch.sh asserts this table equals R22's path tokens).
+# shipping: `crates/**`, `Cargo.toml`, `Cargo.lock`, `install.sh`, `rust-toolchain*`, `clippy.toml`
+# gate: `.github/**`, `lefthook.yml`, `scripts/lint-*.sh`, `scripts/fleet/lane-launch.ps1`, `scripts/fleet-claim-issue.sh`
+# judging: `REVIEW.md`, `docs/fleet/rules.md`, `tests/canaries/**`, `scripts/review-pr.sh`, `scripts/pr-review-watch.sh`, `scripts/review-l0.sh`, `scripts/reviewer-capabilities.sh`, `scripts/fleet/reviewer-capabilities.ps1`, `scripts/fleet/daily-digest.sh`
+# internal-tools: `scripts/fleet/**`, `scripts/test-*.sh`, `docs/**`, `.claude/**` — plus the fallback: everything not matched above
+classify_surface() { # stdin: one changed path per line; stdout: shipping|gate|judging|internal-tools
+  # Most restricted surface any one path falls on; in shell case, * matches
+  # across / so the R22 tokens work verbatim as patterns.
+  rank=0
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    case "$p" in
+      crates/**|Cargo.toml|Cargo.lock|install.sh|rust-toolchain*|clippy.toml) r=3 ;;
+      .github/**|lefthook.yml|scripts/lint-*.sh|scripts/fleet/lane-launch.ps1|scripts/fleet-claim-issue.sh) r=2 ;;
+      REVIEW.md|docs/fleet/rules.md|tests/canaries/**|scripts/review-pr.sh|scripts/pr-review-watch.sh|scripts/review-l0.sh|scripts/reviewer-capabilities.sh|scripts/fleet/reviewer-capabilities.ps1|scripts/fleet/daily-digest.sh) r=1 ;;
+      scripts/fleet/**|scripts/test-*.sh|docs/**|.claude/**) r=0 ;;
+      *) r=0 ;;
+    esac
+    [ "$r" -gt "$rank" ] && rank=$r
+  done
+  case "$rank" in
+    3) echo shipping ;;
+    2) echo gate ;;
+    1) echo judging ;;
+    *) echo internal-tools ;;
+  esac
+}
+
+verdict_engine() { # stdin: verdict carrier; stdout: opus|sol|glm|unknown
+  line=$(awk '/^## Code Review: Round/{seen=1} seen && /^- model_observed:/{print; exit}')
+  case "$line" in
+    *opus*) echo opus ;;
+    *sol*) echo sol ;;
+    *glm*) echo glm ;;
+    *) echo unknown ;;
+  esac
+}
+
+verdict_is_shadow() { # stdin: verdict carrier; exit 0 when the round declares itself SHADOW
+  { head -1 | grep -q ' (SHADOW)$'; } && return 0
+  { grep -qE '^shadow: true'; } && return 0
+  return 1
+}
+
+verdict_surface_ok() { # $1=engine $2=surface; exit 0 only when authoritative per rules.md R22
+  case "$1/$2" in
+    opus/*|sol/*|glm/internal-tools) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+pr_changed_files() { # $1=pr; stdout: one changed path per line (empty on gh failure)
+  gh pr view "$1" --repo "$REPO" --json files 2>/dev/null | jq -r '.files[].path' 2>/dev/null
+}
+
 # ---- in-flight handling ------------------------------------------------------
 settle_pending() {
   [ -s "$PENDING" ] || return 0
@@ -644,7 +702,48 @@ settle_pending() {
       fi
       vl=$(sh "$LABEL_PR" verdict-label < "$1")
       if ! verdict_body_lines "$sha" < "$1" | grep -q .; then
+        # The strict pin rejects SHADOW headings on purpose (a SHADOW verdict
+        # never enters the union), so a well-formed SHADOW-declared carrier
+        # lands here: settle it as SHADOW instead of unreviewed. A carrier
+        # with neither shape is truly malformed (R23).
+        if verdict_is_shadow < "$1"; then
+          log "pr$pr r$round SHADOW-declared verdict on $sha — no status, no label; round settled"
+          state_set "$pr" "$sha" "$round"
+          pending_drop "$pr"
+          return 0
+        fi
         mark_unreviewed "$pr" "$sha" "$round" 'verdict carrier lacked the SHA-pinned REVIEW.md §7 heading'
+        pending_drop "$pr"
+        return 0
+      fi
+      # rules.md R22 (GH-919): engine x surface decides whether this round may
+      # write status or a review:* label. A SHADOW-declared round, a
+      # non-authoritative engine, or an unknown engine is handled as SHADOW:
+      # no status, no label, one notice per (sha, verdict comment id) when the
+      # round is not self-declared, and the round still settles.
+      if verdict_is_shadow < "$1"; then
+        log "pr$pr r$round verdict is marked SHADOW on $sha — no status, no label; round settled"
+        state_set "$pr" "$sha" "$round"
+        pending_drop "$pr"
+        return 0
+      fi
+      engine=$(verdict_engine < "$1")
+      files_changed=$(pr_changed_files "$pr")
+      surface=$(printf '%s
+' "$files_changed" | classify_surface)
+      if ! verdict_surface_ok "$engine" "$surface"; then
+        cid=$(cat "$SCRATCH/review-pr$pr-r$round-comment.id" 2>/dev/null || echo unknown)
+        marker="$SCRATCH/review-pr$pr-shadow-$sha-$cid.noticed"
+        if [ ! -f "$marker" ]; then
+          if gh pr comment "$pr" --repo "$REPO" --body "review: verdict by $engine on $surface surface is SHADOW per rules.md R22 — awaiting an authoritative engine" >/dev/null 2>&1; then
+            : > "$marker"
+            log "pr$pr r$round R22 SHADOW notice posted: $engine on $surface ($sha, comment $cid)"
+          else
+            log "pr$pr r$round R22 SHADOW notice failed to post; will retry next poll"
+          fi
+        fi
+        log "pr$pr r$round verdict by $engine on $surface surface is not authoritative (R22) — no status, no label; round settled"
+        state_set "$pr" "$sha" "$round"
         pending_drop "$pr"
         return 0
       fi
@@ -724,6 +823,12 @@ settle_pending() {
       fi
       if extract_verdict "$LOG" "$VERDICT" && verdict_ok "$VERDICT"; then
         if ! verdict_body_lines "$sha" < "$VERDICT" | grep -q .; then
+          if verdict_is_shadow < "$VERDICT"; then
+            log "pr$pr r$round SHADOW-declared verdict on $sha — no status, no label; round settled"
+            state_set "$pr" "$sha" "$round"
+            pending_drop "$pr"
+            continue
+          fi
           mark_unreviewed "$pr" "$sha" "$round" 'verdict carrier lacked the SHA-pinned REVIEW.md §7 heading'
           pending_drop "$pr"
           continue
@@ -780,7 +885,8 @@ settle_pending() {
           echo "dry-run: would post $COMMENT to PR #$pr and set a review:* label"
           continue
         fi
-        if gh pr comment "$pr" --repo "$REPO" --body-file "$COMMENT" >/dev/null 2>&1; then
+        if comment_url=$(gh pr comment "$pr" --repo "$REPO" --body-file "$COMMENT" 2>/dev/null); then
+          printf '%s\n' "${comment_url##*-}" > "$SCRATCH/review-pr$pr-r$round-comment.id" 2>/dev/null || :
           log "pr$pr r$round posted verdict comment (transport $tdesc, tool flags $tool_flags, worktree check $tree_check, model $REQ observed $OBSERVED, reviewer_session $(reviewer_session_desc "$DONE" "$SIDO"), $costline, detached worktree at $sha)"
           mv "$VERDICT" "$POSTED"
           pending_update "$pr" "$round" "$sha" "$attempts" "$launched" 0

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -70,6 +70,27 @@ case "$1" in
             if [ -n "${GH_STATE:-}" ]; then echo "$GH_STATE"; else echo "OPEN"; fi
             exit 0
             ;;
+          *"--json files"*)
+            # R22 (GH-919): the surface classifier reads the PR's changed
+            # paths from GH_FILES_FILE (one path per line); re-encoded as the
+            # REST array with the caller's --jq applied, ids-free.
+            [ -n "${GH_FAIL_FILES:-}" ] && exit 1
+            if [ -n "${GH_FILES_FILE:-}" ]; then
+              printf '{"files":['
+              sep=
+              while IFS= read -r p; do
+                [ -n "$p" ] || continue
+                esc=${p//\\/\\\\}
+                esc=${esc//\"/\\\"}
+                printf '%s{"path":"%s"}' "$sep" "$esc"
+                sep=,
+              done < "$GH_FILES_FILE"
+              printf ']}'
+            else
+              printf '{"files":[]}'
+            fi
+            exit 0
+            ;;
         esac
         exit 0
         ;;
@@ -177,7 +198,8 @@ reset_stubs() {
     : >"$GH_STUB_LOG"; : >"$PI_STUB_LOG"; : >"$EDDA_STUB_LOG"; : >"$REVIEW_STUB_LOG"
     unset GH_FAIL_COMMENT_FIRST GH_FAIL_COMMENT_ALWAYS GH_FAIL_EDIT GH_FAIL_HEAD \
           GH_PR_LIST_FILE GH_HEAD GH_HEAD_FILE DISPATCH_FAIL_PROBE \
-          GH_COMMENTS_FILE GH_FAIL_STATUS GH_FAIL_COMMENTS 2>/dev/null || true
+          GH_COMMENTS_FILE GH_FAIL_STATUS GH_FAIL_COMMENTS \
+          GH_FILES_FILE GH_FAIL_FILES 2>/dev/null || true
     rm -f "$EDDA_FLEET_SCRATCH"/review-* 2>/dev/null || true
     : >"$EDDA_FLEET_SCRATCH/review-state.tsv"
     : >"$EDDA_FLEET_SCRATCH/review-acks.tsv"
@@ -606,7 +628,7 @@ unset GH_FAIL_COMMENT_ALWAYS
 reset_stubs
 sha=d29dc8f5861322ed664e39900273b0681396da50
 pending_set 42 1 "$sha" 0 0
-printf '## Code Review: Round 1 — PR #42 @ %s\n\n### Verdict\nLGTM (P0=0, P1=0)\n' "$sha" \
+printf '## Code Review: Round 1 — PR #42 @ %s\n\n- model_observed: claude-opus-5\n\n### Verdict\nLGTM (P0=0, P1=0)\n' "$sha" \
     >"$EDDA_FLEET_SCRATCH/review-pr42-r1-verdict.md.posted"
 export GH_FAIL_HEAD=1
 run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (unknown head)\n' >&2; exit 1; }
@@ -647,7 +669,7 @@ reset_stubs
 pending_set 42 1 "$sha" 0 0
 printf 'TRANSPORT=edda-review\nDISPATCH_EXIT=3\nQUALIFIED=false\nDISQUALIFIERS=gates-red,escalation-pending\n' \
     >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
-printf '## Code Review: Round 1 — PR #42 @ %s\n\n### Verdict\nLGTM (P0=0, P1=0)\n' "$sha" \
+printf '## Code Review: Round 1 — PR #42 @ %s\n\n- model_observed: claude-opus-5\n\n### Verdict\nLGTM (P0=0, P1=0)\n' "$sha" \
     >"$EDDA_FLEET_SCRATCH/review-pr42-r1-verdict.md.posted"
 export GH_HEAD="$sha"
 run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (unqualified product LGTM)\n' >&2; exit 1; }
@@ -747,7 +769,7 @@ verdict_log_fixture() {
         >> "$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
     {
         printf '<<<VERDICT\n'
-        printf '## Code Review: Round 1 — PR #42 @ %s\n\n### Verdict\nLGTM (P0=0, P1=0)\n' "$sha"
+        printf '## Code Review: Round 1 — PR #42 @ %s\n\n- model_observed: claude-opus-5\n\n### Verdict\nLGTM (P0=0, P1=0)\n' "$sha"
         printf 'VERDICT>>>\n'
         printf 'Model requested: claude-opus-5\nModel observed: claude-opus-5\nCost: $0.33\nSession: 11111111-2222-4333-8444-555555555555\n'
         # The backend's OWN report of the conversation it ran, which is what
@@ -1082,7 +1104,7 @@ r23_dump_fixture() { # $1=comment id $2=sha — #867's shape: narration, ---, he
         printf '<<<COMMENT %s>>>\n' "$1"
         for i in 1 2 3 4 5 6 7 8 9 10 11 12; do printf 'reviewer narration line %s\n' "$i"; done
         printf -- '---\n'
-        printf '## Code Review: Round 1 — PR #42 @ %s\n\n### Verdict\nLGTM (P0=0, P1=0)\n' "$2"
+        printf '## Code Review: Round 1 — PR #42 @ %s\n\n- model_observed: claude-opus-5\n\n### Verdict\nLGTM (P0=0, P1=0)\n' "$2"
     } >"$tmp/comments-pr42-r23-dump"
 }
 
@@ -1191,6 +1213,209 @@ for r23_state in MERGED CLOSED; do
         printf 'live: r23 case 4 — a %s PR must not be acked\n' "$r23_state" >&2; exit 1
     }
 done
+
+# --- R22 (GH-919): engine x surface decides status/label ----------------------
+# The verdict engine is read from the carrier's first `- model_observed:` line
+# after the heading; the surface from the PR's changed files classified against
+# the rules.md R22 table. Authoritative rounds write status + label exactly as
+# before; SHADOW-declared or non-authoritative rounds write neither.
+
+r22_carrier_log_fixture() { # $1=model_observed carrier value ('' = omit the line)
+    printf 'TRANSPORT=edda-dispatch\nDISPATCH_EXIT=0\nFINAL_EXIT=0\nWORKTREE_CHECK=unchanged\nWORKTREE_CLEANUP=removed\nTASK_CLEANUP=not-applicable\nTERMINAL_RECEIPT=complete\n' \
+        >> "$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
+    {
+        printf '<<<VERDICT\n'
+        if [ -n "$1" ]; then
+            printf '## Code Review: Round 1 — PR #42 @ %s\n\n- model_observed: %s\n\n### Verdict\nLGTM (P0=0, P1=0)\n' "$sha" "$1"
+        else
+            printf '## Code Review: Round 1 — PR #42 @ %s\n\n### Verdict\nLGTM (P0=0, P1=0)\n' "$sha"
+        fi
+        printf 'VERDICT>>>\n'
+        printf 'Model requested: claude-opus-5\nModel observed: %s\nCost: $0.33\nSession: 11111111-2222-4333-8444-555555555555\nSession observed: 11111111-2222-4333-8444-555555555555\n' \
+            "${1:-unknown}"
+    } >"$EDDA_FLEET_SCRATCH/review-pr42-r1.log"
+}
+
+r22_files() { # $@=paths -> GH_FILES_FILE fixture
+    : >"$tmp/r22-files"
+    for p in "$@"; do printf '%s\n' "$p" >> "$tmp/r22-files"; done
+    export GH_FILES_FILE="$tmp/r22-files"
+}
+
+r22_case_setup() { # $1=model_observed value; $2..=paths
+    reset_stubs
+    pending_set 42 1 "$sha" 0 0
+    r22_carrier_log_fixture "$1"
+    shift
+    r22_files "$@"
+    export GH_HEAD="$sha"
+}
+
+r22_notices() { # count of R22 SHADOW notices in the stub log
+    command grep -c 'is SHADOW per rules.md R22' "$GH_STUB_LOG" 2>/dev/null || true
+}
+
+# case 1 — glm is authoritative on internal-tools: status + label as before
+r22_case_setup 'openrouter/z-ai/glm-5.3-flash' 'scripts/fleet/next-issue.sh' 'docs/guides/pi-controller-runbook.md'
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (r22 case 1)
+' >&2; exit 1; }
+grep -qF -- '-f state=success' "$GH_STUB_LOG" || {
+    printf 'live: r22 case 1 — glm on internal-tools must write the status; watch.log tail:
+%s
+' "$(tail -4 "$PR_REVIEW_WATCH_LOG")" >&2; exit 1
+}
+grep -qF -- '--add-label review:lgtm' "$GH_STUB_LOG" || {
+    printf 'live: r22 case 1 — glm on internal-tools must apply the label
+' >&2; exit 1
+}
+[ "$(r22_notices)" = "0" ] || {
+    printf 'live: r22 case 1 — an authoritative round must not draw a SHADOW notice
+' >&2; exit 1
+}
+unset GH_HEAD
+
+# case 2 — glm on the shipping surface is SHADOW: no status, no label, one notice
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+r22_carrier_log_fixture 'openrouter/z-ai/glm-5.3-flash'
+r22_files 'crates/edda-core/src/lib.rs' 'scripts/fleet/next-issue.sh'
+export GH_HEAD="$sha"
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (r22 case 2)\n' >&2; exit 1; }
+[ "$(statuses_calls)" = "0" ] || {
+    printf 'live: r22 case 2 — glm on shipping must not write a status, got %s calls\n' "$(statuses_calls)" >&2; exit 1
+}
+if grep -qF -- '--add-label review:' "$GH_STUB_LOG"; then
+    printf 'live: r22 case 2 — glm on shipping must not apply any review label\n' >&2; exit 1
+fi
+[ "$(r22_notices)" = "1" ] || {
+    printf 'live: r22 case 2 — exactly one SHADOW notice expected, got:\n%s\n' "$(r22_notices)" >&2; exit 1
+}
+grep -qF 'review: verdict by glm on shipping surface is SHADOW per rules.md R22' "$GH_STUB_LOG" || {
+    printf 'live: r22 case 2 — the notice must name the engine and surface\n' >&2; exit 1
+}
+[ -z "$(pending_get)" ] || {
+    printf 'live: r22 case 2 — a settled SHADOW round must drop the pending entry, got:\n%s\n' "$(pending_get)" >&2; exit 1
+}
+unset GH_HEAD
+
+# case 3 — glm on the judging surface is SHADOW the same way
+r22_case_setup 'openrouter/z-ai/glm-5.3-flash' 'scripts/pr-review-watch.sh'
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (r22 case 3)\n' >&2; exit 1; }
+[ "$(statuses_calls)" = "0" ] || {
+    printf 'live: r22 case 3 filesq=%s fixture=[%s]
+' "$(grep -c -- --json\ files "$GH_STUB_LOG")" "$(cat "$GH_FILES_FILE")" >&2; exit 1
+' "$(command grep -c 'json files' "$GH_STUB_LOG")" "$(cat "$GH_FILES_FILE")" >&2; exit 1
+%s
+' "$(tail -4 "$PR_REVIEW_WATCH_LOG")" >&2; exit 1
+}
+grep -qF 'review: verdict by glm on judging surface is SHADOW per rules.md R22' "$GH_STUB_LOG" || {
+    printf 'live: r22 case 3 — the judging-surface notice is missing\n' >&2; exit 1
+}
+unset GH_HEAD
+
+# case 4 — opus is authoritative on the judging surface
+r22_case_setup 'claude-opus-5' 'scripts/pr-review-watch.sh' 'docs/fleet/rules.md'
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (r22 case 4)\n' >&2; exit 1; }
+grep -qF -- '-f state=success' "$GH_STUB_LOG" || {
+    printf 'live: r22 case 4 — opus on judging must write the status\n' >&2; exit 1
+}
+grep -qF -- '--add-label review:lgtm' "$GH_STUB_LOG" || {
+    printf 'live: r22 case 4 — opus on judging must apply the label\n' >&2; exit 1
+}
+unset GH_HEAD
+
+# case 5 — an unknown engine is never authoritative: no status, only the notice
+r22_case_setup '' 'scripts/fleet/next-issue.sh'
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (r22 case 5)\n' >&2; exit 1; }
+[ "$(statuses_calls)" = "0" ] || {
+    printf 'live: r22 case 5 — an unknown engine must not write a status\n' >&2; exit 1
+}
+[ "$(r22_notices)" = "1" ] || {
+    printf 'live: r22 case 5 — exactly the SHADOW notice expected, got:\n%s\n' "$(r22_notices)" >&2; exit 1
+}
+grep -qF 'review: verdict by unknown on internal-tools surface is SHADOW per rules.md R22' "$GH_STUB_LOG" || {
+    printf 'live: r22 case 5 — the notice must name the unknown engine\n' >&2; exit 1
+}
+unset GH_HEAD
+
+# case 6 — a verdict that declares itself SHADOW writes nothing at all
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+    printf 'TRANSPORT=edda-dispatch
+DISPATCH_EXIT=0
+FINAL_EXIT=0
+WORKTREE_CHECK=unchanged
+WORKTREE_CLEANUP=removed
+TASK_CLEANUP=not-applicable
+TERMINAL_RECEIPT=complete
+' \
+    >> "$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
+{
+    printf '<<<VERDICT\n'
+    printf '## Code Review: Round 1 — PR #42 @ %s (SHADOW)\n\n- model_observed: claude-opus-5\n\nshadow: true\n\n### Verdict\nLGTM (P0=0, P1=0)\n' "$sha"
+    printf 'VERDICT>>>\n'
+    printf 'Model observed: claude-opus-5\nCost: $0.33\nSession observed: 11111111-2222-4333-8444-555555555555\n'
+} >"$EDDA_FLEET_SCRATCH/review-pr42-r1.log"
+r22_files 'scripts/fleet/next-issue.sh'
+export GH_HEAD="$sha"
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (r22 case 6)\n' >&2; exit 1; }
+[ "$(statuses_calls)" = "0" ] || {
+    printf 'live: r22 case 6 — a SHADOW-declared verdict must not write status\n' >&2; exit 1
+}
+if grep -qF -- '--add-label review:' "$GH_STUB_LOG"; then
+    printf 'live: r22 case 6 — a SHADOW-declared verdict must not apply a label; hit=%s
+' "$(grep -F -- '--add-label review:' "$GH_STUB_LOG")" >&2; exit 1
+fi
+[ "$(r22_notices)" = "0" ] || {
+    printf 'live: r22 case 6 — a self-declared SHADOW round draws no notice\n' >&2; exit 1
+}
+[ -z "$(pending_get)" ] || {
+    printf 'live: r22 case 6 — the round should still settle, got:\n%s\n' "$(pending_get)" >&2; exit 1
+}
+unset GH_HEAD
+
+# case 7 — composition with R23: a SHADOW round on a PR that also carries a
+# malformed dump posts the R22 notice and never the malformed notice (the
+# status path where that notice lives is not reached), no status, no label
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+r22_carrier_log_fixture 'openrouter/z-ai/glm-5.3-flash'
+r23_dump_fixture 7777009 "$sha"
+r22_files 'scripts/pr-review-watch.sh'
+export GH_HEAD="$sha"
+export GH_COMMENTS_FILE="$tmp/comments-pr42-r23-dump"
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (r22 case 7)\n' >&2; exit 1; }
+[ "$(statuses_calls)" = "0" ] || {
+    printf 'live: r22 case 7 — the SHADOW round must not reach the status path\n' >&2; exit 1
+}
+[ "$(r22_notices)" = "1" ] || {
+    printf 'live: r22 case 7 — exactly one R22 notice expected\n' >&2; exit 1
+}
+grep -qF 'review: malformed verdict comment' "$GH_STUB_LOG" && {
+    printf 'live: r22 case 7 — the malformed notice belongs to the status path and must not fire here\n' >&2; exit 1
+}
+unset GH_HEAD GH_COMMENTS_FILE
+
+# case 8 — anti-drift: the script's path table is exactly rules.md R22's tokens
+path_tokens() {
+    sed 's/`/\n/g' \
+      | awk '/^[A-Za-z0-9_.\/*-]+$/ {
+              if (/\//) { print; next }
+              if (/\*/) { print; next }
+              if (/\.(toml|lock|sh|ps1|yml|md)$/) print
+            }'
+}
+rules_r22_tokens=$(sed -n '/^- \*\*R22 /p' "$root/docs/fleet/rules.md" | path_tokens | sort)
+table_tokens=$(sed -n '/^# shipping:/,/^# internal-tools:/p' "$root/scripts/pr-review-watch.sh" | path_tokens | sort)
+[ "$(printf '%s\n' "$rules_r22_tokens" | command grep -c .)" = "24" ] || {
+    printf 'r22 anti-drift: expected 24 path tokens in rules.md R22, got:\n%s\n' "$rules_r22_tokens" >&2; exit 1
+}
+if [ "$rules_r22_tokens" != "$table_tokens" ]; then
+    printf 'r22 anti-drift: the watcher table drifted from rules.md R22:\n%s\n' \
+        "$(diff <(printf '%s\n' "$rules_r22_tokens") <(printf '%s\n' "$table_tokens"))" >&2
+    exit 1
+fi
+echo "ok r22 anti-drift table"
 
 # --- offline guarantee: the real watcher log was never touched -----------------
 size_after=0


### PR DESCRIPTION
## Problem and change

The watcher wrote `Independent Review` from ANY §7-shaped verdict pinned to the
head — including glm verdicts on the shipping/gate/judging surfaces and on
itself (#888 merged six such PRs). rules.md R22 now states the rule as prose
(#918/#921); this PR gives it its executor.

Changes:

- `scripts/pr-review-watch.sh` —
  - the R22 path table copied verbatim from `docs/fleet/rules.md` R22 as a
    commented table (the anti-drift test in the suite asserts the table equals
    R22's 24 backticked path tokens);
  - `classify_surface` — stdin: one changed path per line → the most
    restricted surface any path falls on (shipping > gate > judging >
    internal-tools), matching the R22 tokens as shell-case patterns verbatim;
  - `verdict_engine` — the first `- model_observed:` line after the heading:
    contains opus/sol/glm → that engine, else unknown;
  - `verdict_is_shadow` — heading ends ` (SHADOW)` or a body line
    `shadow: true`;
  - `verdict_surface_ok` — authoritative only for opus/\*, sol/\*,
    glm/internal-tools; unknown engine never;
  - `finish_verdict` gates before any status/label: a self-declared SHADOW
    round settles quietly (no status, no label, no notice); a
    non-authoritative round posts exactly one
    `review: verdict by <engine> on <surface> surface is SHADOW per rules.md R22 — awaiting an authoritative engine`
    per (sha, verdict comment id) — marker-file de-dup, the same one-shot
    mechanism as the other notices — and settles; authoritative rounds
    continue into the unchanged product-LGTM check, status, and label flow;
  - the verdict comment id is captured from `gh pr comment`'s returned URL at
    post time (`review-pr<N>-r<R>-comment.id` in the scratch dir) and used in
    the de-dup key; a missing id degrades the key to the sha alone;
  - the two "carrier lacked the SHA-pinned heading" paths are now SHADOW-aware:
    a well-formed SHADOW-declared carrier settles quietly instead of being
    marked unreviewed (the strict union pin deliberately rejects SHADOW
    headings, so these carriers landed in the malformed branch before).
- `scripts/test-pr-review-watch.sh` — the gh stub gains a `--json files` arm
  (GH_FILES_FILE fixture re-encoded as the REST `{"files":[...]}` shape with
  the caller's --jq applied); eight new cases: glm+internal-tools writes
  status+label, glm+shipping and glm+judging draw exactly one correctly-named
  SHADOW notice with no status/label and settle, opus+judging writes
  status+label, unknown engine draws only the notice, a SHADOW-declared
  verdict writes nothing and settles, the R23 composition (SHADOW round on a
  PR that also carries a malformed dump: R22 notice only), and the anti-drift
  identity test (R22 tokens == table tokens, 24 expected).

Relation to other work: #890 (open) also touches `scripts/pr-review-watch.sh`;
per the issue's sequencing note this lands after it if it is still open — but
#917 has since merged its own rewrite of the same file, so #890 must rebase
onto this regardless; R5's "earlier, larger change first" has already been
exercised by #917. This PR asserts #917's R23 behavior with tests and does not
re-implement it (`review.verdict-shape-owner`).

## Validation

### RAN

- `sh scripts/test-pr-review-watch.sh` — exit 0, `pr-review-watch fixtures passed` (all prior cases plus the eight new R22 cases).
- `sh scripts/fleet/test-next-loop.sh` — exit 0 (regression: the publisher touched by #917 stays intact).
- `sh scripts/test-review-pr.sh` — exit 0, `review-pr fixtures passed (19 cases)` (the D11 case included in this run).
- `sh -n` on both changed scripts — exit 0.
- `sh scripts/review-l0.sh origin/main HEAD` — exit 0; R1/R2/R3 PASS (R2 zero mixed-operator added lines — one candidate line was rewritten as nested `if`s to keep the diff free of `&&`+`||` mixing); U-routables PASS/N.A. per pre-push scope.
- `git diff --check` — empty.

### READ

- Exact-head CI on this PR's head (Format / Clippy ×3 / Test Linux+macOS / Test Windows subset / MSRV) — scripts-only diff; the fleet script suites above are not yet a CI gate (#910 open), so the local runs are the load-bearing evidence.

Issue: #919
