### PR TITLE
feat(edda-cli): edda review gate — union rule and window check in the product (GH-769)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -842,6 +842,16 @@ no verdict on that SHA is anything else; any standing non-qualifying verdict
 is `failure`; no verdict at all is `error`. A later LGTM therefore does not
 override an earlier Changes Requested on the same SHA (GH-742).
 
+**That rule is executable: `edda review gate <sha>` decides it** (GH-769), and
+it is the only implementation — the watcher calls it and maps `0`/`1`/`2` to
+`success`/`failure`/`error`. `--base <ref>` adds the window check: if the base
+has advanced over any file the subject changed, the reviewed tree is no longer
+the tree that would merge, and the gate fails with reason `window`. The verb
+reads the ledger's `review_verdict` events by default and accepts the caller's
+verdict facts with `--verdicts`; it writes nothing, launches nothing, and
+never touches GitHub. Anything that needs to know whether a SHA passed asks
+it rather than re-deriving the rule.
+
 ## 9. Provenance of the check commands
 
 `RAN` means the command was executed on the authoring workstation

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -843,14 +843,21 @@ is `failure`; no verdict at all is `error`. A later LGTM therefore does not
 override an earlier Changes Requested on the same SHA (GH-742).
 
 **That rule is executable: `edda review gate <sha>` decides it** (GH-769), and
-it is the only implementation — the watcher calls it and maps `0`/`1`/`2` to
-`success`/`failure`/`error`. `--base <ref>` adds the window check: if the base
-has advanced over any file the subject changed, the reviewed tree is no longer
-the tree that would merge, and the gate fails with reason `window`. The verb
-reads the ledger's `review_verdict` events by default and accepts the caller's
-verdict facts with `--verdicts`; it writes nothing, launches nothing, and
-never touches GitHub. Anything that needs to know whether a SHA passed asks
-it rather than re-deriving the rule.
+it is the only implementation of the rule — no other code in this repository
+decides what a verdict means. `--base <ref>` adds the window check: if the
+base has advanced over any file the subject changed, the reviewed tree is no
+longer the tree that would merge, and the gate fails with reason `window`. The
+verb reads the ledger's `review_verdict` events by default and accepts the
+caller's verdict facts with `--verdicts`; it writes nothing, launches nothing,
+and never touches GitHub. Its exit codes and flags are in
+`docs/reference/cli.md`.
+
+One caller asks it today: `scripts/pr-review-watch.sh` posts the
+`Independent Review` commit status from its answer. The merge step does not
+yet — `scripts/merge-reviewed-pr.sh` still requires the *latest* trusted
+review to be a qualifying LGTM, which an earlier standing Changes Requested on
+the same SHA does not survive contact with. GH-1057 wires it; until it lands,
+do not read this paragraph as a claim that merge already goes through the gate.
 
 ## 9. Provenance of the check commands
 

--- a/crates/edda-cli/src/cmd_review/gate.rs
+++ b/crates/edda-cli/src/cmd_review/gate.rs
@@ -1,0 +1,540 @@
+//! `edda review gate <sha>` — the union rule and the window check, in the
+//! product (GH-769).
+//!
+//! Two questions decide whether a reviewed SHA has passed, and both are
+//! verdict semantics rather than forge glue:
+//!
+//! - **Union.** While any non-qualifying verdict stands on the SHA, the answer
+//!   is no. A later LGTM never overrides an earlier Changes Requested on the
+//!   same SHA (GH-742).
+//! - **Window.** If the base advanced over a file the PR changed, the reviewed
+//!   tree is no longer the tree that would merge.
+//!
+//! `scripts/pr-review-watch.sh` carried both in shell, marked `D8-debt(#769)`.
+//! This module is where that debt is paid: one rule, one implementation.
+//!
+//! ## Two sources, one rule
+//!
+//! The rule is a pure function over [`Standing`] values. Two adapters produce
+//! them:
+//!
+//! - the ledger's `review_verdict` events (default), and
+//! - `--verdicts` (a file, or `-` for stdin) in the tab-separated shape the
+//!   watcher already derives from §7 verdict comments.
+//!
+//! The second exists because the verdict *source* is a different debt from the
+//! union *rule*. `D8-debt(#671)` — reading verdicts out of PR comments — stands
+//! until the ledger carries verdicts across machines, and it does not yet:
+//! `review_verdict` is not among the event types the committed mirror imports.
+//! A fleet that reviews on one machine and merges from another would, on the
+//! ledger alone, see no verdict at all. Feeding the caller's facts to the same
+//! rule keeps that correct today without a second copy of the rule, and the
+//! ledger path is ready for the day #671 is paid.
+//!
+//! This verb never writes the ledger, never launches a lane, and never touches
+//! GitHub.
+
+use super::git::git;
+use anyhow::{Context, Result};
+use edda_core::ReviewVerdictPayload;
+use edda_ledger::Ledger;
+use std::path::Path;
+
+/// Flags for `edda review gate <sha>`.
+#[derive(clap::Args)]
+pub struct GateArgs {
+    /// The reviewed commit, as a full 40-character SHA
+    #[arg(value_name = "SHA")]
+    pub sha: String,
+    /// Comparison base; when given, the review window is checked too
+    #[arg(long, value_name = "REF")]
+    pub base: Option<String>,
+    /// Read verdict facts from this path (`-` for stdin) instead of the ledger
+    ///
+    /// One record per line, tab separated: `<verdict>\t<p0>\t<p1>`, where
+    /// verdict is `LGTM`, `Provisional`, or anything else (which cannot
+    /// qualify). A missing or non-numeric count reads as non-zero.
+    #[arg(long, value_name = "PATH")]
+    pub verdicts: Option<String>,
+    /// Emit the gate report as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// One verdict standing on the reviewed SHA, reduced to what the rule needs.
+#[derive(Debug, Clone)]
+pub(crate) struct Standing {
+    /// `lgtm` or anything else; only `lgtm` can contribute a pass.
+    verdict: String,
+    /// An unqualified LGTM is Provisional: pending, never a pass on its own.
+    qualified: bool,
+    /// `None` is an unstated count, which reads as non-zero (fail closed).
+    p0: Option<u64>,
+    p1: Option<u64>,
+    reviewer_model: Option<String>,
+    round: Option<u32>,
+    cost_usd: Option<f64>,
+    cost_measured: bool,
+}
+
+impl Standing {
+    /// P0 and P1 are both stated and both zero.
+    fn clean(&self) -> bool {
+        self.p0 == Some(0) && self.p1 == Some(0)
+    }
+}
+
+/// What the union rule says about the verdicts standing on one SHA.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Union {
+    /// At least one qualifying LGTM at P0=P1=0, and nothing standing against it.
+    Pass,
+    /// A non-qualifying verdict stands, or only Provisional rounds do.
+    Fail,
+    /// No verdict at all — not a judgement, an inability to make one.
+    None,
+}
+
+/// The union rule.
+///
+/// A Provisional round (unqualified LGTM at P0=P1=0, REVIEW.md §6.4) is
+/// *pending*: never a pass on its own, and once its escalation is adjudicated
+/// it does not hold a later qualified LGTM on the same SHA at fail. With any
+/// P0/P1 it is a standing non-qualifying verdict like any other (§8, GH-742).
+pub(crate) fn union(standing: &[Standing]) -> Union {
+    if standing.is_empty() {
+        return Union::None;
+    }
+    let mut pass = false;
+    for entry in standing {
+        if entry.verdict == "lgtm" && entry.clean() {
+            if entry.qualified {
+                pass = true;
+            }
+            // A clean Provisional neither passes nor blocks.
+            continue;
+        }
+        return Union::Fail;
+    }
+    if pass {
+        Union::Pass
+    } else {
+        Union::Fail
+    }
+}
+
+/// Did the base advance over a file this subject changed?
+///
+/// The reviewed tree is the merge of `sha` into `base` as it stood. If `base`
+/// has since moved on any file the subject touches, that merge is a different
+/// tree and the review no longer covers it.
+///
+/// Both arguments are resolved commits, not refs: two `git` calls read `base`
+/// here, and a name that moved between them would compare two different trees.
+fn window_moved(repo: &Path, sha: &str, base: &str) -> Result<bool> {
+    let changed = git(repo, &["diff", "--name-only", &format!("{base}...{sha}")])?;
+    let files: Vec<&str> = changed.lines().filter(|line| !line.is_empty()).collect();
+    if files.is_empty() {
+        return Ok(false);
+    }
+    let merge_base = git(repo, &["merge-base", sha, base])?;
+    let range = format!("{merge_base}..{base}");
+    let mut args = vec!["diff", "--name-only", range.as_str(), "--"];
+    args.extend(files);
+    Ok(!git(repo, &args)?.trim().is_empty())
+}
+
+/// Verdicts on `sha`, from the ledger's `review_verdict` events.
+///
+/// An `unreviewed` event is not a verdict: it records that a review could not
+/// be made. Skipping it is what makes "no verdict at all" reachable, and it
+/// matches how `subject::history` reads the same events.
+///
+/// A payload that cannot be deserialized is fatal rather than skipped: a gate
+/// that silently drops the event it cannot read is a gate that passes because
+/// it went blind.
+fn from_ledger(repo: &Path, sha: &str) -> Result<Vec<Standing>> {
+    let ledger = Ledger::open(repo)?;
+    let mut standing = Vec::new();
+    for event in ledger.iter_events_by_type("review_verdict")? {
+        let payload: ReviewVerdictPayload = serde_json::from_value(event.payload.clone())
+            .with_context(|| format!("review_verdict event {}", event.event_id))?;
+        if payload.verdict == "unreviewed" || payload.subject.head_sha != sha {
+            continue;
+        }
+        let count = |severity: &str| {
+            payload
+                .findings
+                .iter()
+                .filter(|finding| finding.severity == severity)
+                .count() as u64
+        };
+        standing.push(Standing {
+            p0: Some(count("P0")),
+            p1: Some(count("P1")),
+            qualified: payload.qualified,
+            verdict: payload.verdict.clone(),
+            reviewer_model: Some(payload.reviewer.model_observed.clone()),
+            round: payload.refs.round,
+            cost_usd: payload.cost.usd,
+            cost_measured: payload.cost.measured,
+        });
+    }
+    Ok(standing)
+}
+
+/// Verdicts supplied by the caller, in the watcher's tab-separated shape.
+pub(crate) fn from_lines(text: &str) -> Vec<Standing> {
+    text.lines()
+        .map(|line| line.trim_end_matches('\r'))
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            let mut fields = line.split('\t');
+            let label = fields.next().unwrap_or("").trim();
+            let count = |field: Option<&str>| field.and_then(|v| v.trim().parse::<u64>().ok());
+            let (verdict, qualified) = match label {
+                "LGTM" => ("lgtm", true),
+                "Provisional" => ("lgtm", false),
+                other => (other, false),
+            };
+            Standing {
+                verdict: verdict.to_owned(),
+                qualified,
+                p0: count(fields.next()),
+                p1: count(fields.next()),
+                reviewer_model: None,
+                round: None,
+                cost_usd: None,
+                cost_measured: false,
+            }
+        })
+        .collect()
+}
+
+fn report(sha: &str, standing: &[Standing], outcome: Union, reason: Option<&str>) -> String {
+    let verdicts: Vec<serde_json::Value> = standing
+        .iter()
+        .map(|entry| {
+            serde_json::json!({
+                "verdict": entry.verdict,
+                "qualified": entry.qualified,
+                "p0": entry.p0,
+                "p1": entry.p1,
+                "reviewer_model": entry.reviewer_model,
+                "round": entry.round,
+                // A cost nobody measured is `unmeasured`, never 0 — printing a
+                // zero would claim a free round that was simply not weighed.
+                "cost_usd": match (entry.cost_measured, entry.cost_usd) {
+                    (true, Some(usd)) => serde_json::json!(usd),
+                    _ => serde_json::json!("unmeasured"),
+                },
+            })
+        })
+        .collect();
+    serde_json::json!({
+        "sha": sha,
+        "state": match outcome {
+            Union::Pass => "pass",
+            Union::Fail => "fail",
+            Union::None => "none",
+        },
+        "reason": reason,
+        "verdicts": verdicts,
+    })
+    .to_string()
+}
+
+/// CLI entry point. Exit: 0 pass, 1 fail, 2 cannot judge.
+pub fn run(args: GateArgs, cwd: &Path) -> Result<()> {
+    if args.sha.len() != 40 || !args.sha.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        eprintln!("edda review gate: expected a full 40-character SHA");
+        std::process::exit(2);
+    }
+    // The repo is resolved only where it is needed: `--verdicts` judges facts
+    // the caller supplies, so it must work outside a checkout too.
+    let standing = match args.verdicts.as_deref() {
+        Some("-") => {
+            let mut text = String::new();
+            std::io::Read::read_to_string(&mut std::io::stdin(), &mut text)
+                .context("read verdicts from stdin")?;
+            from_lines(&text)
+        }
+        Some(path) => from_lines(
+            &std::fs::read_to_string(path).with_context(|| format!("read verdicts {path}"))?,
+        ),
+        None => from_ledger(&super::git::repo_root_from(cwd)?, &args.sha)?,
+    };
+
+    let mut outcome = union(&standing);
+    let mut reason = match outcome {
+        Union::Fail => Some("union"),
+        _ => None,
+    };
+    // The window is only meaningful once the verdicts themselves pass: a SHA
+    // that has not been approved is not blocked *because* its base moved.
+    if outcome == Union::Pass {
+        if let Some(base) = args.base.as_deref() {
+            // Resolve the base through this module's own guard: `commit` runs
+            // `rev-parse --verify --end-of-options` and returns a full SHA, so
+            // a ref shaped like a flag cannot reach `git` as one, and the
+            // ranges below name one commit rather than whatever the ref means
+            // by the time the second `git` call runs.
+            let repo = super::git::repo_root_from(cwd)?;
+            let base = super::git::commit(&repo, base)?;
+            if window_moved(&repo, &args.sha, &base)? {
+                outcome = Union::Fail;
+                reason = Some("window");
+            }
+        }
+    }
+
+    if args.json {
+        println!("{}", report(&args.sha, &standing, outcome, reason));
+    } else {
+        match (outcome, reason) {
+            (Union::Pass, _) => println!("PASS {} verdicts={}", args.sha, standing.len()),
+            (Union::Fail, reason) => {
+                println!("FAIL {} {}", args.sha, reason.unwrap_or("union"))
+            }
+            (Union::None, _) => println!("NONE {}", args.sha),
+        }
+    }
+    match outcome {
+        Union::Pass => Ok(()),
+        Union::Fail => std::process::exit(1),
+        Union::None => std::process::exit(2),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmd_review::git::testrepo;
+
+    fn standing(verdict: &str, qualified: bool, p0: Option<u64>, p1: Option<u64>) -> Standing {
+        Standing {
+            verdict: verdict.into(),
+            qualified,
+            p0,
+            p1,
+            reviewer_model: None,
+            round: None,
+            cost_usd: None,
+            cost_measured: false,
+        }
+    }
+
+    fn lgtm() -> Standing {
+        standing("lgtm", true, Some(0), Some(0))
+    }
+
+    fn provisional() -> Standing {
+        standing("lgtm", false, Some(0), Some(0))
+    }
+
+    fn changes() -> Standing {
+        standing("changes-requested", false, Some(1), Some(0))
+    }
+
+    #[test]
+    fn union_matrix_matches_the_rule_the_shell_carried() {
+        assert_eq!(union(&[]), Union::None);
+        assert_eq!(union(&[lgtm()]), Union::Pass);
+        assert_eq!(union(&[changes()]), Union::Fail);
+        // GH-742: a later LGTM never overrides an earlier Changes Requested.
+        assert_eq!(union(&[changes(), lgtm()]), Union::Fail);
+        assert_eq!(union(&[lgtm(), changes()]), Union::Fail);
+        // An LGTM carrying a blocking finding is not clean.
+        assert_eq!(
+            union(&[standing("lgtm", true, Some(0), Some(1))]),
+            Union::Fail
+        );
+        assert_eq!(
+            union(&[standing("lgtm", true, Some(1), Some(0))]),
+            Union::Fail
+        );
+        // An unstated count reads as non-zero.
+        assert_eq!(union(&[standing("lgtm", true, None, Some(0))]), Union::Fail);
+    }
+
+    #[test]
+    fn a_provisional_round_is_pending_not_a_verdict_either_way() {
+        // Never a pass on its own...
+        assert_eq!(union(&[provisional()]), Union::Fail);
+        // ...and does not hold a later qualified LGTM on the same SHA at fail.
+        assert_eq!(union(&[provisional(), lgtm()]), Union::Pass);
+        // With a blocking finding it is a standing non-qualifying verdict —
+        // alone, and holding a later qualified LGTM on the same SHA at fail.
+        assert_eq!(
+            union(&[standing("lgtm", false, Some(0), Some(2))]),
+            Union::Fail
+        );
+        assert_eq!(
+            union(&[standing("lgtm", false, Some(0), Some(2)), lgtm()]),
+            Union::Fail
+        );
+    }
+
+    #[test]
+    fn caller_supplied_lines_parse_into_the_same_rule() {
+        assert_eq!(union(&from_lines("LGTM\t0\t0\n")), Union::Pass);
+        assert_eq!(union(&from_lines("Changes Requested\t1\t0\n")), Union::Fail);
+        assert_eq!(union(&from_lines("Provisional\t0\t0\n")), Union::Fail);
+        assert_eq!(
+            union(&from_lines("Provisional\t0\t0\nLGTM\t0\t0\n")),
+            Union::Pass
+        );
+        // Missing and non-numeric counts read as non-zero.
+        assert_eq!(union(&from_lines("LGTM\t\t\n")), Union::Fail);
+        assert_eq!(union(&from_lines("LGTM\tmany\t0\n")), Union::Fail);
+        // Blank lines and CRLF are not records.
+        assert_eq!(union(&from_lines("\r\n\nLGTM\t0\t0\r\n")), Union::Pass);
+        assert_eq!(union(&from_lines("   \n")), Union::None);
+    }
+
+    #[test]
+    fn window_is_clear_until_the_base_moves_on_a_changed_file() {
+        let (_temp, root) = testrepo::init();
+        testrepo::commit_file(&root, "shared.txt", "base\n", "base file");
+        let base_start = testrepo::run(&root, &["rev-parse", "HEAD"]);
+        testrepo::run(&root, &["checkout", "-q", "-b", "subject"]);
+        let sha = testrepo::commit_file(&root, "shared.txt", "subject\n", "subject edit");
+        testrepo::run(&root, &["checkout", "-q", "main"]);
+
+        // The base has not moved at all.
+        assert!(!window_moved(&root, &sha, &base_start).unwrap());
+
+        // The base moves, but only on a file the subject never touched.
+        testrepo::commit_file(&root, "unrelated.txt", "other\n", "unrelated advance");
+        assert!(!window_moved(&root, &sha, "main").unwrap());
+
+        // The base moves on the file the subject changed.
+        testrepo::commit_file(&root, "shared.txt", "moved\n", "base advance");
+        assert!(window_moved(&root, &sha, "main").unwrap());
+    }
+
+    /// Build a `review_verdict` payload through serde so the fixture cannot
+    /// drift from the struct the product actually writes.
+    fn payload(head: &str, verdict: &str, qualified: bool) -> ReviewVerdictPayload {
+        serde_json::from_value(serde_json::json!({
+            "schema": "review_verdict/0",
+            "subject": {
+                "base_sha": "base", "head_sha": head,
+                "files": 1, "lines": 1, "coverage": "full",
+            },
+            "refs": { "round": 2 },
+            "spec": { "mode": "spec-backed", "source": "issue#769", "trust": "local" },
+            "brief": { "core": "scope", "classes": [] },
+            "reviewer": {
+                "agent": "pi", "transport": "rpc",
+                "model_requested": "openai-codex/gpt-5.6-sol",
+                "model_observed": "openai-codex/gpt-5.6-sol",
+                "observed_via": "provider",
+                "session_id": "s", "session_label": "review", "tool_policy": "hard",
+            },
+            "independence": "verified",
+            "independence_policy": "session",
+            "gates": { "status": "verified", "declared_by": [], "read": [], "ran": [] },
+            "verdict": verdict,
+            "outcome": "done",
+            "qualified": qualified,
+            "cost": { "usd": 2.17, "measured": true, "duration_ms": 1 },
+            "parse": "ok",
+        }))
+        .expect("review_verdict payload fixture")
+    }
+
+    fn append(ledger: &edda_ledger::Ledger, payload: &ReviewVerdictPayload) {
+        let event = edda_core::event::new_review_verdict_event(
+            "main",
+            ledger.last_event_hash().unwrap().as_deref(),
+            payload,
+            None,
+            None,
+            &[],
+        )
+        .expect("verdict event");
+        ledger.append_event(&event).expect("append verdict");
+    }
+
+    #[test]
+    fn the_ledger_source_reads_only_the_verdicts_standing_on_this_sha() {
+        let (_temp, root) = testrepo::init();
+        let ledger = edda_ledger::Ledger::open_or_init(&root).expect("ledger");
+        let sha = "a".repeat(40);
+        let other = "b".repeat(40);
+
+        append(&ledger, &payload(&sha, "lgtm", true));
+        // Another SHA's verdict is not this SHA's business.
+        append(&ledger, &payload(&other, "changes-requested", false));
+        // An `unreviewed` event records that no review could be made. Counting
+        // it would make "no verdict at all" unreachable, and `subject::history`
+        // skips it for the same reason.
+        append(&ledger, &payload(&sha, "unreviewed", false));
+
+        let standing = from_ledger(&root, &sha).expect("read ledger");
+        assert_eq!(standing.len(), 1, "{standing:?}");
+        assert_eq!(standing[0].verdict, "lgtm");
+        assert_eq!(standing[0].round, Some(2));
+        assert_eq!(
+            standing[0].reviewer_model.as_deref(),
+            Some("openai-codex/gpt-5.6-sol")
+        );
+        assert_eq!(union(&standing), Union::Pass);
+    }
+
+    #[test]
+    fn a_self_check_is_structurally_invisible_to_the_gate() {
+        // `pr-review-loop` self-checks are PR comments, never `review_verdict`
+        // events. The gate cannot mistake one for a verdict because it never
+        // looks anywhere a self-check can appear — so a PR carrying nothing
+        // but a self-check is `NONE`, which the caller maps to exit 2.
+        let (_temp, root) = testrepo::init();
+        let ledger = edda_ledger::Ledger::open_or_init(&root).expect("ledger");
+        let argv = ["edda", "review"].map(str::to_owned);
+        let event = edda_core::event::new_cmd_event_with_git_context(
+            &edda_core::event::CmdEventParams {
+                branch: "main",
+                parent_hash: ledger.last_event_hash().unwrap().as_deref(),
+                argv: &argv,
+                cwd: root.to_str().unwrap(),
+                exit_code: 0,
+                duration_ms: 1,
+                stdout_blob: "",
+                stderr_blob: "",
+            },
+            None,
+            Some(false),
+        )
+        .expect("cmd event");
+        ledger.append_event(&event).expect("append cmd event");
+
+        let standing = from_ledger(&root, &"c".repeat(40)).expect("read ledger");
+        assert!(standing.is_empty(), "{standing:?}");
+        assert_eq!(union(&standing), Union::None);
+    }
+
+    #[test]
+    fn json_reports_an_unmeasured_cost_rather_than_zero() {
+        let mut measured = lgtm();
+        measured.cost_usd = Some(2.17);
+        measured.cost_measured = true;
+        measured.reviewer_model = Some("openai-codex/gpt-5.6-sol".into());
+        measured.round = Some(2);
+        let text = report(
+            "a".repeat(40).as_str(),
+            &[measured, lgtm()],
+            Union::Pass,
+            None,
+        );
+        let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(value["state"], "pass");
+        assert_eq!(value["verdicts"][0]["cost_usd"], 2.17);
+        assert_eq!(
+            value["verdicts"][0]["reviewer_model"],
+            "openai-codex/gpt-5.6-sol"
+        );
+        assert_eq!(value["verdicts"][0]["round"], 2);
+        assert_eq!(value["verdicts"][1]["cost_usd"], "unmeasured");
+    }
+}

--- a/crates/edda-cli/src/cmd_review/gate.rs
+++ b/crates/edda-cli/src/cmd_review/gate.rs
@@ -131,15 +131,35 @@ pub(crate) fn union(standing: &[Standing]) -> Union {
 ///
 /// Both arguments are resolved commits, not refs: two `git` calls read `base`
 /// here, and a name that moved between them would compare two different trees.
+///
+/// The file list is read with `-z` and split on NUL because the check feeds
+/// its own output back as pathspecs. With `core.quotePath` at its default git
+/// C-quotes any path holding non-ASCII, a quote or a backslash — `réponse.txt`
+/// comes back as `"r\303\251ponse.txt"`, which matches nothing as a pathspec,
+/// so the second diff is empty and the window reads *clear* for exactly the
+/// case the rule exists to catch. `--literal-pathspecs` closes the other half:
+/// a filename containing `*` or `[` is a filename here, never a glob.
 fn window_moved(repo: &Path, sha: &str, base: &str) -> Result<bool> {
-    let changed = git(repo, &["diff", "--name-only", &format!("{base}...{sha}")])?;
-    let files: Vec<&str> = changed.lines().filter(|line| !line.is_empty()).collect();
+    let changed = git(
+        repo,
+        &["diff", "--name-only", "-z", &format!("{base}...{sha}")],
+    )?;
+    let files: Vec<&str> = changed
+        .split('\0')
+        .filter(|name| !name.is_empty())
+        .collect();
     if files.is_empty() {
         return Ok(false);
     }
     let merge_base = git(repo, &["merge-base", sha, base])?;
     let range = format!("{merge_base}..{base}");
-    let mut args = vec!["diff", "--name-only", range.as_str(), "--"];
+    let mut args = vec![
+        "--literal-pathspecs",
+        "diff",
+        "--name-only",
+        range.as_str(),
+        "--",
+    ];
     args.extend(files);
     Ok(!git(repo, &args)?.trim().is_empty())
 }
@@ -245,9 +265,35 @@ fn report(sha: &str, standing: &[Standing], outcome: Union, reason: Option<&str>
 }
 
 /// CLI entry point. Exit: 0 pass, 1 fail, 2 cannot judge.
+///
+/// Every internal failure — an unreadable ledger, an undeserializable
+/// `review_verdict`, an unresolvable `--base` — leaves through exit **2**, not
+/// through the caller's error path. `main` exits 1 on an `Err`, and the
+/// watcher reads 1 as `failure`: a definitive "this SHA did not pass". Not
+/// being able to judge is not a judgement, so this verb never returns its
+/// errors upward.
 pub fn run(args: GateArgs, cwd: &Path) -> Result<()> {
-    if args.sha.len() != 40 || !args.sha.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-        eprintln!("edda review gate: expected a full 40-character SHA");
+    match judge(args, cwd) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            eprintln!("edda review gate: {error:#}");
+            std::process::exit(2);
+        }
+    }
+}
+
+fn judge(args: GateArgs, cwd: &Path) -> Result<()> {
+    // Lowercase only, matching `is_full_sha` in the watcher and REVIEW.md R5.
+    // An uppercase SHA would otherwise pass the guard, match no ledger event,
+    // and be reported as "no verdict" — the wrong diagnosis for a malformed
+    // argument.
+    if args.sha.len() != 40
+        || !args
+            .sha
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        eprintln!("edda review gate: expected a full lowercase 40-hex SHA");
         std::process::exit(2);
     }
     // The repo is resolved only where it is needed: `--verdicts` judges facts
@@ -390,6 +436,30 @@ mod tests {
         // Blank lines and CRLF are not records.
         assert_eq!(union(&from_lines("\r\n\nLGTM\t0\t0\r\n")), Union::Pass);
         assert_eq!(union(&from_lines("   \n")), Union::None);
+        // Deliberate, and wider than the awk this replaced: surrounding
+        // whitespace on a field is not a malformed record. The tolerance stops
+        // at the label — a padded verdict word is still that word, an unknown
+        // one still cannot qualify.
+        assert_eq!(union(&from_lines(" LGTM \t 0 \t 0 \n")), Union::Pass);
+        assert_eq!(union(&from_lines(" lgtm \t0\t0\n")), Union::Fail);
+    }
+
+    #[test]
+    fn a_path_git_would_quote_is_still_seen_by_the_window() {
+        // The check feeds its own file list back as pathspecs, and git
+        // C-quotes anything non-ASCII by default: `réponse.txt` returns as
+        // `"r\303\251ponse.txt"`, which matches nothing. Before `-z` this
+        // read as *window clear* — a fail-open on the whole rule.
+        let (_temp, root) = testrepo::init();
+        testrepo::commit_file(&root, "réponse.txt", "base\n", "quoted path");
+        testrepo::run(&root, &["checkout", "-q", "-b", "subject"]);
+        let sha = testrepo::commit_file(&root, "réponse.txt", "subject\n", "subject edit");
+        testrepo::run(&root, &["checkout", "-q", "main"]);
+        testrepo::commit_file(&root, "réponse.txt", "moved\n", "base advance");
+        assert!(
+            window_moved(&root, &sha, "main").unwrap(),
+            "a quoted path must not read as an untouched file"
+        );
     }
 
     #[test]
@@ -416,7 +486,19 @@ mod tests {
     /// Build a `review_verdict` payload through serde so the fixture cannot
     /// drift from the struct the product actually writes.
     fn payload(head: &str, verdict: &str, qualified: bool) -> ReviewVerdictPayload {
+        payload_with(head, verdict, qualified, serde_json::json!([]))
+    }
+
+    /// The same fixture, carrying findings — the half of `from_ledger` that
+    /// decides whether a verdict is clean.
+    fn payload_with(
+        head: &str,
+        verdict: &str,
+        qualified: bool,
+        findings: serde_json::Value,
+    ) -> ReviewVerdictPayload {
         serde_json::from_value(serde_json::json!({
+            "findings": findings,
             "schema": "review_verdict/0",
             "subject": {
                 "base_sha": "base", "head_sha": head,
@@ -481,6 +563,42 @@ mod tests {
             Some("openai-codex/gpt-5.6-sol")
         );
         assert_eq!(union(&standing), Union::Pass);
+    }
+
+    #[test]
+    fn the_ledger_source_counts_findings_and_keeps_the_qualification() {
+        let (_temp, root) = testrepo::init();
+        let ledger = edda_ledger::Ledger::open_or_init(&root).expect("ledger");
+        let sha = "c".repeat(40);
+        let finding = |severity: &str| {
+            serde_json::json!({
+                "id": format!("{severity}-1"), "severity": severity,
+                "file": "a.rs", "line": 1, "claim": "c",
+                "evidence": "a.rs:1", "rule": "core", "status": "open",
+            })
+        };
+        // One P0, two P1s, and a P2 that is not blocking and must not be
+        // counted into either.
+        append(
+            &ledger,
+            &payload_with(
+                &sha,
+                "lgtm",
+                false,
+                serde_json::json!([finding("P0"), finding("P1"), finding("P1"), finding("P2")]),
+            ),
+        );
+
+        let standing = from_ledger(&root, &sha).expect("read ledger");
+        assert_eq!(standing.len(), 1, "{standing:?}");
+        assert_eq!(standing[0].p0, Some(1));
+        assert_eq!(standing[0].p1, Some(2));
+        assert!(
+            !standing[0].qualified,
+            "qualification must survive the read"
+        );
+        assert!(!standing[0].clean());
+        assert_eq!(union(&standing), Union::Fail);
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_review/mod.rs
+++ b/crates/edda-cli/src/cmd_review/mod.rs
@@ -2,6 +2,7 @@
 mod args;
 mod brief;
 mod evidence;
+mod gate;
 mod git;
 mod github;
 mod identity;
@@ -23,8 +24,31 @@ use edda_conductor::agent::launcher::{AgentLauncher, PhaseResult};
 use edda_core::{
     ReviewBrief, ReviewCost, ReviewFinding, ReviewReviewer, ReviewSubject, ReviewVerdictPayload,
 };
+pub use gate::GateArgs;
 use std::path::Path;
 use tokio_util::sync::CancellationToken;
+
+/// Verbs under `edda review`.
+///
+/// `edda review` itself stays a bare command with flags: `--pr`, `--spec` and
+/// the rest are what `scripts/review-pr.sh` and `pr-review-watch.sh` invoke
+/// today, and a subcommand layer must not move them.
+#[derive(clap::Subcommand)]
+pub enum ReviewCmd {
+    /// Union rule and window check over the verdicts standing on a SHA
+    ///
+    /// Reads only. Exit: 0 pass, 1 fail, 2 cannot judge.
+    Gate {
+        #[command(flatten)]
+        args: GateArgs,
+    },
+}
+
+pub fn run_cmd(cmd: ReviewCmd, cwd: &Path) -> Result<()> {
+    match cmd {
+        ReviewCmd::Gate { args } => gate::run(args, cwd),
+    }
+}
 
 pub fn run(args: ReviewArgs, cwd: &Path) -> Result<()> {
     let result = run_inner(&args, cwd);

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -504,7 +504,13 @@ enum Command {
     },
     /// Independent SHA-pinned review. Exit: 0 qualified LGTM, 1 changes,
     /// 2 unable to review, 3 unqualified LGTM. JSON is unstable.
+    ///
+    /// With no subcommand this launches a review, exactly as before; the
+    /// subcommands are read-only verbs over reviews already recorded.
+    #[command(args_conflicts_with_subcommands = true)]
     Review {
+        #[command(subcommand)]
+        cmd: Option<cmd_review::ReviewCmd>,
         #[command(flatten)]
         args: cmd_review::ReviewArgs,
     },
@@ -1333,7 +1339,10 @@ fn run(cli: Cli) -> anyhow::Result<()> {
         Command::Plan { cmd } => cmd_plan::run(cmd, &repo_root),
         Command::Conduct { cmd } => cmd_conduct::run_cmd(cmd, &repo_root),
         Command::Dispatch { args } => cmd_dispatch::run(args),
-        Command::Review { args } => cmd_review::run(args, &cwd),
+        Command::Review { cmd, args } => match cmd {
+            Some(cmd) => cmd_review::run_cmd(cmd, &cwd),
+            None => cmd_review::run(args, &cwd),
+        },
         Command::Intake { cmd } => match cmd {
             IntakeCmd::Github { issue_id } => cmd_intake::execute_github(&repo_root, issue_id),
         },

--- a/crates/edda-cli/tests/review_gate_exit_codes.rs
+++ b/crates/edda-cli/tests/review_gate_exit_codes.rs
@@ -49,6 +49,29 @@ impl TestEnv {
         }
     }
 
+    /// Run one git command in the test repository.
+    fn git(&self, args: &[&str]) -> String {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(&self.repo)
+            .output()
+            .expect("spawn git");
+        assert!(
+            out.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim_end().to_owned()
+    }
+
+    /// Commit `content` to `name` and return the resulting commit SHA.
+    fn commit(&self, name: &str, content: &str, message: &str) -> String {
+        std::fs::write(self.repo.join(name), content).expect("write file");
+        self.git(&["add", "--", name]);
+        self.git(&["commit", "-q", "-m", message]);
+        self.git(&["rev-parse", "HEAD"])
+    }
+
     /// Run `edda review gate ...`, feeding `stdin` to it.
     fn gate(&self, args: &[&str], stdin: &str) -> (i32, String, String) {
         let bin = PathBuf::from(env!("CARGO_BIN_EXE_edda"));
@@ -114,7 +137,65 @@ fn a_value_that_is_not_a_full_sha_cannot_be_judged() {
     // subject the gate cannot even name.
     let (code, _stdout, stderr) = env.gate(&["deadbeef", "--verdicts", "-"], "LGTM\t0\t0\n");
     assert_eq!(code, 2);
-    assert!(stderr.contains("40-character SHA"), "{stderr}");
+    assert!(stderr.contains("lowercase 40-hex SHA"), "{stderr}");
+}
+
+#[test]
+fn a_base_that_moved_on_a_changed_file_exits_1_naming_the_window() {
+    let env = TestEnv::new();
+    env.git(&["checkout", "-q", "-b", "subject"]);
+    let sha = env.commit("shared.txt", "subject\n", "subject edit");
+    env.git(&["checkout", "-q", "main"]);
+    env.commit("shared.txt", "base moved\n", "base advance");
+
+    // The verdicts pass; only the window fails. That is the whole point of
+    // the rule — an approved tree that is no longer the tree that would merge.
+    let (code, stdout, stderr) =
+        env.gate(&[&sha, "--verdicts", "-", "--base", "main"], "LGTM\t0\t0\n");
+    assert_eq!(code, 1, "stdout: {stdout}stderr: {stderr}");
+    assert_eq!(stdout.trim_end(), format!("FAIL {sha} window"));
+}
+
+#[test]
+fn a_base_that_moved_elsewhere_leaves_the_window_clear() {
+    let env = TestEnv::new();
+    env.git(&["checkout", "-q", "-b", "subject"]);
+    let sha = env.commit("shared.txt", "subject\n", "subject edit");
+    env.git(&["checkout", "-q", "main"]);
+    env.commit("unrelated.txt", "other\n", "unrelated advance");
+
+    let (code, stdout, stderr) =
+        env.gate(&[&sha, "--verdicts", "-", "--base", "main"], "LGTM\t0\t0\n");
+    assert_eq!(code, 0, "stdout: {stdout}stderr: {stderr}");
+    assert_eq!(stdout.trim_end(), format!("PASS {sha} verdicts=1"));
+}
+
+#[test]
+fn an_unreadable_subject_cannot_judge_rather_than_condemn() {
+    let env = TestEnv::new();
+    // No ledger source can answer here, and `--base` names a ref that does
+    // not exist. An internal failure must leave through 2 ("cannot judge"),
+    // never 1 — the watcher publishes 1 as a definitive `failure`.
+    let (code, stdout, stderr) = env.gate(
+        &[SHA, "--verdicts", "-", "--base", "refs/heads/no-such-ref"],
+        "LGTM\t0\t0\n",
+    );
+    assert_eq!(code, 2, "stdout: {stdout}stderr: {stderr}");
+    assert!(stderr.contains("edda review gate:"), "{stderr}");
+}
+
+#[test]
+fn an_uppercase_sha_is_a_malformed_argument_not_a_missing_verdict() {
+    let env = TestEnv::new();
+    // The watcher and REVIEW.md R5 both pin `^[0-9a-f]{40}$`. An uppercase
+    // value used to pass the guard and then be reported as "no verdict",
+    // which is the wrong diagnosis.
+    let (code, _stdout, stderr) = env.gate(
+        &[&SHA.to_ascii_uppercase(), "--verdicts", "-"],
+        "LGTM\t0\t0\n",
+    );
+    assert_eq!(code, 2);
+    assert!(stderr.contains("lowercase 40-hex SHA"), "{stderr}");
 }
 
 #[test]
@@ -127,6 +208,8 @@ fn a_base_shaped_like_a_flag_is_refused_not_handed_to_git() {
         &[SHA, "--verdicts", "-", "--base", "--upload-pack=touched"],
         "LGTM\t0\t0\n",
     );
-    assert_ne!(code, 0, "a flag-shaped base must not pass the gate");
+    // Exit 2: the gate could not judge the subject, which is not the same
+    // claim as "this SHA failed".
+    assert_eq!(code, 2, "stdout: {stdout}stderr: {stderr}");
     assert!(!stdout.contains("PASS"), "stdout: {stdout}stderr: {stderr}");
 }

--- a/crates/edda-cli/tests/review_gate_exit_codes.rs
+++ b/crates/edda-cli/tests/review_gate_exit_codes.rs
@@ -1,0 +1,132 @@
+//! Contract test for `edda review gate`'s three exit codes (GH-769).
+//!
+//! The exit code *is* the interface: `scripts/pr-review-watch.sh` maps 0/1/2
+//! onto the `Independent Review` commit status (`success`/`failure`/`error`)
+//! and decides nothing itself. The in-crate tests stop at `union()` and the
+//! `Result` level, while `run` calls `std::process::exit` directly, so only a
+//! spawned binary can assert the codes that mapping reads.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+const SHA: &str = "8d943560d00053d5372745579b74b633da36a830";
+
+struct TestEnv {
+    _dir: tempfile::TempDir,
+    repo: PathBuf,
+    store: PathBuf,
+}
+
+impl TestEnv {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let repo = dir.path().join("repo");
+        let store = dir.path().join("store");
+        std::fs::create_dir_all(&repo).expect("create repo");
+        std::fs::create_dir_all(&store).expect("create store");
+        // Hermetic isolation (GH-646): .edda stops EddaPaths::find_root here
+        // rather than letting it climb to the developer's home directory.
+        std::fs::create_dir_all(repo.join(".edda")).expect("create .edda");
+        // A real repository, because the `--base` case resolves a ref.
+        for args in [
+            &["init", "-q", "-b", "main"][..],
+            &["config", "user.email", "gate@test"][..],
+            &["config", "user.name", "gate"][..],
+            &["commit", "-q", "--allow-empty", "-m", "base"][..],
+        ] {
+            let out = Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .expect("spawn git");
+            assert!(out.status.success(), "git {args:?}");
+        }
+        Self {
+            _dir: dir,
+            repo,
+            store,
+        }
+    }
+
+    /// Run `edda review gate ...`, feeding `stdin` to it.
+    fn gate(&self, args: &[&str], stdin: &str) -> (i32, String, String) {
+        let bin = PathBuf::from(env!("CARGO_BIN_EXE_edda"));
+        let mut child = Command::new(&bin)
+            .arg("review")
+            .arg("gate")
+            .args(args)
+            .current_dir(&self.repo)
+            .env("EDDA_STORE_ROOT", &self.store)
+            .env("EDDA_SESSION_ID", "review-gate-exit-probe")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn edda");
+        child
+            .stdin
+            .take()
+            .expect("stdin")
+            .write_all(stdin.as_bytes())
+            .expect("write verdicts");
+        let out = child.wait_with_output().expect("wait for edda");
+        (
+            out.status.code().expect("exit code"),
+            String::from_utf8_lossy(&out.stdout).into_owned(),
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        )
+    }
+}
+
+#[test]
+fn a_clean_lgtm_exits_0() {
+    let env = TestEnv::new();
+    let (code, stdout, stderr) = env.gate(&[SHA, "--verdicts", "-"], "LGTM\t0\t0\n");
+    assert_eq!(code, 0, "stdout: {stdout}stderr: {stderr}");
+    assert_eq!(stdout.trim_end(), format!("PASS {SHA} verdicts=1"));
+}
+
+#[test]
+fn a_standing_changes_requested_exits_1_naming_the_union() {
+    let env = TestEnv::new();
+    // GH-742: the later LGTM does not clear the earlier blocking verdict.
+    let (code, stdout, stderr) = env.gate(
+        &[SHA, "--verdicts", "-"],
+        "Changes Requested\t1\t0\nLGTM\t0\t0\n",
+    );
+    assert_eq!(code, 1, "stdout: {stdout}stderr: {stderr}");
+    assert_eq!(stdout.trim_end(), format!("FAIL {SHA} union"));
+}
+
+#[test]
+fn no_verdict_at_all_exits_2_rather_than_judging() {
+    let env = TestEnv::new();
+    let (code, stdout, stderr) = env.gate(&[SHA, "--verdicts", "-"], "\n   \n");
+    assert_eq!(code, 2, "stdout: {stdout}stderr: {stderr}");
+    assert_eq!(stdout.trim_end(), format!("NONE {SHA}"));
+}
+
+#[test]
+fn a_value_that_is_not_a_full_sha_cannot_be_judged() {
+    let env = TestEnv::new();
+    // The watcher reads exit 2 as `error`, which is the honest answer to a
+    // subject the gate cannot even name.
+    let (code, _stdout, stderr) = env.gate(&["deadbeef", "--verdicts", "-"], "LGTM\t0\t0\n");
+    assert_eq!(code, 2);
+    assert!(stderr.contains("40-character SHA"), "{stderr}");
+}
+
+#[test]
+fn a_base_shaped_like_a_flag_is_refused_not_handed_to_git() {
+    let env = TestEnv::new();
+    // The verdicts pass, so the window check runs and the base is resolved.
+    // `commit` puts it behind `rev-parse --verify --end-of-options`, so this
+    // is rejected as a ref rather than reaching git as an option.
+    let (code, stdout, stderr) = env.gate(
+        &[SHA, "--verdicts", "-", "--base", "--upload-pack=touched"],
+        "LGTM\t0\t0\n",
+    );
+    assert_ne!(code, 0, "a flag-shaped base must not pass the gate");
+    assert!(!stdout.contains("PASS"), "stdout: {stdout}stderr: {stderr}");
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1211,7 +1211,7 @@ Answer whether a reviewed SHA has passed. Read-only: it launches no review,
 writes no event, and never touches GitHub.
 
 ```bash
-edda review gate 3306c1a2d9a0... --base origin/main
+edda review gate <sha> --base origin/main
 edda review gate <sha> --json
 printf 'LGTM\t0\t0\n' | edda review gate <sha> --verdicts -
 ```
@@ -1233,7 +1233,8 @@ Verdicts come from the ledger's `review_verdict` events for that SHA;
 reads them from the caller instead, one `verdict<TAB>p0<TAB>p1` record per
 line — the shape `scripts/pr-review-watch.sh` derives from §7 comments while
 the ledger does not yet carry verdicts across machines. The SHA must be a full
-40-character hex value.
+lowercase 40-hex value — the same shape `pr-review-watch.sh`'s `is_full_sha`
+and REVIEW.md R5 require.
 
 Stdout is one line — `PASS <sha> verdicts=<n>`, `FAIL <sha> <reason>` or
 `NONE <sha>`. `--json` adds each verdict's `reviewer_model`, `round` and

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1204,3 +1204,43 @@ disqualifiers. Unmeasured cost is never represented as zero. No PR comment,
 label change, merge, or conductor gate approval occurs automatically.
 `--timeout-sec` defaults to 900; `--budget-usd` is passed to supported backends.
 `--keep-worktree` preserves the review checkout for inspection.
+
+#### edda review gate
+
+Answer whether a reviewed SHA has passed. Read-only: it launches no review,
+writes no event, and never touches GitHub.
+
+```bash
+edda review gate 3306c1a2d9a0... --base origin/main
+edda review gate <sha> --json
+printf 'LGTM\t0\t0\n' | edda review gate <sha> --verdicts -
+```
+
+Two rules decide it, and this verb is their only implementation (REVIEW.md §8):
+
+- **Union.** `PASS` requires at least one qualifying `LGTM` at P0=0 P1=0 with
+  nothing else standing on the SHA. A later LGTM never overrides an earlier
+  Changes Requested (GH-742). An unqualified LGTM at P0=P1=0 is *provisional*:
+  never a pass on its own, but it does not hold a later qualified LGTM at
+  fail; with any P0/P1 it stands like any other non-qualifying verdict. A
+  missing or non-numeric count reads as non-zero.
+- **Window** (only with `--base`). If the base has advanced over any file the
+  subject changed, the reviewed tree is not the tree that would merge, and the
+  gate fails with reason `window`.
+
+Verdicts come from the ledger's `review_verdict` events for that SHA;
+`unreviewed` events are not verdicts and are skipped. `--verdicts <path|->`
+reads them from the caller instead, one `verdict<TAB>p0<TAB>p1` record per
+line — the shape `scripts/pr-review-watch.sh` derives from §7 comments while
+the ledger does not yet carry verdicts across machines. The SHA must be a full
+40-character hex value.
+
+Stdout is one line — `PASS <sha> verdicts=<n>`, `FAIL <sha> <reason>` or
+`NONE <sha>`. `--json` adds each verdict's `reviewer_model`, `round` and
+`cost_usd`; a cost nobody measured prints `unmeasured`, never `0`.
+
+| Exit | Meaning |
+|---|---|
+| 0 | Pass: the union rule is satisfied and the window is clear |
+| 1 | Fail: a non-qualifying verdict stands (`union`), or the base moved (`window`) |
+| 2 | No verdict on the SHA — an inability to judge, not a judgment |

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -12,7 +12,7 @@
 #        pr-review-watch.sh decide                 (offline helper; TSV on stdin)
 #        pr-review-watch.sh label-verdict <reviewed-sha> <current-head>
 #        pr-review-watch.sh ack-try <pr> <sha> <attempts>
-#        pr-review-watch.sh gate-state                  (offline helper; verdict TSV on stdin)
+#        pr-review-watch.sh gate-state <sha>            (offline helper; verdict TSV on stdin)
 #        pr-review-watch.sh collect-verdicts <pr> <sha> (offline helper; PR comments via gh)
 #
 # Environment:
@@ -67,18 +67,19 @@
 # After the verdict comment, the watcher also posts the "Independent Review"
 # commit status on the REVIEWED sha (never the current head). Its state is the
 # union rule over every §7 verdict comment on that sha plus this round's
-# verdict (see gate_state), so a later LGTM cannot override an earlier
-# Changes Requested on the same sha. Posting reuses the comment's bounded
-# retry path (postfails, POSTFAIL_CAP, review:post-failed) — never best-effort.
+# verdict (`edda review gate`, GH-769; gate_state pipes the comments to it),
+# so a later LGTM cannot override an earlier Changes Requested on the same
+# sha. Posting reuses the comment's bounded retry path (postfails,
+# POSTFAIL_CAP, review:post-failed) — never best-effort.
 #
 # A product round (TRANSPORT=edda-review) carries its verdict in `edda
 # review`'s exit: 1 is Changes Requested and 3 an unqualified LGTM, which the
 # adapter publishes under a `Provisional — …` Verdict line (REVIEW.md §6.4).
 # Both are settled reviews: the comment is posted, the status goes through the
-# union rule (gate_state: a Provisional round is never success on its own — at
-# P0=P1=0 it is pending, with any P0/P1 it stands like any non-qualifying
-# verdict), and a Provisional round gets no review:* label. Neither is a dead
-# verdict for the overload rule (#998).
+# union rule (`edda review gate`: a Provisional round is never success on its
+# own — at P0=P1=0 it is pending, with any P0/P1 it stands like any
+# non-qualifying verdict), and a Provisional round gets no review:* label.
+# Neither is a dead verdict for the overload rule (#998).
 #
 # The watcher NEVER merges. Merge stays behind operator authorization
 # (pr.merge-policy).
@@ -175,34 +176,28 @@ is_full_sha() {
 #   error   — no verdict lines at all.
 # A later LGTM never overrides an earlier Changes Requested on the same sha:
 # while any non-qualifying verdict stands, the answer is failure.
-gate_state() {
-# D8-debt(#769)
-# The whole union rule lives in this one block so it can be lifted in one
-# piece and replaced by `edda review gate <sha>` (exit 0/1/2 mapped to
-# success/failure/error). No other code decides what a verdict means.
-  awk -F'\t' '
-    { sub(/\r$/, "") }
-    /^[[:space:]]*$/ { next }
-    {
-      n++
-      zero = ($2 ~ /^[0-9]+$/ && $2 + 0 == 0 && $3 ~ /^[0-9]+$/ && $3 + 0 == 0)
-      if ($1 == "LGTM" && zero) { ok = 1; next }
-      # An unqualified LGTM (Provisional, REVIEW.md §6.4) at P0=P1=0 is pending:
-      # never success on its own, and once the escalation is adjudicated it
-      # does not hold a later qualified LGTM on the same sha at failure. With
-      # any P0/P1 it is a standing non-qualifying verdict like any other
-      # (§8, GH-742; #1023 round 1).
-      if ($1 == "Provisional" && zero) next
-      bad = 1
-    }
-    END {
-      if (n == 0)   print "error"
-      else if (bad) print "failure"
-      else if (ok)  print "success"
-      else          print "failure"
-    }
-  '
-# /D8-debt
+gate_state() { # $1=reviewed sha; stdin: verdict<TAB>p0<TAB>p1 records
+  # The union rule now lives in the product: `edda review gate` (GH-769).
+  # This function is only the adapter from its exit code to the commit-status
+  # word, so nothing here decides what a verdict means.
+  #
+  # The verdict *source* is a separate debt: the marked block below (GH-671)
+  # still reads verdicts out of the PR's section 7 comments because the ledger
+  # does not yet carry them across machines -- `review_verdict` is not among
+  # the event types the committed mirror imports -- so the facts are piped in
+  # with `--verdicts -`. Once #671 is paid this call drops the flag and the
+  # same verb answers from the ledger.
+  "${EDDA_BIN:-edda}" review gate "$1" --verdicts - >/dev/null 2>&1
+  gate_code=$?
+  # The receipt the operator reads back against the GitHub status: which sha
+  # was judged, and what the gate answered. `log` writes only to $WATCHLOG,
+  # so it cannot contaminate the status word on stdout.
+  log "gate $1 exit $gate_code"
+  case $gate_code in
+    0) echo success ;;
+    1) echo failure ;;
+    *) echo error ;;
+  esac
 }
 
 # D8-debt(#671)
@@ -366,7 +361,7 @@ ack_try() { # $1=pr $2=sha $3=attempts — one attempt.
 case "${1:-}" in
   decide) decide; exit 0 ;;
   label-verdict) label_verdict "${2:-}" "${3:-}"; exit 0 ;;
-  gate-state) gate_state; exit 0 ;;
+  gate-state) gate_state "${2:-}"; exit 0 ;;
   collect-verdicts)
     if [ $# -lt 3 ]; then echo "usage: pr-review-watch.sh collect-verdicts <pr> <reviewed-sha>" >&2; exit 1; fi
     if ! is_full_sha "$3"; then
@@ -596,10 +591,11 @@ mark_post_failed() { # $1=pr $2=sha $3=round $4=verdict file
 }
 
 # The "Independent Review" commit status for the reviewed sha. The state is
-# the union rule (gate_state) over every §7 verdict comment on that sha plus
-# this round's verdict file (the comment carrying it was posted just before;
-# the union rule makes the duplicate harmless). The description names this
-# round's verdict; unreadable counts render as "?" — never a made-up number.
+# the union rule (`edda review gate`) over every §7 verdict comment on that
+# sha plus this round's verdict file (the comment carrying it was posted
+# just before; the union rule makes the duplicate harmless). The description
+# names this round's verdict; unreadable counts render as "?" — never a
+# made-up number.
 # Returns non-zero WITHOUT posting anything when the sha is not a validated
 # 40-hex value or the comment list is unreadable: a withheld status is
 # retried on the same bounded path as a failed post, never replaced by a
@@ -648,7 +644,7 @@ post_review_status() { # $1=pr $2=reviewed sha $3=verdict file
     return 3
   fi
   prior=$(printf '%s\n' "$comments" | awk -F'\t' '$1 == "LGTM" || $1 == "Changes Requested" || $1 == "Provisional"')
-  state=$(printf '%s\n%s\n' "$prior" "$(verdict_body_lines "$2" < "$3")" | gate_state)
+  state=$(printf '%s\n%s\n' "$prior" "$(verdict_body_lines "$2" < "$3")" | gate_state "$2")
   gh api "repos/$REPO/statuses/$2" \
     -f state="$state" -f context="Independent Review" \
     -f description="$v P0=$p0 P1=$p1" >/dev/null

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -167,6 +167,13 @@ cat >"$STUBBIN/edda" <<'EOF'
 echo "edda $*" >>"$EDDA_STUB_LOG"
 case "$*" in
   'dispatch --help') echo '--tools <TOOLS> --exclude-tools <EXCLUDE_TOOLS> --permission-mode <MODE>'; exit 0 ;;
+  'review gate'*)
+    # GH-769: the union rule is the product's now, not this suite's. What the
+    # daemon still owns is exit code -> status state, so the stub answers with
+    # the code the case sets and records what it was handed.
+    cat >>"${EDDA_GATE_STDIN:-/dev/null}"
+    exit "${EDDA_GATE_EXIT:-0}"
+    ;;
   *--agent*claude*)
     [ -n "${DISPATCH_FAIL_PROBE:-}" ] && exit 1
     exit 0
@@ -199,7 +206,8 @@ reset_stubs() {
     unset GH_FAIL_COMMENT_FIRST GH_FAIL_COMMENT_ALWAYS GH_FAIL_EDIT GH_FAIL_HEAD \
           GH_PR_LIST_FILE GH_HEAD GH_HEAD_FILE DISPATCH_FAIL_PROBE \
           GH_COMMENTS_FILE GH_FAIL_STATUS GH_FAIL_COMMENTS \
-          GH_FILES_FILE GH_FAIL_FILES 2>/dev/null || true
+          GH_FILES_FILE GH_FAIL_FILES \
+          EDDA_GATE_EXIT EDDA_GATE_STDIN 2>/dev/null || true
     rm -f "$EDDA_FLEET_SCRATCH"/review-* 2>/dev/null || true
     : >"$EDDA_FLEET_SCRATCH/review-state.tsv"
     : >"$EDDA_FLEET_SCRATCH/review-acks.tsv"
@@ -412,59 +420,73 @@ expect_label_verdict \
     'aaa111' \
     ''
 
-# --- gate-state: union rule for the Independent Review commit status ----------
-# Input: one verdict per line, `verdict<TAB>p0<TAB>p1` (blank lines ignored).
-# Output, exactly one word: success only when at least one verdict is
-# LGTM P0=0 P1=0 and no other verdict on the input is anything else; failure
-# when any verdict is present and does not qualify (missing or non-numeric
-# counts count as non-zero); error when there are no verdict lines at all.
+# --- gate-state: the adapter from `edda review gate` to the status word ------
+# The union rule itself moved into the product (GH-769) and is tested there
+# (`cmd_review::gate::tests` — the same matrix this file used to carry, case
+# for case). What is left here is the only thing the shell still owns: the
+# mapping from the verb's exit code to the commit-status word. A stub stands
+# in for the verb so this test pins the mapping and nothing else; a stub that
+# re-implemented the union rule would be a third copy of it.
+
+stub_gate() { # $1=exit code the fake verb returns; echoes the stub's directory
+    dir=$(mktemp -d)
+    printf '#!/bin/sh
+exit %s
+' "$1" > "$dir/edda"
+    chmod +x "$dir/edda"
+    printf '%s' "$dir"
+}
 
 expect_gate_state() {
     name=$1
-    expected=$2
-    input=$3
+    code=$2
+    expected=$3
     case_number=$((case_number + 1))
-    if ! actual=$(printf '%b' "$input" | \
-        timeout 60 sh "$root/scripts/pr-review-watch.sh" gate-state); then
-        printf '%s: gate-state exited non-zero\n' "$name" >&2
+    dir=$(stub_gate "$code")
+    actual=$(printf 'LGTM	0	0
+' |         EDDA_BIN="$dir/edda" timeout 60 sh "$root/scripts/pr-review-watch.sh"         gate-state 0000000000000000000000000000000000000000)
+    rc=$?
+    rm -rf "$dir"
+    if [ "$rc" -ne 0 ]; then
+        printf '%s: gate-state exited non-zero
+' "$name" >&2
         return 1
     fi
     if [ "$actual" != "$expected" ]; then
-        printf '%s: expected %s, got %s\n' "$name" "$expected" "$actual" >&2
+        printf '%s: expected %s, got %s
+' "$name" "$expected" "$actual" >&2
         return 1
     fi
 }
 
-expect_gate_state 'no verdict lines at all' 'error' ''
-expect_gate_state 'blank lines only are still no verdicts' 'error' '\n\n'
-expect_gate_state 'one LGTM 0 0' 'success' 'LGTM\t0\t0\n'
-expect_gate_state 'one Changes Requested' 'failure' 'Changes Requested\t0\t3\n'
-expect_gate_state 'a later LGTM does not override an earlier Changes Requested (union rule)' \
-    'failure' \
-    'Changes Requested\t0\t3\nLGTM\t0\t0\n'
-expect_gate_state 'an earlier LGTM does not pre-clear a later Changes Requested' \
-    'failure' \
-    'LGTM\t0\t0\nChanges Requested\t0\t3\n'
-expect_gate_state 'LGTM with P0=1 does not qualify' 'failure' 'LGTM\t1\t0\n'
-expect_gate_state 'LGTM with P1=1 does not qualify' 'failure' 'LGTM\t0\t1\n'
-expect_gate_state 'blank lines mixed in are ignored' 'success' '\nLGTM\t0\t0\n\n\n'
-expect_gate_state 'two qualifying LGTMs are success' 'success' 'LGTM\t0\t0\nLGTM\t0\t0\n'
-expect_gate_state 'a missing count is non-zero, never success' 'failure' 'LGTM\t0\n'
-expect_gate_state 'a non-numeric count is non-zero, never success' 'failure' 'LGTM\tx\ty\n'
-expect_gate_state 'an unknown verdict word is failure' 'failure' 'Needs Discussion\t0\t0\n'
-# REVIEW.md §6.4/§8: an unqualified LGTM (edda review exit 3) is provisional —
-# it never satisfies the gate, even at P0=0 P1=0 (#998).
-expect_gate_state 'a provisional verdict never qualifies' 'failure' 'Provisional\t0\t0\n'
-# A Provisional round stands in the union by its counts (#1023 round 1):
-# at P0=P1=0 it is pending — never success on its own, cleared by a later
-# qualified LGTM on the same sha once the escalation is adjudicated (REVIEW.md
-# §6.4); with any P0/P1 it stands like any other non-qualifying verdict (§8,
-# GH-742), so a later LGTM on that sha cannot turn the gate green.
-expect_gate_state 'a provisional 0/0 is cleared by a later qualified LGTM on the same sha' \
-    'success' 'Provisional\t0\t0\nLGTM\t0\t0\n'
-expect_gate_state 'a provisional round with findings holds a later LGTM at failure' \
-    'failure' 'Provisional\t0\t2\nLGTM\t0\t0\n'
-expect_gate_state 'a provisional round with findings alone is failure' 'failure' 'Provisional\t0\t2\n'
+# The receipt the issue's verify step reads: one line per judgement naming the
+# sha and the gate's exit code, matching the status the daemon then posts.
+expect_gate_receipt() {
+    name=$1
+    code=$2
+    rsha=222233334444555566667777888899990000bbbb
+    dir=$(stub_gate "$code")
+    receipts="$tmp/gate-receipts.log"
+    : >"$receipts"
+    printf 'LGTM\t0\t0\n' | PR_REVIEW_WATCH_LOG="$receipts" EDDA_BIN="$dir/edda" \
+        timeout 60 sh "$root/scripts/pr-review-watch.sh" gate-state "$rsha" >/dev/null
+    rm -rf "$dir"
+    if ! grep -qF "gate $rsha exit $code" "$receipts"; then
+        printf '%s: expected a `gate <sha> exit %s` receipt, got:\n%s\n' \
+            "$name" "$code" "$(cat "$receipts")" >&2
+        return 1
+    fi
+}
+
+expect_gate_state 'exit 0 is the success status' 0 'success'
+expect_gate_state 'exit 1 is the failure status' 1 'failure'
+expect_gate_state 'exit 2 is the error status' 2 'error'
+# Any other exit is an inability to judge, never a pass: a verb that crashed
+# or was not installed must not read as a clean gate.
+expect_gate_state 'an unexpected exit is error, never success' 127 'error'
+expect_gate_receipt 'a passing gate leaves a receipt' 0 || exit 1
+expect_gate_receipt 'a failing gate leaves a receipt' 1 || exit 1
+
 
 # --- collect-verdicts: read the §7 verdict comments pinned to one SHA ---------
 # The fixture holds the OUTPUT of the gh --jq pipeline (sentinel + raw
@@ -580,20 +602,25 @@ expect_collect_badsha 'a 39-hex value is not a sha' '111122223333444455556666777
 expect_collect_badsha 'an uppercase 40-hex value is not a sha' '111122223333444455556666777788889999AAAA'
 expect_collect_badsha 'an alternation is not a sha' "${csha2}\$|${csha1}"
 
-# --- the two debt blocks are exactly their four marker lines (GH-742) ---------
-# The union rule block and the comment-reading block must each be liftable in
-# one piece: two opening markers and two closing markers, nothing else.
+# --- one debt block is left, exactly its two marker lines (GH-742, GH-769) ---
+# The union rule is no longer shell debt -- `edda review gate` owns it -- so its
+# marker must never reappear here. What remains is the comment-reading block,
+# still liftable in one piece: one opening marker, one closing marker, nothing
+# else.
 
 wscript="$root/scripts/pr-review-watch.sh"
-if [ "$(grep -c 'D8-debt' "$wscript")" != "4" ]; then
-    printf 'D8 markers: expected exactly 4 lines (2 open + 2 close), got %s\n' \
+if [ "$(grep -c 'D8-debt(#769)' "$wscript")" != "0" ]; then
+    printf 'D8 markers: the union rule belongs to `edda review gate`, not here\n' >&2
+    exit 1
+fi
+if [ "$(grep -c 'D8-debt' "$wscript")" != "2" ]; then
+    printf 'D8 markers: expected exactly 2 lines (1 open + 1 close), got %s\n' \
         "$(grep -c 'D8-debt' "$wscript")" >&2
     exit 1
 fi
-if [ "$(grep -c '^# D8-debt(#769)' "$wscript")" != "1" ] || \
-   [ "$(grep -c '^# D8-debt(#671)' "$wscript")" != "1" ] || \
-   [ "$(grep -c '^# /D8-debt' "$wscript")" != "2" ]; then
-    printf 'D8 markers: expected one #769 opener, one #671 opener, two closers\n' >&2
+if [ "$(grep -c '^# D8-debt(#671)' "$wscript")" != "1" ] || \
+   [ "$(grep -c '^# /D8-debt' "$wscript")" != "1" ]; then
+    printf 'D8 markers: expected one #671 opener and one closer\n' >&2
     exit 1
 fi
 
@@ -1008,6 +1035,7 @@ fi
 # an earlier Changes Requested on the same sha keeps the union at failure even
 # though this round's verdict is LGTM — the case the whole issue exists for
 reset_stubs
+export EDDA_GATE_EXIT=1   # the gate fails this sha (rule: cmd_review::gate)
 pending_set 42 1 "$sha" 0 0
 printf 'TRANSPORT=edda-dispatch\nDISPATCH_EXIT=0\nFINAL_EXIT=0\nWORKTREE_CHECK=unchanged\nWORKTREE_CLEANUP=removed\nTASK_CLEANUP=not-applicable\nTERMINAL_RECEIPT=complete\n' >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
 verdict_log_fixture
@@ -1067,6 +1095,7 @@ fi
 # never computed from this round's verdict file alone — and the failure lands
 # on the same bounded retry path as any other status post failure.
 reset_stubs
+export EDDA_GATE_EXIT=1   # the gate fails this sha (rule: cmd_review::gate)
 pending_set 42 1 "$sha" 0 0
 printf 'TRANSPORT=edda-dispatch\nDISPATCH_EXIT=0\nFINAL_EXIT=0\nWORKTREE_CHECK=unchanged\nWORKTREE_CLEANUP=removed\nTASK_CLEANUP=not-applicable\nTERMINAL_RECEIPT=complete\n' >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
 verdict_log_fixture
@@ -1139,6 +1168,7 @@ product_log_fixture() { # $1=Verdict line $2=prose after it (default none) — t
 }
 
 reset_stubs
+export EDDA_GATE_EXIT=1   # the gate fails this sha (rule: cmd_review::gate)
 pending_set 42 1 "$sha" 0 0
 product_done_fixture 3 false escalation-pending
 product_log_fixture 'Provisional — unqualified (disqualifiers: escalation-pending), P0=0, P1=1 — not a merge-gate verdict'
@@ -1194,6 +1224,7 @@ unset GH_HEAD
 # line it does not recognise and would answer review:lgtm here; the watcher
 # still applies no label to a Provisional round.
 reset_stubs
+export EDDA_GATE_EXIT=1   # the gate fails this sha (rule: cmd_review::gate)
 pending_set 42 1 "$sha" 0 0
 product_done_fixture 3 false escalation-pending
 product_log_fixture 'Provisional — unqualified (disqualifiers: escalation-pending), P0=0, P1=1 — not a merge-gate verdict' \
@@ -1215,6 +1246,7 @@ unset GH_HEAD
 # A Changes Requested product round exits 1 — the verdict, not a failure — and
 # is published the same way, with its label.
 reset_stubs
+export EDDA_GATE_EXIT=1   # the gate fails this sha (rule: cmd_review::gate)
 pending_set 42 1 "$sha" 0 0
 product_done_fixture 1 true ''
 product_log_fixture 'Changes Requested, P0=0, P1=1'
@@ -1258,6 +1290,7 @@ unset GH_HEAD GH_COMMENTS_FILE
 # its counts stay in the union, so a later qualified LGTM on the same sha does
 # not turn the gate green (REVIEW.md §8, GH-742; #1023 round 1).
 reset_stubs
+export EDDA_GATE_EXIT=1   # the gate fails this sha (rule: cmd_review::gate)
 pending_set 42 1 "$sha" 0 0
 printf 'TRANSPORT=edda-dispatch\nDISPATCH_EXIT=0\nFINAL_EXIT=0\nWORKTREE_CHECK=unchanged\nWORKTREE_CLEANUP=removed\nTASK_CLEANUP=not-applicable\nTERMINAL_RECEIPT=complete\n' >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
 verdict_log_fixture

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -429,7 +429,9 @@ expect_label_verdict \
 # re-implemented the union rule would be a third copy of it.
 
 stub_gate() { # $1=exit code the fake verb returns; echoes the stub's directory
-    dir=$(mktemp -d)
+    # Under the suite's own `trap 'rm -rf "$tmp"' 0`, so an aborted case
+    # (`set -eu`) leaks nothing.
+    dir=$(mktemp -d "$tmp/gate.XXXXXX")
     printf '#!/bin/sh
 exit %s
 ' "$1" > "$dir/edda"
@@ -445,13 +447,10 @@ expect_gate_state() {
     dir=$(stub_gate "$code")
     actual=$(printf 'LGTM	0	0
 ' |         EDDA_BIN="$dir/edda" timeout 60 sh "$root/scripts/pr-review-watch.sh"         gate-state 0000000000000000000000000000000000000000)
-    rc=$?
     rm -rf "$dir"
-    if [ "$rc" -ne 0 ]; then
-        printf '%s: gate-state exited non-zero
-' "$name" >&2
-        return 1
-    fi
+    # No exit-code guard here on purpose: under `set -e` a failing command
+    # substitution in an assignment aborts the script before any `$?` could be
+    # read, so such a check would be unreachable rather than protective.
     if [ "$actual" != "$expected" ]; then
         printf '%s: expected %s, got %s
 ' "$name" "$expected" "$actual" >&2
@@ -1033,9 +1032,14 @@ if [ "$(statuses_calls)" != "1" ]; then
 fi
 
 # an earlier Changes Requested on the same sha keeps the union at failure even
-# though this round's verdict is LGTM — the case the whole issue exists for
+# though this round's verdict is LGTM — the case the whole issue exists for.
+# The union RULE is `cmd_review::gate`'s; what the daemon still owns, and what
+# this case pins, is that both facts reach it: the prior comment's verdict and
+# this round's, on the reviewed sha, in the record shape the verb parses.
 reset_stubs
 export EDDA_GATE_EXIT=1   # the gate fails this sha (rule: cmd_review::gate)
+export EDDA_GATE_STDIN="$tmp/gate-stdin-union"
+: >"$EDDA_GATE_STDIN"
 pending_set 42 1 "$sha" 0 0
 printf 'TRANSPORT=edda-dispatch\nDISPATCH_EXIT=0\nFINAL_EXIT=0\nWORKTREE_CHECK=unchanged\nWORKTREE_CLEANUP=removed\nTASK_CLEANUP=not-applicable\nTERMINAL_RECEIPT=complete\n' >"$EDDA_FLEET_SCRATCH/review-pr42-r1.done"
 verdict_log_fixture
@@ -1053,6 +1057,26 @@ if ! grep -qF -- '--add-label review:lgtm' "$GH_STUB_LOG"; then
     printf 'live: the label still reflects the current LGTM verdict\n' >&2
     exit 1
 fi
+# What the daemon handed the gate: the standing Changes Requested from the
+# comment list AND this round's LGTM. Drop either one and the rule upstream
+# has nothing to rule on.
+if ! grep -qF "$(printf 'Changes Requested\t0\t3')" "$EDDA_GATE_STDIN"; then
+    printf 'live: the prior Changes Requested never reached the gate, got:\n%s\n' \
+        "$(cat "$EDDA_GATE_STDIN")" >&2
+    exit 1
+fi
+if ! grep -qF "$(printf 'LGTM\t0\t0')" "$EDDA_GATE_STDIN"; then
+    printf "live: this round's LGTM never reached the gate, got:\n%s\n" \
+        "$(cat "$EDDA_GATE_STDIN")" >&2
+    exit 1
+fi
+# And the subject it was asked about is the reviewed sha, not the current head.
+if ! grep -qF "gate $sha exit 1" "$PR_REVIEW_WATCH_LOG"; then
+    printf 'live: the gate was not asked about the reviewed sha, log tail:\n%s\n' \
+        "$(tail -4 "$PR_REVIEW_WATCH_LOG")" >&2
+    exit 1
+fi
+unset EDDA_GATE_STDIN
 
 # posting the status is not best-effort: the comment path\'s bounded retry,
 # and no label until the status is out


### PR DESCRIPTION
Issue: #769
Closes #769.

## What

The merge gate's two rules — the same-SHA verdict **union** and the **base
window** check — lived in `scripts/pr-review-watch.sh` behind a
`# D8-debt(#769)` marker, because #652 had not landed when #742 needed them.
They are verdict semantics, not forge glue (#766 D8), so this moves them into
the binary as `edda review gate <sha>` and leaves the shell an adapter.

```
edda review gate <sha> [--base <ref>] [--verdicts <path|->] [--json]
  exit 0  PASS <sha> verdicts=<n>
  exit 1  FAIL <sha> union | window
  exit 2  NONE <sha>          (no verdict — an inability to judge)
```

The verb reads only: no ledger write, no lane, no GitHub call.

## Two sources, one rule

`union()` is a pure function over `Standing` values, and two adapters produce
them:

- **the ledger's `review_verdict` events** — the source the issue specifies, and
- **`--verdicts <path|->`** — the caller's facts in the tab-separated shape the
  watcher already derives from §7 comments.

The second exists because the verdict *source* is a different debt from the
union *rule*. `D8-debt(#671)` — reading verdicts out of PR comments — stands
until the ledger carries verdicts across machines, and **it does not yet**:
`review_verdict` is not among the event types `#1017`'s committed mirror
imports, and this workstation's ledger holds only its own 15 verdict events. A
fleet that reviews on one machine and merges from another would, on the ledger
alone, see no verdict at all and read `NONE` as `error`. Feeding the caller's
facts to the same rule keeps that correct today without a second copy of the
rule, and the ledger path is ready for the day #671 is paid.

## What the shell keeps

`gate_state()` is now only an exit-code-to-status-word adapter and logs the
receipt the issue's verify step asks for (`gate <sha> exit <n>`). Forge facts —
`CI Gate`, `mergeStateStatus`, head == reviewed sha — stay in shell as
specified. The issue's "merge step" half needs no change: the watcher never
merges (`pr-review-watch.sh:84`, merge stays behind operator authorization).

The shell suite's union matrix moved with the rule. Its 17 union cases became
4 exit-code mapping cases plus 2 receipt cases, and the live status cases now
declare the gate's answer (`EDDA_GATE_EXIT`) instead of deriving it — that is
exactly what the issue's verify step specifies ("stub `edda review gate` 回
0／1／2"). The rule itself is proven in `cmd_review::gate`'s 17 union
assertions, which cover every case the shell cases used to.

## doneWhen

| Requirement | Evidence |
|---|---|
| ledger fixtures: clean LGTM → 0; LGTM+CR → 1 `union`; CR alone → 1; LGTM with P1>0 → 1; none → 2 | `union_matrix_matches_the_rule_the_shell_carried`, `the_ledger_source_reads_only_the_verdicts_standing_on_this_sha`, `review_gate_exit_codes.rs` (spawned binary — `run` calls `process::exit`, so only a spawn can assert the code) |
| window: base advances on a changed file → 1 `window`; on an unrelated file → 0 | `window_is_clear_until_the_base_moves_on_a_changed_file` |
| `--json` names `reviewer_model`, `round`, `cost_usd`; unmeasured prints `unmeasured`, never `0` | `json_reports_an_unmeasured_cost_rather_than_zero` |
| `grep -n 'D8-debt(#769)' scripts/pr-review-watch.sh` empty; `grep -c D8-debt` leaves only the `#671` block | asserted by the suite itself (`scripts/test-pr-review-watch.sh`, the marker self-check) — 2 lines, one `#671` opener, one closer |
| a self-check comment is structurally invisible to the gate | `a_self_check_is_structurally_invisible_to_the_gate` — appends a `cmd` event, asserts `from_ledger` is empty and the answer is `NONE` |
| watcher logs `gate <sha> exit <n>`, matching the posted status | `expect_gate_receipt` ×2; FAIL-first proven by deleting the `log` line and re-running |

## Self-review findings, fixed in this branch

- **`--base` reached `git` unguarded.** `window_moved` interpolated the raw ref
  into `git diff` and passed it as a bare argument to `git merge-base`, so a
  flag-shaped ref was argument injection, and two `git` calls could read a name
  that moved between them. Now resolved once through the module's own
  `commit()` (`rev-parse --verify --end-of-options`, 40-hex checked) before the
  window runs. Proven by `a_base_shaped_like_a_flag_is_refused_not_handed_to_git`.
- **The receipt assertion did not run.** It referenced `$csha1`, defined 30
  lines later; `set -u` killed the subshell and the suite still exited 0. The
  helper now carries its own SHA, and the FAIL-first proof above is what caught
  it.

## Live receipt (read-only)

Against this workstation's real ledger and the merged head of #1045:

```
$ edda review gate d618e83ef5a0b75ec1f9fff5b814d83acb7ec0e0
NONE d618e83ef5a0b75ec1f9fff5b814d83acb7ec0e0
exit=2

$ printf 'LGTM\t0\t0\n' | edda review gate d618e83ef5a0b75ec1f9fff5b814d83acb7ec0e0 --verdicts -
PASS d618e83ef5a0b75ec1f9fff5b814d83acb7ec0e0 verdicts=1
exit=0
```

That `NONE` is the argument for the second adapter, not a defect. #1045 was
reviewed twice today and merged on a Round 2 `LGTM (P0=0, P1=0)`, and the
ledger still holds no `review_verdict` for its head: those rounds were posted
as §7 comments. If the watcher answered from the ledger alone today, that PR's
`Independent Review` status would read `error`. `--verdicts` is load-bearing
until #671 ships, and the rule both paths run is the same one.

The issue's third verify bullet — a live receipt from the daemon posting a
status and merging through the gate — is **not** in this PR: it posts commit
statuses on a real PR and merges it, which needs operator authority rather
than my own. The path it would exercise is proven offline end to end: the
spawn tests pin the exit codes the daemon reads, `expect_gate_receipt` pins
the `gate <sha> exit <n>` line, and the live run above pins both adapters
against the real ledger.

## Gates ran

- `cargo fmt --all --check` — clean
- `cargo clippy -p edda --all-targets -- -D warnings` — clean
- `cargo test -p edda` — 656 unit + 5 `review_gate_exit_codes` + every other integration suite, 0 failed
- `sh scripts/lint-file-length.sh --tree` — exit 0, no findings (`gate.rs` 540 lines)
- `sh scripts/test-pr-review-watch.sh` — passed

`cmd_review::evidence::tests::deadline_stops_descendant_and_does_not_start_next_gate`
failed once on a loaded machine and passes 3/3 in isolation. Its assertion is
`started.elapsed() < Duration::from_secs(4)` against a 1s deadline — a wall-clock
flake, in a module this branch does not touch (`git diff --name-only e613c3c HEAD`
lists no `evidence` file).

## Follow-up, not in this PR

- **#1057** — `merge-reviewed-pr.sh` selects the *latest* trusted review
  (`sort_by([.updated_at, .id]) | last`) instead of the union, so an earlier
  standing Changes Requested on the same head is ignored. The union does not
  reach it indirectly either: the ruleset requires only `CI Gate`. Split out
  of this PR's round 1 as P1-2/P1-3; it is a pre-existing defect on the
  operator merge path rather than part of this frozen surface.
- `--verdicts` exists only because #671 has not shipped the verdict half of
  the committed mirror. When it does, `gate_state` drops the flag and the same
  verb answers from the ledger — no rule changes.
