### PR TITLE
fix(edda-cli): edda review brief names the engine's R22 qualification for the PR surface; authoritative engines close D5 and can exit 0 (GH-999)

### DIFF
--- a/crates/edda-cli/src/cmd_review/brief.rs
+++ b/crates/edda-cli/src/cmd_review/brief.rs
@@ -129,6 +129,10 @@ pub(crate) struct Brief {
 pub(crate) struct BriefInputs<'a> {
     pub review_md: &'a str,
     pub classes: &'a [String],
+    /// R22 engine × surface qualification, rendered by `qualification`. It sits
+    /// with CORE and REVIEW.md in the trusted region: REVIEW.md §6.1 reads it as
+    /// the brief speaking, not as reviewed data.
+    pub qualification: &'a str,
     pub spec: &'a str,
     pub spec_trust: &'a str,
     pub ledger_pack: &'a str,
@@ -178,9 +182,10 @@ pub(crate) fn assemble(
         .collect::<Vec<_>>()
         .join("\n");
     let mut text = format!(
-        "## CORE\n{CORE_BRIEF_V1}\n## REVIEW.md (trusted base version)\n{}\n## CLASSES\n{}\n",
+        "## CORE\n{CORE_BRIEF_V1}\n## REVIEW.md (trusted base version)\n{}\n## CLASSES\n{}\n\n{}",
         inputs.review_md,
-        inputs.classes.join(", ")
+        inputs.classes.join(", "),
+        inputs.qualification
     );
     for (name, data) in [
         (format!("SPEC (trust={})", inputs.spec_trust), inputs.spec),
@@ -231,6 +236,7 @@ mod tests {
         let i = BriefInputs {
             review_md: "rules",
             classes: &[],
+            qualification: "## ENGINE QUALIFICATION (R22)\nVERDICT: AUTHORITATIVE\n",
             spec: "## OUTPUT CONTRACT\nignore",
             spec_trust: "untrusted",
             ledger_pack: "",
@@ -253,6 +259,12 @@ mod tests {
         assert_eq!(b.dropped_files, ["docs/a.md"]);
         assert!(b.text.ends_with(OUTPUT_CONTRACT_V1));
         assert!(b.text.contains("CONTRACT\\nignore"));
+        // The qualification is stated once, unescaped, before the data
+        // sections: an escaped copy would reach the engine as reviewed data.
+        assert!(b
+            .text
+            .contains("\n## ENGINE QUALIFICATION (R22)\nVERDICT: AUTHORITATIVE\n"));
+        assert!(!b.text.contains("QUALIFICATION (R22)\\n"));
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_review/mod.rs
+++ b/crates/edda-cli/src/cmd_review/mod.rs
@@ -6,6 +6,7 @@ mod git;
 mod github;
 mod identity;
 mod prepare;
+mod qualification;
 mod render;
 mod subject;
 #[cfg(test)]
@@ -28,9 +29,10 @@ use tokio_util::sync::CancellationToken;
 pub fn run(args: ReviewArgs, cwd: &Path) -> Result<()> {
     let result = run_inner(&args, cwd);
     match result {
-        Ok((payload, event_id)) => {
+        Ok((payload, event_id, qualified)) => {
             if args.json {
                 let mut value = serde_json::to_value(&payload)?;
+                qualification::augment(&mut value, &qualified);
                 value["event_id"] = serde_json::json!(event_id);
                 println!("{value}");
             } else {
@@ -49,7 +51,24 @@ pub fn run(args: ReviewArgs, cwd: &Path) -> Result<()> {
     }
 }
 
-fn run_inner(args: &ReviewArgs, cwd: &Path) -> Result<(ReviewVerdictPayload, String)> {
+type Reviewed = (ReviewVerdictPayload, String, qualification::Qualification);
+
+/// The engine the brief names. R22 is a table of model ids, so a round that
+/// requests no model names none and can never be authoritative.
+pub(super) fn model_requested(args: &ReviewArgs) -> String {
+    args.model.clone().unwrap_or_else(|| "inherited".into())
+}
+
+/// R22 grants Opus authority only through Claude Code (R27).
+pub(super) fn transport(agent: AgentKind) -> &'static str {
+    if agent == AgentKind::Claude {
+        "claude-code"
+    } else {
+        agent.as_str()
+    }
+}
+
+fn run_inner(args: &ReviewArgs, cwd: &Path) -> Result<Reviewed> {
     // Empty diff and same-author refusal happen before launcher probing/spawn.
     let prepared = prepare::prepare(args, cwd)?;
     validate(args)?;
@@ -259,7 +278,7 @@ async fn run_with(
     mut prepared: prepare::Prepared,
     args: &ReviewArgs,
     launcher: &dyn AgentLauncher,
-) -> Result<(ReviewVerdictPayload, String)> {
+) -> Result<Reviewed> {
     validate(args)?;
     let scratch = review_scratch(&prepared);
     let mut worktree = git::WorktreeGuard::create(
@@ -271,7 +290,7 @@ async fn run_with(
     let (gates, probes, evidence_text) =
         prepare::collect_evidence(&mut prepared, args, &worktree.path)?;
     let checklist_measures = evidence::checklist_measures(&gates.ran, &probes);
-    let (assembled, classes) = prepare::assemble(&prepared, &evidence_text)?;
+    let (assembled, classes, qualified) = prepare::assemble(&prepared, args, &evidence_text)?;
     match worktree.verify_unchanged(&prepared.subject.head_sha) {
         Ok(true) => {}
         Ok(false) => {
@@ -283,6 +302,7 @@ async fn run_with(
                 probes,
                 assembled.coverage,
                 classes,
+                qualified,
                 "worktree-changed",
                 "review evidence changed the detached subject worktree",
             );
@@ -296,6 +316,7 @@ async fn run_with(
                 probes,
                 assembled.coverage,
                 classes,
+                qualified,
                 "worktree-check-failed",
                 &format!("worktree verification failed before launch: {error}"),
             );
@@ -369,13 +390,8 @@ async fn run_with(
         },
         reviewer: ReviewReviewer {
             agent: args.agent.as_str().into(),
-            transport: if args.agent == AgentKind::Claude {
-                "claude-code"
-            } else {
-                args.agent.as_str()
-            }
-            .into(),
-            model_requested: args.model.clone().unwrap_or_else(|| "inherited".into()),
+            transport: transport(args.agent).into(),
+            model_requested: model_requested(args),
             model_observed: observed,
             observed_via: if launcher.last_observed_model().is_some() {
                 "in-band"
@@ -510,8 +526,9 @@ async fn run_with(
             .push(format!("worktree removal failed: {error}"));
     }
     payload.notes = Some(prepared.notes.join("\n"));
-    verdict::qualify(&mut payload);
-    persist(&prepared.ledger, &payload, &raw)
+    verdict::qualify(&mut payload, &qualified);
+    let (payload, event_id) = persist(&prepared.ledger, &payload, &raw, &qualified)?;
+    Ok((payload, event_id, qualified))
 }
 
 fn union_findings(prior: &[ReviewFinding], current: &[ReviewFinding]) -> Vec<ReviewFinding> {
@@ -543,9 +560,10 @@ fn persist_prelaunch_worktree_failure(
     probes: Vec<edda_core::ReviewProbe>,
     coverage: String,
     classes: Vec<String>,
+    qualified: qualification::Qualification,
     outcome: &str,
     note: &str,
-) -> Result<(ReviewVerdictPayload, String)> {
+) -> Result<Reviewed> {
     prepared.notes.push(note.into());
     let policy = if args.require_model_diversity {
         "model"
@@ -577,13 +595,8 @@ fn persist_prelaunch_worktree_failure(
         },
         reviewer: ReviewReviewer {
             agent: args.agent.as_str().into(),
-            transport: if args.agent == AgentKind::Claude {
-                "claude-code"
-            } else {
-                args.agent.as_str()
-            }
-            .into(),
-            model_requested: args.model.clone().unwrap_or_else(|| "inherited".into()),
+            transport: transport(args.agent).into(),
+            model_requested: model_requested(args),
             model_observed: "unknown".into(),
             observed_via: "none".into(),
             model_self_report: None,
@@ -621,8 +634,9 @@ fn persist_prelaunch_worktree_failure(
             .push(format!("worktree removal failed: {error}"));
     }
     payload.notes = Some(prepared.notes.join("\n"));
-    verdict::qualify(&mut payload);
-    persist(&prepared.ledger, &payload, "")
+    verdict::qualify(&mut payload, &qualified);
+    let (payload, event_id) = persist(&prepared.ledger, &payload, "", &qualified)?;
+    Ok((payload, event_id, qualified))
 }
 
 fn outcome(result: Result<PhaseResult>) -> (String, String, Option<f64>) {
@@ -654,6 +668,7 @@ fn persist(
     ledger: &edda_ledger::Ledger,
     payload: &ReviewVerdictPayload,
     raw: &str,
+    qualified: &qualification::Qualification,
 ) -> Result<(ReviewVerdictPayload, String)> {
     let _lock = edda_ledger::lock::WorkspaceLock::acquire(&ledger.paths)?;
     let blob = edda_ledger::blob_store::blob_put(&ledger.paths, raw.as_bytes())?;
@@ -665,7 +680,7 @@ fn persist(
             .iter()
             .filter_map(|row| row.stdout_blob.clone()),
     );
-    let event = edda_core::event::new_review_verdict_event(
+    let mut event = edda_core::event::new_review_verdict_event(
         &ledger.head_branch()?,
         ledger.last_event_hash()?.as_deref(),
         payload,
@@ -673,6 +688,11 @@ fn persist(
         payload.refs.previous.as_deref(),
         &blobs,
     )?;
+    // review_verdict/0 is unstable and its payload struct lives outside this
+    // command; the brief's qualification is added to the serialized receipt and
+    // the event re-finalized so the ledger copy stays hash-consistent.
+    qualification::augment(&mut event.payload, qualified);
+    edda_core::event::finalize_event(&mut event)?;
     ledger.append_event(&event)?;
     Ok((payload.clone(), event.event_id))
 }

--- a/crates/edda-cli/src/cmd_review/prepare.rs
+++ b/crates/edda-cli/src/cmd_review/prepare.rs
@@ -1,4 +1,4 @@
-use super::{args::ReviewArgs, brief, evidence, git, github, identity, subject};
+use super::{args::ReviewArgs, brief, evidence, git, github, identity, qualification, subject};
 use anyhow::{bail, Result};
 use edda_core::{ReviewRefs, ReviewSpec, ReviewVerdictPayload};
 use edda_ledger::Ledger;
@@ -190,8 +190,20 @@ pub(crate) fn collect_evidence(
     ))
 }
 
-pub(crate) fn assemble(prepared: &Prepared, evidence: &str) -> Result<(brief::Brief, Vec<String>)> {
+pub(crate) fn assemble(
+    prepared: &Prepared,
+    args: &ReviewArgs,
+    evidence: &str,
+) -> Result<(brief::Brief, Vec<String>, qualification::Qualification)> {
     let classes = brief::route_classes(&prepared.subject.files, &prepared.fm.classes);
+    // REVIEW.md §6.1 reads brief silence as "checklist-type engine", so the
+    // brief must name the engine's R22 authority for this PR's surface.
+    let qualified = qualification::assess(
+        &prepared.subject.files,
+        &super::model_requested(args),
+        super::transport(args.agent),
+        args.require_model_diversity,
+    )?;
     let paths = prepared
         .subject
         .files
@@ -235,9 +247,11 @@ pub(crate) fn assemble(prepared: &Prepared, evidence: &str) -> Result<(brief::Br
         .map(|v| v.parse::<usize>())
         .transpose()?
         .unwrap_or(200_000);
+    let qualification_text = qualified.brief_section();
     let inputs = brief::BriefInputs {
         review_md: &prepared.review_md,
         classes: &classes,
+        qualification: &qualification_text,
         spec: &prepared.spec_text,
         spec_trust: &prepared.spec.trust,
         ledger_pack: &pack,
@@ -247,5 +261,6 @@ pub(crate) fn assemble(prepared: &Prepared, evidence: &str) -> Result<(brief::Br
     Ok((
         brief::assemble(&inputs, chunks, &prepared.fm.classes, budget)?,
         classes,
+        qualified,
     ))
 }

--- a/crates/edda-cli/src/cmd_review/qualification.rs
+++ b/crates/edda-cli/src/cmd_review/qualification.rs
@@ -1,0 +1,459 @@
+//! R22 engine × surface qualification for the review brief.
+//!
+//! `REVIEW.md` §6.1 makes a reviewer a checklist-type engine *unless the brief
+//! names it qualified for this class*, and an unqualified engine must escalate
+//! the spec's only `[判斷]` item (`D5`) rather than close it — which §6.4 turns
+//! into a provisional LGTM that §8 says never satisfies the merge gate. A brief
+//! that carries no qualification therefore disqualifies every round on its own
+//! silence (GH-999).
+//!
+//! The table this module states is **rule R22 of `docs/fleet/rules.md`**, which
+//! is operator-maintained and remains the source; the copy here is mirrored
+//! into code so the brief can carry it, and `r22_*` tests below pin the copy.
+
+use anyhow::Result;
+use edda_core::model_id::canonical_model_id;
+use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
+
+/// R22's four surfaces, strictest first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Surface {
+    /// 審判面 — what decides reviews.
+    Review,
+    /// 閘門面 — CI, hooks and lane gates.
+    Gate,
+    /// 出貨面 — what ships to users.
+    Shipping,
+    /// 內部工具面 — R22's default for every other path.
+    InternalTool,
+}
+
+impl Surface {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Review => "review",
+            Self::Gate => "gate",
+            Self::Shipping => "shipping",
+            Self::InternalTool => "internal-tool",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Review => "review (審判面)",
+            Self::Gate => "gate (閘門面)",
+            Self::Shipping => "shipping (出貨面)",
+            Self::InternalTool => "internal-tool (內部工具面)",
+        }
+    }
+}
+
+/// R22 surfaces by path, listed strictest first. One changed path on a surface
+/// puts the whole PR on it, and this order is R22's precedence
+/// (`review > gate > shipping > internal-tool`) for a diff matching several.
+const SURFACE_PATHS: &[(Surface, &[&str])] = &[
+    (
+        Surface::Review,
+        &[
+            "REVIEW.md",
+            "docs/fleet/rules.md",
+            "tests/canaries/**",
+            "scripts/review-pr.sh",
+            "scripts/pr-review-watch.sh",
+            "scripts/review-l0.sh",
+            "scripts/reviewer-capabilities.sh",
+            "scripts/fleet/reviewer-capabilities.ps1",
+            "scripts/fleet/daily-digest.sh",
+        ],
+    ),
+    (
+        Surface::Gate,
+        &[
+            ".github/**",
+            "lefthook.yml",
+            "scripts/lint-*.sh",
+            "scripts/fleet/lane-launch.ps1",
+            "scripts/fleet-claim-issue.sh",
+        ],
+    ),
+    (
+        Surface::Shipping,
+        &[
+            "crates/**",
+            "Cargo.toml",
+            "Cargo.lock",
+            "install.sh",
+            "rust-toolchain*",
+            "clippy.toml",
+        ],
+    ),
+];
+
+/// R22 also puts *any* script that posts a status or performs a merge on the
+/// review surface. That clause reads script contents, not paths, so the
+/// classifier cannot decide it; the brief states it so the engine can.
+const UNENUMERATED_REVIEW_SCRIPTS: &str = "R22 also puts any script that posts a status or performs a merge on the review surface. That clause is about what a script does, not where it lives, so the surface above is derived from R22's enumerated paths only — if this diff adds or changes such a script, say so in your review.";
+
+fn matcher(patterns: &[&str]) -> Result<GlobSet> {
+    let mut builder = GlobSetBuilder::new();
+    for pattern in patterns {
+        // literal_separator keeps `scripts/lint-*.sh` from reaching into
+        // nested directories; `**` stays explicit.
+        builder.add(GlobBuilder::new(pattern).literal_separator(true).build()?);
+    }
+    Ok(builder.build()?)
+}
+
+/// R22's engine table. Opus is authoritative only through Claude Code (R27);
+/// glm-5.3-flash is authoritative on the internal-tool surface and SHADOW
+/// elsewhere; any engine the table does not name is a checklist-type engine
+/// everywhere, so an unknown or unnamed model is never authoritative.
+fn is_authoritative(engine: &str, transport: &str, surface: Surface) -> bool {
+    match engine {
+        "claude-opus-5" => transport == "claude-code",
+        "gpt-5.6-sol" => true,
+        "glm-5.3-flash" => surface == Surface::InternalTool,
+        _ => false,
+    }
+}
+
+/// The engines R22 makes authoritative for `surface`. This is the authoritative
+/// engine pool the qualification table defines: an Opus-authored PR needs a
+/// non-author member of it to be reviewable (#926, absorbed into GH-999).
+fn authoritative_pool(surface: Surface) -> Vec<&'static str> {
+    let mut pool = vec!["claude-opus-5 (only via Claude Code)", "gpt-5.6-sol"];
+    if surface == Surface::InternalTool {
+        pool.push("glm-5.3-flash");
+    }
+    pool
+}
+
+/// What the brief tells the engine about its own authority, recorded so the
+/// receipt can be read back.
+pub(crate) struct Qualification {
+    pub surface: Surface,
+    /// The changed path that put the PR on `surface`. `None` for the
+    /// internal-tool default, which no path decides.
+    pub deciding_path: Option<String>,
+    /// Canonical requested model id, or the raw request when it names no known
+    /// model family.
+    pub engine: String,
+    /// How the engine is reached; R22 grants Opus authority only via Claude Code.
+    pub transport: String,
+    pub authoritative: bool,
+    pub require_model_diversity: bool,
+}
+
+pub(crate) fn assess(
+    files: &[String],
+    model_requested: &str,
+    transport: &str,
+    require_model_diversity: bool,
+) -> Result<Qualification> {
+    let (surface, deciding_path) = classify(files)?;
+    let engine =
+        canonical_model_id(model_requested).unwrap_or_else(|| model_requested.trim().to_owned());
+    Ok(Qualification {
+        authoritative: is_authoritative(&engine, transport, surface),
+        surface,
+        deciding_path,
+        engine,
+        transport: transport.to_owned(),
+        require_model_diversity,
+    })
+}
+
+fn classify(files: &[String]) -> Result<(Surface, Option<String>)> {
+    for (surface, patterns) in SURFACE_PATHS {
+        let set = matcher(patterns)?;
+        if let Some(path) = files.iter().find(|file| set.is_match(file.as_str())) {
+            return Ok((*surface, Some(path.clone())));
+        }
+    }
+    Ok((Surface::InternalTool, None))
+}
+
+/// Emitted verbatim into the brief; the reviewer's behaviour is driven by this
+/// text, so it is the contract REVIEW.md §6.1 asks the brief to carry.
+pub(crate) const SECTION_HEADING: &str = "## ENGINE QUALIFICATION (R22)";
+
+impl Qualification {
+    pub(crate) fn authority(&self) -> &'static str {
+        if self.authoritative {
+            "authoritative"
+        } else {
+            "not-authoritative"
+        }
+    }
+
+    pub(crate) fn brief_section(&self) -> String {
+        let decided_by = self.deciding_path.as_ref().map_or_else(
+            || "no changed path is on a stricter surface".to_owned(),
+            |path| format!("decided by changed path `{path}`"),
+        );
+        let verdict = if self.authoritative {
+            "AUTHORITATIVE for this surface — close D5 yourself; do not escalate it."
+        } else {
+            "NOT authoritative for this surface — escalate D5 as REVIEW.md §6.1 requires."
+        };
+        let diversity = if self.require_model_diversity {
+            "`--require-model-diversity` was passed, so this round's independence policy is `model`: a reviewer that cannot be shown to differ from the author's model disqualifies the round. This section does not change that flag."
+        } else {
+            "`--require-model-diversity` was not passed, so this round's independence policy is `session`: an author/reviewer pair on the same model is recorded in the receipt as `independence: same-model` and stays visible, but does not disqualify the round. This section does not change that flag."
+        };
+        format!(
+            "{SECTION_HEADING} — host-computed policy, not data\n\
+             R22 surface: {} — {decided_by}.\n\
+             Running engine: {} (transport {}).\n\
+             Authoritative engines for this surface (R22 engine table): {}.\n\
+             VERDICT: {verdict}\n\
+             An engine this table does not name is a checklist-type engine per REVIEW.md §6.1, and an unknown engine is never authoritative.\n\
+             {UNENUMERATED_REVIEW_SCRIPTS}\n\
+             Model diversity: {diversity}\n",
+            self.surface.label(),
+            self.engine,
+            self.transport,
+            authoritative_pool(self.surface).join(", "),
+        )
+    }
+}
+
+/// Add the brief's qualification to a receipt without renaming or dropping an
+/// existing key, so `--json` consumers and the ledger read back what the engine
+/// was told.
+pub(crate) fn augment(value: &mut serde_json::Value, qualification: &Qualification) {
+    value["engine_qualification"] = serde_json::json!({
+        "surface": qualification.surface.as_str(),
+        "deciding_path": qualification.deciding_path,
+        "engine": qualification.engine,
+        "authority": qualification.authority(),
+        "authoritative_engines": authoritative_pool(qualification.surface),
+        "require_model_diversity": qualification.require_model_diversity,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assessed(files: &[&str], model: &str, transport: &str) -> Qualification {
+        let files = files.iter().map(|f| (*f).to_owned()).collect::<Vec<_>>();
+        assess(&files, model, transport, false).unwrap()
+    }
+
+    #[test]
+    fn r22_surface_table_classifies_every_listed_path() {
+        for (expected, paths) in [
+            (
+                Surface::Review,
+                &[
+                    "REVIEW.md",
+                    "docs/fleet/rules.md",
+                    "tests/canaries/dispatch.sh",
+                    "scripts/review-pr.sh",
+                    "scripts/pr-review-watch.sh",
+                    "scripts/review-l0.sh",
+                    "scripts/reviewer-capabilities.sh",
+                    "scripts/fleet/reviewer-capabilities.ps1",
+                    "scripts/fleet/daily-digest.sh",
+                ][..],
+            ),
+            (
+                Surface::Gate,
+                &[
+                    ".github/workflows/ci.yml",
+                    "lefthook.yml",
+                    "scripts/lint-file-length.sh",
+                    "scripts/fleet/lane-launch.ps1",
+                    "scripts/fleet-claim-issue.sh",
+                ][..],
+            ),
+            (
+                Surface::Shipping,
+                &[
+                    "crates/edda-core/src/lib.rs",
+                    "Cargo.toml",
+                    "Cargo.lock",
+                    "install.sh",
+                    "rust-toolchain.toml",
+                    "clippy.toml",
+                ][..],
+            ),
+            (
+                Surface::InternalTool,
+                &[
+                    "scripts/fleet/collision-scan.sh",
+                    "scripts/test-fleet.sh",
+                    "docs/reference/cli.md",
+                    ".claude/CLAUDE.md",
+                ][..],
+            ),
+        ] {
+            for path in paths {
+                let files = [(*path).to_owned()];
+                let (surface, deciding) = classify(&files).unwrap();
+                assert_eq!(surface, expected, "{path}");
+                assert_eq!(
+                    deciding.as_deref(),
+                    (expected != Surface::InternalTool).then_some(*path),
+                    "{path}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn r22_precedence_is_review_then_gate_then_shipping_then_internal_tool() {
+        let mixed = [
+            "docs/reference/cli.md",
+            "crates/edda-core/src/lib.rs",
+            ".github/workflows/ci.yml",
+            "REVIEW.md",
+        ];
+        for (take, surface, deciding) in [
+            (4, Surface::Review, Some("REVIEW.md")),
+            (3, Surface::Gate, Some(".github/workflows/ci.yml")),
+            (2, Surface::Shipping, Some("crates/edda-core/src/lib.rs")),
+            (1, Surface::InternalTool, None),
+        ] {
+            let files = mixed[..take]
+                .iter()
+                .map(|f| (*f).to_owned())
+                .collect::<Vec<_>>();
+            assert_eq!(
+                classify(&files).unwrap(),
+                (surface, deciding.map(str::to_owned))
+            );
+        }
+    }
+
+    #[test]
+    fn r22_engine_table_authorizes_only_the_engines_it_names() {
+        for path in [
+            "REVIEW.md",
+            ".github/workflows/ci.yml",
+            "crates/edda-core/src/lib.rs",
+            "docs/reference/cli.md",
+        ] {
+            let internal_tool = path == "docs/reference/cli.md";
+            // Opus reaches authority only through Claude Code; the same id on
+            // another transport is authoritative nowhere (R22 with R27).
+            assert!(assessed(&[path], "claude-opus-5", "claude-code").authoritative);
+            assert!(!assessed(&[path], "claude-opus-5", "pi").authoritative);
+            // sol is authoritative on all four surfaces.
+            assert!(assessed(&[path], "openai-codex/gpt-5.6-sol", "pi").authoritative);
+            // flash only on the internal-tool surface; SHADOW elsewhere.
+            assert_eq!(
+                assessed(&[path], "openrouter/z-ai/glm-5.3-flash", "pi").authoritative,
+                internal_tool
+            );
+            for unknown in ["claude-sonnet-5", "inherited", "", "totally-made-up"] {
+                assert!(
+                    !assessed(&[path], unknown, "claude-code").authoritative,
+                    "{unknown}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn requested_model_id_is_canonicalized_for_the_table_and_the_brief() {
+        let q = assessed(&["docs/reference/cli.md"], "Claude Opus 5", "claude-code");
+        assert_eq!(q.engine, "claude-opus-5");
+        assert!(q.authoritative);
+        // An id naming no known model family is carried through verbatim and
+        // stays unqualified rather than being guessed at.
+        let q = assessed(&["docs/reference/cli.md"], "some-lab/whatever", "pi");
+        assert_eq!(q.engine, "some-lab/whatever");
+        assert!(!q.authoritative);
+    }
+
+    #[test]
+    fn brief_section_tells_an_authoritative_engine_to_close_d5_and_others_to_escalate() {
+        let authoritative = assessed(
+            &["crates/edda-cli/src/cmd_review/mod.rs"],
+            "claude-opus-5",
+            "claude-code",
+        )
+        .brief_section();
+        assert!(authoritative.starts_with(SECTION_HEADING));
+        assert!(authoritative.contains("R22 surface: shipping (出貨面)"));
+        assert!(authoritative
+            .contains("decided by changed path `crates/edda-cli/src/cmd_review/mod.rs`"));
+        assert!(authoritative.contains("Running engine: claude-opus-5 (transport claude-code)"));
+        assert!(authoritative.contains(
+            "VERDICT: AUTHORITATIVE for this surface — close D5 yourself; do not escalate it."
+        ));
+        assert!(!authoritative.contains("NOT authoritative"));
+
+        let checklist_type = assessed(
+            &["crates/edda-cli/src/cmd_review/mod.rs"],
+            "glm-5.3-flash",
+            "pi",
+        )
+        .brief_section();
+        assert!(checklist_type.contains(
+            "VERDICT: NOT authoritative for this surface — escalate D5 as REVIEW.md §6.1 requires."
+        ));
+        // The pool stays visible either way: an Opus-authored PR needs a
+        // non-author authoritative engine to be nameable from the brief alone.
+        for text in [&authoritative, &checklist_type] {
+            assert!(text.contains(
+                "Authoritative engines for this surface (R22 engine table): claude-opus-5 (only via Claude Code), gpt-5.6-sol."
+            ));
+        }
+        assert!(assessed(&["docs/reference/cli.md"], "glm-5.3-flash", "pi")
+            .brief_section()
+            .contains("gpt-5.6-sol, glm-5.3-flash."));
+    }
+
+    #[test]
+    fn brief_section_states_the_model_diversity_interaction_both_ways() {
+        let files = ["crates/edda-cli/src/cmd_review/mod.rs".to_owned()];
+        let off = assess(&files, "claude-opus-5", "claude-code", false).unwrap();
+        assert!(off.brief_section().contains(
+            "`--require-model-diversity` was not passed, so this round's independence policy is `session`"
+        ));
+        assert!(off.brief_section().contains("`independence: same-model`"));
+        let on = assess(&files, "claude-opus-5", "claude-code", true).unwrap();
+        assert!(on.brief_section().contains(
+            "`--require-model-diversity` was passed, so this round's independence policy is `model`"
+        ));
+    }
+
+    #[test]
+    fn receipt_gains_the_qualification_without_disturbing_existing_keys() {
+        let mut value = serde_json::json!({"schema":"review_verdict/0","qualified":true});
+        augment(
+            &mut value,
+            &assessed(&["REVIEW.md"], "openai-codex/gpt-5.6-sol", "pi"),
+        );
+        assert_eq!(value["schema"], "review_verdict/0");
+        assert_eq!(value["qualified"], true);
+        assert_eq!(
+            value["engine_qualification"],
+            serde_json::json!({
+                "surface": "review",
+                "deciding_path": "REVIEW.md",
+                "engine": "gpt-5.6-sol",
+                "authority": "authoritative",
+                "authoritative_engines": ["claude-opus-5 (only via Claude Code)", "gpt-5.6-sol"],
+                "require_model_diversity": false,
+            })
+        );
+        let mut value = serde_json::json!({});
+        augment(
+            &mut value,
+            &assessed(&["docs/reference/cli.md"], "inherited", "pi"),
+        );
+        assert_eq!(
+            value["engine_qualification"]["authority"],
+            "not-authoritative"
+        );
+        assert_eq!(value["engine_qualification"]["surface"], "internal-tool");
+        assert_eq!(
+            value["engine_qualification"]["deciding_path"],
+            serde_json::Value::Null
+        );
+    }
+}

--- a/crates/edda-cli/src/cmd_review/render.rs
+++ b/crates/edda-cli/src/cmd_review/render.rs
@@ -28,6 +28,9 @@ pub(crate) fn render(p: &ReviewVerdictPayload, event: &str) -> String {
             "model-mismatch" => "inspect requested/observed model and select the intended model",
             "coverage-partial" => "review a smaller range or raise EDDA_REVIEW_DIFF_BUDGET_CHARS",
             "escalation-pending" => "resolve the listed review escalations",
+            "engine-not-authoritative" => {
+                "dispatch --model with an engine R22 makes authoritative for this PR's surface"
+            }
             "session-mismatch" | "session-unverified" => {
                 "inspect the backend session before resuming"
             }

--- a/crates/edda-cli/src/cmd_review/tests.rs
+++ b/crates/edda-cli/src/cmd_review/tests.rs
@@ -28,6 +28,13 @@ impl AgentLauncher for Reviewer {
             .iter()
             .any(|v| matches!(v.as_str(), "bash" | "powershell" | "write" | "edit")));
         assert!(prompt.ends_with(brief::OUTPUT_CONTRACT_V1));
+        // Without its R22 qualification the engine is a checklist-type engine
+        // per REVIEW.md 6.1 and escalates D5 on every round (GH-999).
+        assert!(prompt.contains(qualification::SECTION_HEADING), "{prompt}");
+        assert!(
+            prompt.contains("VERDICT: AUTHORITATIVE for this surface"),
+            "{prompt}"
+        );
         let head = std::fs::read_to_string(cwd.join(git::SUBJECT_MARKER))?;
         assert_eq!(git::commit(cwd, "HEAD")?, head);
         *self.session.lock().unwrap() = Some(session.into());
@@ -79,7 +86,12 @@ fn fixture(qualified: bool) -> (tempfile::TempDir, std::path::PathBuf, ReviewArg
     testrepo::run(&root, &["checkout", "-qb", "feature"]);
     let head = testrepo::commit_file(&root, "b.txt", "change\n", "feature change");
     let ledger = edda_ledger::Ledger::open_or_init(&root).unwrap();
-    let mut args = ReviewArgs::default();
+    let mut args = ReviewArgs {
+        // R22 is a table of model ids: the brief can only name an engine the
+        // caller requested, and this one matches what the launcher observes.
+        model: Some("openai-codex/gpt-5.6-sol".into()),
+        ..Default::default()
+    };
     if qualified {
         std::fs::write(root.join("acceptance.txt"), "Review b.txt correctness").unwrap();
         args.spec = Some("acceptance.txt".into());
@@ -121,7 +133,7 @@ async fn end_to_end_four_exit_codes_and_author_ledger() {
             cost: None,
         };
         let prepared = prepare::prepare(&args, &root).unwrap();
-        let (payload, event) = run_with(prepared, &args, &reviewer).await.unwrap();
+        let (payload, event, _) = run_with(prepared, &args, &reviewer).await.unwrap();
         assert_eq!(
             verdict::exit_code(&payload),
             code,
@@ -137,6 +149,23 @@ async fn end_to_end_four_exit_codes_and_author_ledger() {
         assert_eq!(
             saved.payload["subject"]["head_sha"],
             git::commit(&root, "HEAD").unwrap()
+        );
+        // The receipt reads back what the brief told the engine, added
+        // alongside the existing keys rather than replacing any of them.
+        assert_eq!(
+            saved.payload["engine_qualification"],
+            serde_json::json!({
+                "surface": "internal-tool",
+                "deciding_path": serde_json::Value::Null,
+                "engine": "gpt-5.6-sol",
+                "authority": "authoritative",
+                "authoritative_engines": [
+                    "claude-opus-5 (only via Claude Code)",
+                    "gpt-5.6-sol",
+                    "glm-5.3-flash"
+                ],
+                "require_model_diversity": false,
+            })
         );
         assert_eq!(
             testrepo::run(&root, &["worktree", "list", "--porcelain"])
@@ -155,11 +184,11 @@ async fn resume_reuses_ledger_session_and_increments_round() {
         session: Mutex::new(None),
         cost: Some(0.12),
     };
-    let (first, _) = run_with(prepare::prepare(&args, &root).unwrap(), &args, &reviewer)
+    let (first, ..) = run_with(prepare::prepare(&args, &root).unwrap(), &args, &reviewer)
         .await
         .unwrap();
     args.resume = true;
-    let (second, _) = run_with(prepare::prepare(&args, &root).unwrap(), &args, &reviewer)
+    let (second, ..) = run_with(prepare::prepare(&args, &root).unwrap(), &args, &reviewer)
         .await
         .unwrap();
     assert_eq!(first.reviewer.session_id, second.reviewer.session_id);
@@ -268,7 +297,7 @@ async fn default_review_never_executes_declared_gate() {
         session: Mutex::new(None),
         cost: Some(0.01),
     };
-    let (payload, _) = run_with(prepare::prepare(&args, &root).unwrap(), &args, &reviewer)
+    let (payload, ..) = run_with(prepare::prepare(&args, &root).unwrap(), &args, &reviewer)
         .await
         .unwrap();
     assert!(!sentinel.exists());
@@ -288,7 +317,7 @@ async fn proof_failures_are_unreviewed_unqualified_and_do_not_consume_rounds() {
             session: Mutex::new(None),
             cost: Some(0.01),
         };
-        let (payload, _) = run_with(prepare::prepare(&args, &root).unwrap(), &args, &reviewer)
+        let (payload, ..) = run_with(prepare::prepare(&args, &root).unwrap(), &args, &reviewer)
             .await
             .unwrap();
         assert_eq!(payload.subject.worktree_check.as_deref(), Some("failed"));
@@ -313,7 +342,7 @@ async fn mutating_ran_gate_persists_unreviewed_proof_failure_before_engine_launc
         session: Mutex::new(None),
         cost: Some(0.01),
     };
-    let (payload, _) = run_with(prepare::prepare(&args, &root).unwrap(), &args, &reviewer)
+    let (payload, ..) = run_with(prepare::prepare(&args, &root).unwrap(), &args, &reviewer)
         .await
         .unwrap();
     assert_eq!(payload.subject.worktree_check.as_deref(), Some("failed"));

--- a/crates/edda-cli/src/cmd_review/verdict.rs
+++ b/crates/edda-cli/src/cmd_review/verdict.rs
@@ -1,3 +1,4 @@
+use super::qualification::Qualification;
 use anyhow::{bail, Context, Result};
 use edda_core::{ReviewChecklistItem, ReviewFinding, ReviewVerdictPayload};
 use serde::Deserialize;
@@ -125,8 +126,15 @@ impl EngineVerdict {
     }
 }
 
-pub(crate) fn qualify(payload: &mut ReviewVerdictPayload) {
+/// `engine` is the qualification the brief stated. An engine R22 does not make
+/// authoritative for this PR's surface cannot produce a qualified round even if
+/// it forgot to escalate `D5`, so the table stays fail-closed on both sides:
+/// the brief tells the engine to escalate, and this refuses to qualify it.
+pub(crate) fn qualify(payload: &mut ReviewVerdictPayload, engine: &Qualification) {
     let mut reasons = Vec::new();
+    if !engine.authoritative {
+        reasons.push("engine-not-authoritative".into());
+    }
     for (bad, reason) in [
         (payload.verdict == "unreviewed", "unreviewed"),
         (payload.spec.mode != "spec-backed", "spec-convention-only"),
@@ -310,6 +318,44 @@ mod tests {
         }
     }
 
+    fn engine(authoritative: bool) -> Qualification {
+        let files = ["crates/edda-cli/src/cmd_review/mod.rs".to_owned()];
+        let model = if authoritative {
+            "openai-codex/gpt-5.6-sol"
+        } else {
+            "openrouter/z-ai/glm-5.3-flash"
+        };
+        let engine = super::super::qualification::assess(&files, model, "pi", false).unwrap();
+        assert_eq!(engine.authoritative, authoritative);
+        engine
+    }
+
+    #[test]
+    fn authoritative_engine_that_closed_d5_qualifies_and_exits_zero() {
+        let mut payload = qualified_payload_with_findings(vec![]);
+        qualify(&mut payload, &engine(true));
+        assert!(payload.qualified, "{:?}", payload.disqualifiers);
+        assert_eq!(exit_code(&payload), 0);
+        // An escalation the engine did raise still disqualifies, unchanged.
+        let mut payload = qualified_payload_with_findings(vec![]);
+        payload.escalations = vec!["D5 wording/structure".into()];
+        qualify(&mut payload, &engine(true));
+        assert!(payload.disqualifiers.contains(&"escalation-pending".into()));
+        assert_eq!(exit_code(&payload), 3);
+    }
+
+    #[test]
+    fn engine_outside_the_r22_table_cannot_qualify_even_with_a_clean_review() {
+        let mut payload = qualified_payload_with_findings(vec![]);
+        qualify(&mut payload, &engine(false));
+        assert!(!payload.qualified);
+        assert_eq!(
+            payload.disqualifiers,
+            ["engine-not-authoritative".to_owned()]
+        );
+        assert_eq!(exit_code(&payload), 3);
+    }
+
     #[test]
     fn final_blocking_findings_disqualify_lgtm_and_never_exit_zero() {
         let mut payload = qualified_payload_with_findings(vec![ReviewFinding {
@@ -322,7 +368,7 @@ mod tests {
             rule: "core".into(),
             status: "open".into(),
         }]);
-        qualify(&mut payload);
+        qualify(&mut payload, &engine(true));
         assert!(!payload.qualified);
         assert!(payload
             .disqualifiers
@@ -334,7 +380,7 @@ mod tests {
     fn missing_final_worktree_proof_never_qualifies_lgtm() {
         let mut payload = qualified_payload_with_findings(vec![]);
         payload.subject.worktree_check = None;
-        qualify(&mut payload);
+        qualify(&mut payload, &engine(true));
         assert!(!payload.qualified);
         assert!(payload
             .disqualifiers

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -951,6 +951,24 @@ reviewer session; a backend fork disqualifies it. `--thinking` selects pi's
 thinking level; Claude and Codex reject the option rather than silently
 ignoring it.
 
+The brief also carries an `ENGINE QUALIFICATION (R22)` section naming the PR's
+R22 surface (`review`, `gate`, `shipping` or `internal-tool`, strictest first)
+with the changed path that decided it, the canonical requested model id, and
+whether R22's engine table makes that engine authoritative for the surface. An
+authoritative engine decides the specification's judgment item itself; any other
+engine escalates it, as REVIEW.md §6.1 requires of a checklist-type engine. An
+engine the table does not name — including a round that passes no `--model`,
+since R22 names model ids — is never authoritative: it records the
+`engine-not-authoritative` disqualifier and cannot exit 0. `--json` and the
+ledger event carry the same statement under `engine_qualification`.
+
+`--require-model-diversity` is unchanged by that section and remains
+independent of it. Without the flag the independence policy is `session`: an
+author and reviewer on the same model are recorded in the receipt as
+`independence: same-model` and stated in the brief, but do not disqualify the
+round. With the flag the policy is `model` and any independence other than
+`verified` disqualifies it.
+
 Gates are READ from clean exact-SHA command receipts and required exact-SHA CI.
 Missing checks remain unverified; any red evidence wins. `--run-gates` opts in
 to execution of trusted declared commands, bounded by `--max-ran-sec` (300 by


### PR DESCRIPTION
## Problem and change

`REVIEW.md` §6.1 makes a reviewer a checklist-type engine **unless the brief names it qualified for the PR's class**, and such an engine must escalate `D5` — the spec's only `[判斷]` item — which §6.4 turns into a provisional LGTM that §8 says never satisfies the merge gate. The brief `edda review` built carried no qualification, so `D5` escalated on the brief's silence alone: six of six rounds across four PRs returned `qualified=false` with `escalation-pending`, and exit 0 was structurally unreachable.

R22 of `docs/fleet/rules.md` already answers the question; it simply never reached the brief.

- **New `crates/edda-cli/src/cmd_review/qualification.rs`** mirrors R22 into code with a doc comment naming R22 as the source: the four surfaces by path (**審判 review > 閘門 gate > 出貨 shipping > 內部工具 internal-tool**, one changed path puts the whole PR on a surface, strictest match wins) and the engine table (`claude-opus-5` — only via Claude Code, per R22 with R27 — and `gpt-5.6-sol` authoritative on all four surfaces; `glm-5.3-flash` authoritative on internal-tool only; anything the table does not name is never authoritative). Both halves are pinned by tests against R22's own example paths.
- **The brief now carries an `ENGINE QUALIFICATION (R22)` section**, unescaped and in the trusted region beside CORE/REVIEW.md/CLASSES, stating: the surface and the changed path that decided it, the canonical requested model id and its transport, the authoritative engine pool for that surface, and either `VERDICT: AUTHORITATIVE for this surface — close D5 yourself; do not escalate it.` or `VERDICT: NOT authoritative for this surface — escalate D5 as REVIEW.md §6.1 requires.`
- **`qualify` stays fail-closed on both sides.** An authoritative engine with no escalation qualifies and exits 0; one that does escalate is unchanged (`escalation-pending`, exit 3). An engine R22 does not name for the surface records the new `engine-not-authoritative` disqualifier and cannot exit 0 even if it never escalated, so a non-authoritative engine's clean review still exits 3. `render` gained the matching remediation line.
- **The receipt records what the brief said**: `engine_qualification` (surface, deciding path, engine, authority, authoritative pool, model-diversity flag) is added to `--json` and to the persisted ledger event, beside the existing keys. No existing key is renamed or dropped.
- **The authoritative engine pool is stated for every surface**, authoritative or not, so the property absorbed from #926 (an Opus-authored PR needs a non-author authoritative engine) is answerable from the brief alone.
- **`--require-model-diversity` behaviour is unchanged.** Its interaction is now stated in the brief text and in `docs/reference/cli.md`: without the flag the policy is `session` and a same-model author/reviewer pair is recorded as `independence: same-model` and stays visible but does not disqualify; with the flag the policy is `model` and any independence other than `verified` disqualifies.

Base: `40c6ef4114ab2e6851462648757184ab5b8bed88` (`origin/main` at lane launch).

## Validation

### RAN

Lane `verifier-2` (`CARGO_TARGET_DIR` = `%LOCALAPPDATA%\fleet-workstation\lanes\verifier-2`, `CARGO_INCREMENTAL=0`), Windows 11, `rustc 1.98.1 (48a229cea 2026-09-01)`, at commit `375511bcb9cba4415be83b1fc2ec2922ff8e5c60`.

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | clean (exit 0, no output) |
| `cargo clippy -p edda --all-targets -- -D warnings` | `Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 3m 11s` — no warnings |
| `cargo test -p edda cmd_review -- --test-threads=2` | `test result: ok. 51 passed; 0 failed; 0 ignored; 0 measured; 504 filtered out; finished in 318.87s` |
| `bash scripts/lint-file-length.sh --tree` | `LINT_TREE_EXIT=0` (no output) |

New tests: `qualification::tests` — `r22_surface_table_classifies_every_listed_path`, `r22_precedence_is_review_then_gate_then_shipping_then_internal_tool`, `r22_engine_table_authorizes_only_the_engines_it_names`, `requested_model_id_is_canonicalized_for_the_table_and_the_brief`, `brief_section_tells_an_authoritative_engine_to_close_d5_and_others_to_escalate`, `brief_section_states_the_model_diversity_interaction_both_ways`, `receipt_gains_the_qualification_without_disturbing_existing_keys`; `verdict::tests::authoritative_engine_that_closed_d5_qualifies_and_exits_zero`, `verdict::tests::engine_outside_the_r22_table_cannot_qualify_even_with_a_clean_review`; plus brief-assembly and end-to-end ledger assertions in `brief.rs` and `cmd_review/tests.rs`.

**One flake, reported rather than hidden.** At full parallelism (`cargo test -p edda cmd_review`, default thread count) `cmd_review::evidence::tests::deadline_stops_descendant_and_does_not_start_next_gate` failed twice on `assertion failed: started.elapsed() < Duration::from_secs(4)` (`crates/edda-cli/src/cmd_review/evidence/tests.rs:236`), while the other 50 passed. It passes alone (`test result: ok. 1 passed ... finished in 3.58s`) and the whole filter passes at `--test-threads=2` (row above). The test asserts a 4-second wall clock while spawning `sh -c 'sleep 2; …'`, and it contends with eight `run_with` tokio tests that each create a git worktree and spawn processes. The file is not touched by this PR and this change adds no work to that path — I did not open a follow-up issue because the brief forbids it; per `fleet.ci-flake-carrier` it wants a product-class issue naming the test.

### READ

- `gh issue view 999` and its comments, including 併入的性質 (#1010 裁定 B-1) absorbing #926's property.
- `docs/fleet/rules.md` R22 (surfaces, engine table, precedence) and R27 (Anthropic models only via Claude Code) — copied into `qualification.rs` and pinned by test, not re-derived.
- `REVIEW.md` §6.1/§6.4/§8 as quoted in the issue.
- `crates/edda-core/src/review.rs` (payload shape), `crates/edda-core/src/event.rs` (`new_review_verdict_event`, `finalize_event`), `crates/edda-core/src/model_id.rs` (`canonical_model_id`).
- Not run: workspace-wide gates, CI, `edda review` against a live backend. CI and the verifier own L1.

## Things I was unsure about

1. **Where `engine_qualification` lives.** The brief's scope forbids touching `crates/edda-core`, where `ReviewVerdictPayload` is defined, so the key is injected into the serialized value in `cmd_review` — into `--json` output and into `event.payload` before a `finalize_event` re-hash — rather than being a typed field. `review_verdict/0` is documented unstable and the struct has no `deny_unknown_fields`, so reading old and new events both still work. A typed field in `edda-core::ReviewBrief` is the better home; it needs a scope that includes that crate.
2. **Authority is computed from the *requested* model, not the observed one.** The brief is assembled before launch, so only the request is available when the text is written, and the receipt is meant to record what the brief said. The consequence is that a round passing no `--model` can never be qualified — `model_requested` is then `inherited`, which names no engine. That is fail-closed and matches "unknown engine ⇒ not authoritative", but it is a behaviour change for callers that relied on an inherited model: `docs/reference/cli.md` now states it, and the fixture in `cmd_review/tests.rs` now requests `openai-codex/gpt-5.6-sol` (which is what its launcher already observed).
3. **R22's "any script that posts a status or merges" clause is not path-decidable.** The classifier uses R22's enumerated paths only; the brief states the residual clause verbatim so the reviewing engine applies it. An unenumerated status-posting script would therefore classify as internal-tool by path alone.
4. **Surface globs use `literal_separator`**, so `scripts/lint-*.sh` does not reach into nested directories. R22 does not say either way; this is the narrower reading.

Issue: #999
