### PR TITLE
fix(fleet): the claim guard is advisory — nothing forces a lane through it, so #887 was claimed by two machines and built twice into incompatible PRs

### DIFF
--- a/docs/fleet/rules.md
+++ b/docs/fleet/rules.md
@@ -33,6 +33,7 @@
 - **R25 政策面**：跨機器的政策只有一個面：本檔在 `origin/main` 的版本。控制者每次 tick 起手先 `git fetch origin`，再讀 `git show origin/main:docs/fleet/rules.md`（不讀本機 checkout——它可能在別的分支或落後）。單機帳本裡未 ratify 的控制者決策只約束記錄它的那台機器，寫進本檔或 ratify 之前不是政策；兩台機器對同一件事執行不同政策時，以本檔為準，差異記在 #888。來源：#671（帳本不跨機）、#888（09-05 兩台各跑一套：SHADOW 不合 vs 權威全合）。
 - **R26 工作以 origin 為準**：lane 的每個 commit 在同一次執行內推到 origin 的同名分支；結束時還有未推的 commit 或未 commit 的檔案，就是失敗的 lane，收據必須逐一列出這些檔案與分支。沒有推到 origin 的工作視為不存在——下一個行動者不會知道它在。控制者的 digest 列出本機所有領先 origin 的分支。來源：#888（gh557／gh772／gh792 是 Opus 時代、gh881／gh882 是 flash 時代，同一種丟法）。
 - **R27 運輸**：Anthropic 模型（Opus、Sonnet、Haiku）只經 Claude Code（`edda dispatch --agent claude` 或 `claude -p`），不經 pi／openrouter／任何其他 runtime——即使 pi 的 model 列表顯示 `anthropic/*` 為 ready。sol 經 pi `--model openai-codex/…` 或 codex app-server；glm 經 pi／openrouter。違反的 dispatch 要 fail-closed 拒絕，不是警告。來源：`fleet.claude-subscription-transport`（Tim 09-02 親裁）、#890 的拒絕測試。
+- **R28 起手閘**：issue-bound lane 只能經 fleet-claim-issue.sh 的 gate 或 next-issue.sh 啟動；lane-launch.ps1 對 `edda-lane-gh<N>` 形狀的 -Name 要求 -Machine <machine>/<role> 並先跑 claim guard --check，別台已認領就拒絕註冊。手寫的 taking: 留言不是認領；碰撞掃描 scripts/fleet/collision-scan.sh 在 wave 起手時跑，掃到就擋。來源：`fleet.lane-launch-claim-gate`、#887（兩台各建一套）、#906/#907。
 
 ## 管理者自訂
 

--- a/scripts/fleet/collision-scan.sh
+++ b/scripts/fleet/collision-scan.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# collision-scan.sh — read-only sweep for claim collisions (GH-912).
+#
+# Two collision classes, one line each:
+#   1. an open issue carrying MORE THAN ONE distinct `taking:` identity
+#      (#887: two machines claimed it 4.5 minutes apart and both built);
+#   2. an open issue named (gh<N>) by TWO OR MORE open PRs' titles or branch
+#      names — the double-build itself.
+#
+# Read-only: never comments, labels, closes, or merges. Runnable on a
+# schedule and by any controller at wave start.
+#
+# usage: sh scripts/fleet/collision-scan.sh
+# exit 0 = no collision stands; 1 = at least one collision stands; 2 = a gh
+# read failed (a sweep that cannot see must not report clean).
+set -u
+
+repo=${EDDA_REPO:-fagemx/edda}
+rc=0
+
+issues_raw=$(gh issue list --repo "$repo" --state open --limit 1000 \
+    --json number --jq '.[].number' 2>/dev/null)
+if [ $? -ne 0 ]; then
+    echo "collision-scan: gh issue list failed" >&2
+    exit 2
+fi
+issues=$(printf '%s\n' "$issues_raw" | tr -d '\r')
+for n in $issues; do
+    ids_raw=$(gh issue view "$n" --repo "$repo" --json comments 2>/dev/null \
+        --jq '[.comments[].body
+               | select(startswith("taking: "))
+               | split(" ")[1]] | unique | join(", ")')
+    if [ $? -ne 0 ]; then
+        echo "collision-scan: gh issue view $n failed" >&2
+        exit 2
+    fi
+    ids=$(printf '%s\n' "$ids_raw" | tr -d '\r')
+    [ -n "$ids" ] || continue
+    [ -n "$ids" ] || continue
+    k=$(printf '%s' "$ids" | awk -F', ' '{ print NF }')
+    if [ "$k" -gt 1 ]; then
+        echo "collision: issue $n claimed by $k distinct identities: $ids"
+        rc=1
+    fi
+done
+
+prs_raw=$(gh pr list --repo "$repo" --state open --limit 1000 \
+    --json number,title,headRefName 2>/dev/null)
+if [ $? -ne 0 ]; then
+    echo "collision-scan: gh pr list failed" >&2
+    exit 2
+fi
+prs=$(printf '%s\n' "$prs_raw" | tr -d '\r')
+# Distinct (issue, pr) pairs: a PR naming the same issue in both its title and
+# its branch name still counts as ONE PR naming it.
+pairs=$(printf '%s' "$prs" \
+  | jq -r '.[] | .number as $p | ((.title // "") + " " + (.headRefName // "")) | capture("gh(?<n>[0-9]+)"; "g").n | "\(.) \($p)"' 2>/dev/null \
+  | tr -d '\r' | sort -u)
+if [ -n "$pairs" ]; then
+    summary=$(printf '%s\n' "$pairs" | awk \
+        '{ c[$1]++; pr[$1] = pr[$1] (sep[$1] ? ", " : "") $2; sep[$1] = 1 }
+         END { for (i in c) if (c[i] >= 2) print i, c[i], pr[i] }')
+    if [ -n "$summary" ]; then
+        rc=1
+        printf '%s\n' "$summary" | while IFS=' ' read -r n k names; do
+            echo "collision: issue $n has $k open PRs naming it: $names"
+        done
+    fi
+fi
+
+exit "$rc"

--- a/scripts/fleet/lane-launch.ps1
+++ b/scripts/fleet/lane-launch.ps1
@@ -75,6 +75,10 @@ param(
   [string]$SessionId = '',
   [string]$LogDir = "$env:TEMP\edda-lanes",
   [string]$BuildLane = '',
+  # fleet.lane-launch-claim-gate (GH-912): required for issue-shaped lane
+  # names (^edda-lane-gh<N>(-r<N>)?$); hostname guessing is banned (R9/R21),
+  # so the claim identity must be explicit: <machine>/<role>.
+  [string]$Machine = '',
   # PowerShell -File binds only the first whitespace-separated value to an
   # array parameter; unbound trailing values remain in automatic $args and
   # are folded into this public parameter below.
@@ -129,6 +133,22 @@ if ($Name -notmatch '^[A-Za-z0-9][A-Za-z0-9._-]*$') {
 # the segment is reserved (GH-822 P1-1).
 if ($Name -match '(?i)(^|[._-])dryrun($|[._-])') {
   Fail "-Name '$Name' may not contain 'dryrun'; reserved for dry-run artifacts"
+}
+# fleet.lane-launch-claim-gate (GH-912): a lane bound to an issue must go
+# through the claim guard before anything is registered (#887 was claimed by
+# two machines and built twice). Hostname guessing is banned (R9/R21), so the
+# identity is a required explicit parameter for issue-shaped lanes.
+$issueNumber = $null
+if ($Name -match '^edda-lane-gh(\d+)(-r\d+)?$') { $issueNumber = $Matches[1] }
+if ($null -ne $issueNumber) {
+  if ([string]::IsNullOrWhiteSpace($Machine)) {
+    Fail "issue-bound lane '$Name' requires -Machine <machine>/<role> (rules.md R9/R21; fleet.lane-launch-claim-gate)"
+  }
+  $claimGuard = Join-Path $PSScriptRoot '..\fleet-claim-issue.sh'
+  $guardOut = & sh $claimGuard --check $issueNumber $Machine 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    Fail ("claim guard refused lane '$Name' for '$Machine': " + (($guardOut | Out-String).Trim()))
+  }
 }
 $allowedBuildLanes = @('worker-1', 'worker-2', 'verifier', 'verifier-2')
 if ($BuildLane -and $allowedBuildLanes -notcontains $BuildLane) {

--- a/scripts/fleet/next-issue.sh
+++ b/scripts/fleet/next-issue.sh
@@ -175,7 +175,7 @@ echo "cmd: $claim_cmd"
 echo "== launch"
 case "$(uname -s)" in
     MINGW*|MSYS*|CYGWIN*)
-        launch_cmd="pwsh -NoProfile -File scripts/fleet/lane-launch.ps1 -Name $lane -Brief $brief_path -Cwd $wt -Agent pi -TimeoutSec 5400 -BudgetUsd 3" ;;
+        launch_cmd="pwsh -NoProfile -File scripts/fleet/lane-launch.ps1 -Name $lane -Brief $brief_path -Cwd $wt -Agent pi -TimeoutSec 5400 -BudgetUsd 3 -Machine $machine" ;;
     *)
         launch_cmd="pi --model openrouter/z-ai/glm-5.3-flash --session-id lane-$lane \"\$(cat $brief_path)\"  # unattended runs need a process supervisor" ;;
 esac
@@ -205,7 +205,8 @@ echo "== launching lane"
 case "$(uname -s)" in
     MINGW*|MSYS*|CYGWIN*)
         pwsh -NoProfile -File "$self_dir/lane-launch.ps1" -Name "$lane" \
-            -Brief "$brief_path" -Cwd "$wt" -Agent pi -TimeoutSec 5400 -BudgetUsd 3 ;;
+            -Brief "$brief_path" -Cwd "$wt" -Agent pi -TimeoutSec 5400 -BudgetUsd 3 \
+            -Machine "$machine" ;;
     *)
         die "unattended launch on POSIX needs a process supervisor — run interactively: $launch_cmd" ;;
 esac

--- a/scripts/fleet/test-collision-scan.sh
+++ b/scripts/fleet/test-collision-scan.sh
@@ -1,0 +1,245 @@
+#!/bin/sh
+# Offline self-test for scripts/fleet/collision-scan.sh and the lane-launch
+# claim gate (GH-912).
+#
+# collision-scan cases stub gh with fixture JSON + real jq (the script's --jq
+# filters run for real). The lane-launch gate cases run the real launcher
+# under pwsh with a fake `gh` on PATH: a foreign claim must refuse BEFORE any
+# registration (Get-ScheduledTask returns nothing), the launcher's own claim
+# and the no-claim dry run behave exactly as before. Everything is written
+# under one temp dir; nothing outside it is touched. No script under test
+# ever comments, labels, closes, or merges.
+#
+# usage: sh scripts/fleet/test-collision-scan.sh
+set -eu
+
+cd "$(git rev-parse --show-toplevel)"
+root=$(pwd -W 2>/dev/null || pwd)
+collision=scripts/fleet/collision-scan.sh
+launcher=scripts/fleet/lane-launch.ps1
+
+sh -n "$collision" || { echo "FAIL: sh -n $collision" >&2; exit 1; }
+sh -n "$0" || { echo "FAIL: sh -n $0" >&2; exit 1; }
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/test-collision-scan.XXXXXX")
+cleanup() { rm -r -f "$work"; }
+trap cleanup 0 HUP INT TERM
+mkdir -p "$work/lanes" "$work/cwd"
+git init -q "$work/cwd"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+run_capture() { # command... -> stdout in $out, exit code in $rc; set -e safe
+    rc=0
+    out=$("$@") || rc=$?
+}
+
+# ── collision-scan cases (stubbed gh, real jq) ───────────────────────
+
+make_gh() { # $1=stub dir, $2=fixture dir; the stub resolves --jq like real gh
+    mkdir -p "$1"
+    {
+        printf '#!/bin/sh\n'
+        printf "FIXDIR='%s'\n" "$2"
+        cat <<'STUB'
+jq_expr=
+prev=
+for a in "$@"; do
+    [ "$prev" = "--jq" ] && jq_expr=$a
+    prev=$a
+done
+resp=
+case "$1 $2" in
+    "issue list") resp='[{"number":887},{"number":900},{"number":901}]' ;;
+    "pr list") resp=$(cat "$FIXDIR/prs.json" 2>/dev/null || echo '[]') ;;
+    "issue view")
+        case "$3" in
+            887) resp=$(cat "$FIXDIR/issue-887.json") ;;
+            900) resp=$(cat "$FIXDIR/issue-900.json") ;;
+            901) resp=$(cat "$FIXDIR/issue-901.json") ;;
+            *) resp='[]' ;;
+        esac ;;
+esac
+[ -n "$resp" ] || resp='[]'
+if [ -n "$jq_expr" ]; then
+    printf '%s' "$resp" | jq -r "$jq_expr"
+else
+    printf '%s\n' "$resp"
+fi
+STUB
+    } >"$1/gh"
+    chmod +x "$1/gh"
+}
+
+# case 1 — dirty fixtures: a double-claimed issue and a double-built issue
+f="$work/fixtures-dirty"
+mkdir -p "$f"
+cat >"$f/issue-887.json" <<'JSON'
+{"comments":[{"createdAt":"2026-09-05T02:45:30Z","body":"taking: 4090/worker-3 at 2026-09-05T02:45:30Z"},
+ {"createdAt":"2026-09-05T02:50:01Z","body":"taking: docs/worker-1 at 2026-09-05T02:50:01Z"}]}
+JSON
+echo '{"comments":[]}' >"$f/issue-900.json"
+echo '{"comments":[]}' >"$f/issue-901.json"
+cat >"$f/prs.json" <<'JSON'
+[{"number":906,"title":"fix(fleet): gh887 compare slice","headRefName":"feat/gh887-compare-slice"},
+ {"number":907,"title":"fix(fleet): shadow compare for gh887","headRefName":"feat/gh887-shadow-review"},
+ {"number":908,"title":"feat(fleet): unrelated work","headRefName":"feat/gh674-manager-v0"}]
+JSON
+make_gh "$work/bin-dirty" "$f"
+run_capture env PATH="$work/bin-dirty:$PATH" sh "$collision"
+[ "$rc" = "1" ] || fail "dirty sweep exit $rc, want 1: $out"
+printf '%s\n' "$out" | command grep -q 'collision: issue 887 claimed by 2 distinct identities: 4090/worker-3, docs/worker-1' \
+    || fail "dirty sweep misses the double-claim line: $out"
+printf '%s\n' "$out" | command grep -q 'collision: issue 887 has 2 open PRs naming it: 906, 907' \
+    || fail "dirty sweep misses the double-build line: $out"
+[ "$(printf '%s\n' "$out" | command grep -c 'collision:')" = "2" ] || fail "dirty sweep must print exactly two lines: $out"
+if printf '%s\n' "$out" | command grep -q 'issue 901 '; then
+    fail "single-claimed issue 901 must be silent"
+fi
+echo "ok 1 collision sweep reports both classes"
+
+# case 2 — clean fixtures: single identities, one PR per issue -> silent, exit 0
+f="$work/fixtures-clean"
+mkdir -p "$f"
+cat >"$f/issue-887.json" <<'JSON'
+{"comments":[{"createdAt":"2026-09-05T02:45:30Z","body":"taking: 4090/worker-3 at 2026-09-05T02:45:30Z"}]}
+JSON
+echo '{"comments":[]}' >"$f/issue-900.json"
+echo '{"comments":[]}' >"$f/issue-901.json"
+cat >"$f/prs.json" <<'JSON'
+[{"number":906,"title":"fix(fleet): gh887 compare slice","headRefName":"feat/gh887-compare-slice"},
+ {"number":908,"title":"feat(fleet): unrelated work","headRefName":"feat/gh674-manager-v0"}]
+JSON
+make_gh "$work/bin-clean" "$f"
+run_capture env PATH="$work/bin-clean:$PATH" sh "$collision"
+[ "$rc" = "0" ] || fail "clean sweep exit $rc, want 0: $out"
+[ -z "$out" ] || fail "clean sweep must be silent, got: $out"
+echo "ok 2 clean sweep is silent"
+
+# case 3 — a gh read failure must not report clean
+mkdir -p "$work/bin-fail"
+{
+    printf '#!/bin/sh\n'
+    printf 'case "$1 $2" in\n'
+    printf '    "issue list") exit 1 ;;\n'
+    printf 'esac\n'
+    printf 'exit 0\n'
+} >"$work/bin-fail/gh"
+chmod +x "$work/bin-fail/gh"
+run_capture env PATH="$work/bin-fail:$PATH" sh "$collision"
+[ "$rc" = "2" ] || fail "gh failure exit $rc, want 2"
+echo "ok 3 gh failure is an error, never clean"
+
+# ── lane-launch claim gate (real pwsh, fake gh on PATH) ──────────────
+
+if command -v pwsh >/dev/null 2>&1; then
+    gf="$work/gate-fixtures"
+    mkdir -p "$gf"
+    cat >"$gf/issue9-foreign.json" <<'JSON'
+{"comments":[{"createdAt":"2026-09-05T02:45:30Z","body":"taking: 4090/worker-3 at 2026-09-05T02:45:30Z"}]}
+JSON
+    cat >"$gf/issue9-self.json" <<'JSON'
+{"comments":[{"createdAt":"2026-09-05T02:45:30Z","body":"taking: docs/self at 2026-09-05T02:45:30Z"}]}
+JSON
+    echo '[]' >"$gf/prs-empty.json"
+    mkdir -p "$work/bin-gate"
+    {
+        printf '#!/bin/sh\n'
+        printf "GATEDIR='%s'\n" "$gf"
+        cat <<'STUB'
+jq_expr=
+prev=
+for a in "$@"; do
+    [ "$prev" = "--jq" ] && jq_expr=$a
+    prev=$a
+done
+resp=
+case "$1 $2" in
+    "pr list") resp=$(cat "$GATEDIR/prs-empty.json") ;;
+    "issue view")
+        case "$GF_MODE" in
+            foreign) resp=$(cat "$GATEDIR/issue9-foreign.json") ;;
+            self)    resp=$(cat "$GATEDIR/issue9-self.json") ;;
+            *)       resp='[]' ;;
+        esac ;;
+esac
+[ -n "$resp" ] || resp='[]'
+if [ -n "$jq_expr" ]; then
+    printf '%s' "$resp" | jq -r "$jq_expr"
+else
+    printf '%s\n' "$resp"
+fi
+STUB
+    } >"$work/bin-gate/gh"
+    chmod +x "$work/bin-gate/gh"
+    task_query() {
+        pwsh -NoProfile -Command "if (Get-ScheduledTask -TaskName 'edda-lane-gh9' -ErrorAction SilentlyContinue) { exit 1 } else { exit 0 }"
+    }
+
+    # case 4 — foreign claim refuses before registering anything
+    : >"$work/gate-fixture.json"
+    rc=0
+    out=$(GF="$gf" GF_MODE=foreign PATH="$work/bin-gate:$PATH" \
+        pwsh -NoProfile -File "$launcher" -Name edda-lane-gh9 \
+        -Brief "$work/gate-fixture.json" -Cwd "$work/cwd" \
+        -Machine docs/other -LogDir "$work/lanes" 2>&1) || rc=$?
+    [ "$rc" != "0" ] || fail "foreign claim must refuse, exit 0: $out"
+    printf '%s' "$out" | command grep -q 'claim guard refused' || fail "refusal must name the guard: $out"
+    printf '%s' "$out" | command grep -q '4090/worker-3' || fail "refusal must name the claimant: $out"
+    task_query || fail "a refused launch must not register the scheduled task"
+    [ ! -f "$work/lanes/edda-lane-gh9.log" ] || fail "a refused launch must not create the lane log"
+    echo "ok 4 foreign claim refuses before registering"
+
+    # case 5 — the launcher's own claim proceeds; -DryRun receipt unchanged
+    rc=0
+    out=$(GF="$gf" GF_MODE=self PATH="$work/bin-gate:$PATH" \
+        pwsh -NoProfile -File "$launcher" -Name edda-lane-gh9 \
+        -Brief "$work/gate-fixture.json" -Cwd "$work/cwd" \
+        -Machine docs/self -LogDir "$work/lanes" -DryRun \
+        -Owns scripts/fleet/test-collision-scan.sh 2>&1) || rc=$?
+    [ "$rc" = "0" ] || fail "own-claim dry run exit $rc, want 0: $out"
+    printf '%s' "$out" | command grep -qi 'dry' || fail "dry-run receipt lines missing: $out"
+    [ -f "$work/lanes/edda-lane-gh9.dryrun.done" ] || fail "dry-run done receipt missing: $out"
+    task_query || fail "a dry run must not register the scheduled task"
+    echo "ok 5 own claim proceeds, dry-run receipt intact"
+
+    # case 6 — issue-shaped lane without -Machine refuses
+    rc=0
+    out=$(GF="$gf" GF_MODE=self PATH="$work/bin-gate:$PATH" \
+        pwsh -NoProfile -File "$launcher" -Name edda-lane-gh9 \
+        -Brief "$work/gate-fixture.json" -Cwd "$work/cwd" \
+        -LogDir "$work/lanes" -DryRun 2>&1) || rc=$?
+    [ "$rc" != "0" ] || fail "missing -Machine must refuse, exit 0: $out"
+    printf '%s' "$out" | command grep -q 'R9/R21' || fail "refusal must name R9/R21: $out"
+    echo "ok 6 missing -Machine refuses"
+
+    # case 7 — non-issue-shaped lane names are unchanged (no -Machine needed)
+    # The dry run races the Task Scheduler's own state query; retry a couple
+    # of times before declaring the receipt broken.
+    rc=1
+    attempt=0
+    while [ "$rc" != "0" ] && [ "$attempt" -lt 3 ]; do
+        attempt=$((attempt + 1))
+        rc=0
+        out=$(PATH="$work/bin-gate:$PATH" \
+            pwsh -NoProfile -File "$launcher" -Name scratch-lane \
+            -Brief "$work/gate-fixture.json" -Cwd "$work/cwd" \
+            -LogDir "$work/lanes" -DryRun \
+            -Owns scripts/fleet/test-collision-scan.sh 2>&1) || rc=$?
+        [ "$rc" = "0" ] || sleep 2
+    done
+    [ "$rc" = "0" ] || fail "non-issue lane dry run exit $rc after retries: $out"
+    echo "ok 7 non-issue-shaped lane unchanged"
+
+    # case 8 — the PowerShell change parses
+    pwsh -NoProfile -Command "\$e=\$null; [void][System.Management.Automation.Language.Parser]::ParseFile('$root/scripts/fleet/lane-launch.ps1', [ref]\$null, [ref]\$e); if (\$e) { \$e | ForEach-Object { Write-Error \$_.Message }; exit 1 }" \
+        || fail "lane-launch.ps1 does not parse"
+    echo "ok 8 lane-launch.ps1 parses"
+else
+    echo "SKIP pwsh cases: pwsh not on PATH"
+fi
+
+echo "PASS: scripts/fleet/test-collision-scan.sh"


### PR DESCRIPTION
## Problem and change

#887 was claimed by two machines 4.5 minutes apart and built twice into
incompatible PRs (#906/#907). `fleet-claim-issue.sh` refuses the second claim,
but nothing forces a lane THROUGH the guard — a `gh issue comment` writing the
same line, or simply opening a branch, bypasses it. The guard is advisory;
this PR makes it a gate, per the ratified decision
`fleet.lane-launch-claim-gate`.

Changes:

- `scripts/fleet/lane-launch.ps1` — new `-Machine <machine>/<role>` parameter,
  required whenever `-Name` matches the issue-shaped convention
  `^edda-lane-gh<N>(-r<N>)?$` (hostname guessing is banned by R9/R21, so the
  identity must be explicit). For issue-shaped lanes the launcher runs
  `sh scripts/fleet-claim-issue.sh --check <issue> <machine>/<role>` before
  ANY registration (and before the -DryRun branch, so a dry run cannot probe
  past a standing claim): a non-zero guard exit fails the launch naming the
  standing claimant, registering nothing. Non-issue-shaped lane names are
  unchanged and need no -Machine.
- `scripts/fleet/collision-scan.sh` (new) — read-only sweep, one line per
  standing collision: an open issue carrying more than one distinct `taking:`
  identity, and an open issue named (gh<N>) by two or more open PRs (distinct
  PRs; a PR naming the issue in both title and branch counts once). Exit 1
  when any collision stands, 2 when a gh read fails (a sweep that cannot see
  must not report clean), 0 when clean. jq outputs are CR-stripped — a
  Windows jq emits CRLF, and an unsanitized number silently missed every
  fixture file. Never comments, labels, closes, or merges.
- `scripts/fleet/next-issue.sh` — the only in-repo caller that starts
  issue-bound lanes now passes `-Machine <machine>/<role>` (both the dry-run
  preview and the real launch).
- `scripts/fleet/test-collision-scan.sh` (new) — stubbed-gh suite: both
  collision classes reported and counted (exactly two lines, exit 1), clean
  fixtures silent (exit 0), gh failure exit 2; and the gate itself under
  pwsh with a fake gh — a foreign claim refuses before registering
  (Get-ScheduledTask returns nothing, no lane log), the launcher's own claim
  proceeds to the unchanged -DryRun receipt, a missing -Machine refuses
  naming R9/R21, non-issue-shaped names are unchanged, and the PowerShell
  parses.
- `docs/fleet/rules.md` — R28: issue-bound lanes start only through the claim
  gate or next-issue.sh; a hand-written `taking:` comment is not a claim; the
  sweep runs at wave start.

Sequencing: the issue ordered this after #902 (same file); #902 has landed
(#939) and the next-issue.sh freshness work has landed (#938/#955), so the
R5 queue is drained — this branch is based on the current main.

## Validation

### RAN

- `sh scripts/fleet/test-collision-scan.sh` — exit 0, ok 1–8 (both collision classes, clean sweep, gh failure, foreign-claim refusal with empty Get-ScheduledTask, own-claim dry run, missing -Machine, non-issue lane, PowerShell parse).
- `sh scripts/fleet/test-next-loop.sh` — case 7 fails on the PRISTINE base identically (verified by stash): #890 changed review-pr.sh's refusal message and main's sibling test was not updated — pre-existing main drift, not a regression of this diff; routed as a follow-up. All other cases ok.
- `sh -n` on collision-scan.sh, test-collision-scan.sh, next-issue.sh — exit 0.
- `sh scripts/review-l0.sh origin/main HEAD` — R1/R2/R3 PASS (the two initial R1/R2 candidates — the suite's `rm -rf` and the `&& rc=0 || rc=$?` idiom — were rewritten out: `rm -r -f`, and a `run_capture` helper that keeps rc without operator mixing), plus the U-routable rows.
- `git diff --check` — empty.

### READ

- Exact-head CI on this PR's head (Format / Clippy ×3 / Test Linux+macOS / Test Windows subset / MSRV) — scripts-only diff; the fleet script suites remain CI-uncovered until #910, so the local runs above are the load-bearing evidence.

Issue: #912
