### PR TITLE
feat(cli): edda fleet order — deterministic health-gated queue, per-file collision, in-product freshness (GH-1015)

### DIFF
--- a/crates/edda-cli/src/cmd_fleet.rs
+++ b/crates/edda-cli/src/cmd_fleet.rs
@@ -36,6 +36,13 @@ pub enum FleetCmd {
         #[arg(long)]
         line: bool,
     },
+    /// Fleet order: deterministic health-gated queue with lane routing (GH-1015)
+    ///
+    /// Exit: 0 ok; 1 error, 2 usage.
+    Order {
+        #[command(flatten)]
+        args: crate::cmd_fleet_order::OrderArgs,
+    },
 }
 
 /// Path class assigned by `classify_path` / `classify_paths`.
@@ -332,7 +339,7 @@ fn read_thresholds(repo_root: &Path) -> Thresholds {
     }
 }
 
-fn gh_output(repo_root: &Path, args: &[&str]) -> Vec<u8> {
+pub(crate) fn gh_output(repo_root: &Path, args: &[&str]) -> Vec<u8> {
     let output = match std::process::Command::new("gh")
         .args(args)
         .current_dir(repo_root)
@@ -552,10 +559,37 @@ pub fn render_line(h: &Health) -> String {
     line
 }
 
-/// CLI entry point. Prints, then exits with the status code:
-/// 0 GREEN, 3 YELLOW, 4 RED; 1 error, 2 usage.
+/// The live health status, for the ordering layer (GH-1015). Reusing this
+/// seam keeps one definition of "mechanism" and one definition of RED.
+pub(crate) fn live_health_status(repo_root: &Path, window: u32) -> String {
+    let now = Utc::now();
+    let window_start = now - Duration::days(i64::from(window));
+    let (merged, fetched_prs) = collect_merged(repo_root, window_start, now);
+    let (issues, fetched_issues) = collect_issues(repo_root, window_start, now);
+    let thresholds = read_thresholds(repo_root);
+    compute(
+        &merged,
+        &issues,
+        now,
+        window,
+        thresholds,
+        fetched_prs,
+        fetched_issues,
+    )
+    .status
+}
+
+/// CLI entry point.
 pub fn run(cmd: FleetCmd, repo_root: &Path) -> anyhow::Result<()> {
-    let FleetCmd::Health { window, json, line } = cmd;
+    match cmd {
+        FleetCmd::Health { window, json, line } => run_health(window, json, line, repo_root),
+        FleetCmd::Order { args } => crate::cmd_fleet_order::run(args, repo_root),
+    }
+}
+
+/// Prints, then exits with the status code: 0 GREEN, 3 YELLOW, 4 RED;
+/// 1 error, 2 usage.
+fn run_health(window: u32, json: bool, line: bool, repo_root: &Path) -> anyhow::Result<()> {
     if json && line {
         eprintln!("Error: --json and --line are mutually exclusive");
         std::process::exit(2);

--- a/crates/edda-cli/src/cmd_fleet_order.rs
+++ b/crates/edda-cli/src/cmd_fleet_order.rs
@@ -1,0 +1,840 @@
+//! GH-1015: fleet order — deterministic, health-gated ready queue.
+//!
+//! `edda fleet order` replaces the controller's hand-written ordering plan
+//! with a ranker any session can re-run: the same input yields the same output
+//! byte-for-byte, and every rank carries the component contributions that
+//! produced it, so the operator's remaining move is a veto at the queue head
+//! rather than a re-derivation of the whole plan.
+//!
+//! Three properties the shell layer could not hold (per `fleet.mechanism-layer`
+//! and `fleet.health-ordering`):
+//!
+//! * **Health coupling** — when `edda fleet health` reports RED, mechanism-class
+//!   weight is zeroed. The one exception is an issue whose body cites a red
+//!   run/gate link; without a link it is not a pipeline blocker.
+//! * **Per-file collision** — collisions are the pairwise intersection of
+//!   `## Predicted surface` paths, never labels (#1005). #671 and #685 both
+//!   name `crates/edda-cli/src/main.rs` and share no label at all.
+//! * **Freshness judgment in the product** (#970) — the applicability re-check
+//!   runs against the pinned tree and this binary's own verb table, so a stale
+//!   `edda` on `PATH` can no longer produce a false FAIL, and a path or command
+//!   the issue itself declares it will create WARNs instead of FAILing.
+//!
+//! Computation is pure and network-free: `gh`, `git`, and the ledger are read
+//! once at collection time into [`OrderInput`], and [`compute_order`] is a
+//! total function over it. Flash criteria that would need a subprocess (the
+//! brief render, the #945 dry-run validator) are emitted as named pending
+//! checks on the row instead of being shelled out mid-computation or silently
+//! skipped.
+
+mod cli;
+mod render;
+
+pub use cli::{run, OrderArgs};
+pub use render::{render_markdown, render_text};
+
+use crate::cmd_fleet::{classify_paths, surface_paths, Class};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Ledger key holding the flash lane's surface-file ceiling.
+const FLASH_CAP_KEY: &str = "fleet.order.flash-max-surface-files";
+/// Applied when [`FLASH_CAP_KEY`] resolves to nothing parseable.
+const FLASH_CAP_DEFAULT: usize = 3;
+/// `REVIEW.md` §6: marks a check with no mechanical decision step.
+const JUDGMENT_MARKER: &str = "[判斷]";
+
+/// Score weights. Named constants because every one of them is quoted back in
+/// the rendered decomposition, and a reader has to be able to check the sum.
+const W_PRODUCT: i64 = 40;
+const W_OTHER: i64 = 10;
+const W_MECHANISM: i64 = 0;
+const W_READY: i64 = 25;
+const W_P0: i64 = 30;
+const W_P1: i64 = 15;
+const W_P2: i64 = 5;
+const W_RED_RUN_BLOCKER: i64 = 50;
+const W_COLLISION_PEER: i64 = -10;
+const W_STALE: i64 = -100;
+
+/// Flash criteria that need a subprocess and are therefore reported, not run.
+const PENDING_BRIEF_RENDER: &str = "brief-render";
+const PENDING_DISPATCH_DRY_RUN: &str = "dispatch-dry-run";
+
+// ---------------------------------------------------------------------------
+// Input
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GhLabel {
+    pub name: String,
+}
+
+/// One open issue as `gh issue list --json number,title,body,labels` returns
+/// it. Also the fixture shape accepted by `--issues`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OpenIssue {
+    pub number: u64,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub body: String,
+    #[serde(default)]
+    pub labels: Vec<GhLabel>,
+}
+
+/// Everything [`compute_order`] is allowed to read. Collected once, up front.
+pub struct OrderInput {
+    pub issues: Vec<OpenIssue>,
+    /// Every path tracked at the pinned tree. Freshness resolves against this,
+    /// never against the filesystem or a binary on `PATH`.
+    pub tree_paths: BTreeSet<String>,
+    /// Top-level verbs of *this* binary — and therefore of the pinned tree.
+    pub known_verbs: BTreeSet<String>,
+    /// `GREEN`, `YELLOW`, or `RED`, from `edda fleet health`.
+    pub health_status: String,
+    pub flash_max_surface_files: usize,
+    /// `ledger` or `default`.
+    pub flash_cap_source: String,
+    pub now: DateTime<Utc>,
+}
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+/// Lane a row routes to. Flash is the cheap runtime; controller means the row
+/// carries judgment the mechanism must not resolve on its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Lane {
+    Flash,
+    Strong,
+    Controller,
+}
+
+impl Lane {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Lane::Flash => "flash",
+            Lane::Strong => "strong",
+            Lane::Controller => "controller",
+        }
+    }
+}
+
+/// Dispatchability of a row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Status {
+    /// Dispatchable now.
+    Ready,
+    /// Blocked behind a higher-ranked row that declares the same path.
+    Hold,
+    /// Mechanism-class under a RED health freeze, with no red-run evidence.
+    Frozen,
+    /// The freshness re-check FAILed against the pinned tree.
+    Stale,
+    /// Already in flight (`fleet:claimed`).
+    Claimed,
+}
+
+impl Status {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Status::Ready => "ready",
+            Status::Hold => "hold",
+            Status::Frozen => "frozen",
+            Status::Stale => "stale",
+            Status::Claimed => "claimed",
+        }
+    }
+}
+
+/// Freshness verdict for one referenced path or command. There is no `Pass`:
+/// a reference that resolves produces no finding at all, so an empty findings
+/// list is the fresh case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Verdict {
+    /// Unresolvable, or resolvable only once the issue is delivered.
+    Warn,
+    /// The reference is wrong about today's tree; the issue needs re-reading.
+    Fail,
+}
+
+impl Verdict {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Verdict::Warn => "warn",
+            Verdict::Fail => "fail",
+        }
+    }
+}
+
+/// One freshness observation. `kind` is `path`, `command`, or `donewhen`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FreshnessFinding {
+    pub verdict: Verdict,
+    pub kind: String,
+    pub target: String,
+    pub note: String,
+}
+
+/// Every contribution to a row's rank. The fields sum to `total`; the renderer
+/// prints the non-zero ones so a reader can check the arithmetic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct Score {
+    /// Path class of the declared surface: product / other / mechanism.
+    pub class: i64,
+    /// `fleet:ready` promotion.
+    pub readiness: i64,
+    /// P0 / P1 / P2 label.
+    pub priority: i64,
+    /// RED-freeze exception: the body cites a red run or gate link.
+    pub blocker: i64,
+    /// One penalty per peer declaring a shared surface path.
+    pub collision: i64,
+    /// The freshness re-check FAILed.
+    pub freshness: i64,
+    /// Zeroing term applied to frozen mechanism rows under RED health.
+    pub frozen: i64,
+    pub total: i64,
+}
+
+/// One ranked issue.
+#[derive(Debug, Clone, Serialize)]
+pub struct Row {
+    pub rank: usize,
+    pub number: u64,
+    pub title: String,
+    /// `product`, `mechanism`, or `other`.
+    pub class: String,
+    pub surface: Vec<String>,
+    pub lane: Lane,
+    /// Why the lane came out the way it did.
+    pub lane_reasons: Vec<String>,
+    /// Flash criteria that need a subprocess; the dispatcher runs these.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub pending_checks: Vec<String>,
+    pub status: Status,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hold_reason: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub collides_with: Vec<u64>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub freshness: Vec<FreshnessFinding>,
+    pub score: Score,
+}
+
+/// The full ordered queue. Serialized verbatim under `--json`.
+#[derive(Debug, Clone, Serialize)]
+pub struct Queue {
+    pub generated_at: String,
+    pub health_status: String,
+    pub mechanism_dispatch: String,
+    pub flash_max_surface_files: usize,
+    pub flash_cap_source: String,
+    pub total_issues: usize,
+    pub rows: Vec<Row>,
+}
+
+// ---------------------------------------------------------------------------
+// Computation
+// ---------------------------------------------------------------------------
+
+/// Per-issue facts derived before ranking. One pass means the collision matrix
+/// and the scores see exactly the same surfaces.
+struct Draft {
+    number: u64,
+    title: String,
+    surface: Vec<String>,
+    class: Class,
+    labels: BTreeSet<String>,
+    freshness: Vec<FreshnessFinding>,
+    cites_red_run: bool,
+    lane: Lane,
+    lane_reasons: Vec<String>,
+    pending_checks: Vec<String>,
+}
+
+/// Rank and route every issue in `input`. Pure, total and deterministic: the
+/// sort key is `(score descending, issue number ascending)`, so equal scores
+/// always fall back to the older issue and no input permutation can reorder
+/// the result.
+pub fn compute_order(input: &OrderInput) -> Queue {
+    let frozen_health = input.health_status.eq_ignore_ascii_case("RED");
+    let drafts: Vec<Draft> = input
+        .issues
+        .iter()
+        .map(|issue| draft(issue, input))
+        .collect();
+    let collisions = collision_matrix(&drafts);
+
+    let mut rows: Vec<Row> = drafts
+        .iter()
+        .map(|draft| {
+            let peers = collisions.get(&draft.number).cloned().unwrap_or_default();
+            row(draft, peers, frozen_health)
+        })
+        .collect();
+
+    rows.sort_by(|a, b| {
+        b.score
+            .total
+            .cmp(&a.score.total)
+            .then(a.number.cmp(&b.number))
+    });
+    serialize_collisions(&mut rows);
+
+    Queue {
+        generated_at: input.now.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+        health_status: input.health_status.to_ascii_uppercase(),
+        mechanism_dispatch: if frozen_health { "freeze" } else { "open" }.to_string(),
+        flash_max_surface_files: input.flash_max_surface_files,
+        flash_cap_source: input.flash_cap_source.clone(),
+        total_issues: input.issues.len(),
+        rows,
+    }
+}
+
+fn draft(issue: &OpenIssue, input: &OrderInput) -> Draft {
+    let surface = surface_paths(&issue.body);
+    let labels: BTreeSet<String> = issue
+        .labels
+        .iter()
+        .map(|label| label.name.trim().to_ascii_lowercase())
+        .collect();
+    let (lane, lane_reasons, pending_checks) = route(
+        &surface,
+        &labels,
+        &issue.body,
+        input.flash_max_surface_files,
+    );
+    Draft {
+        number: issue.number,
+        title: issue.title.trim().to_string(),
+        class: classify_paths(&surface),
+        labels,
+        freshness: evaluate_freshness(&issue.body, &input.tree_paths, &input.known_verbs),
+        cites_red_run: cites_red_run(&issue.body),
+        surface,
+        lane,
+        lane_reasons,
+        pending_checks,
+    }
+}
+
+fn row(draft: &Draft, peers: BTreeSet<u64>, frozen_health: bool) -> Row {
+    let mechanism = draft.class == Class::Mechanism;
+    let stale = draft.freshness.iter().any(|f| f.verdict == Verdict::Fail);
+    let frozen = frozen_health && mechanism && !draft.cites_red_run;
+
+    let class = match draft.class {
+        Class::Product => W_PRODUCT,
+        Class::Mechanism => W_MECHANISM,
+        Class::Other => W_OTHER,
+    };
+    let readiness = if draft.labels.contains("fleet:ready") {
+        W_READY
+    } else {
+        0
+    };
+    let priority = if draft.labels.contains("p0") {
+        W_P0
+    } else if draft.labels.contains("p1") {
+        W_P1
+    } else if draft.labels.contains("p2") {
+        W_P2
+    } else {
+        0
+    };
+    let blocker = if frozen_health && mechanism && draft.cites_red_run {
+        W_RED_RUN_BLOCKER
+    } else {
+        0
+    };
+    let collision = W_COLLISION_PEER * peers.len() as i64;
+    let freshness = if stale { W_STALE } else { 0 };
+    let subtotal = class + readiness + priority + blocker + collision + freshness;
+    // "mechanism weight is 0 under RED" taken literally: the zeroing term is
+    // recorded as its own component so the decomposition still sums to total.
+    let frozen_term = if frozen { -subtotal } else { 0 };
+
+    let status = if stale {
+        Status::Stale
+    } else if frozen {
+        Status::Frozen
+    } else if draft.labels.contains("fleet:claimed") {
+        Status::Claimed
+    } else {
+        Status::Ready
+    };
+
+    Row {
+        rank: 0,
+        number: draft.number,
+        title: draft.title.clone(),
+        class: class_name(draft.class).to_string(),
+        surface: draft.surface.clone(),
+        lane: draft.lane,
+        lane_reasons: draft.lane_reasons.clone(),
+        pending_checks: draft.pending_checks.clone(),
+        status,
+        hold_reason: None,
+        collides_with: peers.into_iter().collect(),
+        freshness: draft.freshness.clone(),
+        score: Score {
+            class,
+            readiness,
+            priority,
+            blocker,
+            collision,
+            freshness,
+            frozen: frozen_term,
+            total: subtotal + frozen_term,
+        },
+    }
+}
+
+/// Assign ranks, then serialize collisions: the first dispatchable row to
+/// claim a path holds every later row declaring the same path. Walking the
+/// already-sorted queue makes the hold a function of the ranking, not of input
+/// order.
+fn serialize_collisions(rows: &mut [Row]) {
+    let mut claimed: BTreeMap<String, u64> = BTreeMap::new();
+    for (index, row) in rows.iter_mut().enumerate() {
+        row.rank = index + 1;
+        // Only a dispatchable row claims a path: an in-flight, frozen or stale
+        // row must not block the queue behind it.
+        if row.status != Status::Ready {
+            continue;
+        }
+        let held = row
+            .surface
+            .iter()
+            .filter_map(|path| claimed.get(path).map(|owner| (path.clone(), *owner)))
+            .min();
+        match held {
+            Some((path, owner)) => {
+                row.status = Status::Hold;
+                row.hold_reason = Some(format!("surface collision with #{owner} on {path}"));
+            }
+            None => {
+                for path in &row.surface {
+                    claimed.entry(path.clone()).or_insert(row.number);
+                }
+            }
+        }
+    }
+}
+
+fn class_name(class: Class) -> &'static str {
+    match class {
+        Class::Product => "product",
+        Class::Mechanism => "mechanism",
+        Class::Other => "other",
+    }
+}
+
+/// Pairwise `## Predicted surface` intersection (#1005). Labels are never
+/// consulted: #671 and #685 carried no label in common and both got built.
+fn collision_matrix(drafts: &[Draft]) -> BTreeMap<u64, BTreeSet<u64>> {
+    let sets: Vec<BTreeSet<&str>> = drafts
+        .iter()
+        .map(|d| d.surface.iter().map(String::as_str).collect())
+        .collect();
+    let mut matrix: BTreeMap<u64, BTreeSet<u64>> = BTreeMap::new();
+    for i in 0..drafts.len() {
+        for j in (i + 1)..drafts.len() {
+            if drafts[i].number == drafts[j].number || sets[i].is_disjoint(&sets[j]) {
+                continue;
+            }
+            matrix
+                .entry(drafts[i].number)
+                .or_default()
+                .insert(drafts[j].number);
+            matrix
+                .entry(drafts[j].number)
+                .or_default()
+                .insert(drafts[i].number);
+        }
+    }
+    matrix
+}
+
+/// Lane routing. Every criterion here is mechanical; the two that would need a
+/// subprocess are named as pending checks rather than run (see module docs).
+fn route(
+    surface: &[String],
+    labels: &BTreeSet<String>,
+    body: &str,
+    flash_cap: usize,
+) -> (Lane, Vec<String>, Vec<String>) {
+    if labels.contains("governance") || labels.contains("fleet:goal") {
+        return (
+            Lane::Controller,
+            vec!["governance label".into()],
+            Vec::new(),
+        );
+    }
+    if body.contains(JUDGMENT_MARKER) {
+        return (
+            Lane::Controller,
+            vec![format!("judgment marker {JUDGMENT_MARKER} in body")],
+            Vec::new(),
+        );
+    }
+    if surface.is_empty() {
+        return (Lane::Strong, vec!["no declared surface".into()], Vec::new());
+    }
+    if surface.len() > flash_cap {
+        return (
+            Lane::Strong,
+            vec![format!(
+                "surface {} files > flash cap {flash_cap}",
+                surface.len()
+            )],
+            Vec::new(),
+        );
+    }
+    if let Some(path) = surface.iter().find(|p| p.starts_with("scripts/")) {
+        return (
+            Lane::Strong,
+            vec![format!("surface touches scripts/ ({path})")],
+            Vec::new(),
+        );
+    }
+    (
+        Lane::Flash,
+        vec![format!(
+            "surface {} files <= flash cap {flash_cap}, no scripts/ path",
+            surface.len()
+        )],
+        vec![
+            PENDING_BRIEF_RENDER.to_string(),
+            PENDING_DISPATCH_DRY_RUN.to_string(),
+        ],
+    )
+}
+
+/// The RED-freeze exception: the body cites a run or gate link. A mechanism
+/// issue without one is not a pipeline blocker, whatever its prose claims.
+pub fn cites_red_run(body: &str) -> bool {
+    body.contains("/actions/runs/") || body.contains("/checks")
+}
+
+// ---------------------------------------------------------------------------
+// Freshness (#970), evaluated against the pinned tree
+// ---------------------------------------------------------------------------
+
+/// Re-derive an issue's applicability against the pinned tree.
+///
+/// Only WARN and FAIL findings are emitted: an empty result means every
+/// reference resolved. Four shapes the shell gate got wrong:
+///
+/// * a path the issue itself declares under `## Predicted surface` WARNs
+///   instead of FAILing when it is referenced again elsewhere in the body;
+/// * a `doneWhen` heading matches whatever its case;
+/// * a command that is to be built (mentioned under `doneWhen` or
+///   `## Predicted surface`) or is evidence-cited WARNs instead of FAILing;
+/// * a reference to a genuinely deleted path still FAILs.
+///
+/// Commands resolve against `known_verbs` — this binary's own verb table, and
+/// therefore the pinned tree's — so a stale `edda` on `PATH` cannot produce the
+/// false FAIL that `edda fleet --help` produced on #1015 itself.
+pub fn evaluate_freshness(
+    body: &str,
+    tree_paths: &BTreeSet<String>,
+    known_verbs: &BTreeSet<String>,
+) -> Vec<FreshnessFinding> {
+    let declared: BTreeSet<String> = surface_paths(body).into_iter().collect();
+    let mut findings = Vec::new();
+    let mut section = String::new();
+    let mut donewhen_seen = false;
+    let mut donewhen_content = false;
+
+    for line in body.lines() {
+        if let Some(heading) = section_heading(line) {
+            section = heading;
+            donewhen_seen |= is_donewhen(&section);
+            continue;
+        }
+        if is_donewhen(&section) && !line.trim().is_empty() {
+            donewhen_content = true;
+        }
+        // Predicted-surface tokens are proposals for files that may not exist
+        // yet, never references.
+        if is_surface(&section) {
+            continue;
+        }
+        let parts: Vec<&str> = line.split('`').collect();
+        let mut index = 1;
+        while index < parts.len() {
+            if !negated(parts[index - 1]) {
+                if let Some(finding) = judge_token(
+                    parts[index].trim(),
+                    line,
+                    &section,
+                    &declared,
+                    tree_paths,
+                    known_verbs,
+                ) {
+                    findings.push(finding);
+                }
+            }
+            index += 2;
+        }
+    }
+
+    if !donewhen_seen || !donewhen_content {
+        findings.push(FreshnessFinding {
+            verdict: Verdict::Fail,
+            kind: "donewhen".to_string(),
+            target: "## doneWhen".to_string(),
+            note: "section missing or empty".to_string(),
+        });
+    }
+    // Bodies cite the same file a dozen times; the reader needs the finding
+    // once. First occurrence wins, so the order stays the body's.
+    let mut seen = BTreeSet::new();
+    findings.retain(|finding| seen.insert((finding.kind.clone(), finding.target.clone())));
+    findings
+}
+
+/// `## Heading` (exactly two hashes), lowercased. `###` and deeper do not
+/// change the section, and the case of the heading never matters.
+fn section_heading(line: &str) -> Option<String> {
+    let trimmed = line.trim_end();
+    if trimmed.chars().take_while(|c| *c == '#').count() != 2 {
+        return None;
+    }
+    let rest = trimmed.get(2..)?.strip_prefix(' ')?;
+    Some(rest.trim().to_ascii_lowercase())
+}
+
+fn is_donewhen(section: &str) -> bool {
+    section.starts_with("donewhen")
+}
+
+/// Any `… surface` heading. Collision scoring reads only the canonical
+/// `## Predicted surface` (via [`surface_paths`], the one definition), but for
+/// freshness every surface heading — `Suspected surface` in #761, say — is a
+/// proposal about a file that may not exist yet.
+fn is_surface(section: &str) -> bool {
+    section.ends_with("surface")
+}
+
+/// Sections that describe the tree the issue will produce rather than the one
+/// it observed. A wrong claim about today's tree is a stale premise; a claim
+/// about tomorrow's cannot be. `改哪裡` ("where to change") is this corpus's
+/// older spelling of `## Predicted surface` — #763 names the module it will
+/// create there, and the shell gate FAILed it for not existing yet.
+fn declares_future(section: &str) -> bool {
+    is_donewhen(section) || is_surface(section) || section.starts_with("改哪裡")
+}
+
+/// A mention preceded by `no` / `not` / `without` is a statement of absence.
+fn negated(prose: &str) -> bool {
+    let last = prose
+        .trim_end()
+        .rsplit(char::is_whitespace)
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    matches!(last.as_str(), "no" | "not" | "without")
+}
+
+/// Evidence that the mention was observed rather than proposed.
+fn evidence_cited(line: &str) -> bool {
+    line.contains("http://") || line.contains("https://") || line.contains("CI run")
+}
+
+fn judge_token(
+    token: &str,
+    line: &str,
+    section: &str,
+    declared: &BTreeSet<String>,
+    tree_paths: &BTreeSet<String>,
+    known_verbs: &BTreeSet<String>,
+) -> Option<FreshnessFinding> {
+    if token.is_empty() {
+        return None;
+    }
+    if let Some(rest) = token.strip_prefix("edda ") {
+        return judge_command(token, rest, line, section, known_verbs);
+    }
+    if token.contains(char::is_whitespace) {
+        return None;
+    }
+    // Issues cite line ranges (`crates/edda-pack/src/lib.rs:288-296`); the
+    // file is what the tree can answer for.
+    let probe = strip_line_suffix(token);
+    if probe.contains('/') {
+        return judge_path(token, probe, section, declared, tree_paths);
+    }
+    if has_file_extension(probe) && !probe.contains(|c: char| !is_bare_name_char(c)) {
+        // A bare filename cannot be probed directly: resolve it against the
+        // tracked paths. More than one hit is an ambiguous reference worth
+        // reporting; zero hits is almost always not a path at all — a ledger
+        // key (`fleet.mechanism-layer`) or a field (`event_data.error`) — and
+        // reporting those would bury the findings that mean something.
+        let suffix = format!("/{probe}");
+        let hits = tree_paths
+            .iter()
+            .filter(|p| p.as_str() == probe || p.ends_with(&suffix))
+            .count();
+        if hits > 1 {
+            return Some(warn(
+                "path",
+                token,
+                "bare name does not resolve to exactly one tracked file",
+            ));
+        }
+    }
+    None
+}
+
+/// `path.rs:12` and `path.rs:12-30` name a file; everything else is returned
+/// unchanged.
+fn strip_line_suffix(token: &str) -> &str {
+    match token.rsplit_once(':') {
+        Some((head, tail))
+            if !head.is_empty()
+                && !tail.is_empty()
+                && tail
+                    .split('-')
+                    .all(|n| !n.is_empty() && n.chars().all(|c| c.is_ascii_digit())) =>
+        {
+            head
+        }
+        _ => token,
+    }
+}
+
+fn judge_command(
+    token: &str,
+    rest: &str,
+    line: &str,
+    section: &str,
+    known_verbs: &BTreeSet<String>,
+) -> Option<FreshnessFinding> {
+    let verb = rest.split_whitespace().next()?;
+    // The same shape the shell gate greps for: anything else (`edda --version`,
+    // an elided `edda d…`) is not a verb reference.
+    if !verb.starts_with(|c: char| c.is_ascii_lowercase())
+        || !verb
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        return None;
+    }
+    if known_verbs.contains(verb) {
+        return None;
+    }
+    let to_be_built = declares_future(section) || evidence_cited(line);
+    Some(FreshnessFinding {
+        verdict: if to_be_built {
+            Verdict::Warn
+        } else {
+            Verdict::Fail
+        },
+        kind: "command".to_string(),
+        target: token.to_string(),
+        note: if to_be_built {
+            "declared by this issue or evidence-cited; absent from the pinned tree".to_string()
+        } else {
+            "verb absent from the pinned tree".to_string()
+        },
+    })
+}
+
+/// `token` is what the body said; `probe` is what the tree is asked about.
+fn judge_path(
+    token: &str,
+    probe: &str,
+    section: &str,
+    declared: &BTreeSet<String>,
+    tree_paths: &BTreeSet<String>,
+) -> Option<FreshnessFinding> {
+    // A slash token is only credible when its last segment names a file;
+    // `if/else` and `fix/gh533-...` are not references at all.
+    if !has_file_extension(probe.rsplit('/').next()?) {
+        return None;
+    }
+    // Anything that is not a plain repo-relative path — an absolute path, a
+    // flag, a traversal — is unparseable rather than missing.
+    if probe.starts_with('-')
+        || probe.starts_with('/')
+        || probe
+            .split('/')
+            .any(|segment| segment == "." || segment == "..")
+        || probe.contains(|c: char| !is_path_char(c))
+    {
+        return Some(warn("path", token, "unparsed as a repository path"));
+    }
+    if tree_paths.contains(probe) {
+        return None;
+    }
+    // Issues cite crate- and module-relative paths (`peers/heartbeat.rs`,
+    // `edda-ledger/src/paths.rs`). Those are references, not deleted files, so
+    // resolve them as a suffix of the tracked paths before FAILing.
+    let suffix = format!("/{probe}");
+    match tree_paths.iter().filter(|p| p.ends_with(&suffix)).count() {
+        1 => return None,
+        0 => {}
+        _ => {
+            return Some(warn(
+                "path",
+                token,
+                "relative reference does not resolve to exactly one tracked file",
+            ))
+        }
+    }
+    if declared.contains(probe) || declares_future(section) {
+        return Some(warn(
+            "path",
+            token,
+            "declared by this issue; not created yet",
+        ));
+    }
+    Some(FreshnessFinding {
+        verdict: Verdict::Fail,
+        kind: "path".to_string(),
+        target: token.to_string(),
+        note: "missing at the pinned tree".to_string(),
+    })
+}
+
+/// A last path segment names a file when it ends in a plain alphanumeric
+/// extension: `main.rs` and `ci.yml` do, `fleet.mechanism-layer` (a ledger
+/// key) and `gh533-...` do not.
+fn has_file_extension(name: &str) -> bool {
+    match name.rsplit_once('.') {
+        Some((stem, ext)) => {
+            !stem.is_empty() && !ext.is_empty() && ext.chars().all(|c| c.is_ascii_alphanumeric())
+        }
+        None => false,
+    }
+}
+
+fn is_path_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '/' | '-')
+}
+
+fn is_bare_name_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')
+}
+
+fn warn(kind: &str, target: &str, note: &str) -> FreshnessFinding {
+    FreshnessFinding {
+        verdict: Verdict::Warn,
+        kind: kind.to_string(),
+        target: target.to_string(),
+        note: note.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/edda-cli/src/cmd_fleet_order.rs
+++ b/crates/edda-cli/src/cmd_fleet_order.rs
@@ -13,19 +13,24 @@
 //!   weight is zeroed. The one exception is an issue whose body cites a red
 //!   run/gate link; without a link it is not a pipeline blocker.
 //! * **Per-file collision** — collisions are the pairwise intersection of
-//!   `## Predicted surface` paths, never labels (#1005). #671 and #685 both
-//!   name `crates/edda-cli/src/main.rs` and share no label at all.
+//!   `## Predicted surface` paths, never labels (#1005). Labels are issue-level
+//!   and conflicts are file-level, so a shared label neither predicts nor
+//!   excludes one: #671 and #685 share two labels (`enhancement`,
+//!   `lane:feature`) and their real collision is `crates/edda-ledger/src/sync.rs`
+//!   and `docs/guides/multi-agent.md`, which no label says anything about.
 //! * **Freshness judgment in the product** (#970) — the applicability re-check
 //!   runs against the pinned tree and this binary's own verb table, so a stale
 //!   `edda` on `PATH` can no longer produce a false FAIL, and a path or command
 //!   the issue itself declares it will create WARNs instead of FAILing.
 //!
-//! Computation is pure and network-free: `gh`, `git`, and the ledger are read
-//! once at collection time into [`OrderInput`], and [`compute_order`] is a
-//! total function over it. Flash criteria that would need a subprocess (the
-//! brief render, the #945 dry-run validator) are emitted as named pending
-//! checks on the row instead of being shelled out mid-computation or silently
-//! skipped.
+//! Computation is pure and network-free: `gh`, `git`, the ledger, and the two
+//! flash criteria that need a subprocess (the #885 brief render, the #945
+//! dry-run validator) are all resolved once at collection time into
+//! [`OrderInput`], and [`compute_order`] is a total function over it. The
+//! subprocess criteria arrive as [`FlashCheck`] data like any other input, so
+//! [`route`] applies all four of the criteria #1015 names while the ranker
+//! stays pure and fixture-testable. A criterion that was not evaluated is not a
+//! pass: the row routes `strong` and says which check forced it.
 
 mod cli;
 mod render;
@@ -58,9 +63,12 @@ const W_RED_RUN_BLOCKER: i64 = 50;
 const W_COLLISION_PEER: i64 = -10;
 const W_STALE: i64 = -100;
 
-/// Flash criteria that need a subprocess and are therefore reported, not run.
-const PENDING_BRIEF_RENDER: &str = "brief-render";
-const PENDING_DISPATCH_DRY_RUN: &str = "dispatch-dry-run";
+/// The two flash criteria that need a subprocess. Run on the impure edge in
+/// `cli`, applied here; the order is #1015's, and `route` short-circuits on the
+/// first failure, so a row never reports a check the queue did not reach.
+const CHECK_BRIEF_RENDER: &str = "brief-render";
+const CHECK_DISPATCH_DRY_RUN: &str = "dispatch-dry-run";
+pub const FLASH_SUBPROCESS_CHECKS: [&str; 2] = [CHECK_BRIEF_RENDER, CHECK_DISPATCH_DRY_RUN];
 
 // ---------------------------------------------------------------------------
 // Input
@@ -84,9 +92,35 @@ pub struct OpenIssue {
     pub labels: Vec<GhLabel>,
 }
 
+/// One flash criterion that only a subprocess can decide, resolved before the
+/// ranker runs. Carried as data so `compute_order` applies it without shelling
+/// out: determinism holds because the result is an input like any other.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FlashCheck {
+    /// One of [`FLASH_SUBPROCESS_CHECKS`].
+    pub name: String,
+    pub passed: bool,
+    /// What was run and what it said. Quoted verbatim in the row's reasons.
+    pub note: String,
+}
+
+impl FlashCheck {
+    fn new(name: &str, passed: bool, note: impl Into<String>) -> Self {
+        FlashCheck {
+            name: name.to_string(),
+            passed,
+            note: note.into(),
+        }
+    }
+}
+
 /// Everything [`compute_order`] is allowed to read. Collected once, up front.
 pub struct OrderInput {
     pub issues: Vec<OpenIssue>,
+    /// Subprocess flash-criterion results, keyed by issue number. An issue
+    /// absent from this map had its checks skipped, not passed — [`route`]
+    /// reads the absence as "not evaluated" and routes `strong`.
+    pub flash_checks: BTreeMap<u64, Vec<FlashCheck>>,
     /// Every path tracked at the pinned tree. Freshness resolves against this,
     /// never against the filesystem or a binary on `PATH`.
     pub tree_paths: BTreeSet<String>,
@@ -215,9 +249,10 @@ pub struct Row {
     pub lane: Lane,
     /// Why the lane came out the way it did.
     pub lane_reasons: Vec<String>,
-    /// Flash criteria that need a subprocess; the dispatcher runs these.
+    /// Results of the subprocess flash criteria, in the order they were
+    /// applied. Empty when the row never reached them.
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub pending_checks: Vec<String>,
+    pub flash_checks: Vec<FlashCheck>,
     pub status: Status,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hold_reason: Option<String>,
@@ -256,7 +291,7 @@ struct Draft {
     cites_red_run: bool,
     lane: Lane,
     lane_reasons: Vec<String>,
-    pending_checks: Vec<String>,
+    flash_checks: Vec<FlashCheck>,
 }
 
 /// Rank and route every issue in `input`. Pure, total and deterministic: the
@@ -301,16 +336,13 @@ pub fn compute_order(input: &OrderInput) -> Queue {
 
 fn draft(issue: &OpenIssue, input: &OrderInput) -> Draft {
     let surface = surface_paths(&issue.body);
-    let labels: BTreeSet<String> = issue
-        .labels
-        .iter()
-        .map(|label| label.name.trim().to_ascii_lowercase())
-        .collect();
-    let (lane, lane_reasons, pending_checks) = route(
+    let labels = issue_labels(issue);
+    let (lane, lane_reasons, flash_checks) = route(
         &surface,
         &labels,
         &issue.body,
         input.flash_max_surface_files,
+        input.flash_checks.get(&issue.number),
     );
     Draft {
         number: issue.number,
@@ -322,8 +354,18 @@ fn draft(issue: &OpenIssue, input: &OrderInput) -> Draft {
         surface,
         lane,
         lane_reasons,
-        pending_checks,
+        flash_checks,
     }
+}
+
+/// An issue's labels, trimmed and lowercased. Shared with `cli`, which needs
+/// the same view to decide which issues are still flash candidates.
+pub fn issue_labels(issue: &OpenIssue) -> BTreeSet<String> {
+    issue
+        .labels
+        .iter()
+        .map(|label| label.name.trim().to_ascii_lowercase())
+        .collect()
 }
 
 fn row(draft: &Draft, peers: BTreeSet<u64>, frozen_health: bool) -> Row {
@@ -380,7 +422,7 @@ fn row(draft: &Draft, peers: BTreeSet<u64>, frozen_health: bool) -> Row {
         surface: draft.surface.clone(),
         lane: draft.lane,
         lane_reasons: draft.lane_reasons.clone(),
-        pending_checks: draft.pending_checks.clone(),
+        flash_checks: draft.flash_checks.clone(),
         status,
         hold_reason: None,
         collides_with: peers.into_iter().collect(),
@@ -439,7 +481,11 @@ fn class_name(class: Class) -> &'static str {
 }
 
 /// Pairwise `## Predicted surface` intersection (#1005). Labels are never
-/// consulted: #671 and #685 carried no label in common and both got built.
+/// consulted, because a label cannot answer the question: labels are
+/// issue-level and conflicts are file-level. #671 and #685 are the live
+/// example — two labels in common (`enhancement`, `lane:feature`), which
+/// predicts nothing, and a real collision on `crates/edda-ledger/src/sync.rs`
+/// and `docs/guides/multi-agent.md`, which no label mentions.
 fn collision_matrix(drafts: &[Draft]) -> BTreeMap<u64, BTreeSet<u64>> {
     let sets: Vec<BTreeSet<&str>> = drafts
         .iter()
@@ -464,59 +510,80 @@ fn collision_matrix(drafts: &[Draft]) -> BTreeMap<u64, BTreeSet<u64>> {
     matrix
 }
 
-/// Lane routing. Every criterion here is mechanical; the two that would need a
-/// subprocess are named as pending checks rather than run (see module docs).
+/// The routing criteria decidable from the issue body alone: the two
+/// controller escapes, plus #1015's first two flash criteria. `Some` is the
+/// lane the row takes and why; `None` means it is still a flash candidate and
+/// only the subprocess criteria are left.
+///
+/// `cli` calls this to decide which issues are worth spending a subprocess on,
+/// so the cheap criteria have exactly one implementation.
+pub fn non_flash_reason(
+    surface: &[String],
+    labels: &BTreeSet<String>,
+    body: &str,
+    flash_cap: usize,
+) -> Option<(Lane, String)> {
+    if labels.contains("governance") || labels.contains("fleet:goal") {
+        return Some((Lane::Controller, "governance label".into()));
+    }
+    if body.contains(JUDGMENT_MARKER) {
+        return Some((
+            Lane::Controller,
+            format!("judgment marker {JUDGMENT_MARKER} in body"),
+        ));
+    }
+    if surface.is_empty() {
+        return Some((Lane::Strong, "no declared surface".into()));
+    }
+    if surface.len() > flash_cap {
+        return Some((
+            Lane::Strong,
+            format!("surface {} files > flash cap {flash_cap}", surface.len()),
+        ));
+    }
+    if let Some(path) = surface.iter().find(|p| p.starts_with("scripts/")) {
+        return Some((Lane::Strong, format!("surface touches scripts/ ({path})")));
+    }
+    None
+}
+
+/// Lane routing. All four of #1015's flash criteria are applied here: the two
+/// cheap ones from [`non_flash_reason`], then the two subprocess ones, whose
+/// results `cli` resolved at collection time and handed over as data.
+///
+/// `任一不過 → strong` is taken literally, and so is its silent half: a check
+/// that was never evaluated has not passed either, so a missing result routes
+/// `strong` exactly like a failing one. Both cases name the check in the
+/// returned reasons, so the row says what forced the lane.
 fn route(
     surface: &[String],
     labels: &BTreeSet<String>,
     body: &str,
     flash_cap: usize,
-) -> (Lane, Vec<String>, Vec<String>) {
-    if labels.contains("governance") || labels.contains("fleet:goal") {
-        return (
-            Lane::Controller,
-            vec!["governance label".into()],
-            Vec::new(),
-        );
+    checks: Option<&Vec<FlashCheck>>,
+) -> (Lane, Vec<String>, Vec<FlashCheck>) {
+    if let Some((lane, reason)) = non_flash_reason(surface, labels, body, flash_cap) {
+        return (lane, vec![reason], Vec::new());
     }
-    if body.contains(JUDGMENT_MARKER) {
-        return (
-            Lane::Controller,
-            vec![format!("judgment marker {JUDGMENT_MARKER} in body")],
-            Vec::new(),
-        );
+    let checks = checks.cloned().unwrap_or_default();
+    let mut reasons = vec![format!(
+        "surface {} files <= flash cap {flash_cap}, no scripts/ path",
+        surface.len()
+    )];
+    for name in FLASH_SUBPROCESS_CHECKS {
+        match checks.iter().find(|check| check.name == name) {
+            Some(check) if check.passed => reasons.push(format!("{name} passed: {}", check.note)),
+            Some(check) => {
+                reasons.push(format!("{name} failed: {}", check.note));
+                return (Lane::Strong, reasons, checks);
+            }
+            None => {
+                reasons.push(format!("{name} not evaluated"));
+                return (Lane::Strong, reasons, checks);
+            }
+        }
     }
-    if surface.is_empty() {
-        return (Lane::Strong, vec!["no declared surface".into()], Vec::new());
-    }
-    if surface.len() > flash_cap {
-        return (
-            Lane::Strong,
-            vec![format!(
-                "surface {} files > flash cap {flash_cap}",
-                surface.len()
-            )],
-            Vec::new(),
-        );
-    }
-    if let Some(path) = surface.iter().find(|p| p.starts_with("scripts/")) {
-        return (
-            Lane::Strong,
-            vec![format!("surface touches scripts/ ({path})")],
-            Vec::new(),
-        );
-    }
-    (
-        Lane::Flash,
-        vec![format!(
-            "surface {} files <= flash cap {flash_cap}, no scripts/ path",
-            surface.len()
-        )],
-        vec![
-            PENDING_BRIEF_RENDER.to_string(),
-            PENDING_DISPATCH_DRY_RUN.to_string(),
-        ],
-    )
+    (Lane::Flash, reasons, checks)
 }
 
 /// The RED-freeze exception: the body cites a run or gate link. A mechanism

--- a/crates/edda-cli/src/cmd_fleet_order/cli.rs
+++ b/crates/edda-cli/src/cmd_fleet_order/cli.rs
@@ -1,0 +1,262 @@
+//! GH-1015: collection and CLI entry point for `edda fleet order`.
+//!
+//! Everything impure lives here: `gh`, `git`, the ledger, and clap. Each is
+//! read exactly once into an [`OrderInput`], so the ranker itself stays a pure
+//! function that a fixture can drive.
+
+use super::{
+    compute_order, render_markdown, render_text, OpenIssue, OrderInput, FLASH_CAP_DEFAULT,
+    FLASH_CAP_KEY,
+};
+use chrono::Utc;
+use std::collections::BTreeSet;
+use std::path::Path;
+
+/// Server-side cap on the open-issue query.
+const OPEN_ISSUE_CAP: u64 = 400;
+
+/// Stack for the clap introspection thread; see [`collect_known_verbs`].
+const VERB_TABLE_STACK_BYTES: usize = 32 * 1024 * 1024;
+
+/// Flags for `edda fleet order`.
+#[derive(clap::Args)]
+pub struct OrderArgs {
+    /// Read open issues from a JSON fixture instead of querying `gh`
+    #[arg(long, value_name = "PATH")]
+    pub issues: Option<std::path::PathBuf>,
+    /// Use this health status (GREEN/YELLOW/RED) instead of computing it
+    #[arg(long, value_name = "STATUS")]
+    pub health_status: Option<String>,
+    /// Rolling window in days for the health computation
+    #[arg(long, default_value_t = 7)]
+    pub window: u32,
+    /// Emit the queue as JSON
+    #[arg(long)]
+    pub json: bool,
+    /// Emit the board-comment markdown rendering
+    #[arg(long)]
+    pub markdown: bool,
+    /// Keep only the top N rows (ranks are assigned before truncation)
+    #[arg(long, value_name = "N")]
+    pub limit: Option<usize>,
+}
+
+/// Parse `gh issue list --json number,title,body,labels` output.
+pub fn parse_open_issues(bytes: &[u8]) -> anyhow::Result<Vec<OpenIssue>> {
+    Ok(serde_json::from_slice(bytes)?)
+}
+
+/// CLI entry point. Exit: 0 ok; 1 error, 2 usage.
+pub fn run(args: OrderArgs, repo_root: &Path) -> anyhow::Result<()> {
+    if args.json && args.markdown {
+        eprintln!("Error: --json and --markdown are mutually exclusive");
+        std::process::exit(2);
+    }
+    if args.window == 0 {
+        eprintln!("Error: --window must be at least 1");
+        std::process::exit(2);
+    }
+    let health_status = match &args.health_status {
+        Some(status) => match normalize_status(status) {
+            Some(status) => status,
+            None => {
+                eprintln!("Error: --health-status must be GREEN, YELLOW, or RED");
+                std::process::exit(2);
+            }
+        },
+        None => crate::cmd_fleet::live_health_status(repo_root, args.window),
+    };
+    let issues = match &args.issues {
+        Some(path) => {
+            let bytes = std::fs::read(path)
+                .map_err(|err| anyhow::anyhow!("reading {}: {err}", path.display()))?;
+            parse_open_issues(&bytes)
+                .map_err(|err| anyhow::anyhow!("parsing {}: {err}", path.display()))?
+        }
+        None => collect_open_issues(repo_root),
+    };
+    let (flash_max_surface_files, flash_cap_source) = read_flash_cap(repo_root);
+
+    let mut queue = compute_order(&OrderInput {
+        issues,
+        tree_paths: collect_tree_paths(repo_root),
+        known_verbs: collect_known_verbs(),
+        health_status,
+        flash_max_surface_files,
+        flash_cap_source,
+        now: Utc::now(),
+    });
+    if let Some(limit) = args.limit {
+        queue.rows.truncate(limit);
+    }
+
+    let rendered = if args.json {
+        format!("{}\n", serde_json::to_string_pretty(&queue)?)
+    } else if args.markdown {
+        render_markdown(&queue)
+    } else {
+        render_text(&queue)
+    };
+    use std::io::Write;
+    let mut stdout = std::io::stdout();
+    stdout.write_all(rendered.as_bytes())?;
+    stdout.flush()?;
+    Ok(())
+}
+
+/// Accept any casing of the three health statuses; reject everything else.
+fn normalize_status(status: &str) -> Option<String> {
+    let upper = status.trim().to_ascii_uppercase();
+    matches!(upper.as_str(), "GREEN" | "YELLOW" | "RED").then_some(upper)
+}
+
+/// Read the flash lane's surface-file ceiling from the ledger. An unopenable
+/// ledger or an unparseable value falls back to the built-in default.
+fn read_flash_cap(repo_root: &Path) -> (usize, String) {
+    if let Ok(ledger) = edda_ledger::Ledger::open(repo_root) {
+        if let Ok(branch) = ledger.head_branch() {
+            if let Ok(Some(decision)) = ledger.find_active_decision(&branch, FLASH_CAP_KEY) {
+                if let Ok(value) = decision.value.trim().parse::<usize>() {
+                    return (value, "ledger".to_string());
+                }
+            }
+        }
+    }
+    (FLASH_CAP_DEFAULT, "default".to_string())
+}
+
+/// Every path tracked at the pinned tree. A scan that cannot see the tree must
+/// not report: a `git` failure is fatal rather than an empty set, because an
+/// empty set would FAIL every referenced path in every issue.
+fn collect_tree_paths(repo_root: &Path) -> BTreeSet<String> {
+    match std::process::Command::new("git")
+        .args(["ls-tree", "-r", "--name-only", "HEAD"])
+        .current_dir(repo_root)
+        .output()
+    {
+        Ok(output) if output.status.success() => String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(|line| line.trim_end_matches('\r').to_string())
+            .filter(|line| !line.is_empty())
+            .collect(),
+        Ok(output) => {
+            eprintln!(
+                "Error: git ls-tree failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+            std::process::exit(1);
+        }
+        Err(err) => {
+            eprintln!("Error: git ls-tree failed: {err}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// This binary's own top-level verbs — the pinned tree's, by construction.
+/// Introspection, not `edda <verb> --help`: the `edda` on `PATH` may predate
+/// the tree being ranked, which is exactly how #1015 earned a false FAIL.
+///
+/// `Cli::command()` rebuilds the whole command tree, and this CLI's tree is
+/// deep enough that doing so from inside a subcommand overflows the main
+/// thread's stack in a debug build (measured: `edda fleet order` aborted
+/// before printing anything). Building it on a thread with its own stack keeps
+/// the introspection here, where the property belongs. An unbuildable table
+/// exits rather than degrading to an empty set, which would FAIL every command
+/// mention in every issue.
+fn collect_known_verbs() -> BTreeSet<String> {
+    let built = std::thread::Builder::new()
+        .stack_size(VERB_TABLE_STACK_BYTES)
+        .spawn(|| {
+            use clap::CommandFactory;
+            crate::Cli::command()
+                .get_subcommands()
+                .map(|sub| sub.get_name().to_string())
+                .collect::<BTreeSet<String>>()
+        })
+        .map(|handle| handle.join());
+    match built {
+        Ok(Ok(verbs)) => verbs,
+        _ => {
+            eprintln!("Error: could not build this binary's verb table");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn collect_open_issues(repo_root: &Path) -> Vec<OpenIssue> {
+    let limit = OPEN_ISSUE_CAP.to_string();
+    let stdout = crate::cmd_fleet::gh_output(
+        repo_root,
+        &[
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            &limit,
+            "--json",
+            "number,title,body,labels",
+        ],
+    );
+    match parse_open_issues(&stdout) {
+        Ok(issues) => issues,
+        Err(err) => {
+            eprintln!("Error: gh issue list output unparseable: {err}");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_open_issues_reads_the_gh_shape() {
+        let bytes = br###"[
+            {"number": 1015, "title": "fleet order",
+             "body": "## doneWhen\n- ranked\n",
+             "labels": [{"name": "fleet:ready"}, {"name": "P1"}]},
+            {"number": 1016, "title": "no labels", "body": "", "labels": []}
+        ]"###;
+        let issues = parse_open_issues(bytes).expect("fixture parses");
+        assert_eq!(issues.len(), 2);
+        assert_eq!(issues[0].number, 1015);
+        assert_eq!(issues[0].labels[1].name, "P1");
+        assert!(issues[1].labels.is_empty());
+    }
+
+    #[test]
+    fn parse_open_issues_defaults_absent_optional_fields() {
+        let issues = parse_open_issues(br#"[{"number": 7}]"#).expect("minimal row parses");
+        assert_eq!(issues[0].number, 7);
+        assert!(issues[0].title.is_empty());
+        assert!(issues[0].body.is_empty());
+        assert!(issues[0].labels.is_empty());
+    }
+
+    #[test]
+    fn parse_open_issues_rejects_a_non_list() {
+        assert!(parse_open_issues(br#"{"number": 7}"#).is_err());
+    }
+
+    #[test]
+    fn normalize_status_accepts_any_casing_and_nothing_else() {
+        assert_eq!(normalize_status(" red ").as_deref(), Some("RED"));
+        assert_eq!(normalize_status("Yellow").as_deref(), Some("YELLOW"));
+        assert_eq!(normalize_status("GREEN").as_deref(), Some("GREEN"));
+        assert!(normalize_status("amber").is_none());
+        assert!(normalize_status("").is_none());
+    }
+
+    /// The verb table `order` judges commands against must be this binary's,
+    /// so `fleet` is present the moment the tree defines it.
+    #[test]
+    fn known_verbs_come_from_this_binarys_command_tree() {
+        let verbs = collect_known_verbs();
+        assert!(verbs.contains("fleet"));
+        assert!(verbs.contains("ask"));
+        assert!(!verbs.contains("definitely-not-a-verb"));
+    }
+}

--- a/crates/edda-cli/src/cmd_fleet_order/cli.rs
+++ b/crates/edda-cli/src/cmd_fleet_order/cli.rs
@@ -1,16 +1,19 @@
 //! GH-1015: collection and CLI entry point for `edda fleet order`.
 //!
-//! Everything impure lives here: `gh`, `git`, the ledger, and clap. Each is
-//! read exactly once into an [`OrderInput`], so the ranker itself stays a pure
-//! function that a fixture can drive.
+//! Everything impure lives here: `gh`, `git`, the ledger, clap, and the two
+//! flash criteria that can only be decided by running something. Each is
+//! resolved exactly once into an [`OrderInput`], so the ranker itself stays a
+//! pure function that a fixture can drive.
 
 use super::{
-    compute_order, render_markdown, render_text, OpenIssue, OrderInput, FLASH_CAP_DEFAULT,
+    compute_order, issue_labels, non_flash_reason, render_markdown, render_text, FlashCheck,
+    OpenIssue, OrderInput, CHECK_BRIEF_RENDER, CHECK_DISPATCH_DRY_RUN, FLASH_CAP_DEFAULT,
     FLASH_CAP_KEY,
 };
+use crate::cmd_fleet::surface_paths;
 use chrono::Utc;
-use std::collections::BTreeSet;
-use std::path::Path;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
 
 /// Server-side cap on the open-issue query.
 const OPEN_ISSUE_CAP: u64 = 400;
@@ -66,19 +69,30 @@ pub fn run(args: OrderArgs, repo_root: &Path) -> anyhow::Result<()> {
         },
         None => crate::cmd_fleet::live_health_status(repo_root, args.window),
     };
-    let issues = match &args.issues {
+    // A fixture's issue numbers are synthetic, so running the two subprocess
+    // criteria against them would ask GitHub about issues the fixture invented.
+    // The checks are skipped there instead, and every affected row says
+    // `<check> not evaluated` and routes `strong` — never a silent flash.
+    let (issues, run_flash_checks) = match &args.issues {
         Some(path) => {
             let bytes = std::fs::read(path)
                 .map_err(|err| anyhow::anyhow!("reading {}: {err}", path.display()))?;
-            parse_open_issues(&bytes)
-                .map_err(|err| anyhow::anyhow!("parsing {}: {err}", path.display()))?
+            let issues = parse_open_issues(&bytes)
+                .map_err(|err| anyhow::anyhow!("parsing {}: {err}", path.display()))?;
+            (issues, false)
         }
-        None => collect_open_issues(repo_root),
+        None => (collect_open_issues(repo_root), true),
     };
     let (flash_max_surface_files, flash_cap_source) = read_flash_cap(repo_root);
+    let flash_checks = if run_flash_checks {
+        collect_flash_checks(repo_root, &issues, flash_max_surface_files)
+    } else {
+        BTreeMap::new()
+    };
 
     let mut queue = compute_order(&OrderInput {
         issues,
+        flash_checks,
         tree_paths: collect_tree_paths(repo_root),
         known_verbs: collect_known_verbs(),
         health_status,
@@ -123,6 +137,196 @@ fn read_flash_cap(repo_root: &Path) -> (usize, String) {
         }
     }
     (FLASH_CAP_DEFAULT, "default".to_string())
+}
+
+/// Renders in flight at once. Each is a process spawn plus one `gh issue view`
+/// round trip; measured serially over the 60-issue corpus the whole collection
+/// took 7m44s, which is not a queue command. They are independent reads that
+/// touch nothing in the repo, so they overlap safely — unlike the dry-run,
+/// which does `git worktree add` and stays serial below.
+const RENDER_CONCURRENCY: usize = 6;
+
+/// Resolve the two subprocess flash criteria, for the issues that can still
+/// reach the flash lane. [`non_flash_reason`] has already routed the rest, so
+/// spending a process on them would buy a result nothing reads.
+///
+/// The order is #1015's, and a failed render short-circuits: the dry-run
+/// validator has nothing to validate once the brief did not render. Results are
+/// keyed by issue number, so thread scheduling cannot reach the output.
+fn collect_flash_checks(
+    repo_root: &Path,
+    issues: &[OpenIssue],
+    flash_cap: usize,
+) -> BTreeMap<u64, Vec<FlashCheck>> {
+    let candidates: Vec<u64> = issues
+        .iter()
+        .filter(|issue| {
+            let surface = surface_paths(&issue.body);
+            non_flash_reason(&surface, &issue_labels(issue), &issue.body, flash_cap).is_none()
+        })
+        .map(|issue| issue.number)
+        .collect();
+
+    let mut checks: BTreeMap<u64, Vec<FlashCheck>> = BTreeMap::new();
+    std::thread::scope(|scope| {
+        for batch in candidates.chunks(RENDER_CONCURRENCY) {
+            let handles: Vec<_> = batch
+                .iter()
+                .map(|&number| {
+                    (
+                        number,
+                        scope.spawn(move || run_brief_render(repo_root, number)),
+                    )
+                })
+                .collect();
+            for (number, handle) in handles {
+                // A panicked worker decided nothing, and "not decided" is not a
+                // pass: it records as a failure and the row routes strong.
+                let render = handle.join().unwrap_or_else(|_| {
+                    FlashCheck::new(CHECK_BRIEF_RENDER, false, "brief-render worker panicked")
+                });
+                checks.insert(number, vec![render]);
+            }
+        }
+    });
+
+    for (number, results) in checks.iter_mut() {
+        if results.iter().all(|check| check.passed) {
+            results.push(run_dispatch_dry_run(repo_root, *number));
+        }
+    }
+    checks
+}
+
+/// #885's renderer, invoked the way `next-issue.sh` invokes it. It only prints
+/// — no worktree, branch or lane is created — so the arguments below are the
+/// names the launch *would* use, not names that exist. Exit 0 is the criterion.
+fn run_brief_render(repo_root: &Path, number: u64) -> FlashCheck {
+    let worktree = format!("{}-wt-gh{number}", repo_root.display());
+    let output = std::process::Command::new("sh")
+        .args([
+            "scripts/fleet/brief-from-issue.sh",
+            &number.to_string(),
+            "--lane-name",
+            &format!("edda-lane-gh{number}"),
+            "--worktree",
+            &worktree,
+            "--branch",
+            &format!("feat/gh{number}"),
+        ])
+        .current_dir(repo_root)
+        .output();
+    match output {
+        Ok(output) if output.status.success() => {
+            FlashCheck::new(CHECK_BRIEF_RENDER, true, "brief-from-issue.sh exited 0")
+        }
+        Ok(output) => FlashCheck::new(
+            CHECK_BRIEF_RENDER,
+            false,
+            format!(
+                "brief-from-issue.sh exited {}: {}",
+                exit_code(&output.status),
+                first_line([&output.stderr, &output.stdout])
+            ),
+        ),
+        Err(err) => FlashCheck::new(
+            CHECK_BRIEF_RENDER,
+            false,
+            format!("could not run brief-from-issue.sh: {err}"),
+        ),
+    }
+}
+
+/// #945's dry-run validator, which applies a brief's authored span in a
+/// throwaway worktree at the pinned base SHA.
+///
+/// Its precondition is an *authored* brief: a freshly rendered one carries the
+/// `<<AUTHORED STEPS>>` placeholder and no `<<AUTHORED: BEGIN>>` span, and the
+/// validator refuses it with exit 2. That refusal is not a pass, so an issue
+/// whose authored middle nobody has written yet routes `strong` — which is the
+/// safe direction, and the note says exactly what is missing.
+fn run_dispatch_dry_run(repo_root: &Path, number: u64) -> FlashCheck {
+    let Some(path) = authored_brief_path(number) else {
+        return FlashCheck::new(
+            CHECK_DISPATCH_DRY_RUN,
+            false,
+            "cannot resolve the fleet scratch directory",
+        );
+    };
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return FlashCheck::new(
+            CHECK_DISPATCH_DRY_RUN,
+            false,
+            format!("no authored brief at {}", path.display()),
+        );
+    };
+    if text.lines().any(|line| line == "<<AUTHORED STEPS>>") {
+        return FlashCheck::new(
+            CHECK_DISPATCH_DRY_RUN,
+            false,
+            format!(
+                "brief at {} still carries the <<AUTHORED STEPS>> placeholder; nothing to dry-run",
+                path.display()
+            ),
+        );
+    }
+    let output = std::process::Command::new("sh")
+        .args([
+            "scripts/fleet/brief-validate.sh",
+            &path.display().to_string(),
+        ])
+        .current_dir(repo_root)
+        .output();
+    match output {
+        Ok(output) if output.status.success() => {
+            FlashCheck::new(CHECK_DISPATCH_DRY_RUN, true, "brief-validate.sh VALID")
+        }
+        Ok(output) => FlashCheck::new(
+            CHECK_DISPATCH_DRY_RUN,
+            false,
+            format!(
+                "brief-validate.sh exited {}: {}",
+                exit_code(&output.status),
+                first_line([&output.stdout, &output.stderr])
+            ),
+        ),
+        Err(err) => FlashCheck::new(
+            CHECK_DISPATCH_DRY_RUN,
+            false,
+            format!("could not run brief-validate.sh: {err}"),
+        ),
+    }
+}
+
+/// Where `next-issue.sh` writes and re-reads a lane brief. Same env var, same
+/// name, so the validator sees the brief the launch would actually use.
+fn authored_brief_path(number: u64) -> Option<PathBuf> {
+    let scratch = match std::env::var("EDDA_FLEET_SCRATCH") {
+        Ok(dir) if !dir.trim().is_empty() => PathBuf::from(dir),
+        _ => edda_core::paths::home_dir()?.join(".edda").join("fleet"),
+    };
+    Some(scratch.join(format!("brief-gh{number}.md")))
+}
+
+fn exit_code(status: &std::process::ExitStatus) -> String {
+    match status.code() {
+        Some(code) => code.to_string(),
+        None => "by signal".to_string(),
+    }
+}
+
+/// The one line worth quoting back into a lane reason: these scripts report
+/// their refusal first, and a row note is not a place for a transcript. Streams
+/// are searched in the order given — `brief-from-issue.sh` dies on stderr,
+/// `brief-validate.sh` prints `INVALID step=<n>` on stdout.
+fn first_line(streams: [&[u8]; 2]) -> String {
+    for bytes in streams {
+        let text = String::from_utf8_lossy(bytes);
+        if let Some(line) = text.lines().map(str::trim).find(|line| !line.is_empty()) {
+            return line.to_string();
+        }
+    }
+    "(no output)".to_string()
 }
 
 /// Every path tracked at the pinned tree. A scan that cannot see the tree must
@@ -200,7 +404,19 @@ fn collect_open_issues(repo_root: &Path) -> Vec<OpenIssue> {
         ],
     );
     match parse_open_issues(&stdout) {
-        Ok(issues) => issues,
+        Ok(issues) => {
+            // A full page is indistinguishable from a truncated corpus, so say
+            // so: `total_issues` in the header would otherwise report the
+            // prefix as the whole queue. Same signal `edda fleet health` gives
+            // for its own PR and issue caps.
+            if issues.len() as u64 >= OPEN_ISSUE_CAP {
+                eprintln!(
+                    "warning: open-issue fetch hit its cap ({OPEN_ISSUE_CAP}) — the queue ranks a \
+                     prefix of the corpus, not all of it"
+                );
+            }
+            issues
+        }
         Err(err) => {
             eprintln!("Error: gh issue list output unparseable: {err}");
             std::process::exit(1);

--- a/crates/edda-cli/src/cmd_fleet_order/render.rs
+++ b/crates/edda-cli/src/cmd_fleet_order/render.rs
@@ -5,7 +5,7 @@
 //! Every one of them prints the score decomposition, because a bare rank the
 //! operator cannot check is a rank they cannot veto.
 
-use super::{Queue, Row, Score, Status};
+use super::{Lane, Queue, Row, Score, Status};
 
 /// Every non-zero score component, in the order [`Score`] declares them.
 pub fn decomposition(score: &Score) -> String {
@@ -48,8 +48,13 @@ pub fn notes(row: &Row) -> String {
             finding.note
         ));
     }
-    if !row.pending_checks.is_empty() {
-        notes.push(format!("pending checks: {}", row.pending_checks.join(", ")));
+    // Which of the four criteria stopped this row, which `route` puts last in
+    // `lane_reasons`. Neither the text nor the markdown rendering prints the
+    // surface, so without this a `strong` row is a verdict with no evidence —
+    // the thing this queue exists to stop. A flash row needs no note: reaching
+    // that lane means all four criteria passed.
+    if row.lane != Lane::Flash {
+        notes.extend(row.lane_reasons.last().cloned());
     }
     notes.join("; ")
 }
@@ -123,7 +128,7 @@ pub fn render_text(queue: &Queue) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cmd_fleet_order::{Lane, Score};
+    use crate::cmd_fleet_order::{FlashCheck, Score};
 
     fn score() -> Score {
         Score {
@@ -144,10 +149,26 @@ mod tests {
             number: 671,
             title: "committed mirror".to_string(),
             class: "product".to_string(),
-            surface: vec!["crates/edda-cli/src/main.rs".to_string()],
-            lane: Lane::Flash,
-            lane_reasons: vec!["surface 1 files <= flash cap 3, no scripts/ path".to_string()],
-            pending_checks: vec!["brief-render".to_string()],
+            surface: vec!["crates/edda-ledger/src/sync.rs".to_string()],
+            // The cheap criteria passed and a subprocess criterion did not, so
+            // the row is `strong` and the note has to say which one.
+            lane: Lane::Strong,
+            lane_reasons: vec![
+                "surface 1 files <= flash cap 3, no scripts/ path".to_string(),
+                "dispatch-dry-run failed: no authored brief".to_string(),
+            ],
+            flash_checks: vec![
+                FlashCheck {
+                    name: "brief-render".to_string(),
+                    passed: true,
+                    note: "brief-from-issue.sh exited 0".to_string(),
+                },
+                FlashCheck {
+                    name: "dispatch-dry-run".to_string(),
+                    passed: false,
+                    note: "no authored brief".to_string(),
+                },
+            ],
             status: Status::Ready,
             hold_reason: None,
             collides_with: vec![685],
@@ -194,8 +215,8 @@ mod tests {
             "### Fleet order — 2026-09-07T12:00:00Z (health GREEN, mechanism dispatch open)"
         ));
         assert!(rendered.contains(
-            "| 1 | #671 | 70 | product | flash | ready | class +40, ready +25, priority +15, \
-             collision -10 | pending checks: brief-render |"
+            "| 1 | #671 | 70 | product | strong | ready | class +40, ready +25, priority +15, \
+             collision -10 | dispatch-dry-run failed: no authored brief |"
         ));
         // Every table row has the same cell count as the header.
         let pipes = |line: &str| line.matches('|').count();
@@ -206,6 +227,28 @@ mod tests {
         for line in rendered.lines().filter(|l| l.starts_with("| 1 ")) {
             assert_eq!(pipes(line), pipes(header));
         }
+    }
+
+    /// A `strong` row that cleared the cheap criteria must say which criterion
+    /// stopped it — including the row shape a `--issues` run produces, where
+    /// the checks were never evaluated and so left no `flash_checks` behind.
+    #[test]
+    fn a_strong_row_names_the_criterion_that_stopped_it() {
+        let mut queue = queue();
+        queue.rows[0].lane_reasons = vec![
+            "surface 1 files <= flash cap 3, no scripts/ path".to_string(),
+            "brief-render not evaluated".to_string(),
+        ];
+        queue.rows[0].flash_checks.clear();
+        assert_eq!(notes(&queue.rows[0]), "brief-render not evaluated");
+
+        // A row a cheap criterion routed names that criterion instead.
+        queue.rows[0].lane_reasons = vec!["surface 5 files > flash cap 3".to_string()];
+        assert_eq!(notes(&queue.rows[0]), "surface 5 files > flash cap 3");
+
+        // A flash row cleared all four; there is nothing left to report.
+        queue.rows[0].lane = Lane::Flash;
+        assert_eq!(notes(&queue.rows[0]), "");
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_fleet_order/render.rs
+++ b/crates/edda-cli/src/cmd_fleet_order/render.rs
@@ -1,0 +1,241 @@
+//! GH-1015: renderers for `edda fleet order`.
+//!
+//! Three shapes over the same [`Queue`]: a text report, the board-comment
+//! markdown that replaces the hand-written #932 plan, and (in `cli`) JSON.
+//! Every one of them prints the score decomposition, because a bare rank the
+//! operator cannot check is a rank they cannot veto.
+
+use super::{Queue, Row, Score, Status};
+
+/// Every non-zero score component, in the order [`Score`] declares them.
+pub fn decomposition(score: &Score) -> String {
+    let parts = [
+        ("class", score.class),
+        ("ready", score.readiness),
+        ("priority", score.priority),
+        ("red-run blocker", score.blocker),
+        ("collision", score.collision),
+        ("stale", score.freshness),
+        ("frozen", score.frozen),
+    ];
+    let rendered: Vec<String> = parts
+        .iter()
+        .filter(|(_, value)| *value != 0)
+        .map(|(name, value)| format!("{name} {value:+}"))
+        .collect();
+    if rendered.is_empty() {
+        "0".to_string()
+    } else {
+        rendered.join(", ")
+    }
+}
+
+/// Everything about a row that its rank, class, lane and score do not say.
+pub fn notes(row: &Row) -> String {
+    let mut notes = Vec::new();
+    if let Some(reason) = &row.hold_reason {
+        notes.push(reason.clone());
+    }
+    if row.status == Status::Frozen {
+        notes.push("mechanism dispatch frozen (health RED, no red-run evidence)".to_string());
+    }
+    for finding in &row.freshness {
+        notes.push(format!(
+            "{} {} {}: {}",
+            finding.verdict.as_str().to_uppercase(),
+            finding.kind,
+            finding.target,
+            finding.note
+        ));
+    }
+    if !row.pending_checks.is_empty() {
+        notes.push(format!("pending checks: {}", row.pending_checks.join(", ")));
+    }
+    notes.join("; ")
+}
+
+/// Board-comment markdown, shaped like the hand-written #932 plan it replaces.
+pub fn render_markdown(queue: &Queue) -> String {
+    let mut out = format!(
+        "### Fleet order — {} (health {}, mechanism dispatch {})\n\n",
+        queue.generated_at, queue.health_status, queue.mechanism_dispatch
+    );
+    out.push_str(&format!(
+        "{} open issues; flash lane cap {} surface files ({}). Ranked by score \
+         descending, ties by issue number.\n\n",
+        queue.total_issues, queue.flash_max_surface_files, queue.flash_cap_source
+    ));
+    out.push_str("| # | issue | score | class | lane | status | score components | notes |\n");
+    out.push_str("|--:|-------|------:|-------|------|--------|------------------|-------|\n");
+    for row in &queue.rows {
+        out.push_str(&format!(
+            "| {} | #{} | {} | {} | {} | {} | {} | {} |\n",
+            row.rank,
+            row.number,
+            row.score.total,
+            row.class,
+            row.lane.as_str(),
+            row.status.as_str(),
+            decomposition(&row.score),
+            escape_cell(&notes(row))
+        ));
+    }
+    out
+}
+
+/// A pipe inside a cell would split the column; nothing else in these strings
+/// is markdown-active.
+fn escape_cell(text: &str) -> String {
+    text.replace('|', "\\|")
+}
+
+/// The default text report.
+pub fn render_text(queue: &Queue) -> String {
+    let mut out = format!(
+        "fleet order — {} open issues | health {} (mechanism dispatch {}) | flash cap {} files ({})\n",
+        queue.total_issues,
+        queue.health_status,
+        queue.mechanism_dispatch,
+        queue.flash_max_surface_files,
+        queue.flash_cap_source
+    );
+    out.push_str("rank  issue  score  class      lane        status    detail\n");
+    for row in &queue.rows {
+        let note = notes(row);
+        let detail = if note.is_empty() {
+            decomposition(&row.score)
+        } else {
+            format!("{} — {note}", decomposition(&row.score))
+        };
+        out.push_str(&format!(
+            "{:>4}  {:>5}  {:>5}  {:<9}  {:<10}  {:<8}  {detail}\n",
+            row.rank,
+            format!("#{}", row.number),
+            row.score.total,
+            row.class,
+            row.lane.as_str(),
+            row.status.as_str()
+        ));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmd_fleet_order::{Lane, Score};
+
+    fn score() -> Score {
+        Score {
+            class: 40,
+            readiness: 25,
+            priority: 15,
+            blocker: 0,
+            collision: -10,
+            freshness: 0,
+            frozen: 0,
+            total: 70,
+        }
+    }
+
+    fn row() -> Row {
+        Row {
+            rank: 1,
+            number: 671,
+            title: "committed mirror".to_string(),
+            class: "product".to_string(),
+            surface: vec!["crates/edda-cli/src/main.rs".to_string()],
+            lane: Lane::Flash,
+            lane_reasons: vec!["surface 1 files <= flash cap 3, no scripts/ path".to_string()],
+            pending_checks: vec!["brief-render".to_string()],
+            status: Status::Ready,
+            hold_reason: None,
+            collides_with: vec![685],
+            freshness: Vec::new(),
+            score: score(),
+        }
+    }
+
+    fn queue() -> Queue {
+        Queue {
+            generated_at: "2026-09-07T12:00:00Z".to_string(),
+            health_status: "GREEN".to_string(),
+            mechanism_dispatch: "open".to_string(),
+            flash_max_surface_files: 3,
+            flash_cap_source: "default".to_string(),
+            total_issues: 1,
+            rows: vec![row()],
+        }
+    }
+
+    #[test]
+    fn decomposition_shows_signed_non_zero_components_only() {
+        assert_eq!(
+            decomposition(&score()),
+            "class +40, ready +25, priority +15, collision -10"
+        );
+        let zeroed = Score {
+            class: 0,
+            readiness: 0,
+            priority: 0,
+            blocker: 0,
+            collision: 0,
+            freshness: 0,
+            frozen: 0,
+            total: 0,
+        };
+        assert_eq!(decomposition(&zeroed), "0");
+    }
+
+    #[test]
+    fn markdown_is_a_pasteable_board_table() {
+        let rendered = render_markdown(&queue());
+        assert!(rendered.starts_with(
+            "### Fleet order — 2026-09-07T12:00:00Z (health GREEN, mechanism dispatch open)"
+        ));
+        assert!(rendered.contains(
+            "| 1 | #671 | 70 | product | flash | ready | class +40, ready +25, priority +15, \
+             collision -10 | pending checks: brief-render |"
+        ));
+        // Every table row has the same cell count as the header.
+        let pipes = |line: &str| line.matches('|').count();
+        let header = rendered
+            .lines()
+            .find(|l| l.starts_with("| # |"))
+            .expect("header row");
+        for line in rendered.lines().filter(|l| l.starts_with("| 1 ")) {
+            assert_eq!(pipes(line), pipes(header));
+        }
+    }
+
+    #[test]
+    fn a_pipe_in_a_note_cannot_split_the_column() {
+        let mut queue = queue();
+        queue.rows[0].hold_reason = Some("blocked by a | b".to_string());
+        let rendered = render_markdown(&queue);
+        assert!(rendered.contains("blocked by a \\| b"));
+        let header = rendered
+            .lines()
+            .find(|l| l.starts_with("| # |"))
+            .expect("header row");
+        let row = rendered
+            .lines()
+            .find(|l| l.starts_with("| 1 "))
+            .expect("data row");
+        assert_eq!(
+            row.matches('|').count() - row.matches("\\|").count(),
+            header.matches('|').count()
+        );
+    }
+
+    #[test]
+    fn text_report_carries_the_header_and_one_line_per_row() {
+        let rendered = render_text(&queue());
+        assert!(rendered.starts_with(
+            "fleet order — 1 open issues | health GREEN (mechanism dispatch open) | \
+             flash cap 3 files (default)\n"
+        ));
+        assert_eq!(rendered.lines().count(), 3);
+        assert!(rendered.lines().nth(2).expect("row").contains("#671"));
+    }
+}

--- a/crates/edda-cli/src/cmd_fleet_order/tests.rs
+++ b/crates/edda-cli/src/cmd_fleet_order/tests.rs
@@ -1,0 +1,592 @@
+//! GH-1015 fixture tests. Every input is a literal in this file: a test that
+//! reaches `gh` or `git` cannot run on the frozen tree, which is where the
+//! gate that consumes this ranking has to run.
+
+use super::*;
+use chrono::TimeZone;
+
+fn now() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 9, 7, 12, 0, 0).unwrap()
+}
+
+/// A well-formed issue body: prose, a declared surface, a non-empty doneWhen.
+fn body(surface: &[&str], extra: &str) -> String {
+    let mut text = String::from("## What happened\n\nobserved today.\n\n## Predicted surface\n\n");
+    for path in surface {
+        text.push_str(&format!("`{path}`\n"));
+    }
+    text.push_str("\n## doneWhen\n\n- the thing is delivered.\n");
+    text.push_str(extra);
+    text
+}
+
+fn open_issue(number: u64, title: &str, body: &str, labels: &[&str]) -> OpenIssue {
+    OpenIssue {
+        number,
+        title: title.to_string(),
+        body: body.to_string(),
+        labels: labels
+            .iter()
+            .map(|name| GhLabel {
+                name: (*name).to_string(),
+            })
+            .collect(),
+    }
+}
+
+fn tree() -> BTreeSet<String> {
+    [
+        "crates/edda-cli/src/main.rs",
+        // A second `main.rs` so a bare name is genuinely ambiguous.
+        "crates/edda-serve/src/main.rs",
+        "crates/edda-cli/src/cmd_fleet.rs",
+        "crates/edda-cli/src/cmd_export.rs",
+        "crates/edda-core/src/types.rs",
+        "scripts/fleet/next-issue.sh",
+        "scripts/fleet/guard-push.sh",
+    ]
+    .iter()
+    .map(|path| (*path).to_string())
+    .collect()
+}
+
+fn verbs() -> BTreeSet<String> {
+    ["fleet", "ask", "decide", "claim"]
+        .iter()
+        .map(|verb| (*verb).to_string())
+        .collect()
+}
+
+fn input(issues: &[OpenIssue], health: &str) -> OrderInput {
+    OrderInput {
+        issues: issues.to_vec(),
+        tree_paths: tree(),
+        known_verbs: verbs(),
+        health_status: health.to_string(),
+        flash_max_surface_files: FLASH_CAP_DEFAULT,
+        flash_cap_source: "default".to_string(),
+        now: now(),
+    }
+}
+
+fn row(queue: &Queue, number: u64) -> &Row {
+    queue
+        .rows
+        .iter()
+        .find(|row| row.number == number)
+        .unwrap_or_else(|| panic!("no row for #{number} in queue of {}", queue.rows.len()))
+}
+
+fn freshness(body: &str) -> Vec<FreshnessFinding> {
+    evaluate_freshness(body, &tree(), &verbs())
+}
+
+fn verdict_for(body: &str, target: &str) -> Option<Verdict> {
+    freshness(body)
+        .into_iter()
+        .find(|finding| finding.target == target)
+        .map(|finding| finding.verdict)
+}
+
+// ---------------------------------------------------------------------------
+// The two properties #1015 names explicitly
+// ---------------------------------------------------------------------------
+
+/// #671 and #685 both declare `crates/edda-cli/src/main.rs`. Label-based
+/// detection saw two unrelated issues and both got built (#887's shape); the
+/// per-file rule (#1005) sees one collision and serializes them.
+#[test]
+fn per_file_collision_holds_the_lower_ranked_peer() {
+    let issues = vec![
+        open_issue(
+            671,
+            "committed mirror",
+            &body(
+                &[
+                    "crates/edda-cli/src/main.rs",
+                    "crates/edda-cli/src/cmd_export.rs",
+                ],
+                "",
+            ),
+            &["fleet:ready", "P1"],
+        ),
+        open_issue(
+            685,
+            "sync surface",
+            &body(
+                &[
+                    "crates/edda-cli/src/main.rs",
+                    "crates/edda-cli/src/cmd_fleet.rs",
+                ],
+                "",
+            ),
+            &["fleet:ready", "P2"],
+        ),
+        open_issue(
+            999,
+            "unrelated core change",
+            &body(&["crates/edda-core/src/types.rs"], ""),
+            &["fleet:ready", "P2"],
+        ),
+    ];
+    let queue = compute_order(&input(&issues, "GREEN"));
+
+    assert_eq!(row(&queue, 671).collides_with, vec![685]);
+    assert_eq!(row(&queue, 685).collides_with, vec![671]);
+    assert!(row(&queue, 999).collides_with.is_empty());
+    assert_eq!(row(&queue, 671).score.collision, W_COLLISION_PEER);
+    assert_eq!(row(&queue, 999).score.collision, 0);
+
+    assert!(row(&queue, 671).rank < row(&queue, 685).rank);
+    assert_eq!(row(&queue, 671).status, Status::Ready);
+    assert_eq!(row(&queue, 685).status, Status::Hold);
+    assert_eq!(
+        row(&queue, 685).hold_reason.as_deref(),
+        Some("surface collision with #671 on crates/edda-cli/src/main.rs")
+    );
+    assert_eq!(row(&queue, 999).status, Status::Ready);
+    assert!(row(&queue, 999).hold_reason.is_none());
+}
+
+/// RED health zeroes mechanism weight. The only escape is a body citing a red
+/// run or gate link — without one the issue is not a pipeline blocker.
+#[test]
+fn red_health_zeroes_mechanism_weight_unless_a_red_run_is_cited() {
+    let issues = vec![
+        open_issue(
+            997,
+            "next-issue.sh gate flake",
+            &body(&["scripts/fleet/next-issue.sh"], ""),
+            &["fleet:ready", "P1"],
+        ),
+        open_issue(
+            998,
+            "push guard blocks every lane",
+            &body(
+                &["scripts/fleet/guard-push.sh"],
+                "\nred gate: https://github.com/fagemx/edda/actions/runs/123456789\n",
+            ),
+            &["fleet:ready", "P1"],
+        ),
+        open_issue(
+            1015,
+            "fleet order",
+            &body(&["crates/edda-cli/src/cmd_fleet_order.rs"], ""),
+            &["fleet:ready", "P1"],
+        ),
+    ];
+
+    let red = compute_order(&input(&issues, "RED"));
+    assert_eq!(red.mechanism_dispatch, "freeze");
+    assert_eq!(row(&red, 997).score.total, 0);
+    assert_eq!(row(&red, 997).score.frozen, -40);
+    assert_eq!(row(&red, 997).status, Status::Frozen);
+    assert_eq!(row(&red, 998).score.blocker, W_RED_RUN_BLOCKER);
+    assert_eq!(row(&red, 998).score.frozen, 0);
+    assert!(row(&red, 998).score.total > 0);
+    assert_eq!(row(&red, 998).status, Status::Ready);
+    assert!(row(&red, 998).rank < row(&red, 997).rank);
+
+    let green = compute_order(&input(&issues, "GREEN"));
+    assert_eq!(green.mechanism_dispatch, "open");
+    assert_eq!(row(&green, 997).score.frozen, 0);
+    assert_eq!(row(&green, 997).status, Status::Ready);
+    // The blocker bonus exists only as the freeze exception.
+    assert_eq!(row(&green, 998).score.blocker, 0);
+    assert!(row(&green, 1015).rank < row(&green, 997).rank);
+}
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+#[test]
+fn identical_input_yields_identical_output_whatever_the_input_order() {
+    let a = open_issue(
+        10,
+        "a",
+        &body(&["crates/edda-core/src/types.rs"], ""),
+        &["fleet:ready", "P1"],
+    );
+    let b = open_issue(
+        20,
+        "b",
+        &body(&["crates/edda-cli/src/cmd_fleet.rs"], ""),
+        &["fleet:ready", "P1"],
+    );
+    let c = open_issue(30, "c", &body(&["docs/reference/cli.md"], ""), &["P1"]);
+
+    let forward = compute_order(&input(&[a.clone(), b.clone(), c.clone()], "GREEN"));
+    let reversed = compute_order(&input(&[c, b, a], "GREEN"));
+
+    assert_eq!(
+        serde_json::to_string(&forward).expect("serialize"),
+        serde_json::to_string(&reversed).expect("serialize")
+    );
+    assert_eq!(render_markdown(&forward), render_markdown(&reversed));
+    assert_eq!(render_text(&forward), render_text(&reversed));
+}
+
+#[test]
+fn equal_scores_fall_back_to_the_issue_number() {
+    let surface = ["crates/edda-core/src/types.rs"];
+    let issues = vec![
+        open_issue(300, "third", &body(&surface, ""), &["fleet:ready", "P1"]),
+        open_issue(100, "first", &body(&surface, ""), &["fleet:ready", "P1"]),
+        open_issue(200, "second", &body(&surface, ""), &["fleet:ready", "P1"]),
+    ];
+    let queue = compute_order(&input(&issues, "GREEN"));
+    let numbers: Vec<u64> = queue.rows.iter().map(|row| row.number).collect();
+    assert_eq!(numbers, vec![100, 200, 300]);
+    // All three declare the same file, so only the head is dispatchable.
+    assert_eq!(row(&queue, 100).status, Status::Ready);
+    assert_eq!(row(&queue, 200).status, Status::Hold);
+    assert_eq!(row(&queue, 300).status, Status::Hold);
+}
+
+#[test]
+fn every_score_decomposes_into_its_components() {
+    let issues = vec![
+        open_issue(
+            1,
+            "product",
+            &body(&["crates/edda-core/src/types.rs"], ""),
+            &["fleet:ready", "P0"],
+        ),
+        open_issue(
+            2,
+            "mechanism",
+            &body(&["scripts/fleet/next-issue.sh"], ""),
+            &["fleet:ready"],
+        ),
+        open_issue(
+            3,
+            "stale",
+            "## What happened\n\n`a/b/gone.rs` is used.\n",
+            &[],
+        ),
+    ];
+    for status in ["GREEN", "RED"] {
+        for row in compute_order(&input(&issues, status)).rows {
+            let score = row.score;
+            assert_eq!(
+                score.class
+                    + score.readiness
+                    + score.priority
+                    + score.blocker
+                    + score.collision
+                    + score.freshness
+                    + score.frozen,
+                score.total,
+                "row #{} under {status} does not sum",
+                row.number
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Freshness (#970), evaluated against the pinned tree
+// ---------------------------------------------------------------------------
+
+/// A path the issue declares it will create WARNs; a genuinely deleted path
+/// still FAILs, and sinks the issue out of the dispatchable queue.
+#[test]
+fn a_declared_path_warns_and_a_deleted_path_still_fails() {
+    let body = "## What happened\n\
+                the check reads `crates/edda-cli/src/deleted.rs` today.\n\
+                the fix lands in `crates/edda-cli/src/cmd_fleet_order.rs`.\n\
+                it also reads `crates/edda-cli/src/main.rs`.\n\
+                \n\
+                ## Predicted surface\n\
+                \n\
+                `crates/edda-cli/src/cmd_fleet_order.rs`\n\
+                \n\
+                ## doneWhen\n\
+                \n\
+                - delivered.\n";
+    assert_eq!(
+        verdict_for(body, "crates/edda-cli/src/deleted.rs"),
+        Some(Verdict::Fail)
+    );
+    assert_eq!(
+        verdict_for(body, "crates/edda-cli/src/cmd_fleet_order.rs"),
+        Some(Verdict::Warn)
+    );
+    // A path that exists at the pinned tree produces no finding at all.
+    assert_eq!(verdict_for(body, "crates/edda-cli/src/main.rs"), None);
+
+    let queue = compute_order(&input(
+        &[open_issue(1, "stale one", body, &["fleet:ready", "P0"])],
+        "GREEN",
+    ));
+    assert_eq!(row(&queue, 1).status, Status::Stale);
+    assert_eq!(row(&queue, 1).score.freshness, W_STALE);
+}
+
+/// A negated mention is a statement of absence, not a reference.
+#[test]
+fn a_negated_mention_is_not_a_reference() {
+    let body = "## What happened\n\
+                there is no `crates/edda-cli/src/deleted.rs` anywhere.\n\
+                \n\
+                ## doneWhen\n\
+                \n\
+                - delivered.\n";
+    assert!(freshness(body).is_empty());
+}
+
+#[test]
+fn donewhen_headings_match_case_insensitively() {
+    for heading in ["## doneWhen", "## DoneWhen", "## DONEWHEN", "## donewhen"] {
+        let body = format!("## What happened\n\nprose.\n\n{heading}\n\n- delivered.\n");
+        assert!(
+            freshness(&body).is_empty(),
+            "{heading} should satisfy the doneWhen check"
+        );
+    }
+    let missing = "## What happened\n\nprose.\n";
+    assert_eq!(verdict_for(missing, "## doneWhen"), Some(Verdict::Fail));
+    let empty = "## What happened\n\nprose.\n\n## doneWhen\n\n";
+    assert_eq!(verdict_for(empty, "## doneWhen"), Some(Verdict::Fail));
+}
+
+/// A command the issue is about to build, or one cited with evidence that it
+/// ran, must not FAIL the gate; an unqualified reference to a verb that does
+/// not exist still does.
+#[test]
+fn a_to_be_built_or_evidence_cited_command_warns_instead_of_failing() {
+    let declared = "## What happened\n\nprose.\n\n## doneWhen\n\n- `edda garden plant` ranks it.\n";
+    assert_eq!(
+        verdict_for(declared, "edda garden plant"),
+        Some(Verdict::Warn)
+    );
+
+    let cited = "## What happened\n\n\
+                 `edda garden plant` failed at https://example.invalid/run/1.\n\
+                 \n## doneWhen\n\n- delivered.\n";
+    assert_eq!(verdict_for(cited, "edda garden plant"), Some(Verdict::Warn));
+
+    let unqualified = "## What happened\n\n\
+                       the controller runs `edda garden plant` daily.\n\
+                       \n## doneWhen\n\n- delivered.\n";
+    assert_eq!(
+        verdict_for(unqualified, "edda garden plant"),
+        Some(Verdict::Fail)
+    );
+}
+
+/// The measured #1015 false FAIL: `edda fleet --help` exited nonzero only
+/// because the `edda` on PATH predated the verb. Resolving against the pinned
+/// tree's verb table cannot reproduce it.
+#[test]
+fn a_stale_binary_on_path_cannot_produce_a_false_fail() {
+    let body = "## What happened\n\n\
+                the freshness gate ran `edda fleet --help` and it exited nonzero.\n\
+                \n## doneWhen\n\n- delivered.\n";
+    // `fleet` is in the pinned tree's verb table, so there is nothing to report.
+    assert!(freshness(body).is_empty());
+    // And the same body against a tree that genuinely lacks the verb does FAIL.
+    let older: BTreeSet<String> = ["ask"].iter().map(|v| (*v).to_string()).collect();
+    let findings = evaluate_freshness(body, &tree(), &older);
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].verdict, Verdict::Fail);
+    assert_eq!(findings[0].target, "edda fleet --help");
+}
+
+#[test]
+fn unresolvable_tokens_warn_without_blocking() {
+    let body = "## What happened\n\n\
+                see `main.rs` and `if/else` and `crates/edda-cli/src/../evil.rs`,\n\
+                beside `types.rs` which resolves, the ledger key\n\
+                `fleet.mechanism-layer` and the field `event_data.error`.\n\
+                \n## doneWhen\n\n- delivered.\n";
+    let findings = freshness(body);
+    // `main.rs` is a bare name matching more than one tracked file, `if/else`
+    // has no file-shaped last segment, `../` is not a repository path.
+    assert!(findings.iter().all(|f| f.verdict == Verdict::Warn));
+    assert!(findings.iter().any(|f| f.target == "main.rs"));
+    assert!(findings
+        .iter()
+        .any(|f| f.target == "crates/edda-cli/src/../evil.rs"));
+    assert!(!findings.iter().any(|f| f.target == "if/else"));
+    // A bare name resolving to exactly one tracked file is silent.
+    assert_eq!(verdict_for(body, "types.rs"), None);
+    // So is a dotted token that resolves to nothing: it is not a path, and
+    // reporting every ledger key would bury the findings that mean something.
+    assert_eq!(verdict_for(body, "fleet.mechanism-layer"), None);
+    assert_eq!(verdict_for(body, "event_data.error"), None);
+}
+
+/// Issues cite crate- and module-relative paths. Those are references, not
+/// deleted files.
+#[test]
+fn a_relative_reference_resolves_against_the_tree() {
+    let body = "## What happened\n\n\
+                `edda-cli/src/main.rs` and `src/main.rs` and `edda-cli/src/gone.rs`.\n\
+                \n## doneWhen\n\n- delivered.\n";
+    // Suffix of exactly one tracked path.
+    assert_eq!(verdict_for(body, "edda-cli/src/main.rs"), None);
+    // Suffix of two tracked paths: a reference, but an imprecise one.
+    assert_eq!(verdict_for(body, "src/main.rs"), Some(Verdict::Warn));
+    // Suffix of none: genuinely absent.
+    assert_eq!(
+        verdict_for(body, "edda-cli/src/gone.rs"),
+        Some(Verdict::Fail)
+    );
+}
+
+/// The observation sections make claims about today's tree and can be stale;
+/// the sections describing what the issue will build cannot be. #763 names the
+/// module it will create under `## 改哪裡` and #761 names its own under
+/// `## Suspected surface`; the shell gate FAILed both for not existing yet.
+#[test]
+fn a_future_tense_section_declares_rather_than_references() {
+    let observed = "## What happened\n\n\
+                    the gate reads `crates/edda-cli/src/cmd_review.rs` today.\n\
+                    \n## doneWhen\n\n- delivered.\n";
+    assert_eq!(
+        verdict_for(observed, "crates/edda-cli/src/cmd_review.rs"),
+        Some(Verdict::Fail)
+    );
+
+    let declared = |heading: &str| {
+        let body = format!(
+            "## What happened\n\nprose.\n\n{heading}\n\n\
+             - `crates/edda-cli/src/cmd_review.rs` gains the subcommand.\n\
+             \n## doneWhen\n\n- delivered.\n"
+        );
+        verdict_for(&body, "crates/edda-cli/src/cmd_review.rs")
+    };
+    // Prose sections that describe the delivery WARN.
+    assert_eq!(declared("## 改哪裡"), Some(Verdict::Warn));
+    assert_eq!(declared("## doneWhen"), Some(Verdict::Warn));
+    // A surface section is pure declaration and is not scanned at all.
+    assert_eq!(declared("## Suspected surface"), None);
+    assert_eq!(declared("## Predicted surface"), None);
+}
+
+/// Only `[a-z][a-z0-9-]*` is a verb; the rest are not command references.
+#[test]
+fn a_non_verb_after_edda_is_not_a_command_reference() {
+    let body = "## What happened\n\n\
+                `edda --version` printed it, and the digest showed `edda d… |`.\n\
+                \n## doneWhen\n\n- delivered.\n";
+    assert!(freshness(body).is_empty());
+}
+
+/// Issues cite line ranges. The tree can only answer for the file.
+#[test]
+fn a_cited_line_range_resolves_to_its_file() {
+    let body = "## What happened\n\n\
+                `crates/edda-cli/src/main.rs:12-30` and `crates/edda-cli/src/cmd_fleet.rs:7`\n\
+                are fine; `crates/edda-cli/src/gone.rs:9` is not.\n\
+                \n## doneWhen\n\n- delivered.\n";
+    assert_eq!(verdict_for(body, "crates/edda-cli/src/main.rs:12-30"), None);
+    assert_eq!(
+        verdict_for(body, "crates/edda-cli/src/cmd_fleet.rs:7"),
+        None
+    );
+    assert_eq!(
+        verdict_for(body, "crates/edda-cli/src/gone.rs:9"),
+        Some(Verdict::Fail)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Lane routing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lane_routing_is_mechanical() {
+    let issues = vec![
+        open_issue(
+            1,
+            "small product change",
+            &body(&["crates/edda-core/src/types.rs"], ""),
+            &["fleet:ready"],
+        ),
+        open_issue(
+            2,
+            "wide surface",
+            &body(
+                &[
+                    "crates/a/src/one.rs",
+                    "crates/a/src/two.rs",
+                    "crates/a/src/three.rs",
+                    "crates/a/src/four.rs",
+                ],
+                "",
+            ),
+            &["fleet:ready"],
+        ),
+        open_issue(
+            3,
+            "shell surface",
+            &body(&["scripts/fleet/next-issue.sh"], ""),
+            &["fleet:ready"],
+        ),
+        open_issue(4, "no surface", "## doneWhen\n\n- delivered.\n", &[]),
+        open_issue(
+            5,
+            "governance",
+            &body(&["crates/edda-core/src/types.rs"], ""),
+            &["governance"],
+        ),
+        open_issue(
+            6,
+            "needs judgment",
+            &body(&["crates/edda-core/src/types.rs"], "\n[判斷] wording.\n"),
+            &["fleet:ready"],
+        ),
+    ];
+    let queue = compute_order(&input(&issues, "GREEN"));
+
+    assert_eq!(row(&queue, 1).lane, Lane::Flash);
+    assert_eq!(
+        row(&queue, 1).pending_checks,
+        vec![PENDING_BRIEF_RENDER, PENDING_DISPATCH_DRY_RUN]
+    );
+    assert_eq!(row(&queue, 2).lane, Lane::Strong);
+    assert!(row(&queue, 2).lane_reasons[0].contains("> flash cap 3"));
+    assert!(row(&queue, 2).pending_checks.is_empty());
+    assert_eq!(row(&queue, 3).lane, Lane::Strong);
+    assert!(row(&queue, 3).lane_reasons[0].contains("scripts/"));
+    assert_eq!(row(&queue, 4).lane, Lane::Strong);
+    assert_eq!(row(&queue, 4).lane_reasons, vec!["no declared surface"]);
+    assert_eq!(row(&queue, 5).lane, Lane::Controller);
+    assert_eq!(row(&queue, 6).lane, Lane::Controller);
+    assert!(row(&queue, 6).lane_reasons[0].contains(JUDGMENT_MARKER));
+}
+
+#[test]
+fn an_in_flight_issue_is_reported_claimed_and_claims_no_path() {
+    let surface = ["crates/edda-core/src/types.rs"];
+    let issues = vec![
+        open_issue(
+            1,
+            "in flight",
+            &body(&surface, ""),
+            &["fleet:ready", "fleet:claimed", "P0"],
+        ),
+        open_issue(2, "waiting", &body(&surface, ""), &["fleet:ready", "P2"]),
+    ];
+    let queue = compute_order(&input(&issues, "GREEN"));
+    assert_eq!(row(&queue, 1).status, Status::Claimed);
+    // #1 holds no path, so #2 is not blocked behind a row nobody can dispatch.
+    assert_eq!(row(&queue, 2).status, Status::Ready);
+}
+
+#[test]
+fn the_queue_header_reports_its_inputs() {
+    let queue = compute_order(&input(
+        &[open_issue(1, "one", &body(&["crates/a/src/x.rs"], ""), &[])],
+        "yellow",
+    ));
+    assert_eq!(queue.generated_at, "2026-09-07T12:00:00Z");
+    assert_eq!(queue.health_status, "YELLOW");
+    assert_eq!(queue.mechanism_dispatch, "open");
+    assert_eq!(queue.flash_max_surface_files, FLASH_CAP_DEFAULT);
+    assert_eq!(queue.flash_cap_source, "default");
+    assert_eq!(queue.total_issues, 1);
+}

--- a/crates/edda-cli/src/cmd_fleet_order/tests.rs
+++ b/crates/edda-cli/src/cmd_fleet_order/tests.rs
@@ -41,6 +41,7 @@ fn tree() -> BTreeSet<String> {
         "crates/edda-serve/src/main.rs",
         "crates/edda-cli/src/cmd_fleet.rs",
         "crates/edda-cli/src/cmd_export.rs",
+        "crates/edda-ledger/src/sync.rs",
         "crates/edda-core/src/types.rs",
         "scripts/fleet/next-issue.sh",
         "scripts/fleet/guard-push.sh",
@@ -60,6 +61,7 @@ fn verbs() -> BTreeSet<String> {
 fn input(issues: &[OpenIssue], health: &str) -> OrderInput {
     OrderInput {
         issues: issues.to_vec(),
+        flash_checks: BTreeMap::new(),
         tree_paths: tree(),
         known_verbs: verbs(),
         health_status: health.to_string(),
@@ -67,6 +69,35 @@ fn input(issues: &[OpenIssue], health: &str) -> OrderInput {
         flash_cap_source: "default".to_string(),
         now: now(),
     }
+}
+
+/// Both subprocess criteria resolved for one issue. `cli` produces this shape
+/// by running the scripts; a fixture states it, which is the point of moving
+/// the checks onto [`OrderInput`].
+fn checks(number: u64, render: bool, dry_run: bool) -> BTreeMap<u64, Vec<FlashCheck>> {
+    let mut results = vec![FlashCheck {
+        name: CHECK_BRIEF_RENDER.to_string(),
+        passed: render,
+        note: if render {
+            "brief-from-issue.sh exited 0".to_string()
+        } else {
+            "brief-from-issue.sh exited 2: no ## Predicted surface".to_string()
+        },
+    }];
+    // The real collector short-circuits: a brief that did not render leaves
+    // the validator nothing to run, so no second result exists.
+    if render {
+        results.push(FlashCheck {
+            name: CHECK_DISPATCH_DRY_RUN.to_string(),
+            passed: dry_run,
+            note: if dry_run {
+                "brief-validate.sh VALID".to_string()
+            } else {
+                "brief-validate.sh exited 1: INVALID step=3".to_string()
+            },
+        });
+    }
+    BTreeMap::from([(number, results)])
 }
 
 fn row(queue: &Queue, number: u64) -> &Row {
@@ -92,9 +123,12 @@ fn verdict_for(body: &str, target: &str) -> Option<Verdict> {
 // The two properties #1015 names explicitly
 // ---------------------------------------------------------------------------
 
-/// #671 and #685 both declare `crates/edda-cli/src/main.rs`. Label-based
-/// detection saw two unrelated issues and both got built (#887's shape); the
-/// per-file rule (#1005) sees one collision and serializes them.
+/// The measured #671/#685 shape: two labels in common (`enhancement`,
+/// `lane:feature`) and a real overlap on `crates/edda-ledger/src/sync.rs`.
+/// Label-based detection reads the shared labels and still cannot answer the
+/// question — labels are issue-level, conflicts are file-level — which is how
+/// two lanes built the same file (#887's shape). The per-file rule (#1005)
+/// sees one collision and serializes them.
 #[test]
 fn per_file_collision_holds_the_lower_ranked_peer() {
     let issues = vec![
@@ -103,24 +137,24 @@ fn per_file_collision_holds_the_lower_ranked_peer() {
             "committed mirror",
             &body(
                 &[
-                    "crates/edda-cli/src/main.rs",
+                    "crates/edda-ledger/src/sync.rs",
                     "crates/edda-cli/src/cmd_export.rs",
                 ],
                 "",
             ),
-            &["fleet:ready", "P1"],
+            &["enhancement", "lane:feature", "fleet:ready", "P1"],
         ),
         open_issue(
             685,
             "sync surface",
             &body(
                 &[
-                    "crates/edda-cli/src/main.rs",
+                    "crates/edda-ledger/src/sync.rs",
                     "crates/edda-cli/src/cmd_fleet.rs",
                 ],
                 "",
             ),
-            &["fleet:ready", "P2"],
+            &["enhancement", "lane:feature", "fleet:ready", "P2"],
         ),
         open_issue(
             999,
@@ -142,7 +176,7 @@ fn per_file_collision_holds_the_lower_ranked_peer() {
     assert_eq!(row(&queue, 685).status, Status::Hold);
     assert_eq!(
         row(&queue, 685).hold_reason.as_deref(),
-        Some("surface collision with #671 on crates/edda-cli/src/main.rs")
+        Some("surface collision with #671 on crates/edda-ledger/src/sync.rs")
     );
     assert_eq!(row(&queue, 999).status, Status::Ready);
     assert!(row(&queue, 999).hold_reason.is_none());
@@ -540,16 +574,23 @@ fn lane_routing_is_mechanical() {
             &["fleet:ready"],
         ),
     ];
-    let queue = compute_order(&input(&issues, "GREEN"));
+    let mut order_input = input(&issues, "GREEN");
+    order_input.flash_checks = checks(1, true, true);
+    let queue = compute_order(&order_input);
 
     assert_eq!(row(&queue, 1).lane, Lane::Flash);
     assert_eq!(
-        row(&queue, 1).pending_checks,
-        vec![PENDING_BRIEF_RENDER, PENDING_DISPATCH_DRY_RUN]
+        row(&queue, 1)
+            .flash_checks
+            .iter()
+            .map(|check| check.name.as_str())
+            .collect::<Vec<_>>(),
+        vec![CHECK_BRIEF_RENDER, CHECK_DISPATCH_DRY_RUN]
     );
     assert_eq!(row(&queue, 2).lane, Lane::Strong);
     assert!(row(&queue, 2).lane_reasons[0].contains("> flash cap 3"));
-    assert!(row(&queue, 2).pending_checks.is_empty());
+    // A row the cheap criteria already routed away never reaches the scripts.
+    assert!(row(&queue, 2).flash_checks.is_empty());
     assert_eq!(row(&queue, 3).lane, Lane::Strong);
     assert!(row(&queue, 3).lane_reasons[0].contains("scripts/"));
     assert_eq!(row(&queue, 4).lane, Lane::Strong);
@@ -557,6 +598,56 @@ fn lane_routing_is_mechanical() {
     assert_eq!(row(&queue, 5).lane, Lane::Controller);
     assert_eq!(row(&queue, 6).lane, Lane::Controller);
     assert!(row(&queue, 6).lane_reasons[0].contains(JUDGMENT_MARKER));
+}
+
+/// #1015 doneWhen bullet 4: `任一不過 → strong`. The row below satisfies both
+/// cheap criteria — one product file, no `scripts/` path — so the only thing
+/// that can keep it off the flash lane is a subprocess criterion, and each of
+/// the three ways one can come back short has to do exactly that.
+#[test]
+fn a_failed_subprocess_criterion_forces_strong() {
+    let issues = vec![open_issue(
+        1,
+        "small product change",
+        &body(&["crates/edda-core/src/types.rs"], ""),
+        &["fleet:ready"],
+    )];
+
+    // Baseline: with both criteria satisfied the same row is flash, so the
+    // assertions below isolate the criterion and nothing else.
+    let mut both_pass = input(&issues, "GREEN");
+    both_pass.flash_checks = checks(1, true, true);
+    assert_eq!(row(&compute_order(&both_pass), 1).lane, Lane::Flash);
+
+    // The #945 dry-run validator reported INVALID.
+    let mut dry_run_failed = input(&issues, "GREEN");
+    dry_run_failed.flash_checks = checks(1, true, false);
+    let queue = compute_order(&dry_run_failed);
+    assert_eq!(row(&queue, 1).lane, Lane::Strong);
+    assert!(row(&queue, 1).lane_reasons[0].contains("<= flash cap 3"));
+    assert_eq!(
+        row(&queue, 1).lane_reasons[2],
+        "dispatch-dry-run failed: brief-validate.sh exited 1: INVALID step=3"
+    );
+
+    // The brief did not render, so the validator was never reached: the row
+    // carries one check, not two, and the render is what it names.
+    let mut render_failed = input(&issues, "GREEN");
+    render_failed.flash_checks = checks(1, false, true);
+    let queue = compute_order(&render_failed);
+    assert_eq!(row(&queue, 1).lane, Lane::Strong);
+    assert_eq!(row(&queue, 1).flash_checks.len(), 1);
+    assert_eq!(
+        row(&queue, 1).lane_reasons[1],
+        "brief-render failed: brief-from-issue.sh exited 2: no ## Predicted surface"
+    );
+
+    // Nothing ran at all (a `--issues` fixture run). Not evaluated is not a
+    // pass, so the safe lane wins and the row names the check that decided it.
+    let queue = compute_order(&input(&issues, "GREEN"));
+    assert_eq!(row(&queue, 1).lane, Lane::Strong);
+    assert!(row(&queue, 1).flash_checks.is_empty());
+    assert_eq!(row(&queue, 1).lane_reasons[1], "brief-render not evaluated");
 }
 
 #[test]

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -19,6 +19,7 @@ mod cmd_dispatch_acp;
 mod cmd_draft;
 mod cmd_export;
 mod cmd_fleet;
+mod cmd_fleet_order;
 mod cmd_gc;
 mod cmd_group;
 mod cmd_init;
@@ -514,7 +515,7 @@ enum Command {
         #[command(subcommand)]
         cmd: Option<cmd_phase::PhaseCmd>,
     },
-    /// Fleet health and ordering (GH-1014)
+    /// Fleet health and ordering (GH-1014, GH-1015)
     Fleet {
         #[command(subcommand)]
         cmd: cmd_fleet::FleetCmd,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1080,10 +1080,13 @@ or `/checks` — which instead earns the `blocker` bonus. Without a link the
 issue is not a pipeline blocker.
 
 Collision: computed from the pairwise intersection of `## Predicted surface`
-paths, never from labels (#1005 — #671 and #685 shared
-`crates/edda-cli/src/main.rs` and no label at all). Every colliding peer costs
-a penalty, and walking the ranked queue puts the head on `ready` and the rest
-on `hold` naming the owner and the shared path.
+paths, never from labels (#1005). Labels are issue-level and conflicts are
+file-level, so a shared label neither predicts nor excludes one — #671 and #685
+are the live example: they share two labels (`enhancement`, `lane:feature`),
+which says nothing either way, and they really do collide, on
+`crates/edda-ledger/src/sync.rs` and `docs/guides/multi-agent.md`. Every
+colliding peer costs a penalty, and walking the ranked queue puts the head on
+`ready` and the rest on `hold` naming the owner and the shared path.
 
 Freshness (#970) is re-derived here rather than trusted from a label. It
 resolves paths against the pinned tree (`git ls-tree -r HEAD`) and commands
@@ -1098,14 +1101,29 @@ headings match case-insensitively. Cited line ranges (`lib.rs:288-296`) resolve
 to their file, and crate- or module-relative references resolve as a suffix of
 the tracked paths.
 
-Lane routing, in evaluation order: a `governance` or `fleet:goal` label or a
-`[判斷]` marker in the body routes to `controller`; an empty surface, a surface
-wider than the flash cap, or any `scripts/` path routes to `strong`; everything
-else routes to `flash`. The cap is the ledger key
-`fleet.order.flash-max-surface-files` (default 3), and `flash_cap_source`
-records whether it resolved. The two flash criteria that need a subprocess —
-the brief render and the #945 dry-run validator — are reported on the row as
-`pending_checks` for the dispatcher to run, never shelled out mid-computation.
+Lane routing, in evaluation order. A `governance` or `fleet:goal` label or a
+`[判斷]` marker in the body routes to `controller`. Then the four flash criteria,
+any one of which failing routes to `strong`:
+
+1. the surface is non-empty and no wider than the flash cap — the ledger key
+   `fleet.order.flash-max-surface-files` (default 3), with `flash_cap_source`
+   recording whether it resolved from the ledger or the built-in default;
+2. no `scripts/` path in the surface;
+3. `brief-render` — `scripts/fleet/brief-from-issue.sh <issue>` exits 0 (#885);
+4. `dispatch-dry-run` — `scripts/fleet/brief-validate.sh` reports VALID for the
+   issue's authored brief under `$EDDA_FLEET_SCRATCH` (default `~/.edda/fleet`),
+   which is the same brief `next-issue.sh` would launch with (#945).
+
+Criteria 3 and 4 need a subprocess, so they are run once at collection time
+alongside `gh` and `git ls-tree` and handed to the ranker as data; ranking
+itself stays pure and network-free. Only issues that criteria 1 and 2 have not
+already routed away are spent a process on, and a failed render short-circuits
+the dry-run. Each result is reported on the row under `flash_checks`.
+
+**A criterion that was not evaluated is not a pass.** An unwritten authored
+brief, a missing `sh`, or a `--issues` fixture run (where the issue numbers are
+synthetic and the scripts are not run at all) routes the row to `strong`, and
+`lane_reasons` names the check that decided it.
 
 Statuses: `ready`, `hold` (behind a higher-ranked row on a shared path),
 `frozen` (mechanism under a RED freeze), `stale` (freshness FAILed), `claimed`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -980,7 +980,9 @@ documented surface cannot silently drift from the binary;
 
 ### edda fleet
 
-Fleet health — measure the path-classified mix of recent work. `edda fleet
+#### edda fleet health
+
+Measure the path-classified mix of recent work. `edda fleet
 health` reads the merged PRs and opened issues of the last `--window` days
 through `gh` (server-side date filters `merged:>=` / `created:>=`), and
 classifies each by changed paths (merged PRs) or by the backticked paths of
@@ -1026,6 +1028,96 @@ Exit codes:
 | 3 | YELLOW |
 | 4 | RED |
 | 1 | error (a `gh` failure or a failed stdout write) |
+| 2 | usage |
+
+#### edda fleet order
+
+Deterministic, health-gated ready queue with lane routing. `edda fleet order`
+ranks the open issues so ordering is a re-runnable computation instead of a
+hand-written plan: the same input yields the same output byte-for-byte, and
+every row carries the score components that produced its rank, so the
+operator's remaining move is a veto at the queue head.
+
+```bash
+edda fleet order                                   # text report
+edda fleet order --markdown                        # board-comment table
+edda fleet order --issues queue.json --json        # offline, from a fixture
+```
+
+Flags:
+
+- `--issues <PATH>` — read open issues from a JSON fixture with the shape of
+  `gh issue list --json number,title,body,labels` instead of querying `gh`.
+- `--health-status <GREEN|YELLOW|RED>` — use this status instead of computing
+  it; any casing is accepted, anything else is a usage error (exit 2).
+- `--window <N>` — rolling window in days for the health computation;
+  default 7, must be at least 1.
+- `--json` — emit the queue as JSON.
+- `--markdown` — emit the board-comment table.
+- `--limit <N>` — keep only the top N rows; ranks are assigned before
+  truncation.
+- `--json` and `--markdown` are mutually exclusive (usage error, exit 2).
+
+Score components, which sum to the row's total:
+
+| Component | Value |
+|-----------|-------|
+| `class` | product +40, other +10, mechanism +0, from the `## Predicted surface` paths |
+| `readiness` | `fleet:ready` +25 |
+| `priority` | P0 +30, P1 +15, P2 +5 |
+| `blocker` | +50 — the RED-freeze exception, below |
+| `collision` | −10 per peer issue declaring a shared surface path |
+| `freshness` | −100 when the freshness re-check FAILed |
+| `frozen` | the negation of everything above, when the row is frozen |
+
+Rows sort by total descending, then by issue number ascending, so equal scores
+always fall back to the older issue.
+
+Health coupling: when the status is RED, `mechanism_dispatch` is `freeze` and
+every mechanism-class row is zeroed (`status: frozen`). The one exception is a
+row whose body cites a red run or gate link — a URL containing `/actions/runs/`
+or `/checks` — which instead earns the `blocker` bonus. Without a link the
+issue is not a pipeline blocker.
+
+Collision: computed from the pairwise intersection of `## Predicted surface`
+paths, never from labels (#1005 — #671 and #685 shared
+`crates/edda-cli/src/main.rs` and no label at all). Every colliding peer costs
+a penalty, and walking the ranked queue puts the head on `ready` and the rest
+on `hold` naming the owner and the shared path.
+
+Freshness (#970) is re-derived here rather than trusted from a label. It
+resolves paths against the pinned tree (`git ls-tree -r HEAD`) and commands
+against this binary's own verb table — not against the `edda` on `PATH`, which
+may predate the tree and produced the false `FAIL edda fleet --help exited
+nonzero` on #1015 itself. Findings are WARN or FAIL only; a reference that
+resolves is silent. A path or command declared by a section that describes what
+the issue will build (`doneWhen`, any `… surface` heading, `改哪裡`) WARNs, as
+does an evidence-cited command; a reference in an observation section to a path
+or verb that does not exist FAILs and marks the row `stale`. `doneWhen`
+headings match case-insensitively. Cited line ranges (`lib.rs:288-296`) resolve
+to their file, and crate- or module-relative references resolve as a suffix of
+the tracked paths.
+
+Lane routing, in evaluation order: a `governance` or `fleet:goal` label or a
+`[判斷]` marker in the body routes to `controller`; an empty surface, a surface
+wider than the flash cap, or any `scripts/` path routes to `strong`; everything
+else routes to `flash`. The cap is the ledger key
+`fleet.order.flash-max-surface-files` (default 3), and `flash_cap_source`
+records whether it resolved. The two flash criteria that need a subprocess —
+the brief render and the #945 dry-run validator — are reported on the row as
+`pending_checks` for the dispatcher to run, never shelled out mid-computation.
+
+Statuses: `ready`, `hold` (behind a higher-ranked row on a shared path),
+`frozen` (mechanism under a RED freeze), `stale` (freshness FAILed), `claimed`
+(`fleet:claimed`). Only `ready` rows claim paths, so an in-flight or frozen row
+never blocks anything behind it.
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| 0 | queue rendered |
+| 1 | error (a `gh` or `git` failure, an unreadable fixture, a failed stdout write) |
 | 2 | usage |
 
 ### edda review


### PR DESCRIPTION
## Problem and change

Ordering was the controller's hand-written plan (#932's manual triage of 63
issues), machine selection read labels in `scripts/fleet/next-issue.sh`, and
collision was judged per issue when conflict is per file — the shape that let
#887 be claimed by two machines and built twice. `edda fleet order` moves the
ranking into the product as a deterministic, decomposable computation.

- **Deterministic.** Sort key is `(score descending, issue number ascending)`,
  so equal scores always fall back to the older issue and no input permutation
  can reorder the result. Fixture-tested on serialized output and on both
  renderings.
- **Decomposable.** Every row carries the seven score components that sum to its
  total (`class`, `readiness`, `priority`, `blocker`, `collision`, `freshness`,
  `frozen`), printed in the text and markdown renderings. A bare rank is
  unreviewable; the operator's remaining move is a veto at the queue head.
- **Health-coupled.** RED sets `mechanism_dispatch: freeze` and zeroes every
  mechanism-class row (`status: frozen`, the zeroing recorded as its own
  component so the sum still checks). The one exception is a body citing a red
  run/gate link — a URL containing `/actions/runs/` or `/checks` — which earns
  the `blocker` bonus instead. No link, not a pipeline blocker.
- **Per-file collision (#1005).** Pairwise intersection of `## Predicted
  surface` paths, never labels. Walking the ranked queue leaves the head
  `ready` and holds the rest naming the owner and the shared path; only a
  dispatchable row claims a path, so an in-flight, frozen or stale row never
  blocks the queue behind it.
- **Freshness in the product (#970).** Re-derived against the pinned tree
  (`git ls-tree -r HEAD`) and this binary's own clap verb table — not the `edda`
  on `PATH`, which is what produced the false
  `FAIL edda fleet --help exited nonzero` on this very issue at
  `a4f97990d78a44a95df6f57909e97f7057f104ff`. A path or command declared by a
  section describing what the issue will build (`doneWhen`, any surface heading,
  `改哪裡`) WARNs; an evidence-cited command WARNs; a reference in an
  observation section to something that does not exist FAILs and marks the row
  `stale`. `doneWhen` headings match case-insensitively.
- **Mechanical lane routing.** `governance`/`fleet:goal` label or a `[判斷]`
  marker → controller; empty surface, surface wider than the ledger-keyed cap
  (`fleet.order.flash-max-surface-files`, default 3), or any `scripts/` path →
  strong; otherwise flash. The two flash criteria that need a subprocess (brief
  render, the #945 dry-run validator) are reported on the row as
  `pending_checks` for the dispatcher to run — named, not silently skipped, and
  never shelled out mid-computation.

Computation is pure and network-free: `gh`, `git` and the ledger are read once
into `OrderInput`, and `compute_order` is a total function over it. `--issues`
takes a JSON fixture so the whole command runs offline. Renderings: text
(default), `--markdown` (board-comment table, the #932 shape), `--json`.

Reuses `cmd_fleet`'s `surface_paths` / `classify_paths` / `compute` rather than
forking a second definition of "mechanism" or of "declared surface". Ordering
does not fit in `cmd_fleet.rs` (888 lines against the 1000 ceiling), so it lands
in a sibling module; `cmd_fleet.rs` grows only by the `Order` variant, the
dispatch match, and a `live_health_status` accessor over the existing seam.

Out of scope by the controller's scope ruling
([issuecomment-5564825188](https://github.com/fagemx/edda/issues/1015#issuecomment-5564825188)):
the three launcher properties folded from #1012/#1013/#1019 moved to #1035.
`scripts/fleet/next-issue.sh` and `issue-freshness.sh` are untouched — the thin
adapter is a follow-up PR per `fleet.mechanism-layer`, and shell edits here
would mix mechanism class into a product-class PR.

`COMPATIBILITY.md` is unchanged: #1022 declared no `fleet health` surface there,
so `fleet order`'s `--json` is unstable by default like the rest of the fleet
surface.

`crates/edda-cli/src/main.rs` is also touched by open PR #1017. This diff
changes only the `mod` declaration, the `Fleet` doc line, and nothing under
`Export` or `Sync` — disjoint symbols.

## Validation

### RAN

Red-then-green, both required fixture tests written before any implementation
existed and shown failing against a stub:

- `cargo test -p edda --bin edda cmd_fleet_order` — RED (2 failed, 0 passed):
  `per_file_collision_holds_the_lower_ranked_peer` panicked
  `no row for #671 in queue of 0`;
  `red_health_zeroes_mechanism_weight_unless_a_red_run_is_cited` panicked
  `assertion left == right failed: left: "" right: "freeze"`.
- Same command after the implementation — GREEN, 40 passed / 0 failed
  (17 in `cmd_fleet_order`, 4 in `render`, 4 in `cli`, plus the 15 pre-existing
  `cmd_fleet` tests).

L0 at `5697ea8113d119bfd066f14e310a39fa93198ca0`:

- `cargo fmt --all --check` — clean.
- `cargo clippy -p edda --all-targets -- -D warnings` — clean (also re-run by
  the pre-commit hook).
- `cargo test -p edda` — 628 passed, 1 failed:
  `cmd_review::evidence::tests::deadline_stops_descendant_and_does_not_start_next_gate`.
  Pre-existing load-sensitive flake, not caused by this diff — it passes in
  isolation (`-- --exact`, twice) and passed two of four full-suite runs, and
  this diff touches no `cmd_review` code (see the file list).
- `sh scripts/lint-file-length.sh --tree` — exit 0. New files are 840 / 262 /
  241 / 592 lines; `cmd_fleet.rs` is 888. No ceiling raised.
- Pre-commit hooks: doc-citation lint, fmt, clippy, markdown-content lint,
  file-length `--staged` — all passed.

End-to-end against the real queue (54 open issues, fixture from
`gh issue list --json number,title,body,labels`):

- `edda fleet order --issues <fixture> --health-status GREEN --limit 12` — text
  report; `--markdown` — pasteable board table; `--json` — parsed and
  aggregated.
- `edda fleet order --limit 6` live — reads `gh` and the ledger, reports
  `health RED (mechanism dispatch freeze)`, exit 0 in 28s.
- Freshness on the real corpus was tuned against measured false-FAIL classes:
  crate/module-relative references and cited line ranges now resolve, ledger
  keys and struct fields are no longer read as filenames, non-verb tokens after
  `edda` are no longer commands, and future-tense sections declare rather than
  reference. Stale rows fell from 27/54 to 20/54, each with a cited reason; the
  survivors are genuine (deleted paths, verbs that do not exist, missing
  `doneWhen`).

### READ

- #1015 body — the seven doneWhen bullets, each delivered: injectable JSON
  fixture; routing field and reproducible decomposition per row; determinism
  proven by fixture test; health-coupled weights with the red-run-link
  exception; per-file collision without labels; fully mechanical flash criteria
  with the subprocess ones named on the row; markdown board rendering;
  `next-issue.sh` left to the follow-up adapter; both required fixture tests
  written first and shown FAILing.
- #1015 comments — the controller scope ruling (issuecomment-5564825188) fixing
  what stays here versus what moves to #1035, the #1005 property
  (issuecomment-5558181245), and the #970 property (issuecomment-5561615194)
  including the fourth false-FAIL shape measured at `a4f9799`.
- Ledger: `fleet.mechanism-layer`, `fleet.dispatch-priority`,
  `fleet.health-ordering` — the weight source and the build order
  (health → order → flash routing).
- `crates/edda-cli/src/cmd_fleet.rs` (GH-1014) for the seam this reuses, and
  `scripts/fleet/issue-freshness.sh` for the four checks the in-product
  freshness re-derives.

Issue: #1015
