### PR TITLE
feat(edda-cli): edda review due — the trigger policy in the product (GH-763)

### DIFF
--- a/crates/edda-cli/src/cmd_review/config.rs
+++ b/crates/edda-cli/src/cmd_review/config.rs
@@ -1,0 +1,98 @@
+//! Repository-level review settings (GH-763).
+//!
+//! One small file, `.edda/review/due.json`, holding only what an operator
+//! actually needs to turn: how long a pushed head must settle before it is
+//! worth a review, and which triggers are live at all. Absent means defaults,
+//! which is the normal case — the file exists so a repository *can* differ,
+//! not so every repository must carry one.
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::path::Path;
+
+/// Settings for `edda review due`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct DueConfig {
+    /// How long a pushed head must sit unchanged before it is worth reviewing.
+    ///
+    /// Ten minutes by default. The cost it guards is real: a round-1 Opus
+    /// review measured $1.28–$2.57 on #754, so a five-push burst reviewed
+    /// per push costs about ten dollars for one tree.
+    pub debounce_seconds: u64,
+    /// Which triggers may fire. `draft` is not among them — refusing a draft
+    /// is not a trigger and cannot be switched off.
+    pub triggers: Vec<String>,
+}
+
+impl Default for DueConfig {
+    fn default() -> Self {
+        Self {
+            debounce_seconds: 600,
+            triggers: vec!["ready".into(), "response".into(), "push".into()],
+        }
+    }
+}
+
+impl DueConfig {
+    pub(crate) fn enabled(&self, trigger: &str) -> bool {
+        self.triggers.iter().any(|name| name == trigger)
+    }
+
+    /// Read `.edda/review/due.json`, or the defaults when it is absent.
+    ///
+    /// A file that exists but cannot be parsed is an error rather than a
+    /// silent fall back to defaults: an operator who wrote a debounce and got
+    /// the default one would be paying for a switch they believe they threw.
+    pub(crate) fn load(repo: &Path) -> Result<Self> {
+        let path = repo.join(".edda").join("review").join("due.json");
+        match std::fs::read_to_string(&path) {
+            Ok(text) => serde_json::from_str(&text)
+                .with_context(|| format!("read review config {}", path.display())),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(error) => {
+                Err(error).with_context(|| format!("read review config {}", path.display()))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_apply_when_no_file_exists() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = DueConfig::load(dir.path()).expect("absent config is not an error");
+        assert_eq!(config.debounce_seconds, 600);
+        assert!(config.enabled("ready") && config.enabled("response") && config.enabled("push"));
+        assert!(!config.enabled("draft"), "draft is not a trigger");
+    }
+
+    #[test]
+    fn a_partial_file_keeps_the_defaults_it_does_not_mention() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let review = dir.path().join(".edda").join("review");
+        std::fs::create_dir_all(&review).expect("config dir");
+        std::fs::write(review.join("due.json"), r#"{"debounce_seconds": 30}"#).expect("write");
+        let config = DueConfig::load(dir.path()).expect("load");
+        assert_eq!(config.debounce_seconds, 30);
+        assert!(config.enabled("push"), "triggers keep their default");
+    }
+
+    #[test]
+    fn an_unreadable_file_is_an_error_not_a_silent_default() {
+        // An operator who wrote a debounce and silently got 600 would be
+        // paying for a switch they believe they threw.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let review = dir.path().join(".edda").join("review");
+        std::fs::create_dir_all(&review).expect("config dir");
+        std::fs::write(review.join("due.json"), "{ not json").expect("write");
+        assert!(DueConfig::load(dir.path()).is_err());
+
+        // A typo in a key is the same failure wearing a friendlier face.
+        std::fs::write(review.join("due.json"), r#"{"debounce_second": 30}"#).expect("write");
+        assert!(DueConfig::load(dir.path()).is_err());
+    }
+}

--- a/crates/edda-cli/src/cmd_review/due.rs
+++ b/crates/edda-cli/src/cmd_review/due.rs
@@ -1,0 +1,551 @@
+//! `edda review due` — the trigger policy, in the product (GH-763).
+//!
+//! Whether a PR is worth reviewing again is a judgement, not forge glue
+//! (#766 D8), and it is the main cost switch in the whole review system. The
+//! watcher's `decide()` used to answer it in awk with one rule — *head differs
+//! from the last reviewed SHA* — which means **one review per push**. A round-1
+//! Opus review measured $1.28–$2.57 on #754; the resumed delta round of the
+//! same PR measured $0.22 and then $0.02. Five pushes on one PR bought five
+//! round-1 prices for what a debounce plus a resume would have charged once.
+//!
+//! So this verb decides, and the daemon only gathers forge facts and acts on
+//! the exit code. It reads the ledger and writes nothing.
+//!
+//! ## The policy, in order
+//!
+//! | Condition | Answer |
+//! |---|---|
+//! | `--draft` | `SKIP draft` |
+//! | `--ready` (left draft this cycle) | `REVIEW ready` |
+//! | `--response-at` newer than the last verdict | `REVIEW response` |
+//! | head moved and the push has settled | `REVIEW push` |
+//! | head moved, still inside the debounce | `SKIP debounce <n>s` |
+//! | otherwise | `SKIP reviewed` |
+//!
+//! Draft comes first because a draft is not a subject at all. `ready` and
+//! `response` are events rather than states, so neither is debounced: they
+//! happen once and the operator is waiting on them. Only `push` is, because
+//! only `push` repeats.
+
+use super::config::DueConfig;
+use anyhow::{Context, Result};
+use edda_core::ReviewVerdictPayload;
+use edda_ledger::Ledger;
+use std::path::Path;
+
+/// Flags for `edda review due`.
+#[derive(clap::Args)]
+pub struct DueArgs {
+    /// The PR's current head, as a full lowercase 40-hex SHA
+    #[arg(long, value_name = "SHA")]
+    pub head: String,
+    /// When that head was pushed (RFC3339); without it a moved head is due at once
+    #[arg(long, value_name = "RFC3339")]
+    pub pushed_at: Option<String>,
+    /// The PR left draft during this cycle
+    #[arg(long)]
+    pub ready: bool,
+    /// Timestamp of the newest `Review Response: Round N` comment (RFC3339)
+    #[arg(long, value_name = "RFC3339")]
+    pub response_at: Option<String>,
+    /// The PR is a draft
+    #[arg(long)]
+    pub draft: bool,
+    /// PR number, which is how the ledger's rounds are found
+    #[arg(long, value_name = "N")]
+    pub pr: Option<u64>,
+    /// The SHA the caller last reviewed, when it knows better than the ledger
+    ///
+    /// The daemon keeps its own reviewed-head state, and it is the only record
+    /// of a round that went through the §7 comment path rather than
+    /// `edda review` — those write no `review_verdict` event, so the ledger
+    /// would read them as "never reviewed" and make every cycle due.
+    #[arg(long, value_name = "SHA")]
+    pub last_reviewed: Option<String>,
+    /// The PR carries `review:unreviewed`: a head the watcher already gave up on
+    #[arg(long)]
+    pub unreviewed_label: bool,
+    /// Clock override, for tests
+    #[arg(long, value_name = "RFC3339", hide = true)]
+    pub now: Option<String>,
+}
+
+/// What the ledger knows about the rounds already spent on this PR.
+#[derive(Debug, Default)]
+pub(crate) struct History {
+    /// Head SHA of the newest verdict, in ledger insertion order.
+    pub(crate) last_sha: Option<String>,
+    /// Timestamp of that verdict's event.
+    pub(crate) last_ts: Option<String>,
+    /// Reviewer session of round 1 — what a later round resumes.
+    pub(crate) first_session: Option<String>,
+    /// Rounds that produced a verdict.
+    pub(crate) rounds: u32,
+    /// Summed cost of those rounds, and whether every one of them was measured.
+    pub(crate) cost_usd: f64,
+    pub(crate) all_measured: bool,
+}
+
+impl History {
+    /// `review cost so far: …` — the line that makes the cost switch visible
+    /// at the moment it is thrown.
+    ///
+    /// An unmeasured round makes the whole total unmeasured rather than
+    /// quietly contributing zero: a sum that silently drops a round reads as
+    /// cheaper than the truth, which is the one direction a cost display must
+    /// never fail in.
+    pub(crate) fn cost_line(&self) -> String {
+        let rounds = if self.rounds == 1 { "round" } else { "rounds" };
+        if self.rounds == 0 {
+            return format!("review cost so far: $0.00 over 0 {rounds}");
+        }
+        if !self.all_measured {
+            return format!(
+                "review cost so far: unmeasured over {} {rounds}",
+                self.rounds
+            );
+        }
+        format!(
+            "review cost so far: ${:.2} over {} {rounds}",
+            self.cost_usd, self.rounds
+        )
+    }
+}
+
+/// Rounds already spent on `pr`, from the ledger's `review_verdict` events.
+///
+/// Ordered by insertion (`ORDER BY rowid`), like every other ledger fold —
+/// RFC3339 strings with mixed precision do not sort chronologically, so the
+/// newest verdict is the last row, not the largest timestamp.
+///
+/// `unreviewed` events are skipped: they record that no review could be made,
+/// so they consume no round, carry no cost, and cannot be resumed.
+pub(crate) fn history(repo: &Path, pr: u64) -> Result<History> {
+    let ledger = Ledger::open(repo)?;
+    let mut history = History {
+        all_measured: true,
+        ..Default::default()
+    };
+    for event in ledger.iter_events_by_type("review_verdict")? {
+        let payload: ReviewVerdictPayload = serde_json::from_value(event.payload.clone())
+            .with_context(|| format!("review_verdict event {}", event.event_id))?;
+        if payload.verdict == "unreviewed" || payload.refs.pr != Some(pr) {
+            continue;
+        }
+        history.rounds += 1;
+        history.last_sha = Some(payload.subject.head_sha.clone());
+        history.last_ts = Some(event.ts.clone());
+        if history.first_session.is_none() {
+            history.first_session = Some(payload.reviewer.session_id.clone());
+        }
+        match (payload.cost.measured, payload.cost.usd) {
+            (true, Some(usd)) => history.cost_usd += usd,
+            _ => history.all_measured = false,
+        }
+    }
+    Ok(history)
+}
+
+/// The answer, and why.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Due {
+    /// Review, for this reason.
+    Review(String),
+    /// Do not review, for this reason.
+    Skip(String),
+}
+
+/// The facts the policy runs on, with every clock already resolved to epoch
+/// seconds so the rule itself has no I/O and no ambient time.
+pub(crate) struct Facts<'a> {
+    pub(crate) head: &'a str,
+    pub(crate) draft: bool,
+    pub(crate) ready: bool,
+    /// The PR carries `review:unreviewed`.
+    pub(crate) unreviewed_label: bool,
+    pub(crate) pushed_at: Option<i64>,
+    pub(crate) response_at: Option<i64>,
+    pub(crate) now: i64,
+    pub(crate) last_sha: Option<&'a str>,
+    pub(crate) last_verdict_at: Option<i64>,
+}
+
+/// The trigger policy. Pure: same facts, same answer, on every machine.
+pub(crate) fn decide(facts: &Facts, config: &DueConfig) -> Due {
+    // A draft is not a subject. This is first and is not configurable: an
+    // enabled trigger cannot make a draft reviewable.
+    if facts.draft {
+        return Due::Skip("draft".into());
+    }
+
+    // `review:unreviewed` marks a head the watcher already gave up on. It is
+    // released by the head moving — and only by that, so a PR whose reviewed
+    // SHA was never recorded stays skipped rather than looping: without a
+    // recorded SHA there is no way to tell that the head moved, and guessing
+    // in the reviewing direction buys a round-1 price per cycle.
+    if facts.unreviewed_label {
+        let moved_from_known = facts.last_sha.is_some_and(|last| last != facts.head);
+        if !moved_from_known {
+            return Due::Skip("review-unreviewed".into());
+        }
+    }
+
+    // Leaving draft is a one-time event the operator is waiting on, so it is
+    // never debounced.
+    if facts.ready && config.enabled("ready") {
+        return Due::Review("ready".into());
+    }
+
+    // A Review Response is the implementer saying "look again", and it counts
+    // only if it arrived after the verdict it answers. An older one is the
+    // previous round's, already answered.
+    if config.enabled("response") {
+        if let Some(response_at) = facts.response_at {
+            let after_verdict = facts
+                .last_verdict_at
+                .is_none_or(|verdict_at| response_at > verdict_at);
+            if after_verdict {
+                return Due::Review("response".into());
+            }
+        }
+    }
+
+    let moved = facts.last_sha != Some(facts.head);
+    if !moved {
+        return Due::Skip("reviewed".into());
+    }
+    if !config.enabled("push") {
+        return Due::Skip("push-trigger-disabled".into());
+    }
+
+    // The debounce is the cost switch. A head that moved 20 seconds ago is
+    // usually mid-sequence — the fixup, the second thought, the CI-driven
+    // amend — and reviewing it buys a round-1 price for a tree about to
+    // change again. Without `--pushed-at` there is nothing to wait on, so the
+    // moved head is due at once rather than silently held.
+    let Some(pushed_at) = facts.pushed_at else {
+        return Due::Review("push".into());
+    };
+    let settled_for = facts.now.saturating_sub(pushed_at);
+    let debounce = config.debounce_seconds as i64;
+    if settled_for >= debounce {
+        Due::Review("push".into())
+    } else {
+        Due::Skip(format!("debounce {}s", debounce - settled_for))
+    }
+}
+
+/// Parse an RFC3339 timestamp to epoch seconds.
+fn epoch(value: &str, what: &str) -> Result<i64> {
+    Ok(
+        time::OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339)
+            .with_context(|| format!("{what}: expected an RFC3339 timestamp, got {value:?}"))?
+            .unix_timestamp(),
+    )
+}
+
+/// CLI entry point. Exit: 0 due, 1 not due, 2 cannot judge.
+///
+/// Every internal failure leaves through exit 2. The daemon reads 1 as a
+/// decision not to review; an unreadable ledger is not that decision, and
+/// publishing it as one would silently stop reviewing the repository.
+pub fn run(args: DueArgs, cwd: &Path) -> Result<()> {
+    match judge(args, cwd) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            eprintln!("edda review due: {error:#}");
+            std::process::exit(2);
+        }
+    }
+}
+
+fn judge(args: DueArgs, cwd: &Path) -> Result<()> {
+    if args.head.len() != 40
+        || !args
+            .head
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || byte.is_ascii_lowercase() && byte <= b'f')
+    {
+        eprintln!("edda review due: expected a full lowercase 40-hex SHA");
+        std::process::exit(2);
+    }
+
+    let now = match args.now.as_deref() {
+        Some(value) => epoch(value, "--now")?,
+        None => time::OffsetDateTime::now_utc().unix_timestamp(),
+    };
+    let pushed_at = args
+        .pushed_at
+        .as_deref()
+        .map(|value| epoch(value, "--pushed-at"))
+        .transpose()?;
+    let response_at = args
+        .response_at
+        .as_deref()
+        .map(|value| epoch(value, "--response-at"))
+        .transpose()?;
+
+    // The repo is only needed once a PR number gives the ledger something to
+    // look up, so the flag-only cases work outside a checkout.
+    let (config, history) = match args.pr {
+        Some(pr) => {
+            let repo = super::git::repo_root_from(cwd)?;
+            (DueConfig::load(&repo)?, history(&repo, pr)?)
+        }
+        None => (DueConfig::default(), History::default()),
+    };
+    let last_verdict_at = history
+        .last_ts
+        .as_deref()
+        .map(|value| epoch(value, "ledger verdict timestamp"))
+        .transpose()?;
+    // The caller's record wins over the ledger's for "has this head been
+    // reviewed": it is the one that also covers comment-path rounds.
+    let last_sha = args
+        .last_reviewed
+        .as_deref()
+        .or(history.last_sha.as_deref());
+
+    let answer = decide(
+        &Facts {
+            head: &args.head,
+            draft: args.draft,
+            ready: args.ready,
+            unreviewed_label: args.unreviewed_label,
+            pushed_at,
+            response_at,
+            now,
+            last_sha,
+            last_verdict_at,
+        },
+        &config,
+    );
+
+    match answer {
+        Due::Review(reason) => {
+            // A second round resumes the first round's session: the reviewer
+            // already holds the diff, the spec and its own findings, which is
+            // the difference between a $2 round and a $0.02 one.
+            let resume = match (history.rounds >= 1, history.first_session.as_deref()) {
+                (true, Some(session)) => format!(" --resume {session}"),
+                _ => String::new(),
+            };
+            println!("REVIEW {reason}{resume}");
+            println!("{}", history.cost_line());
+            Ok(())
+        }
+        Due::Skip(reason) => {
+            println!("SKIP {reason}");
+            println!("{}", history.cost_line());
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HEAD: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const OLD: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    fn facts() -> Facts<'static> {
+        Facts {
+            head: HEAD,
+            draft: false,
+            ready: false,
+            unreviewed_label: false,
+            pushed_at: None,
+            response_at: None,
+            now: 10_000,
+            last_sha: None,
+            last_verdict_at: None,
+        }
+    }
+
+    #[test]
+    fn a_draft_is_not_a_subject() {
+        let config = DueConfig::default();
+        let mut f = facts();
+        f.draft = true;
+        // Not even when everything else would fire — a draft is refused first.
+        f.ready = true;
+        f.response_at = Some(9_999);
+        f.last_sha = Some(OLD);
+        assert_eq!(decide(&f, &config), Due::Skip("draft".into()));
+    }
+
+    #[test]
+    fn leaving_draft_and_answering_a_review_are_never_debounced() {
+        let config = DueConfig::default();
+        let mut ready = facts();
+        ready.ready = true;
+        ready.pushed_at = Some(9_999); // one second ago, deep inside the debounce
+        assert_eq!(decide(&ready, &config), Due::Review("ready".into()));
+
+        let mut response = facts();
+        response.response_at = Some(9_999);
+        response.pushed_at = Some(9_999);
+        response.last_sha = Some(HEAD); // the head has not even moved
+        response.last_verdict_at = Some(9_000);
+        assert_eq!(decide(&response, &config), Due::Review("response".into()));
+    }
+
+    #[test]
+    fn a_response_older_than_the_verdict_it_answers_is_the_previous_round() {
+        let config = DueConfig::default();
+        let mut f = facts();
+        f.last_sha = Some(HEAD);
+        f.last_verdict_at = Some(9_000);
+        f.response_at = Some(8_000); // answered a round that is already closed
+        assert_eq!(decide(&f, &config), Due::Skip("reviewed".into()));
+    }
+
+    #[test]
+    fn an_unmoved_head_is_already_reviewed() {
+        let config = DueConfig::default();
+        let mut f = facts();
+        f.last_sha = Some(HEAD);
+        f.pushed_at = Some(0); // long settled, and still not due
+        assert_eq!(decide(&f, &config), Due::Skip("reviewed".into()));
+    }
+
+    #[test]
+    fn a_moved_head_waits_out_the_debounce_then_becomes_due() {
+        let config = DueConfig::default(); // 600s
+        let mut f = facts();
+        f.last_sha = Some(OLD);
+        f.pushed_at = Some(10_000 - 599);
+        assert_eq!(decide(&f, &config), Due::Skip("debounce 1s".into()));
+        f.pushed_at = Some(10_000 - 600);
+        assert_eq!(decide(&f, &config), Due::Review("push".into()));
+    }
+
+    #[test]
+    fn three_pushes_inside_one_debounce_window_are_due_once() {
+        // The whole point of the switch: a burst of pushes buys one review,
+        // not one per push. Each push resets the wait, because each one
+        // changes the tree the reviewer would read.
+        let config = DueConfig::default();
+        let mut f = facts();
+        f.last_sha = Some(OLD);
+        let mut due = 0;
+        for (now, pushed) in [(10_000, 10_000), (10_100, 10_100), (10_200, 10_200)] {
+            f.now = now;
+            f.pushed_at = Some(pushed);
+            if matches!(decide(&f, &config), Due::Review(_)) {
+                due += 1;
+            }
+        }
+        assert_eq!(due, 0, "a burst must not buy three round-1 reviews");
+        // Once the last push settles, exactly one review is due.
+        f.now = 10_200 + 600;
+        assert_eq!(decide(&f, &config), Due::Review("push".into()));
+    }
+
+    #[test]
+    fn a_moved_head_with_no_push_time_is_due_at_once() {
+        // Nothing to wait on, so holding it would be an indefinite hold, not
+        // a debounce.
+        let config = DueConfig::default();
+        let mut f = facts();
+        f.last_sha = Some(OLD);
+        assert_eq!(decide(&f, &config), Due::Review("push".into()));
+    }
+
+    #[test]
+    fn an_unreviewed_label_is_released_only_by_a_head_that_demonstrably_moved() {
+        let config = DueConfig::default();
+
+        // Never recorded a reviewed SHA: nothing proves the head moved, so
+        // the label holds. Guessing the other way buys a round-1 price every
+        // cycle, forever.
+        let mut unknown = facts();
+        unknown.unreviewed_label = true;
+        assert_eq!(
+            decide(&unknown, &config),
+            Due::Skip("review-unreviewed".into())
+        );
+
+        // Recorded, and equal: still the head that was given up on.
+        let mut same = facts();
+        same.unreviewed_label = true;
+        same.last_sha = Some(HEAD);
+        assert_eq!(
+            decide(&same, &config),
+            Due::Skip("review-unreviewed".into())
+        );
+
+        // Recorded, and different: the label is stale and the PR is due.
+        let mut moved = facts();
+        moved.unreviewed_label = true;
+        moved.last_sha = Some(OLD);
+        assert_eq!(decide(&moved, &config), Due::Review("push".into()));
+
+        // A draft still wins over everything.
+        let mut draft = facts();
+        draft.unreviewed_label = true;
+        draft.last_sha = Some(OLD);
+        draft.draft = true;
+        assert_eq!(decide(&draft, &config), Due::Skip("draft".into()));
+    }
+
+    #[test]
+    fn a_disabled_trigger_does_not_fire() {
+        let config = DueConfig {
+            debounce_seconds: 600,
+            triggers: vec!["push".into()],
+        };
+        let mut ready = facts();
+        ready.ready = true;
+        ready.last_sha = Some(HEAD);
+        assert_eq!(decide(&ready, &config), Due::Skip("reviewed".into()));
+
+        let no_push = DueConfig {
+            debounce_seconds: 600,
+            triggers: vec!["ready".into()],
+        };
+        let mut moved = facts();
+        moved.last_sha = Some(OLD);
+        assert_eq!(
+            decide(&moved, &no_push),
+            Due::Skip("push-trigger-disabled".into())
+        );
+    }
+
+    #[test]
+    fn an_unmeasured_round_makes_the_total_unmeasured_not_cheaper() {
+        let none = History::default();
+        assert_eq!(none.cost_line(), "review cost so far: $0.00 over 0 rounds");
+
+        let measured = History {
+            rounds: 2,
+            cost_usd: 1.5,
+            all_measured: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            measured.cost_line(),
+            "review cost so far: $1.50 over 2 rounds"
+        );
+
+        let partial = History {
+            rounds: 2,
+            cost_usd: 1.5,
+            all_measured: false,
+            ..Default::default()
+        };
+        assert_eq!(
+            partial.cost_line(),
+            "review cost so far: unmeasured over 2 rounds"
+        );
+
+        let one = History {
+            rounds: 1,
+            cost_usd: 2.0,
+            all_measured: true,
+            ..Default::default()
+        };
+        assert_eq!(one.cost_line(), "review cost so far: $2.00 over 1 round");
+    }
+}

--- a/crates/edda-cli/src/cmd_review/due.rs
+++ b/crates/edda-cli/src/cmd_review/due.rs
@@ -127,15 +127,29 @@ pub(crate) fn history(repo: &Path, pr: u64) -> Result<History> {
         ..Default::default()
     };
     for event in ledger.iter_events_by_type("review_verdict")? {
+        // Scope by PR *before* deserializing. A `review_verdict` this build
+        // cannot read is fatal for the PR it belongs to — a policy that
+        // silently drops the event it cannot parse is a policy that decides
+        // while blind — but it must not be fatal for every other PR. Reading
+        // `refs.pr` from the raw JSON keeps one malformed event from turning
+        // the whole daemon into `SKIP due-unknown` until the ledger is
+        // repaired.
+        if event.payload.pointer("/refs/pr").and_then(|v| v.as_u64()) != Some(pr) {
+            continue;
+        }
         let payload: ReviewVerdictPayload = serde_json::from_value(event.payload.clone())
             .with_context(|| format!("review_verdict event {}", event.event_id))?;
-        if payload.verdict == "unreviewed" || payload.refs.pr != Some(pr) {
+        if payload.verdict == "unreviewed" {
             continue;
         }
         history.rounds += 1;
         history.last_sha = Some(payload.subject.head_sha.clone());
         history.last_ts = Some(event.ts.clone());
-        if history.first_session.is_none() {
+        // Round 1's reviewer is the one to resume, and the payload says which
+        // round it is. Taking the first event seen would name whichever round
+        // happens to sit earliest in this ledger — not the same thing on a
+        // machine that only imported later rounds.
+        if payload.refs.round == Some(1) {
             history.first_session = Some(payload.reviewer.session_id.clone());
         }
         match (payload.cost.measured, payload.cost.usd) {
@@ -199,12 +213,21 @@ pub(crate) fn decide(facts: &Facts, config: &DueConfig) -> Due {
     // A Review Response is the implementer saying "look again", and it counts
     // only if it arrived after the verdict it answers. An older one is the
     // previous round's, already answered.
+    //
+    // A response with **no** verdict to compare against is not a trigger. It
+    // reads like one — the comment is right there — but this branch is not
+    // debounced and nothing records that a response was acted on, so answering
+    // "review" to an uncomparable response answers it again on the next poll,
+    // and every poll after that, each at round-1 price. Verdicts do not cross
+    // machines yet (GH-671: `review_verdict` is not among the event types the
+    // committed mirror imports) and a round published only through the §7
+    // comment path writes no event at all, so "no verdict in this ledger" is
+    // the common case rather than the exotic one. Such a PR falls through to
+    // the push rule below, which is debounced and reads the daemon's own
+    // recorded head — the record that actually exists.
     if config.enabled("response") {
-        if let Some(response_at) = facts.response_at {
-            let after_verdict = facts
-                .last_verdict_at
-                .is_none_or(|verdict_at| response_at > verdict_at);
-            if after_verdict {
+        if let (Some(response_at), Some(verdict_at)) = (facts.response_at, facts.last_verdict_at) {
+            if response_at > verdict_at {
                 return Due::Review("response".into());
             }
         }
@@ -221,13 +244,19 @@ pub(crate) fn decide(facts: &Facts, config: &DueConfig) -> Due {
     // The debounce is the cost switch. A head that moved 20 seconds ago is
     // usually mid-sequence — the fixup, the second thought, the CI-driven
     // amend — and reviewing it buys a round-1 price for a tree about to
-    // change again. Without `--pushed-at` there is nothing to wait on, so the
-    // moved head is due at once rather than silently held.
+    // change again.
+    //
+    // An unknown push time waits rather than proceeding. The caller cannot
+    // tell "this PR has no commit date" from "the forge call failed", and the
+    // second is the dangerous one: a rate limit or an expired token would
+    // otherwise turn the cost switch off for every PR at once, which is
+    // exactly when the daemon is polling hardest. Holding costs one cycle;
+    // proceeding costs a round.
+    let debounce = i64::try_from(config.debounce_seconds).unwrap_or(i64::MAX);
     let Some(pushed_at) = facts.pushed_at else {
-        return Due::Review("push".into());
+        return Due::Skip("debounce push-time-unknown".into());
     };
     let settled_for = facts.now.saturating_sub(pushed_at);
-    let debounce = config.debounce_seconds as i64;
     if settled_for >= debounce {
         Due::Review("push".into())
     } else {
@@ -364,6 +393,86 @@ mod tests {
     }
 
     #[test]
+    fn a_response_with_no_verdict_to_answer_is_not_a_trigger() {
+        // Round 1's P1: `is_none_or` read a missing verdict as "the response
+        // is newer", so a PR carrying a Review Response and no ledger verdict
+        // was due on every poll, forever, at round-1 price. Verdicts do not
+        // cross machines (GH-671) and a §7-comment round writes no event, so
+        // this is the ordinary shape, not an exotic one.
+        let config = DueConfig::default();
+        let mut f = facts();
+        f.response_at = Some(9_000);
+        f.last_verdict_at = None;
+        f.last_sha = Some(HEAD); // head unmoved: nothing else can make it due
+        assert_eq!(decide(&f, &config), Due::Skip("reviewed".into()));
+    }
+
+    #[test]
+    fn a_response_still_opens_the_next_round_when_a_verdict_exists() {
+        // The trigger itself is unchanged for the case it was written for.
+        let config = DueConfig::default();
+        let mut f = facts();
+        f.last_sha = Some(HEAD);
+        f.last_verdict_at = Some(9_000);
+        f.response_at = Some(9_001);
+        assert_eq!(decide(&f, &config), Due::Review("response".into()));
+        // ...and an older response is the previous round's, already answered.
+        f.response_at = Some(8_999);
+        assert_eq!(decide(&f, &config), Due::Skip("reviewed".into()));
+    }
+
+    #[test]
+    fn an_unverdicted_response_falls_through_to_the_debounced_push_rule() {
+        // Falling through is the point: the PR is still reviewable, but by the
+        // rule that has a cost switch on it rather than the one that does not.
+        let config = DueConfig::default();
+        let mut f = facts();
+        f.response_at = Some(9_000);
+        f.last_verdict_at = None;
+        f.last_sha = Some(OLD);
+        f.pushed_at = Some(f.now - 10);
+        assert_eq!(
+            decide(&f, &config),
+            Due::Skip(format!("debounce {}s", config.debounce_seconds - 10))
+        );
+        f.pushed_at = Some(f.now - config.debounce_seconds as i64);
+        assert_eq!(decide(&f, &config), Due::Review("push".into()));
+    }
+
+    #[test]
+    fn an_unknown_push_time_waits_rather_than_opening_the_switch() {
+        // Round 1's other P1: the caller cannot tell "no commit date" from
+        // "the forge call failed", and a rate limit would otherwise disable
+        // the debounce for every PR at once — precisely when the daemon is
+        // polling hardest. Holding costs a cycle; proceeding costs a round.
+        let config = DueConfig::default();
+        let mut f = facts();
+        f.last_sha = Some(OLD);
+        f.pushed_at = None;
+        assert_eq!(
+            decide(&f, &config),
+            Due::Skip("debounce push-time-unknown".into())
+        );
+    }
+
+    #[test]
+    fn an_enormous_configured_debounce_does_not_wrap_the_switch_open() {
+        // `as i64` turned a debounce >= 2^63 negative, so `settled_for >=
+        // debounce` always held and the switch was permanently open.
+        let config = DueConfig {
+            debounce_seconds: u64::MAX,
+            ..DueConfig::default()
+        };
+        let mut f = facts();
+        f.last_sha = Some(OLD);
+        f.pushed_at = Some(f.now - 1);
+        assert!(
+            matches!(decide(&f, &config), Due::Skip(reason) if reason.starts_with("debounce ")),
+            "a saturating debounce must hold, never open"
+        );
+    }
+
+    #[test]
     fn a_draft_is_not_a_subject() {
         let config = DueConfig::default();
         let mut f = facts();
@@ -444,16 +553,6 @@ mod tests {
     }
 
     #[test]
-    fn a_moved_head_with_no_push_time_is_due_at_once() {
-        // Nothing to wait on, so holding it would be an indefinite hold, not
-        // a debounce.
-        let config = DueConfig::default();
-        let mut f = facts();
-        f.last_sha = Some(OLD);
-        assert_eq!(decide(&f, &config), Due::Review("push".into()));
-    }
-
-    #[test]
     fn an_unreviewed_label_is_released_only_by_a_head_that_demonstrably_moved() {
         let config = DueConfig::default();
 
@@ -477,9 +576,13 @@ mod tests {
         );
 
         // Recorded, and different: the label is stale and the PR is due.
+        // The push time is settled so this asserts the label rule rather than
+        // the debounce — without one the answer would be "wait", which is
+        // true but about a different rule.
         let mut moved = facts();
         moved.unreviewed_label = true;
         moved.last_sha = Some(OLD);
+        moved.pushed_at = Some(moved.now - config.debounce_seconds as i64);
         assert_eq!(decide(&moved, &config), Due::Review("push".into()));
 
         // A draft still wins over everything.

--- a/crates/edda-cli/src/cmd_review/mod.rs
+++ b/crates/edda-cli/src/cmd_review/mod.rs
@@ -1,6 +1,8 @@
 //! Cross-vendor review: the host owns evidence and policy, the engine judges.
 mod args;
 mod brief;
+mod config;
+mod due;
 mod evidence;
 mod gate;
 mod git;
@@ -20,6 +22,7 @@ use crate::agent_kind::{
 use crate::cmd_dispatch::{build_phase, CapabilityOptions};
 use anyhow::{bail, Result};
 pub use args::ReviewArgs;
+pub use due::DueArgs;
 use edda_conductor::agent::launcher::{AgentLauncher, PhaseResult};
 use edda_core::{
     ReviewBrief, ReviewCost, ReviewFinding, ReviewReviewer, ReviewSubject, ReviewVerdictPayload,
@@ -35,6 +38,13 @@ use tokio_util::sync::CancellationToken;
 /// today, and a subcommand layer must not move them.
 #[derive(clap::Subcommand)]
 pub enum ReviewCmd {
+    /// Is this PR worth reviewing again? The trigger policy (GH-763)
+    ///
+    /// Reads only. Exit: 0 due, 1 not due, 2 cannot judge.
+    Due {
+        #[command(flatten)]
+        args: DueArgs,
+    },
     /// Union rule and window check over the verdicts standing on a SHA
     ///
     /// Reads only. Exit: 0 pass, 1 fail, 2 cannot judge.
@@ -46,6 +56,7 @@ pub enum ReviewCmd {
 
 pub fn run_cmd(cmd: ReviewCmd, cwd: &Path) -> Result<()> {
     match cmd {
+        ReviewCmd::Due { args } => due::run(args, cwd),
         ReviewCmd::Gate { args } => gate::run(args, cwd),
     }
 }

--- a/docs/guides/pr-review-watcher.md
+++ b/docs/guides/pr-review-watcher.md
@@ -157,6 +157,29 @@ sh scripts/test-pr-review-watch.sh         # 離線測試：審/跳過決策 + v
 | `review:unreviewed` | 同運輸重試一次後仍無判決（或連續 3 次啟動失敗）；**per head**——只擋被記錄的那個 head，新 head 會自動摘 label 重審 |
 | `review:post-failed` | 判決或 ack 連續多次貼不出去（判決 5 次／ack 3 次）；判決檔留在 scratch 目錄，人工補貼後照 `review:unreviewed` 的救法收尾 |
 
+## 觸發與成本
+
+「這張 PR 值不值得再審一輪」是本系統的**主成本開關**，規則住在
+`edda review due`（GH-763），daemon 只蒐集事實。#754 實測：round 1 的 Opus 審查
+$1.28–$2.57，同一張 PR 續談的 delta 輪 $0.22 → $0.02。舊規則是「head 變了就審」，
+一張 PR push 五次就是五次 round 1 的價錢。
+
+| 觸發 | 是否 debounce | 說明 |
+|---|---|---|
+| `draft` | — | 草稿不是審查對象，最先擋掉，任何設定都打不開 |
+| `ready` | 否 | 離開草稿是一次性事件，操作者正在等 |
+| `response` | 否 | `## Review Response: Round N` 晚於上一則判決才算 |
+| `push` | **是** | 只有 push 會重複，所以只有它要等 head 靜下來 |
+
+預設 debounce 600 秒。改 `.edda/review/due.json`：
+
+```json
+{ "debounce_seconds": 600, "triggers": ["ready", "response", "push"] }
+```
+
+每次判斷都會在 `watch.log` 留一行 `prN review cost so far: …`，缺量測印
+`unmeasured` 而不是 `$0.00`。
+
 ## 離線測試
 
 `sh scripts/test-pr-review-watch.sh`（移植自 PR #639，Round 2–4 擴充）：**完全離線**——
@@ -166,11 +189,13 @@ sh scripts/test-pr-review-watch.sh         # 離線測試：審/跳過決策 + v
 `~/.edda/fleet/watch.log` 在整輪測試前後大小不變」；每個場景都包
 `timeout`，卡住＝FAIL，不會吊住呼叫端。實況：
 
-- `decide` 子命令吃的是 `gh pr list --jq '… \| @tsv'` 產出的 **TSV** 行（draft 在
-  `--jq` 的 `select(.isDraft\|not)` 就被濾掉，套件中沒有 draft fixture）：新 PR → 審、
-  同 SHA 已審 → 跳過、push 新 head → 再審、label 逐 PR 判讀（無 label 的 PR 1 不被
-  PR 2 的 `review:unreviewed` 壓住）、`review:unreviewed` per head（同 head 擋、
-  新 head 摘 label 重審、無記錄 head 保守擋）、空佇列、缺 head SHA。
+- `decide` 子命令吃的是 `gh pr list --jq '… \| @tsv'` 產出的 **TSV** 行，逐 PR 蒐集
+  forge 事實後呼叫 `edda review due`（GH-763）。套件測的是**接線**，不是規則：
+  exit 0 → 入審查佇列、1 → 帶著 verb 自己的理由跳過、其他 → 記 log 並跳過（絕不
+  因為判斷不了就去審）。另外斷言 daemon 確實把 `--head`／`--pr`／`--last-reviewed`／
+  `--unreviewed-label` 交出去，以及 `decide()` 內不再有任何 SHA 或時間比較。
+  規則本身（draft、ready、response、debounce）在 `cmd_review::due` 的單元測試裡驗，
+  因為只有那裡能注入時鐘。
 - `verdict-label`：判決文字 → label，後者贏。
 - `label-verdict`：verdict label 只在「目前 head == 被審 SHA」時套用；head 未知也跳過。
 - `ack-try`（stub gh）：失敗記 "launched, ack pending" → 成功才清；3 次都失敗且

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1245,3 +1245,61 @@ Stdout is one line — `PASS <sha> verdicts=<n>`, `FAIL <sha> <reason>` or
 | 0 | Pass: the union rule is satisfied and the window is clear |
 | 1 | Fail: a non-qualifying verdict stands (`union`), or the base moved (`window`) |
 | 2 | No verdict on the SHA — an inability to judge, not a judgment |
+
+#### edda review due
+
+Is this PR worth reviewing again? Read-only: it launches nothing, writes no
+event, and never touches GitHub.
+
+```bash
+edda review due --head <sha> --pr 42 --pushed-at 2026-09-07T12:00:00Z
+edda review due --head <sha> --pr 42 --draft
+```
+
+This is the main cost switch in the review system. A round-1 Opus review
+measured $1.28-$2.57 on #754; the resumed delta round of the same PR measured
+$0.22 and then $0.02. Reviewing once per push therefore buys a round-1 price
+per push, which is what this verb exists to stop.
+
+The policy, in order — the first matching row wins:
+
+| Condition | Answer |
+|---|---|
+| `--draft` | `SKIP draft` |
+| `--unreviewed-label` and the head has not demonstrably moved | `SKIP review-unreviewed` |
+| `--ready` (the PR left draft this cycle) | `REVIEW ready` |
+| `--response-at` newer than the last verdict | `REVIEW response` |
+| head moved and the push has settled | `REVIEW push` |
+| head moved, still inside the debounce | `SKIP debounce <n>s` |
+| otherwise | `SKIP reviewed` |
+
+`ready` and `response` are one-time events the operator is waiting on, so
+neither is debounced; only `push` is, because only `push` repeats. A draft is
+refused first and cannot be enabled by any trigger.
+
+Facts come from the caller, and rounds from the ledger. `--last-reviewed`
+matters: a round published through the §7 comment path writes no
+`review_verdict` event, so the daemon's own record is the only evidence it
+happened, and without it every cycle would read as never-reviewed.
+
+Stdout is two lines — `REVIEW <reason>` or `SKIP <reason>`, then
+`review cost so far: $X over N rounds`. A round whose cost was never measured
+makes the whole total read `unmeasured` rather than contributing zero: a sum
+that silently drops a round reads cheaper than the truth. A second or later
+round appends ` --resume <session id>` naming round 1's reviewer session.
+
+Settings live in `.edda/review/due.json`, and absent means defaults:
+
+```json
+{ "debounce_seconds": 600, "triggers": ["ready", "response", "push"] }
+```
+
+A file that exists but cannot be parsed is an error, not a silent fallback —
+an operator who wrote a debounce and got the default one would be paying for a
+switch they believe they threw.
+
+| Exit | Meaning |
+|---|---|
+| 0 | Due: start a round |
+| 1 | Not due, for the printed reason |
+| 2 | Cannot judge — an unreadable ledger or a malformed argument, never a decision |

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -113,37 +113,94 @@ log() { echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') $*" >> "$WATCHLOG"; }
 #     --jq '.[] | select(.isDraft|not) | [.number, .headRefOid, ([.labels[].name]|join(",")), .updatedAt] | @tsv'
 # (row: number<TAB>sha<TAB>labels<TAB>updatedAt; drafts are filtered by the --jq).
 # Output per PR: "REVIEW <n> <sha>" (+" drop-unreviewed-label" when a stale
-# review:unreviewed label must be removed) or "SKIP <n> <reason>". Pure: no
-# network, no state mutation; the state file is read-only here.
+# review:unreviewed label must be removed) or "SKIP <n> <reason>".
+#
+# GH-763: this function gathers forge facts and asks `edda review due` whether
+# each PR is worth a round; it decides nothing itself. Nothing here compares a
+# SHA or a timestamp, because "is this worth reviewing again" is the main cost
+# switch in the system — a round-1 Opus review measured $1.28-$2.57 on #754 —
+# and that judgement belongs in the binary (#766 D8). Exit 0 launches, 1
+# skips with the verb's own reason, anything else is logged and skipped.
+# The state file is still read-only here; the cost line is logged per PR.
 decide() {
   state=${PR_REVIEW_WATCH_STATE:-$SCRATCH/review-state.tsv}
-  # Pass the state path via the environment, not -v: gawk processes escape
-  # sequences in -v values, which mangles Windows paths (C:\Users\...).
-  PR_REVIEW_STATE_TMP="$state" awk -F'\t' '
-    BEGIN {
-      sf = ENVIRON["PR_REVIEW_STATE_TMP"]
-      if (sf != "") {
-        while ((getline line < sf) > 0) {
-          split(line, s, "\t")
-          rev[s[1]] = s[2]
-        }
-        close(sf)
-      }
-    }
-    {
-      num = $1; sha = $2; labels = $3
-      if (num !~ /^[0-9]+$/) next
-      if (sha == "") { print "SKIP " num " missing-head"; next }
-      if (("," labels ",") ~ /,review:unreviewed,/) {
-        if (rev[num] == sha || rev[num] == "") {
-          print "SKIP " num " review-unreviewed"; next
-        }
-        print "REVIEW " num " " sha " drop-unreviewed-label"; next
-      }
-      if (rev[num] == sha) { print "SKIP " num " already-reviewed"; next }
-      print "REVIEW " num " " sha
-    }
-  '
+  # `|| [ -n "$row" ]` because a final line with no trailing newline makes
+  # `read` return non-zero after it has already assigned; awk, which this
+  # replaced, never had that edge and the fixtures feed exactly that shape.
+  while IFS= read -r row || [ -n "${row:-}" ]; do
+    # Split on tabs by hand. `IFS=<tab> read a b c` collapses runs of tabs,
+    # because tab is IFS whitespace — so a row whose head SHA is empty arrives
+    # with its timestamp sitting in the SHA field, and the daemon would queue a
+    # review of a timestamp. awk's -F'\t' never did that.
+    num=${row%%"$TAB"*}
+    rest=${row#*"$TAB"}
+    [ "$rest" = "$row" ] && rest=
+    sha=${rest%%"$TAB"*}
+    rest=${rest#*"$TAB"}
+    [ "$rest" = "$sha" ] && rest=
+    labels=${rest%%"$TAB"*}
+    case "$num" in ''|*[!0-9]*) continue ;; esac
+    if [ -z "$sha" ]; then
+      printf 'SKIP %s missing-head\n' "$num"
+      continue
+    fi
+
+    # ---- facts, and only facts ------------------------------------------
+    # The reviewed head THIS daemon recorded. Deliberately not the ledger's:
+    # a round published through the §7 comment path writes no review_verdict
+    # event, so the daemon's own state is the only record that it happened.
+    prev=$(awk -F'\t' -v n="$num" '$1 == n { last = $2 } END { print last }' \
+      "$state" 2>/dev/null)
+
+    unreviewed=""
+    case ",$labels," in *,review:unreviewed,*) unreviewed=--unreviewed-label ;; esac
+
+    facts=$(gh pr view "$num" --repo "$REPO" --json isDraft,commits,comments \
+      --jq '[
+        (if .isDraft then "draft" else "" end),
+        ((.commits // []) | last | .committedDate // ""),
+        ((.comments // [])
+          | map(select(.body | test("(?m)^## Review Response: Round [0-9]+")))
+          | last | .createdAt // "")
+      ] | @tsv' 2>/dev/null) || facts=""
+    draft=$(printf '%s' "$facts" | cut -f1)
+    pushed_at=$(printf '%s' "$facts" | cut -f2)
+    response_at=$(printf '%s' "$facts" | cut -f3)
+    if [ "$draft" = draft ]; then draft=--draft; else draft=""; fi
+
+    # ---- the judgement is the product's ----------------------------------
+    out=$SCRATCH/due.$num
+    "${EDDA_BIN:-edda}" review due --head "$sha" --pr "$num" \
+      ${prev:+--last-reviewed "$prev"} \
+      ${pushed_at:+--pushed-at "$pushed_at"} \
+      ${response_at:+--response-at "$response_at"} \
+      ${draft:+$draft} ${unreviewed:+$unreviewed} >"$out" 2>&1
+    rc=$?
+
+    cost=$(sed -n "s/^review cost so far/pr$num review cost so far/p" "$out" | head -1)
+    [ -n "$cost" ] && log "$cost"
+
+    case $rc in
+      0)
+        # The stale review:unreviewed label is dropped by whoever launches;
+        # reaching here at all means the policy released it.
+        if [ -n "$unreviewed" ]; then
+          printf 'REVIEW %s %s drop-unreviewed-label\n' "$num" "$sha"
+        else
+          printf 'REVIEW %s %s\n' "$num" "$sha"
+        fi
+        ;;
+      1)
+        printf 'SKIP %s %s\n' "$num" \
+          "$(sed -n 's/^SKIP //p' "$out" | head -1)"
+        ;;
+      *)
+        log "pr$num due check could not judge: $(head -2 "$out" | tr '\n' ' ')"
+        printf 'SKIP %s due-unknown\n' "$num"
+        ;;
+    esac
+    rm -f "$out"
+  done
 }
 
 # label-verdict: should the verdict label be applied? Only when the PR's

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -9,7 +9,7 @@
 # no status, no label), and posts its own receipts to the log, not the comment.
 #
 # usage: pr-review-watch.sh [--once] [--dry-run]
-#        pr-review-watch.sh decide                 (offline helper; TSV on stdin)
+#        pr-review-watch.sh decide                 (TSV on stdin; calls gh + edda)
 #        pr-review-watch.sh label-verdict <reviewed-sha> <current-head>
 #        pr-review-watch.sh ack-try <pr> <sha> <attempts>
 #        pr-review-watch.sh gate-state <sha>            (offline helper; verdict TSV on stdin)
@@ -106,7 +106,7 @@ WATCHLOG=${PR_REVIEW_WATCH_LOG:-$SCRATCH/watch.log}   # set early: offline
                      # subcommands log gh failures too, not just the main loop
 log() { echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') $*" >> "$WATCHLOG"; }
 
-# ---- offline helpers (unit-tested by scripts/test-pr-review-watch.sh) --------
+# ---- helpers (unit-tested by scripts/test-pr-review-watch.sh) ----------------
 
 # decide: PR queue triage. Input: one TSV row per open non-draft PR from
 #   gh pr list --repo R --state open --json number,headRefOid,isDraft,labels,updatedAt \
@@ -155,14 +155,24 @@ decide() {
     unreviewed=""
     case ",$labels," in *,review:unreviewed,*) unreviewed=--unreviewed-label ;; esac
 
-    facts=$(gh pr view "$num" --repo "$REPO" --json isDraft,commits,comments \
+    # A failure here — rate limit, expired token, network — must be visible.
+    # Losing these facts does not stop the cycle, but it does remove the
+    # inputs the debounce runs on, and the verb holds rather than proceeding
+    # when it cannot see a push time. Silently degrading to "no facts" hid
+    # both halves: the outage, and the reason the answers changed.
+    if facts=$(gh pr view "$num" --repo "$REPO" --json isDraft,commits,comments \
       --jq '[
         (if .isDraft then "draft" else "" end),
         ((.commits // []) | last | .committedDate // ""),
         ((.comments // [])
           | map(select(.body | test("(?m)^## Review Response: Round [0-9]+")))
           | last | .createdAt // "")
-      ] | @tsv' 2>/dev/null) || facts=""
+      ] | @tsv' 2>/dev/null); then
+      :
+    else
+      log "pr$num gh pr view failed; deciding without draft/push/response facts"
+      facts=""
+    fi
     draft=$(printf '%s' "$facts" | cut -f1)
     pushed_at=$(printf '%s' "$facts" | cut -f2)
     response_at=$(printf '%s' "$facts" | cut -f3)
@@ -179,6 +189,11 @@ decide() {
 
     cost=$(sed -n "s/^review cost so far/pr$num review cost so far/p" "$out" | head -1)
     [ -n "$cost" ] && log "$cost"
+    # The decision line carries `--resume <session>` from round 2 on. Logging
+    # it is what makes the published id observable at all: nothing downstream
+    # parses it, and without this the id was written and deleted unread.
+    decision=$(sed -n '1{/^REVIEW /p;}' "$out")
+    [ -n "$decision" ] && log "pr$num $decision"
 
     case $rc in
       0)
@@ -416,7 +431,9 @@ ack_try() { # $1=pr $2=sha $3=attempts — one attempt.
 
 # ---- offline subcommand dispatch (after all definitions) ---------------------
 case "${1:-}" in
-  decide) decide; exit 0 ;;
+  # decide writes a per-row scratch file, so it needs $SCRATCH the way
+  # ack-try does. The daemon path creates it below; this one runs before that.
+  decide) mkdir -p "$SCRATCH"; decide; exit 0 ;;
   label-verdict) label_verdict "${2:-}" "${3:-}"; exit 0 ;;
   gate-state) gate_state "${2:-}"; exit 0 ;;
   collect-verdicts)

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -217,25 +217,6 @@ reset_stubs() {
 
 # --- decide: PR queue triage from `gh pr list --jq @tsv` rows -----------------
 # Each input line: number<TAB>headRefOid<TAB>labels(joined by ",")<TAB>updatedAt
-expect_decide() {
-    name=$1
-    expected=$2
-    state_lines=$3
-    rows=$4
-    case_number=$((case_number + 1))
-    state="$tmp/state-$case_number"
-    printf '%b' "$state_lines" >"$state"
-    if ! actual=$(printf '%b' "$rows" | \
-        PR_REVIEW_WATCH_STATE="$state" timeout 60 sh "$root/scripts/pr-review-watch.sh" decide); then
-        printf '%s: decide exited non-zero\n' "$name" >&2
-        return 1
-    fi
-    if [ "$actual" != "$expected" ]; then
-        printf '%s: expected\n  %s\ngot\n  %s\n' "$name" "$expected" "$actual" >&2
-        return 1
-    fi
-}
-
 # --- verdict-label: verdict text to review label ------------------------------
 
 expect_label() {
@@ -308,69 +289,124 @@ pending_get() { cat "$EDDA_FLEET_SCRATCH/review-pending.tsv" 2>/dev/null || true
 state_get()   { cat "$EDDA_FLEET_SCRATCH/review-state.tsv" 2>/dev/null || true; }
 
 # --- decide -------------------------------------------------------------------
+# GH-763 moved the trigger rule into `edda review due`, so what the daemon owns
+# here — and all these cases can now assert — is the wiring: it gathers the
+# forge facts, hands them to the verb, and turns the verb's exit code into a
+# queue decision. The rule itself (draft, ready, response, debounce, the
+# review:unreviewed release) is proven in `cmd_review::due`'s unit tests, which
+# can inject a clock; a shell fixture cannot.
 
-expect_decide \
-    'new PR is queued for review' \
+# A fake `edda` whose `review due` returns a fixed exit code and body, and which
+# records the argv it was handed so the fact-gathering can be asserted.
+stub_due() { # $1=exit code  $2=stdout body
+    dir=$(mktemp -d "$tmp/due.XXXXXX")
+    {
+        printf '#!/bin/sh\n'
+        printf 'printf "%%s\\n" "$*" >>"%s/argv"\n' "$dir"
+        printf 'printf "%%b" %s\n' "'$2'"
+        printf 'exit %s\n' "$1"
+    } >"$dir/edda"
+    chmod +x "$dir/edda"
+    printf '%s' "$dir"
+}
+
+expect_decide_wired() { # name expected-stdout exit body state rows
+    name=$1; expected=$2; code=$3; body=$4; state_lines=$5; rows=$6
+    case_number=$((case_number + 1))
+    state="$tmp/state-$case_number"
+    printf '%b' "$state_lines" >"$state"
+    dir=$(stub_due "$code" "$body")
+    actual=$(printf '%b' "$rows" | EDDA_BIN="$dir/edda" \
+        PR_REVIEW_WATCH_STATE="$state" timeout 60 \
+        sh "$root/scripts/pr-review-watch.sh" decide)
+    DUE_ARGV="$dir/argv"
+    if [ "$actual" != "$expected" ]; then
+        printf '%s: expected\n  %s\ngot\n  %s\n' "$name" "$expected" "$actual" >&2
+        return 1
+    fi
+}
+
+expect_decide_wired \
+    'exit 0 queues the PR for review' \
     'REVIEW 42 abc123' \
+    0 'REVIEW push\nreview cost so far: $0.00 over 0 rounds\n' \
     '' \
     '42\tabc123\t\t2026-09-02T00:00:00Z'
 
-expect_decide \
-    'same SHA already reviewed is skipped' \
-    'SKIP 42 already-reviewed' \
-    '42\tabc123\n' \
-    '42\tabc123\t\t2026-09-02T00:00:00Z'
-
-expect_decide \
-    'new head SHA after push is reviewed again' \
-    'REVIEW 42 def456' \
+expect_decide_wired \
+    "exit 1 skips it, carrying the verb's own reason" \
+    'SKIP 42 debounce 540s' \
+    1 'SKIP debounce 540s\nreview cost so far: $1.28 over 1 round\n' \
     '42\tabc123\n' \
     '42\tdef456\t\t2026-09-02T00:00:00Z'
 
-expect_decide \
-    'labels are scoped per PR: unlabeled PR 1 is REVIEW while PR 2 has review:unreviewed' \
-    'REVIEW 1 aaa111
-SKIP 2 review-unreviewed' \
+expect_decide_wired \
+    'a verb that cannot judge skips rather than reviews' \
+    'SKIP 42 due-unknown' \
+    2 'edda review due: unreadable ledger\n' \
     '' \
-    '1\taaa111\t\t2026-09-02T00:00:00Z\n2\tbbb222\treview:unreviewed\t2026-09-02T00:00:00Z'
+    '42\tabc123\t\t2026-09-02T00:00:00Z'
 
-expect_decide \
-    'review:unreviewed blocks the head it was recorded for' \
-    'SKIP 42 review-unreviewed' \
-    '42\tabc123\t2\n' \
-    '42\tabc123\treview:unreviewed\t2026-09-02T00:00:00Z'
+expect_decide_wired \
+    'an unexpected exit is also not a review' \
+    'SKIP 42 due-unknown' \
+    127 '' \
+    '' \
+    '42\tabc123\t\t2026-09-02T00:00:00Z'
 
-expect_decide \
-    'a new head after review:unreviewed is reviewed again and drops the stale label' \
+# The daemon's own reviewed-head record and the label are facts it must hand
+# over — the verb cannot see either. A round published through the §7 comment
+# path writes no ledger event, so `--last-reviewed` is the only evidence it
+# happened.
+expect_decide_wired \
+    'the recorded head and the unreviewed label are handed to the verb' \
     'REVIEW 42 def456 drop-unreviewed-label' \
+    0 'REVIEW push\n' \
     '42\tabc123\t2\n' \
     '42\tdef456\treview:unreviewed\t2026-09-02T00:00:00Z'
+argv=$(cat "$DUE_ARGV" 2>/dev/null)
+for flag in '--head def456' '--pr 42' '--last-reviewed abc123' '--unreviewed-label'; do
+    case "$argv" in
+        *"$flag"*) ;;
+        *) printf 'decide: the verb was not handed %s, got:\n  %s\n' "$flag" "$argv" >&2; exit 1 ;;
+    esac
+done
 
-expect_decide \
-    'review:unreviewed with no recorded head still blocks' \
-    'SKIP 42 review-unreviewed' \
-    '' \
-    '42\tabc123\treview:unreviewed\t2026-09-02T00:00:00Z'
-
-expect_decide \
-    'empty open-PR queue decides nothing' \
-    '' \
-    '' \
-    ''
-
-expect_decide \
-    'missing head SHA is skipped, not queued' \
+expect_decide_wired \
+    'a PR with no head is refused before the verb is asked' \
     'SKIP 42 missing-head' \
+    0 'REVIEW push\n' \
     '' \
     '42\t\t\t2026-09-02T00:00:00Z'
 
-expect_decide \
-    'decisions are independent per PR' \
-    'SKIP 7 already-reviewed
-REVIEW 8 beefff
-SKIP 9 review-unreviewed' \
-    '7\tcccccc\n' \
-    '7\tcccccc\t\t2026-09-02T00:00:00Z\n8\tbeefff\t\t2026-09-02T00:00:00Z\n9\tdddddd\treview:unreviewed\t2026-09-02T00:00:00Z'
+expect_decide_wired \
+    'an empty queue decides nothing' \
+    '' \
+    0 'REVIEW push\n' \
+    '' \
+    ''
+
+expect_decide_wired \
+    'each PR in the queue is decided on its own' \
+    'REVIEW 7 cccccc
+REVIEW 8 beefff' \
+    0 'REVIEW push\n' \
+    '' \
+    '7\tcccccc\t\t2026-09-02T00:00:00Z\n8\tbeefff\t\t2026-09-02T00:00:00Z'
+
+# doneWhen: no trigger judgement is left in the shell. `decide()` may branch on
+# whether a field is present and on the verb's exit code; it may not compare a
+# SHA or a timestamp, because that comparison is the cost switch.
+decide_body=$(sed -n '/^decide()/,/^}/p' "$root/scripts/pr-review-watch.sh")
+if printf '%s\n' "$decide_body" | grep -qE '\$(prev|sha|pushed_at|response_at)"? *(=|!=|-eq|-ne|-lt|-gt|<|>)'; then
+    printf 'decide: a SHA or timestamp comparison is back in the shell:\n%s\n' \
+        "$(printf '%s\n' "$decide_body" | grep -nE '\$(prev|sha|pushed_at|response_at)"? *(=|!=|-eq|-ne|-lt|-gt|<|>)')" >&2
+    exit 1
+fi
+if ! printf '%s\n' "$decide_body" | grep -q 'review due'; then
+    printf 'decide: the trigger policy is no longer asked\n' >&2
+    exit 1
+fi
 
 # --- verdict-label ------------------------------------------------------------
 # The label comes from the Verdict line of REVIEW.md §7, not from the last

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -55,6 +55,16 @@ case "$1" in
         ;;
       view)
         case "$*" in
+          *"--json isDraft,commits,comments"*)
+            # decide()'s facts query (GH-763). Without this arm the stub falls
+            # through to a bare `exit 0`, decide() reads three empty fields,
+            # and every assertion about --draft/--pushed-at/--response-at
+            # passes whether or not the wiring exists.
+            [ -n "${GH_FAIL_FACTS:-}" ] && exit 1
+            printf '%s\t%s\t%s\n' "${GH_FACTS_DRAFT:-}" \
+                "${GH_FACTS_PUSHED_AT:-}" "${GH_FACTS_RESPONSE_AT:-}"
+            exit 0
+            ;;
           *"--json comments"*)
             [ -n "${GH_FAIL_COMMENTS:-}" ] && exit 1
             [ -n "${GH_COMMENTS_FILE:-}" ] && cat "$GH_COMMENTS_FILE"
@@ -371,6 +381,45 @@ for flag in '--head def456' '--pr 42' '--last-reviewed abc123' '--unreviewed-lab
         *) printf 'decide: the verb was not handed %s, got:\n  %s\n' "$flag" "$argv" >&2; exit 1 ;;
     esac
 done
+
+# The three facts the debounce runs on must reach the verb. Round 1 of #1070
+# found the suite could not see them go missing: with the entire `gh pr view`
+# block replaced by `facts=""` it still passed, byte-identical.
+export GH_FACTS_DRAFT=draft
+export GH_FACTS_PUSHED_AT=2026-09-02T00:00:00Z
+export GH_FACTS_RESPONSE_AT=2026-09-03T00:00:00Z
+expect_decide_wired \
+    'the draft, push-time and response facts are handed to the verb' \
+    'SKIP 42 draft' \
+    1 'SKIP draft\n' \
+    '42\tabc123\t2\n' \
+    '42\tdef456\t\t2026-09-02T00:00:00Z'
+argv=$(cat "$DUE_ARGV" 2>/dev/null)
+for flag in '--draft' '--pushed-at 2026-09-02T00:00:00Z' '--response-at 2026-09-03T00:00:00Z'; do
+    case "$argv" in
+        *"$flag"*) ;;
+        *) printf 'decide: the verb was not handed %s, got:\n  %s\n' "$flag" "$argv" >&2; exit 1 ;;
+    esac
+done
+unset GH_FACTS_DRAFT GH_FACTS_PUSHED_AT GH_FACTS_RESPONSE_AT
+
+# A failed facts query is logged and does not stop the row. Round 1: every
+# other gh failure in this script logs; this one degraded silently, and it is
+# the one that removes the debounce's inputs.
+: >"$PR_REVIEW_WATCH_LOG"
+export GH_FAIL_FACTS=1
+expect_decide_wired \
+    'a failed facts query is logged and the row still reaches the verb' \
+    'SKIP 42 debounce push-time-unknown' \
+    1 'SKIP debounce push-time-unknown\n' \
+    '42\tabc123\t2\n' \
+    '42\tdef456\t\t2026-09-02T00:00:00Z'
+case "$(cat "$PR_REVIEW_WATCH_LOG" 2>/dev/null)" in
+    *"gh pr view failed"*) ;;
+    *) printf 'decide: a failed facts query was not logged, got:\n  %s\n' \
+        "$(cat "$PR_REVIEW_WATCH_LOG" 2>/dev/null)" >&2; exit 1 ;;
+esac
+unset GH_FAIL_FACTS
 
 expect_decide_wired \
     'a PR with no head is refused before the verb is asked' \


### PR DESCRIPTION
Issue: #763

## What

"Is this PR worth reviewing again" is the main cost switch in the whole review
system, and it lived in `scripts/pr-review-watch.sh`'s awk with one rule: *head
differs from the last reviewed SHA*. That is **one review per push**. A round-1
Opus review measured $1.28–$2.57 on #754; the resumed delta round of the same
PR measured $0.22 and then $0.02. Five pushes on one PR bought five round-1
prices for what a debounce would have charged once.

It is also a judgement, not forge glue (#766 D8). So `edda review due` decides
and the daemon gathers facts:

```
edda review due --head <sha> [--pr N] [--pushed-at T] [--ready]
                [--response-at T] [--draft] [--last-reviewed SHA]
                [--unreviewed-label]
  exit 0  REVIEW <reason> [--resume <session>]
  exit 1  SKIP <reason>
  exit 2  cannot judge
```

Both lines print `review cost so far: $X over N rounds`, so the switch is
visible at the moment it is thrown.

## The policy, in order

| Condition | Answer |
|---|---|
| `--draft` | `SKIP draft` |
| `--unreviewed-label` and the head has not demonstrably moved | `SKIP review-unreviewed` |
| `--ready` | `REVIEW ready` |
| `--response-at` newer than the last verdict | `REVIEW response` |
| head moved, push settled | `REVIEW push` |
| head moved, inside the debounce | `SKIP debounce <n>s` |
| otherwise | `SKIP reviewed` |

`ready` and `response` are one-time events the operator is waiting on, so
neither is debounced; only `push` repeats, so only `push` waits. A draft is
refused first and no trigger setting can open it.

## Two facts the verb cannot see

- **`--last-reviewed`** — the daemon's own reviewed-head record. A round
  published through the §7 comment path writes no `review_verdict` event, so
  the ledger would read it as never-reviewed and make every cycle due. This is
  the same source split as #769's `--verdicts`, and for the same reason: the
  rule is the product's, the facts are the caller's.
- **`--unreviewed-label`** — `review:unreviewed` marks a head the watcher gave
  up on. It is released by the head demonstrably moving, and only by that: with
  no recorded SHA there is no way to tell that it moved, and guessing in the
  reviewing direction buys a round-1 price every cycle, forever.

## `--resume` is published, not re-wired

The REVIEW line carries ` --resume <round-1 session id>` from round 2 on, as
the issue asks. It is **not** threaded into the launcher, because the resume
already exists: `scripts/review-pr.sh:383` sets `PRODUCT_RESUME=--resume` when
`ROUND > 1`, and `edda review`'s `--resume` is a bare flag (`args.rs:38`) that
resumes the session the product itself recorded — it takes no id. Passing an id
from the watcher would be a second mechanism deciding the same thing. So the
verb publishes the id it read from the ledger on its decision line, and the
daemon logs that line (`pr-review-watch.sh`, after the cost line). Round 1 of
this PR found the earlier version of this claim false: the id was written to a
scratch file the daemon read only for the cost line and then deleted, so it had
no consumer at all. Logging it is what makes it observable; comparing it
against `Session observed:` still needs the product arm to emit that line,
which it does not, so **doneWhen 3's second clause is not delivered here** —
hence `Issue:` rather than `Closes`.

## doneWhen

| Requirement | Evidence |
|---|---|
| `SKIP debounce <secs>` / `REVIEW response` / `REVIEW ready` / draft → exit 1 | `cmd_review::due` — `a_draft_is_not_a_subject`, `leaving_draft_and_answering_a_review_are_never_debounced`, `a_moved_head_waits_out_the_debounce_then_becomes_due` |
| three pushes in one debounce window are due once | `three_pushes_inside_one_debounce_window_are_due_once` (injected clock) |
| round ≥ 2 outputs round 1's session id | `judge` appends `--resume <session>` from `History::first_session`; see the section above for why it is not re-wired |
| `decide()` holds no trigger judgement | asserted by the suite itself: `sed -n '/^decide()/,/^}/p'` is grepped for any `$prev`/`$sha`/`$pushed_at`/`$response_at` comparison, and for the `review due` call |
| cost line from the ledger, `unmeasured` never `0` | `an_unmeasured_round_makes_the_total_unmeasured_not_cheaper` |

## Two bugs the rewrite surfaced

Replacing awk with a shell loop broke two things the old fixtures caught, both
fixed here and both worth naming because they are silent:

- `read` returns non-zero on a **final line with no trailing newline** after it
  has already assigned the fields, so the last PR in the queue was dropped. The
  fixtures feed exactly that shape.
- `IFS=<tab> read a b c` **collapses runs of tabs**, because tab is IFS
  whitespace. A row whose head SHA is empty therefore arrived with its
  timestamp sitting in the SHA column, and the daemon would have queued a
  review of a timestamp. `awk -F'\t'` never did that.

## The shell suite

The 11 `expect_decide` cases tested a rule that no longer lives in shell. They
are replaced by cases that test what the daemon still owns — the exit-code
wiring, the facts it hands over, and the absence of any SHA or timestamp
comparison — which is what the issue's verify step specifies. The rule itself
is proven in `cmd_review::due`, which can inject a clock; a shell fixture
cannot.

## Config

`.edda/review/due.json`, absent means defaults:

```json
{ "debounce_seconds": 600, "triggers": ["ready", "response", "push"] }
```

A file that exists but cannot be parsed is an error rather than a silent
fallback: an operator who wrote a debounce and got the default one would be
paying for a switch they believe they threw. `deny_unknown_fields` makes a
typo'd key the same failure.

## Gates ran

- `cargo fmt --all --check` — clean
- `cargo clippy -p edda --all-targets -- -D warnings` — clean
- `cargo test -p edda` — 670 passed, 1 failed
- `sh scripts/lint-file-length.sh --tree` — exit 0
- `sh scripts/test-pr-review-watch.sh` — passed

The one failure is `cmd_review::evidence::tests::deadline_stops_descendant_and_does_not_start_next_gate`,
whose assertion is `started.elapsed() < Duration::from_secs(4)` against a 1s
deadline — a wall-clock flake on a loaded machine, in a module this branch does
not touch. It failed the same way on #1055 and passed 3/3 in isolation there.

## Not in this PR

The issue's third verify bullet — a live receipt showing round 2 costing under
30% of round 1 — needs two real rounds on a real PR through the daemon, which
posts comments and statuses. That is operator-authorized work, not mine.


