### PR TITLE
fix(fleet): the collision-scan test asserts on a task name the launcher never registers

### DIFF
--- a/scripts/fleet/run-fleet-tests.sh
+++ b/scripts/fleet/run-fleet-tests.sh
@@ -60,16 +60,6 @@ for t in scripts/fleet/test-*.sh; do
     q_issue=''
     q_why=''
     case "$t" in
-        scripts/fleet/test-collision-scan.sh)
-            # Its Windows block is gated on `command -v pwsh` (:138), but
-            # ubuntu runners ship pwsh, so the block runs there and
-            # task_query() (:178-180) calls Get-ScheduledTask — a Windows-only
-            # cmdlet — and :192 fires every run. A presence check for pwsh is
-            # not a check for Windows. Landed on main in 586cb07 (#967) after
-            # this branch's base, red on ubuntu from its first gated run.
-            q_issue='#971'
-            q_why='Windows block gated on pwsh presence, not on Windows'
-            ;;
         scripts/fleet/test-lane-helpers.sh)
             # Red on windows-latest (case 0, `prepare: worktree not
             # registered`) and on a Windows workstation against origin/main

--- a/scripts/fleet/test-collision-scan.sh
+++ b/scripts/fleet/test-collision-scan.sh
@@ -8,8 +8,9 @@
 # registration (no scheduled task by the name lane-launch.ps1 builds), the
 # launcher's own claim and the no-claim dry run behave exactly as before.
 # Those cases are Windows-only, gated on the OS rather than on pwsh being
-# installed, and the absence query carries a control case proving it can also
-# report presence (GH-971).
+# installed; the absence query carries a control case proving it can also
+# report presence, and case 7 binds the test's edda-lane-$Name derivation to
+# the name the launcher itself prints on registration (GH-971).
 #
 # Everything is written under one temp dir, plus the scheduled tasks named in
 # cleanup(); nothing else is touched. No script under test ever comments,
@@ -30,9 +31,10 @@ work=$(mktemp -d "${TMPDIR:-/tmp}/test-collision-scan.XXXXXX")
 # Scheduled tasks outlive the temp dir, so every task this test can register
 # is reclaimed here too: the task_absent control, and the dry-run tasks a raced
 # scheduler poll leaves registered when the launcher exits early. Each name is
-# appended BEFORE the launch that would create it, so a kill mid-launch still
-# reclaims it. By name, never by wildcard — this must never reap a task it
-# did not create.
+# added by reap_later BEFORE the launch that would create it (a kill mid-launch
+# still reclaims it), and only when no task by that name pre-exists — so a
+# production task that happens to share a name is never reaped (PR #995
+# Round 1 P2-1). By name, never by wildcard.
 registered_tasks=
 cleanup() {
     for t in $registered_tasks; do
@@ -212,6 +214,13 @@ STUB
     task_absent() { # 0 when no scheduled task named $1 exists, 1 when one does
         pwsh -NoProfile -Command "if (Get-ScheduledTask -TaskName '$1' -ErrorAction SilentlyContinue) { exit 1 } else { exit 0 }"
     }
+    reap_later() { # mark $1 for cleanup — unless a foreign task pre-exists
+        if task_absent "$1"; then
+            registered_tasks="$registered_tasks $1"
+        else
+            echo "WARN: scheduled task $1 pre-exists; this run will not reap it" >&2
+        fi
+    }
 
     # case 3a — control. An assertion that can only ever pass proves nothing,
     # so before relying on task_absent, prove it reports BOTH answers: register
@@ -219,7 +228,7 @@ STUB
     # this a query naming a task nobody registers reads exactly like a launcher
     # that registered nothing, which is how the doubled prefix survived review.
     control="edda-selftest-collision-$$"
-    registered_tasks="$registered_tasks $control"
+    reap_later "$control"
     pwsh -NoProfile -Command "\$a = New-ScheduledTaskAction -Execute 'cmd.exe' -Argument '/c exit 0'; Register-ScheduledTask -TaskName '$control' -Action \$a -RunLevel Limited | Out-Null" >/dev/null 2>&1 \
         || fail "control: cannot register a scheduled task; every absence assertion below would be untestable"
     if task_absent "$control"; then
@@ -230,7 +239,11 @@ STUB
     task_absent "$control" || fail "control: task_absent still reports $control after removal"
     echo "ok 3a task_absent reports both presence and absence"
 
-    # case 4 — foreign claim refuses before registering anything
+    # case 4 — foreign claim refuses before registering anything.
+    # $task is marked for cleanup here — before the FIRST launch that could
+    # register it under the regression this case exists to detect (Round 1
+    # P2-2), not merely before case 5's dry run.
+    reap_later "$task"
     : >"$work/gate-fixture.json"
     rc=0
     out=$(GF="$gf" GF_MODE=foreign PATH="$work/bin-gate:$PATH" \
@@ -256,7 +269,6 @@ STUB
     # with the retries the race needs; asserting it a second time here bought
     # no coverage and put a flaky assertion in a blocking CI gate (GH-971, same
     # scheduler path as GH-963).
-    registered_tasks="$registered_tasks $task"
     rc=0
     out=$(GF="$gf" GF_MODE=self PATH="$work/bin-gate:$PATH" \
         pwsh -NoProfile -File "$launcher" -Name "$lane" \
@@ -285,21 +297,32 @@ STUB
     # case 7 — non-issue-shaped lane names are unchanged (no -Machine needed)
     # The dry run races the Task Scheduler's own state query; retry a couple
     # of times before declaring the receipt broken.
-    registered_tasks="$registered_tasks edda-lane-scratch-lane"
+    scratch_lane=scratch-lane
+    scratch_task="edda-lane-$scratch_lane"
+    reap_later "$scratch_task"
     rc=1
     attempt=0
     while [ "$rc" != "0" ] && [ "$attempt" -lt 3 ]; do
         attempt=$((attempt + 1))
         rc=0
         out=$(PATH="$work/bin-gate:$PATH" \
-            pwsh -NoProfile -File "$launcher" -Name scratch-lane \
+            pwsh -NoProfile -File "$launcher" -Name "$scratch_lane" \
             -Brief "$work/gate-fixture.json" -Cwd "$work/cwd" \
             -LogDir "$work/lanes" -DryRun \
             -Owns scripts/fleet/test-collision-scan.sh 2>&1) || rc=$?
         [ "$rc" = "0" ] || sleep 2
     done
     [ "$rc" = "0" ] || fail "non-issue lane dry run exit $rc after retries: $out"
-    echo "ok 7 non-issue-shaped lane unchanged"
+    # Round 1 P0-1: bind this test's name derivation to the name the launcher
+    # actually registered. On the success path the launcher prints
+    # "dry-run task=<registered name> state=..." from its own $TaskName, so
+    # this grep goes red the moment lane-launch.ps1 stops building
+    # "edda-lane-$Name" — the drift that made task_query unfalsifiable in
+    # #967. Zero timing dependence: the line is printed by the same invocation
+    # whose exit 0 the assertion above already requires.
+    printf '%s' "$out" | command grep -q "dry-run task=$scratch_task " \
+        || fail "dry-run receipt does not name the derived task $scratch_task: $out"
+    echo "ok 7 non-issue lane unchanged; registered name matches the derivation"
 
     # case 8 — the PowerShell change parses
     pwsh -NoProfile -Command "\$e=\$null; [void][System.Management.Automation.Language.Parser]::ParseFile('$root/scripts/fleet/lane-launch.ps1', [ref]\$null, [ref]\$e); if (\$e) { \$e | ForEach-Object { Write-Error \$_.Message }; exit 1 }" \

--- a/scripts/fleet/test-collision-scan.sh
+++ b/scripts/fleet/test-collision-scan.sh
@@ -5,10 +5,15 @@
 # collision-scan cases stub gh with fixture JSON + real jq (the script's --jq
 # filters run for real). The lane-launch gate cases run the real launcher
 # under pwsh with a fake `gh` on PATH: a foreign claim must refuse BEFORE any
-# registration (Get-ScheduledTask returns nothing), the launcher's own claim
-# and the no-claim dry run behave exactly as before. Everything is written
-# under one temp dir; nothing outside it is touched. No script under test
-# ever comments, labels, closes, or merges.
+# registration (no scheduled task by the name lane-launch.ps1 builds), the
+# launcher's own claim and the no-claim dry run behave exactly as before.
+# Those cases are Windows-only, gated on the OS rather than on pwsh being
+# installed, and the absence query carries a control case proving it can also
+# report presence (GH-971).
+#
+# Everything is written under one temp dir, plus the scheduled tasks named in
+# cleanup(); nothing else is touched. No script under test ever comments,
+# labels, closes, or merges.
 #
 # usage: sh scripts/fleet/test-collision-scan.sh
 set -eu
@@ -22,7 +27,19 @@ sh -n "$collision" || { echo "FAIL: sh -n $collision" >&2; exit 1; }
 sh -n "$0" || { echo "FAIL: sh -n $0" >&2; exit 1; }
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/test-collision-scan.XXXXXX")
-cleanup() { rm -r -f "$work"; }
+# Scheduled tasks outlive the temp dir, so every task this test can register
+# is reclaimed here too: the task_absent control, and the dry-run tasks a raced
+# scheduler poll leaves registered when the launcher exits early. Each name is
+# appended BEFORE the launch that would create it, so a kill mid-launch still
+# reclaims it. By name, never by wildcard — this must never reap a task it
+# did not create.
+registered_tasks=
+cleanup() {
+    for t in $registered_tasks; do
+        pwsh -NoProfile -Command "Unregister-ScheduledTask -TaskName '$t' -Confirm:\$false -ErrorAction SilentlyContinue" >/dev/null 2>&1 || :
+    done
+    rm -r -f "$work"
+}
 trap cleanup 0 HUP INT TERM
 mkdir -p "$work/lanes" "$work/cwd"
 git init -q "$work/cwd"
@@ -135,7 +152,18 @@ echo "ok 3 gh failure is an error, never clean"
 
 # ── lane-launch claim gate (real pwsh, fake gh on PATH) ──────────────
 
-if command -v pwsh >/dev/null 2>&1; then
+# These cases drive the real launcher, which registers Windows Scheduled
+# Tasks; Get-ScheduledTask exists only on Windows. `command -v pwsh` is a
+# presence check, not an OS check — ubuntu runners ship pwsh, so gating
+# alone ran this whole block on Linux, where the task query could only ever
+# fail and case 4 fired on every run. That is why #910 quarantined this file
+# in scripts/fleet/run-fleet-tests.sh (GH-971).
+case "$(uname -s 2>/dev/null || echo unknown)" in
+    MINGW*|MSYS*|CYGWIN*|Windows*) on_windows=1 ;;
+    *) on_windows=0 ;;
+esac
+
+if [ "$on_windows" = 1 ] && command -v pwsh >/dev/null 2>&1; then
     gf="$work/gate-fixtures"
     mkdir -p "$gf"
     cat >"$gf/issue9-foreign.json" <<'JSON'
@@ -175,41 +203,79 @@ fi
 STUB
     } >"$work/bin-gate/gh"
     chmod +x "$work/bin-gate/gh"
-    task_query() {
-        pwsh -NoProfile -Command "if (Get-ScheduledTask -TaskName 'edda-lane-gh9' -ErrorAction SilentlyContinue) { exit 1 } else { exit 0 }"
+    # lane-launch.ps1:178 registers "edda-lane-$Name", so the lane named
+    # edda-lane-gh9 below becomes the scheduled task edda-lane-edda-lane-gh9.
+    # Querying the lane name instead of the task name made every "registered
+    # nothing" assertion here unfalsifiable (GH-971).
+    lane=edda-lane-gh9
+    task="edda-lane-$lane"
+    task_absent() { # 0 when no scheduled task named $1 exists, 1 when one does
+        pwsh -NoProfile -Command "if (Get-ScheduledTask -TaskName '$1' -ErrorAction SilentlyContinue) { exit 1 } else { exit 0 }"
     }
+
+    # case 3a — control. An assertion that can only ever pass proves nothing,
+    # so before relying on task_absent, prove it reports BOTH answers: register
+    # a throwaway task, require PRESENT, remove it, require ABSENT. Without
+    # this a query naming a task nobody registers reads exactly like a launcher
+    # that registered nothing, which is how the doubled prefix survived review.
+    control="edda-selftest-collision-$$"
+    registered_tasks="$registered_tasks $control"
+    pwsh -NoProfile -Command "\$a = New-ScheduledTaskAction -Execute 'cmd.exe' -Argument '/c exit 0'; Register-ScheduledTask -TaskName '$control' -Action \$a -RunLevel Limited | Out-Null" >/dev/null 2>&1 \
+        || fail "control: cannot register a scheduled task; every absence assertion below would be untestable"
+    if task_absent "$control"; then
+        fail "control: task_absent called a registered task absent — the query is dead"
+    fi
+    pwsh -NoProfile -Command "Unregister-ScheduledTask -TaskName '$control' -Confirm:\$false" >/dev/null 2>&1 \
+        || fail "control: cannot unregister $control"
+    task_absent "$control" || fail "control: task_absent still reports $control after removal"
+    echo "ok 3a task_absent reports both presence and absence"
 
     # case 4 — foreign claim refuses before registering anything
     : >"$work/gate-fixture.json"
     rc=0
     out=$(GF="$gf" GF_MODE=foreign PATH="$work/bin-gate:$PATH" \
-        pwsh -NoProfile -File "$launcher" -Name edda-lane-gh9 \
+        pwsh -NoProfile -File "$launcher" -Name "$lane" \
         -Brief "$work/gate-fixture.json" -Cwd "$work/cwd" \
         -Machine docs/other -LogDir "$work/lanes" 2>&1) || rc=$?
     [ "$rc" != "0" ] || fail "foreign claim must refuse, exit 0: $out"
     printf '%s' "$out" | command grep -q 'claim guard refused' || fail "refusal must name the guard: $out"
     printf '%s' "$out" | command grep -q '4090/worker-3' || fail "refusal must name the claimant: $out"
-    task_query || fail "a refused launch must not register the scheduled task"
-    [ ! -f "$work/lanes/edda-lane-gh9.log" ] || fail "a refused launch must not create the lane log"
+    task_absent "$task" || fail "a refused launch must not register the scheduled task"
+    [ ! -f "$work/lanes/$lane.log" ] || fail "a refused launch must not create the lane log"
     echo "ok 4 foreign claim refuses before registering"
 
-    # case 5 — the launcher's own claim proceeds; -DryRun receipt unchanged
+    # case 5 — the launcher's own claim passes the gate.
+    #
+    # What this case owns is the gate decision, and the launcher prints its
+    # dry-run receipt lines before it registers anything, so the proof needs no
+    # scheduler at all. It deliberately does not assert the exit code: past the
+    # gate, -DryRun registers a task, starts it and polls
+    # Get-ScheduledTaskInfo, which intermittently returns nothing and exits the
+    # launcher 1 on a Windows workstation ("dry-run task ... exists but its
+    # scheduler result is unavailable"). Case 7 already carries that round trip
+    # with the retries the race needs; asserting it a second time here bought
+    # no coverage and put a flaky assertion in a blocking CI gate (GH-971, same
+    # scheduler path as GH-963).
+    registered_tasks="$registered_tasks $task"
     rc=0
     out=$(GF="$gf" GF_MODE=self PATH="$work/bin-gate:$PATH" \
-        pwsh -NoProfile -File "$launcher" -Name edda-lane-gh9 \
+        pwsh -NoProfile -File "$launcher" -Name "$lane" \
         -Brief "$work/gate-fixture.json" -Cwd "$work/cwd" \
         -Machine docs/self -LogDir "$work/lanes" -DryRun \
         -Owns scripts/fleet/test-collision-scan.sh 2>&1) || rc=$?
-    [ "$rc" = "0" ] || fail "own-claim dry run exit $rc, want 0: $out"
-    printf '%s' "$out" | command grep -qi 'dry' || fail "dry-run receipt lines missing: $out"
-    [ -f "$work/lanes/edda-lane-gh9.dryrun.done" ] || fail "dry-run done receipt missing: $out"
-    task_query || fail "a dry run must not register the scheduled task"
-    echo "ok 5 own claim proceeds, dry-run receipt intact"
+    if printf '%s' "$out" | command grep -q 'claim guard refused'; then
+        fail "own claim must pass the guard: $out"
+    fi
+    printf '%s' "$out" | command grep -q 'dry-run real command line' \
+        || fail "own claim did not reach the dry-run body (launcher exit $rc): $out"
+    printf '%s' "$out" | command grep -q 'dry-run done=' \
+        || fail "dry-run receipt lines missing (launcher exit $rc): $out"
+    echo "ok 5 own claim passes the guard and reaches the dry-run body"
 
     # case 6 — issue-shaped lane without -Machine refuses
     rc=0
     out=$(GF="$gf" GF_MODE=self PATH="$work/bin-gate:$PATH" \
-        pwsh -NoProfile -File "$launcher" -Name edda-lane-gh9 \
+        pwsh -NoProfile -File "$launcher" -Name "$lane" \
         -Brief "$work/gate-fixture.json" -Cwd "$work/cwd" \
         -LogDir "$work/lanes" -DryRun 2>&1) || rc=$?
     [ "$rc" != "0" ] || fail "missing -Machine must refuse, exit 0: $out"
@@ -219,6 +285,7 @@ STUB
     # case 7 — non-issue-shaped lane names are unchanged (no -Machine needed)
     # The dry run races the Task Scheduler's own state query; retry a couple
     # of times before declaring the receipt broken.
+    registered_tasks="$registered_tasks edda-lane-scratch-lane"
     rc=1
     attempt=0
     while [ "$rc" != "0" ] && [ "$attempt" -lt 3 ]; do
@@ -238,8 +305,10 @@ STUB
     pwsh -NoProfile -Command "\$e=\$null; [void][System.Management.Automation.Language.Parser]::ParseFile('$root/scripts/fleet/lane-launch.ps1', [ref]\$null, [ref]\$e); if (\$e) { \$e | ForEach-Object { Write-Error \$_.Message }; exit 1 }" \
         || fail "lane-launch.ps1 does not parse"
     echo "ok 8 lane-launch.ps1 parses"
+elif [ "$on_windows" = 1 ]; then
+    echo "SKIP lane-launch gate cases: pwsh not on PATH"
 else
-    echo "SKIP pwsh cases: pwsh not on PATH"
+    echo "SKIP lane-launch gate cases: not Windows (Get-ScheduledTask is Windows-only)"
 fi
 
 echo "PASS: scripts/fleet/test-collision-scan.sh"

--- a/scripts/fleet/test-collision-scan.sh
+++ b/scripts/fleet/test-collision-scan.sh
@@ -297,7 +297,13 @@ STUB
     # case 7 — non-issue-shaped lane names are unchanged (no -Machine needed)
     # The dry run races the Task Scheduler's own state query; retry a couple
     # of times before declaring the receipt broken.
-    scratch_lane=scratch-lane
+    # The scratch name carries the edda-lane- prefix like the issue-shaped
+    # lane whose doubled prefix case 4's absence assertion depends on, but
+    # it is not issue-shaped (no gh<n>), so the receipt below exercises the
+    # doubled-prefix class edda-lane-edda-lane-scratch: a migration that
+    # stops re-prefixing issue-shaped names (#1012) turns this case red
+    # instead of leaving case 4 vacuous again (Round 2 P1).
+    scratch_lane=edda-lane-scratch
     scratch_task="edda-lane-$scratch_lane"
     reap_later "$scratch_task"
     rc=1


### PR DESCRIPTION
Issue: #971

Closes #971

`scripts/fleet/test-collision-scan.sh` landed with #967 carrying three defects that
between them meant the claim gate #912 added has no working mechanical protection:
its "registered nothing" assertion could never fire, its case 5 raced the Task
Scheduler, and its Windows-only block was gated on pwsh being installed rather than
on the OS — so #910 had to quarantine the whole file out of the new CI gate before
it had run once.

## What changed

**1. The absence assertion queries the name the launcher actually registers.**
`lane-launch.ps1:178` builds `$TaskName = "edda-lane-$Name"`, so the lane named
`edda-lane-gh9` becomes the scheduled task `edda-lane-edda-lane-gh9`. The old
`task_query()` asked about `edda-lane-gh9`, which nothing ever registers, so

```sh
task_query || fail "a refused launch must not register the scheduled task"
```

reported "absent" whether or not the launcher had registered anything. The lane
name and the task name are now two variables, derived one from the other with the
launcher's own rule, and `task_absent` takes the name as an argument.

**2. A control case proves the query can report presence.** New `ok 3a`: register
a throwaway task, require `task_absent` to report it PRESENT, remove it, require
ABSENT. An assertion that can only ever pass proves nothing — that is exactly how
the doubled prefix survived a review round.

**3. Case 5 asserts the gate decision, not the scheduler round trip.** The
launcher prints `dry-run real command line`, `dry-run wrapper=`, `dry-run log=` and
`dry-run done=` *before* it calls `Register-ScheduledTask`, so proving the own-claim
passed the guard needs no scheduler at all. Case 5 now asserts on those lines plus
the absence of `claim guard refused`, and no longer asserts the launcher's exit
code. Past the gate, `-DryRun` registers a task, starts it and polls
`Get-ScheduledTaskInfo`, which intermittently returns nothing and makes the launcher
exit 1 with `dry-run task ... exists but its scheduler result is unavailable` — the
same path GH-963 records as red. Case 7 already carries that round trip **with the
retries the race needs**; asserting it a second time in case 5 bought no coverage
and put a flaky assertion into a blocking CI gate. Reproduced live below.

**4. The Windows block is gated on Windows.** `command -v pwsh` is a presence
check, not an OS check: ubuntu runners ship pwsh, so the whole block ran on Linux
where `Get-ScheduledTask` does not exist and case 4 fired every run. That is the
failure #910's quarantine arm names, and it is why this fix and the quarantine
removal are one PR. The skip is now decided by `uname -s`, and the two skip reasons
print differently. This follows `fleet.test-lane-helpers-exclusion=windows-only-
skipped-with-reason` — a Windows-only test skips with a stated reason rather than
failing or hiding.

**5. The quarantine arm is removed** from `scripts/fleet/run-fleet-tests.sh`, in
this PR, per #971's doneWhen.

**6. Cleanup reclaims every scheduled task the test can create.** By name, never
by wildcard, and each name is appended *before* the launch that would create it, so
a kill mid-launch still reclaims it. This covers the control task and both dry-run
tasks (case 5's and case 7's) — a raced poll leaves the latter registered after the
launcher exits early.

## Evidence

All RAN on a Windows workstation at this branch head.

### A — the test, on Windows

```
ok 1 collision sweep reports both classes
ok 2 clean sweep is silent
collision-scan: gh issue list failed
ok 3 gh failure is an error, never clean
ok 3a task_absent reports both presence and absence
ok 4 foreign claim refuses before registering
ok 5 own claim passes the guard and reaches the dry-run body
ok 6 missing -Machine refuses
ok 7 non-issue-shaped lane unchanged
ok 8 lane-launch.ps1 parses
PASS: scripts/fleet/test-collision-scan.sh
STANDALONE_EXIT=0
```

### B — the same test with `uname` stubbed to `Linux` (the ubuntu path)

```
ok 1 collision sweep reports both classes
ok 2 clean sweep is silent
collision-scan: gh issue list failed
ok 3 gh failure is an error, never clean
SKIP lane-launch gate cases: not Windows (Get-ScheduledTask is Windows-only)
PASS: scripts/fleet/test-collision-scan.sh
LINUX_SIM_EXIT=0
```

Before this change the block was entered on that path regardless of OS, because
the gate asked only whether pwsh existed.

### C — the pre-fix flake, reproduced live

`origin/main` `b19742b`, same machine, same session, minutes apart:

```
dry-run process pid=39260 ppid=2728 parent=svchost.exe
lane-launch: dry-run task edda-lane-edda-lane-gh9 exists but its scheduler result is unavailable
PREFIX_LINUX_SIM_EXIT=1
```

An earlier run of the same unmodified file on the same machine exited 0. So the
`is red on Windows` half of #971 is a **race**, not a deterministic failure — the
underlying defect (case 5 depends on a path case 7 already treats as racy) is
unchanged, but the issue's wording overstates it and this PR does not repeat that
claim. That line also shows the doubled task name in the launcher's own output.

### D — no leaked scheduled tasks after the run

```
(nothing above = none leaked)
```

### E — the CI gate runner

CI run `34018015065 @ f817e8d`, job `Fleet shell tests` (ubuntu-latest) — the only
job that executes `run-fleet-tests.sh`, so this is the authoritative run and the
first time this file has executed on the runner that would have carried it:

```
RUN  scripts/fleet/test-brief-from-issue.sh
PASS scripts/fleet/test-brief-from-issue.sh
RUN  scripts/fleet/test-brief-validate.sh
PASS scripts/fleet/test-brief-validate.sh
RUN  scripts/fleet/test-collision-scan.sh
PASS scripts/fleet/test-collision-scan.sh
RUN  scripts/fleet/test-daily-digest.sh
PASS scripts/fleet/test-daily-digest.sh
RUN  scripts/fleet/test-guard-push.sh
PASS scripts/fleet/test-guard-push.sh
RUN  scripts/fleet/test-issue-freshness.sh
PASS scripts/fleet/test-issue-freshness.sh
QUARANTINE scripts/fleet/test-lane-helpers.sh (red on every Windows environment; tracked as #963)
RUN  scripts/fleet/test-manager-tick.sh
PASS scripts/fleet/test-manager-tick.sh
QUARANTINE scripts/fleet/test-next-loop.sh (red on both CI platforms; tracked as #964)
RUN  scripts/fleet/test-ready-queue-lint.sh
PASS scripts/fleet/test-ready-queue-lint.sh
RUN  scripts/fleet/test-verdict-drift.sh
PASS scripts/fleet/test-verdict-drift.sh
2 test(s) quarantined - see the QUARANTINE lines above
```

`scripts/fleet/test-collision-scan.sh` runs and passes instead of printing a
QUARANTINE line, and the count drops from 3 to 2. Only #963 and #964 remain.

### Gates

- `sh -n scripts/fleet/test-collision-scan.sh` → 0
- `sh -n scripts/fleet/run-fleet-tests.sh` → 0
- `git diff --check` → clean
- No `crates/**` in the diff, so the ladder's C5 selector is empty and no Cargo gate
  applies. `scripts/lint-file-length.sh` ratchets `*.rs` only (`:5-6`), so it is
  n/a here. No build lane: this session compiled nothing.

## Round 1 (resolved deviation and mitigations)

Round 1 (https://github.com/fagemx/edda/pull/995#issuecomment-5557834825) held the
original control insufficient: it proved the query mechanism was live but never
bound the test's `edda-lane-$Name` derivation to the name the launcher actually
registers — had it existed at #967's head it would still have passed. The round
also refuted this body's earlier claim that a launcher-bound control must
reintroduce the scheduler race: case 7's success path already prints
`dry-run task=<registered name>` deterministically.

Delivered accordingly: case 7 now greps that receipt for the name built by the
same rule the absence assertions use, so changing `lane-launch.ps1:178` turns
case 7 red with zero added timing dependence. doneWhen item 2 is thereby
delivered in the form the round specified as satisfying it, and `Closes #971`
stands.

Also from Round 1: `reap_later()` marks a task name for cleanup only when no
task by that name pre-exists, so a production task sharing a name is never
reaped (P2-1); `$task` is marked before case 4's launch — the first launch that
could register it under the regression case 4 detects (P2-2); the scratch-lane
task name is derived once, not spelled twice.

The item-5 deviation stands as before and was accepted on the record by Round 1:
the test registers one namespaced throwaway task beyond its `mktemp -d`,
required by item 2's control, reclaimed by name.

## FOLLOW-UP ISSUE

- `lane-launch.ps1` doubles its own prefix: callers must pass `-Name edda-lane-gh<N>`
  (the R28 gate regex requires it) and the launcher then registers
  `edda-lane-edda-lane-gh<N>`. Nothing is broken by it — `lane-status.ps1` and the
  launcher agree — but it is why this test's assertion was wrong, and it makes every
  `Get-ScheduledTask` transcript harder to read than it needs to be. Out of scope
  here: renaming the registered task is a live-fleet migration, not a test fix — filed as #1012 after Round 1. The other gap Round 1 surfaced, that these gate cases execute in no CI job, is #1011.


