### PR TITLE
docs(fleet): direct review is the default path; the watcher lane is the flash tier and the independence source

### DIFF
--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -133,26 +133,31 @@
     Rust lane 設 `CARGO_TARGET_DIR` 為
     `$env:LOCALAPPDATA\fleet-workstation\lanes\worker-1|worker-2|verifier|verifier-2`。
    lane 的**啟動方式**用 `scripts/fleet/lane-launch.ps1`（見 START HERE；Task Scheduler，不是 nohup，規則見 §六）。
-4. **審查：強引擎直審是預設，watcher lane 是 flash 檔與獨立性來源**
-   （`review.default-path=direct-review-default-shell-reserved-for-flash`，
-   `review.merge-gate=ci-gate-only-independent-review-status-removed`，兩者皆 2026-09-07）。
+4. **審查：強引擎直審是預設；沒有輪詢器**
+   （`review.default-path=direct-review-default-shell-reserved-for-flash`、
+   `review.merge-gate=ci-gate-only-independent-review-status-removed`、
+   `review.watcher=polling-stopped-independent-rounds-dispatched-on-demand`，皆 2026-09-07）。
 
    預設路徑：任一在線的強引擎 session 直接讀 diff、照 `REVIEW.md` 從頭跑到尾、把 §7 判決貼上
    PR，LGTM 且 CI 綠即可合。**不起 lane、不建 review worktree、不做全檔快照。**
-   這條路今天實測每張 PR 約 5–20 分鐘；同一批 PR 的 watcher lane 在 40 分鐘後仍卡在快照階段。
+   這條路今天實測每張 PR 約 5–20 分鐘；同一批 PR 的審查 lane 在 40 分鐘後仍卡在快照階段。
    審查內容一點都沒放寬——`REVIEW.md` 全規則照跑、判決釘 full SHA、每次 push 使前一輪失效、
    合前做窗檢查——省掉的只有排隊。
 
-   `Independent Review` 必要 status 已於同日從 ruleset 移除，合併閘只剩 `CI Gate`；
-   watcher 照跑但**判決降為 advisory**，它死了不再擋任何事。回復路徑是把 context 加回 ruleset。
+   `Independent Review` 必要 status 已於同日從 ruleset 移除，合併閘只剩 `CI Gate`。
+   **watcher 的輪詢已停用**（排程任務 `edda-pr-review-watcher` 設為 Disabled）：它對每一張
+   open PR 無差別自動派 lane，連只改一個 markdown 檔的 docs PR 也照收全額快照稅，
+   這正是樸實流程要拿掉的東西。回復路徑：`Enable-ScheduledTask -TaskName edda-pr-review-watcher`。
 
-   仍然走下面 watcher lane 的兩種情況：(a) flash 引擎執行的單——brief 渲染、`brief-validate`、
-   oracle bundle、資格表、SHADOW 校準整套是它安全上工的前提；(b) 需要一個不是實作者、
-   也不是控制者的獨立判決時（例如控制者自己派的 lane 寫的 PR）。殼的成本只該由需要殼的引擎付。
+   要一份**獨立**判決時（實作者與控制者以外的第三方），用第 5 步的 lane 機制**按需刻意派一條**，
+   不靠輪詢器。值得付這筆錢的兩種情況：(a) flash 引擎執行的單——brief 渲染、`brief-validate`、
+   oracle bundle、資格表、SHADOW 校準整套是它安全上工的前提；(b) 實作者就是控制者的 PR。
+   殼的成本只該由需要殼的引擎付，而且只在真的需要那一次付。
 
-5. **PR 一開就派審（自動，不用人手）**：本機 watcher（`scripts/pr-review-watch.sh`，由
-   `scripts/pr-review-launch.ps1` 註冊成隱藏排程任務 `edda-pr-review-watcher`）每 60 秒掃 open PR：
-   非 draft、head 沒審過的 PR 在 **3 分鐘內**自動起唯讀審查者（Claude Opus `claude-opus-5`，經
+5. **審查 lane 的機制**（`scripts/pr-review-watch.sh`，由 `scripts/pr-review-launch.ps1` 註冊成隱藏排程
+   任務 `edda-pr-review-watcher`）。**輪詢已停用**——以下是它啟用時的行為，也是按需派一條 lane 時
+   仍然成立的行為：每 60 秒掃 open PR，
+   非 draft、head 沒審過的 PR 在 **3 分鐘內**起唯讀審查者（Claude Opus `claude-opus-5`，經
    `edda dispatch --agent claude` 訂閱運輸——pi/openrouter 到不了 Anthropic；Task Scheduler 隱藏視窗，
    worktree 在 `$EDDA_FLEET_SCRATCH/wt-review-prN`；brief 超過 Windows 32767 字元 spawn 上限時，
    lane 的 fallback 以唯讀工具集 `--allowedTools "Read,Glob,Grep,Bash"` 經 `claude -p` stdin 跑同一份 brief，

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -133,7 +133,24 @@
     Rust lane 設 `CARGO_TARGET_DIR` 為
     `$env:LOCALAPPDATA\fleet-workstation\lanes\worker-1|worker-2|verifier|verifier-2`。
    lane 的**啟動方式**用 `scripts/fleet/lane-launch.ps1`（見 START HERE；Task Scheduler，不是 nohup，規則見 §六）。
-4. **PR 一開就派審（自動，不用人手）**：本機 watcher（`scripts/pr-review-watch.sh`，由
+4. **審查：強引擎直審是預設，watcher lane 是 flash 檔與獨立性來源**
+   （`review.default-path=direct-review-default-shell-reserved-for-flash`，
+   `review.merge-gate=ci-gate-only-independent-review-status-removed`，兩者皆 2026-09-07）。
+
+   預設路徑：任一在線的強引擎 session 直接讀 diff、照 `REVIEW.md` 從頭跑到尾、把 §7 判決貼上
+   PR，LGTM 且 CI 綠即可合。**不起 lane、不建 review worktree、不做全檔快照。**
+   這條路今天實測每張 PR 約 5–20 分鐘；同一批 PR 的 watcher lane 在 40 分鐘後仍卡在快照階段。
+   審查內容一點都沒放寬——`REVIEW.md` 全規則照跑、判決釘 full SHA、每次 push 使前一輪失效、
+   合前做窗檢查——省掉的只有排隊。
+
+   `Independent Review` 必要 status 已於同日從 ruleset 移除，合併閘只剩 `CI Gate`；
+   watcher 照跑但**判決降為 advisory**，它死了不再擋任何事。回復路徑是把 context 加回 ruleset。
+
+   仍然走下面 watcher lane 的兩種情況：(a) flash 引擎執行的單——brief 渲染、`brief-validate`、
+   oracle bundle、資格表、SHADOW 校準整套是它安全上工的前提；(b) 需要一個不是實作者、
+   也不是控制者的獨立判決時（例如控制者自己派的 lane 寫的 PR）。殼的成本只該由需要殼的引擎付。
+
+5. **PR 一開就派審（自動，不用人手）**：本機 watcher（`scripts/pr-review-watch.sh`，由
    `scripts/pr-review-launch.ps1` 註冊成隱藏排程任務 `edda-pr-review-watcher`）每 60 秒掃 open PR：
    非 draft、head 沒審過的 PR 在 **3 分鐘內**自動起唯讀審查者（Claude Opus `claude-opus-5`，經
    `edda dispatch --agent claude` 訂閱運輸——pi/openrouter 到不了 Anthropic；Task Scheduler 隱藏視窗，
@@ -153,13 +170,13 @@
    provider 過載時：同模型探測通過後重試一次（同一 `edda dispatch --agent claude` 運輸），仍沒有判決就標
    `review:unreviewed` 並對該 head 停手
    （v1 無 codex 後備——它做不到唯讀，且在新決策下 codex 也到不了 Opus；§六 `fleet.review-provider-overload` 的決策全文仍可 `edda ask` 查）。
-   啟停、狀態檔與疑難排解見 `docs/guides/pr-review-watcher.md`。watcher **不合併**——合併仍在第 6 步、要授權。
-5. **收斂**：`/fleet-pr-loop` 的 bash driver 吐 `ACTION: REVIEW | FIX | DONE | BLOCKED`，照做到 LGTM；driver 不合併。
-6. **合併**（有操作者授權時）：先執行 `sh scripts/merge-reviewed-pr.sh <PR>`，核對最新可信審查是目前完整 SHA 的 LGTM、P0=0/P1=0、無待升級項目且必要 CI 檢查通過。取得合併授權後使用 `sh scripts/merge-reviewed-pr.sh <PR> --merge`；它以 `--match-head-commit` 鎖定審查 SHA，避免最後一刻 push 越過判決。合併後對剩下的 PR 做 Layer-3 交集：不相交直接合，相交要 rebase → 判決失效 → 再一輪。
+   啟停、狀態檔與疑難排解見 `docs/guides/pr-review-watcher.md`。watcher **不合併**——合併仍在第 7 步、要授權。
+6. **收斂**：`/fleet-pr-loop` 的 bash driver 吐 `ACTION: REVIEW | FIX | DONE | BLOCKED`，照做到 LGTM；driver 不合併。走第 4 步直審路徑時不需要 driver：判決與修正在同一個 session 內來回。
+7. **合併**（有操作者授權時）：先執行 `sh scripts/merge-reviewed-pr.sh <PR>`，核對最新可信審查是目前完整 SHA 的 LGTM、P0=0/P1=0、無待升級項目且必要 CI 檢查通過。取得合併授權後使用 `sh scripts/merge-reviewed-pr.sh <PR> --merge`；它以 `--match-head-commit` 鎖定審查 SHA，避免最後一刻 push 越過判決。合併後對剩下的 PR 做 Layer-3 交集：不相交直接合，相交要 rebase → 判決失效 → 再一輪。
 
    手動啟動與 watcher 共用 `scripts/review-round.sh` 的每個 repository／PR 認領與輪次，儲存在 `$HOME/.edda/review-coordination/`，不跟隨個別 scratch 目錄。已發表的 PR 審查輪次是下限；有尚未寫入終止 receipt 的審查時，第二個啟動者會被拒絕。中斷且沒有 receipt 的認領保持拒絕狀態，操作者應先確認舊 lane 已停止再恢復，不能只依 PID 或經過時間認定它已退出。
-7. **開單**：審查 exhaust、runtime 的傷、重複兩次的手動步驟，當場 `/issue-intake`／`/issue-create`（含四問接線審計）。不要留在對話裡。
-8. **收工**：`edda note "completed X; decided Y; next: Z" --tag session`；回報你：合了什麼、開了什麼、等你什麼。
+8. **開單**：審查 exhaust、runtime 的傷、重複兩次的手動步驟，當場 `/issue-intake`／`/issue-create`（含四問接線審計）。不要留在對話裡。
+9. **收工**：`edda note "completed X; decided Y; next: Z" --tag session`；回報你：合了什麼、開了什麼、等你什麼。
 
 ---
 


### PR DESCRIPTION
Issue: #1032
Decision: review.watcher

## Why

Three decisions recorded on 2026-09-07, after the operator read the review of PRs #1017 and #1040 and ruled that a green PR must not queue behind the review shell:

- `review.merge-gate=ci-gate-only-independent-review-status-removed` — the `Independent Review` required status is out of ruleset 18852689; the merge gate is `CI Gate` alone.
- `review.default-path=direct-review-default-shell-reserved-for-flash` — a strong-engine session reviews directly; the shell (brief render, `brief-validate`, oracle bundle, qualification table, SHADOW calibration) is reserved for flash lanes, which cannot work safely without it.
- `review.watcher=polling-stopped-independent-rounds-dispatched-on-demand` — the watcher's 60-second poll is stopped; an independent round is dispatched deliberately when one is warranted.

`docs/guides/operator-runbook.md` still told every session to wait for a watcher lane and for a status that no longer exists. Per `governance.landing-definition`, a rule is landed only when the ledger entry **and every carrier** say the same thing; this is the runbook half. #1032 tracks the full carrier sweep.

## What changed

One file, one section, two commits.

`0348b3f` writes the default path into a new step 4: any strong-engine session reads the diff, runs `REVIEW.md` top to bottom, posts the §7 verdict, and merges on LGTM plus a green `CI Gate` — no lane, no review worktree, no per-file snapshot. Old step 4 (the lane mechanism) becomes step 5; steps 5–8 renumber to 6–9; the cross-reference to the merge step follows.

`8b78d9f` corrects that first commit. It had kept the watcher running and described it in the runbook as "the flash tier and the independence source". The operator caught it: the plain-flow review this documents lists **no watcher** in its tool inventory, and nothing in the instruction asked for one. The reason for keeping it — that a watcher round supplies the independent pair of eyes a controller reviewing its own lane's work otherwise lacks — was the author's own addition, and it does not justify a blanket poller: independence comes from the round being run by someone other than the implementer, which a deliberate dispatch supplies just as well, and only when needed.

The scheduled task `edda-pr-review-watcher` is now `Disabled`. Step 4 says so, names the reversal (`Enable-ScheduledTask -TaskName edda-pr-review-watcher`), and names the two cases still worth dispatching a lane for by hand. Step 5 keeps the lane mechanics — they are correct and still describe an on-demand round — under a heading that no longer claims a poller launches them.

Review content is explicitly **not** relaxed: `REVIEW.md` still runs top to bottom, verdicts still pin the full SHA, every push still invalidates the previous verdict, and the window check still runs before merge. What is removed is the queue.

## Evidence

- The two PRs merged this morning under the new path (#1045, #1046): about 5–20 minutes each, including the mechanical rule table, adversarial checks, and two rounds. The watcher lanes for those same two PRs were still in the per-file snapshot phase 40 minutes after launch (`logBytes=0`).
- Caught in the act while this PR was being written: at 11:40Z the watcher auto-launched `edda-review-pr1051-r1` against **this PR** — one file, 23 lines of markdown — and 16 processes were into the 1077-file snapshot before it was stopped.

## Gates

Docs-only; no code, no `Cargo.lock`, no toolchain change, so no Cargo gate runs locally and exact-head CI is the gate (`.claude/CLAUDE.md`, verification ladder).

| Gate | Result |
|---|---|
| `sh scripts/lint-markdown-content.sh` | exit 0 (both commits) |
| pre-commit `lint-doc-citations.sh --staged` | passed |
| pre-commit `lint-markdown-content.sh` | passed |
| pre-commit `lint-file-length.sh --staged` | passed |

`lint-file-length.sh --tree` was not run locally: on this workstation a process spawn costs ~2.7 s (`review.readonly-proof`), which makes a whole-tree run hours for a one-file docs change. CI runs it.

## Review note

Authored by the controller session that also recorded the three decisions it lands, which is exactly the case step 4 now reserves for a deliberately dispatched independent round. Not self-merged: an independent read-only round is dispatched for it, and the read-only property is proved the way `review.readonly-proof` prescribes — capability flags plus `git status --porcelain` before and after — rather than by hashing 1077 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
