### PR TITLE
fix(fleet): review-l0.sh reports ERROR for a block that refused to run (GH-950)

### DIFF
--- a/scripts/review-l0.sh
+++ b/scripts/review-l0.sh
@@ -24,9 +24,11 @@
 #            blocks diff "origin/$BASE..$SHA", so a leading "origin/" is
 #            stripped before BASE is exported (a plain branch name works too).
 #            A full SHA is NOT an accepted shape: "origin/<40-hex>" is not a
-#            revision, so every block refuses and every routed rule reports
-#            ERROR. Pin an immutable base by naming a remote-tracking ref, or
-#            create one for the SHA (GH-950).
+#            revision, so every block that reads the range refuses and every
+#            rule routed to one of them reports ERROR. (A rule whose block
+#            never touches the range — U5 lints the tree — still runs and
+#            still reports its own verdict.) Pin an immutable base by naming a
+#            remote-tracking ref, or create one for the SHA (GH-950).
 #   <head>   a commit, a ref, or the literal HEAD. With the literal HEAD the
 #            classifier's file list is the working tree against <base>
 #            (staged and unstaged work included) while the blocks diff the
@@ -58,13 +60,28 @@
 #           "CANDIDATE" line (D1), or a "MISSING" line (D3) — or exited
 #           non-zero for any other reason. The script reports exit codes and
 #           printed lines; it does not adjudicate what a finding means.
-#   ERROR   the block failed for a non-finding reason: exit 127 (command not
-#           found), exit 128 (bad range), or output carrying a `fatal:` line —
-#           the command refused to run, so there is no verdict to report. The
-#           last is checked independently of the exit code, because a block
-#           that pipes a failing command into a grep reports the grep's status
-#           (REVIEW.md §0) and the failure would otherwise be read as a
-#           finding, or as a clean PASS (GH-950).
+#   ERROR   the block failed for a non-finding reason — it refused to run, so
+#           there is no verdict to report (GH-950). Two independent signals,
+#           because neither one covers the other:
+#             * output carrying a `fatal:` line, whatever the exit code. A
+#               block that pipes a failing command into a grep reports the
+#               grep's status (REVIEW.md §0), so git's 128 never arrives and
+#               the refusal would otherwise read as a finding, or as a clean
+#               PASS. Printed text is the only surviving evidence there —
+#               which is also this signal's limit: git localizes its messages,
+#               so a translated `fatal:` would not match. Measured English on
+#               the Git for Windows build here (2.49.0, which ships no
+#               share/locale); not guaranteed everywhere. The exit-code signal
+#               below is the locale-independent half, and reaches a refusal
+#               only when a pipeline has not swallowed the status.
+#             * exit 127 (command not found), 128 (bad range) or 2. Exit 2 is
+#               this repo's could-not-run code — the runner's own, grep's for
+#               a bad pattern (which a pipeline does report), and
+#               wiring-scan.sh's for a usage error or an unknown revision.
+#               It is needed because a refusal is not always worded `fatal:`:
+#               wiring-scan.sh writes `error:`, and that prefix must not be
+#               matched on, since check-cli-docs.sh uses the same word for
+#               genuine findings.
 #   N.A.    the rule needs reviewer input (D2's decision key), needs a PR
 #           number, or has no command block in the spec (U7, S2, S3, C1,
 #           R4, R5).
@@ -391,7 +408,21 @@ run_block() { # <rule> <class> <severity> <blocks-file line> <marker attrs>
     fi
     return
   fi
-  if [ "$rc" -eq 127 ] || [ "$rc" -eq 128 ]; then
+  # Exit codes that mean the block could not run. 2 joins 127/128 because a
+  # refusal is not always worded `fatal:` and the text net above cannot be
+  # widened to cover it: WIRING's tool refuses with `error: unknown revision`
+  # (scripts/wiring-scan.sh:32), but `^error:` is ambiguous in this repo —
+  # check-cli-docs.sh writes `error: undocumented verb` for a genuine finding,
+  # so matching that prefix would relabel findings as "did not run", which is
+  # the inverse of the bug GH-950 fixes.
+  #
+  # 2 is safe as a code where the prefix is not safe as text: it is this
+  # repo's could-not-run code (the runner's own exits, grep's for a bad
+  # pattern, wiring-scan.sh's for usage and unknown revisions), and no block
+  # in REVIEW.md signals a finding with it — the enumerator greps signal with
+  # 0/1, and the tools that signal by printed lines (U5, R3, D1, D3) are
+  # caught by `badline` above, which is checked first.
+  if [ "$rc" -eq 127 ] || [ "$rc" -eq 128 ] || [ "$rc" -eq 2 ]; then
     HAS_ERROR=1
     if [ -n "$OUT" ]; then ev=$(printf '%s\n' "$OUT" | oneline); else ev="(no output)"; fi
     print_row "$rule" "$2" "$3" "ERROR $rc" "$ev"

--- a/scripts/review-l0.sh
+++ b/scripts/review-l0.sh
@@ -23,6 +23,10 @@
 #   <base>   base ref the way the blocks write it, e.g. origin/main — the
 #            blocks diff "origin/$BASE..$SHA", so a leading "origin/" is
 #            stripped before BASE is exported (a plain branch name works too).
+#            A full SHA is NOT an accepted shape: "origin/<40-hex>" is not a
+#            revision, so every block refuses and every routed rule reports
+#            ERROR. Pin an immutable base by naming a remote-tracking ref, or
+#            create one for the SHA (GH-950).
 #   <head>   a commit, a ref, or the literal HEAD. With the literal HEAD the
 #            classifier's file list is the working tree against <base>
 #            (staged and unstaged work included) while the blocks diff the
@@ -55,7 +59,12 @@
 #           non-zero for any other reason. The script reports exit codes and
 #           printed lines; it does not adjudicate what a finding means.
 #   ERROR   the block failed for a non-finding reason: exit 127 (command not
-#           found) or exit 128 (bad range).
+#           found), exit 128 (bad range), or output carrying a `fatal:` line —
+#           the command refused to run, so there is no verdict to report. The
+#           last is checked independently of the exit code, because a block
+#           that pipes a failing command into a grep reports the grep's status
+#           (REVIEW.md §0) and the failure would otherwise be read as a
+#           finding, or as a clean PASS (GH-950).
 #   N.A.    the rule needs reviewer input (D2's decision key), needs a PR
 #           number, or has no command block in the spec (U7, S2, S3, C1,
 #           R4, R5).
@@ -306,16 +315,37 @@ run_block() { # <rule> <class> <severity> <blocks-file line> <marker attrs>
   # candidates the reviewer adjudicates against the issue - and this runner
   # never reads the issue. Reporting them as FAIL marks every correctly formed
   # PR failed (GH-882 review round 1), so U2 joins D2 as reviewer input.
+  rc=0
+  OUT=$(sh "$TMP/block.sh" 2>&1) || rc=$?
+
+  # A `fatal:` line is the command refusing to run at all — a bad range, a
+  # missing ref, a broken repo. Inside a pipeline that text arrives as
+  # ordinary output while the failing stage's own status never reaches this
+  # classifier ($? is the last stage's, REVIEW.md §0), so every branch below
+  # reads it as a finding signal, or — for a grep tail that printed nothing —
+  # as a clean PASS. GH-950 measured all three misreadings in one run against
+  # a full-SHA base: D1 and D3 PASS, U4 and R1 FAIL, no row ERROR. The rule
+  # did not run, and only ERROR says that.
+  #
+  # Checked before every other classification, and before U2's reviewer-input
+  # row, so no result is ever built on output the block never produced. It is
+  # deliberately at the classifier rather than at the argument: it holds for
+  # any future block that pipes a failing command into a grep, whatever made
+  # the command fail.
+  if printf '%s\n' "$OUT" | grep -q '^fatal:'; then
+    HAS_ERROR=1
+    # The exit code goes in the evidence, not the result cell: it is the
+    # grep's, not the failing command's, so "ERROR 0" would read as an error
+    # code rather than as the contradiction it records.
+    print_row "$rule" "$2" "$3" 'ERROR' "exit=$rc; $(printf '%s\n' "$OUT" | oneline)"
+    return
+  fi
+
   if [ "$1" = "U2" ]; then
-    rc=0
-    OUT=$(sh "$TMP/block.sh" 2>&1) || rc=$?
     if [ -n "$OUT" ]; then ev=$(printf '%s\n' "$OUT" | oneline); else ev='(no closing keyword)'; fi
     print_row "$rule" "$2" "$3" 'N.A.(needs reviewer input)' "$ev"
     return
   fi
-
-  rc=0
-  OUT=$(sh "$TMP/block.sh" 2>&1) || rc=$?
 
   # Finding signals carried by printed lines (REVIEW.md §0: a piped check
   # signals by its output; U5 and R3 print their exit, D1 prints CANDIDATE,

--- a/scripts/test-review-l0.sh
+++ b/scripts/test-review-l0.sh
@@ -123,12 +123,15 @@ make_fixture() {
 run_l0() { # <fixture-dir> <spec> <out-file> [PR-number] — runner exit code via $?
   # With no PR-number argument the runner runs in the pre-push shape
   # (GH-922): U1/C5/R3 must still run, from the runner's own file list.
+  # L0_BASE overrides the <base> argument for the GH-950 cases; every other
+  # caller gets the ordinary origin/main shape.
   (cd "$1" \
     && PATH="$TMP/bin:$PATH" \
        GH_STUB_DIR="$TMP" \
        REVIEW_L0_SPEC="$2" \
-       sh "$RUNNER" origin/main HEAD ${4:-}) > "$3" 2>&1
+       sh "$RUNNER" "${L0_BASE:-origin/main}" HEAD ${4:-}) > "$3" 2>&1
 }
+L0_BASE=
 
 # ---- 1. dirty fixture: R1 + R3 FAIL, exit 1 ---------------------------------
 make_fixture dirty
@@ -248,5 +251,60 @@ grep -F '| U1 |' "$TMP/undeclared.out" | grep -Fq 'N.A.(needs PR number)' \
 grep -F '| C5 |' "$TMP/undeclared.out" | grep -Fq 'N.A.(needs PR number)' \
   && fail "attribute fixture: C5 keeps its attribute and must still run"
 echo "attribute fixture: the gate reads the marker, not the command text — OK"
+
+# ---- 7. a block that never ran is ERROR, never PASS or FAIL (GH-950) -------
+# 7a. A full SHA as <base>. The blocks diff "origin/$BASE..$SHA", so
+# "origin/<40-hex>" is not a revision and every git-backed block refuses. The
+# refusal text arrives as ordinary output — the failing stage's status never
+# reaches the classifier ($? is the pipeline's last stage) — so before the fix
+# D1 and D3 reported PASS with a `fatal:` line sitting in their own evidence,
+# and U4, C2, C4, R1 reported FAIL. None of them ran.
+make_fixture clean
+# A prefix assignment on a function call persists in POSIX sh, so set and
+# clear it explicitly rather than relying on that.
+L0_BASE=$(cat "$TMP/base-sha")
+rc=0
+run_l0 "$FIXDIR" "$SPEC" "$TMP/sha-base.out" || rc=$?
+L0_BASE=
+[ "$rc" -ne 0 ] || fail "full-SHA base: runner exited 0 over rules that never ran"
+grep -Fq 'fatal:' "$TMP/sha-base.out" \
+  || fail "full-SHA base: fixture produced no refusal at all — the case is not being exercised"
+# The defect in one assertion: no row may carry a verdict over `fatal:` output.
+if grep -E '\| (PASS|FAIL) \|' "$TMP/sha-base.out" | grep -Fq 'fatal:'; then
+  fail "full-SHA base: a PASS/FAIL row reports a verdict over 'fatal:' output: $(grep -E '\| (PASS|FAIL) \|' "$TMP/sha-base.out" | grep -F 'fatal:')"
+fi
+grep -F '| ERROR |' "$TMP/sha-base.out" | grep -Fq 'fatal:' \
+  || fail "full-SHA base: no ERROR row for the refused blocks"
+echo "full-SHA base: refused blocks are ERROR, none PASS/FAIL — OK"
+
+# 7b. The generic case, with no bad range anywhere: a block that prints a
+# `fatal:` line and still EXITS 0 through a grep tail. Before the fix this was
+# the reassuring misreading — an enumerator tail with output reads as FAIL, and
+# with none as PASS; either way the runner reports a verdict for a rule that
+# refused to run. The fix is at the classifier, so it holds for any block and
+# any cause, not only for git and not only for this argument shape.
+sub_cmd='echo "fatal: simulated refusal" >&2; echo ok | grep -v ZZZ'
+awk -v s="$sub_cmd" '
+  /^# review-spec:check U5( |$)/ { print; print "```sh"; print s; print "```"; incut = 1; next }
+  incut && /^# review-spec:check-end$/ { incut = 0; print; next }
+  incut { next }
+  { print }
+' "$SPEC" > "$TMP/fatal-spec.md"
+grep -Fq 'fatal: simulated refusal' "$TMP/fatal-spec.md" \
+  || fail "generic fatal: the substituted spec copy was not produced"
+make_fixture clean
+rc=0
+run_l0 "$FIXDIR" "$TMP/fatal-spec.md" "$TMP/fatal.out" || rc=$?
+u5=$(grep -F '| U5 |' "$TMP/fatal.out")
+case "$u5" in
+  *'| ERROR |'*) : ;;
+  *) fail "generic fatal: U5 exited 0 with a 'fatal:' line and was not ERROR: $u5" ;;
+esac
+case "$u5" in
+  *'exit=0'*) : ;;
+  *) fail "generic fatal: U5's evidence does not record the exit-0 contradiction: $u5" ;;
+esac
+[ "$rc" -eq 2 ] || fail "generic fatal: expected runner exit 2 (ERROR, no FAIL), got $rc"
+echo "generic fatal: an exit-0 block printing 'fatal:' is ERROR — OK"
 
 echo "test-review-l0.sh: all fixture assertions held"

--- a/scripts/test-review-l0.sh
+++ b/scripts/test-review-l0.sh
@@ -85,7 +85,21 @@ make_fixture() {
   git -C "$fix" config user.name fixture
   printf '[workspace.package]\nversion = "0.0.0-fixture"\n' > "$fix/Cargo.toml"
   printf '# fixture lint stub\nexit 0\n' > "$fix/scripts/lint-markdown-content.sh"
-  printf '# fixture wiring stub\nexit 0\n' > "$fix/scripts/wiring-scan.sh"
+  # The wiring stub mirrors the one thing about the real script the runner
+  # has to classify: its refusal (scripts/wiring-scan.sh:30-34). An
+  # unconditional `exit 0` would make WIRING report PASS on a range no block
+  # can resolve, which is exactly the GH-950 defect the §7a case exists to
+  # catch — the stub would hide it rather than stand in for the tool.
+  cat > "$fix/scripts/wiring-scan.sh" <<'STUB'
+# fixture wiring stub — mirrors the real script's refusal contract
+for ref in "$1" "$2"; do
+  if ! git rev-parse --verify --quiet "${ref}^{commit}" >/dev/null 2>&1; then
+    echo "error: unknown revision $ref" >&2
+    exit 2
+  fi
+done
+exit 0
+STUB
   git -C "$fix" add -A
   git -C "$fix" commit -q -m "chore(fleet): fixture base"
   git -C "$fix" rev-parse HEAD > "$TMP/base-sha"
@@ -269,12 +283,28 @@ L0_BASE=
 [ "$rc" -ne 0 ] || fail "full-SHA base: runner exited 0 over rules that never ran"
 grep -Fq 'fatal:' "$TMP/sha-base.out" \
   || fail "full-SHA base: fixture produced no refusal at all — the case is not being exercised"
-# The defect in one assertion: no row may carry a verdict over `fatal:` output.
-if grep -E '\| (PASS|FAIL) \|' "$TMP/sha-base.out" | grep -Fq 'fatal:'; then
-  fail "full-SHA base: a PASS/FAIL row reports a verdict over 'fatal:' output: $(grep -E '\| (PASS|FAIL) \|' "$TMP/sha-base.out" | grep -F 'fatal:')"
-fi
+# The defect in one assertion: no row may carry a verdict over a refusal —
+# stated over both wordings, because the two arrive by different routes. A
+# git-backed block's `fatal:` survives only as text (its status is eaten by
+# the grep it feeds); WIRING's tool is invoked directly, so its `error:` line
+# comes with a truthful exit 2. Asserting only the first would leave the
+# doneWhen's "ERROR for every affected rule" half-tested.
+verdicts=$(grep -E '\| (PASS|FAIL) \|' "$TMP/sha-base.out" | grep -E 'fatal:|error: unknown revision' || true)
+[ -z "$verdicts" ] \
+  || fail "full-SHA base: a PASS/FAIL row reports a verdict over a refusal: $verdicts"
 grep -F '| ERROR |' "$TMP/sha-base.out" | grep -Fq 'fatal:' \
   || fail "full-SHA base: no ERROR row for the refused blocks"
+# WIRING by name: it is the rule the `fatal:` net alone does not reach, and
+# the one that proved the runner still had to key on the exit code too.
+wiring=$(grep -F '| WIRING |' "$TMP/sha-base.out")
+case "$wiring" in
+  *'| ERROR '*) : ;;
+  *) fail "full-SHA base: WIRING refused and was not ERROR: $wiring" ;;
+esac
+# Exit 2 (a rule could not run), not 1 (a rule failed): with every affected
+# rule ERROR there is no finding left to report, and the two exits mean
+# different things to a caller.
+[ "$rc" -eq 2 ] || fail "full-SHA base: expected runner exit 2 (could not run), got $rc"
 echo "full-SHA base: refused blocks are ERROR, none PASS/FAIL — OK"
 
 # 7b. The generic case, with no bad range anywhere: a block that prints a


### PR DESCRIPTION
Closes #950
Closes #1054
Issue: #950, #1054

## What was wrong

`run_block` classifies a rule by its exit code and its printed lines. Every
git-backed block pipes `git` into a `grep`, so `$?` is the grep's status and
git's 128 never reaches the classifier — the POSIX hazard `REVIEW.md` §0 states
in prose. The `fatal:` text arrives as ordinary output and is then read as a
finding signal, or, for a grep tail that printed nothing, as a clean PASS.

Measured on this branch with the fix disabled, against a full-SHA base (every
block that reads the range builds `origin/<40-hex>..HEAD`, which is not a
revision, so every one of them refuses):

```
| C2     | code-plain | P0 | PASS | exit=1; fatal: ambiguous argument 'origin/3ace0c34…..HEAD': unknown revision or path not in the working tree. |
| U4     | any        | P1 | FAIL | exit=1; fatal: ambiguous argument 'origin/3ace0c34…..HEAD': unknown revision or path not in the working tree. |
| C3     | code-plain | P1 | FAIL | exit=1; fatal: bad revision 'origin/3ace0c34…..HEAD' |
| R1     | code-risk  | P0 | FAIL | exit=1; fatal: ambiguous argument 'origin/3ace0c34…..HEAD': unknown revision or path not in the working tree. |
| WIRING | any        | P1 | FAIL | exit=2; error: unknown revision origin/d4883414… |
```

The `C2` row is the defect in its clearest form: **a P0 rule reports PASS with a
`fatal:` line sitting in its own evidence column.** No row reports ERROR, which
is the outcome the runner's own header defines for exactly this case. A reviewer
or a flash lane pinning L0 to a base SHA gets a table that looks like a clean
pass over rules that never executed, and `scripts/review-l0.sh` is on the
judging surface (`docs/fleet/rules.md` R22).

## The fix — two signals, because neither covers the other

**Text**, for the blocks whose exit code is destroyed by a pipe: a `fatal:`
line in a block's output is `ERROR` regardless of the exit code, checked before
every other classification **and** before `U2`'s reviewer-input row, so no
result is ever built on output the block never produced. It therefore holds for
any future block that pipes a failing command into a grep — the narrower fix
the issue's "Suspected surface" prefers, catching the class rather than one
argument shape. The exit code goes in the evidence rather than the result cell:
it is the grep's, not the failing command's, so `ERROR 0` would read as an error
code rather than as the contradiction it records.

**Exit code**, for the blocks that invoke a tool directly: `2` joins `127`/`128`
as a could-not-run code. Added in round 1 — see below for why `error:` could not
simply be added to the text net.

Two comment surfaces follow: the header's ERROR contract states both signals and
each one's limit, and the `<base>` usage text states that a full SHA is **not**
an accepted shape (the issue's fourth doneWhen item).

## Round 1: the `WIRING` P0

Round 1 found that the first commit did **not** deliver doneWhen item 1 —
"reports `ERROR` for **every affected rule**". `WIRING` invokes
`scripts/wiring-scan.sh` directly, and that tool refuses in its own words
(`scripts/wiring-scan.sh:32-33`):

```sh
echo "error: unknown revision $ref" >&2
exit 2
```

so it escaped the `fatal:` net, fell to `run_block`'s final arm, and reported
**FAIL** for a rule that never ran — dragging the runner's exit to 1 (findings)
instead of 2 (could not run). I had routed this to a follow-up on a selective
reading of my own acceptance criteria: I quoted the second doneWhen bullet,
which is written specifically against `fatal:`, and treated it as the whole
item. It is not. `WIRING` is an affected rule.

**Why not widen the text net to `^(fatal|error):`** — the obvious one-liner, and
wrong here. `error:` is ambiguous in this repo: `wiring-scan.sh` uses it for a
refusal, but `scripts/check-cli-docs.sh` uses the same prefix for genuine
findings (`error: undocumented verb`, `error: undocumented flag`). Matching it
would relabel findings as "did not run", which is the inverse of the bug this
PR fixes.

**Exit 2 instead**, which is safe as a code where the prefix is not safe as
text. It is this repo's could-not-run code — the runner's own exits, `grep`'s
for a bad pattern (a status a pipeline *does* report faithfully), and
`wiring-scan.sh`'s for usage and unknown revisions. I checked every
check-marked block in `REVIEW.md`: none signals a finding with 2 — the
enumerator greps signal with 0/1, and the tools that signal by printed lines
(U5, R3, D1, D3) are caught by `badline`, which is checked first. And
`wiring-scan.sh` itself exits only 0 or 2, never non-zero for a finding.

The fixture's wiring stub was an unconditional `exit 0`, which is why §7a could
not see this: it made `WIRING` report PASS on a range no block can resolve. It
now mirrors the real script's refusal contract, so the stub stands in for the
tool instead of hiding it.

This delivers #1054, which I filed for this gap before round 1 corrected the
routing — closed by this PR rather than left open.

## doneWhen

| Item | Where |
|---|---|
| full-SHA base reports ERROR for every affected rule / exits nonzero, no PASS/FAIL over a refusal | `scripts/test-review-l0.sh` §7a — asserted over both wordings, plus `WIRING` by name, plus `exit == 2` |
| `fatal:` ⇒ ERROR independent of exit code, at the classifier | `scripts/review-l0.sh` `run_block`; `test-review-l0.sh` §7b |
| suite covers both cases and still exits 0 with existing assertions held | run below |
| usage comment states accepted `<base>` shapes | `scripts/review-l0.sh:23-31` |

## Gates RAN (Windows workstation)

```
sh scripts/test-review-l0.sh
  dirty fixture: R1 and R3 rows FAIL, runner exit 1 — OK
  clean fixture: every routed rule printed a row — OK
  clean fixture: all rows PASS/N.A./需升級, runner exit 0 — OK
  unmarked spec: UNMARKED line printed, runner exit 3 — OK
  pre-push fixture: U1/C5/R3 ran without a PR, R3 FAIL, U2/U3/U6 stay N.A. — OK
  cjk fixture: R1 evidence cell survives the cap as valid UTF-8 — OK
  attribute fixture: an unknown marker attribute exits 2 — OK
  attribute fixture: the gate reads the marker, not the command text — OK
  full-SHA base: refused blocks are ERROR, none PASS/FAIL — OK
  generic fatal: an exit-0 block printing 'fatal:' is ERROR — OK
  test-review-l0.sh: all fixture assertions held
  exit 0

sh -n scripts/review-l0.sh scripts/test-review-l0.sh   ok
bash scripts/lint-file-length.sh --tree                exit 0
```

**FAIL-first, both arms, separately:**

- text arm — replacing the classifier's `if` with `if false` turns §7a red and
  prints the `fatal:` table above (`SUITE_EXIT=1`);
- exit-code arm — dropping `|| [ "$rc" -eq 2 ]` turns §7a red on exactly the row
  round 1 found:
  `full-SHA base: a PASS/FAIL row reports a verdict over a refusal: | WIRING | any | P1 | FAIL | exit=2; error: unknown revision origin/d4883414… |`

No crate changed, so no Cargo gate applies locally; `scripts/test-review-l0.sh`
runs in the `fleet-tests` job (it is not in `run-fleet-tests.sh`'s quarantine
list), so CI exercises it on ubuntu/dash too.

## Known limit (stated, not fixed)

The text signal is locale-shaped: git localizes its messages, so a translated
`fatal:` would not match. Measured English on the Git for Windows build here
(2.49.0, which ships no `share/locale`); not guaranteed everywhere. The
exit-code signal is the locale-independent half, but it reaches a refusal only
when a pipeline has not swallowed the status — which is the whole reason the
text signal exists. Both limits are now stated in the header contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
