### PR TITLE
docs(fleet): pi-controller-runbook — a flash controller must route STOP to needs-operator, not fix the brief

### DIFF
--- a/docs/guides/pi-controller-runbook.md
+++ b/docs/guides/pi-controller-runbook.md
@@ -67,11 +67,16 @@ Expected: one row per lane with its state. The done marker is
 last five lines of the log are the lane's report.
 
 - `DONE issue=#<issue> task=<id>` + PR URL + SHA — go to the review step.
-- `STOP step=<n> output=<...>` — read the five lines, fix the brief
+- `STOP step=<n> output=<...>` — route by controller engine. An authoritative
+  engine (Opus/sol) reads the five lines, fixes the brief
   (`~/.edda/fleet/brief-gh<issue>.md`) so the failing step cannot recur, and
-  relaunch: delete the stale marker only if the lane is not running, and start
-  the next round with the `-r<n+1>` lane name (next-issue.sh picks the next
-  free suffix automatically). Do not continue a stopped lane's session.
+  relaunches: delete the stale marker only if the lane is not running, and
+  start the next round with the `-r<n+1>` lane name (next-issue.sh picks the
+  next free suffix automatically). Do not continue a stopped lane's session.
+  A flash-level controller never modifies the brief: the 09-05 window measured
+  five STOPs — all brief-authoring defects, zero engine misjudgments — so
+  brief authoring is not a flash function; label `needs-operator` and stop
+  (GH-933).
 - Round cap: three rounds without a PR → STOP `needs-operator`.
 
 ## Review the PR
@@ -109,6 +114,8 @@ verdict on the SHA. Anything else waits for the operator.
 - round cap (three rounds without a delivered PR, or a fourth review round
   without `--operator-granted`)
 - a `[判斷]` escalation on a code-risk PR that the controller cannot adjudicate
+- a flash-level controller's `STOP step=<n>` on a lane — brief authoring is
+  not a flash function; label `needs-operator`, do not fix the brief (GH-933)
 - any operator-only action: merging a code-risk PR, `edda ratify`, ruleset
   changes, force push, deleting unmerged branches
 - known lane failure modes: a lane that delivers nothing before timeout


### PR DESCRIPTION
## Problem and change

`docs/guides/pi-controller-runbook.md` (#899) instructed the controller, on `STOP step=<n>`, to fix the brief and relaunch — with no engine qualification. In the all-flash window the runbook's audience is glm-5.3-flash, so the current text instructed a flash controller to do the one function the 09-05 window measured as flash-unsafe: brief authoring (five STOPs, all brief-authoring defects, zero engine misjudgments; a flash re-author meets the original author's failure modes and has no validate-in-a-throwaway-worktree habit).

Changed behavior, per #933's doneWhen:

- **Watch the lane** — the `STOP step=<n>` bullet now routes by controller engine: an authoritative engine (Opus/sol) reads the five lines, fixes the brief, and relaunches (the previous text, preserved for the qualified case); a flash-level controller never modifies the brief — it labels `needs-operator` and stops, with the 09-05 measurement cited as the reason. The #930-validator relaxation stays out of scope as the issue states.
- **STOP conditions** — the routing line is added: a flash-level controller's `STOP step=<n>` on a lane routes to `needs-operator`, not a brief edit.

## Validation

### RAN

- Authored-span dry-run: `sh scripts/fleet/brief-validate.sh <brief>` → **VALID** at the pinned base `586cb07e762170bd0768be8d66b4451b764dca45` (both edits matched exactly once in a throwaway worktree; all output expectations matched; the validator's measured stat corrected the author's line arithmetic once).
- At the delivery head: `grep -c "needs-operator"` = 7 (was 5; +1 per edit), `grep -c "flash-level"` = 2 (was 0), `sh scripts/lint-doc-citations.sh` exit 0, `git diff --check` clean.

### READ

- doneWhen item 3: `git diff --name-only` shows exactly `docs/guides/pi-controller-runbook.md` — no other file touched.
- doneWhen item 1 is the text itself (engine-routed STOP handling; flash → `needs-operator`, no brief modification); item 2 is the new STOP-conditions line.

Issue: #933
