### PR TITLE
fix(fleet): review-pr.sh publishes an unqualified-LGTM (exit 3) round instead of discarding its payload

### DIFF
--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -75,8 +75,10 @@
 # review`'s exit: 1 is Changes Requested and 3 an unqualified LGTM, which the
 # adapter publishes under a `Provisional — …` Verdict line (REVIEW.md §6.4).
 # Both are settled reviews: the comment is posted, the status goes through the
-# union rule (a Provisional round is never success), and a Provisional round
-# gets no review:* label. Neither is a dead verdict for the overload rule (#998).
+# union rule (gate_state: a Provisional round is never success on its own — at
+# P0=P1=0 it is pending, with any P0/P1 it stands like any non-qualifying
+# verdict), and a Provisional round gets no review:* label. Neither is a dead
+# verdict for the overload rule (#998).
 #
 # The watcher NEVER merges. Merge stays behind operator authorization
 # (pr.merge-policy).
@@ -183,14 +185,21 @@ gate_state() {
     /^[[:space:]]*$/ { next }
     {
       n++
-      if ($1 == "LGTM" && $2 ~ /^[0-9]+$/ && $2 + 0 == 0 &&
-          $3 ~ /^[0-9]+$/ && $3 + 0 == 0) next
+      zero = ($2 ~ /^[0-9]+$/ && $2 + 0 == 0 && $3 ~ /^[0-9]+$/ && $3 + 0 == 0)
+      if ($1 == "LGTM" && zero) { ok = 1; next }
+      # An unqualified LGTM (Provisional, REVIEW.md §6.4) at P0=P1=0 is pending:
+      # never success on its own, and once the escalation is adjudicated it
+      # does not hold a later qualified LGTM on the same sha at failure. With
+      # any P0/P1 it is a standing non-qualifying verdict like any other
+      # (§8, GH-742; #1023 round 1).
+      if ($1 == "Provisional" && zero) next
       bad = 1
     }
     END {
       if (n == 0)   print "error"
       else if (bad) print "failure"
-      else          print "success"
+      else if (ok)  print "success"
+      else          print "failure"
     }
   '
 # /D8-debt
@@ -638,7 +647,7 @@ post_review_status() { # $1=pr $2=reviewed sha $3=verdict file
     log "pr$1 status withheld this poll: new malformed verdict notice(s):$seen"
     return 3
   fi
-  prior=$(printf '%s\n' "$comments" | awk -F'\t' '$1 == "LGTM" || $1 == "Changes Requested"')
+  prior=$(printf '%s\n' "$comments" | awk -F'\t' '$1 == "LGTM" || $1 == "Changes Requested" || $1 == "Provisional"')
   state=$(printf '%s\n%s\n' "$prior" "$(verdict_body_lines "$2" < "$3")" | gate_state)
   gh api "repos/$REPO/statuses/$2" \
     -f state="$state" -f context="Independent Review" \

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -71,6 +71,13 @@
 # Changes Requested on the same sha. Posting reuses the comment's bounded
 # retry path (postfails, POSTFAIL_CAP, review:post-failed) — never best-effort.
 #
+# A product round (TRANSPORT=edda-review) carries its verdict in `edda
+# review`'s exit: 1 is Changes Requested and 3 an unqualified LGTM, which the
+# adapter publishes under a `Provisional — …` Verdict line (REVIEW.md §6.4).
+# Both are settled reviews: the comment is posted, the status goes through the
+# union rule (a Provisional round is never success), and a Provisional round
+# gets no review:* label. Neither is a dead verdict for the overload rule (#998).
+#
 # The watcher NEVER merges. Merge stays behind operator authorization
 # (pr.merge-policy).
 set -u
@@ -236,13 +243,17 @@ verdict_body_lines() { # $1=reviewed sha; stdin: one body per <<<COMMENT>>> bloc
       inh = 0; vline = ""
       for (i = 2; i <= n; i++) {
         if (L[i] ~ /^#{1,}[[:space:]]*Verdict/) { inh = 1; continue }
-        if (inh && vline == "" && L[i] ~ /LGTM|Changes Requested/) {
+        if (inh && vline == "" && L[i] ~ /LGTM|Changes Requested|^Provisional/) {
           vline = L[i]
         }
       }
       if (vline == "") return
+      # Blocking side first; then the line the product adapter writes for an
+      # unqualified LGTM (edda review exit 3; REVIEW.md §6.4), which starts
+      # with Provisional and never qualifies (#998); plain LGTM last.
       v = "LGTM"
       if (vline ~ /Changes Requested/) v = "Changes Requested"
+      else if (vline ~ /^Provisional/) v = "Provisional"
       p0 = ""; p1 = ""
       if (match(vline, /P0=[0-9]+/)) p0 = substr(vline, RSTART + 3, RLENGTH - 3)
       if (match(vline, /P1=[0-9]+/)) p1 = substr(vline, RSTART + 3, RLENGTH - 3)
@@ -440,7 +451,24 @@ extract_verdict() { # $1=log file, $2=out file
 }
 
 verdict_ok() { # $1=verdict file
-  grep -qE '^(LGTM|Changes Requested)' "$1" 2>/dev/null
+  # `Provisional` is the product adapter's Verdict line for an unqualified LGTM
+  # (edda review exit 3; REVIEW.md §6.4) — a settled review to publish, never
+  # a dead verdict to retry (#998).
+  grep -qE '^(LGTM|Changes Requested|Provisional)' "$1" 2>/dev/null
+}
+
+# The exit pair a clean terminal receipt may carry. A lane's `edda dispatch`
+# exits 0 on any completed review — the verdict is text — so DISPATCH_EXIT and
+# FINAL_EXIT must both be 0. `edda review` (TRANSPORT=edda-review) encodes the
+# verdict in its exit instead: 0 qualified LGTM, 1 Changes Requested, 3
+# unqualified LGTM (provisional); 2 alone is a failure (#998).
+receipt_exit_ok() { # $1=.done file
+  d=$(sed -n 's/^DISPATCH_EXIT=//p' "$1" 2>/dev/null | tail -1)
+  f=$(sed -n 's/^FINAL_EXIT=//p' "$1" 2>/dev/null | tail -1)
+  case "$(sed -n 's/^TRANSPORT=//p' "$1" 2>/dev/null | tail -1)" in
+    edda-review) case "$d/$f" in 0/0|1/1|3/3) return 0 ;; esac; return 1 ;;
+    *) [ "$d" = "0" ] && [ "$f" = "0" ] ;;
+  esac
 }
 
 # Model observed + cost, read from the transcript's receipt lines (edda
@@ -713,6 +741,12 @@ settle_pending() {
         return 0
       fi
       vl=$(sh "$LABEL_PR" verdict-label < "$1")
+      # The Verdict line decides, not the prose after it: a Provisional round
+      # (unqualified LGTM, REVIEW.md §6.4) carries no review:* label even when
+      # a finding under it says "LGTM" — verdict-label reads on past the line
+      # it does not recognise, so its answer is overridden here (#998).
+      vw=$(verdict_body_lines "$sha" < "$1" | head -1 | cut -f1)
+      [ "$vw" != "Provisional" ] || vl=""
       if ! verdict_body_lines "$sha" < "$1" | grep -q .; then
         # The strict pin rejects SHADOW headings on purpose (a SHADOW verdict
         # never enters the union), so a well-formed SHADOW-declared carrier
@@ -786,6 +820,14 @@ settle_pending() {
           return 0
         fi
       fi
+      if [ "$vw" = "Provisional" ]; then
+        # Published and status-gated (the union above cannot be success), but
+        # not a merge-gate verdict (REVIEW.md §6.4/§8): no review:* label.
+        log "pr$pr r$round Provisional verdict on $sha — not a merge-gate verdict (REVIEW.md §6.4): no review:* label; round settled"
+        state_set "$pr" "$sha" "$round"
+        pending_drop "$pr"
+        return 0
+      fi
       if [ -n "$vl" ] && gh pr edit "$pr" --repo "$REPO" --add-label "$vl" >/dev/null 2>&1; then
         gh pr edit "$pr" --repo "$REPO" --remove-label "review:unreviewed"  >/dev/null 2>&1 || true
         gh pr edit "$pr" --repo "$REPO" --remove-label "review:post-failed" >/dev/null 2>&1 || true
@@ -850,8 +892,7 @@ settle_pending() {
         # and partial receipts fail
         # closed: source verification, worktree removal and task teardown must
         # all be proven before this watcher publishes a verdict.
-        if ! grep -qx 'DISPATCH_EXIT=0' "$DONE" 2>/dev/null \
-          || ! grep -qx 'FINAL_EXIT=0' "$DONE" 2>/dev/null \
+        if ! receipt_exit_ok "$DONE" \
           || ! grep -qx 'WORKTREE_CHECK=unchanged' "$DONE" 2>/dev/null \
           || ! grep -qx 'WORKTREE_CLEANUP=removed' "$DONE" 2>/dev/null \
           || ! grep -Eq '^TASK_CLEANUP=(unregistered|not-applicable)$' "$DONE" 2>/dev/null \

--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -59,7 +59,15 @@
 #                                  source proof, worktree removal and task
 #                                  teardown ("TRANSPORT=<arm>", "SESSION=<uuid>",
 #                                  raw "DISPATCH_EXIT=<code>", final exit and
-#                                  terminal WORKTREE/TASK cleanup proof)
+#                                  terminal WORKTREE/TASK cleanup proof); the
+#                                  product arm (TRANSPORT=edda-review) publishes
+#                                  the same shape, where DISPATCH_EXIT is
+#                                  `edda review`'s verdict-bearing exit (0
+#                                  qualified LGTM, 1 Changes Requested, 3
+#                                  unqualified LGTM = provisional, #998)
+#   review-pr<N>-r<R>-launch.ps1   Windows: the Task Scheduler launcher, written
+#                                  even on --dry-run so the registered -File
+#                                  argument is inspectable
 #   wt-review-pr<N>/               detached worktree at the PR head, removed by
 #                                  the lane once the round's verdict is in the
 #                                  log and recreated at the same path next
@@ -241,15 +249,124 @@ product_review_supported() {
   done
 }
 
+# ---- launchers shared by the product and legacy transports ------------------
+# Windows: Task Scheduler, not nohup (fleet.lane-launch). The launcher is a
+# generated .ps1, written before the dry-run exit, so the exact -Argument it
+# registers is inspectable on disk: a -File argument pwsh cannot open is the
+# #683 failure, and the product path used to register it inline in a
+# single-quoted PowerShell string whose backticks stayed literal
+# (`-File `"C:\…`"`), so every product task ended with LastTaskResult=64
+# before its lane ran (#998). Callers set LANE_FILE_ARG (cygpath -w of the
+# lane), LAUNCH_DIRW (the task's working directory), LOGW, DONEW, PWSH_EXE,
+# SID and SESSION_MODE first.
+write_windows_launcher() {
+  TASK="edda-review-pr$PR-r$ROUND"
+  cat > "$SCRATCH/review-pr$PR-r$ROUND-launch.ps1" <<PS
+foreach (\$f in @("$LOGW", "$DONEW", "$DONEW.err")) { if (Test-Path \$f) { [System.IO.File]::Delete(\$f) } }
+Unregister-ScheduledTask -TaskName '$TASK' -Confirm:\$false -ErrorAction SilentlyContinue
+\$action = New-ScheduledTaskAction -Execute "$PWSH_EXE" -Argument "-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File \`"$LANE_FILE_ARG\`"" -WorkingDirectory '$LAUNCH_DIRW'
+# The dispatch timeout is handled inside the child lane. Scheduler must not
+# preempt its finally block before it publishes the terminal receipt and
+# unregisters itself.
+\$settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Seconds 0) -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
+try {
+  Register-ScheduledTask -TaskName '$TASK' -Action \$action -Settings \$settings -RunLevel Limited -ErrorAction Stop | Out-Null
+  try { Start-ScheduledTask -TaskName '$TASK' -ErrorAction Stop }
+  catch {
+    \$startFailure = \$_.Exception.Message
+    \$taskCleanup = 'failed; task start did not reach cleanup'
+    try {
+      Unregister-ScheduledTask -TaskName '$TASK' -Confirm:\$false -ErrorAction Stop
+      \$taskCleanup = 'unregistered'
+    } catch {
+      \$taskCleanup = "failed; \$(\$_.Exception.Message)"
+      \$_ | Out-File '$LOGW' -Append -Encoding utf8
+    }
+    "review-pr launcher: Start-ScheduledTask failed: \$startFailure" | Out-File '$LOGW' -Append -Encoding utf8
+    \$receiptTmp = "$DONEW.pending-\$PID"
+    try {
+      [System.IO.File]::WriteAllLines(\$receiptTmp, [string[]]@(
+        'TRANSPORT=not-started',
+        'TOOL_FLAGS=not-started',
+        'SESSION=$SID',
+        'SESSION_MODE=$SESSION_MODE',
+        'DISPATCH_EXIT=2',
+        'FINAL_EXIT=2',
+        'WORKTREE_CHECK=not-started',
+        'WORKTREE_CLEANUP=preserved; scheduler start failed',
+        "TASK_CLEANUP=\$taskCleanup",
+        'TERMINAL_RECEIPT=complete'
+      ), [System.Text.UTF8Encoding]::new(\$false))
+      Move-Item -LiteralPath \$receiptTmp -Destination '$DONEW' -Force
+    } catch {
+      \$_ | Out-File '$LOGW' -Append -Encoding utf8
+    }
+    throw
+  }
+} catch { throw }
+\$st = ""
+for (\$i = 0; \$i -lt 20; \$i++) {
+  Start-Sleep -Seconds 1
+  \$st = (Get-ScheduledTask -TaskName '$TASK').State
+  if (\$st -eq 'Running') { break }
+}
+\$info = Get-ScheduledTaskInfo -TaskName '$TASK'
+"task=$TASK state=\$st lastTaskResult=\$(\$info.LastTaskResult)"
+PS
+
+}
+
+# Run the generated launcher and require the task to reach Running.
+start_windows_launcher() {
+  command -v pwsh >/dev/null 2>&1 || { echo "review-pr.sh: pwsh not found" >&2; exit 1; }
+  out=$(pwsh -NoProfile -ExecutionPolicy Bypass -File "$SCRATCH/review-pr$PR-r$ROUND-launch.ps1" 2>&1); rc=$?
+  echo "$out"
+  [ $rc -eq 0 ] || exit 1
+  case "$out" in
+    *state=Running*) : ;;
+    *)
+      # Task Scheduler says nothing useful about why. LastTaskResult=64 has now
+      # been observed from three unrelated path faults on two machines, and the
+      # lane script that everyone reads next was never reached, so name the one
+      # thing only this process knows: whether the -File argument it generated
+      # resolves for the pwsh that Task Scheduler starts (issue #683).
+      echo "review-pr.sh: scheduled task did not reach Running" >&2
+      if pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass \
+           -Command "if (Test-Path -LiteralPath '$LANE_FILE_ARG') { exit 0 } else { exit 1 }" \
+           >/dev/null 2>&1; then
+        echo "review-pr.sh: the task's -File argument resolves for pwsh: $LANE_FILE_ARG — the fault is inside the lane script or its environment, not the path. Read $SCRATCH/review-pr$PR-r$ROUND.log" >&2
+      else
+        echo "review-pr.sh: the task's -File argument does NOT resolve for pwsh: $LANE_FILE_ARG — this is the LastTaskResult=64 failure of issue #683: the task registers and starts, then exits before writing any log or .done file. Check that \$EDDA_FLEET_SCRATCH is Windows-resolvable" >&2
+      fi
+      exit 1
+      ;;
+  esac
+}
+
+# Linux: nohup. A runner that dies within a second never launched.
+start_posix_runner() {
+  nohup "$RUNNER" >/dev/null 2>&1 &
+  pid=$!
+  sleep 1
+  kill -0 "$pid" 2>/dev/null || { echo "review-pr.sh: nohup process $pid died immediately" >&2; exit 1; }
+  echo "task=nohup pid=$pid state=Running"
+}
+
 launch_product_review() {
-  # This branch owns its per-round artifacts, including on its first use.
-  mkdir -p "$SCRATCH" || { echo "review-pr.sh: cannot create scratch directory $SCRATCH" >&2; exit 1; }
+  # Runs after the round reservation below, so $ROUND is the shared round and
+  # the receipts this prints (`review_round=`) are what the watcher tracks it
+  # by; the reservation is released only through this round's terminal
+  # receipt, which the generated adapters publish in full (#998).
   LOG="$SCRATCH/review-pr$PR-r$ROUND.log"
   DONE="$SCRATCH/review-pr$PR-r$ROUND.done"
   LANE="$SCRATCH/review-pr$PR-r$ROUND-lane.ps1"
   RUNNER="$SCRATCH/review-pr$PR-r$ROUND-run.sh"
   PRODUCT_RESUME=""
-  [ "$ROUND" -gt 1 ] && PRODUCT_RESUME="--resume"
+  SESSION_MODE=new
+  if [ "$ROUND" -gt 1 ]; then PRODUCT_RESUME="--resume"; SESSION_MODE=resume; fi
+  # edda review assigns and resumes its own reviewer session; the launched id
+  # is unknown here, and the .done SESSION= line records what it reported.
+  SID=assigned-by-edda-review
   [ -n "$ROOT" ] || { echo "review-pr.sh: cannot locate main checkout (set EDDA_FLEET_ROOT)" >&2; exit 1; }
 
   if [ "$IS_WIN" = "1" ]; then
@@ -273,11 +390,14 @@ function Invoke-EddaReview {
 \$payload = \$null
 try { \$payload = \$json | ConvertFrom-Json } catch { }
 \$proof = \$payload -and \$payload.subject.head_sha -eq '$SHA' -and \$payload.subject.subject_seen -eq '$SHA' -and \$payload.subject.worktree_check -eq 'unchanged' -and \$payload.reviewer.tool_policy -eq 'hard'
+\$qualified = \$false
+\$disqualifiers = ''
 if (-not \$proof) {
   'edda review product receipt failed subject, internal-worktree, or hard-policy validation' | Out-File '$LOGW' -Encoding utf8
   \$json | Add-Content '$LOGW' -Encoding utf8
   \$code = 2
   \$tree = 'failed; product JSON lacked a matching internal worktree proof'
+  \$treeCleanup = 'not-attempted'
   \$policy = 'missing'
   \$session = 'unknown'
 } else {
@@ -288,14 +408,26 @@ if (-not \$proof) {
   \$p0 = @(\$findings | Where-Object severity -eq 'P0').Count
   \$p1 = @(\$findings | Where-Object severity -eq 'P1').Count
   \$qualified = (\$payload.qualified -eq \$true) -and (\$disqualifierItems.Count -eq 0)
-  \$label = if (\$payload.verdict -eq 'lgtm' -and \$qualified) { 'LGTM' } elseif (\$payload.verdict -eq 'changes-requested') { 'Changes Requested' } else { '' }
+  \$disqualifierList = if (\$disqualifierItems.Count -eq 0) { 'none' } else { \$disqualifierItems -join ', ' }
+  # An unqualified LGTM (product exit 3) is provisional under REVIEW.md §6.4
+  # and never the merge gate (§8): its Verdict line says so without the LGTM
+  # token, so \`verdict-label\` cannot resolve it to review:lgtm, and its
+  # payload is published like any other outcome instead of discarded (#998).
+  \$label = if (\$payload.verdict -eq 'lgtm' -and \$qualified) { 'LGTM' } elseif (\$payload.verdict -eq 'changes-requested') { 'Changes Requested' } elseif (\$payload.verdict -eq 'lgtm') { "Provisional — unqualified (disqualifiers: \$disqualifierList)" } else { '' }
+  \$gate = if (\$label -like 'Provisional*') { ' — not a merge-gate verdict' } else { '' }
+  \$escalationList = if (\$escalations.Count -eq 0) { 'none' } else { (\$escalations | ForEach-Object { "\$_" -replace '\s+', ' ' }) -join '; ' }
+  # REVIEW.md §7 order — the Verdict line is the LAST line of the envelope,
+  # so every first-match reader (verdict-label, the watcher, the merge guard)
+  # reads the verdict and never a finding's prose.
   if (\$label) {
-    "<<<VERDICT\`n## Code Review: Round $ROUND — PR #$PR @ $SHA\`n\`n### Verdict\`n\$label, P0=\$p0, P1=\$p1\`nEvent identity: \$(\$payload.event_id ?? 'unknown')\`nQualification: \$qualified\`nDisqualifiers: \$((\$disqualifierItems -join ', ') ?? 'none')\`n### Findings" | Out-File '$LOGW' -Encoding utf8
+    "<<<VERDICT\`n## Code Review: Round $ROUND — PR #$PR @ $SHA\`n\`n- model_requested: \$(\$payload.reviewer.model_requested)\`n- model_observed: \$(\$payload.reviewer.model_observed)\`n- reviewer_session: \$(\$payload.reviewer.session_id)\`n- escalations: \$escalationList\`n\`nEvent identity: \$(\$payload.event_id ?? 'unknown')\`nQualification: \$qualified\`nDisqualifiers: \$disqualifierList\`n### Findings" | Out-File '$LOGW' -Encoding utf8
     foreach (\$finding in \$findings) { Add-Content '$LOGW' ("finding: " + (\$finding | ConvertTo-Json -Compress)) -Encoding utf8 }
     Add-Content '$LOGW' '### Checklist' -Encoding utf8
     foreach (\$item in \$checklist) { Add-Content '$LOGW' ("checklist: " + (\$item | ConvertTo-Json -Compress)) -Encoding utf8 }
     Add-Content '$LOGW' '### Escalations' -Encoding utf8
     foreach (\$escalation in \$escalations) { Add-Content '$LOGW' ("escalation: " + (\$escalation | ConvertTo-Json -Compress)) -Encoding utf8 }
+    Add-Content '$LOGW' '### Verdict' -Encoding utf8
+    Add-Content '$LOGW' "\$label, P0=\$p0, P1=\$p1\$gate" -Encoding utf8
     Add-Content '$LOGW' 'VERDICT>>>' -Encoding utf8
   }
   Add-Content '$LOGW' "Model requested: \$(\$payload.reviewer.model_requested)" -Encoding utf8
@@ -303,18 +435,44 @@ if (-not \$proof) {
   if (\$null -ne \$payload.cost.usd) { Add-Content '$LOGW' ("Cost: \$" + [string]::Format([System.Globalization.CultureInfo]::InvariantCulture, '{0:0.####}', \$payload.cost.usd)) -Encoding utf8 }
   Add-Content '$LOGW' "Session: \$(\$payload.reviewer.session_id)" -Encoding utf8
   \$tree = 'unchanged'
+  # edda review removes the internal worktree it added and reports a failure
+  # only in its notes; the receipt relays that report, never assumes it.
+  \$treeCleanup = if ("\$(\$payload.notes)" -match 'worktree removal failed') { 'failed; product notes report a worktree removal failure' } else { 'removed' }
   \$policy = 'product-json:hard'
   \$session = \$payload.reviewer.session_id
   \$disqualifiers = \$disqualifierItems -join ','
 }
-"TRANSPORT=edda-review" | Out-File '$DONEW' -Encoding utf8
-"POLICY_RECEIPT=\$policy" | Add-Content '$DONEW' -Encoding utf8
-"SESSION=\$session" | Add-Content '$DONEW' -Encoding utf8
-"SESSION_MODE=$( [ -n "$PRODUCT_RESUME" ] && echo resume || echo new )" | Add-Content '$DONEW' -Encoding utf8
-"DISPATCH_EXIT=\$code" | Add-Content '$DONEW' -Encoding utf8
-"WORKTREE_CHECK=\$tree" | Add-Content '$DONEW' -Encoding utf8
-"QUALIFIED=\$(if (\$qualified) { 'true' } else { 'false' })" | Add-Content '$DONEW' -Encoding utf8
-"DISQUALIFIERS=\$disqualifiers" | Add-Content '$DONEW' -Encoding utf8
+\$dispatchExit = \$code
+# The scheduled task that runs this lane unregisters itself, as the legacy
+# lane does; a direct run (fixtures) has no task to clean.
+\$taskCleanup = 'not-applicable'
+if (Get-ScheduledTask -TaskName 'edda-review-pr$PR-r$ROUND' -ErrorAction SilentlyContinue) {
+  try { Unregister-ScheduledTask -TaskName 'edda-review-pr$PR-r$ROUND' -Confirm:\$false -ErrorAction Stop; \$taskCleanup = 'unregistered' }
+  catch { \$taskCleanup = "failed; \$(\$_.Exception.Message)"; \$_ | Out-File '$LOGW' -Append -Encoding utf8; \$code = 2 }
+}
+# One atomic terminal receipt, the shape review-round.sh reserve and the
+# watcher admit: buffered, then renamed into place.
+\$receiptTmp = "$DONEW.pending-\$PID"
+try {
+  [System.IO.File]::WriteAllLines(\$receiptTmp, [string[]]@(
+    'TRANSPORT=edda-review',
+    "POLICY_RECEIPT=\$policy",
+    "SESSION=\$session",
+    'SESSION_MODE=$SESSION_MODE',
+    "DISPATCH_EXIT=\$dispatchExit",
+    "FINAL_EXIT=\$code",
+    "WORKTREE_CHECK=\$tree",
+    "WORKTREE_CLEANUP=\$treeCleanup",
+    "TASK_CLEANUP=\$taskCleanup",
+    'TERMINAL_RECEIPT=complete',
+    "QUALIFIED=\$(if (\$qualified) { 'true' } else { 'false' })",
+    "DISQUALIFIERS=\$disqualifiers"
+  ), [System.Text.UTF8Encoding]::new(\$false))
+  Move-Item -LiteralPath \$receiptTmp -Destination '$DONEW' -Force
+} catch {
+  \$_ | Out-File '$LOGW' -Append -Encoding utf8
+  \$code = 2
+}
 exit \$code
 PS
     [ -s "$LANE" ] || { echo "review-pr.sh: Windows product lane generation produced no artifact" >&2; exit 1; }
@@ -335,18 +493,36 @@ if ! command -v jq >/dev/null 2>&1 || ! jq -e --arg sha '$SHA' '.subject.head_sh
   policy=missing
   session=unknown
   code=2
+  tree_cleanup=not-attempted
 else
   verdict=\$(jq -r '.verdict' "\$json")
   p0=\$(jq '[(.findings // [])[] | select(.severity == "P0")] | length' "\$json")
   p1=\$(jq '[(.findings // [])[] | select(.severity == "P1")] | length' "\$json")
   qualified=\$(jq -r '.qualified == true and ((.disqualifiers // []) | length == 0)' "\$json")
   disqualifiers=\$(jq -r '(.disqualifiers // []) | join(",")' "\$json")
-  case "\$verdict" in lgtm) label=LGTM;; changes-requested) label='Changes Requested';; *) label='';; esac
-  [ "\$label" != LGTM ] || [ "\$qualified" = true ] || label=''
+  disqualifier_list=\$(jq -r '(.disqualifiers // []) | if length == 0 then "none" else join(", ") end' "\$json")
+  # An unqualified LGTM (product exit 3) is provisional under REVIEW.md §6.4
+  # and never the merge gate (§8): its Verdict line says so without the LGTM
+  # token, so \`verdict-label\` cannot resolve it to review:lgtm, and its
+  # payload is published like any other outcome instead of discarded (#998).
+  gate=''
+  case "\$verdict" in
+    lgtm) if [ "\$qualified" = true ]; then label=LGTM; else label="Provisional — unqualified (disqualifiers: \$disqualifier_list)"; gate=' — not a merge-gate verdict'; fi ;;
+    changes-requested) label='Changes Requested' ;;
+    *) label='' ;;
+  esac
   : > '$LOG'
+  # REVIEW.md §7 order — the Verdict line is the LAST line of the envelope,
+  # so every first-match reader (verdict-label, the watcher, the merge guard)
+  # reads the verdict and never a finding's prose.
   if [ -n "\$label" ]; then
-    printf '<<<VERDICT\n## Code Review: Round $ROUND — PR #$PR @ $SHA\n\n### Verdict\n%s, P0=%s, P1=%s\n' "\$label" "\$p0" "\$p1" >> '$LOG'
+    printf '<<<VERDICT\n## Code Review: Round $ROUND — PR #$PR @ $SHA\n\n' >> '$LOG'
     jq -r '
+      "- model_requested: " + .reviewer.model_requested,
+      "- model_observed: " + .reviewer.model_observed,
+      "- reviewer_session: " + .reviewer.session_id,
+      "- escalations: " + ((.escalations // []) | if length == 0 then "none" else map(tostring | gsub("[[:space:]]+"; " ")) | join("; ") end),
+      "",
       "Event identity: " + (.event_id // "unknown"),
       "Qualification: " + ((.qualified == true and ((.disqualifiers // []) | length == 0)) | tostring),
       "Disqualifiers: " + ((.disqualifiers // []) | if length == 0 then "none" else join(", ") end),
@@ -356,39 +532,47 @@ else
       (.checklist[]? | "checklist: " + tojson),
       "### Escalations",
       (.escalations[]? | "escalation: " + tojson),
-      "VERDICT>>>"
+      "### Verdict"
     ' "\$json" >> '$LOG'
+    printf '%s, P0=%s, P1=%s%s\nVERDICT>>>\n' "\$label" "\$p0" "\$p1" "\$gate" >> '$LOG'
   fi
   jq -r '"Model requested: " + .reviewer.model_requested, "Model observed: " + .reviewer.model_observed, (if .cost.usd == null then empty else "Cost: $" + (.cost.usd|tostring) end), "Session: " + .reviewer.session_id' "\$json" >> '$LOG'
   tree=unchanged
+  # edda review removes the internal worktree it added and reports a failure
+  # only in its notes; the receipt relays that report, never assumes it.
+  tree_cleanup=\$(jq -r 'if ((.notes // "") | test("worktree removal failed")) then "failed; product notes report a worktree removal failure" else "removed" end' "\$json")
   policy=product-json:hard
   session=\$(jq -r '.reviewer.session_id' "\$json")
 fi
-printf 'TRANSPORT=edda-review\nPOLICY_RECEIPT=%s\nSESSION=%s\nSESSION_MODE=$( [ -n "$PRODUCT_RESUME" ] && echo resume || echo new )\nDISPATCH_EXIT=%s\nWORKTREE_CHECK=%s\nQUALIFIED=%s\nDISQUALIFIERS=%s\n' "\$policy" "\$session" "\$code" "\$tree" "\${qualified:-false}" "\${disqualifiers:-}" > '$DONE'
+# One atomic terminal receipt, the shape review-round.sh reserve and the
+# watcher admit: buffered, then renamed into place.
+receipt_tmp='$DONE.pending-'"\$\$"
+if printf 'TRANSPORT=edda-review\nPOLICY_RECEIPT=%s\nSESSION=%s\nSESSION_MODE=$SESSION_MODE\nDISPATCH_EXIT=%s\nFINAL_EXIT=%s\nWORKTREE_CHECK=%s\nWORKTREE_CLEANUP=%s\nTASK_CLEANUP=not-applicable\nTERMINAL_RECEIPT=complete\nQUALIFIED=%s\nDISQUALIFIERS=%s\n' \
+     "\$policy" "\$session" "\$code" "\$code" "\$tree" "\$tree_cleanup" "\${qualified:-false}" "\${disqualifiers:-}" > "\$receipt_tmp" \
+   && mv -f "\$receipt_tmp" '$DONE'; then :; else
+  echo "review-pr runner: terminal receipt publish failed; retained \$receipt_tmp" >> '$LOG'
+  code=2
+fi
 exit "\$code"
 RUN
     sh -n "$RUNNER" || exit 1
     chmod +x "$RUNNER"
   fi
+  if [ "$IS_WIN" = "1" ]; then
+    LANE_FILE_ARG=$LANEW
+    LAUNCH_DIRW=$ROOTW
+    write_windows_launcher
+  fi
   if [ "$DRY" = "1" ]; then echo "dry-run: product review adapter generated; nothing launched."; exit 0; fi
   rm -f "$LOG" "$DONE"
-  if [ "$IS_WIN" = "1" ]; then
-    TASK="edda-review-pr$PR-r$ROUND"
-    pwsh -NoProfile -Command "Unregister-ScheduledTask -TaskName '$TASK' -Confirm:\$false -ErrorAction SilentlyContinue; \$a=New-ScheduledTaskAction -Execute '$PWSH_EXE' -Argument '-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File \`\"$LANEW\`\"' -WorkingDirectory '$ROOTW'; Register-ScheduledTask -TaskName '$TASK' -Action \$a -RunLevel Limited | Out-Null; Start-ScheduledTask -TaskName '$TASK'" || exit 1
-  else
-    nohup "$RUNNER" >/dev/null 2>&1 &
-    pid=$!
-    sleep 1
-    kill -0 "$pid" 2>/dev/null || { echo "review-pr.sh: nohup process $pid died immediately" >&2; exit 1; }
-    echo "task=nohup pid=$pid state=Running"
-  fi
-  echo "log=$LOG"; echo "done=$DONE"
+  REVIEW_MAY_BE_RUNNING=1
+  if [ "$IS_WIN" = "1" ]; then start_windows_launcher; else start_posix_runner; fi
+  echo "log=$LOG"
+  echo "done=$DONE"
+  echo "session=$SID"
+  echo "review_round=$ROUND"
   exit 0
 }
-
-if [ "${EDDA_REVIEW_PRODUCT_ADAPTER:-1}" != "0" ] && product_review_supported; then
-  launch_product_review
-fi
 
 # ---- the spec, read at the BASE SHA -----------------------------------------
 # review.brief-source: REVIEW.md is always the base_sha version, never the head,
@@ -410,6 +594,13 @@ trap 'exit 1' HUP INT TERM
 if [ "$DRY" = 0 ]; then
   ROUND=$(sh "$SELF_DIR/review-round.sh" reserve "$PR" "$SHA" "$ROUND" "$SCRATCH") || exit 1
   REVIEW_RESERVED=1
+fi
+
+# The product-owned review command, once the shared round is reserved: it
+# launches and exits here, so the brief/spec machinery below is the legacy
+# transport only.
+if [ "${EDDA_REVIEW_PRODUCT_ADAPTER:-1}" != "0" ] && product_review_supported; then
+  launch_product_review
 fi
 SPEC="$SCRATCH/review-pr$PR-r$ROUND-spec.md"
 if [ -n "$SPEC_OVERRIDE" ]; then
@@ -644,6 +835,7 @@ fi
 if [ "$IS_WIN" = "1" ]; then
   command -v cygpath >/dev/null 2>&1 || { echo "review-pr.sh: cygpath not found" >&2; exit 1; }
   WTW=$(cygpath -w "$WT")
+  LAUNCH_DIRW=$WTW
   BRIEFW=$(cygpath -w "$BRIEF")
   LOGW=$(cygpath -w "$LOG")
   DONEW=$(cygpath -w "$DONE")
@@ -959,63 +1151,6 @@ if [ -z "$ISSUES" ]; then
   echo "review-pr.sh: WARNING: PR #$PR links no issue — the brief carries NO doneWhen, so this review has no acceptance ceiling (issue #683). The brief states this; obtain the issue before trusting the verdict." >&2
 fi
 
-write_windows_launcher() {
-  TASK="edda-review-pr$PR-r$ROUND"
-  cat > "$SCRATCH/review-pr$PR-r$ROUND-launch.ps1" <<PS
-foreach (\$f in @("$LOGW", "$DONEW", "$DONEW.err")) { if (Test-Path \$f) { [System.IO.File]::Delete(\$f) } }
-Unregister-ScheduledTask -TaskName '$TASK' -Confirm:\$false -ErrorAction SilentlyContinue
-\$action = New-ScheduledTaskAction -Execute "$PWSH_EXE" -Argument "-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File \`"$LANE_FILE_ARG\`"" -WorkingDirectory '$WTW'
-# The dispatch timeout is handled inside the child lane. Scheduler must not
-# preempt its finally block before it publishes the terminal receipt and
-# unregisters itself.
-\$settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Seconds 0) -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
-try {
-  Register-ScheduledTask -TaskName '$TASK' -Action \$action -Settings \$settings -RunLevel Limited -ErrorAction Stop | Out-Null
-  try { Start-ScheduledTask -TaskName '$TASK' -ErrorAction Stop }
-  catch {
-    \$startFailure = \$_.Exception.Message
-    \$taskCleanup = 'failed; task start did not reach cleanup'
-    try {
-      Unregister-ScheduledTask -TaskName '$TASK' -Confirm:\$false -ErrorAction Stop
-      \$taskCleanup = 'unregistered'
-    } catch {
-      \$taskCleanup = "failed; \$(\$_.Exception.Message)"
-      \$_ | Out-File '$LOGW' -Append -Encoding utf8
-    }
-    "review-pr launcher: Start-ScheduledTask failed: \$startFailure" | Out-File '$LOGW' -Append -Encoding utf8
-    \$receiptTmp = "$DONEW.pending-\$PID"
-    try {
-      [System.IO.File]::WriteAllLines(\$receiptTmp, [string[]]@(
-        'TRANSPORT=not-started',
-        'TOOL_FLAGS=not-started',
-        'SESSION=$SID',
-        'SESSION_MODE=$SESSION_MODE',
-        'DISPATCH_EXIT=2',
-        'FINAL_EXIT=2',
-        'WORKTREE_CHECK=not-started',
-        'WORKTREE_CLEANUP=preserved; scheduler start failed',
-        "TASK_CLEANUP=\$taskCleanup",
-        'TERMINAL_RECEIPT=complete'
-      ), [System.Text.UTF8Encoding]::new(\$false))
-      Move-Item -LiteralPath \$receiptTmp -Destination '$DONEW' -Force
-    } catch {
-      \$_ | Out-File '$LOGW' -Append -Encoding utf8
-    }
-    throw
-  }
-} catch { throw }
-\$st = ""
-for (\$i = 0; \$i -lt 20; \$i++) {
-  Start-Sleep -Seconds 1
-  \$st = (Get-ScheduledTask -TaskName '$TASK').State
-  if (\$st -eq 'Running') { break }
-}
-\$info = Get-ScheduledTaskInfo -TaskName '$TASK'
-"task=$TASK state=\$st lastTaskResult=\$(\$info.LastTaskResult)"
-PS
-
-}
-
 if [ "$DRY" = "1" ] && [ "$IS_WIN" = "1" ]; then
   write_windows_launcher
 fi
@@ -1073,45 +1208,12 @@ if [ "$IS_WIN" = "1" ]; then
   # Windows: Task Scheduler, not nohup (fleet.lane-launch). HOME and UTF-8 are
   # empty/CP950 in the scheduled-task environment; the lane script generated
   # above sets them explicitly before dispatching.
-  command -v pwsh >/dev/null 2>&1 || { echo "review-pr.sh: pwsh not found" >&2; exit 1; }
   write_windows_launcher
-
   REVIEW_MAY_BE_RUNNING=1
-  out=$(pwsh -NoProfile -ExecutionPolicy Bypass -File "$SCRATCH/review-pr$PR-r$ROUND-launch.ps1" 2>&1); rc=$?
-  echo "$out"
-  [ $rc -eq 0 ] || exit 1
-  case "$out" in
-    *state=Running*) : ;;
-    *)
-      # Task Scheduler says nothing useful about why. LastTaskResult=64 has now
-      # been observed from three unrelated path faults on two machines, and the
-      # lane script that everyone reads next was never reached, so name the one
-      # thing only this process knows: whether the -File argument it generated
-      # resolves for the pwsh that Task Scheduler starts (issue #683).
-      echo "review-pr.sh: scheduled task did not reach Running" >&2
-      if pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass \
-           -Command "if (Test-Path -LiteralPath '$LANE_FILE_ARG') { exit 0 } else { exit 1 }" \
-           >/dev/null 2>&1; then
-        echo "review-pr.sh: the task's -File argument resolves for pwsh: $LANE_FILE_ARG — the fault is inside the lane script or its environment, not the path. Read $SCRATCH/review-pr$PR-r$ROUND.log" >&2
-      else
-        echo "review-pr.sh: the task's -File argument does NOT resolve for pwsh: $LANE_FILE_ARG — this is the LastTaskResult=64 failure of issue #683: the task registers and starts, then exits before writing any log or .done file. Check that \$EDDA_FLEET_SCRATCH is Windows-resolvable" >&2
-      fi
-      exit 1
-      ;;
-  esac
-fi
-
-if [ "$IS_WIN" = "0" ]; then
+  start_windows_launcher
+else
   REVIEW_MAY_BE_RUNNING=1
-  nohup "$RUNNER" >/dev/null 2>&1 &
-  pid=$!
-  sleep 1
-  if kill -0 "$pid" 2>/dev/null; then
-    echo "task=nohup pid=$pid state=Running"
-  else
-    echo "review-pr.sh: nohup process $pid died immediately" >&2
-    exit 1
-  fi
+  start_posix_runner
 fi
 
 echo "log=$LOG"

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -452,6 +452,9 @@ expect_gate_state 'two qualifying LGTMs are success' 'success' 'LGTM\t0\t0\nLGTM
 expect_gate_state 'a missing count is non-zero, never success' 'failure' 'LGTM\t0\n'
 expect_gate_state 'a non-numeric count is non-zero, never success' 'failure' 'LGTM\tx\ty\n'
 expect_gate_state 'an unknown verdict word is failure' 'failure' 'Needs Discussion\t0\t0\n'
+# REVIEW.md §6.4/§8: an unqualified LGTM (edda review exit 3) is provisional —
+# it never satisfies the gate, even at P0=0 P1=0 (#998).
+expect_gate_state 'a provisional verdict never qualifies' 'failure' 'Provisional\t0\t0\n'
 
 # --- collect-verdicts: read the §7 verdict comments pinned to one SHA ---------
 # The fixture holds the OUTPUT of the gh --jq pipeline (sentinel + raw
@@ -511,6 +514,13 @@ f="$tmp/comments-wrong-sha"
 verdict_comment 1 "$csha2" 'Changes Requested, P0=1, P1=0 — x' >"$f"
 expect_collect 'a verdict pinned to another sha contributes nothing' \
     '' "$f" "$csha1"
+
+# #998: the product adapter's exit-3 Verdict line carries no LGTM token; the
+# reader names it Provisional and still reads its counts.
+f="$tmp/comments-provisional"
+verdict_comment 1 "$csha1" 'Provisional — unqualified (disqualifiers: escalation-pending), P0=0, P1=1 — not a merge-gate verdict' >"$f"
+expect_collect 'a provisional (unqualified LGTM) verdict line is read as Provisional with its counts' \
+    "$(printf 'Provisional\t0\t1')" "$f" "$csha1"
 
 # T1: a failed comments fetch must be an error, never "no prior verdicts" —
 # otherwise the union rule would run on this round's verdict alone.
@@ -1087,6 +1097,152 @@ if ! grep -qF -- '--add-label review:lgtm' "$GH_STUB_LOG"; then
     printf 'live: the label should be applied after the comments recover\n' >&2
     exit 1
 fi
+
+# --- live loop: an exit-3 product round is published, not retried (#998) ------
+# `edda review` exit 3 is an unqualified LGTM — provisional under REVIEW.md
+# §6.4, never `LGTM (P0=0, P1=0)`, never the merge gate (§8). The product
+# adapter writes the whole payload under a `Provisional — …` Verdict line. The
+# watcher posts that comment, writes the Independent Review status through the
+# union rule (non-success), applies no review:* label and settles the round —
+# it neither probes the provider nor spends the single dispatch retry. The
+# stale-envelope guard above (an LGTM line with exit 3) is untouched.
+
+product_done_fixture() { # $1=product exit (DISPATCH_EXIT and FINAL_EXIT) $2=qualified $3=disqualifiers
+    printf 'TRANSPORT=edda-review\nPOLICY_RECEIPT=product-json:hard\nSESSION=11111111-2222-4333-8444-555555555555\nSESSION_MODE=new\nDISPATCH_EXIT=%s\nFINAL_EXIT=%s\nWORKTREE_CHECK=unchanged\nWORKTREE_CLEANUP=removed\nTASK_CLEANUP=not-applicable\nTERMINAL_RECEIPT=complete\nQUALIFIED=%s\nDISQUALIFIERS=%s\n' \
+        "$1" "$1" "$2" "$3" >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
+}
+
+product_log_fixture() { # $1=Verdict line $2=prose after it (default none) — the envelope
+                        # scripts/review-pr.sh's product adapter writes: §7 order, Verdict last
+    {
+        printf '<<<VERDICT\n## Code Review: Round 1 — PR #42 @ %s\n\n' "$sha"
+        printf -- '- model_requested: claude-opus-5\n- model_observed: claude-opus-5\n- reviewer_session: 11111111-2222-4333-8444-555555555555\n- escalations: D5 escalation-pending\n\n'
+        printf 'Event identity: evt_fixture\nQualification: false\nDisqualifiers: escalation-pending\n'
+        printf '### Findings\nfinding: {"severity":"P1","file":"scripts/x.sh","line":1,"claim":"would be LGTM once D5 closes","evidence":"x:1","rule":"D5","status":"open"}\n'
+        printf '### Checklist\nchecklist: {"item":"D5","result":"escalate","measure":"cannot close"}\n'
+        printf '### Escalations\nescalation: "D5 escalation-pending"\n'
+        printf '### Verdict\n%s\n' "$1"
+        [ -z "${2:-}" ] || printf '%s\n' "$2"
+        printf 'VERDICT>>>\n'
+        printf 'Model requested: claude-opus-5\nModel observed: claude-opus-5\nCost: $3.12\nSession: 11111111-2222-4333-8444-555555555555\n'
+    } >"$EDDA_FLEET_SCRATCH/review-pr42-r1.log"
+}
+
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+product_done_fixture 3 false escalation-pending
+product_log_fixture 'Provisional — unqualified (disqualifiers: escalation-pending), P0=0, P1=1 — not a merge-gate verdict'
+export GH_HEAD="$sha"
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (product exit 3)\n' >&2; exit 1; }
+cfile=$(header_comment_path)
+[ -n "$cfile" ] || {
+    printf 'live: product exit 3 — the provisional verdict comment was not posted; watch.log tail:\n%s\n' \
+        "$(tail -4 "$PR_REVIEW_WATCH_LOG")" >&2; exit 1
+}
+comment_head_is_heading "$cfile" || {
+    printf 'live: product exit 3 — the posted comment must begin with the §7 heading, got:\n%s\n' "$(head -1 "$cfile")" >&2; exit 1
+}
+grep -qF 'Provisional — unqualified' "$cfile" || {
+    printf 'live: product exit 3 — the posted comment lost the provisional Verdict line\n' >&2; exit 1
+}
+grep -qF '"rule":"D5"' "$cfile" || {
+    printf 'live: product exit 3 — the posted comment lost the findings\n' >&2; exit 1
+}
+[ "$(statuses_calls)" = "1" ] || {
+    printf 'live: product exit 3 — exactly one Independent Review status expected, got %s\n' "$(statuses_calls)" >&2; exit 1
+}
+grep -qF -- '-f state=failure' "$GH_STUB_LOG" || {
+    printf 'live: product exit 3 — a provisional round must not be status success, got:\n%s\n' \
+        "$(grep 'statuses/' "$GH_STUB_LOG")" >&2; exit 1
+}
+grep -qF -- '-f description=Provisional P0=0 P1=1' "$GH_STUB_LOG" || {
+    printf 'live: product exit 3 — the status description must name the provisional verdict, got:\n%s\n' \
+        "$(grep 'statuses/' "$GH_STUB_LOG")" >&2; exit 1
+}
+if grep -qF -- '--add-label review:' "$GH_STUB_LOG"; then
+    printf 'live: product exit 3 — a provisional round applies no review:* label, got:\n%s\n' \
+        "$(grep -F -- '--add-label review:' "$GH_STUB_LOG")" >&2; exit 1
+fi
+[ -z "$(cat "$REVIEW_STUB_LOG")" ] || {
+    printf 'live: product exit 3 — must not spend the dispatch retry, got:\n%s\n' "$(cat "$REVIEW_STUB_LOG")" >&2; exit 1
+}
+if grep -q 'agent claude' "$EDDA_STUB_LOG"; then
+    printf 'live: product exit 3 — must not probe the provider (it is not a dead verdict)\n' >&2; exit 1
+fi
+[ "$(state_get)" = "$(printf '42\t%s\t1' "$sha")" ] || {
+    printf 'live: product exit 3 — the round must settle as reviewed, got:\n%s\n' "$(state_get)" >&2; exit 1
+}
+[ -z "$(pending_get)" ] || {
+    printf 'live: product exit 3 — the pending entry must be dropped, got:\n%s\n' "$(pending_get)" >&2; exit 1
+}
+grep -qF 'not a merge-gate verdict' "$PR_REVIEW_WATCH_LOG" || {
+    printf 'live: product exit 3 — the log must say why no label was applied, got:\n%s\n' "$(tail -3 "$PR_REVIEW_WATCH_LOG")" >&2; exit 1
+}
+unset GH_HEAD
+
+# The Verdict line decides, not prose after it: verdict-label reads on past a
+# line it does not recognise and would answer review:lgtm here; the watcher
+# still applies no label to a Provisional round.
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+product_done_fixture 3 false escalation-pending
+product_log_fixture 'Provisional — unqualified (disqualifiers: escalation-pending), P0=0, P1=1 — not a merge-gate verdict' \
+    'Note: would be LGTM once D5 closes.'
+export GH_HEAD="$sha"
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (product exit 3, trailing prose)\n' >&2; exit 1; }
+if grep -qF -- '--add-label review:' "$GH_STUB_LOG"; then
+    printf 'live: product exit 3 — prose after the Provisional line must not earn a label, got:\n%s\n' \
+        "$(grep -F -- '--add-label review:' "$GH_STUB_LOG")" >&2; exit 1
+fi
+grep -qF -- '-f state=failure' "$GH_STUB_LOG" || {
+    printf 'live: product exit 3 (trailing prose) — the status must still be failure\n' >&2; exit 1
+}
+[ -z "$(pending_get)" ] || {
+    printf 'live: product exit 3 (trailing prose) — the round must settle, got:\n%s\n' "$(pending_get)" >&2; exit 1
+}
+unset GH_HEAD
+
+# A Changes Requested product round exits 1 — the verdict, not a failure — and
+# is published the same way, with its label.
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+product_done_fixture 1 true ''
+product_log_fixture 'Changes Requested, P0=0, P1=1'
+export GH_HEAD="$sha"
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (product exit 1)\n' >&2; exit 1; }
+cfile=$(header_comment_path)
+[ -n "$cfile" ] || {
+    printf 'live: product exit 1 — the Changes Requested comment was not posted; watch.log tail:\n%s\n' \
+        "$(tail -4 "$PR_REVIEW_WATCH_LOG")" >&2; exit 1
+}
+grep -qF -- '-f state=failure' "$GH_STUB_LOG" || {
+    printf 'live: product exit 1 — the status must be failure\n' >&2; exit 1
+}
+grep -qF -- '--add-label review:changes-requested' "$GH_STUB_LOG" || {
+    printf 'live: product exit 1 — the label must be applied\n' >&2; exit 1
+}
+[ -z "$(pending_get)" ] || {
+    printf 'live: product exit 1 — the round must settle, got:\n%s\n' "$(pending_get)" >&2; exit 1
+}
+unset GH_HEAD
+
+# A prior Provisional comment on the same sha is not a standing verdict: once
+# the escalation is adjudicated, a qualified LGTM round on that sha clears the
+# gate (the merge guard reads the latest round, and so does this union).
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+printf 'TRANSPORT=edda-dispatch\nDISPATCH_EXIT=0\nFINAL_EXIT=0\nWORKTREE_CHECK=unchanged\nWORKTREE_CLEANUP=removed\nTASK_CLEANUP=not-applicable\nTERMINAL_RECEIPT=complete\n' >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
+verdict_log_fixture
+printf '<<<COMMENT>>>\n## Code Review: Round 1 — PR #42 @ %s\n\n### Verdict\nProvisional — unqualified (disqualifiers: escalation-pending), P0=0, P1=0 — not a merge-gate verdict\n' \
+    "$sha" >"$tmp/comments-pr42-prior-provisional"
+export GH_HEAD="$sha"
+export GH_COMMENTS_FILE="$tmp/comments-pr42-prior-provisional"
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (prior provisional)\n' >&2; exit 1; }
+grep -qF -- '-f state=success' "$GH_STUB_LOG" || {
+    printf 'live: a prior provisional round must not hold a later qualified LGTM at failure, got:\n%s\n' \
+        "$(grep 'statuses/' "$GH_STUB_LOG")" >&2; exit 1
+}
+unset GH_HEAD GH_COMMENTS_FILE
 
 # --- R23 (#917): verdict shape and non-open PRs --------------------------------
 # 1. the happy path is unchanged: a §7 carrier (heading first) posts the

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -455,6 +455,16 @@ expect_gate_state 'an unknown verdict word is failure' 'failure' 'Needs Discussi
 # REVIEW.md §6.4/§8: an unqualified LGTM (edda review exit 3) is provisional —
 # it never satisfies the gate, even at P0=0 P1=0 (#998).
 expect_gate_state 'a provisional verdict never qualifies' 'failure' 'Provisional\t0\t0\n'
+# A Provisional round stands in the union by its counts (#1023 round 1):
+# at P0=P1=0 it is pending — never success on its own, cleared by a later
+# qualified LGTM on the same sha once the escalation is adjudicated (REVIEW.md
+# §6.4); with any P0/P1 it stands like any other non-qualifying verdict (§8,
+# GH-742), so a later LGTM on that sha cannot turn the gate green.
+expect_gate_state 'a provisional 0/0 is cleared by a later qualified LGTM on the same sha' \
+    'success' 'Provisional\t0\t0\nLGTM\t0\t0\n'
+expect_gate_state 'a provisional round with findings holds a later LGTM at failure' \
+    'failure' 'Provisional\t0\t2\nLGTM\t0\t0\n'
+expect_gate_state 'a provisional round with findings alone is failure' 'failure' 'Provisional\t0\t2\n'
 
 # --- collect-verdicts: read the §7 verdict comments pinned to one SHA ---------
 # The fixture holds the OUTPUT of the gh --jq pipeline (sentinel + raw
@@ -1240,6 +1250,24 @@ export GH_COMMENTS_FILE="$tmp/comments-pr42-prior-provisional"
 run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (prior provisional)\n' >&2; exit 1; }
 grep -qF -- '-f state=success' "$GH_STUB_LOG" || {
     printf 'live: a prior provisional round must not hold a later qualified LGTM at failure, got:\n%s\n' \
+        "$(grep 'statuses/' "$GH_STUB_LOG")" >&2; exit 1
+}
+unset GH_HEAD GH_COMMENTS_FILE
+
+# A prior Provisional round WITH findings is a standing non-qualifying verdict:
+# its counts stay in the union, so a later qualified LGTM on the same sha does
+# not turn the gate green (REVIEW.md §8, GH-742; #1023 round 1).
+reset_stubs
+pending_set 42 1 "$sha" 0 0
+printf 'TRANSPORT=edda-dispatch\nDISPATCH_EXIT=0\nFINAL_EXIT=0\nWORKTREE_CHECK=unchanged\nWORKTREE_CLEANUP=removed\nTASK_CLEANUP=not-applicable\nTERMINAL_RECEIPT=complete\n' >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
+verdict_log_fixture
+printf '<<<COMMENT>>>\n## Code Review: Round 1 — PR #42 @ %s\n\n### Verdict\nProvisional — unqualified (disqualifiers: escalation-pending), P0=0, P1=1 — not a merge-gate verdict\n' \
+    "$sha" >"$tmp/comments-pr42-prior-provisional-findings"
+export GH_HEAD="$sha"
+export GH_COMMENTS_FILE="$tmp/comments-pr42-prior-provisional-findings"
+run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (prior provisional with findings)\n' >&2; exit 1; }
+grep -qF -- '-f state=failure' "$GH_STUB_LOG" || {
+    printf 'live: a prior provisional round with open findings must hold a later LGTM at failure, got:\n%s\n' \
         "$(grep 'statuses/' "$GH_STUB_LOG")" >&2; exit 1
 }
 unset GH_HEAD GH_COMMENTS_FILE

--- a/scripts/test-review-adapter.sh
+++ b/scripts/test-review-adapter.sh
@@ -10,6 +10,9 @@ mkdir -p "$tmp/bin" "$tmp/scratch"
 sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 export EDDA_FLEET_ROOT="$root" EDDA_FLEET_SCRATCH="$tmp/scratch" EDDA_REPO=fixture/repo
 export EDDA_REVIEW_PRODUCT_ADAPTER=1 PATH="$tmp/bin:$PATH"
+# Round reservation (scripts/review-round.sh) is machine-local shared state:
+# the launch fixtures below must never write the real ~/.edda/review-coordination.
+export EDDA_REVIEW_COORD_DIR="$tmp/coord"
 
 cat >"$tmp/bin/uname" <<'EOF'
 #!/bin/sh
@@ -18,6 +21,7 @@ EOF
 cat >"$tmp/bin/gh" <<EOF
 #!/bin/sh
 case "\$*" in
+  *api*comments*) echo '[]' ;;
   *headRefOid*) echo '$sha' ;;
   *headRefName*|*baseRefName*) echo main ;;
   *baseRefOid*) echo bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ;;
@@ -29,6 +33,7 @@ cat >"$tmp/bin/edda" <<EOF
 #!/bin/sh
 if [ "\$1 \$2" = 'review --help' ]; then echo '--pr N --agent AGENT --model MODEL --json --resume'; exit 0; fi
 printf '%s\n' "\$*" >> "\$EDDA_FLEET_SCRATCH/argv"
+[ -z "\${ADAPTER_SLEEP:-}" ] || sleep "\$ADAPTER_SLEEP"
 case "\${ADAPTER_CASE:-ok}" in
   malformed) printf '{not json\n'; exit 2 ;;
   changed) proof=failed; policy=hard; head='$sha' ;;
@@ -36,9 +41,10 @@ case "\${ADAPTER_CASE:-ok}" in
   wrong-head) proof=unchanged; policy=hard; head=cccccccccccccccccccccccccccccccccccccccc ;;
   unqualified) proof=unchanged; policy=hard; head='$sha'; verdict=lgtm; qualified=false; disqualifiers='["gates-red","escalation-pending"]'; exit_code=3 ;;
   detailed) proof=unchanged; policy=hard; head='$sha'; verdict=changes-requested; qualified=true; disqualifiers='[]'; exit_code=1 ;;
+  removal-failed) proof=unchanged; policy=hard; head='$sha'; verdict=changes-requested; qualified=true; disqualifiers='[]'; exit_code=1; notes='worktree removal failed: fixture' ;;
   *) proof=unchanged; policy=hard; head='$sha'; verdict=changes-requested; qualified=true; disqualifiers='[]'; exit_code=1 ;;
 esac
-printf '{"event_id":"evt_fixture_review","subject":{"head_sha":"%s","subject_seen":"%s","worktree_check":"%s"},"reviewer":{"tool_policy":"%s","model_requested":"fixture-model","model_observed":"fixture-observed","session_id":"fixture-session"},"verdict":"%s","qualified":%s,"disqualifiers":%s,"findings":[{"severity":"P1","file":"scripts/review-pr.sh","line":261,"claim":"fixture claim","evidence":"fixture:evidence","rule":"C1","status":"open"}],"checklist":[{"item":"adapter fixture","result":"ran","measure":"fixture-measure"}],"escalations":["fixture escalation"],"cost":{"usd":0.25}}\n' "\$head" "\$head" "\$proof" "\$policy" "\${verdict:-changes-requested}" "\${qualified:-true}" "\${disqualifiers:-[]}"
+printf '{"event_id":"evt_fixture_review","subject":{"head_sha":"%s","subject_seen":"%s","worktree_check":"%s"},"reviewer":{"tool_policy":"%s","model_requested":"fixture-model","model_observed":"fixture-observed","session_id":"fixture-session"},"verdict":"%s","qualified":%s,"disqualifiers":%s,"findings":[{"severity":"P1","file":"scripts/review-pr.sh","line":261,"claim":"fixture claim","evidence":"fixture:evidence","rule":"C1","status":"open"}],"checklist":[{"item":"adapter fixture","result":"ran","measure":"fixture-measure"}],"escalations":["fixture escalation"],"cost":{"usd":0.25},"notes":"%s"}\n' "\$head" "\$head" "\$proof" "\$policy" "\${verdict:-changes-requested}" "\${qualified:-true}" "\${disqualifiers:-[]}" "\${notes:-}"
 exit "\${exit_code:-1}"
 EOF
 chmod +x "$tmp/bin/uname" "$tmp/bin/gh" "$tmp/bin/edda"
@@ -54,6 +60,18 @@ run_case() { # name expected-check round
   grep -q "^WORKTREE_CHECK=$expected" "$done" || { cat "$done" >&2; echo "$name: unexpected worktree receipt" >&2; return 1; }
 }
 
+# The Verdict line `scripts/review-pr.sh verdict-label` reads from one round's
+# envelope — the label the watcher would apply.
+label_of() { # $1=lane log
+  sed -n '/^<<<VERDICT$/,/^VERDICT>>>$/p' "$1" | sh "$root/scripts/review-pr.sh" verdict-label
+}
+# REVIEW.md §7 order: the Verdict line is the last line of the envelope, so a
+# first-match reader can never take a finding's prose for the verdict (#998).
+verdict_is_last() { # $1=lane log
+  [ "$(sed -n '/^### Verdict$/,/^VERDICT>>>$/p' "$1" | wc -l | tr -d ' ')" = 3 ] \
+    || { cat "$1" >&2; echo "$2: the Verdict line is not the last line of the envelope" >&2; exit 1; }
+}
+
 run_case ok unchanged 1
 done="$EDDA_FLEET_SCRATCH/review-pr9999-r1.done"
 log="$EDDA_FLEET_SCRATCH/review-pr9999-r1.log"
@@ -62,21 +80,47 @@ grep -q '^POLICY_RECEIPT=product-json:hard$' "$done"
 grep -q '^Changes Requested, P0=0, P1=1$' "$log"
 if grep -q '^TOOL_FLAGS=' "$done"; then echo 'ok: legacy policy string was fabricated' >&2; exit 1; fi
 grep -q 'nohup "\$RUNNER"' "$root/scripts/review-pr.sh"
+# The product receipt is the same atomic terminal object the legacy lane
+# publishes (#998): scripts/review-round.sh reserve and the watcher's terminal
+# gate read FINAL_EXIT / WORKTREE_CLEANUP / TASK_CLEANUP / TERMINAL_RECEIPT,
+# and a receipt without them blocks every later round of the PR.
+for line in 'FINAL_EXIT=1' 'WORKTREE_CLEANUP=removed' 'TASK_CLEANUP=not-applicable' 'TERMINAL_RECEIPT=complete'; do
+  grep -qx "$line" "$done" || { cat "$done" >&2; echo "ok: product receipt lacks $line" >&2; exit 1; }
+done
+# The envelope names the engine the way REVIEW.md §7 does, so the watcher's
+# rules.md R22 executor can tell an authoritative round from a SHADOW one.
+grep -qx -- '- model_observed: fixture-observed' "$log" || { cat "$log" >&2; echo 'ok: envelope carries no model_observed header' >&2; exit 1; }
+grep -qx -- '- escalations: fixture escalation' "$log" || { cat "$log" >&2; echo 'ok: envelope carries no escalations header' >&2; exit 1; }
+verdict_is_last "$log" ok
+[ "$(label_of "$log")" = review:changes-requested ] || { echo 'ok: verdict-label did not read Changes Requested' >&2; exit 1; }
 
 for case_name in changed policy wrong-head malformed; do run_case "$case_name" 'failed;' 1; done
 ADAPTER_CASE=ok run_case ok unchanged 2
 grep -q -- '--resume' "$EDDA_FLEET_SCRATCH/argv"
 grep -q -- '--agent claude --model claude-opus-5 --json --resume' "$EDDA_FLEET_SCRATCH/argv"
 
-# An unqualified LGTM has product exit 3. It must reach the adapter receipt as
-# such and must never manufacture the marker the watcher maps to review:lgtm.
+# An unqualified LGTM has product exit 3 — provisional under REVIEW.md §6.4,
+# never `LGTM (P0=0, P1=0)`, never the merge gate (§8). The adapter publishes
+# the whole payload (findings, checklist, escalations) under a Verdict line
+# that says so without the LGTM token, so verdict-label cannot resolve it to
+# review:lgtm and the watcher posts it instead of discarding a $3 review (#998).
 run_case unqualified unchanged 3
 done="$EDDA_FLEET_SCRATCH/review-pr9999-r3.done"
 log="$EDDA_FLEET_SCRATCH/review-pr9999-r3.log"
 grep -q '^DISPATCH_EXIT=3$' "$done"
+grep -q '^FINAL_EXIT=3$' "$done" || { cat "$done" >&2; echo 'unqualified: FINAL_EXIT does not carry the product exit' >&2; exit 1; }
 grep -q '^QUALIFIED=false$' "$done"
 grep -q '^DISQUALIFIERS=gates-red,escalation-pending$' "$done"
-if grep -q '^<<<VERDICT$' "$log"; then echo 'unqualified: adapter emitted an approval-capable verdict envelope' >&2; exit 1; fi
+grep -q '^<<<VERDICT$' "$log" || { cat "$log" >&2; echo 'unqualified: exit 3 discarded the review payload (no verdict envelope)' >&2; exit 1; }
+grep -qx 'Provisional — unqualified (disqualifiers: gates-red, escalation-pending), P0=0, P1=1 — not a merge-gate verdict' "$log" \
+  || { cat "$log" >&2; echo 'unqualified: the Verdict line does not state the provisional outcome' >&2; exit 1; }
+grep -q '"claim":"fixture claim"' "$log" || { echo 'unqualified: findings were not written' >&2; exit 1; }
+grep -q '"item":"adapter fixture"' "$log" || { echo 'unqualified: checklist was not written' >&2; exit 1; }
+grep -q 'fixture escalation' "$log" || { echo 'unqualified: escalations were not written' >&2; exit 1; }
+if grep -qE '^(LGTM|Changes Requested)' "$log"; then echo 'unqualified: adapter emitted a merge-gate verdict line for an unqualified LGTM' >&2; exit 1; fi
+verdict_is_last "$log" unqualified
+vl=$(label_of "$log")
+[ -z "$vl" ] || { echo "unqualified: verdict-label resolved the provisional round to '$vl'" >&2; exit 1; }
 
 # The generated child retains the complete structured product material inside
 # the verdict envelope that the watcher copies into its PR comment carrier.
@@ -93,6 +137,12 @@ grep -q '^### Escalations$' "$log"
 grep -q 'fixture escalation' "$log"
 [ -s "$log.json" ] || { echo 'detailed: product JSON was discarded before a reviewer could inspect it' >&2; exit 1; }
 
+# WORKTREE_CLEANUP relays the product's own report: `edda review` removes the
+# internal worktree it added and records a failure only in `notes`.
+run_case removal-failed unchanged 7
+done="$EDDA_FLEET_SCRATCH/review-pr9999-r7.done"
+grep -q '^WORKTREE_CLEANUP=failed' "$done" || { cat "$done" >&2; echo 'removal-failed: a product-reported removal failure was relayed as removed' >&2; exit 1; }
+
 # First use starts without the state directory. The selected product path owns
 # creation before it writes its lane/runner artifacts.
 rm -rf "$EDDA_FLEET_SCRATCH"
@@ -100,11 +150,44 @@ ADAPTER_CASE=ok timeout 20 "$root/scripts/review-pr.sh" 9999 5 --dry-run >/dev/n
 [ -d "$EDDA_FLEET_SCRATCH" ] || { echo 'fresh scratch: product adapter did not create its state directory' >&2; exit 1; }
 [ -s "$EDDA_FLEET_SCRATCH/review-pr9999-r5-run.sh" ] || { echo 'fresh scratch: product runner was not generated' >&2; exit 1; }
 
+# Not a dry run: the product path reserves the shared round exactly like the
+# brief path and prints the same receipts — without `review_round=` the
+# watcher logs "launcher returned no shared round receipt; refusing to guess
+# artifact paths" and never tracks the round (#998). Round 2 is admitted only
+# through round 1's clean terminal receipt, so a product receipt short of one
+# would block every later round of the PR.
+wait_done() { # $1=.done path
+  for _ in $(seq 1 30); do [ -f "$1" ] && return 0; sleep 1; done
+  echo "launch: no terminal receipt at $1" >&2; exit 1
+}
+launch() { # $1=case $2=round -> stdout of the launcher (fails loudly)
+  if ! ADAPTER_CASE=$1 ADAPTER_SLEEP=2 timeout 30 "$root/scripts/review-pr.sh" 9999 "$2"; then
+    echo "launch: round $2 ($1) failed to launch" >&2; exit 1
+  fi
+}
+rm -f "$EDDA_FLEET_SCRATCH/argv"
+out=$(launch unqualified 1)
+for key in log done session review_round; do
+  printf '%s\n' "$out" | grep -q "^$key=" || { printf '%s\n' "$out" >&2; echo "launch: product path printed no $key= receipt" >&2; exit 1; }
+done
+printf '%s\n' "$out" | grep -qx 'review_round=1' || { printf '%s\n' "$out" >&2; echo 'launch: round 1 was not reserved as round 1' >&2; exit 1; }
+[ -f "$tmp/coord/fixture/repo/pr9999/active" ] || { echo 'launch: the product path reserved no shared round' >&2; exit 1; }
+wait_done "$EDDA_FLEET_SCRATCH/review-pr9999-r1.done"
+grep -q '^DISPATCH_EXIT=3$' "$EDDA_FLEET_SCRATCH/review-pr9999-r1.done"
+out=$(launch ok 2)
+printf '%s\n' "$out" | grep -qx 'review_round=2' || { printf '%s\n' "$out" >&2; echo 'launch: round 2 was not admitted through round 1 terminal receipt' >&2; exit 1; }
+wait_done "$EDDA_FLEET_SCRATCH/review-pr9999-r2.done"
+grep -q -- '--resume' "$EDDA_FLEET_SCRATCH/argv"
+
 # Execute the generated Windows artifact itself. This catches Bash expanding
 # PowerShell backticks in the generator, which outer sh -n cannot see.
 cat >"$tmp/bin/edda.cmd" <<EOF
 @echo off
 if "%1"=="review" if "%2"=="--help" (echo --pr N --agent AGENT --model MODEL --json --resume & exit /b 0)
+if "%ADAPTER_CASE%"=="unqualified" (
+ echo {"event_id":"evt_fixture_review","subject":{"head_sha":"$sha","subject_seen":"$sha","worktree_check":"unchanged"},"reviewer":{"tool_policy":"hard","model_requested":"fixture-model","model_observed":"fixture-observed","session_id":"fixture-session"},"verdict":"lgtm","qualified":false,"disqualifiers":["gates-red","escalation-pending"],"findings":[{"severity":"P1","file":"fixture.ps1","line":12,"claim":"windows fixture","evidence":"fixture:evidence","rule":"C1","status":"open"}],"checklist":[{"item":"adapter fixture","result":"ran","measure":"fixture-measure"}],"escalations":["fixture escalation"],"cost":{"usd":0.25}}
+ exit /b 3
+)
 echo {"event_id":"evt_fixture_review","subject":{"head_sha":"$sha","subject_seen":"$sha","worktree_check":"unchanged"},"reviewer":{"tool_policy":"hard","model_requested":"fixture-model","model_observed":"fixture-observed","session_id":"fixture-session"},"verdict":"changes-requested","qualified":true,"disqualifiers":[],"findings":[{"severity":"P1","file":"fixture.ps1","line":12,"claim":"windows fixture","evidence":"fixture:evidence","rule":"C1","status":"open"}],"checklist":[],"escalations":[],"cost":{"usd":0.25}}
 exit /b 1
 EOF
@@ -112,13 +195,82 @@ rm -rf "$EDDA_FLEET_SCRATCH"
 ADAPTER_PLATFORM=MINGW64_NT ADAPTER_CASE=ok timeout 20 "$root/scripts/review-pr.sh" 9999 6 --dry-run >/dev/null
 lane="$EDDA_FLEET_SCRATCH/review-pr9999-r6-lane.ps1"
 [ -s "$lane" ] || { echo 'windows: generated lane is empty' >&2; exit 1; }
+pwsh_bin=$(command -v pwsh)
+
+# The scheduled-task launcher is generated on disk as well, so the exact
+# -Argument Task Scheduler would register is provable without registering a
+# task: the inline registration used to single-quote it, which made the
+# backticks literal (`-File `"C:\…`"`) and every product task died with
+# LastTaskResult=64 before the lane ran (#998; the #683 signature).
+launch_ps1="$EDDA_FLEET_SCRATCH/review-pr9999-r6-launch.ps1"
+[ -s "$launch_ps1" ] || { echo 'windows: product launcher was not generated on disk' >&2; exit 1; }
+cat >"$tmp/ps-check.ps1" <<'EOF'
+param([string]$Path, [string]$Mode)
+$tokens = $null; $errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$tokens, [ref]$errors)
+if ($errors.Count -gt 0) { $errors | ForEach-Object { [Console]::Error.WriteLine($_.Message) }; exit 1 }
+if ($Mode -ne 'task-argument') { exit 0 }
+$cmd = $ast.Find({ param($n) $n -is [System.Management.Automation.Language.CommandAst] -and $n.GetCommandName() -eq 'New-ScheduledTaskAction' }, $true)
+if (-not $cmd) { [Console]::Error.WriteLine('no New-ScheduledTaskAction in the launcher'); exit 1 }
+$elements = @($cmd.CommandElements)
+for ($i = 0; $i -lt $elements.Count; $i++) {
+  if ($elements[$i] -is [System.Management.Automation.Language.CommandParameterAst] -and $elements[$i].ParameterName -eq 'Argument') {
+    # Evaluate the literal exactly as PowerShell will when the launcher runs.
+    [scriptblock]::Create($elements[$i + 1].Extent.Text).Invoke()[0]
+    exit 0
+  }
+}
+[Console]::Error.WriteLine('no -Argument on New-ScheduledTaskAction'); exit 1
+EOF
+ps_check() { # $1=.ps1 $2=mode
+  "$pwsh_bin" -NoProfile -NonInteractive -File "$(cygpath -w "$tmp/ps-check.ps1")" -Path "$(cygpath -w "$1")" -Mode "$2"
+}
+for f in "$lane" "$launch_ps1"; do
+  ps_check "$f" parse >/dev/null || { echo "windows: $f does not parse" >&2; exit 1; }
+done
+task_arg=$(ps_check "$launch_ps1" task-argument | tr -d '\r')
+expected_arg="-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File \"$(cygpath -w "$lane")\""
+[ "$task_arg" = "$expected_arg" ] || {
+  printf 'windows: the registered task argument would be\n  %s\nexpected\n  %s\n' "$task_arg" "$expected_arg" >&2
+  exit 1
+}
+
 win_rc=0
-"$(command -v pwsh)" -NoProfile -NonInteractive -File "$(cygpath -w "$lane")" || win_rc=$?
+"$pwsh_bin" -NoProfile -NonInteractive -File "$(cygpath -w "$lane")" || win_rc=$?
 [ "$win_rc" = 1 ] || { echo "windows: generated lane exit=$win_rc, expected product changes-requested 1" >&2; exit 1; }
 done="$EDDA_FLEET_SCRATCH/review-pr9999-r6.done"
 log="$EDDA_FLEET_SCRATCH/review-pr9999-r6.log"
 grep -q '^TRANSPORT=edda-review$' "$done"
 grep -q '^WORKTREE_CHECK=unchanged$' "$done"
-grep -q '^QUALIFIED=True$' "$done"
+grep -q '^QUALIFIED=true$' "$done"
 grep -q '"claim":"windows fixture"' "$log"
-printf 'review product-adapter fixtures passed (proof, qualification, detail carrier, fresh scratch, generated Windows lane)\n'
+# A direct run has no scheduled task to unregister; the receipt still closes.
+for line in 'FINAL_EXIT=1' 'WORKTREE_CLEANUP=removed' 'TASK_CLEANUP=not-applicable' 'TERMINAL_RECEIPT=complete'; do
+  grep -qx "$line" "$done" || { cat "$done" >&2; echo "windows: product receipt lacks $line" >&2; exit 1; }
+done
+grep -qx -- '- model_observed: fixture-observed' "$log" || { cat "$log" >&2; echo 'windows: envelope carries no model_observed header' >&2; exit 1; }
+grep -qx -- '- escalations: none' "$log" || { cat "$log" >&2; echo 'windows: envelope carries no escalations header' >&2; exit 1; }
+verdict_is_last "$log" windows
+
+# The same lane on an unqualified LGTM (exit 3): payload published, provisional
+# Verdict line, no label.
+ADAPTER_PLATFORM=MINGW64_NT ADAPTER_CASE=unqualified timeout 20 "$root/scripts/review-pr.sh" 9999 8 --dry-run >/dev/null
+lane="$EDDA_FLEET_SCRATCH/review-pr9999-r8-lane.ps1"
+win_rc=0
+ADAPTER_CASE=unqualified "$pwsh_bin" -NoProfile -NonInteractive -File "$(cygpath -w "$lane")" || win_rc=$?
+[ "$win_rc" = 3 ] || { echo "windows: unqualified lane exit=$win_rc, expected product exit 3" >&2; exit 1; }
+done="$EDDA_FLEET_SCRATCH/review-pr9999-r8.done"
+log="$EDDA_FLEET_SCRATCH/review-pr9999-r8.log"
+for line in 'DISPATCH_EXIT=3' 'FINAL_EXIT=3' 'QUALIFIED=false' 'DISQUALIFIERS=gates-red,escalation-pending' 'TERMINAL_RECEIPT=complete'; do
+  grep -qx "$line" "$done" || { cat "$done" >&2; echo "windows unqualified: receipt lacks $line" >&2; exit 1; }
+done
+grep -qx 'Provisional — unqualified (disqualifiers: gates-red, escalation-pending), P0=0, P1=1 — not a merge-gate verdict' "$log" \
+  || { cat "$log" >&2; echo 'windows unqualified: the Verdict line does not state the provisional outcome' >&2; exit 1; }
+grep -q '"claim":"windows fixture"' "$log" || { echo 'windows unqualified: findings were not written' >&2; exit 1; }
+grep -q 'fixture escalation' "$log" || { echo 'windows unqualified: escalations were not written' >&2; exit 1; }
+if grep -qE '^(LGTM|Changes Requested)' "$log"; then echo 'windows unqualified: adapter emitted a merge-gate verdict line' >&2; exit 1; fi
+grep -qx -- '- escalations: fixture escalation' "$log" || { cat "$log" >&2; echo 'windows unqualified: envelope carries no escalations header' >&2; exit 1; }
+verdict_is_last "$log" 'windows unqualified'
+vl=$(label_of "$log")
+[ -z "$vl" ] || { echo "windows unqualified: verdict-label resolved the provisional round to '$vl'" >&2; exit 1; }
+printf 'review product-adapter fixtures passed (proof, qualification, provisional exit 3, detail carrier, terminal receipt, round reservation, fresh scratch, generated Windows lane and launcher)\n'

--- a/scripts/test-review-pr.sh
+++ b/scripts/test-review-pr.sh
@@ -606,7 +606,9 @@ chmod +x "$STUBBIN/edda"
 hash -r
 export EDDA_REVIEW_PRODUCT_ADAPTER=1 TEST_PRODUCT_UNIX=1 EDDA_FLEET_ROOT="$root"
 rm -f "$EDDA_FLEET_SCRATCH/review-pr$FIXTURE_PR-r1.log" "$EDDA_FLEET_SCRATCH/review-pr$FIXTURE_PR-r1.done" "$EDDA_FLEET_SCRATCH/review-pr$FIXTURE_PR-r1-run.sh"
-out=$(timeout "${EDDA_TEST_TIMEOUT_SECONDS:-60}" sh "$root/scripts/review-pr.sh" "$FIXTURE_PR" 1 2>"$tmp/product.err") || {
+# The product path reserves the shared round like the brief path (#998);
+# keep that machine-local state out of the real ~/.edda/review-coordination.
+out=$(EDDA_REVIEW_COORD_DIR="$tmp/coord" timeout "${EDDA_TEST_TIMEOUT_SECONDS:-60}" sh "$root/scripts/review-pr.sh" "$FIXTURE_PR" 1 2>"$tmp/product.err") || {
     fail "D11: product adapter launch failed: $(cat "$tmp/product.err")"
 }
 for _ in $(seq 1 30); do [ -f "$EDDA_FLEET_SCRATCH/review-pr$FIXTURE_PR-r1.done" ] && break; sleep 1; done

--- a/scripts/test-review-product-adapter-r4.sh
+++ b/scripts/test-review-product-adapter-r4.sh
@@ -75,5 +75,9 @@ env PATH="$windows_path" "$pwsh_bin" -NoProfile -NonInteractive -ExecutionPolicy
 grep -qx 'DISPATCH_EXIT=3' "$scratch/review-pr9998-r2.done"
 grep -qx 'QUALIFIED=false' "$scratch/review-pr9998-r2.done"
 grep -qx 'DISQUALIFIERS=gate-red' "$scratch/review-pr9998-r2.done"
-! grep -q '^<<<VERDICT' "$scratch/review-pr9998-r2.log"
+# #998: exit 3 publishes its payload under a provisional Verdict line — never
+# an `LGTM` line the watcher could map to review:lgtm.
+grep -q '^<<<VERDICT' "$scratch/review-pr9998-r2.log"
+grep -qx 'Provisional — unqualified (disqualifiers: gate-red), P0=0, P1=0 — not a merge-gate verdict' "$scratch/review-pr9998-r2.log"
+! grep -qE '^(LGTM|Changes Requested)' "$scratch/review-pr9998-r2.log"
 echo 'review product adapter R4 fixture passed'


### PR DESCRIPTION
Issue: #998

Closes #998

## What happened

`edda review --json` exit 3 is the documented "unqualified LGTM" (verdict `lgtm`, `qualified=false`, e.g. `disqualifiers=escalation-pending`). The product adapter that `scripts/review-pr.sh` generates computed `$label` as `LGTM` only when qualified, `Changes Requested` for `changes-requested`, else empty — and wrote the `<<<VERDICT … VERDICT>>>` block, findings, checklist and escalations only inside `if ($label)`. An exit-3 round therefore left a four-line log (model, cost, session) and `scripts/pr-review-watch.sh` posted nothing; on 2026-09-06 three round-1 lanes (#974, #980, #981) did exactly that at ~$3 each.

Two more defects on the same path kept **every** product round invisible to the watcher, which is why nothing the watcher launched today produced a verdict:

- the product launcher exited 0 before `review-round.sh reserve` and never printed the `review_round=` receipt, so the watcher logged `launcher returned no shared round receipt; refusing to guess artifact paths` and dropped the round (`~/.edda/fleet/watch.log`, 08:00–08:11Z, six PRs × two attempts);
- the Windows task registration wrapped `-File` in `` `"…`" `` inside a **single-quoted** PowerShell string, so the backticks were literal and every product task ended with `LastTaskResult=0x40` before the lane ran — issue #683's signature. Verified on this workstation with a throwaway scheduled task: the old argument shape → 0x40 and no output; the double-quoted shape → the script's own exit code and its marker file.

## What changed

| File | Change |
|---|---|
| `scripts/review-pr.sh` | both product adapters (Windows `.ps1`, POSIX runner) publish the payload for every outcome. An unqualified LGTM gets the Verdict line `Provisional — unqualified (disqualifiers: …), P0=n, P1=n — not a merge-gate verdict`: no bare `LGTM` token, so `verdict-label` cannot map it to `review:lgtm`, and the Verdict line is the last line of the envelope (REVIEW.md §7 order). The product path now runs after the round reservation and prints `session=` / `review_round=` like the brief path. One shared `write_windows_launcher` (double-quoted `-Argument`) / `start_windows_launcher` / `start_posix_runner` serves both transports; the launcher is written even on `--dry-run` so the registered `-File` argument is inspectable on disk. |
| `scripts/pr-review-watch.sh` | a `Provisional` Verdict line is a settled review: the comment is posted, the `Independent Review` status goes through the union rule (never `success`), no `review:*` label, and it is never retried under the provider-overload rule. `receipt_exit_ok` accepts `DISPATCH_EXIT`/`FINAL_EXIT` = 0/0, 1/1, 3/3 for `TRANSPORT=edda-review` (the verdict is in the exit); 2 stays a failure. |
| `scripts/test-review-adapter.sh` | exit-3 fixture: envelope published, `Provisional` line, no `LGTM`/`Changes Requested` line, terminal receipt, round reservation, generated launcher argument |
| `scripts/test-pr-review-watch.sh` | exit-3 posting case: comment posted, status not `success`, no label, no retry |
| `scripts/test-review-pr.sh`, `scripts/test-review-product-adapter-r4.sh` | updated to the new receipts (product path reserves the round under `EDDA_REVIEW_COORD_DIR`; exit 3 publishes its envelope) |

Commit order is fixture first, fix second: the exit-3 fixture asserts the envelope the old adapter never wrote, so it fails on the unfixed adapter and passes after (verification run posted as a comment).

## Why the two launcher prerequisites are in this PR

doneWhen 3 ("the watcher posts a comment for an exit-3 round") cannot be observed in production unless the watcher can track a product round (needs the `review_round=` receipt) and the lane actually runs (needs a `-File` argument pwsh can open). Both sit on the surface #998 names, both are minimal, and without them the exit-3 publication would be correct and unreachable.

Relation: #1021 (GH-999, merged today) lets authoritative engines close D5 and exit 0; this PR handles the exit-3 outcome that remains for checklist-type engines.

## Gates (RAN at the gate-tested tree `0a04f932`, whose six files are byte-identical to this head; Windows workstation; L0 — no `crates/**`, C5 selector empty)

| Check | Result |
|---|---|
| `sh -n` on the six touched scripts | 6/6 |
| `sh scripts/test-review-adapter.sh` | passed (proof, qualification, provisional exit 3, detail carrier, terminal receipt, round reservation, fresh scratch, generated Windows lane and launcher) |
| `sh scripts/test-pr-review-watch.sh` | passed |
| `sh scripts/test-review-product-adapter-r4.sh` | passed |
| `sh scripts/lint-file-length.sh --tree` | exit 0 |
| `sh scripts/test-review-pr.sh` | running at post time; result posted as a comment |
| fixture-fails-before-fix (adapter fixture at the fixture-only commit) | running at post time; result posted as a comment |

No real `edda review` was launched (cost); the launcher fix is verified by the generated `launch.ps1` on disk and the throwaway-task probe above. No follow-up issues are filed (operator ruling for this batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
