### PR TITLE
fix(fleet): readiness follow-ups — shared PR limit, R24's third field, a jq-applying digest stub, a declared L0 gate marker

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -275,7 +275,7 @@ must hold and input shapes to confirm — never as an attack plan (decision
 **U1 — surface. P0.** Every changed file is inside the surface the issue or the
 lane brief allows. A file outside it is a lane-boundary violation.
 
-# review-spec:check U1
+# review-spec:check U1 no-pr-needed
 ```sh
 if [ -n "${REVIEW_FILES:-}" ]; then cat "$REVIEW_FILES"; else gh pr diff "$N" --name-only; fi
 ```
@@ -564,7 +564,7 @@ the ladder's own L2 command for that crate — `cargo test -p <crate>` on
 Windows — not a new gate invented here (`ladder`). One focused check per
 uncovered crate; never the whole workspace to reach one.
 
-# review-spec:check C5
+# review-spec:check C5 no-pr-needed
 ```sh
 { if [ -n "${REVIEW_FILES:-}" ]; then cat "$REVIEW_FILES"; else gh pr diff "$N" --name-only; fi; } \
   | grep '^crates/' | cut -d/ -f2 | sort -u \
@@ -609,7 +609,7 @@ git diff "origin/$BASE..$SHA" --unified=0 -- '*.sh' '*.bash' '*.ps1' '.github' \
 
 **R3 — every changed shell script parses. P0.** Exit code is the signal.
 
-# review-spec:check R3
+# review-spec:check R3 no-pr-needed
 ```sh
 for f in $(if [ -n "${REVIEW_FILES:-}" ]; then cat "$REVIEW_FILES"; else gh pr diff "$N" --name-only; fi | grep -E '\.(sh|bash)$'); do
   [ -f "$f" ] && { sh -n "$f"; echo "$f -> sh -n exit=$?"; }

--- a/scripts/fleet/daily-digest.sh
+++ b/scripts/fleet/daily-digest.sh
@@ -144,7 +144,13 @@ blocked_body="$tmp/blocked-body.md"
 # CLEAN with zero verdicts and must still appear. BLOCKED/DIRTY PRs keep the
 # status-reasons treatment below; every other state is reachable only through
 # its drift reason.
-open_rows=$(gh pr list --repo "$EDDA_REPO" --state open --limit 100 \
+# GH-958: the same enumeration limit verdict-drift.sh uses, from the same
+# variable. They were 100 here and 200 there, so PRs 101-200 got a drift
+# line that could never reach a digest row — invisible in the one artefact
+# R24 calls the report. It is exported below so the drift subprocess reads
+# the value this run actually used, not its own default.
+open_pr_limit=${EDDA_OPEN_PR_LIMIT:-200}
+open_rows=$(gh pr list --repo "$EDDA_REPO" --state open --limit "$open_pr_limit" \
     --json number,title,mergeStateStatus,headRefOid \
     --jq '.[] | [.number, .title, .mergeStateStatus, .headRefOid] | @tsv' \
 ) || { printf '%s: gh pr list (open) failed\n' "$prog" >&2; exit 1; }
@@ -159,7 +165,7 @@ open_rows=$(gh pr list --repo "$EDDA_REPO" --state open --limit 100 \
 # post-jq `gh pr list` output is not re-parsed as raw JSON by the drift check.
 drift_out="$tmp/drift.txt"
 drift_rc=0
-GH_OPEN_JSON= sh "$self_dir/verdict-drift.sh" >"$drift_out" 2>"$tmp/drift.err" || drift_rc=$?
+GH_OPEN_JSON= EDDA_OPEN_PR_LIMIT="$open_pr_limit" sh "$self_dir/verdict-drift.sh" >"$drift_out" 2>"$tmp/drift.err" || drift_rc=$?
 if [ "$drift_rc" -ge 2 ]; then
     printf '%s: verdict-drift.sh failed (exit %s)\n' "$prog" "$drift_rc" >&2
     cat "$tmp/drift.err" >&2

--- a/scripts/fleet/test-daily-digest.sh
+++ b/scripts/fleet/test-daily-digest.sh
@@ -33,18 +33,49 @@ cat >"$STUBBIN/gh" <<'EOF'
 #!/bin/sh
 echo "gh $*" >>"$GH_STUB_LOG"
 echo "gh $*" >>"$ORDER_LOG"
+# GH-958: apply the caller's --jq when the fixture is raw JSON, the way
+# scripts/fleet/test-verdict-drift.sh already does. With the old cat-the-TSV
+# stub the script's own --jq never ran, so restoring a
+# `select(.mergeStateStatus …)` to the open-PR query would have dropped PRs
+# from the digest with every fixture still green — the #914 defect exactly.
+# TSV fixtures are passed through untouched, so the older cases still read.
+# The --jq argument is captured HERE, from the real argv: a filter like
+# '.[] | [.number, .title] | @tsv' carries spaces, and re-splitting a
+# flattened "$*" inside the function would keep only its first word.
+gh_jq=
+gh_prev=
+for a in "$@"; do
+    [ "$gh_prev" = "--jq" ] && gh_jq=$a
+    gh_prev=$a
+done
+emit() { # <fixture file>
+    [ -n "${1:-}" ] && [ -f "$1" ] || return 0
+    case "$(head -c 1 "$1")" in
+        '['|'{')
+            if [ -n "$gh_jq" ]; then jq -r "$gh_jq" <"$1"; else cat "$1"; fi ;;
+        *) cat "$1" ;;
+    esac
+}
 case "$1" in
   pr)
     case "$2" in
       list)
         case "$*" in
-          *"--state merged"*) [ -n "${GH_MERGED_JSON:-}" ] && cat "$GH_MERGED_JSON" ; exit 0 ;;
-          *"--state open"*)   [ -n "${GH_OPEN_JSON:-}" ] && cat "$GH_OPEN_JSON" ; exit 0 ;;
+          *"--state merged"*) emit "${GH_MERGED_JSON:-}" ; exit 0 ;;
+          # The digest clears GH_OPEN_JSON for the verdict-drift subprocess,
+          # so an empty one means this call came from the drift check.
+          *"--state open"*)
+            if [ -n "${GH_OPEN_JSON:-}" ]; then emit "$GH_OPEN_JSON"
+            else emit "${GH_DRIFT_OPEN_JSON:-}"
+            fi
+            exit 0 ;;
         esac
         exit 0
         ;;
       view)
-        [ -n "${GH_COMMENTS_FILE:-}" ] && cat "$GH_COMMENTS_FILE"
+        if [ -n "${GH_OPEN_JSON:-}" ]; then emit "${GH_COMMENTS_FILE:-}"
+        else emit "${GH_DRIFT_COMMENTS_JSON:-${GH_COMMENTS_FILE:-}}"
+        fi
         exit 0
         ;;
     esac
@@ -100,7 +131,8 @@ export PATH="$STUBBIN:$PATH"
 reset_stubs() {
     : >"$GH_STUB_LOG"; : >"$EDDA_STUB_LOG"; : >"$ORDER_LOG"
     unset GH_MERGED_JSON GH_OPEN_JSON GH_STATUS_JSON GH_CHECK_RUNS_JSON GH_COMMENTS_FILE \
-          GH_BOARD_FILE GH_READY_JSON EDDA_RECAP_FILE 2>/dev/null || true
+          GH_BOARD_FILE GH_READY_JSON EDDA_RECAP_FILE \
+          GH_DRIFT_OPEN_JSON GH_DRIFT_COMMENTS_JSON 2>/dev/null || true
 }
 
 # canned recap digest (the three ledger blocks, exactly as edda recap --digest prints)
@@ -184,6 +216,8 @@ awk '/^## 擋住什麼/{f=1;next} /^## /{f=0} f' "$tmp/case2.out" | grep -qxF '�
 printf '%s\n' "$out" | grep -qF -- '- 審查（gh verdict 留言 Cost:）：n/a' \
     || fail 'case 2: review cost line should be n/a'
 
+SHA79=7979797979797979797979797979797979797979
+
 # --- case 3: one BLOCKED PR with a failing Independent Review ------------------
 reset_stubs
 printf '77\tBlocked thing\tBLOCKED\tabc123\n' >"$tmp/open.tsv"
@@ -210,6 +244,33 @@ export EDDA_RECAP_FILE="$RECAP_CANNED"
 out=$(run_digest --dry-run 2>&1) || fail 'case 3b: daily-digest.sh exited non-zero'
 printf '%s\n' "$out" | grep -qF -- '- #78 Check run thing — Independent Review=failure' \
     || fail "case 3b: check-run CI Gate should be accepted, got: $(printf '%s' "$out" | grep '#78' || true)"
+
+# --- case 3c: a CLEAN PR that the drift check calls not-ready still gets a row -
+# GH-958. Two things are proven only with the jq-applying stub above:
+#   * the open-PR query's own --jq runs, so restoring a
+#     `select(.mergeStateStatus …)` would drop #79 and fail here (the #914
+#     defect: the blocked-PR filter skipped a CLEAN PR and #899 was reported
+#     complete on a stale SHA);
+#   * both enumerations use the same --limit, so no PR gets a drift line it
+#     can never turn into a digest row.
+reset_stubs
+printf '[{"number":79,"title":"Clean but unreviewed","mergeStateStatus":"CLEAN","headRefOid":"%s"}]\n' "$SHA79" >"$tmp/open-clean.json"
+printf '[{"number":79,"headRefOid":"%s","baseRefName":"main","mergeable":"MERGEABLE"}]\n' "$SHA79" >"$tmp/drift-open.json"
+printf '{"comments":[]}\n' >"$tmp/drift-comments.json"
+export GH_OPEN_JSON="$tmp/open-clean.json"
+export GH_DRIFT_OPEN_JSON="$tmp/drift-open.json"
+export GH_DRIFT_COMMENTS_JSON="$tmp/drift-comments.json"
+export EDDA_RECAP_FILE="$RECAP_CANNED"
+out=$(run_digest --dry-run 2>&1) || fail 'case 3c: daily-digest.sh exited non-zero'
+printf '%s\n' "$out" | grep -qF -- '- #79 Clean but unreviewed — no verdict on head' \
+    || fail "case 3c: a CLEAN drift-not-ready PR is missing from 擋住什麼, got: $(printf '%s' "$out" | grep '#79' || true)"
+printf '%s\n' "$out" | awk '/^## 擋住什麼/{f=1;next} /^## /{f=0} f' | grep -qF '#79' \
+    || fail 'case 3c: the #79 row is not inside the 擋住什麼 section'
+# both enumerations request the same page size — the mismatch GH-958 names
+limits=$(grep -- '--state open' "$GH_STUB_LOG" | sed -n 's/.*--limit \([0-9]*\).*/\1/p' | sort -u)
+[ "$(printf '%s\n' "$limits" | grep -c .)" = 1 ] \
+    || fail "case 3c: digest and verdict-drift enumerate different --limit values: $(printf '%s' "$limits" | tr '\n' ' ')"
+unset GH_DRIFT_OPEN_JSON GH_DRIFT_COMMENTS_JSON
 
 # --- case 4: board comment with needs-operator lands under 例外 ----------------
 reset_stubs

--- a/scripts/fleet/test-verdict-drift.sh
+++ b/scripts/fleet/test-verdict-drift.sh
@@ -26,6 +26,7 @@ trap 'rm -rf "$tmp"' 0 HUP INT TERM
 mkdir -p "$tmp/bin"
 cat >"$tmp/bin/gh" <<'EOF'
 #!/bin/sh
+[ -n "${GH_ARGV_LOG:-}" ] && echo "gh $*" >>"$GH_ARGV_LOG"
 if [ -n "${GH_FAIL:-}" ]; then
     echo "gh: stub failure" >&2
     exit 1
@@ -137,5 +138,50 @@ unset GH_FAIL
 grep -q 'could not read' "$tmp/err" ||
     fail 7 "stderr must say the read failed, got: $(cat "$tmp/err")"
 echo "PASS 7"
+
+# --- case 8: mergeable CONFLICTING holds the PR (R24 field 3, GH-958) ----------
+# The head carries an authoritative LGTM, so every field the check covered
+# before says ready. R24's third field does not, and used to be left to the
+# digest's DIRTY row — invisible whenever this check ran standalone.
+printf '[{"number":8,"headRefOid":"%s","baseRefName":"main","mergeable":"CONFLICTING"}]\n' "$SHA1" >"$tmp/prs.json"
+printf '{"comments":[{"body":"## Code Review: Round 1 — PR #8 @ %s\\n\\n### Verdict\\nLGTM (P0=0, P1=0)"}]}\n' "$SHA1" >"$tmp/comments-8.json"
+run_drift
+expect 8 1 "#8 111111111111 main LGTM mergeable=CONFLICTING"
+
+# --- case 9: mergeable UNKNOWN is surfaced but does not hold the PR ------------
+# GitHub has not computed the merge yet; that is a transient answer, not a
+# verdict, so it is annotated and the exit code stays 0.
+printf '[{"number":9,"headRefOid":"%s","baseRefName":"main","mergeable":"UNKNOWN"}]\n' "$SHA2" >"$tmp/prs.json"
+printf '{"comments":[{"body":"## Code Review: Round 1 — PR #9 @ %s\\n\\n### Verdict\\nLGTM (P0=0, P1=0)"}]}\n' "$SHA2" >"$tmp/comments-9.json"
+run_drift
+expect 9 0 "#9 222222222222 main LGTM mergeable=UNKNOWN"
+
+# --- case 10: the enumeration limit is EDDA_OPEN_PR_LIMIT, shared with the -----
+# digest (GH-958). The two scripts hardcoded 200 and 100, so a PR past the
+# digest's 100 got a line here that could never reach a digest row.
+printf '[{"number":10,"headRefOid":"%s","baseRefName":"main","mergeable":"MERGEABLE"}]\n' "$SHA3" >"$tmp/prs.json"
+printf '{"comments":[{"body":"## Code Review: Round 1 — PR #10 @ %s\\n\\n### Verdict\\nLGTM (P0=0, P1=0)"}]}\n' "$SHA3" >"$tmp/comments-10.json"
+: >"$tmp/gh-argv.log"
+GH_ARGV_LOG="$tmp/gh-argv.log"
+export GH_ARGV_LOG
+EDDA_OPEN_PR_LIMIT=7
+export EDDA_OPEN_PR_LIMIT
+run_drift
+unset EDDA_OPEN_PR_LIMIT
+grep -q -- '--limit 7' "$tmp/gh-argv.log" ||
+    fail 10 "the pr list call ignored EDDA_OPEN_PR_LIMIT: $(cat "$tmp/gh-argv.log")"
+[ "$rc" = 0 ] || fail 10 "exit $rc, expected 0 (stderr: $(cat "$tmp/err"))"
+echo "PASS 10"
+
+# --- case 11: a saturated enumeration says so on stderr instead of dropping ----
+# the tail in silence.
+EDDA_OPEN_PR_LIMIT=1
+export EDDA_OPEN_PR_LIMIT
+run_drift
+unset EDDA_OPEN_PR_LIMIT
+grep -q 'hit its limit' "$tmp/err" ||
+    fail 11 "a saturated enumeration printed no warning: $(cat "$tmp/err")"
+echo "PASS 11"
+unset GH_ARGV_LOG
 
 echo "verdict-drift fixtures passed"

--- a/scripts/fleet/verdict-drift.sh
+++ b/scripts/fleet/verdict-drift.sh
@@ -7,19 +7,36 @@
 # reports CLEAN with zero verdicts.
 #
 # Output, one line per open PR:
-#   #<n> <head12> <base> <state> [ base=<branch> (status contexts not enforced) ]
+#   #<n> <head12> <base> <state> [ mergeable=<v> ] [ base=<branch> (...) ]
 # with <state> one of:
 #   no verdict on head | stale from <sha12> | SHADOW only | LGTM | Changes Requested
 # The base annotation is appended when the PR's base is not `main`, whose
 # status contexts are the only ones any ruleset enforces.
 #
-# Exit 0 every PR carries a verdict on its head; exit 1 when any PR has
-# `no verdict on head` or is `stale from ...`; exit 2 when a gh read fails —
-# a check that could not read must never print nothing and exit 0.
+# GH-958: R24 names THREE readiness fields, and this check now covers all
+# three — (1) the newest verdict's SHA equals the head, (2) the
+# mergeStateStatus caveat above, and (3) `mergeable` is not CONFLICTING,
+# which used to be left to the digest's DIRTY row and so went missing
+# whenever this check ran standalone. CONFLICTING is a not-ready state;
+# UNKNOWN (GitHub has not computed the merge yet) is annotated but does not
+# hold the PR, because it is a transient answer, not a verdict.
+#
+# The open-PR enumeration limit is shared with daily-digest.sh through
+# EDDA_OPEN_PR_LIMIT (GH-958): the two used 200 and 100, so a PR past the
+# digest's 100 got a drift line here that could never reach a digest row —
+# invisible in the one artefact R24 calls the report.
+#
+# Exit 0 every PR carries a verdict on its head and is not CONFLICTING;
+# exit 1 when any PR has `no verdict on head`, is `stale from ...`, or is
+# CONFLICTING; exit 2 when a gh read fails — a check that could not read
+# must never print nothing and exit 0.
 # Read-only: no posting, no labels, no merges, no ledger writes.
 set -eu
 
 repo=${EDDA_REPO:-fagemx/edda}
+# Shared with daily-digest.sh; see the note above. A saturated enumeration
+# is announced on stderr rather than silently dropping the tail.
+open_limit=${EDDA_OPEN_PR_LIMIT:-200}
 
 fail_read() {
     echo "verdict-drift: could not read PR state from gh ($1) — refusing to print a clean bill" >&2
@@ -29,13 +46,16 @@ fail_read() {
 # The R23 verdict heading, canonical REVIEW.md §7 shape: the ` (SHADOW)`
 # suffix follows `Round <N>`. The trailing-suffix variant is also accepted so
 # the issue #914 spelling of the pattern matches the same comments.
-open_rows=$(gh pr list --repo "$repo" --state open --limit 200 \
-    --json number,headRefOid,baseRefName \
-    --jq '.[] | [.number, .headRefOid, .baseRefName] | @tsv' \
+open_rows=$(gh pr list --repo "$repo" --state open --limit "$open_limit" \
+    --json number,headRefOid,baseRefName,mergeable \
+    --jq '.[] | [.number, .headRefOid, .baseRefName, .mergeable] | @tsv' \
 ) || fail_read "pr list"
+if [ "$(printf %s "$open_rows" | grep -c .)" -ge "$open_limit" ]; then
+    echo "verdict-drift: the open-PR enumeration hit its limit of $open_limit; PRs past it were not examined (raise EDDA_OPEN_PR_LIMIT)" >&2
+fi
 
 not_ready=0
-while IFS="$(printf '\t')" read -r num head base; do
+while IFS="$(printf '\t')" read -r num head base mergeable; do
     [ -n "$num" ] || continue
     verdicts=$(gh pr view "$num" --repo "$repo" --json comments --jq '
         .comments[]
@@ -86,7 +106,16 @@ EOF
         state="Changes Requested"
     fi
 
+    # R24 field (3). CONFLICTING holds the PR; UNKNOWN is surfaced without
+    # holding it; MERGEABLE and an empty value (an older gh without the
+    # field) add nothing to the line.
     line="#$num $head12 $base $state"
+    if [ "$mergeable" = "CONFLICTING" ]; then
+        line="$line mergeable=CONFLICTING"
+        not_ready=1
+    elif [ "$mergeable" = "UNKNOWN" ]; then
+        line="$line mergeable=UNKNOWN"
+    fi
     if [ "$base" != "main" ]; then
         line="$line base=$base (status contexts not enforced)"
     fi

--- a/scripts/fleet/verdict-drift.sh
+++ b/scripts/fleet/verdict-drift.sh
@@ -107,8 +107,10 @@ EOF
     fi
 
     # R24 field (3). CONFLICTING holds the PR; UNKNOWN is surfaced without
-    # holding it; MERGEABLE and an empty value (an older gh without the
-    # field) add nothing to the line.
+    # holding it; MERGEABLE and an empty value add nothing to the line. An
+    # empty value means the object carried no mergeable key at all, as the
+    # older fixtures do — NOT an older gh, which rejects an unknown --json
+    # field before the request and so lands in fail_read instead.
     line="#$num $head12 $base $state"
     if [ "$mergeable" = "CONFLICTING" ]; then
         line="$line mergeable=CONFLICTING"

--- a/scripts/review-l0.sh
+++ b/scripts/review-l0.sh
@@ -29,9 +29,11 @@
 #            committed range — the pre-push shape of Example B step 20.
 #   [PR-number]  blocks referencing "$N" (U2, U3, U6) run only when a PR
 #            number is passed; without one they report N.A.(needs PR number)
-#            instead of failing. U1, C5 and R3 enumerate the changed files
-#            from REVIEW_FILES (GH-922 d-004 option A), so the pre-push pass
-#            — no PR number — runs them too. Offline callers can still fake
+#            instead of failing. A block whose marker declares
+#            `no-pr-needed` (U1, C5, R3) runs anyway: it enumerates the
+#            changed files from REVIEW_FILES (GH-922 d-004 option A) and
+#            reaches the "$N" only in a fallback branch that stays
+#            unreached, so the pre-push pass runs it too. Offline callers can still fake
 #            the PR surface by putting a stub gh earlier in PATH —
 #            scripts/test-review-l0.sh does exactly that.
 #   REVIEW_L0_SPEC  spec file to extract from (default REVIEW.md in the cwd —
@@ -97,21 +99,30 @@ trap 'exit 130' INT TERM
 # ---- extract the marked blocks ---------------------------------------------
 # One pass over the spec. A fenced sh block inside check markers lands in
 # $TMP/blocks as:
-#   @@BLOCK@@ <RULE> <n>
+#   @@BLOCK@@ <RULE> <n> <attrs>
 #   ...block body...
 #   @@END@@
 # A fenced sh block with no check markers prints "UNMARKED <first line>" and
 # the run dies with 3 — an unmarked check is never silently skipped.
 : > "$TMP/blocks"
 unmarked=$(awk -v out="$TMP/blocks" '
-  !infence && /^# review-spec:check /    { marked = 1; id = $3; next }
+  # GH-958: the marker carries optional attributes after the rule id
+  # (`# review-spec:check U1 no-pr-needed`). They are metadata about the
+  # block, so they live in the marker, not in the block body, and the
+  # runner never has to infer a capability from what the command text
+  # happens to mention.
+  !infence && /^# review-spec:check / {
+    marked = 1; id = $3; attrs = "-"
+    for (i = 4; i <= NF; i++) attrs = (attrs == "-" ? $i : attrs "," $i)
+    next
+  }
   !infence && /^# review-spec:check-end/ { marked = 0; next }
   !infence && /^```sh/ { infence = 1; body = ""; first = ""; next }
   infence && /^```/ {
     infence = 0
     if (marked) {
       n++
-      print "@@BLOCK@@ " id " " n > out
+      print "@@BLOCK@@ " id " " n " " attrs > out
       printf "%s", body > out
       print "@@END@@" > out
     } else {
@@ -131,10 +142,24 @@ if [ "$ext_status" -ne 0 ]; then
   exit "$ext_status"
 fi
 
-# block map: "<line of @@BLOCK@@ header in blocks file> <rule id>"
+# block map: "<line of @@BLOCK@@ header in blocks file> <rule id> <attrs>"
 grep -n '^@@BLOCK@@ ' "$TMP/blocks" \
-  | sed 's/^\([0-9]*\):@@BLOCK@@ \([^ ]*\) [0-9]*$/\1 \2/' > "$TMP/map"
+  | sed 's/^\([0-9]*\):@@BLOCK@@ \([^ ]*\) [0-9]* \(.*\)$/\1 \2 \3/' > "$TMP/map"
 [ -s "$TMP/map" ] || { echo "review-l0.sh: spec has no check-marked blocks" >&2; exit 2; }
+# A marker attribute is a contract between the spec and this runner, so an
+# unrecognised one is a spec error, not something to ignore: a typo in
+# `no-pr-needed` would otherwise silently send the rule back to
+# N.A.(needs PR number) on every pre-push pass.
+bad_attrs=$(awk '
+  $3 != "-" {
+    n = split($3, a, ",")
+    for (i = 1; i <= n; i++) if (a[i] != "no-pr-needed") print $2 ":" a[i]
+  }
+' "$TMP/map")
+[ -z "$bad_attrs" ] || {
+  echo "review-l0.sh: unknown review-spec:check attribute(s): $bad_attrs" >&2
+  exit 2
+}
 
 block_body_at() { # <line of @@BLOCK@@ header> — the body below it
   awk -v start="$1" '
@@ -229,13 +254,23 @@ oneline() { # first line of stdin, pipes escaped for the table cell, capped
   # would end in a partial UTF-8 sequence. The cap is a byte cap (LC_ALL=C)
   # plus a back-off that strips a trailing partial multi-byte sequence, so
   # the cell always decodes as valid UTF-8.
+  #
+  # The back-off is deliberately blunt (GH-958): the pattern matches ANY
+  # trailing lead byte plus its continuation bytes, so when the cut lands
+  # exactly on a character boundary it removes one COMPLETE character
+  # instead of nothing. That over-strip is accepted — the cell is truncated
+  # evidence either way, one glyph shorter changes no verdict, and the
+  # alternative (decoding to count characters) is more machinery than a
+  # table cell is worth. What it must never do is emit invalid UTF-8, and
+  # stripping one character too many cannot.
   head -n 1 | sed 's/|/\\|/g' \
     | LC_ALL=C cut -c1-160 \
     | LC_ALL=C sed -E 's/[\xC0-\xFF][\x80-\xBF]*$//'
 }
 
-run_block() { # <rule> <class> <severity> <blocks-file line>
+run_block() { # <rule> <class> <severity> <blocks-file line> <marker attrs>
   rule=$1
+  attrs=${5:--}
   block_body_at "$4" > "$TMP/block.sh"
 
   # A block with a <placeholder> needs reviewer input (D2's decision key);
@@ -245,18 +280,23 @@ run_block() { # <rule> <class> <severity> <blocks-file line>
     return
   fi
   # Blocks referencing "$N" are PR-surface probes; without a number they
-  # cannot run and must say so rather than fail — unless the block reads its
-  # file list from REVIEW_FILES (GH-922 d-004 option A): there the "$N" lives
-  # only in the fallback branch, which REVIEW_FILES being set keeps unreached.
+  # cannot run and must say so rather than fail — unless the block's own
+  # marker declares `no-pr-needed` (GH-958). Those blocks (U1, C5, R3) take
+  # their file list from REVIEW_FILES and reach the "$N" only in a fallback
+  # branch REVIEW_FILES keeps unreached (GH-922 d-004 option A). The gate
+  # used to infer that by grepping the command text for the string
+  # REVIEW_FILES: correct for every block that existed, but it coupled the
+  # runner to one variable name inside someone else's command, and a block
+  # mentioning it for any other reason would have been waved through.
   case "$(cat "$TMP/block.sh")" in
     *'$N'*)
       if [ -z "$N" ]; then
-        if [ -n "${REVIEW_FILES:-}" ] && grep -q 'REVIEW_FILES' "$TMP/block.sh"; then
-          :
-        else
-          print_row "$rule" "$2" "$3" 'N.A.(needs PR number)' '-'
-          return
-        fi
+        case ",$attrs," in
+          *,no-pr-needed,*) : ;;
+          *)
+            print_row "$rule" "$2" "$3" 'N.A.(needs PR number)' '-'
+            return ;;
+        esac
       fi
       ;;
   esac
@@ -354,7 +394,8 @@ process_rule() { # <rule> <class> <severity>
   found=0
   for ln in $(awk -v want="$1" '$2 == want { print $1 }' "$TMP/map"); do
     found=1
-    run_block "$1" "$2" "$3" "$ln"
+    battrs=$(awk -v l="$ln" '$1 == l { print $3 }' "$TMP/map")
+    run_block "$1" "$2" "$3" "$ln" "$battrs"
   done
   if [ "$found" -eq 0 ]; then
     print_row "$1" "$2" "$3" 'N.A.(no command block in the spec)' '-'

--- a/scripts/test-review-l0.sh
+++ b/scripts/test-review-l0.sh
@@ -168,7 +168,7 @@ echo "clean fixture: all rows PASS/N.A./需升級, runner exit 0 — OK"
 # Cut the U1 marker pair out of a temp copy of the spec; the U1 fence then
 # has no markers and the runner must never skip it silently.
 awk '
-  !open_cut && /^# review-spec:check U1$/  { open_cut = 1; next }
+  !open_cut && /^# review-spec:check U1( |$)/ { open_cut = 1; next }
   open_cut && !end_cut && /^# review-spec:check-end$/ { end_cut = 1; next }
   { print }
 ' "$SPEC" > "$TMP/unmarked-spec.md"
@@ -215,5 +215,38 @@ grep -Fq '| R1 | code-risk | P0 | FAIL' "$TMP/cjk.out" \
 grep -F '| R1 |' "$TMP/cjk.out" | iconv -f UTF-8 -t UTF-8 >/dev/null \
   || fail "cjk fixture: R1 evidence cell does not decode as valid UTF-8"
 echo "cjk fixture: R1 evidence cell survives the cap as valid UTF-8 — OK"
+
+# ---- 6. marker attributes: a declared capability, not a text guess (GH-958) -
+# The $N gate used to decide a block could run without a PR number by grepping
+# its command text for the string REVIEW_FILES. The capability is now declared
+# on the marker (`# review-spec:check U1 no-pr-needed`), so:
+#   (a) an unknown attribute is a spec error, exit 2 — a typo must not silently
+#       send the rule back to N.A. on every pre-push pass;
+#   (b) dropping the attribute while the body still mentions REVIEW_FILES puts
+#       U1 back to N.A.(needs PR number). Under the old textual gate the block
+#       still ran, which is exactly the coupling this replaces.
+make_fixture dirty
+
+sed 's/^# review-spec:check U1 no-pr-needed$/# review-spec:check U1 no-pr-neded/' \
+  "$SPEC" > "$TMP/typo-spec.md"
+grep -q '^# review-spec:check U1 no-pr-neded$' "$TMP/typo-spec.md" \
+  || fail "attribute fixture: the typo copy was not produced"
+rc=0
+run_l0 "$FIXDIR" "$TMP/typo-spec.md" "$TMP/typo.out" || rc=$?
+[ "$rc" -eq 2 ] || fail "attribute fixture: unknown attribute should exit 2, got $rc"
+# run_l0 folds the runner stderr into the out file
+grep -q 'unknown review-spec:check attribute' "$TMP/typo.out" \
+  || fail "attribute fixture: output does not name the unknown attribute: $(cat "$TMP/typo.out")"
+echo "attribute fixture: an unknown marker attribute exits 2 — OK"
+
+sed 's/^# review-spec:check U1 no-pr-needed$/# review-spec:check U1/' \
+  "$SPEC" > "$TMP/undeclared-spec.md"
+rc=0
+run_l0 "$FIXDIR" "$TMP/undeclared-spec.md" "$TMP/undeclared.out" || rc=$?
+grep -F '| U1 |' "$TMP/undeclared.out" | grep -Fq 'N.A.(needs PR number)' \
+  || fail "attribute fixture: U1 without the marker attribute should be N.A.(needs PR number), got: $(grep -F '| U1 |' "$TMP/undeclared.out" || true)"
+grep -F '| C5 |' "$TMP/undeclared.out" | grep -Fq 'N.A.(needs PR number)' \
+  && fail "attribute fixture: C5 keeps its attribute and must still run"
+echo "attribute fixture: the gate reads the marker, not the command text — OK"
 
 echo "test-review-l0.sh: all fixture assertions held"


### PR DESCRIPTION
Closes #958

Four follow-ups from the #946 review (GH-914). The issue carries no `doneWhen`
block — its four numbered items are the acceptance list, one section each.

## 1. Limit mismatch

`verdict-drift.sh` enumerated `--limit 200`, `daily-digest.sh` walked
`--limit 100`. A PR past the digest's 100 got a drift line that could never
become a digest row — invisible in the one artefact R24 calls *the report*.

Both now read `EDDA_OPEN_PR_LIMIT` (default 200), and the digest **exports the
value it used** to the drift subprocess, so a run is governed by one number
rather than two literals that agree today. A saturated enumeration is announced
on stderr instead of silently dropping the tail.

## 2. R24's third readiness field

R24 names three; the drift check covered (1) newest-verdict-SHA == head and
(2) the `mergeStateStatus` caveat. `mergeable != CONFLICTING` was left to the
digest's DIRTY row, so it was simply absent whenever the check ran standalone —
which is exactly the case the issue flags.

`CONFLICTING` now annotates the line and sets the not-ready exit. `UNKNOWN` is
annotated but does **not** hold the PR: GitHub has not computed the merge yet,
which is a not-yet answer, not a verdict. `MERGEABLE` and an absent field (an
older `gh`) add nothing to the line, so every existing output shape is
unchanged.

## 3. Digest-side regression fixture

The digest's `gh` stub `cat`ed TSV fixtures and never ran the script's own
`--jq`. Restoring a `select(.mergeStateStatus …)` to the open-PR query would
therefore have dropped PRs from the digest **with every fixture still green** —
the #914 defect exactly (the blocked-PR filter skipped a CLEAN PR, and #899 was
reported complete on a stale SHA).

The stub now applies the caller's `--jq` with real `jq` when the fixture is raw
JSON — the pattern `test-verdict-drift.sh` already used — and passes TSV
through untouched, so every older case reads unchanged. New **case 3c** walks a
CLEAN, drift-not-ready PR end to end and also asserts both enumerations request
the same `--limit`.

One thing worth flagging for review: the stub captures `--jq` from the real
`"$@"` at script top, not inside the emit function. A filter like
`.[] | [.number, .title] | @tsv` carries spaces, and re-splitting a flattened
`"$*"` keeps only its first word — which is how the first version of this stub
failed.

## 4. Structured gate marker, and the oneline() comment

`review-l0.sh` decided whether a block could run without a PR number by
`grep`ping its command text for the string `REVIEW_FILES`. Correct for every
block that exists, loud on failure — but it coupled the runner to one variable
name inside someone else's command, and any block mentioning it for another
reason would have been waved through.

The capability is now **declared on the block's own marker**:

```
# review-spec:check U1 no-pr-needed
```

Attributes are parsed by the same extractor pass, carried through
`@@BLOCK@@ <RULE> <n> <attrs>` and the block map, and passed to `run_block`.
They are **validated**: an unrecognised attribute exits 2, because a typo in
`no-pr-needed` would otherwise silently send U1/C5/R3 back to
`N.A.(needs PR number)` on every pre-push pass — a check quietly not running is
the failure mode this whole runner exists to prevent.

`oneline()`'s back-off comment now states the case it was silent about: the
pattern matches **any** trailing lead byte plus continuations, so when the byte
cap lands exactly on a character boundary it strips one **complete** character
rather than nothing. Accepted, with the reason recorded — the cell is truncated
evidence either way, one glyph changes no verdict, and decoding to count
characters is more machinery than a table cell is worth. What it must never do
is emit invalid UTF-8, and over-stripping cannot.

## Evidence — red before, green after

```
verdict-drift fixtures passed          (7 cases -> 11)
daily-digest fixtures passed           (case 3c added)
test-review-l0.sh: all fixture assertions held   (case 6 added, two assertions)
```

Each new assertion fails on this branch's base, isolated one at a time:

| probe | result on base |
|---|---|
| revert `daily-digest.sh` | `FAIL: case 3c: digest and verdict-drift enumerate different --limit values: 100 200` |
| add `select(.mergeStateStatus != "CLEAN")` to the digest's open query | `FAIL: case 3c: a CLEAN drift-not-ready PR is missing from 擋住什麼` — the point of item 3: with the old cat-the-TSV stub this injection changed nothing |
| drop `no-pr-needed` from U1's marker (body still says `REVIEW_FILES`) | U1 becomes `N.A.(needs PR number)`; under the old textual gate it still ran |
| misspell the attribute `no-pr-neded` | runner exits 2, `unknown review-spec:check attribute(s): U1:no-pr-neded` |
| drift cases 8/9 | `mergeable` was not requested at all before this change |

Also updated: `test-review-l0.sh` case 3 anchored `/^# review-spec:check U1$/`,
which the attribute broke; it now matches `U1( |$)`.

## Gates ran (docs + scripts only — no crate, `Cargo.*` or toolchain change, so no Cargo gate applies)

| gate | result |
|---|---|
| `sh scripts/fleet/test-verdict-drift.sh` | passed, 11/11 |
| `sh scripts/fleet/test-daily-digest.sh` | passed |
| `sh scripts/test-review-l0.sh` | all fixture assertions held |
| `bash scripts/lint-file-length.sh --tree` | pass |
| `sh scripts/lint-markdown-content.sh` | pass |
| `bash scripts/lint-doc-citations.sh --tree` | pass |
| `sh -n` on all five changed shell scripts | pass |
| `git diff --check` | clean |

SHA: `89d49dd1f4906c7ffe321f3bf1b65baa5330e9bb`

## Not extended here

- **`scripts/fleet/test-verdict-drift.sh` and `scripts/test-review-l0.sh` still
  have no CI consumer** — tracked on #927. This PR adds cases to suites nothing
  runs automatically.
- **Beyond `EDDA_OPEN_PR_LIMIT` the enumeration still truncates.** The stderr
  warning reaches a direct caller; it does not reach the operator's digest,
  which would want a 例外 row. Follow-up, not this issue's item 1 (the
  *mismatch*), and the digest surfacing is its own decision.

## Review surface

R22: `REVIEW.md`, `scripts/review-l0.sh` and `scripts/fleet/daily-digest.sh` are
all 審判面, so this PR needs an authoritative engine (Opus or sol), not a SHADOW
round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
