### PR TITLE
chore(sdk): make the TypeScript and Python packages publishable (GH-611)

### DIFF
--- a/SDK_HANDOFF.md
+++ b/SDK_HANDOFF.md
@@ -47,12 +47,13 @@ Scope claimed: `sdk/*`, `docs/reference/client-contract.md`,
 ## Remaining (do NOT do unilaterally)
 
 1. **Publication pending the operator**: npm/PyPI credentials are not in this
-   repository (no NPM_TOKEN/TWINE_PASSWORD), and `@edda` / `edda-sdk` were
-   unclaimed when written — verify before assuming. The packages themselves
-   are publishable as of GH-611: both build, carry dual licences, and pass
-   their registries' own validators. GH-611 doneWhen includes the real
-   release — this is the separate acceptance blocker, tracked, not silently
-   dropped. Issue reference carries `Issue: #611`, **no Closes**.
+   repository (no NPM_TOKEN/TWINE_PASSWORD), and `@fagem/edda-sdk` (npm) /
+   `edda-sdk` (PyPI) were unclaimed when written — verify before assuming. The
+   packages themselves are publishable as of GH-611: both build, carry dual
+   licences, and pass their registries' own validators. GH-611 doneWhen
+   includes the real release — this is the separate acceptance blocker,
+   tracked, not silently dropped. Issue reference carries `Issue: #611`, **no
+   Closes**.
 2. `claim check` glob-intersection stays CLI-only (documented in contract
    §5); extracting it would touch `cmd_claim.rs`, outside the granted scope.
 3. CI branch protection must mark the `contract` job required for the

--- a/SDK_HANDOFF.md
+++ b/SDK_HANDOFF.md
@@ -46,11 +46,13 @@ Scope claimed: `sdk/*`, `docs/reference/client-contract.md`,
 
 ## Remaining (do NOT do unilaterally)
 
-1. **Publication BLOCKED**: npm/PyPI namespace and credentials pending user
-   (no NPM_TOKEN/TWINE_PASSWORD; `@edda` / `edda-sdk` names are assumptions).
-   Release files are prepared as reviewed drafts. GH-611 doneWhen includes
-   the real release — this is the separate acceptance blocker, tracked, not
-   silently dropped. Issue reference carries `Issue: #611`, **no Closes**.
+1. **Publication pending the operator**: npm/PyPI credentials are not in this
+   repository (no NPM_TOKEN/TWINE_PASSWORD), and `@edda` / `edda-sdk` were
+   unclaimed when written — verify before assuming. The packages themselves
+   are publishable as of GH-611: both build, carry dual licences, and pass
+   their registries' own validators. GH-611 doneWhen includes the real
+   release — this is the separate acceptance blocker, tracked, not silently
+   dropped. Issue reference carries `Issue: #611`, **no Closes**.
 2. `claim check` glob-intersection stays CLI-only (documented in contract
    §5); extracting it would touch `cmd_claim.rs`, outside the granted scope.
 3. CI branch protection must mark the `contract` job required for the

--- a/sdk/.gitignore
+++ b/sdk/.gitignore
@@ -7,11 +7,14 @@
 # the bytes are reproducible from the sha, so the checkout is not committed).
 sdk/spec-pin/
 
-# Python
+# Python build/install artifacts; `python -m build`, which the publish runbook
+# in README.md tells the operator to run, writes both of these.
 __pycache__/
 *.pyc
 .venv/
 *.egg-info/
+python/dist/
+python/build/
 
 # TypeScript build/install artifacts; the packed smoke installs only from the
 # generated tarball and must not leave an artifact in the source tree.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -23,7 +23,7 @@ sdk/
 | Canon/hash (TS + Py) | implemented, independently; verify all golden fixtures |
 | Transports (MCP/HTTP) | implemented; MCP writes, HTTP read-only, typed timeout/cancel |
 | Contract tests | both languages + cross-language equivalence runner (task/receipt/claim/verify included) |
-| Spec pin | pinned: `9e3f6ddb8660e730be2cee631aa1eff7dd208a18` (sdk/SPEC_PIN.json) |
+| Spec pin | pinned: `04b58b1e8efbc589417cd44120e2611fecf89229` (sdk/SPEC_PIN.json) |
 | Publication | packages are publishable; **the publish itself needs the operator's registry accounts** — see below |
 
 See `SDK_HANDOFF.md` at the repo root for open controller decisions.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -24,9 +24,33 @@ sdk/
 | Transports (MCP/HTTP) | implemented; MCP writes, HTTP read-only, typed timeout/cancel |
 | Contract tests | both languages + cross-language equivalence runner (task/receipt/claim/verify included) |
 | Spec pin | pinned: `9e3f6ddb8660e730be2cee631aa1eff7dd208a18` (sdk/SPEC_PIN.json) |
-| Publication | **blocked: no npm/PyPI namespace/account authorization** (no NPM_TOKEN, `npm whoami` → ENEEDAUTH, no TWINE_PASSWORD) |
+| Publication | packages are publishable; **the publish itself needs the operator's registry accounts** — see below |
 
 See `SDK_HANDOFF.md` at the repo root for open controller decisions.
+
+## Publishing the first version (operator)
+
+Everything a repository can settle is settled: both packages build, carry
+dual MIT/Apache-2.0 licences, and pass their registries' own validators
+(`npm pack`, `twine check`). What is left needs credentials this repository
+does not hold, so it is the operator's to run.
+
+`@edda/sdk` is a **scoped** name: publishing it needs the `edda` npm
+organisation to exist and the publishing account to be a member. All three
+names — `@edda/sdk`, `edda-sdk` on npm, `edda-sdk` on PyPI — were unclaimed
+when this was written; verify before assuming.
+
+```sh
+# TypeScript — prepublishOnly runs the build; publishConfig sets public access
+cd sdk/ts && npm login && npm publish
+
+# Python
+cd sdk/python && python -m build && python -m twine upload dist/*
+```
+
+`0.1.0` is deliberate: the SDKs track **spec v1** at the commit pinned in
+`SPEC_PIN.json`, and stay `0.x` until the client contract is frozen
+(`docs/reference/client-contract.md`).
 
 ## Running the contract tests
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -8,7 +8,7 @@ writes, HTTP read-only (until write authorization lands, GH-609), types
 ```
 sdk/
   generator/            type generator + spec pinning (no deps)
-  ts/                   TypeScript client (@edda/sdk draft)
+  ts/                   TypeScript client (@fagem/edda-sdk)
   python/               Python client (edda-sdk draft)
   run-contract-tests.mjs  cross-language contract runner
   spec-pin/             pinned spec checkout (created by pin-spec.sh; gitignored)
@@ -35,14 +35,21 @@ dual MIT/Apache-2.0 licences, and pass their registries' own validators
 (`npm pack`, `twine check`). What is left needs credentials this repository
 does not hold, so it is the operator's to run.
 
-`@edda/sdk` is a **scoped** name: publishing it needs the `edda` npm
-organisation to exist and the publishing account to be a member. All three
-names — `@edda/sdk`, `edda-sdk` on npm, `edda-sdk` on PyPI — were unclaimed
-when this was written; verify before assuming.
+The npm package is `@fagem/edda-sdk` — the maintainer's own npm user scope,
+which exists by virtue of the account and needs no organisation to be created
+first. It deliberately does not match the GitHub org (`fagemx`): matching that
+would mean creating an npm organisation and waiting on it, and the scope is
+transferable to one later if the project ever wants that. PyPI has no scopes,
+so the Python package is plain `edda-sdk`.
+
+`@fagem/edda-sdk` and PyPI `edda-sdk` were both unclaimed when this was
+written; verify before assuming.
 
 ```sh
-# TypeScript — prepublishOnly runs the build; publishConfig sets public access
-cd sdk/ts && npm login && npm publish
+# TypeScript — npm ci first: prepublishOnly runs tsc, which a fresh clone
+# does not have until devDependencies are installed. publishConfig sets
+# public access.
+cd sdk/ts && npm ci && npm login && npm publish
 
 # Python
 cd sdk/python && python -m build && python -m twine upload dist/*

--- a/sdk/python/LICENSE-APACHE
+++ b/sdk/python/LICENSE-APACHE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025-2026 fagemx
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/sdk/python/LICENSE-MIT
+++ b/sdk/python/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 fagemx
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,4 +1,4 @@
-# edda-sdk (draft name — publication pending namespace authorization)
+# edda-sdk
 
 Thin Python client for the edda client contract. Zero runtime dependencies
 (stdlib only). Types are **generated** from the v1 event spec — do not

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -5,11 +5,25 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "edda-sdk"
 version = "0.1.0"
-description = "Thin Python client for the edda client contract (MCP writes, read-only HTTP). Types generated from the v1 event spec (GH-608). Publishing pending namespace authorization — see SDK_HANDOFF.md."
+description = "Thin Python client for the edda client contract: MCP writes, read-only HTTP, types generated from the v1 event spec."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT OR Apache-2.0" }
+keywords = ["edda", "sdk", "mcp", "agent", "decision-ledger"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Typing :: Typed",
+]
 dependencies = []
+
+[project.urls]
+Homepage = "https://edda.sh"
+Repository = "https://github.com/fagemx/edda"
+Issues = "https://github.com/fagemx/edda/issues"
 
 [project.optional-dependencies]
 dev = []

--- a/sdk/ts/LICENSE-APACHE
+++ b/sdk/ts/LICENSE-APACHE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025-2026 fagemx
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/sdk/ts/LICENSE-MIT
+++ b/sdk/ts/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 fagemx
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/ts/README.md
+++ b/sdk/ts/README.md
@@ -1,4 +1,4 @@
-# @edda/sdk (draft name — publication pending namespace authorization)
+# @fagem/edda-sdk
 
 Thin TypeScript client for the edda client contract. Zero runtime
 dependencies. Types are **generated** from the v1 event spec — do not
@@ -17,7 +17,7 @@ hand-edit `src/types.gen.ts` (generated on demand; see `../generator/`).
 ## Ten-line example
 
 ```ts
-import { EddaClient } from "@edda/sdk";
+import { EddaClient } from "@fagem/edda-sdk";
 const client = new EddaClient({ mcp: { command: "edda", args: ["mcp", "serve"], cwd: "." } });
 const caps = await client.capabilities();
 await client.call("note", { note: "hello from the SDK" });

--- a/sdk/ts/package-lock.json
+++ b/sdk/ts/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "@edda/sdk",
+  "name": "@fagem/edda-sdk",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@edda/sdk",
+      "name": "@fagem/edda-sdk",
       "version": "0.1.0",
+      "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@types/node": "^18.19.0",
         "typescript": "^5.7.0"

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@edda/sdk",
+  "name": "@fagem/edda-sdk",
   "version": "0.1.0",
   "description": "Thin TypeScript client for the edda client contract (MCP writes, read-only HTTP).",
   "license": "MIT OR Apache-2.0",

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -2,21 +2,31 @@
   "name": "@edda/sdk",
   "version": "0.1.0",
   "description": "Thin TypeScript client for the edda client contract (MCP writes, read-only HTTP).",
-  "private": true,
+  "license": "MIT OR Apache-2.0",
+  "homepage": "https://edda.sh",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fagemx/edda.git",
+    "directory": "sdk/ts"
+  },
+  "bugs": { "url": "https://github.com/fagemx/edda/issues" },
+  "keywords": ["edda", "sdk", "mcp", "agent", "decision-ledger"],
   "type": "module",
   "engines": { "node": ">=18.17" },
   "exports": {
     ".": { "types": "./dist/src/index.d.ts", "import": "./dist/src/index.js" },
     "./canon": { "types": "./dist/src/canon.d.ts", "import": "./dist/src/canon.js" }
   },
-  "files": ["dist", "README.md"],
+  "files": ["dist/src", "README.md", "LICENSE-MIT", "LICENSE-APACHE"],
+  "publishConfig": { "access": "public" },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "npm run build && node --test dist/test/",
     "test:golden": "npm run build && node --test dist/test/golden.test.js",
     "test:contract": "npm run build && node --test dist/test/contract.test.js",
     "generate:types": "node ../generator/generate-types.mjs",
-    "pack-smoke": "npm pack --json | node ./test/packed-install-smoke.mjs"
+    "pack-smoke": "npm pack --json | node ./test/packed-install-smoke.mjs",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@types/node": "^18.19.0",

--- a/sdk/ts/test/packed-install-smoke.mjs
+++ b/sdk/ts/test/packed-install-smoke.mjs
@@ -9,15 +9,20 @@ import { pathToFileURL } from "node:url";
 const packed = JSON.parse(readFileSync(0, "utf8"));
 const tarball = resolve(packed[0].filename);
 const root = mkdtempSync(join(tmpdir(), "edda-sdk-packed-"));
+// Read the installed path from the manifest rather than spelling the package
+// name here: hard-coded scope segments silently outlive a rename, and this
+// test is the only thing that would have caught one.
+const pkgName = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")).name;
+const installedDir = join(root, "node_modules", ...pkgName.split("/"));
 const npm = process.env.npm_execpath ? [process.execPath, process.env.npm_execpath] : ["npm"];
 const npmRun = (args, options) => execFileSync(npm[0], [...npm.slice(1), ...args], options);
 try {
   npmRun(["init", "-y"], { cwd: root, stdio: "ignore" });
   npmRun(["install", "--offline", "--ignore-scripts", "--no-audit", "--no-fund", tarball], { cwd: root, stdio: "inherit" });
-  const sdk = await import(pathToFileURL(join(root, "node_modules", "@edda", "sdk", "dist", "src", "index.js")).href);
+  const sdk = await import(pathToFileURL(join(installedDir, "dist", "src", "index.js")).href);
   assert.equal(typeof sdk.canonicalizeText, "function");
   assert.equal(typeof sdk.HttpTransport, "function");
-  assert.ok(readFileSync(join(root, "node_modules", "@edda", "sdk", "dist", "src", "types.gen.d.ts"), "utf8").includes("Layer1Payload"));
+  assert.ok(readFileSync(join(installedDir, "dist", "src", "types.gen.d.ts"), "utf8").includes("Layer1Payload"));
 } finally {
   rmSync(root, { recursive: true, force: true });
 }


### PR DESCRIPTION
Issue: #611

**No `Closes`** — **no `Closes`**: the publish itself is the operator's, and this PR does not perform it.

#611's only remaining doneWhen item is "發佈：npm / PyPI 首版". `sdk/README.md` recorded it as blocked on credentials alone. It was not.

## Two blockers a token would not have fixed

| | |
|---|---|
| `sdk/ts/package.json` had `"private": true` | `npm publish` **refuses outright** on a private package, with or without a token |
| no `publishConfig.access` | the package is published under a **scope** (`@fagem/edda-sdk`, see below); scoped packages default to `restricted`, which a free account cannot publish |

Both would have surfaced as a confusing failure at the moment the operator finally had credentials in hand.

## Also wrong for a first release

- `sdk/python/pyproject.toml`'s `description` read `"… Publishing pending namespace authorization — see SDK_HANDOFF.md."` — that string becomes the **package summary on PyPI**.
- TS `files: ["dist"]` shipped the compiled test suite alongside the client.
- Neither package carried a licence, a repository link, or classifiers.

## What changed

| File | Change |
|---|---|
| `sdk/ts/package.json` | drop `private`; `publishConfig.access=public`; `license`, `repository`, `homepage`, `bugs`, `keywords`; `prepublishOnly` build; `files` narrowed to `dist/src` |
| `sdk/python/pyproject.toml` | honest `description`; `[project.urls]`; classifiers; keywords |
| `sdk/{ts,python}/LICENSE-{MIT,APACHE}` | the repository's dual licence, so it ships inside both packages |
| `sdk/README.md` | status row corrected; publish runbook added |

`0.1.0` is unchanged and deliberate — the SDKs track spec v1 at the commit pinned in `SPEC_PIN.json` and stay `0.x` until the client contract freezes, which is #611's own "版本 0.x，明示對應 spec v1".

## Verification (this worktree, Windows)

| Check | Result |
|---|---|
| `npm ci && npm run build` | clean |
| `npm pack --dry-run` | 18 files — `dist/src/*`, `README.md`, both licences, `package.json`; no test output |
| `node -p` on the manifest | `private` absent, `access: public`, `license: MIT OR Apache-2.0` |
| `python -m build` (isolated venv) | `edda_sdk-0.1.0.tar.gz` + `edda_sdk-0.1.0-py3-none-any.whl` |
| `python -m twine check dist/*` | both PASSED |

Registry probe, 2026-09-06 — all names unclaimed (`404`): npm `@edda/sdk` and `edda-sdk` at the first push; `@fagem/edda-sdk` (and an empty `@fagem` scope) at `0c522d9d`; PyPI `edda-sdk`.

Build artifacts (`dist/`, `node_modules/`, `*.egg-info`, `*.tgz`) were removed before committing; no crate is touched, so no Cargo gate applies.

## What is left for the operator

```bash
cd sdk/ts && npm ci && npm login && npm publish
```

```bash
cd sdk/python && python -m build && python -m twine upload dist/*
```

**Package name (operator ruling, `0c522d9d`):** the npm package is `@fagem/edda-sdk` — the maintainer's own npm user scope, which exists by virtue of the account, so no organisation has to be created and nobody is waited on; a user scope is transferable to an organisation later if the project wants one. PyPI has no scopes, so the Python package is plain `edda-sdk`. Once both are on their registries, #611 can close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



