### PR TITLE
fix(edda-cli): dispatch claim guard bounds bare-CLI claims in time (GH-1018)

### DIFF
--- a/crates/edda-bridge-claude/src/peers/liveness.rs
+++ b/crates/edda-bridge-claude/src/peers/liveness.rs
@@ -81,8 +81,38 @@ pub fn classify_session_liveness_at(
 
 /// Classify one session's liveness using the current clock.
 pub fn classify_session_liveness(project_id: &str, session_id: &str) -> SessionLiveness {
-    let now = parse_rfc3339_to_epoch(&now_rfc3339()).unwrap_or(0);
-    classify_session_liveness_at(project_id, session_id, now)
+    classify_session_liveness_at(project_id, session_id, now_epoch())
+}
+
+/// The clock reading both criteria are measured against.
+pub fn now_epoch() -> u64 {
+    parse_rfc3339_to_epoch(&now_rfc3339()).unwrap_or(0)
+}
+
+/// Age of a board claim, from the claim's own recorded timestamp.
+///
+/// This is a different fact from the claimant session's heartbeat age. A
+/// claim records when it was written; a heartbeat records when the session
+/// was last heard from. For a bare CLI session (`cli-*`) only the first
+/// exists — nothing ever refreshes a heartbeat for a one-shot process — so
+/// the claim's own age is the only judgeable thing about it.
+///
+/// An unparseable timestamp reads as epoch 0, i.e. maximally old. That is the
+/// same reading `edda peers --json` has always given it, and it fails towards
+/// "this claim is ancient" rather than "this claim is fresh".
+pub fn claim_age_secs_at(claim_ts: &str, now_epoch: u64) -> u64 {
+    now_epoch.saturating_sub(parse_rfc3339_to_epoch(claim_ts).unwrap_or(0))
+}
+
+/// Is this board claim stale by its own timestamp?
+///
+/// The rule `edda peers --json` publishes for every claim (GH-569): older
+/// than [`stale_secs`] is stale, so a 55-day-old zombie claim and a
+/// 37-second-old live one are distinguishable to a program. It lives here,
+/// beside the session criterion, because a caller asking "does this claim
+/// still stand?" must share one rule rather than grow a second (GH-1018).
+pub fn claim_is_stale_at(claim_ts: &str, now_epoch: u64) -> bool {
+    claim_age_secs_at(claim_ts, now_epoch) > stale_secs()
 }
 
 #[cfg(test)]
@@ -172,5 +202,25 @@ mod tests {
             liveness_from_heartbeat(&hb, t0 + stale_secs() + 1),
             SessionLiveness::Stale { .. }
         ));
+    }
+
+    #[test]
+    fn claim_staleness_shares_the_session_boundary() {
+        // The claim rule reads its own timestamp, but against the same
+        // threshold and the same `age > threshold` boundary as the session
+        // criterion above — that shared edge is the point (GH-1018).
+        let t0 = parse_rfc3339_to_epoch("2026-09-02T12:00:00Z").unwrap();
+        let ts = "2026-09-02T12:00:00Z";
+        assert_eq!(claim_age_secs_at(ts, t0 + 30), 30);
+        assert!(!claim_is_stale_at(ts, t0 + stale_secs()));
+        assert!(claim_is_stale_at(ts, t0 + stale_secs() + 1));
+    }
+
+    #[test]
+    fn an_unparseable_claim_timestamp_reads_as_ancient() {
+        // Fail towards "ancient", never towards "fresh": a claim nobody can
+        // date must not be able to stand forever by being unreadable.
+        assert!(claim_is_stale_at("not a timestamp", 1_000_000));
+        assert!(claim_is_stale_at("", 1_000_000));
     }
 }

--- a/crates/edda-cli/src/cmd_bridge/peers.rs
+++ b/crates/edda-cli/src/cmd_bridge/peers.rs
@@ -1,8 +1,8 @@
+use edda_bridge_claude::peers::liveness;
 use std::path::Path;
 
 /// JSON board snapshot for `edda peers --json`.
 pub(super) fn peers_json(project_id: &str) -> serde_json::Value {
-    let stale_threshold = edda_bridge_claude::peers::stale_secs();
     let sessions: Vec<serde_json::Value> =
         edda_bridge_claude::peers::discover_all_sessions(project_id)
             .into_iter()
@@ -17,21 +17,17 @@ pub(super) fn peers_json(project_id: &str) -> serde_json::Value {
     // GH-569: claims are part of the JSON surface programs consume, so each
     // carries its age and a stale flag — otherwise a 55-day-old zombie claim
     // and a 37-second-old live claim are indistinguishable to a program.
-    let now_epoch = time::OffsetDateTime::now_utc().unix_timestamp();
+    // The rule itself lives in `peers::liveness` beside the session criterion
+    // so the dispatch guard can honour the same verdict (GH-1018).
+    let now_epoch = liveness::now_epoch();
     let claims: Vec<serde_json::Value> = board
         .claims
         .iter()
         .map(|claim| {
             let mut value = serde_json::to_value(claim).unwrap_or_default();
-            let ts_epoch = time::OffsetDateTime::parse(
-                &claim.ts,
-                &time::format_description::well_known::Rfc3339,
-            )
-            .map(|t| t.unix_timestamp())
-            .unwrap_or(0);
-            let age_secs = (now_epoch - ts_epoch).max(0) as u64;
-            value["age_secs"] = serde_json::json!(age_secs);
-            value["stale"] = serde_json::json!(age_secs > stale_threshold);
+            value["age_secs"] =
+                serde_json::json!(liveness::claim_age_secs_at(&claim.ts, now_epoch));
+            value["stale"] = serde_json::json!(liveness::claim_is_stale_at(&claim.ts, now_epoch));
             value
         })
         .collect();

--- a/crates/edda-cli/src/cmd_claim.rs
+++ b/crates/edda-cli/src/cmd_claim.rs
@@ -271,7 +271,7 @@ fn exit_code_for(report: &CheckReport) -> i32 {
 /// for it, so heartbeat age carries no liveness information (GH-705). The
 /// same shape is already classified in `cmd_bridge` when it names the
 /// actor of a `cli-*` session.
-fn is_bare_cli_session(session_id: &str) -> bool {
+pub(crate) fn is_bare_cli_session(session_id: &str) -> bool {
     session_id.starts_with("cli-")
 }
 

--- a/crates/edda-cli/src/dispatch_claim.rs
+++ b/crates/edda-cli/src/dispatch_claim.rs
@@ -10,6 +10,32 @@ pub struct Claim {
     released: bool,
 }
 
+/// Does this board claim still stand against a new writer?
+///
+/// A session that heartbeats is judged by the one shared session criterion,
+/// exactly as before.
+///
+/// A bare-CLI claim (`cli-*`) never heartbeats — its claimant is a one-shot
+/// process — so that criterion can only ever call it dead. GH-705 answered
+/// that by treating every such claim as live, fail-closed, so a one-shot
+/// writer could not be stomped on mid-write. Unconditionally, though,
+/// "fail-closed" reads as "never expires": GH-1018 found 100 claims left from
+/// July and August still refusing September lanes, with no `unclaim` able to
+/// clear them, which made the guard something lanes had to route around
+/// rather than obey.
+///
+/// The claim's own timestamp is judgeable even when its session's heartbeat
+/// is not, and `edda peers --json` already publishes exactly that verdict
+/// (GH-569). Sharing that one rule bounds the bare-CLI case in time without
+/// weakening it: a claim written moments ago still refuses a second writer.
+fn claim_still_stands(project: &str, claim: &peers::ClaimEntry, now_epoch: u64) -> bool {
+    if peers::liveness::classify_session_liveness(project, &claim.session_id).is_live() {
+        return true;
+    }
+    crate::cmd_claim::is_bare_cli_session(&claim.session_id)
+        && !peers::liveness::claim_is_stale_at(&claim.ts, now_epoch)
+}
+
 pub fn acquire(cwd: &Path, session: &str, paths: &[String]) -> Result<Option<Claim>> {
     if paths.is_empty() {
         return Ok(None);
@@ -24,13 +50,10 @@ pub fn acquire(cwd: &Path, session: &str, paths: &[String]) -> Result<Option<Cla
         .open(edda_store::project_dir(&project).join("dispatch-admission.lock"))?;
     lock.lock().context("lock dispatch admission")?;
     let claims = crate::cmd_claim::read_active_claims(&project)?;
+    let now_epoch = peers::liveness::now_epoch();
     let live: Vec<_> = claims
         .into_iter()
-        .filter(|c| {
-            // Same-session concurrent dispatch is a second writer too; do not ignore it.
-            c.session_id.starts_with("cli-")
-                || peers::liveness::classify_session_liveness(&project, &c.session_id).is_live()
-        })
+        .filter(|c| claim_still_stands(&project, c, now_epoch))
         .collect();
     if live.iter().any(|claim| claim.session_id == session) {
         bail!("session {session} already owns a live dispatch claim");
@@ -174,6 +197,45 @@ mod tests {
             .expect("second claim")
             .release()
             .expect("release second claim");
+    }
+
+    #[test]
+    fn a_stale_bare_cli_claim_no_longer_refuses_a_new_writer() {
+        let _store = crate::test_support::isolated_store();
+        let cwd = tempfile::tempdir().expect("dispatch claim cwd");
+        let project = edda_store::project_id(cwd.path());
+        let paths = vec!["docs/reference/cli.md".to_owned()];
+        // The shape GH-1018 found on a long-lived board: a bare-CLI claim
+        // from three weeks ago, no heartbeat ever written for it, nothing
+        // that expires it.
+        crate::test_support::write_aged_claim(
+            &project,
+            "cli-gh466-round1-fixes",
+            60 * 60 * 24 * 22,
+            &paths,
+        );
+
+        let claim = acquire(cwd.path(), "lane-gh1018", &paths)
+            .expect("a three-week-old claim must not refuse a new writer")
+            .expect("writer claim");
+        claim.release().expect("release the admitted claim");
+    }
+
+    #[test]
+    fn a_fresh_bare_cli_claim_still_refuses_a_new_writer() {
+        let _store = crate::test_support::isolated_store();
+        let cwd = tempfile::tempdir().expect("dispatch claim cwd");
+        let project = edda_store::project_id(cwd.path());
+        let paths = vec!["docs/reference/cli.md".to_owned()];
+        // GH-705's case, unweakened: a one-shot CLI writer that claimed
+        // seconds ago has no heartbeat either, and must still be honoured.
+        crate::test_support::write_aged_claim(&project, "cli-just-now", 5, &paths);
+
+        let error = match acquire(cwd.path(), "lane-gh1018", &paths) {
+            Ok(_) => panic!("a fresh bare-CLI claim must still refuse a second writer"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("cli-just-now"), "{error:#}");
     }
 
     #[test]

--- a/crates/edda-cli/src/test_support.rs
+++ b/crates/edda-cli/src/test_support.rs
@@ -81,6 +81,46 @@ pub(crate) fn write_aged_heartbeat(
     .expect("heartbeat file");
 }
 
+/// Append one claim event to the coordination board, dated `age_secs` ago.
+///
+/// The board is append-only and nothing expires a claim on it, so this is the
+/// only way to reproduce the shape a long-lived machine accumulates: a claim
+/// whose session left months ago (GH-1018).
+pub(crate) fn write_aged_claim(
+    project_id: &str,
+    session_id: &str,
+    age_secs: u64,
+    paths: &[String],
+) {
+    let _ = edda_store::ensure_dirs(project_id);
+    let state_dir = edda_store::project_dir(project_id).join("state");
+    std::fs::create_dir_all(&state_dir).expect("state dir");
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock")
+        .as_secs()
+        .saturating_sub(age_secs);
+    let ts = time::OffsetDateTime::from_unix_timestamp(now as i64)
+        .expect("unix timestamp")
+        .format(&time::format_description::well_known::Rfc3339)
+        .expect("rfc3339");
+    let event = serde_json::json!({
+        "ts": ts,
+        "session_id": session_id,
+        "event_type": "claim",
+        "payload": { "label": session_id, "paths": paths },
+    });
+    let mut line = event.to_string();
+    line.push('\n');
+    use std::io::Write;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(state_dir.join("coordination.jsonl"))
+        .expect("coordination board");
+    file.write_all(line.as_bytes()).expect("append claim event");
+}
+
 // Guard-restore semantics (RAII on drop, panic safety, thread locality) are
 // tested at the source in `edda-store::test_support`; a duplicate here could
 // only re-prove them through an extra indirection.


### PR DESCRIPTION
Issue: #1018

Closes #1018.  ## What was wrong  `dispatch_claim::acquire` decided which board claims still stand with:  ```rust c.session_id.starts_with("cli-")     || classify_session_liveness(&project, &c.session_id).is_live() ```  The left arm is unconditional. Every `cli-*` claim counted as live forever.  That arm is GH-705's rule: a bare CLI claim's owner is a one-shot process that never heartbeats, so the shared session criterion can only ever call it dead, and reading such an occupation as clear is a false negative. The reasoning is sound — but applied without a bound, "fail closed" becomes "never expires". #1018 measured the result: 100 claims left from July and August still refusing September lanes, `edda unclaim` unable to clear them, and the only way past was to shrink `-Owns` until it no longer overlapped the zombies. A guard lanes route around is not a guard.  `peers/liveness.rs` says this in its own module doc: *"There is one liveness surface — the heartbeat file — and one criterion ... Do not add a parallel one."* The `starts_with("cli-")` arm is a parallel one.  ## The fix  A claim's own `ts` is judgeable even when its session's heartbeat is not — and `edda peers --json` has published exactly that verdict since GH-569 (`age > stale_secs()`), with the comment *"otherwise a 55-day-old zombie claim and a 37-second-old live claim are indistinguishable to a program"*.  So the rule moves to `peers::liveness`, beside the session criterion, and both callers share it:  - `claim_age_secs_at` / `claim_is_stale_at` / `now_epoch` — new, in `liveness.rs` - `cmd_bridge/peers.rs` — drops its inline RFC3339 parse + threshold compare, calls the shared rule - `dispatch_claim.rs` — `claim_still_stands()` replaces the blanket  ```rust fn claim_still_stands(project: &str, claim: &peers::ClaimEntry, now_epoch: u64) -> bool {     if classify_session_liveness(project, &claim.session_id).is_live() {         return true;     }     is_bare_cli_session(&claim.session_id) && !claim_is_stale_at(&claim.ts, now_epoch) } ```  `is_bare_cli_session` is reused from `cmd_claim` rather than re-spelled, for the same reason.  **This is a narrowing, not a loosening.** Everything the heartbeat criterion called live is still live — that arm is checked first and unchanged. Only the unbounded half of the bare-CLI blanket gains a time bound.  ## doneWhen  | # | Requirement | Status | |---|---|---| | 1 | Guard shares one rule / one `stale_secs()` source with `edda peers` | ✅ same function, `peers::liveness::claim_is_stale_at` | | 2 | `unclaim` clears `cli-*`, **or** guard offers an auditable cleanup path | ⚠️ see below | | 3 | Regression test FAILs before, PASSes after | ✅ proof below | | 4 | A real lane owning `docs/reference/cli.md` no longer blocked by the 2026-08-16 `cli-gh466-round1-fixes` claim | ✅ that is the fixture, by name |  ### FAIL-first proof  With the predicate reverted to the pre-fix rule, on this branch:  ``` test dispatch_claim::tests::a_fresh_bare_cli_claim_still_refuses_a_new_writer ... ok test dispatch_claim::tests::a_stale_bare_cli_claim_no_longer_refuses_a_new_writer ... FAILED  a three-week-old claim must not refuse a new writer:   owned paths conflict with live claim(s): cli-gh466-round1-fixes ```  That is the issue's error verbatim. The guard-preservation test passes under both rules, which is what makes it a guard-preservation test.  ### On doneWhen 2 — not implemented, deliberately  The bullet was "擇一", and both options exist to stop zombie claims blocking. This fix stops the blocking itself, so neither cleanup path is needed for the issue's purpose; the zombies remain on the append-only board, ignored, which is what an append-only audit log is for.  I also could not reproduce `unclaim` being broken. Its fold is correct (`"unclaim" => claims.remove(session_id)`), and the reported exit-0-with-no- removal is the `--if-claimed` branch printing "Nothing to unclaim" when the session is absent from **that** project's board — which points at a project-id/board mismatch (`project_id` is derived from cwd, so a lane worktree and the main checkout resolve to different boards), not at a defect in `unclaim`. Diagnosing that needs the live zombie board, so it is a **FOLLOW-UP ISSUE**, not silently dropped.  ## Gates ran (L0, touched crates)  | Gate | Result | |---|---| | `cargo fmt --all --check` | clean | | `cargo clippy -p edda-bridge-claude --all-targets -- -D warnings` | clean | | `cargo clippy -p edda --all-targets -- -D warnings` | clean | | `cargo test -p edda-bridge-claude` | 656 passed, 0 failed | | `cargo test -p edda --bin edda` | 647 passed, 0 failed (baseline on `3306c1a`: 645 + 2 new) | | `sh scripts/lint-file-length.sh --tree` | exit 0 |  Baseline recorded on `3306c1a` before the first edit: 645 passed, 0 failed.  🤖 Generated with [Claude Code](https://claude.com/claude-code) 
