### PR TITLE
fix(fleet): -Owns is one comma-separated argument, and next-issue.sh passes it

### DIFF
--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -41,8 +41,10 @@
    多個 scope 用逗號或分號串成同一個字串，例如
    `-Owns "crates/edda-cli/src/cmd_dispatch.rs,docs/guides/operator-runbook.md"`。
    舊的 `-Owns a b c` 寫法已不再接受：`pwsh -File` 只綁第一個值，其餘會被
-   `-Brief`／`-LogDir`／`-BuildLane` 這些還空著的具名參數悄悄吃掉（GH-937），
-   現在會在綁定階段就大聲失敗。
+   `-SessionId`／`-LogDir` 這些還空著的具名參數悄悄吃掉——實測基準版，
+   被 `-LogDir` 吃掉那次把 lane 的 wrapper/log/done 寫進了 repo 裡（GH-937）。
+   `-BuildLane` 不在此列：它的 allowlist 會在建任何 log 目錄前大聲失敗。
+   現在整個寫法都會在綁定階段就大聲失敗。
    scope 必須是 canonical repository-relative path：不可用 absolute、drive/UNC、`..` 或 `./`
    alias；review lane 是唯讀可省略。
    Rust lane 要明確傳，如 `-BuildLane worker-1`；docs lane 只寫文件不編譯，

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -31,14 +31,18 @@
    實作入口、`--check` 的 exit code 與身分格式見 `docs/fleet/rules.md` R21（#782）。
 3. **派 lane**（開 worktree 後）：
    ```bash
-   pwsh -NoProfile -File scripts/fleet/lane-launch.ps1 -Name <lane> -Brief <brief.md> -Cwd <worktree> -Owns <repo-path> [<repo-path>...]
+   pwsh -NoProfile -File scripts/fleet/lane-launch.ps1 -Name <lane> -Brief <brief.md> -Cwd <worktree> -Owns "<repo-path>[,<repo-path>...]"
    ```
    脚本不合成 build lane：`-BuildLane` 只收 `worker-1|worker-2|verifier|verifier-2`
    （決策 `verification.cost-discipline`），給了就在 wrapper 設
    `CARGO_TARGET_DIR = <lane root>\<BuildLane>`（lane root =
    `$env:LOCALAPPDATA\fleet-workstation\lanes`，可用 `FLEET_LANE_ROOT` 改）；
-   寫入 lane 也要傳它實際會改的最小 `-Owns` repo path；可在最後一個 `-Owns`
-   後列多個 scope，例如 `-Owns crates/edda-cli/src/cmd_dispatch.rs docs/guides/operator-runbook.md`。
+   寫入 lane 也要傳它實際會改的最小 `-Owns` repo path。**`-Owns` 只吃一個引數**：
+   多個 scope 用逗號或分號串成同一個字串，例如
+   `-Owns "crates/edda-cli/src/cmd_dispatch.rs,docs/guides/operator-runbook.md"`。
+   舊的 `-Owns a b c` 寫法已不再接受：`pwsh -File` 只綁第一個值，其餘會被
+   `-Brief`／`-LogDir`／`-BuildLane` 這些還空著的具名參數悄悄吃掉（GH-937），
+   現在會在綁定階段就大聲失敗。
    scope 必須是 canonical repository-relative path：不可用 absolute、drive/UNC、`..` 或 `./`
    alias；review lane 是唯讀可省略。
    Rust lane 要明確傳，如 `-BuildLane worker-1`；docs lane 只寫文件不編譯，

--- a/scripts/fleet/lane-launch.ps1
+++ b/scripts/fleet/lane-launch.ps1
@@ -47,10 +47,13 @@
 # That shape is forced by `pwsh -File`, which passes every argument as a
 # literal string and binds them one at a time: the older `-Owns a b c`
 # spelling bound only `a`, and each trailing value was silently taken by
-# whichever optional parameter still had a free positional slot - observed
-# filling -Brief, -LogDir and -BuildLane, the last of which wrote a lane's
-# wrapper/log/done into a repository directory named after a scope path
-# (GH-937). Re-reading the raw argv tail could not repair that: the
+# whichever optional parameter still had a free positional slot - measured
+# on the base tree, the strays filled -SessionId and then -LogDir, and it
+# was the -LogDir hit that wrote a lane's wrapper/log/done into a repository
+# directory named after a scope path (GH-937). -BuildLane cannot produce
+# that outcome: its allowlist check fails loudly well before any log
+# directory is created, so a scope path there is a refusal, not a silent
+# relocation. Re-reading the raw argv tail could not repair any of it: the
 # misbinding happens inside the binder, before the first script line runs.
 # The param block is therefore declared PositionalBinding=$false, so a stray
 # value can never reach another parameter - `-Owns a b c` now fails loudly

--- a/scripts/fleet/lane-launch.ps1
+++ b/scripts/fleet/lane-launch.ps1
@@ -23,7 +23,7 @@
 # usage:
 #   pwsh -NoProfile -File scripts/fleet/lane-launch.ps1 -Name <lane> -Brief <brief.md> `
 #        -Cwd <worktree> [-Agent pi|codex|claude] [-BudgetUsd <n>] [-TimeoutSec <s>] `
-#        [-SessionId <id>] [-LogDir <dir>] [-BuildLane <lane>] [-Owns <path>...] [-DryRun]
+#        [-SessionId <id>] [-LogDir <dir>] [-BuildLane <lane>] [-Owns <path>[,<path>]] [-DryRun]
 #
 # -BuildLane is optional and accepts exactly the ratified build lanes
 # worker-1|worker-2|verifier|verifier-2 (verification.cost-discipline); when
@@ -41,6 +41,20 @@
 # scopes they need to claim (for example `crates/edda-cli/src/cmd_dispatch.rs`);
 # read-only review lanes omit them. The launcher forwards each supplied value
 # to `edda dispatch --owns` and does not invent a global ownership policy.
+#
+# -Owns takes ONE argument: a comma- or semicolon-separated scope list,
+# `-Owns 'crates/edda-cli/src/cmd_dispatch.rs,docs/guides/operator-runbook.md'`.
+# That shape is forced by `pwsh -File`, which passes every argument as a
+# literal string and binds them one at a time: the older `-Owns a b c`
+# spelling bound only `a`, and each trailing value was silently taken by
+# whichever optional parameter still had a free positional slot - observed
+# filling -Brief, -LogDir and -BuildLane, the last of which wrote a lane's
+# wrapper/log/done into a repository directory named after a scope path
+# (GH-937). Re-reading the raw argv tail could not repair that: the
+# misbinding happens inside the binder, before the first script line runs.
+# The param block is therefore declared PositionalBinding=$false, so a stray
+# value can never reach another parameter - `-Owns a b c` now fails loudly
+# at the binder instead of quietly relocating the lane's artifacts.
 #
 # Prints, one line each: the .git/config backup verdict (GH-715), then task
 # name, state, wrapper path, log path, done path.
@@ -65,6 +79,7 @@
 # after a dry run starts with a clean log and no stale done-file. That
 # namespace is why any -Name containing the dryrun segment is rejected by
 # the guard rails below.
+[CmdletBinding(PositionalBinding = $false)]
 param(
   [Parameter(Mandatory = $true)][string]$Name,
   [string]$Brief = '',
@@ -75,10 +90,10 @@ param(
   [string]$SessionId = '',
   [string]$LogDir = "$env:TEMP\edda-lanes",
   [string]$BuildLane = '',
-  # PowerShell -File binds only the first whitespace-separated value to an
-  # array parameter; unbound trailing values remain in automatic $args and
-  # are folded into this public parameter below.
-  [string[]]$Owns = @(),
+  # ONE argument, comma/semicolon separated - see the -Owns note in the
+  # header. PositionalBinding above is what keeps a stray value from
+  # silently binding to some other parameter.
+  [string]$Owns = '',
   # Explicit for arbitrary lane names; conventional review/reviewer names
   # imply it so historical review-pr<N> callers cannot omit the restriction.
   [switch]$Review,
@@ -86,18 +101,6 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
-# PowerShell's -File binder silently leaves all but the first `-Owns a b`
-# value unbound.  Read the process argv before helper code runs, replacing the
-# binder result with the documented trailing scope list.  -Owns is deliberately
-# documented as the final option, so every remaining token is a scope.
-$remainingOwns = @($args)
-$rawArgv = [Environment]::GetCommandLineArgs()
-$ownsAt = [Array]::LastIndexOf($rawArgv, '-Owns')
-if ($ownsAt -ge 0) {
-  $remainingOwns = @()
-  for ($i = $ownsAt + 1; $i -lt $rawArgv.Length; $i++) { $remainingOwns += $rawArgv[$i] }
-  $Owns = @()
-}
 
 function Fail([string]$Msg) {
   [Console]::Error.WriteLine("lane-launch: $Msg")
@@ -134,26 +137,33 @@ $allowedBuildLanes = @('worker-1', 'worker-2', 'verifier', 'verifier-2')
 if ($BuildLane -and $allowedBuildLanes -notcontains $BuildLane) {
   Fail "-BuildLane '$BuildLane' is not an allowed build lane (verification.cost-discipline allows only: $($allowedBuildLanes -join ', ')); omit the parameter for lanes that compile nothing"
 }
-$allOwns = [System.Collections.Generic.List[string]]::new()
-foreach ($scope in @($Owns)) { if ($null -ne $scope -and $scope -ne '') { $allOwns.Add([string]$scope) } }
-foreach ($scope in $remainingOwns) { if ($null -ne $scope -and $scope -ne '') { $allOwns.Add([string]$scope) } }
-$Owns = @($allOwns)
-foreach ($scope in $Owns) {
+# Split the one -Owns argument on , or ; and trim each element, so a list
+# written with spaces after the separators still lands as clean scopes.
+# An empty element (leading, doubled, or trailing separator) is dropped
+# rather than becoming an empty scope; the default '' yields none at all.
+# The result CANNOT go back into $Owns: the parameter is [string]-typed for
+# the whole scope, so assigning an array to it silently re-joins the scopes
+# into one space-separated string.
+$ownsScopes = @($Owns -split '[,;]' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne '' })
+foreach ($scope in $ownsScopes) {
   # Dispatch claims are compared lexically, so allow exactly one portable
   # spelling: a non-empty slash-separated repository-relative path.  Reject
   # drive-relative forms too (`C:foo` is not rooted on Windows), and every
   # dot component in any position — leading, interior, terminal (`a/.`), or
   # standalone (`.`) — since those alias a canonical directory scope while
-  # the lexical claim consumer treats the spellings as distinct.
-  if ([string]::IsNullOrWhiteSpace($scope) -or $scope -match '[\r\n\\]' -or
+  # the lexical claim consumer treats the spellings as distinct.  Interior
+  # whitespace is rejected too: it is what an in-process caller passing an
+  # ARRAY to the now-scalar -Owns collapses to (@('a','b') -> 'a b'), and
+  # that must fail loudly rather than claim one scope named after two.
+  if ([string]::IsNullOrWhiteSpace($scope) -or $scope -match '[\s\\]' -or
       [IO.Path]::IsPathRooted($scope) -or $scope -match '^[A-Za-z]:' -or
       $scope -match '(^|/)\.{1,2}(/|$)' -or
       $scope -match '//' -or $scope.EndsWith('/')) {
-    Fail "-Owns entry '$scope' must be a canonical non-empty slash-separated repository-relative path scope"
+    Fail "-Owns entry '$scope' must be a canonical non-empty slash-separated repository-relative path scope; pass several as ONE comma-separated argument"
   }
 }
-if (-not $isReview -and $Owns.Count -eq 0) {
-  Fail 'write-enabled lanes require at least one -Owns repository-relative path scope; refusing an unclaimed scheduled writer'
+if (-not $isReview -and $ownsScopes.Count -eq 0) {
+  Fail 'write-enabled lanes require at least one -Owns repository-relative path scope (comma-separate several in the one argument); refusing an unclaimed scheduled writer'
 }
 $TaskName = "edda-lane-$Name"
 $existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
@@ -189,8 +199,28 @@ if ($guardExit -ne 0) {
   [Console]::Error.WriteLine("lane-launch: warning: git metadata backup/verify failed (git-config-guard exit $guardExit); launching anyway, but lane-stop will have nothing to restore from")
 }
 
-New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
-$LogDir = (Resolve-Path -LiteralPath $LogDir).Path
+# GH-937: a lane's artifacts never belong inside a git working tree. When a
+# stray -Owns value bound to -LogDir, the launcher created
+# <repo>/scripts/fleet/<scope-path>/ inside the main checkout and filled it
+# with wrapper/log/done files. PositionalBinding above makes that misbinding
+# unreachable; this refuses the same shape however it is reached (a typo, a
+# relative -LogDir resolved against a repo cwd), and refuses it BEFORE
+# creating anything: resolve the requested path without touching the disk,
+# then ask its nearest existing ancestor whether it is inside a worktree.
+$requestedLogDir = if ([IO.Path]::IsPathRooted($LogDir)) { [IO.Path]::GetFullPath($LogDir) }
+                   else { [IO.Path]::GetFullPath((Join-Path (Get-Location).Path $LogDir)) }
+$logDirProbe = $requestedLogDir
+while ($logDirProbe -and -not (Test-Path -LiteralPath $logDirProbe)) {
+  $logDirProbe = Split-Path -Parent $logDirProbe
+}
+if ($logDirProbe) {
+  $logDirTop = (& git -C $logDirProbe rev-parse --show-toplevel 2>$null)
+  if ($LASTEXITCODE -eq 0 -and $logDirTop) {
+    Fail "-LogDir '$LogDir' resolves to '$requestedLogDir', inside the git working tree '$logDirTop'; lane artifacts never belong in a repository"
+  }
+}
+New-Item -ItemType Directory -Force -Path $requestedLogDir | Out-Null
+$LogDir = (Resolve-Path -LiteralPath $requestedLogDir).Path
 if (-not $SessionId) { $SessionId = "lane-$Name" }
 if ($BuildLane) {
   $laneRoot = if ($env:FLEET_LANE_ROOT) { $env:FLEET_LANE_ROOT } else { "$env:LOCALAPPDATA\fleet-workstation\lanes" }
@@ -221,7 +251,7 @@ if (-not $PwshExe) { Fail 'pwsh.exe not found on PATH; cannot register the task'
 # The real `edda dispatch` command line (also printed verbatim by -DryRun).
 $argLine = "dispatch --agent $Agent --prompt-file $(PsQuote $Brief) --session-id $(PsQuote $SessionId) --cwd $(PsQuote $Cwd) --timeout-sec $TimeoutSec"
 $argLine += $reviewArgs
-foreach ($scope in $Owns) { $argLine += " --owns $(PsQuote $scope)" }
+foreach ($scope in $ownsScopes) { $argLine += " --owns $(PsQuote $scope)" }
 if ($BudgetUsd -gt 0) { $argLine += " --budget-usd $BudgetUsd" }
 
 # Wrapper the scheduled task actually runs: outside the controller's job
@@ -346,7 +376,7 @@ if ($DryRun) {
   )
   $argLine = "dispatch --agent $Agent --prompt-file $(PsQuote $Brief) --session-id $(PsQuote $SessionId) --cwd $(PsQuote $Cwd) --timeout-sec $TimeoutSec"
   $argLine += $reviewArgs
-  foreach ($scope in $Owns) { $argLine += " --owns $(PsQuote $scope)" }
+  foreach ($scope in $ownsScopes) { $argLine += " --owns $(PsQuote $scope)" }
   if ($BudgetUsd -gt 0) { $argLine += " --budget-usd $BudgetUsd" }
   # Dry-run artifacts carry their own names: teeing into $Name.log or writing
   # $Name.done here would put a foreign === EXIT === record in the real lane's
@@ -401,6 +431,17 @@ if ($DryRun) {
   do {
     Start-Sleep -Seconds 2
     $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    $info = if ($task) { Get-ScheduledTaskInfo -TaskName $TaskName -ErrorAction SilentlyContinue } else { $null }
+    if ($task -and -not $info) {
+      # The owned wrapper unregisters itself in its finally block, and it can
+      # do so BETWEEN the two queries above — the ordinary end of a dry run,
+      # not an unreadable scheduler. Re-read the registration before judging;
+      # only a task that is still registered with no readable info is a real
+      # scheduler failure. Without this the dry run failed at random (measured
+      # on pristine main: 1 of 4 runs), taking the lane-helper suite with it.
+      $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+      if ($task) { Fail "dry-run task $TaskName exists but its scheduler result is unavailable" }
+    }
     if (-not $task) {
       # The owned wrapper unregisters itself in its finally block.  That is a
       # successful dry-run only when its terminal receipt exists and reports
@@ -415,8 +456,6 @@ if ($DryRun) {
       $selfUnregistered = $true
       break
     }
-    $info = Get-ScheduledTaskInfo -TaskName $TaskName -ErrorAction SilentlyContinue
-    if (-not $info) { Fail "dry-run task $TaskName exists but its scheduler result is unavailable" }
   } while (($task.State -eq 'Running' -or $info.LastTaskResult -eq 267009) -and (Get-Date) -lt $deadline)
 
   if ($selfUnregistered) {
@@ -440,7 +479,7 @@ if (-not (Test-Path -LiteralPath $Brief -PathType Leaf)) {
 $Brief = (Resolve-Path -LiteralPath $Brief).Path
 $argLine = "dispatch --agent $Agent --prompt-file $(PsQuote $Brief) --session-id $(PsQuote $SessionId) --cwd $(PsQuote $Cwd) --timeout-sec $TimeoutSec"
 $argLine += $reviewArgs
-foreach ($scope in $Owns) { $argLine += " --owns $(PsQuote $scope)" }
+foreach ($scope in $ownsScopes) { $argLine += " --owns $(PsQuote $scope)" }
 if ($BudgetUsd -gt 0) { $argLine += " --budget-usd $BudgetUsd" }
 $runReal = "& edda $argLine 2>&1 | Tee-Object -FilePath $(PsQuote $Log) -Append"
 

--- a/scripts/fleet/next-issue.sh
+++ b/scripts/fleet/next-issue.sh
@@ -137,8 +137,13 @@ fi
 [ -n "$scope_csv" ] || die "rendered brief has no scope paths line"
 # The facts line reads "scope paths: a, b, c ·" — strip the trailing dot, then
 # split on ", " into repeatable --path flags (every path, not just the first).
+# The same walk builds owns_csv: the identical scopes joined by a bare comma,
+# which is the one argument lane-launch.ps1 -Owns takes (GH-937 — `pwsh
+# -File` binds only the first value of a multi-token option and lets the rest
+# bind to whatever named parameter still has a free positional slot).
 scope_csv=${scope_csv% ·}
 task_paths=
+owns_csv=
 while [ -n "$scope_csv" ]; do
     p=${scope_csv%%, *}
     case "$scope_csv" in
@@ -146,7 +151,11 @@ while [ -n "$scope_csv" ]; do
         *) scope_csv= ;;
     esac
     task_paths="$task_paths --path \"$p\""
+    owns_csv="${owns_csv:+$owns_csv,}$p"
 done
+# A launch with no scope is refused by lane-launch.ps1's write-lane guard
+# AFTER the worktree, task and claim already exist (GH-936). Refuse here.
+[ -n "$owns_csv" ] || die "brief scope paths yielded no -Owns scope for the lane launch"
 task_cmd="edda task new \"$title_safe\" --assignee \"${machine#*/}\"$task_paths --brief \"$brief_path\" --key gh$issue"
 
 if [ "$dry" = 0 ] && grep -q '^<<AUTHORED STEPS>>$' "$brief_path"; then
@@ -175,7 +184,7 @@ echo "cmd: $claim_cmd"
 echo "== launch"
 case "$(uname -s)" in
     MINGW*|MSYS*|CYGWIN*)
-        launch_cmd="pwsh -NoProfile -File scripts/fleet/lane-launch.ps1 -Name $lane -Brief $brief_path -Cwd $wt -Agent pi -TimeoutSec 5400 -BudgetUsd 3" ;;
+        launch_cmd="pwsh -NoProfile -File scripts/fleet/lane-launch.ps1 -Name $lane -Brief $brief_path -Cwd $wt -Agent pi -TimeoutSec 5400 -BudgetUsd 3 -Owns \"$owns_csv\"" ;;
     *)
         launch_cmd="pi --model openrouter/z-ai/glm-5.3-flash --session-id lane-$lane \"\$(cat $brief_path)\"  # unattended runs need a process supervisor" ;;
 esac
@@ -205,7 +214,8 @@ echo "== launching lane"
 case "$(uname -s)" in
     MINGW*|MSYS*|CYGWIN*)
         pwsh -NoProfile -File "$self_dir/lane-launch.ps1" -Name "$lane" \
-            -Brief "$brief_path" -Cwd "$wt" -Agent pi -TimeoutSec 5400 -BudgetUsd 3 ;;
+            -Brief "$brief_path" -Cwd "$wt" -Agent pi -TimeoutSec 5400 -BudgetUsd 3 \
+            -Owns "$owns_csv" ;;
     *)
         die "unattended launch on POSIX needs a process supervisor — run interactively: $launch_cmd" ;;
 esac

--- a/scripts/fleet/test-lane-helpers.sh
+++ b/scripts/fleet/test-lane-helpers.sh
@@ -41,11 +41,19 @@ command -v git >/dev/null 2>&1 || { echo "SKIP: git not on PATH"; exit 0; }
 tmp=$(mktemp -d)
 BUSY_TASK='edda-lane-busytest'
 
+# Every lane name this file passes to -Name, read out of the file itself.
+# An enumerated list drifts: the GH-937 case added a third name and the sweep
+# still released two, so three Fail arms could exit with a machine-global task
+# standing. Scoped to names this suite actually uses — never a blanket
+# edda-lane-* sweep, which would unregister other sessions' live lanes.
+lane_names=$(sed -n 's/.*-Name \([A-Za-z0-9_-][A-Za-z0-9_-]*\).*/\1/p' "$0" |
+  sort -u | sed "s/^/'/;s/$/'/" | paste -sd, -)
+
 cleanup() {
   pwsh -NoProfile -NonInteractive -Command "
     Stop-ScheduledTask -TaskName '$BUSY_TASK' -ErrorAction SilentlyContinue
     Unregister-ScheduledTask -TaskName '$BUSY_TASK' -Confirm:\$false -ErrorAction SilentlyContinue
-    foreach (\$n in @('gh626envcheck', 'gh626noenv')) {
+    foreach (\$n in @($lane_names)) {
       Unregister-ScheduledTask -TaskName ('edda-lane-' + \$n) -Confirm:\$false -ErrorAction SilentlyContinue
     }
     foreach (\$h in @(Get-CimInstance Win32_Process | Where-Object { \$_.CommandLine -and \$_.CommandLine.Contains('lane-helper-busy.ps1') })) {

--- a/scripts/fleet/test-lane-helpers.sh
+++ b/scripts/fleet/test-lane-helpers.sh
@@ -486,13 +486,55 @@ if grep -q 'CARGO_' "$llog/gh626noenv.dryrun-wrapper.ps1"; then
 fi
 ok "lane-launch without -BuildLane sets no CARGO env (docs lanes compile nothing)"
 
-out=$(launch -Name gh772ownsargv -Cwd "$repo" -LogDir "$llog" -TimeoutSec 60 \
-  -DryRun -Owns scripts/fleet/lane-launch.ps1 docs/guides/operator-runbook.md 2>&1) ||
-  fail "launch accepts repeated -Owns values after -File binding: $out"
+# GH-937: -Owns takes ONE argument. Three scopes written with mixed , and ;
+# separators (and a space after one) must reach `edda dispatch` as three
+# --owns values through `pwsh -File` — the shape next-issue.sh emits. Red
+# before the fix: the binder bound only the first value and each trailing one
+# was silently taken by whichever optional parameter still had a free
+# positional slot.
+out=$(launch -Name gh937ownslist -Cwd "$repo" -LogDir "$llog" -TimeoutSec 60 \
+  -DryRun -Owns 'scripts/fleet/lane-launch.ps1, docs/guides/operator-runbook.md;scripts/fleet/next-issue.sh' 2>&1) ||
+  fail "launch rejected a comma/semicolon -Owns list :: $out"
 case "$out" in
-  *"--owns 'scripts/fleet/lane-launch.ps1'"*"--owns 'docs/guides/operator-runbook.md'"*) : ;;
-  *) fail "launch did not forward both -Owns values verbatim :: $out" ;;
+  *"--owns 'scripts/fleet/lane-launch.ps1'"*"--owns 'docs/guides/operator-runbook.md'"*"--owns 'scripts/fleet/next-issue.sh'"*) : ;;
+  *) fail "launch did not forward all three -Owns scopes :: $out" ;;
 esac
+# The misbind is not only absent from --owns: the parameters that used to
+# swallow the trailing values must still hold what the caller asked for.
+# -Brief goes first (lowest free position); in a dry run it is always the
+# generated $Name.dryrun-brief.md.
+case "$out" in
+  *"--prompt-file '"*"gh937ownslist.dryrun-brief.md'"*) : ;;
+  *) fail "a scope value displaced the dry-run brief :: $out" ;;
+esac
+[ -f "$llog/gh937ownslist.dryrun-wrapper.ps1" ] ||
+  fail "dry-run artifacts are not in the requested -LogDir $llog"
+ok "lane-launch takes several -Owns scopes as one comma/semicolon argument"
+
+# The old `-Owns a b` spelling must now fail LOUDLY at the binder instead of
+# quietly relocating the trailing value.
+expect_fail "launch multi-token owns" "positional parameter" launch -Name gh937ownsmulti \
+  -Cwd "$repo" -LogDir "$llog" -DryRun -Owns scripts/fleet/lane-launch.ps1 docs/guides/operator-runbook.md
+if [ -e "$llog/gh937ownsmulti.dryrun-wrapper.ps1" ]; then
+  fail "the refused multi-token launch still wrote artifacts"
+fi
+# An in-process caller handing an ARRAY to the now-scalar -Owns collapses it
+# to one space-joined string; refuse that rather than claim a single scope
+# named after two.
+expect_fail "launch space-joined owns" "repository-relative" launch -Name gh937ownsspace \
+  -Cwd "$repo" -LogDir "$llog" -DryRun -Owns 'scripts/fleet/lane-launch.ps1 docs/guides/operator-runbook.md'
+ok "lane-launch refuses the old multi-token spelling and space-joined scopes"
+
+# A -LogDir inside a git working tree is refused BEFORE anything is created —
+# exactly the shape the misbind produced: <repo>/scripts/fleet/<scope-path>/
+# filled with wrapper, log and done files inside the main checkout.
+expect_fail "launch logdir inside a repo" "never belong in a repository" launch \
+  -Name gh937logdir -Cwd "$repo" -LogDir "$repo/scripts/fleet/docs" -DryRun \
+  -Owns scripts/fleet/lane-launch.ps1
+if [ -e "$repo/scripts" ]; then
+  fail "the refused -LogDir was created anyway inside $repo"
+fi
+ok "lane-launch refuses a -LogDir inside a git working tree and creates nothing"
 expect_fail "launch absolute owns" "repository-relative" launch -Name gh772ownsabs -Cwd "$repo" \
   -LogDir "$llog" -DryRun -Owns 'C:\\outside'
 expect_fail "launch traversal owns" "repository-relative" launch -Name gh772ownstraversal -Cwd "$repo" \
@@ -501,7 +543,7 @@ expect_fail "launch standalone dot owns" "repository-relative" launch -Name gh77
   -LogDir "$llog" -DryRun -Owns '.'
 expect_fail "launch terminal dot owns" "repository-relative" launch -Name gh772ownstermdot -Cwd "$repo" \
   -LogDir "$llog" -DryRun -Owns 'scripts/fleet/.'
-ok "lane-launch binds every -Owns value and rejects absolute, traversal, and dot-component aliases"
+ok "lane-launch rejects absolute, traversal, and dot-component -Owns aliases"
 
 echo "1..$case_number"
 echo "PASS: lane helper self-test ($case_number cases)"

--- a/scripts/fleet/test-next-loop.sh
+++ b/scripts/fleet/test-next-loop.sh
@@ -214,6 +214,18 @@ grep -q '^cmd: edda task new ' "$work/out/dry.txt" || fail "dry-run output misse
 grep -q '^brief path: ' "$work/out/dry.txt" || fail "dry-run output misses the brief path"
 grep -q 'fleet-claim-issue.sh 886 docs/worker-1' "$work/out/dry.txt" || fail "dry-run output misses the claim command"
 grep -q 'lane-launch.ps1 -Name edda-lane-gh886 ' "$work/out/dry.txt" || fail "dry-run output misses the launch command"
+# GH-936: the launch line must carry the brief's scope paths as -Owns.
+# Without it lane-launch.ps1's write-lane guard refuses the launch AFTER the
+# worktree, task and claim already exist, which is where every next-issue.sh
+# run died on current main. GH-937 fixes the shape: ONE comma-separated
+# argument, because `pwsh -File` binds only the first value of a multi-token
+# option and lets the rest bind to whatever named parameter is still free.
+grep -qF -- '-Owns "scripts/fleet/next-issue.sh,docs/guides/pi-controller-runbook.md"' "$work/out/dry.txt" ||
+    fail "launch command misses the -Owns scope list :: $(grep 'lane-launch.ps1' "$work/out/dry.txt" || true)"
+# -Owns stays the final option, so a future trailing addition cannot be read
+# as one of its scopes by a human copying the line.
+grep -q 'lane-launch.ps1 .*-Owns "[^"]*"$' "$work/out/dry.txt" ||
+    fail "-Owns is not the final option on the launch line :: $(grep 'lane-launch.ps1' "$work/out/dry.txt" || true)"
 grep -q 'nothing created, claimed, or launched' "$work/out/dry.txt" || fail "dry-run output misses the closing line"
 grep -qF -- '--path "scripts/fleet/next-issue.sh"' "$work/out/dry.txt" || fail "task-new line misses the first scope path"
 grep -qF -- '--path "docs/guides/pi-controller-runbook.md"' "$work/out/dry.txt" || fail "task-new line misses the second scope path"

--- a/tests/fleet/test-lane-launch-dryrun.ps1
+++ b/tests/fleet/test-lane-launch-dryrun.ps1
@@ -89,6 +89,10 @@ $name = "gh822-test-$PID-$(Get-Date -Format 'HHmmss')"
 $logDir = Join-Path $env:TEMP "gh822-lane-test-$PID"
 $cwd = Join-Path $env:TEMP "gh822-lane-test-cwd-$PID"
 $realLog = Join-Path $logDir "$name.log"
+# Every write-enabled lane needs at least one -Owns scope (GH-772); this
+# test predates that guard and every leg below died at it until GH-937
+# made the parameter usable from a `pwsh -File` caller in the first place.
+$ownsScope = "tests/fleet/test-lane-launch-dryrun.ps1"
 $realDone = Join-Path $logDir "$name.done"
 
 New-Item -ItemType Directory -Force -Path $logDir, $cwd | Out-Null
@@ -115,7 +119,7 @@ try {
   # --- leg 1: dry-run on a clean LogDir (AC2, AC3, AC4) ----------------------
 
   "=== leg 1: dry-run on a clean LogDir ==="
-  $dry = Invoke-ChildScript $launch @("-Name", $name, "-Cwd", "`"$cwd`"", "-LogDir", "`"$logDir`"", "-DryRun")
+  $dry = Invoke-ChildScript $launch @("-Name", $name, "-Cwd", "`"$cwd`"", "-LogDir", "`"$logDir`"", "-DryRun", "-Owns", $ownsScope)
   if ($dry.ExitCode -ne 0) {
     "--- dry-run stdout ---"; $dry.StdOut; "--- dry-run stderr ---"; $dry.StdErr
     throw "lane-launch -DryRun exited $($dry.ExitCode)"
@@ -148,7 +152,7 @@ try {
       '# regression-test brief (GH-822)'
       'Trivial turn: reply with the single word ok and do nothing else.'
     )
-    $real = Invoke-ChildScript $launch @("-Name", $name, "-Brief", "`"$brief`"", "-Cwd", "`"$cwd`"", "-LogDir", "`"$logDir`"", "-TimeoutSec", "90")
+    $real = Invoke-ChildScript $launch @("-Name", $name, "-Brief", "`"$brief`"", "-Cwd", "`"$cwd`"", "-LogDir", "`"$logDir`"", "-TimeoutSec", "90", "-Owns", $ownsScope)
     if ($real.ExitCode -ne 0) {
       "--- real-launch stdout ---"; $real.StdOut; "--- real-launch stderr ---"; $real.StdErr
       throw "lane-launch (real) exited $($real.ExitCode)"
@@ -194,7 +198,7 @@ try {
   # --- leg 3: the guard rail reserves the dryrun namespace (P1-1) -------------
 
   "=== leg 3: -Name containing 'dryrun' is rejected ==="
-  $collision = Invoke-ChildScript $launch @("-Name", "$name.dryrun", "-Cwd", "`"$cwd`"", "-LogDir", "`"$logDir`"")
+  $collision = Invoke-ChildScript $launch @("-Name", "$name.dryrun", "-Cwd", "`"$cwd`"", "-LogDir", "`"$logDir`"", "-Owns", $ownsScope)
   Assert-True ($collision.ExitCode -ne 0) "guard rail: lane-launch rejects -Name '$name.dryrun' (GH-822 P1-1)"
   Assert-True ($collision.StdErr -match "may not contain 'dryrun'") "guard rail: the rejection names the dryrun reservation (stderr: $($collision.StdErr.Trim()))"
 
@@ -202,10 +206,10 @@ try {
   # dryrun segment onto the lane name — dot, underscore, and hyphen all end
   # in a distinct $Name.dryrun.log/$Name.dryrun.done-style artifact family,
   # so each must be rejected too.
-  $collisionUnder = Invoke-ChildScript $launch @("-Name", "${name}_dryrun", "-Cwd", "`"$cwd`"", "-LogDir", "`"$logDir`"")
+  $collisionUnder = Invoke-ChildScript $launch @("-Name", "${name}_dryrun", "-Cwd", "`"$cwd`"", "-LogDir", "`"$logDir`"", "-Owns", $ownsScope)
   Assert-True ($collisionUnder.ExitCode -ne 0) "guard rail: lane-launch rejects underscore delimiter -Name '${name}_dryrun' (GH-822 P1-1)"
 
-  $collisionHyphen = Invoke-ChildScript $launch @("-Name", "$name-dryrun", "-Cwd", "`"$cwd`"", "-LogDir", "`"$logDir`"")
+  $collisionHyphen = Invoke-ChildScript $launch @("-Name", "$name-dryrun", "-Cwd", "`"$cwd`"", "-LogDir", "`"$logDir`"", "-Owns", $ownsScope)
   Assert-True ($collisionHyphen.ExitCode -ne 0) "guard rail: lane-launch rejects hyphen delimiter -Name '$name-dryrun' (GH-822 P1-1)"
 
   # --- leg 4: lane-status after unregister (AC5) ------------------------------

--- a/tests/fleet/test-lane-launch-dryrun.ps1
+++ b/tests/fleet/test-lane-launch-dryrun.ps1
@@ -89,9 +89,10 @@ $name = "gh822-test-$PID-$(Get-Date -Format 'HHmmss')"
 $logDir = Join-Path $env:TEMP "gh822-lane-test-$PID"
 $cwd = Join-Path $env:TEMP "gh822-lane-test-cwd-$PID"
 $realLog = Join-Path $logDir "$name.log"
-# Every write-enabled lane needs at least one -Owns scope (GH-772); this
-# test predates that guard and every leg below died at it until GH-937
-# made the parameter usable from a `pwsh -File` caller in the first place.
+# Every write-enabled lane needs at least one -Owns scope (GH-772). This
+# test predates that guard and passed none, so every leg below died at it —
+# not for want of GH-937: the single-value spelling used here bound on the
+# base too. GH-937 is why one argument now carries every scope.
 $ownsScope = "tests/fleet/test-lane-launch-dryrun.ps1"
 $realDone = Join-Path $logDir "$name.done"
 


### PR DESCRIPTION
Issue: #936, #937
Closes #936
Closes #937

## What was broken

`pwsh -File` passes every argument as a literal string and binds one value per
option. `-Owns a b c` therefore bound only `a`; each trailing value was taken by
whichever optional parameter still had a free positional slot. Reproduced on
this branch's base:

| passed | landed |
|---|---|
| `-Owns a b c` (nothing else named) | `b` -> `-Brief`, `c` -> `-Agent` (ValidateSet error) |
| `-Owns a b c` (`-Brief`/`-Agent` named) | `b` -> `-LogDir`, `c` -> `-BuildLane` |
| `-LogDir <repo>/scripts/fleet/docs` | `<repo>/scripts/fleet/docs/red2.dryrun-wrapper.ps1` — lane artifacts written **inside the checkout** |

The existing argv-tail rescue (`GetCommandLineArgs` + `LastIndexOf '-Owns'`)
could never repair this: the misbinding happens in the binder, before the first
script line runs. It only made the damage invisible — `--owns` looked right
while `-Brief` had been silently replaced.

Separately, `next-issue.sh` never passed `-Owns` at all, so every non-dry launch
on main died at lane-launch's write-lane guard **after** the worktree, `edda task
new` and the issue claim had already happened (#936).

## What changed

- `scripts/fleet/lane-launch.ps1`
  - `[CmdletBinding(PositionalBinding = $false)]` — a stray value can no longer
    reach another parameter; `-Owns a b c` now fails at the binder with
    *"A positional parameter cannot be found that accepts argument 'b'."*
  - `-Owns` is ONE comma/semicolon-separated argument the script splits and
    trims itself. The result lands in `$ownsScopes`, **not** back in `$Owns`:
    the parameter is `[string]`-typed for the whole scope, so assigning an array
    to it silently re-joins the scopes into one space-separated string (this bit
    during development — the first fix looked correct and claimed one scope
    named `a/b.rs c/d.md e/f.sh`).
  - a scope containing whitespace is rejected — that is exactly what an
    in-process caller handing `@('a','b')` to the now-scalar parameter collapses
    to, and it must fail rather than claim one scope named after two.
  - `-LogDir` resolving inside a git working tree is refused **before** anything
    is created (resolve without touching disk, probe the nearest existing
    ancestor). That is the harm the misbind actually did.
  - **unrelated pre-existing race, fixed because it made this PR's own gate
    non-deterministic:** the dry run polls `Get-ScheduledTask` then
    `Get-ScheduledTaskInfo`; the owned wrapper can unregister itself between the
    two, which was reported as *"scheduler result is unavailable"*. Measured on
    pristine `origin/main`: 1 of 4 dry runs, and it took the whole 33-case
    lane-helper suite down twice before I fixed it. The launcher now re-reads
    the registration before judging.
- `scripts/fleet/next-issue.sh` — builds `owns_csv` from the same brief
  scope-paths walk that feeds `edda task new --path`, passes it as the final
  `-Owns` option in both the printed and the executed launch, and dies early
  (before worktree/task/claim) if the walk yields no scope.
- `docs/guides/operator-runbook.md` §三 — the working `-Owns` shape.
- tests — see below.

## doneWhen

**#936**

| item | evidence |
|---|---|
| non-dry `next-issue.sh` reaches `lane launched:` with the brief's scope paths as `-Owns` | `next-issue.sh` passes `-Owns "$owns_csv"` in both arms; `-Owns` stays the final option |
| `test-next-loop.sh` grows a case, red before / green after | new assertions in case 1. Red on base: `FAIL: launch command misses the -Owns scope list :: cmd: pwsh … -BudgetUsd 3`. Green after: `ok 1 ready issue dry-run` |
| no regression | cases 1-6 green before and after; case 7 fails identically on pristine `origin/main` (see Pre-existing below) |

**#937**

| item | evidence |
|---|---|
| multiple scopes from a `pwsh -File` caller, header updated | `-Owns 'a/b.rs, c/d.md;e/f.sh'` -> `--owns 'a/b.rs' --owns 'c/d.md' --owns 'e/f.sh'` |
| a test proves a three-scope launch reaches `edda dispatch` with three `--owns` | `test-lane-helpers.sh` case 30. Red on base: the same one-argument list is accepted as a *single* scope `a/b.rs, c/d.md;e/f.sh` |
| no scope value can land in `-LogDir`/`-BuildLane` | structural via `PositionalBinding=$false` (case 31: the old spelling now fails at the binder and writes no artifacts); case 30 also asserts `--prompt-file` still names the dry-run brief, i.e. `-Brief` — the first free slot — was not displaced |
| the launcher refuses a bad `-LogDir` | case 32: `-LogDir <repo>/scripts/fleet/docs` is refused and **nothing is created**. On base the same call wrote `red2.dryrun-wrapper.ps1` into the repo |

## Gates ran (docs + scripts only — no crate, `Cargo.*` or toolchain change, so no Cargo gate applies)

| gate | result |
|---|---|
| `sh scripts/fleet/test-lane-helpers.sh` | **PASS**, 33/33 (was 29 cases) |
| `pwsh -File tests/fleet/test-lane-launch-dryrun.ps1 -SkipRealLaunch` | **RESULT: PASS** — this file was fully red on main (see below) |
| `sh scripts/fleet/test-next-loop.sh` | cases 1-6, 8-10 green; case 7 red identically on pristine base |
| `bash scripts/lint-file-length.sh --tree` | pass |
| `sh scripts/lint-markdown-content.sh` | pass |
| `bash scripts/lint-doc-citations.sh --tree` | pass |
| `git diff --check` | clean |
| `sh -n` on both changed shell scripts, PowerShell `Parser::ParseFile` on both `.ps1` | clean |

SHA: `c1e0b3e935d9dfcca95798a1d658f523a632e26a`

## Pre-existing, evidenced, NOT extended here (follow-ups)

1. **`tests/fleet/test-lane-launch-dryrun.ps1` was fully red on main.** It predates the GH-772 write-lane `-Owns` guard and passed no scope, so leg 1 died at
   `write-enabled lanes require at least one -Owns …`. Fixed here because it is a
   direct consumer of the parameter this PR changes; it has no CI consumer, which
   is why nobody noticed (tracked on #927).
2. **`test-next-loop.sh` case 7 is red on pristine `origin/main`.** The non-shadow
   delegation now dies at the R27 transport refusal
   (`refusing EDDA_REVIEW_AGENT=pi with model claude-opus-5`) before it can print
   the `no pi arm yet` message the case greps for. Not in this diff's surface.
3. **A second, rarer race in the same dry-run loop.** The wrapper unregisters
   itself *before* writing the terminal receipt, so a task that disappears in
   that sub-millisecond window is reported as
   `disappeared without its terminal receipt`. Untouched here; ~100x rarer than
   the one fixed (a WMI call gap vs. two adjacent statements).
4. **#912's `fleet.lane-launch-claim-gate` decision is not implemented.**
   `lane-launch.ps1` still has no `-Machine` parameter and runs no
   `fleet-claim-issue.sh --check`. Out of scope; that is #912's own work, and it
   will touch this same call site in `next-issue.sh`.


## Follow-up push: merged current `main`

#967 (GH-912) landed the `fleet.lane-launch-claim-gate` on the same param
block and the same two launch call sites, so this branch went `CONFLICTING`.
Resolved by merge (never a rebase — R7): `-Machine` sits before `-Owns` in the
param block and on both launch command lines, so `-Owns` stays the final
option and the claim guard still runs before anything is registered. Nothing
of either change is dropped, and `-Machine` being a named parameter is exactly
what `PositionalBinding=$false` requires.

Re-ran after the merge: `test-lane-helpers.sh` 33/33 PASS,
`test-next-loop.sh` cases 1-6 and 8-10 green (case 7 red identically on
`origin/main`), `tests/fleet/test-lane-launch-dryrun.ps1 -SkipRealLaunch`
RESULT: PASS, the three tree-wide lints and `git diff --check` clean.

## Review surface

R22: `scripts/fleet/lane-launch.ps1` is 閘門面, so this PR needs an authoritative
engine (Opus or sol), not a SHADOW round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


