### PR TITLE
fix(fleet): the calibration runner accepts a verdict whose model_observed came from PI_MODEL — six of six did (#884 calibration v1)

### DIFF
--- a/docs/superpowers/specs/2026-09-02-reviewer-brief-template-v2.md
+++ b/docs/superpowers/specs/2026-09-02-reviewer-brief-template-v2.md
@@ -172,6 +172,12 @@ sol 抓到而他人漏掉的 finding 會固化為新清單項或新金絲雀，�
 `total_cost_usd`、`usage`、`modelUsage`、`session_id` … 但**沒有** `model`）。
 引擎的自我標示、模板照抄值、環境變數身分（`PI_MODEL`）都不是系統觀察值；
 取不到就寫 `unverified`。長期來源是 #574 S5（dispatch 收據自動附帶）。
+**違反來源規則有後果**：校準 runner（`scripts/calibrate-canaries.sh`）會把判決
+自報的 `model_observed` 與它自己從系統讀到的值比對，並對來源分類——引用環境
+變數、未命名來源、或自我認證（宣稱「系統告知」卻不指名系統載體）皆記為
+sourcing violation、該次 run 記 `void`；引用了系統載體但值與系統讀值不符記為
+sourcing mismatch。兩者都是獨立於 swap 的 void 結果（#949：校準 v1 六份判決
+全部違反本條，即為迴歸語料）。
 合併政策讀**欄位**不讀標頭（裁定 `fleet.review-engine`）。
 
 ### Review elapsed source (GH-644)

--- a/scripts/calibrate-canaries.sh
+++ b/scripts/calibrate-canaries.sh
@@ -38,6 +38,15 @@
 # front-matter severity. A run whose engine exit ≠ 0 or whose model_observed
 # differs from model_requested marks every row of that run `void` — never
 # silently scored (model_requested ≠ model_observed is a P0 incident).
+#
+# Sourcing (GH-949): the verdict's own `model_observed` line is classified
+# against template v2 §7 — the system is the only source. A verdict citing an
+# environment variable, naming no source, or self-certifying ("由系統環境宣告
+# 取得" names no carrier) is a sourcing violation and voids the run with its
+# own reason; a verdict citing a system carrier whose value differs from the
+# system-read value is a sourcing mismatch. Both are distinct outcomes from
+# the swap void. A verdict reporting no model_observed at all is not flagged —
+# nothing to compare; the #574 dispatch receipt is the durable shape.
 # The mechanical score is conservative: human scoring per the expected.md
 # 評分提示 remains the authority for qualification decisions.
 #
@@ -420,6 +429,64 @@ score_run() { # <transcript> -> ROW lines (canary result severity_match) on stdo
   rm -f "$findings_file"
 }
 
+# verdict_sourcing <transcript> — classify the verdict's own `model_observed`
+# line (template v2 §7, GH-949). Prints "<kind><TAB><value>"; prints nothing
+# when the verdict reports no model_observed line at all. kind:
+#   ok         the citation names a system carrier (session file / modelUsage)
+#   env        the citation names an environment variable
+#   unnamed    a value is reported but no source is named
+#   unverified the citation names something that is not a system carrier
+#              (self-certification, e.g. 由系統環境宣告取得)
+verdict_sourcing() { # <transcript>
+  awk '
+    index($0, "model_observed") > 0 {
+      i = index($0, "model_observed") + 14
+      if (substr($0, i) ~ /^[[:space:]]*:/) line = $0
+    }
+    END {
+      if (line == "") exit 0
+      sub(/^[^:]*:[[:space:]]*/, "", line)
+      value = line
+      cit = ""
+      p = index(line, "（")
+      q = index(line, "(")
+      if (p > 0 && (q == 0 || p < q)) { value = substr(line, 1, p - 1); cit = substr(line, p) }
+      else if (q > 0) { value = substr(line, 1, q - 1); cit = substr(line, q) }
+      sub(/[[:space:]]+$/, "", value)
+      kind = "unnamed"
+      if (cit != "") {
+        if (cit ~ /PI_MODEL|環境變數|environment variable|env var/) kind = "env"
+        else if (cit ~ /session|\.jsonl|modelUsage|modelId|output-format/) kind = "ok"
+        else kind = "unverified"
+      }
+      printf "%s\t%s\n", kind, value
+    }' "$1"
+}
+
+# sourcing_outcome <transcript> <system-observed> — the void reason for the
+# verdict's own model_observed claim, or empty when clean (#949). Distinct
+# from the swap check: a sourcing violation voids a run whose requested and
+# observed models agree, because a correct value from a forbidden source is
+# not a measurement.
+sourcing_outcome() { # <transcript> <system-observed>
+  sv=$(verdict_sourcing "$1")
+  [ -n "$sv" ] || return 0
+  skind=$(printf '%s' "$sv" | cut -f1)
+  svalue=$(printf '%s' "$sv" | cut -f2)
+  case $skind in
+    env)
+      printf 'model_observed sourcing violation (environment variable cited: %s; template v2 §7 — the system is the only source)' "$svalue" ;;
+    unnamed)
+      printf 'model_observed sourcing violation (no source named: %s)' "$svalue" ;;
+    unverified)
+      printf 'model_observed sourcing violation (source is not a system carrier: %s)' "$svalue" ;;
+    ok)
+      if [ "$2" != unknown ] && [ "$svalue" != "$2" ]; then
+        printf 'model_observed sourcing mismatch (verdict reports %s; system read %s — a sourcing mismatch, not a swap)' "$svalue" "$2"
+      fi ;;
+  esac
+}
+
 for pair in $VALIDATED; do
   backend=${pair%%|*}
   id=${pair#*|}
@@ -434,6 +501,7 @@ for pair in $VALIDATED; do
   costs=''
   last_observed=unknown
   last_cost='-'
+  last_sourcing=''
 
   run=1
   while [ "$run" -le "$RUNS" ]; do
@@ -476,12 +544,22 @@ for pair in $VALIDATED; do
     if [ "$exit_code" -ne 0 ]; then
       any_void=1
       reason="engine exit $exit_code"
+      sourcing_reason=''
     elif [ "$observed" != "$id" ]; then
       any_void=1
       reason='model_observed mismatch (model_requested ≠ model_observed is a P0 incident)'
+      sourcing_reason=''
     else
-      reason=''
+      sourcing_reason=$(sourcing_outcome "$out" "$observed")
+      if [ -n "$sourcing_reason" ]; then
+        any_void=1
+        reason=$sourcing_reason
+      else
+        reason=''
+      fi
     fi
+
+    last_sourcing=$sourcing_reason
 
     rows_file="$CLONE/rows-$san-$run"
     if [ -n "$reason" ]; then
@@ -558,6 +636,7 @@ UNIONEOF
   echo "engine: $backend:$id"
   echo "requested: $id"
   echo "observed: $last_observed"
+  echo "sourcing: ${last_sourcing:--}"
   echo "cost_usd: $usum"
   echo "runs: $RUNS (void runs are marked void in the table)"
   echo

--- a/scripts/test-calibrate-canaries.sh
+++ b/scripts/test-calibrate-canaries.sh
@@ -328,6 +328,60 @@ case $out in
   *) bad 'claude model_observed mismatch did not void the row' ;;
 esac
 
+# --- 9. model_observed sourcing (GH-949) ------------------------------------
+# Regression corpus: the six calibration-v1 verdicts (#884, recorded in
+# #949) all supplied a model_observed value whose cited source violates
+# template v2 §7 — the five glm runs cited the PI_MODEL environment variable
+# (documented shape: `（env PI_MODEL）` and close variants), the Opus run
+# self-certified an "environment declaration" (`（由系統環境宣告取得）`), which
+# names no system carrier. Each corpus row below must void the run with a
+# sourcing violation on stderr and exit 1 — the value being correct is not a
+# measurement. A verdict citing the session file (the system carrier) is not
+# flagged; a verdict reporting no model_observed line at all is not flagged
+# either (nothing to compare — the #574 receipt is the durable shape), which
+# is what the earlier scenarios' transcripts already exercise.
+sourcing_case() { # <name> <model_observed-line> <want-rc> <want-stderr-substr>
+  name=$1
+  {
+    printf '%s
+' 'FINDING P0 canaries-fixture/c1-shell-precedence/deploy.sh:7 — POSIX sh 把 || 與 && 同優先序、左結合'
+    printf '%s
+' "$2"
+  } > "$WORK/transcript.txt"
+  CALIB_STUB_TRANSCRIPT="$WORK/transcript.txt"
+  export CALIB_STUB_TRANSCRIPT
+  unset CALIB_STUB_SESSION_MODEL
+  out=$(run_calibrate --runs 1)
+  got=$?
+  if [ "$got" -eq "$3" ]; then
+    good "$name exit $got"
+  else
+    bad "$name: expected exit $3, got $got (stderr: $(head -2 "$WORK/stderr.txt"))"
+  fi
+  case $(cat "$WORK/stderr.txt") in
+    *"$4"*) good "$name stderr: $4" ;;
+    *) bad "$name: stderr '$4' not found ($(head -2 "$WORK/stderr.txt"))" ;;
+  esac
+}
+
+# the six calibration-v1 verdicts (regression corpus) — all flagged
+sourcing_case 'corpus glm r1 (env PI_MODEL)'   'model_observed: z-ai/glm-5.3-flash（env PI_MODEL）' 1 'sourcing violation (environment variable cited'
+sourcing_case 'corpus glm r2 (env var words)'   'model_observed: z-ai/glm-5.3-flash (from PI_MODEL env var)' 1 'sourcing violation (environment variable cited'
+sourcing_case 'corpus glm r3 (bare PI_MODEL)'   'model_observed: z-ai/glm-5.3-flash（PI_MODEL）' 1 'sourcing violation (environment variable cited'
+sourcing_case 'corpus glm r4 (env-var zh)'   'model_observed: z-ai/glm-5.3-flash（環境變數 PI_MODEL）' 1 'sourcing violation (environment variable cited'
+sourcing_case 'corpus glm r5 (environment variable en)'   'model_observed: z-ai/glm-5.3-flash (copied from environment variable)' 1 'sourcing violation (environment variable cited'
+sourcing_case 'corpus opus o1 (self-certified declaration)'   'model_observed: claude-opus-5（由系統環境宣告取得）' 1 'sourcing violation (source is not a system carrier'
+
+# correct value, forbidden source — still a violation (#949 doneWhen 3)
+sourcing_case 'env source with correct value'   'model_observed: openrouter/z-ai/glm-5.3-flash（env PI_MODEL）' 1 'sourcing violation'
+
+# verdict citing the session file — the system carrier — is not flagged
+sourcing_case 'session-file citation is clean'   'model_observed: openrouter/z-ai/glm-5.3-flash (pi session file, modelId)' 0 ''
+
+# sourcing-ok but the verdict value differs from the system read — its own
+# outcome (a sourcing mismatch, not a swap: requested == observed here)
+sourcing_case 'sourcing mismatch is distinct from swap'   'model_observed: some/other-model (pi session file, modelId)' 1 'sourcing mismatch (verdict reports some/other-model; system read openrouter/z-ai/glm-5.3-flash'
+
 # --- nothing written outside the temp dir -----------------------------------
 # By construction every script write goes under $TMPDIR (clone, out files,
 # session dirs); the per-scenario assertions proved the clone is removed and


### PR DESCRIPTION
## Problem and change

The calibration runner (`scripts/calibrate-canaries.sh`) read `model_observed` from the system and voided on `model_requested ≠ model_observed`, but never examined what the verdict itself reported or where it claimed to source it. In calibration v1 (#884) all six verdicts supplied a `model_observed` value with a non-system source — five glm runs citing the `PI_MODEL` environment variable, the Opus run self-certifying an "environment declaration" — and nothing flagged it: a correct value from a forbidden source is not a measurement, and the anti-substitution control was bypassable while looking compliant.

Changes, per #949's doneWhen:

- **`verdict_sourcing`** (new): classifies the verdict's own `model_observed` citation per template v2 §7 — `env` (environment variable cited), `unnamed` (value reported, no source named), `unverified` (a citation that is not a system carrier, e.g. the Opus "由系統環境宣告取得"), `ok` (names a session file / modelUsage carrier), or nothing (verdict reports no `model_observed` line at all — not flagged; nothing to compare, and the #574 dispatch receipt is the durable shape).
- **`sourcing_outcome`** (new): turns the classification into a void reason. `env`/`unnamed`/`unverified` void the run as **sourcing violations**; an `ok` citation whose value differs from the system-read value voids as a **sourcing mismatch** — both distinct outcomes from the swap void (doneWhen item 1), and a run whose requested and observed models agree can still void because the sourcing was never a measurement.
- **for-ledger block** carries a `sourcing:` line so the recorded block shows the round's sourcing outcome.
- **`scripts/test-calibrate-canaries.sh`**: the six calibration-v1 verdict shapes are the regression corpus (five glm `PI_MODEL` citation variants + the Opus self-certification — each must void with a sourcing violation and exit 1), plus the two doneWhen-3 cases: a verdict quoting `PI_MODEL` with a *correct* value (still voids) and a verdict quoting the session file (clean, exit 0), plus the sourcing-mismatch-is-not-a-swap case. Offline, stubbed, no network — same style as the existing scenarios.
- **template v2 §7**: states the consequence explicitly — the runner classifies the verdict's citation and voids on sourcing violation/mismatch, distinct from swap (doneWhen item 4).

## Validation

### RAN

- `sh scripts/test-calibrate-canaries.sh` — **all checks passed** (exit 0), including the new section 9: six corpus rows flagged, `env source with correct value` voids, `session-file citation is clean` exits 0, `sourcing mismatch is distinct from swap` voids with the distinct reason.
- `sh -n` on both scripts; `sh scripts/lint-file-length.sh --tree` clean; `git diff --check` clean.
- No Cargo gate: no crate touched (shell + a spec doc); exact-head CI is the compile gate.

### READ

- doneWhen mapping: item 1 = `sourcing_outcome` distinct reasons; item 2 = env/unnamed/unverified classifications; item 3 = the new test section; item 4 = §7 consequence paragraph; item 5 = the six-row regression corpus (citation shapes as recorded in #884/#949 — the exact per-run strings live in the calibration transcripts on the calibration host; the shapes are the documented record).
- The runner's swap void and exit-code void are unchanged; sourcing runs only when neither fired (priority documented in the script header).

Issue: #949
