### PR TITLE
fix(fleet): review-pr.sh matches the doneWhen heading case-insensitively (GH-953)

### DIFF
--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -775,8 +775,15 @@ BRIEF="$SCRATCH/review-pr$PR-r$ROUND-brief.md"
     for i in $ISSUES; do
       echo
       echo "### Issue #$i doneWhen (the acceptance ceiling, REVIEW.md §1)"
+      # The heading is matched case- and space-insensitively: issues are
+      # written by hand and spell it `## doneWhen`, `## Done when`, `## Done
+      # When`. A case-sensitive match silently yields an EMPTY ceiling rather
+      # than an error, so the brief tells the reviewer to judge against a
+      # doneWhen it was never given (GH-953; #902 is the issue that found it,
+      # and #953 itself is written `## Done when`).
       gh issue view "$i" --repo "$REPO" --json body --jq .body 2>/dev/null \
-        | awk '/^## doneWhen/{f=1;next} /^## /{f=0} f' || echo "(issue #$i could not be read)"
+        | awk 'tolower($0) ~ /^##[[:space:]]+done[[:space:]]*when([[:space:]]|$)/ {f=1;next} /^## /{f=0} f' \
+        || echo "(issue #$i could not be read)"
     done
   fi
   echo

--- a/scripts/test-review-pr.sh
+++ b/scripts/test-review-pr.sh
@@ -158,6 +158,23 @@ Some preamble about the defect.
 nothing
 EOF
 
+# GH-953: the heading is written by hand and is not always the repo's own
+# `## doneWhen` spelling — #902 writes `## Done when`, and #953 itself does
+# too. A case-sensitive extractor yields an EMPTY ceiling, not an error, so
+# the brief tells the reviewer to judge against a doneWhen it never received.
+cat >"$GH_ISSUE_DIR/902" <<'EOF'
+Some preamble about the defect.
+
+## Done when
+
+- the machine assignee identity is validated before dispatch
+- `sh -n scripts/review-pr.sh` exits 0
+
+## Predicted surface
+
+nothing
+EOF
+
 fail() { printf 'FAIL %s\n' "$1" >&2; failures=$((failures + 1)); }
 
 # Run one --dry-run and leave stdout in $out, the brief path in $brief.
@@ -357,6 +374,27 @@ if ! grep -qi 'no acceptance criteria' "$brief"; then
 fi
 if ! grep -q '#683' "$tmp/err"; then
     fail "D2e: a brief generated with no acceptance criteria printed no warning on stderr"
+fi
+
+# D2f (#953): the heading spelling is the issue author's, not the repo's. A
+# case-sensitive '/^## doneWhen/' silently yields an EMPTY ceiling for the
+# `## Done when` issues that already exist (#902, and #953 itself), which is
+# the same failure D2e guards against — except nothing warns, because an issue
+# WAS linked and its section WAS "found". The brief must carry the items.
+dry_run 'Closes #902.\n\nSome prose about the change.\n'
+if [ "$(field issues)" != "902" ]; then
+    fail "D2f: a body linking its issue as 'Closes #902' yielded issues=$(field issues)"
+fi
+if ! grep -q '^### Issue #902 doneWhen' "$brief"; then
+    fail "D2f: the brief carries no doneWhen section for #902"
+fi
+if ! grep -q 'the machine assignee identity is validated before dispatch' "$brief"; then
+    fail "D2f: '## Done when' yielded an empty acceptance ceiling — the heading was matched case-sensitively (#953)"
+fi
+# The section must still END at the next heading: an over-eager match would
+# swallow '## Predicted surface' into the ceiling.
+if grep -q 'Predicted surface' "$brief"; then
+    fail "D2f: the doneWhen extraction ran past the next '## ' heading"
 fi
 
 # --- D3 (#691): the reviewer must never be told to open a browser manual -------


### PR DESCRIPTION
Closes #953
Issue: #953

## What was wrong

`scripts/review-pr.sh` mines the review brief's acceptance ceiling with

```sh
awk '/^## doneWhen/{f=1;next} /^## /{f=0} f'
```

The heading is written by hand and is not always the repo's own spelling.
Issue #902 writes `## Done when`; so does #953 itself. Against either, the
extractor matches nothing.

The failure is silent, and that is what makes it worse than an error. `gh issue
view` succeeds, the section is "found" as empty, and the brief carries a
`### Issue #N doneWhen (the acceptance ceiling, REVIEW.md §1)` header with
nothing under it. The reviewer is told to judge against an acceptance ceiling it
was never given — and unlike the no-issue-linked path, which warns on stderr
(#683), nothing warns here, because an issue *was* linked and its section *was*
located.

## The fix

One line, case- and space-insensitive, still anchored and still bounded:

```sh
awk 'tolower($0) ~ /^##[[:space:]]+done[[:space:]]*when([[:space:]]|$)/ {f=1;next} /^## /{f=0} f'
```

`doneWhen`, `Done when`, `Done When`, `DONE WHEN` and `##   done  when` all
match; `## doneWhenever` does not, because of the trailing word boundary; and
the section still ends at the next `## ` heading, unchanged.

### Correction (round 1): it is not the only matcher

An earlier revision of this body claimed `scripts/review-pr.sh:785` was the
repo's only doneWhen extractor. **That was wrong** — my search was scoped to
`scripts/` and spelled `doneWhen` case-sensitively, which is the same mistake
as the bug. Three more matchers still reject `## Done when`:

| Site | Shape | Effect |
|---|---|---|
| `crates/edda-cli/src/cmd_fleet_order.rs:684` | `section.starts_with("donewhen")` on a heading already lowercased at `:681` | `"done when"` fails the prefix ⇒ `Verdict::Fail` ⇒ `edda fleet order` calls a fresh issue stale |
| `scripts/fleet/issue-freshness.sh:137` | `/^##[ 	]*doneWhen[ 	]*$/` | `next-issue.sh` exits 2 and applies `fleet:stale` |
| `REVIEW.md:128` | the pre-fix awk, verbatim | a reviewer following the spec by hand still gets an empty ceiling |

None of them are changed here: #953's doneWhen is one item about *the*
extractor this PR fixes, and the product-crate one would drag a Rust gate into
a shell-only change. They are filed together as **#1056**, which also records
why this is not a re-open of #968/#970 — both were closed as carrier closures
with the case-insensitivity property explicitly *preserved into #1015*, and
#1015 shipped (PR #1040) without it.

## doneWhen

| Item | Where |
|---|---|
| the extractor accepts the heading case-insensitively | `scripts/review-pr.sh:785` |
| a test proves a `## Done when` body yields the doneWhen lines | `scripts/test-review-pr.sh` D2f |

D2f uses #902's actual shape as its fixture and asserts three things: the brief
carries a `### Issue #902 doneWhen` section, it carries the section's items, and
it stops before the next `## ` heading (an over-eager match would swallow
`## Predicted surface` into the ceiling).

## Gates RAN (Windows workstation, `50834ef`)

```
sh scripts/test-review-pr.sh
  FAIL D11: product adapter launch failed: review-pr.sh: nohup process 8562 died immediately
  review-pr fixtures: 1 of 25 cases failed

sh -n scripts/review-pr.sh scripts/test-review-pr.sh   ok
bash scripts/lint-file-length.sh --tree                exit 0
```

**D11 is pre-existing, not introduced here.** A pristine `origin/main` worktree
run on this same machine fails identically —

```
FAIL D11: product adapter launch failed: review-pr.sh: nohup process 4876 died immediately
review-pr fixtures: 1 of 24 cases failed
```

— 24 cases there against 25 here, the one extra being D2f, which passes. It is
also already owned: `scripts/fleet/run-fleet-tests.sh` quarantines this whole
file under **#1024**, naming this exact failure ("on windows-latest case D11 hit
the nohup launch race in review-pr.sh's product-adapter path"). So the file runs
in no CI job, and this PR neither fixes nor worsens that.

No crate changed, so no Cargo gate applies locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
