### PR TITLE
fix(edda-cli): review resolves its subject from a private ref, not FETCH_HEAD (GH-997)

### DIFF
--- a/crates/edda-cli/src/cmd_review/github.rs
+++ b/crates/edda-cli/src/cmd_review/github.rs
@@ -24,6 +24,37 @@ pub(crate) struct PrSubject {
     pub issue: Option<u64>,
 }
 
+/// Fetch one remote ref into a review-private ref, and resolve that.
+///
+/// `FETCH_HEAD` lives in the **common** git directory, so the main checkout
+/// and every linked worktree share one cell. Two `edda review` processes
+/// fetching at the same time overwrite each other's between one process's
+/// fetch and its `rev-parse`, and the loser resolves whatever the other left
+/// behind — a foreign commit, or the multi-line value git reports as
+/// `fatal: Needed a single revision` (GH-997). The fleet launches per-PR
+/// review lanes into one checkout and serialises none of them.
+///
+/// Naming a private destination removes the shared cell rather than guarding
+/// it: concurrent reviews of different PRs never name the same ref, and two
+/// reviews of the same PR fetch the same objects to it. `--force` is required
+/// because a PR head that was rebased or force-pushed moves the ref
+/// non-fast-forward. The ref is left in place: it costs one file, and it
+/// keeps the reviewed objects resolvable for a SHA-pinned verdict.
+fn fetch_private_ref(repo: &Path, number: u64, role: &str, remote_ref: &str) -> Result<String> {
+    let private = format!("refs/edda/review/pr{number}/{role}");
+    git(
+        repo,
+        &[
+            "fetch",
+            "--no-tags",
+            "--force",
+            "origin",
+            &format!("{remote_ref}:{private}"),
+        ],
+    )?;
+    commit(repo, &private)
+}
+
 pub(crate) fn resolve_pr(repo: &Path, number: u64) -> Result<PrSubject> {
     for _ in 0..2 {
         let value = gh(
@@ -40,30 +71,12 @@ pub(crate) fn resolve_pr(repo: &Path, number: u64) -> Result<PrSubject> {
         if expected.len() != 40 || !expected.bytes().all(|v| v.is_ascii_hexdigit()) {
             bail!("invalid PR head SHA");
         }
-        git(
-            repo,
-            &[
-                "fetch",
-                "--no-tags",
-                "origin",
-                &format!("pull/{number}/head"),
-            ],
-        )?;
-        if commit(repo, "FETCH_HEAD")? != expected {
+        if fetch_private_ref(repo, number, "head", &format!("pull/{number}/head"))? != expected {
             continue;
         }
         let base = value["baseRefName"].as_str().context("PR base missing")?;
         git(repo, &["check-ref-format", &format!("refs/heads/{base}")])?;
-        git(
-            repo,
-            &[
-                "fetch",
-                "--no-tags",
-                "origin",
-                &format!("refs/heads/{base}"),
-            ],
-        )?;
-        let base_sha = commit(repo, "FETCH_HEAD")?;
+        let base_sha = fetch_private_ref(repo, number, "base", &format!("refs/heads/{base}"))?;
         return Ok(PrSubject {
             head: expected.into(),
             base: base_sha,
@@ -180,10 +193,80 @@ pub(crate) fn load_spec(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cmd_review::git::testrepo;
+
     #[test]
     fn closing_keywords_ignore_mentions_and_use_first_closing_issue() {
         assert_eq!(closing_issue("Issue: #1\nCloses #652. Fixes #3"), Some(652));
         assert_eq!(closing_issue("encloses #9; related #652"), None);
         assert_eq!(closing_issue("resolved #7"), Some(7));
+    }
+
+    /// Two review lanes in one checkout, interleaved at the point that used
+    /// to lose the subject: lane 1 fetches, lane 2 fetches, lane 1 resolves.
+    /// Driving the interleaving directly rather than racing two threads makes
+    /// the regression deterministic — the old code loses on every run, not on
+    /// an unlucky one.
+    #[test]
+    fn a_concurrent_fetch_cannot_redirect_a_resolved_subject() {
+        let (_origin_temp, origin) = testrepo::init();
+        let pr1 = testrepo::commit_file(&origin, "pr1.txt", "one\n", "pr 1");
+        testrepo::run(&origin, &["update-ref", "refs/pull/1/head", &pr1]);
+        let pr2 = testrepo::commit_file(&origin, "pr2.txt", "two\n", "pr 2");
+        testrepo::run(&origin, &["update-ref", "refs/pull/2/head", &pr2]);
+        assert_ne!(pr1, pr2);
+
+        let (_work_temp, work) = testrepo::init();
+        testrepo::run(
+            &work,
+            &["remote", "add", "origin", &origin.to_string_lossy()],
+        );
+
+        // Lane 1 fetches its PR.
+        let resolved = fetch_private_ref(&work, 1, "head", "pull/1/head").expect("lane 1 fetch");
+        assert_eq!(resolved, pr1);
+
+        // Lane 2 fetches its own, moving the cell both lanes used to read.
+        fetch_private_ref(&work, 2, "head", "pull/2/head").expect("lane 2 fetch");
+        assert_eq!(
+            commit(&work, "FETCH_HEAD").expect("shared cell"),
+            pr2,
+            "precondition: the shared FETCH_HEAD really did move under lane 1"
+        );
+
+        // Lane 1 resolves its subject. Anything reading the shared cell now
+        // answers pr2; lane 1's own ref still answers pr1.
+        assert_eq!(
+            commit(&work, "refs/edda/review/pr1/head").expect("lane 1 subject"),
+            pr1,
+            "lane 1 must resolve its own PR, not whatever lane 2 last fetched"
+        );
+    }
+
+    /// A rebased or force-pushed head moves the private ref non-fast-forward;
+    /// a second review of the same PR must follow it rather than fail.
+    #[test]
+    fn a_force_pushed_head_moves_the_private_ref() {
+        let (_origin_temp, origin) = testrepo::init();
+        let first = testrepo::commit_file(&origin, "pr.txt", "first\n", "round 1");
+        testrepo::run(&origin, &["update-ref", "refs/pull/7/head", &first]);
+
+        let (_work_temp, work) = testrepo::init();
+        testrepo::run(
+            &work,
+            &["remote", "add", "origin", &origin.to_string_lossy()],
+        );
+        assert_eq!(
+            fetch_private_ref(&work, 7, "head", "pull/7/head").expect("round 1"),
+            first
+        );
+
+        testrepo::run(&origin, &["reset", "-q", "--hard", "HEAD~1"]);
+        let rewritten = testrepo::commit_file(&origin, "pr.txt", "rewritten\n", "round 2");
+        testrepo::run(&origin, &["update-ref", "refs/pull/7/head", &rewritten]);
+        assert_eq!(
+            fetch_private_ref(&work, 7, "head", "pull/7/head").expect("round 2"),
+            rewritten
+        );
     }
 }


### PR DESCRIPTION
Issue: #997

Closes #997.  ## What was wrong  `resolve_pr` fetched, then resolved the shared cell:  ```rust git(repo, &["fetch", "--no-tags", "origin", &format!("pull/{number}/head")])?; if commit(repo, "FETCH_HEAD")? != expected { continue; } ... git(repo, &["fetch", "--no-tags", "origin", &format!("refs/heads/{base}")])?; let base_sha = commit(repo, "FETCH_HEAD")?; ```  `FETCH_HEAD` lives in the **common** git directory — one cell shared by the main checkout and every linked worktree. Within one process the sequence is correct. Across two it is not: process A fetches, process B fetches, process A rev-parses and gets B's ref. The fleet launches per-PR review lanes into one checkout and serialises none of them.  ## The fix  Fetch into `refs/edda/review/pr<N>/{head,base}` and resolve that:  ```rust fn fetch_private_ref(repo: &Path, number: u64, role: &str, remote_ref: &str) -> Result<String> {     let private = format!("refs/edda/review/pr{number}/{role}");     git(repo, &["fetch", "--no-tags", "--force", "origin",                 &format!("{remote_ref}:{private}")])?;     commit(repo, &private) } ```  This **removes** the shared cell rather than guarding it. Concurrent reviews of different PRs never name the same ref; two reviews of one PR fetch the same objects to it. So no lock, and no lane ever waits — which the issue named as the acceptable alternative, and this is the better half of that either/or.  `--force` is required: a rebased or force-pushed PR head moves the ref non-fast-forward. The refs are left in place — one file each, and they keep the reviewed objects resolvable for a SHA-pinned verdict.  No production path in `crates/edda-cli/src/` reads `FETCH_HEAD` any more. It survives in two places on purpose: the doc comment above explaining why, and the test's precondition assertion that the shared cell really did move.  ## doneWhen  | # | Requirement | Status | |---|---|---| | 1 | Resolve the fetched head without depending on shared `FETCH_HEAD` | ✅ private ref per PR and role | | 2 | Two concurrent runs against different PRs both complete | ✅ `a_concurrent_fetch_cannot_redirect_a_resolved_subject` | | 3 | Regression test covers the concurrent case | ✅ FAIL-first proof below |  ### FAIL-first proof  With `fetch_private_ref` reverted to `fetch` + `commit("FETCH_HEAD")`, on this branch:  ``` test cmd_review::github::tests::a_concurrent_fetch_cannot_redirect_a_resolved_subject ... FAILED  lane 1 subject: git ["rev-parse", "--verify", "--end-of-options",   "refs/edda/review/pr1/head^{commit}"]: fatal: Needed a single revision ```  Same error class the issue reports.  **One honest limit on that proof.** Under the reverted code the direct cause is that the private ref does not exist — the old code has nowhere but the shared cell to hold a lane's subject. The test's precondition assertion is what carries the consequence:  ```rust assert_eq!(commit(&work, "FETCH_HEAD")?, pr2,     "precondition: the shared FETCH_HEAD really did move under lane 1"); ```  With `pr1 != pr2` also asserted, that says: at the moment lane 1 resolves, the shared cell answers lane 2's commit. Any resolution through it returns the wrong subject. The test drives the interleaving directly rather than racing two threads, so the regression is deterministic — the old code loses on every run, not on an unlucky one.  A second test, `a_force_pushed_head_moves_the_private_ref`, pins the `--force` requirement: without it the second round of a rebased PR fails non-fast-forward.  ## Gates ran (L0, touched crate)  | Gate | Result | |---|---| | `cargo fmt --all --check` | clean | | `cargo clippy -p edda --all-targets -- -D warnings` | clean | | `cargo test -p edda --bin edda` | 647 passed, 0 failed (baseline on `3306c1a`: 645 + 2 new) | | `sh scripts/lint-file-length.sh --tree` | exit 0 |  🤖 Generated with [Claude Code](https://claude.com/claude-code) 
