### PR TITLE
fix(edda-cli): give the claim guard its own window and one shared rule (GH-1018)

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -202,7 +202,7 @@ it, `edda status` produces the same exit code and the same stderr in every
 state (measured). Success is exit `0` with the object on stdout. Failures do
 not emit JSON — a newer ledger schema exits `2` (§1.2), and every other
 failure (no `.edda/`, unreadable database) takes the CLI's shared error path
-and exits `1` (`crates/edda-cli/src/main.rs:1107-1114#if let Err(err) = run(cli) {`).
+and exits `1` (`crates/edda-cli/src/main.rs:1109-1116#if let Err(err) = run(cli) {`).
 
 That last row differs from `edda verify --json`, which answers `2` to the
 same questions. The split is pre-existing and outside #730, but it is

--- a/crates/edda-bridge-claude/src/peers/liveness.rs
+++ b/crates/edda-bridge-claude/src/peers/liveness.rs
@@ -27,11 +27,10 @@
 //! | Is this claim fresh? (display) | [`claim_is_stale_at`] | [`stale_secs`] |
 //! | May it still refuse a writer? | [`claim_guard_expired_at`] | [`claim_ttl_secs`] |
 //!
-//! Collapsing those into one threshold is not simplification, it is a bug:
-//! [`stale_secs`] is calibrated for something refreshed every 30 seconds, and
-//! a claim is written once. The rule against parallel criteria is about
-//! answering one question two ways — not about refusing to notice that these
-//! are two questions.
+//! Collapsing those into one threshold is not simplification, it is a bug —
+//! [`claim_guard_expired_at`] records why. The rule against parallel criteria
+//! is about answering one question two ways, not about refusing to notice that
+//! these are two questions.
 
 use serde::Serialize;
 

--- a/crates/edda-bridge-claude/src/peers/liveness.rs
+++ b/crates/edda-bridge-claude/src/peers/liveness.rs
@@ -10,9 +10,32 @@
 //!
 //! There is one liveness surface — the heartbeat file — and one criterion —
 //! [`liveness_from_heartbeat`]. Do not add a parallel one.
+//!
+//! ## Claims are a second fact, not a second criterion
+//!
+//! A board claim carries its own timestamp, and for a bare CLI session
+//! (`cli-*`) that timestamp is the only judgeable thing about it: nothing ever
+//! refreshes a heartbeat for a one-shot process, so the criterion above can
+//! only ever call it dead (GH-705, GH-1018). [`claim_age_secs_at`] is the one
+//! place that age is computed.
+//!
+//! Two questions are asked of that one age, and they take **different**
+//! thresholds on purpose:
+//!
+//! | Question | Function | Threshold |
+//! |---|---|---|
+//! | Is this claim fresh? (display) | [`claim_is_stale_at`] | [`stale_secs`] |
+//! | May it still refuse a writer? | [`claim_guard_expired_at`] | [`claim_ttl_secs`] |
+//!
+//! Collapsing those into one threshold is not simplification, it is a bug:
+//! [`stale_secs`] is calibrated for something refreshed every 30 seconds, and
+//! a claim is written once. The rule against parallel criteria is about
+//! answering one question two ways — not about refusing to notice that these
+//! are two questions.
 
 use serde::Serialize;
 
+use super::claim_ttl_secs;
 use super::read_heartbeat;
 use super::stale_secs;
 use crate::parse::now_rfc3339;
@@ -108,11 +131,34 @@ pub fn claim_age_secs_at(claim_ts: &str, now_epoch: u64) -> u64 {
 ///
 /// The rule `edda peers --json` publishes for every claim (GH-569): older
 /// than [`stale_secs`] is stale, so a 55-day-old zombie claim and a
-/// 37-second-old live one are distinguishable to a program. It lives here,
-/// beside the session criterion, because a caller asking "does this claim
-/// still stand?" must share one rule rather than grow a second (GH-1018).
+/// 37-second-old live one are distinguishable to a program.
+///
+/// This answers a **display** question — "is this claim still fresh?" — and it
+/// is not the question a write guard asks. See [`claim_guard_expired_at`].
 pub fn claim_is_stale_at(claim_ts: &str, now_epoch: u64) -> bool {
     claim_age_secs_at(claim_ts, now_epoch) > stale_secs()
+}
+
+/// Has this board claim outlived the window in which it may refuse a writer?
+///
+/// Two questions look alike here and are not the same:
+///
+/// - *Is this claim fresh?* — [`claim_is_stale_at`], measured against
+///   [`stale_secs`] (120s), the window a **heartbeat** is refreshed inside
+///   (every 30s). Past it, nobody has been heard from lately.
+/// - *May this claim still refuse a writer?* — this function. A board claim is
+///   written **once** and never refreshed, so measuring it against a
+///   refresh-calibrated window would expire a claim its owner is still working
+///   under. An `edda claim` + `edda conduct run` session from the operator
+///   runbook occupies its surface for minutes to hours; two minutes in, the
+///   surface would silently open.
+///
+/// So the guard gets its own window, [`claim_ttl_secs`]. Both questions share
+/// one age computation ([`claim_age_secs_at`]) and one place to read the
+/// difference from; what they must not share is a threshold calibrated for the
+/// other one's fact (GH-1018).
+pub fn claim_guard_expired_at(claim_ts: &str, now_epoch: u64) -> bool {
+    claim_age_secs_at(claim_ts, now_epoch) > claim_ttl_secs()
 }
 
 #[cfg(test)]
@@ -222,5 +268,37 @@ mod tests {
         // date must not be able to stand forever by being unreadable.
         assert!(claim_is_stale_at("not a timestamp", 1_000_000));
         assert!(claim_is_stale_at("", 1_000_000));
+    }
+
+    #[test]
+    fn the_guard_window_is_not_the_display_window() {
+        // The two questions this module answers about one claim age take
+        // different thresholds on purpose, and the gap between them is where
+        // the bug lives: a claim two minutes old is no longer *fresh*, and it
+        // must still refuse a writer. Collapsing them opens an operator's
+        // claimed surface two minutes after they claimed it (GH-1018).
+        let t0 = parse_rfc3339_to_epoch("2026-09-02T12:00:00Z").unwrap();
+        let ts = "2026-09-02T12:00:00Z";
+        assert!(claim_is_stale_at(ts, t0 + stale_secs() + 1));
+        assert!(!claim_guard_expired_at(ts, t0 + stale_secs() + 1));
+    }
+
+    #[test]
+    fn the_guard_shares_the_boundary_every_criterion_here_uses() {
+        // `age > threshold`, same edge as the session criterion and the
+        // display rule: at exactly the TTL the claim still stands.
+        let t0 = parse_rfc3339_to_epoch("2026-09-02T12:00:00Z").unwrap();
+        let ts = "2026-09-02T12:00:00Z";
+        assert!(!claim_guard_expired_at(ts, t0 + claim_ttl_secs()));
+        assert!(claim_guard_expired_at(ts, t0 + claim_ttl_secs() + 1));
+    }
+
+    #[test]
+    fn an_undateable_claim_cannot_refuse_a_writer_forever() {
+        // The guard fails the same direction the display rule does. A claim
+        // nobody can date is the one shape that could otherwise hold a
+        // surface permanently — exactly the standstill GH-1018 found.
+        assert!(claim_guard_expired_at("not a timestamp", 1_000_000));
+        assert!(claim_guard_expired_at("", 1_000_000));
     }
 }

--- a/crates/edda-bridge-claude/src/peers/mod.rs
+++ b/crates/edda-bridge-claude/src/peers/mod.rs
@@ -17,6 +17,22 @@ pub fn stale_secs() -> u64 {
         .unwrap_or(120)
 }
 
+/// How long a board claim may keep refusing a writer.
+///
+/// Deliberately **not** [`stale_secs`]. That threshold is calibrated for a
+/// heartbeat, which is refreshed every 30s; a claim is written once and never
+/// refreshed, so measuring it against a refresh window opens an occupied
+/// surface two minutes after its owner claimed it (GH-1018). The default is a
+/// day: long enough to cover any single working session an operator claims a
+/// surface for, short enough that the months-old claims a long-lived machine
+/// accumulates stop refusing lanes.
+pub fn claim_ttl_secs() -> u64 {
+    std::env::var("EDDA_CLAIM_TTL_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(86_400)
+}
+
 /// Dead-letter horizon: unacked requests older than this are expired.
 ///
 /// Requests are addressed by label, and a label can go away — the session

--- a/crates/edda-cli/src/claim_standing.rs
+++ b/crates/edda-cli/src/claim_standing.rs
@@ -1,0 +1,65 @@
+//! The one admission rule over a board claim (GH-617, GH-705, GH-1018).
+//!
+//! `edda claim check` and the `edda dispatch --owns` guard read the same
+//! board to decide the same thing, so the rule lives here rather than inside
+//! either verb's command module: neither can grow its own answer without
+//! deleting this one.
+
+use edda_bridge_claude::peers::{self, classify_session_liveness_at, ClaimEntry};
+
+/// Session ids minted by `cmd_bridge::resolve_session_id` tier 4 for bare
+/// CLI invocations (`cli-<label>`). Such a session is a one-shot process:
+/// it wrote its claim and exited, and no hook ever refreshes a heartbeat
+/// for it, so heartbeat age carries no liveness information (GH-705). The
+/// same shape is already classified in `cmd_bridge` when it names the
+/// actor of a `cli-*` session.
+pub(crate) fn is_bare_cli_session(session_id: &str) -> bool {
+    session_id.starts_with("cli-")
+}
+
+/// Why a board claim does — or does not — still stand against a writer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ClaimStanding {
+    /// A live heartbeat says the claimant is still here (GH-617).
+    Live,
+    /// No heartbeat can judge it, and its claim is inside the guard's TTL.
+    BareWithinTtl,
+    /// Nothing keeps it standing: it no longer refuses a writer.
+    Expired,
+}
+
+/// The one admission rule over a board claim.
+///
+/// `edda claim check` and the `edda dispatch --owns` guard must answer this
+/// identically — they read the same board to decide the same thing. Before
+/// GH-1018 they did, by coincidence: two separate expressions that both came
+/// out to `live || cli-*`. Bounding the bare-CLI arm in time would have turned
+/// that coincidence into a disagreement, where `claim check` reports CONFLICT
+/// on a surface `dispatch` has already admitted a writer to. One function is
+/// what keeps them honest; the variants exist so `claim check` can still say
+/// *why* a claim stands.
+///
+/// The heartbeat is consulted first, and that order is load-bearing rather
+/// than a cost choice. Deciding the bare-CLI arm from the claim record alone
+/// would be one file read cheaper per claim, but it would also reclassify a
+/// `cli-*` claim whose session is genuinely here — answering `BareWithinTtl`
+/// where GH-705 answers `Live`. Both still refuse a writer, so the exit code
+/// hides the difference; the JSON report does not, and telling "a live peer
+/// holds this" apart from "nobody can judge who holds this" is the whole
+/// reason `unjudgeable_claims` is a separate bucket. The read this costs is
+/// the read `claim check` already did for every claim before GH-1018.
+pub(crate) fn claim_standing(
+    project_id: &str,
+    claim: &ClaimEntry,
+    now_epoch: u64,
+) -> ClaimStanding {
+    if classify_session_liveness_at(project_id, &claim.session_id, now_epoch).is_live() {
+        return ClaimStanding::Live;
+    }
+    if is_bare_cli_session(&claim.session_id)
+        && !peers::liveness::claim_guard_expired_at(&claim.ts, now_epoch)
+    {
+        return ClaimStanding::BareWithinTtl;
+    }
+    ClaimStanding::Expired
+}

--- a/crates/edda-cli/src/cmd_claim.rs
+++ b/crates/edda-cli/src/cmd_claim.rs
@@ -22,8 +22,9 @@
 //!   meant to become the machine judgement GH-563's dispatch guard calls
 //!   before letting two lanes write the same file.
 
+use crate::claim_standing::{claim_standing, is_bare_cli_session, ClaimStanding};
 use anyhow::Context;
-use edda_bridge_claude::peers::{classify_session_liveness, ClaimEntry, SessionLiveness};
+use edda_bridge_claude::peers::{self, classify_session_liveness_at, ClaimEntry, SessionLiveness};
 use serde::Serialize;
 use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::io::ErrorKind;
@@ -141,23 +142,32 @@ pub fn claim_check(repo_root: &Path, query: &[String], json: bool) -> anyhow::Re
     // counted toward the exit code when its surface intersects the query
     // (fail-closed). A session with a live heartbeat still conflicts
     // normally; the GH-617 criterion itself is untouched.
+    // GH-1018: that occupation is bounded in time. `claim_standing` is the one
+    // admission rule, shared with the `edda dispatch --owns` guard, so the two
+    // verbs cannot answer differently about the same board on the same second.
     let mut unjudgeable: Vec<ClaimEntry> = Vec::new();
+    let now_epoch = peers::liveness::now_epoch();
     for c in claims {
-        let liveness = classify_session_liveness(&project_id, &c.session_id);
-        if liveness.is_live() {
-            live.push(c);
-        } else if is_bare_cli_session(&c.session_id) {
-            unjudgeable.push(c);
-        } else {
-            let age_secs = match liveness {
-                SessionLiveness::Stale { age_secs } => Some(age_secs),
-                _ => None, // NoHeartbeat: never heard from
-            };
-            stale_claims.push(StaleClaim {
-                label: c.label,
-                session_id: c.session_id,
-                age_secs,
-            });
+        match claim_standing(&project_id, &c, now_epoch) {
+            ClaimStanding::Live => live.push(c),
+            ClaimStanding::BareWithinTtl => unjudgeable.push(c),
+            ClaimStanding::Expired => {
+                let age_secs = if is_bare_cli_session(&c.session_id) {
+                    // Nothing ever heartbeated for it; what expired is the
+                    // claim, so the claim's own age is what to report.
+                    Some(peers::liveness::claim_age_secs_at(&c.ts, now_epoch))
+                } else {
+                    match classify_session_liveness_at(&project_id, &c.session_id, now_epoch) {
+                        SessionLiveness::Stale { age_secs } => Some(age_secs),
+                        _ => None, // NoHeartbeat: never heard from
+                    }
+                };
+                stale_claims.push(StaleClaim {
+                    label: c.label,
+                    session_id: c.session_id,
+                    age_secs,
+                });
+            }
         }
     }
 
@@ -263,16 +273,6 @@ fn exit_code_for(report: &CheckReport) -> i32 {
     } else {
         1
     }
-}
-
-/// Session ids minted by `cmd_bridge::resolve_session_id` tier 4 for bare
-/// CLI invocations (`cli-<label>`). Such a session is a one-shot process:
-/// it wrote its claim and exited, and no hook ever refreshes a heartbeat
-/// for it, so heartbeat age carries no liveness information (GH-705). The
-/// same shape is already classified in `cmd_bridge` when it names the
-/// actor of a `cli-*` session.
-pub(crate) fn is_bare_cli_session(session_id: &str) -> bool {
-    session_id.starts_with("cli-")
 }
 
 fn print_standing_bare_claims(standing: &[StandingBareClaim]) {

--- a/crates/edda-cli/src/cmd_claim.rs
+++ b/crates/edda-cli/src/cmd_claim.rs
@@ -9,10 +9,10 @@
 //!   holds no claims)
 //! - 1 — at least one active claim overlaps; the conflicting labels/sessions
 //!   are named on stdout. That includes a bare CLI claim (`cli-*`, minted by
-//!   `resolve_session_id` tier 4): its claimant is a one-shot process, so no
-//!   heartbeat age can prove it gone and its claim stands on the board until
-//!   `unclaim` (GH-705). Reading such an occupation as clear is the false
-//!   negative this verb exists to prevent.
+//!   `resolve_session_id` tier 4): no heartbeat age can prove a one-shot
+//!   claimant gone, so it stands on its own timestamp for `claim_ttl_secs`
+//!   (GH-705, bounded by GH-1018). Reading it as clear while it stands is
+//!   the false negative this verb exists to prevent.
 //! - 2 — the query could not be answered soundly: usage error, the board
 //!   cannot be read or parsed, a glob pattern is malformed, or a pair of
 //!   surfaces cannot be decided soundly (for example two tokens differing
@@ -22,7 +22,7 @@
 //!   meant to become the machine judgement GH-563's dispatch guard calls
 //!   before letting two lanes write the same file.
 
-use crate::claim_standing::{claim_standing, is_bare_cli_session, ClaimStanding};
+use crate::claim_standing::{claim_standing, ClaimStanding};
 use anyhow::Context;
 use edda_bridge_claude::peers::{self, classify_session_liveness_at, ClaimEntry, SessionLiveness};
 use serde::Serialize;
@@ -58,8 +58,13 @@ pub struct StaleClaim {
     /// report when the session has no heartbeat file at all (never heard
     /// from). The field is always serialized — GH-705: a consumer must be
     /// able to distinguish "expired heartbeat" from "no heartbeat file"
-    /// without guessing.
+    /// without guessing. A bare-CLI claim is the case that needs the `null`
+    /// most, so it keeps it: nothing writes a heartbeat for a one-shot
+    /// process, and what expires such a claim is reported below instead.
     pub age_secs: Option<u64>,
+    /// Seconds since the claim itself was recorded — always knowable, and for
+    /// a bare-CLI claim the fact that expired it (GH-1018).
+    pub claim_age_secs: u64,
 }
 
 /// A bare-CLI claim standing outside the queried surface (GH-780).
@@ -78,13 +83,11 @@ pub struct CheckReport {
     /// A bare CLI session is a one-shot process: no heartbeat writer ever
     /// refreshes for it, so heartbeat age carries no liveness information —
     /// an old heartbeat does not mean the claim is gone, and no heartbeat
-    /// does not mean it was never real. The claim stands on the board until
-    /// `unclaim` (board claims never expire), so the gate must never read
-    /// the surface as genuinely clear while it stands: these are counted
-    /// toward the exit code exactly like `conflicts`, separated only so a
-    /// consumer can tell a live peer from an occupation whose liveness
-    /// cannot be judged. Unlike the GH-617 liveness filter, this does not
-    /// decay with time.
+    /// does not mean it was never real. So these count toward the exit code
+    /// exactly like `conflicts`, separated only so a consumer can tell a live
+    /// peer from an occupation whose liveness cannot be judged. What bounds
+    /// them is the claim's own timestamp against `claim_ttl_secs`, not the
+    /// GH-617 heartbeat filter (GH-1018); past it they are reported stale.
     #[serde(default)]
     pub unjudgeable_claims: Vec<ClaimConflict>,
     /// Claims filtered out because their session is dead (GH-617). Reported
@@ -135,10 +138,10 @@ pub fn claim_check(repo_root: &Path, query: &[String], json: bool) -> anyhow::Re
     let mut stale_claims: Vec<StaleClaim> = Vec::new();
     // GH-705: a claim owned by a bare CLI session (`cli-*`, minted by
     // resolve_session_id tier 4) is an occupation whose liveness cannot be
-    // judged from a heartbeat. The claimant is a one-shot process; nothing
-    // ever refreshes a heartbeat for it; and the board claim never expires.
-    // Age therefore proves nothing, so instead of dismissing such a claim as
-    // stale when its heartbeat ages out, it is separated out here and
+    // judged from a heartbeat. The claimant is a one-shot process and nothing
+    // ever refreshes a heartbeat for it, so heartbeat age proves nothing:
+    // instead of dismissing such a claim as stale when its heartbeat ages
+    // out, it is separated out here and
     // counted toward the exit code when its surface intersects the query
     // (fail-closed). A session with a live heartbeat still conflicts
     // normally; the GH-617 criterion itself is untouched.
@@ -152,20 +155,17 @@ pub fn claim_check(repo_root: &Path, query: &[String], json: bool) -> anyhow::Re
             ClaimStanding::Live => live.push(c),
             ClaimStanding::BareWithinTtl => unjudgeable.push(c),
             ClaimStanding::Expired => {
-                let age_secs = if is_bare_cli_session(&c.session_id) {
-                    // Nothing ever heartbeated for it; what expired is the
-                    // claim, so the claim's own age is what to report.
-                    Some(peers::liveness::claim_age_secs_at(&c.ts, now_epoch))
-                } else {
+                let claim_age_secs = peers::liveness::claim_age_secs_at(&c.ts, now_epoch);
+                let age_secs =
                     match classify_session_liveness_at(&project_id, &c.session_id, now_epoch) {
                         SessionLiveness::Stale { age_secs } => Some(age_secs),
                         _ => None, // NoHeartbeat: never heard from
-                    }
-                };
+                    };
                 stale_claims.push(StaleClaim {
                     label: c.label,
                     session_id: c.session_id,
                     age_secs,
+                    claim_age_secs,
                 });
             }
         }
@@ -238,7 +238,8 @@ pub fn claim_check(repo_root: &Path, query: &[String], json: bool) -> anyhow::Re
         for conflict in &report.unjudgeable_claims {
             println!(
                 "CONFLICT with claim \"{}\" (session {}) — bare-CLI claim, liveness cannot be \
-                 judged; it counts until it is unclaimed",
+                 judged; it counts until it is unclaimed or outlives \
+                 EDDA_CLAIM_TTL_SECS",
                 conflict.label, conflict.session_id
             );
             for pair in &conflict.intersections {
@@ -307,16 +308,14 @@ fn print_stale_claims(stale: &[StaleClaim]) {
         stale.len()
     );
     for s in stale {
-        match s.age_secs {
-            Some(age) => eprintln!(
-                "  stale, not counted: claim \"{}\" (session {}) — heartbeat {}s ago",
-                s.label, s.session_id, age
-            ),
-            None => eprintln!(
-                "  stale, not counted: claim \"{}\" (session {}) — no heartbeat",
-                s.label, s.session_id
-            ),
-        }
+        let heartbeat = match s.age_secs {
+            Some(age) => format!("heartbeat {age}s ago"),
+            None => "no heartbeat".to_string(),
+        };
+        eprintln!(
+            "  stale, not counted: claim \"{}\" (session {}) — claimed {}s ago, {heartbeat}",
+            s.label, s.session_id, s.claim_age_secs
+        );
     }
 }
 
@@ -1723,6 +1722,7 @@ mod tests {
                 label: "ghost".into(),
                 session_id: "dead".into(),
                 age_secs: None,
+                claim_age_secs: 0,
             }],
             standing_bare_claims: vec![],
         };

--- a/crates/edda-cli/src/dispatch_claim.rs
+++ b/crates/edda-cli/src/dispatch_claim.rs
@@ -17,6 +17,24 @@ pub struct Claim {
 /// able to answer differently. Why the bare-CLI arm is bounded, and why by its
 /// own window rather than the heartbeat one, is recorded there and in
 /// `peers::liveness`; it is not restated here.
+///
+/// ## Same-session concurrent dispatch
+///
+/// The predicate this replaced carried the note that a second dispatch from
+/// the *same* session is a second writer too. It still is: [`acquire`] refuses
+/// a session that already stands on the board, so two concurrent
+/// `edda dispatch --owns` runs under one session id cannot both start, even
+/// when their path sets are disjoint (`same_session_disjoint_writer_is_refused_\
+/// without_releasing_the_first`).
+///
+/// GH-1049 made that guard **conditional**, and deliberately so. `acquire`
+/// tests membership against the list this predicate has already filtered, so
+/// once a session's own claim stops standing — a dead heartbeat, or a bare-CLI
+/// claim past `claim_ttl_secs` — the session is admitted again. Before the
+/// bound existed, a `cli-*` session that never released was refused *by its
+/// own claim* forever, which is one of the shapes GH-1018 found on a
+/// long-lived board. The guard protects a writer that is still there; it is
+/// not a permanent lock on a session id.
 fn claim_still_stands(project: &str, claim: &peers::ClaimEntry, now_epoch: u64) -> bool {
     crate::claim_standing::claim_standing(project, claim, now_epoch)
         != crate::claim_standing::ClaimStanding::Expired

--- a/crates/edda-cli/src/dispatch_claim.rs
+++ b/crates/edda-cli/src/dispatch_claim.rs
@@ -12,24 +12,11 @@ pub struct Claim {
 
 /// Does this board claim still stand against a new writer?
 ///
-/// A bare-CLI claim (`cli-*`) never heartbeats — its claimant is a one-shot
-/// process — so the session criterion can only ever call it dead. GH-705
-/// answered that by treating every such claim as live, fail-closed, so a
-/// one-shot writer could not be stomped on mid-write. Unconditionally, though,
-/// "fail-closed" reads as "never expires": GH-1018 found 100 claims left from
-/// July and August still refusing September lanes, with no `unclaim` able to
-/// clear them, which made the guard something lanes had to route around rather
-/// than obey.
-///
-/// The claim's own timestamp is judgeable even when its session's heartbeat is
-/// not, so the bare-CLI arm is bounded by [`peers::liveness::claim_ttl_secs`]
-/// — a day, deliberately not the heartbeat window: a claim is written once and
-/// never refreshed, and an operator's claimed surface is occupied for the
-/// length of a working session, not for two minutes.
-///
-/// The rule itself is `claim_standing::claim_standing`, shared with `edda claim
-/// check`, because two verbs reading one board to decide one thing must not be
-/// able to answer differently.
+/// The rule is [`crate::claim_standing::claim_standing`], shared with `edda
+/// claim check` — two verbs reading one board to decide one thing must not be
+/// able to answer differently. Why the bare-CLI arm is bounded, and why by its
+/// own window rather than the heartbeat one, is recorded there and in
+/// `peers::liveness`; it is not restated here.
 fn claim_still_stands(project: &str, claim: &peers::ClaimEntry, now_epoch: u64) -> bool {
     crate::claim_standing::claim_standing(project, claim, now_epoch)
         != crate::claim_standing::ClaimStanding::Expired
@@ -260,10 +247,21 @@ mod tests {
             5,
             &["docs/seconds.md".to_owned()],
         );
+        // The load-bearing fixture: an hour sits past the heartbeat window and
+        // short of the guard's, so it is the only one of the three that can
+        // catch either verb measuring the claim against `stale_secs`. With
+        // only the 22-day and 5-second claims both rules agree everywhere and
+        // this test cannot fail.
+        crate::test_support::write_aged_claim(
+            &project,
+            "cli-an-hour",
+            3600,
+            &["docs/an-hour.md".to_owned()],
+        );
 
         let now_epoch = peers::liveness::now_epoch();
         let board = crate::cmd_claim::read_active_claims(&project).expect("read board");
-        assert_eq!(board.len(), 2, "both claims must be on the board");
+        assert_eq!(board.len(), 3, "every claim must be on the board");
 
         for claim in &board {
             let expired = crate::claim_standing::claim_standing(&project, claim, now_epoch)

--- a/crates/edda-cli/src/dispatch_claim.rs
+++ b/crates/edda-cli/src/dispatch_claim.rs
@@ -12,28 +12,27 @@ pub struct Claim {
 
 /// Does this board claim still stand against a new writer?
 ///
-/// A session that heartbeats is judged by the one shared session criterion,
-/// exactly as before.
-///
 /// A bare-CLI claim (`cli-*`) never heartbeats — its claimant is a one-shot
-/// process — so that criterion can only ever call it dead. GH-705 answered
-/// that by treating every such claim as live, fail-closed, so a one-shot
-/// writer could not be stomped on mid-write. Unconditionally, though,
+/// process — so the session criterion can only ever call it dead. GH-705
+/// answered that by treating every such claim as live, fail-closed, so a
+/// one-shot writer could not be stomped on mid-write. Unconditionally, though,
 /// "fail-closed" reads as "never expires": GH-1018 found 100 claims left from
 /// July and August still refusing September lanes, with no `unclaim` able to
-/// clear them, which made the guard something lanes had to route around
-/// rather than obey.
+/// clear them, which made the guard something lanes had to route around rather
+/// than obey.
 ///
-/// The claim's own timestamp is judgeable even when its session's heartbeat
-/// is not, and `edda peers --json` already publishes exactly that verdict
-/// (GH-569). Sharing that one rule bounds the bare-CLI case in time without
-/// weakening it: a claim written moments ago still refuses a second writer.
+/// The claim's own timestamp is judgeable even when its session's heartbeat is
+/// not, so the bare-CLI arm is bounded by [`peers::liveness::claim_ttl_secs`]
+/// — a day, deliberately not the heartbeat window: a claim is written once and
+/// never refreshed, and an operator's claimed surface is occupied for the
+/// length of a working session, not for two minutes.
+///
+/// The rule itself is `claim_standing::claim_standing`, shared with `edda claim
+/// check`, because two verbs reading one board to decide one thing must not be
+/// able to answer differently.
 fn claim_still_stands(project: &str, claim: &peers::ClaimEntry, now_epoch: u64) -> bool {
-    if peers::liveness::classify_session_liveness(project, &claim.session_id).is_live() {
-        return true;
-    }
-    crate::cmd_claim::is_bare_cli_session(&claim.session_id)
-        && !peers::liveness::claim_is_stale_at(&claim.ts, now_epoch)
+    crate::claim_standing::claim_standing(project, claim, now_epoch)
+        != crate::claim_standing::ClaimStanding::Expired
 }
 
 pub fn acquire(cwd: &Path, session: &str, paths: &[String]) -> Result<Option<Claim>> {
@@ -236,6 +235,55 @@ mod tests {
             Err(error) => error,
         };
         assert!(error.to_string().contains("cli-just-now"), "{error:#}");
+    }
+
+    #[test]
+    fn the_dispatch_guard_and_claim_check_read_one_rule() {
+        // Before GH-1018 these were two expressions that happened to agree
+        // (`live || cli-*` written twice). Bounding the bare-CLI arm in only
+        // one of them would have made them disagree, and the failure is
+        // silent: `edda claim check` reporting CONFLICT on a surface `edda
+        // dispatch` has already admitted a writer to. Pin both sides of the
+        // boundary against the bucket `claim check` actually reads.
+        let _store = crate::test_support::isolated_store();
+        let cwd = tempfile::tempdir().expect("dispatch claim cwd");
+        let project = edda_store::project_id(cwd.path());
+        crate::test_support::write_aged_claim(
+            &project,
+            "cli-three-weeks",
+            60 * 60 * 24 * 22,
+            &["docs/three-weeks.md".to_owned()],
+        );
+        crate::test_support::write_aged_claim(
+            &project,
+            "cli-seconds",
+            5,
+            &["docs/seconds.md".to_owned()],
+        );
+
+        let now_epoch = peers::liveness::now_epoch();
+        let board = crate::cmd_claim::read_active_claims(&project).expect("read board");
+        assert_eq!(board.len(), 2, "both claims must be on the board");
+
+        for claim in &board {
+            let expired = crate::claim_standing::claim_standing(&project, claim, now_epoch)
+                == crate::claim_standing::ClaimStanding::Expired;
+            let admitted = match acquire(cwd.path(), "lane-agreement", &claim.paths) {
+                Ok(guard) => {
+                    guard
+                        .expect("admitted writer claim")
+                        .release()
+                        .expect("release the admitted claim");
+                    true
+                }
+                Err(_) => false,
+            };
+            assert_eq!(
+                expired, admitted,
+                "claim {} is bucketed one way by `claim check` and the other by `dispatch`",
+                claim.session_id
+            );
+        }
     }
 
     #[test]

--- a/crates/edda-cli/src/dispatch_claim.rs
+++ b/crates/edda-cli/src/dispatch_claim.rs
@@ -24,17 +24,22 @@ pub struct Claim {
 /// the *same* session is a second writer too. It still is: [`acquire`] refuses
 /// a session that already stands on the board, so two concurrent
 /// `edda dispatch --owns` runs under one session id cannot both start, even
-/// when their path sets are disjoint (`same_session_disjoint_writer_is_refused_\
-/// without_releasing_the_first`).
+/// when their path sets are disjoint. The test is
+/// `same_session_disjoint_writer_is_refused_without_releasing_the_first`.
 ///
-/// GH-1049 made that guard **conditional**, and deliberately so. `acquire`
-/// tests membership against the list this predicate has already filtered, so
-/// once a session's own claim stops standing — a dead heartbeat, or a bare-CLI
-/// claim past `claim_ttl_secs` — the session is admitted again. Before the
-/// bound existed, a `cli-*` session that never released was refused *by its
-/// own claim* forever, which is one of the shapes GH-1018 found on a
-/// long-lived board. The guard protects a writer that is still there; it is
-/// not a permanent lock on a session id.
+/// The guard has always been conditional for a session that heartbeats:
+/// `acquire` tests membership against the list this predicate has already
+/// filtered, so a session whose own claim stops standing is admitted again.
+/// What changed is only the `cli-*` arm, and in two steps — GH-1018 bounded it
+/// at all (before that a `cli-*` session that never released was refused *by
+/// its own claim* forever, one of the shapes found on a long-lived board), and
+/// GH-1049 rechose the window it is bounded by. Neither introduced the
+/// conditionality; both narrowed a permanent lock into a bounded one.
+///
+/// For a `cli-*` claim, "stops standing" needs *both* to fail: no fresh
+/// heartbeat **and** a claim older than `claim_ttl_secs`. The rule is a
+/// disjunction, not a partition — a stale heartbeat alone does not open the
+/// surface.
 fn claim_still_stands(project: &str, claim: &peers::ClaimEntry, now_epoch: u64) -> bool {
     crate::claim_standing::claim_standing(project, claim, now_epoch)
         != crate::claim_standing::ClaimStanding::Expired

--- a/crates/edda-cli/src/main.rs
+++ b/crates/edda-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod agent_kind;
 mod claim_guard;
+mod claim_standing;
 mod cmd_actor;
 mod cmd_ask;
 mod cmd_blob;

--- a/crates/edda-cli/src/skills/coord-handoff.md
+++ b/crates/edda-cli/src/skills/coord-handoff.md
@@ -131,11 +131,13 @@ $ edda peers
 > No active sessions
 ```
 
-A bare CLI claim is machine-visible for as long as it stands, not for a
-freshness window: the claimant is a one-shot process, so no heartbeat age can
-prove it gone, and `edda claim check` counts the claim — exit 1, and
-`unjudgeable_claims` in `--json` — until it is unclaimed (GH-705). That is
-deliberately fail-closed: the gate never reads an occupied surface as clear.
+A bare CLI claim is not judged by a freshness window: the claimant is a
+one-shot process, so no heartbeat age can prove it gone, and `edda claim check`
+counts the claim — exit 1, and `unjudgeable_claims` in `--json` — until it is
+unclaimed (GH-705). That is deliberately fail-closed: the gate never reads an
+occupied surface as clear. It is bounded by the claim's own timestamp, not by
+the heartbeat threshold: after `EDDA_CLAIM_TTL_SECS` (24h) it stops counting,
+so a machine that accumulates claims does not deadlock (GH-1018).
 
 ```bash edda-doctest
 $ edda claim "auth" --paths "src/auth/*"

--- a/crates/edda-cli/tests/claim_e2e_contract.rs
+++ b/crates/edda-cli/tests/claim_e2e_contract.rs
@@ -304,9 +304,9 @@ fn e2e_bare_cli_claim_with_an_aged_heartbeat_still_conflicts() {
     // moment the command returns, so a heartbeat written at claim time
     // ages with nothing to refresh it. Backdating it past stale_secs
     // (120s by default — the round-1 probe) must NOT return the surface
-    // to clear: the claim stands on the board until it is unclaimed, so
-    // the gate keeps counting it (fail-closed) instead of dismissing it
-    // as a dead session's claim.
+    // to clear: the claim still stands on its own timestamp, so the gate
+    // keeps counting it (fail-closed) instead of dismissing it as a dead
+    // session's claim.
     //
     // The variable here is the *heartbeat* age; the claim itself is fresh.
     let repo = e2e_repo();

--- a/crates/edda-cli/tests/claim_e2e_contract.rs
+++ b/crates/edda-cli/tests/claim_e2e_contract.rs
@@ -61,12 +61,9 @@ fn write_board(store_root: &Path, project_id: &str, lines: &[String]) {
         .expect("coordination.jsonl");
 }
 
-/// A claim recorded now.
-///
-/// The timestamp is load-bearing: since GH-1018 a claim stops refusing
-/// writers once it is older than `claim_ttl_secs`, so a fixture pinned to a
-/// fixed calendar date would silently become an expired claim as the repo
-/// ages. Tests that want an old claim ask for one — `coord_event_aged`.
+/// A claim recorded now. The timestamp is load-bearing since GH-1018, so a
+/// fixture pinned to a calendar date would age into an expired claim on its
+/// own; tests that want an old claim ask via `coord_event_aged`.
 fn coord_event(session: &str, label: &str, paths: &[&str]) -> String {
     coord_event_aged(session, label, paths, 0)
 }
@@ -312,8 +309,6 @@ fn e2e_bare_cli_claim_with_an_aged_heartbeat_still_conflicts() {
     // as a dead session's claim.
     //
     // The variable here is the *heartbeat* age; the claim itself is fresh.
-    // GH-1018 bounds the other age — see
-    // `e2e_bare_cli_claim_past_its_ttl_no_longer_conflicts`.
     let repo = e2e_repo();
     let project_id = edda_store::project_id(repo.path());
     let store = tempfile::tempdir().expect("store tempdir");
@@ -395,11 +390,9 @@ fn e2e_non_intersecting_bare_cli_claim_is_listed_in_json() {
 #[test]
 fn e2e_a_live_session_holding_a_cli_claim_is_a_live_conflict() {
     // The bare-CLI arm exists because a one-shot process leaves no heartbeat
-    // to judge (GH-705). When a heartbeat *is* there and live, there is
-    // nothing unjudgeable about the occupation, and the report must keep
-    // saying so: `conflicts`, not `unjudgeable_claims`. Both refuse a writer,
-    // so the exit code cannot tell these apart — only the JSON can, which is
-    // why the distinction is pinned here and not through an exit code.
+    // to judge (GH-705). A live heartbeat makes the occupation judgeable, so
+    // it belongs in `conflicts`. Both refuse a writer, so only the JSON can
+    // tell them apart — hence the assertion shape here.
     let repo = e2e_repo();
     let project_id = edda_store::project_id(repo.path());
     let store = tempfile::tempdir().expect("store tempdir");
@@ -429,14 +422,47 @@ fn e2e_a_live_session_holding_a_cli_claim_is_a_live_conflict() {
 }
 
 #[test]
+fn e2e_bare_cli_claim_inside_its_ttl_outlives_the_heartbeat_window() {
+    // Only a fixture *between* the two windows can tell them apart. An hour
+    // is past `stale_secs` (120s) and far short of `claim_ttl_secs` (24h):
+    // judged by the heartbeat threshold the surface opens, judged by the
+    // guard's own window it still holds. Every other bare-CLI fixture here
+    // sits on one side of both — which is how the first version of this fix
+    // shipped with the wrong threshold and a green suite.
+    let repo = e2e_repo();
+    let project_id = edda_store::project_id(repo.path());
+    let store = tempfile::tempdir().expect("store tempdir");
+    write_board(
+        store.path(),
+        &project_id,
+        &[coord_event_aged(
+            "cli-an-hour-in",
+            "ghost-cli",
+            &["src/*"],
+            3600,
+        )],
+    );
+    let (code, stdout, stderr) = run_edda_bare(
+        &["claim", "check", "src/main.rs"],
+        repo.path(),
+        store.path(),
+    );
+    assert_eq!(
+        code, 1,
+        "an hour-old bare-CLI claim is inside the guard's window and must still \
+         refuse a writer; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        stdout.contains("cli-an-hour-in"),
+        "the standing claim must be named, got {stdout:?}"
+    );
+}
+
+#[test]
 fn e2e_bare_cli_claim_past_its_ttl_no_longer_conflicts() {
-    // GH-1018: fail-closed was unconditional, so it read as "never
-    // expires" — 100 claims left from July and August were still refusing
-    // September lanes, and no `unclaim` could reach them. The claim's own
-    // timestamp is judgeable even when its session's heartbeat is not, so
-    // the occupation is bounded: past `claim_ttl_secs` (24h) the surface is
-    // genuinely clear. Everything the three tests around this one pin is
-    // unchanged inside that window.
+    // GH-1018: unconditional fail-closed read as "never expires" — claims
+    // from July and August still refused September lanes. Past
+    // `claim_ttl_secs` (24h) the surface is genuinely clear.
     let repo = e2e_repo();
     let project_id = edda_store::project_id(repo.path());
     let store = tempfile::tempdir().expect("store tempdir");
@@ -879,6 +905,49 @@ fn e2e_never_heartbeated_stale_claim_is_explicit_in_json() {
     assert!(
         stale[0]["age_secs"].is_null(),
         "a never-heartbeated session has no age, got {stale:?}"
+    );
+}
+
+#[test]
+fn e2e_an_expired_bare_cli_claim_keeps_the_no_heartbeat_signal() {
+    // GH-705 made `age_secs: null` mean "no heartbeat file ever existed", and
+    // GH-1018 is what first routes bare-CLI claims into `stale_claims`.
+    // Putting the claim's age in that field would make the signal
+    // unreachable for the class it was added for.
+    let repo = e2e_repo();
+    let project_id = edda_store::project_id(repo.path());
+    let store = tempfile::tempdir().expect("store tempdir");
+    write_board(
+        store.path(),
+        &project_id,
+        &[coord_event_aged(
+            "cli-two-months",
+            "ghost-cli",
+            &["src/*"],
+            60 * 60 * 24 * 60,
+        )],
+    );
+    let (code, stdout, stderr) = run_edda_bare(
+        &["claim", "check", "src/main.rs", "--json"],
+        repo.path(),
+        store.path(),
+    );
+    assert_eq!(code, 0, "stdout={stdout:?} stderr={stderr:?}");
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON report");
+    let stale = parsed["stale_claims"]
+        .as_array()
+        .expect("stale_claims array in JSON report");
+    assert_eq!(stale.len(), 1, "got {parsed:?}");
+    assert_eq!(stale[0]["session_id"], "cli-two-months");
+    assert!(
+        stale[0]["age_secs"].is_null(),
+        "a bare-CLI claim has no heartbeat to age; age_secs must stay null, got {stale:?}"
+    );
+    assert!(
+        stale[0]["claim_age_secs"]
+            .as_u64()
+            .is_some_and(|a| a > 60 * 60 * 24 * 59),
+        "the claim's own age is what expired it and must be reported, got {stale:?}"
     );
 }
 

--- a/crates/edda-cli/tests/claim_e2e_contract.rs
+++ b/crates/edda-cli/tests/claim_e2e_contract.rs
@@ -61,9 +61,20 @@ fn write_board(store_root: &Path, project_id: &str, lines: &[String]) {
         .expect("coordination.jsonl");
 }
 
+/// A claim recorded now.
+///
+/// The timestamp is load-bearing: since GH-1018 a claim stops refusing
+/// writers once it is older than `claim_ttl_secs`, so a fixture pinned to a
+/// fixed calendar date would silently become an expired claim as the repo
+/// ages. Tests that want an old claim ask for one — `coord_event_aged`.
 fn coord_event(session: &str, label: &str, paths: &[&str]) -> String {
+    coord_event_aged(session, label, paths, 0)
+}
+
+/// A claim recorded `age_secs` ago.
+fn coord_event_aged(session: &str, label: &str, paths: &[&str], age_secs: u64) -> String {
     serde_json::json!({
-        "ts": "2026-01-01T00:00:00Z",
+        "ts": rfc3339_now_minus(age_secs),
         "session_id": session,
         "event_type": "claim",
         "payload": { "label": label, "paths": paths }
@@ -291,7 +302,7 @@ fn e2e_bare_cli_claim_is_visible_to_claim_check() {
 }
 
 #[test]
-fn e2e_aged_bare_cli_claim_still_conflicts() {
+fn e2e_bare_cli_claim_with_an_aged_heartbeat_still_conflicts() {
     // GH-705 round-1 P0: the claimant is a one-shot process, gone the
     // moment the command returns, so a heartbeat written at claim time
     // ages with nothing to refresh it. Backdating it past stale_secs
@@ -299,6 +310,10 @@ fn e2e_aged_bare_cli_claim_still_conflicts() {
     // to clear: the claim stands on the board until it is unclaimed, so
     // the gate keeps counting it (fail-closed) instead of dismissing it
     // as a dead session's claim.
+    //
+    // The variable here is the *heartbeat* age; the claim itself is fresh.
+    // GH-1018 bounds the other age — see
+    // `e2e_bare_cli_claim_past_its_ttl_no_longer_conflicts`.
     let repo = e2e_repo();
     let project_id = edda_store::project_id(repo.path());
     let store = tempfile::tempdir().expect("store tempdir");
@@ -378,6 +393,76 @@ fn e2e_non_intersecting_bare_cli_claim_is_listed_in_json() {
 }
 
 #[test]
+fn e2e_a_live_session_holding_a_cli_claim_is_a_live_conflict() {
+    // The bare-CLI arm exists because a one-shot process leaves no heartbeat
+    // to judge (GH-705). When a heartbeat *is* there and live, there is
+    // nothing unjudgeable about the occupation, and the report must keep
+    // saying so: `conflicts`, not `unjudgeable_claims`. Both refuse a writer,
+    // so the exit code cannot tell these apart — only the JSON can, which is
+    // why the distinction is pinned here and not through an exit code.
+    let repo = e2e_repo();
+    let project_id = edda_store::project_id(repo.path());
+    let store = tempfile::tempdir().expect("store tempdir");
+    write_board(
+        store.path(),
+        &project_id,
+        &[coord_event("cli-here-now", "live-cli", &["src/*"])],
+    );
+    write_heartbeat(store.path(), &project_id, "cli-here-now", 0);
+    let (code, stdout, stderr) = run_edda_bare(
+        &["claim", "check", "src/main.rs", "--json"],
+        repo.path(),
+        store.path(),
+    );
+    assert_eq!(code, 1, "stdout={stdout:?} stderr={stderr:?}");
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON report");
+    assert_eq!(
+        parsed["conflicts"][0]["session_id"], "cli-here-now",
+        "a live session's claim must be a live conflict, got {parsed:?}"
+    );
+    assert!(
+        parsed["unjudgeable_claims"]
+            .as_array()
+            .is_some_and(Vec::is_empty),
+        "a judgeable claim must not be filed as unjudgeable, got {parsed:?}"
+    );
+}
+
+#[test]
+fn e2e_bare_cli_claim_past_its_ttl_no_longer_conflicts() {
+    // GH-1018: fail-closed was unconditional, so it read as "never
+    // expires" — 100 claims left from July and August were still refusing
+    // September lanes, and no `unclaim` could reach them. The claim's own
+    // timestamp is judgeable even when its session's heartbeat is not, so
+    // the occupation is bounded: past `claim_ttl_secs` (24h) the surface is
+    // genuinely clear. Everything the three tests around this one pin is
+    // unchanged inside that window.
+    let repo = e2e_repo();
+    let project_id = edda_store::project_id(repo.path());
+    let store = tempfile::tempdir().expect("store tempdir");
+    write_board(
+        store.path(),
+        &project_id,
+        &[coord_event_aged(
+            "cli-july",
+            "ghost-cli",
+            &["src/*"],
+            60 * 60 * 24 * 60,
+        )],
+    );
+    let (code, stdout, stderr) = run_edda_bare(
+        &["claim", "check", "src/main.rs"],
+        repo.path(),
+        store.path(),
+    );
+    assert_eq!(
+        code, 0,
+        "a two-month-old bare-CLI claim must not refuse a new writer; \
+         stdout={stdout:?} stderr={stderr:?}"
+    );
+}
+
+#[test]
 fn e2e_never_heartbeated_bare_cli_claim_conflicts() {
     // The same fail-closed verdict when the one-shot claim left no
     // heartbeat at all: for a session id this binary itself mints,
@@ -408,7 +493,7 @@ fn e2e_never_heartbeated_bare_cli_claim_conflicts() {
 }
 
 #[test]
-fn e2e_aged_bare_cli_claim_is_classified_in_json() {
+fn e2e_bare_cli_claim_with_an_aged_heartbeat_is_classified_in_json() {
     // Machine-readable classification (GH-705 doneWhen): an overlapping
     // bare-CLI claim appears in its own `unjudgeable_claims` bucket — an
     // occupation whose liveness cannot be judged, distinct from a live

--- a/docs/architecture/consistency-contract.md
+++ b/docs/architecture/consistency-contract.md
@@ -115,7 +115,7 @@ scoping, and durability guarantees.
 | Signal | Default | Env Override | Notes |
 |--------|---------|-------------|-------|
 | Heartbeat liveness | 120 s | `EDDA_PEER_STALE_SECS` | Peers older than this are excluded from discovery |
-| Bare-CLI claim guard | 86 400 s | `EDDA_CLAIM_TTL_SECS` | How long a `cli-*` board claim may refuse a writer, measured on the claim's own timestamp. Only this class — a claim whose session has a heartbeat is judged by the row above. Deliberately not the heartbeat window: a heartbeat is refreshed every 30 s, a claim is written once (GH-1018) |
+| Bare-CLI claim guard | 86 400 s | `EDDA_CLAIM_TTL_SECS` | How long a `cli-*` board claim may refuse a writer, measured on the claim's own timestamp. Additional to the row above, not exclusive of it: a claim stands while its session heartbeats **or** it is `cli-*` and under this window. Deliberately not the heartbeat window: a heartbeat is refreshed every 30 s, a claim is written once (GH-1018) |
 | Sub-agent heartbeat | 1800 s (15×) | — | Sub-agents cannot fire hooks; extended threshold |
 | Nudge cooldown | 180 s | `EDDA_NUDGE_COOLDOWN_SECS` | Minimum interval between nudge injections |
 | Hook timeout | 10 000 ms | `EDDA_HOOK_TIMEOUT_MS` | Max hook execution time before graceful exit |

--- a/docs/architecture/consistency-contract.md
+++ b/docs/architecture/consistency-contract.md
@@ -115,6 +115,7 @@ scoping, and durability guarantees.
 | Signal | Default | Env Override | Notes |
 |--------|---------|-------------|-------|
 | Heartbeat liveness | 120 s | `EDDA_PEER_STALE_SECS` | Peers older than this are excluded from discovery |
+| Board claim guard | 86 400 s | `EDDA_CLAIM_TTL_SECS` | How long a claim may refuse a writer. Deliberately not the heartbeat window: a heartbeat is refreshed every 30 s, a claim is written once (GH-1018) |
 | Sub-agent heartbeat | 1800 s (15×) | — | Sub-agents cannot fire hooks; extended threshold |
 | Nudge cooldown | 180 s | `EDDA_NUDGE_COOLDOWN_SECS` | Minimum interval between nudge injections |
 | Hook timeout | 10 000 ms | `EDDA_HOOK_TIMEOUT_MS` | Max hook execution time before graceful exit |

--- a/docs/architecture/consistency-contract.md
+++ b/docs/architecture/consistency-contract.md
@@ -115,7 +115,7 @@ scoping, and durability guarantees.
 | Signal | Default | Env Override | Notes |
 |--------|---------|-------------|-------|
 | Heartbeat liveness | 120 s | `EDDA_PEER_STALE_SECS` | Peers older than this are excluded from discovery |
-| Board claim guard | 86 400 s | `EDDA_CLAIM_TTL_SECS` | How long a claim may refuse a writer. Deliberately not the heartbeat window: a heartbeat is refreshed every 30 s, a claim is written once (GH-1018) |
+| Bare-CLI claim guard | 86 400 s | `EDDA_CLAIM_TTL_SECS` | How long a `cli-*` board claim may refuse a writer, measured on the claim's own timestamp. Only this class — a claim whose session has a heartbeat is judged by the row above. Deliberately not the heartbeat window: a heartbeat is refreshed every 30 s, a claim is written once (GH-1018) |
 | Sub-agent heartbeat | 1800 s (15×) | — | Sub-agents cannot fire hooks; extended threshold |
 | Nudge cooldown | 180 s | `EDDA_NUDGE_COOLDOWN_SECS` | Minimum interval between nudge injections |
 | Hook timeout | 10 000 ms | `EDDA_HOOK_TIMEOUT_MS` | Max hook execution time before graceful exit |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -374,15 +374,23 @@ session replaces its previous label and complete path list; it does not add a
 second claim. Pass each path pattern with its own `--paths` flag; comma-separated
 values are not split.
 
-A claim stops refusing writers 24 hours after it was recorded
-(`EDDA_CLAIM_TTL_SECS`). That window is deliberately not the 120-second
-heartbeat window `edda peers` uses: a heartbeat is refreshed every 30 seconds,
-while a claim is written once and never refreshed, so a refresh-calibrated
-window would open a surface two minutes after its owner claimed it. Before the
-guard was bounded, claims from months-gone sessions refused every new lane and
-no `unclaim` could reach them (GH-1018). `edda claim check` and the `edda
-dispatch --owns` admission guard read one rule, so they cannot answer
-differently about the same board.
+How long a claim keeps refusing writers depends on what can be known about
+its claimant:
+
+| Claim | Stops refusing when |
+|---|---|
+| A session with a heartbeat | that heartbeat goes stale — 120 s (`EDDA_PEER_STALE_SECS`). A running session keeps refreshing it, so it is protected for as long as it runs. |
+| A bare-CLI claim (`cli-*`, a one-shot `edda claim` with no session) | the claim's own timestamp is 24 h old (`EDDA_CLAIM_TTL_SECS`). Nothing ever refreshes a heartbeat for a one-shot process, so there is no heartbeat to judge. |
+
+The second window is deliberately not the first. A heartbeat is refreshed every
+30 seconds; a claim is written once, so measuring it against a
+refresh-calibrated window would open a surface two minutes after its owner
+claimed it. Before the bare-CLI case was bounded at all, claims from
+months-gone sessions refused every new lane and no `unclaim` could reach them
+(GH-1018).
+
+`edda claim check` and the `edda dispatch --owns` admission guard read one
+rule, so they cannot answer differently about the same board.
 
 ### `edda request`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -379,7 +379,7 @@ A claim keeps refusing writers while **either** of two things is true, so a
 
 | A claim stands while | Window |
 |---|---|
-| its session has a fresh heartbeat | 120 s (`EDDA_PEER_STALE_SECS`). A running session keeps refreshing it, so it is protected for as long as it runs. |
+| its session has a fresh heartbeat | 120 s (`EDDA_PEER_STALE_SECS`), or 15× that for a sub-agent whose heartbeat records a parent — no hook events fire during a sub-agent's run, so a heartbeat written once at spawn would otherwise age out mid-run. A running session keeps refreshing it, so it is protected for as long as it runs. |
 | **or** it is a bare-CLI claim (`cli-*`) young enough by its own timestamp | 24 h (`EDDA_CLAIM_TTL_SECS`). Nothing refreshes a heartbeat for a one-shot process, so the claim's own age is what is judged. |
 
 Neither true, and the claim stops refusing. That has an edge worth knowing:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -374,6 +374,16 @@ session replaces its previous label and complete path list; it does not add a
 second claim. Pass each path pattern with its own `--paths` flag; comma-separated
 values are not split.
 
+A claim stops refusing writers 24 hours after it was recorded
+(`EDDA_CLAIM_TTL_SECS`). That window is deliberately not the 120-second
+heartbeat window `edda peers` uses: a heartbeat is refreshed every 30 seconds,
+while a claim is written once and never refreshed, so a refresh-calibrated
+window would open a surface two minutes after its owner claimed it. Before the
+guard was bounded, claims from months-gone sessions refused every new lane and
+no `unclaim` could reach them (GH-1018). `edda claim check` and the `edda
+dispatch --owns` admission guard read one rule, so they cannot answer
+differently about the same board.
+
 ### `edda request`
 
 Send a request to another active session.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -374,13 +374,18 @@ session replaces its previous label and complete path list; it does not add a
 second claim. Pass each path pattern with its own `--paths` flag; comma-separated
 values are not split.
 
-How long a claim keeps refusing writers depends on what can be known about
-its claimant:
+A claim keeps refusing writers while **either** of two things is true, so a
+`cli-*` claim can outlive its own stale heartbeat:
 
-| Claim | Stops refusing when |
+| A claim stands while | Window |
 |---|---|
-| A session with a heartbeat | that heartbeat goes stale — 120 s (`EDDA_PEER_STALE_SECS`). A running session keeps refreshing it, so it is protected for as long as it runs. |
-| A bare-CLI claim (`cli-*`, a one-shot `edda claim` with no session) | the claim's own timestamp is 24 h old (`EDDA_CLAIM_TTL_SECS`). Nothing ever refreshes a heartbeat for a one-shot process, so there is no heartbeat to judge. |
+| its session has a fresh heartbeat | 120 s (`EDDA_PEER_STALE_SECS`). A running session keeps refreshing it, so it is protected for as long as it runs. |
+| **or** it is a bare-CLI claim (`cli-*`) young enough by its own timestamp | 24 h (`EDDA_CLAIM_TTL_SECS`). Nothing refreshes a heartbeat for a one-shot process, so the claim's own age is what is judged. |
+
+Neither true, and the claim stops refusing. That has an edge worth knowing:
+a claim from a session that is **not** `cli-*` and has never written a
+heartbeat refuses nobody, from the moment it is recorded — the board entry
+alone is not evidence such a session exists (GH-617).
 
 The second window is deliberately not the first. A heartbeat is refreshed every
 30 seconds; a claim is written once, so measuring it against a

--- a/scripts/file-length-ceilings.txt
+++ b/scripts/file-length-ceilings.txt
@@ -21,6 +21,7 @@ crates/edda-cli/src/cmd_gc.rs 1117
 crates/edda-cli/src/cmd_plan.rs 1022
 crates/edda-cli/src/cmd_prs/merge_gate.rs 1295
 crates/edda-cli/src/main.rs 1463
+crates/edda-cli/tests/claim_e2e_contract.rs 1050
 crates/edda-conductor/src/agent/codex_app_server.rs 1062
 crates/edda-conductor/src/agent/codex_rpc.rs 1378
 crates/edda-conductor/src/agent/pi_rpc.rs 1480
@@ -36,4 +37,3 @@ crates/edda-mcp/src/lib.rs 1199
 crates/edda-pack/src/lib.rs 1186
 crates/edda-search-fts/src/indexer.rs 1461
 crates/edda-serve/src/tests.rs 5378
-crates/edda-cli/tests/claim_e2e_contract.rs 1050

--- a/scripts/file-length-ceilings.txt
+++ b/scripts/file-length-ceilings.txt
@@ -36,3 +36,4 @@ crates/edda-mcp/src/lib.rs 1199
 crates/edda-pack/src/lib.rs 1186
 crates/edda-search-fts/src/indexer.rs 1461
 crates/edda-serve/src/tests.rs 5378
+crates/edda-cli/tests/claim_e2e_contract.rs 1050


### PR DESCRIPTION
Follow-up to #1045, which merged before its round-1 review was answered. This
lands the two P1 findings against that merged code.

Issue: #1049

## What was wrong

**The guard borrowed a threshold calibrated for a different fact.** #1045
bounded the bare-CLI claim arm with `stale_secs()` — 120 seconds, the window a
*heartbeat* is refreshed inside (every 30s). A board claim is written once and
never refreshed. So an operator who runs `edda claim` and then works for an
hour had their claimed surface silently open two minutes in. The fix traded a
guard that never expired for one that expires during normal use.

**Two verbs decided the same board separately.** `edda claim check` and the
`edda dispatch --owns` guard each carried their own expression. Before #1045
both happened to reduce to `live || cli-*`, so the duplication was invisible.
Bounding one arm in only one of them turned that coincidence into a
disagreement: `claim check` reporting CONFLICT on a surface `dispatch` had
already admitted a writer to.

## What changed

- `claim_ttl_secs()` (`EDDA_CLAIM_TTL_SECS`, default 24h) is the guard's own
  window, with the reason it is not `stale_secs()` recorded at both
  definitions. `liveness.rs` now states the two questions and their two
  thresholds in one table, so the next reader does not "simplify" them back
  together.
- `claim_standing()` is the one admission rule. It lives in its own module
  (`claim_standing.rs`) rather than inside either verb, so neither can grow a
  second answer without deleting the shared one. Both verbs call it.
- The heartbeat is consulted **first**. Deciding the bare-CLI arm from the
  claim record alone is one file read cheaper per claim, and I intended to
  take that — but it reclassifies a live session's `cli-*` claim out of
  `conflicts` into `unjudgeable_claims`, which is exactly the distinction
  GH-705 created that bucket to make. Both still refuse a writer, so the exit
  code hides it and only the JSON shows it. Declined the optimization; pinned
  the ordering with a test that fails under the cheaper one.
- `coord_event` fixtures date from `now()`. Pinned to a fixed calendar date
  they age into expired claims on their own — which is what broke three GH-705
  e2e tests here. Two of those tests also said "aged" while varying the
  *heartbeat* age, so they now name which age they mean.

## Tests

| Test | Pins |
|---|---|
| `e2e_bare_cli_claim_inside_its_ttl_outlives_the_heartbeat_window` | **The threshold itself.** An hour-old claim is past `stale_secs` and short of `claim_ttl_secs` — the only window that separates them — and must still refuse a writer. Fails if the guard is reverted to `stale_secs`. |
| `the_dispatch_guard_and_claim_check_read_one_rule` | **The shared rule.** Three claims — 5 s, 1 h, 22 d — where the bucket `claim check` reads must equal whether `dispatch` admits. Fails on `cli-an-hour` if `dispatch` regrows its own expression. |
| `e2e_a_live_session_holding_a_cli_claim_is_a_live_conflict` | A judgeable claim is not filed as unjudgeable. Fails under the cheaper bare-arm-first ordering. |
| `e2e_an_expired_bare_cli_claim_keeps_the_no_heartbeat_signal` | GH-705's `age_secs: null` stays reachable for bare-CLI claims; `claim_age_secs` carries what expired them. |
| `e2e_bare_cli_claim_past_its_ttl_no_longer_conflicts` | A two-month-old claim does not refuse a lane. |
| `the_guard_window_is_not_the_display_window` / `the_guard_shares_the_boundary_every_criterion_here_uses` / `an_undateable_claim_cannot_refuse_a_writer_forever` | Unit boundaries on the two helpers in isolation — the `age > threshold` edge and the fail-towards-expired direction. These do **not** reach `claim_standing`, `acquire` or `claim check`; the rows above carry those claims. |

Round 1 found that the first version of this table overstated what the unit
rows pinned, and that no fixture sat in the window where the two rules
disagree. Both mutations round 1 used to prove that now fail.

## Correction to #1045

I diagnosed the `unclaim` failure there as a project-id/board mismatch. That
was a guess from reading the issue without `--comments`, and it was wrong: the
issue records releases written under `cli-gh466-round1-fixes-released`, a
derived session id, so `claims.remove(session_id)` never matched. That defect
is untouched here and is filed separately — bounding the guard in time is what
makes the stuck board recoverable without it.

## Gates

L0 on both touched crates, Windows: `cargo fmt --all --check`;
`cargo clippy -p edda-bridge-claude -p edda --all-targets -- -D warnings`;
`cargo test -p edda-bridge-claude` (659 passed); `cargo test -p edda`
(all suites, 0 failed); `scripts/lint-file-length.sh --tree`. Both crates are
inside the CI Windows subset, so the C5 focused-Windows selector is empty.

Note for the reviewer: a peer session was running cargo against the same
`target/` during part of this work, which produced a zero-byte `.rmeta`, a
locked `edda.exe`, and intermittent phantom failures (including an E0425 for a
function that was present). All were artifacts of that contention, not of this
diff — `cargo clean -p edda-bridge-claude` cleared them, and the gate above ran
clean afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


