### PR TITLE
fix(edda-cli): edda review due — the response trigger, and the resume layer's tests (GH-763 follow-up)

### DIFF
--- a/crates/edda-cli/src/cmd_review/due.rs
+++ b/crates/edda-cli/src/cmd_review/due.rs
@@ -170,7 +170,13 @@ pub(crate) fn history(repo: &Path, pr: u64) -> Result<History> {
         }
         let payload: ReviewVerdictPayload = serde_json::from_value(event.payload.clone())
             .with_context(|| format!("review_verdict event {}", event.event_id))?;
-        if payload.verdict == "unreviewed" {
+        // The raw gate above is a cheap pre-filter, not the decision. A
+        // verdict with no `refs.pr` at all — what `edda review --base X --head
+        // Y` writes when no PR is named — reaches here, and counting it as
+        // this PR's history would attribute another subject's rounds, cost and
+        // resume session to it, and raise `last_verdict_at` enough to answer a
+        // genuine Review Response with `SKIP reviewed`.
+        if payload.verdict == "unreviewed" || payload.refs.pr != Some(pr) {
             continue;
         }
         history.rounds += 1;
@@ -186,8 +192,11 @@ pub(crate) fn history(repo: &Path, pr: u64) -> Result<History> {
         // present is the best available resume target; answering "no session"
         // would send a continuing review back to round-1 price for want of an
         // event this machine never received.
+        // A verdict that records no round at all still names a reviewer worth
+        // resuming; `u32::MAX` would leave `first_session` empty for a ledger
+        // where no event carries a round.
         let round = payload.refs.round.unwrap_or(u32::MAX);
-        if round < history.first_round {
+        if round < history.first_round || history.first_session.is_none() {
             history.first_round = round;
             history.first_session = Some(payload.reviewer.session_id.clone());
         }
@@ -636,6 +645,44 @@ mod tests {
         );
         assert_eq!(history.rounds, 2);
         assert_eq!(history.resume_suffix(), " --resume round-1-session");
+    }
+
+    #[test]
+    fn a_verdict_with_no_pr_belongs_to_no_pr() {
+        // `edda review --base X --head Y` with no --pr writes a verdict whose
+        // refs.pr is absent. Counting it here would attribute another
+        // subject's rounds, cost and resume session to this PR — and raise
+        // last_verdict_at enough to answer a real Review Response with
+        // "reviewed", which is the under-review failure this policy exists to
+        // avoid.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().to_path_buf();
+        let ledger = edda_ledger::Ledger::open_or_init(&root).expect("ledger");
+        let mut value = verdict_payload(42, 1, "orphan", "orphan-session");
+        value["refs"] = serde_json::json!({ "round": 1 });
+        let payload: edda_core::ReviewVerdictPayload =
+            serde_json::from_value(value).expect("payload");
+        let event = edda_core::event::new_review_verdict_event(
+            "main",
+            ledger.last_event_hash().expect("hash").as_deref(),
+            &payload,
+            None,
+            None,
+            &[],
+        )
+        .expect("event");
+        ledger.append_event(&event).expect("append");
+
+        let history = history(&root, 42).expect("history");
+        assert_eq!(
+            history.rounds, 0,
+            "a PR-less verdict is not this PR's round"
+        );
+        assert_eq!(history.resume_suffix(), "");
+        assert!(
+            history.last_ts.is_none(),
+            "and it cannot age this PR's verdict"
+        );
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_review/due.rs
+++ b/crates/edda-cli/src/cmd_review/due.rs
@@ -39,7 +39,7 @@ pub struct DueArgs {
     /// The PR's current head, as a full lowercase 40-hex SHA
     #[arg(long, value_name = "SHA")]
     pub head: String,
-    /// When that head was pushed (RFC3339); without it a moved head is due at once
+    /// When that head was pushed (RFC3339); without it a moved head waits
     #[arg(long, value_name = "RFC3339")]
     pub pushed_at: Option<String>,
     /// The PR left draft during this cycle
@@ -48,6 +48,14 @@ pub struct DueArgs {
     /// Timestamp of the newest `Review Response: Round N` comment (RFC3339)
     #[arg(long, value_name = "RFC3339")]
     pub response_at: Option<String>,
+    /// When the caller last reviewed this PR (RFC3339), from its own record
+    ///
+    /// A ledger verdict answers the same question but only when one exists:
+    /// verdicts do not cross machines (GH-671) and a round published through
+    /// the §7 comment path writes none at all. Without this, a response older
+    /// than a review that did happen still reads as unanswered.
+    #[arg(long, value_name = "RFC3339")]
+    pub last_reviewed_at: Option<String>,
     /// The PR is a draft
     #[arg(long)]
     pub draft: bool,
@@ -77,8 +85,11 @@ pub(crate) struct History {
     pub(crate) last_sha: Option<String>,
     /// Timestamp of that verdict's event.
     pub(crate) last_ts: Option<String>,
-    /// Reviewer session of round 1 — what a later round resumes.
+    /// Reviewer session of the lowest round present — what a later round
+    /// resumes. Round 1 when this ledger has it.
     pub(crate) first_session: Option<String>,
+    /// The round `first_session` came from; `u32::MAX` until one is seen.
+    pub(crate) first_round: u32,
     /// Rounds that produced a verdict.
     pub(crate) rounds: u32,
     /// Summed cost of those rounds, and whether every one of them was measured.
@@ -94,6 +105,19 @@ impl History {
     /// quietly contributing zero: a sum that silently drops a round reads as
     /// cheaper than the truth, which is the one direction a cost display must
     /// never fail in.
+    /// The ` --resume <session>` suffix on a REVIEW line, or empty.
+    ///
+    /// A second round resumes the first round's session: the reviewer already
+    /// holds the diff, the spec and its own findings, which is the difference
+    /// between a $2 round and a $0.02 one. Round 1's session is the one to
+    /// resume — a later round's reviewer holds a delta, not the whole subject.
+    pub(crate) fn resume_suffix(&self) -> String {
+        match (self.rounds >= 1, self.first_session.as_deref()) {
+            (true, Some(session)) => format!(" --resume {session}"),
+            _ => String::new(),
+        }
+    }
+
     pub(crate) fn cost_line(&self) -> String {
         let rounds = if self.rounds == 1 { "round" } else { "rounds" };
         if self.rounds == 0 {
@@ -124,6 +148,7 @@ pub(crate) fn history(repo: &Path, pr: u64) -> Result<History> {
     let ledger = Ledger::open(repo)?;
     let mut history = History {
         all_measured: true,
+        first_round: u32::MAX,
         ..Default::default()
     };
     for event in ledger.iter_events_by_type("review_verdict")? {
@@ -134,8 +159,14 @@ pub(crate) fn history(repo: &Path, pr: u64) -> Result<History> {
         // `refs.pr` from the raw JSON keeps one malformed event from turning
         // the whole daemon into `SKIP due-unknown` until the ledger is
         // repaired.
-        if event.payload.pointer("/refs/pr").and_then(|v| v.as_u64()) != Some(pr) {
-            continue;
+        // Skip only what is *positively* another PR's. An event whose
+        // `refs.pr` is absent or unreadable falls through to the full
+        // deserialize below, which either reads it or fails loudly — skipping
+        // it here would be the same blindness this gate exists to avoid, just
+        // moved one line up.
+        match event.payload.pointer("/refs/pr").and_then(|v| v.as_u64()) {
+            Some(other) if other != pr => continue,
+            _ => {}
         }
         let payload: ReviewVerdictPayload = serde_json::from_value(event.payload.clone())
             .with_context(|| format!("review_verdict event {}", event.event_id))?;
@@ -145,11 +176,19 @@ pub(crate) fn history(repo: &Path, pr: u64) -> Result<History> {
         history.rounds += 1;
         history.last_sha = Some(payload.subject.head_sha.clone());
         history.last_ts = Some(event.ts.clone());
-        // Round 1's reviewer is the one to resume, and the payload says which
-        // round it is. Taking the first event seen would name whichever round
-        // happens to sit earliest in this ledger — not the same thing on a
-        // machine that only imported later rounds.
-        if payload.refs.round == Some(1) {
+        // Round 1's reviewer is the one to resume — it holds the whole
+        // subject, where a later round holds a delta — and the payload says
+        // which round it is. Selecting by ledger position instead would name
+        // whichever round happens to sit earliest here, which is not the same
+        // thing on a machine that imported only later rounds.
+        //
+        // When no round 1 is present at all, the lowest round that *is*
+        // present is the best available resume target; answering "no session"
+        // would send a continuing review back to round-1 price for want of an
+        // event this machine never received.
+        let round = payload.refs.round.unwrap_or(u32::MAX);
+        if round < history.first_round {
+            history.first_round = round;
             history.first_session = Some(payload.reviewer.session_id.clone());
         }
         match (payload.cost.measured, payload.cost.usd) {
@@ -182,6 +221,8 @@ pub(crate) struct Facts<'a> {
     pub(crate) now: i64,
     pub(crate) last_sha: Option<&'a str>,
     pub(crate) last_verdict_at: Option<i64>,
+    /// When the caller itself last reviewed, if it keeps such a record.
+    pub(crate) last_reviewed_at: Option<i64>,
 }
 
 /// The trigger policy. Pure: same facts, same answer, on every machine.
@@ -211,23 +252,31 @@ pub(crate) fn decide(facts: &Facts, config: &DueConfig) -> Due {
     }
 
     // A Review Response is the implementer saying "look again", and it counts
-    // only if it arrived after the verdict it answers. An older one is the
+    // only if it arrived after the review it answers. An older one is the
     // previous round's, already answered.
     //
-    // A response with **no** verdict to compare against is not a trigger. It
-    // reads like one — the comment is right there — but this branch is not
-    // debounced and nothing records that a response was acted on, so answering
-    // "review" to an uncomparable response answers it again on the next poll,
-    // and every poll after that, each at round-1 price. Verdicts do not cross
-    // machines yet (GH-671: `review_verdict` is not among the event types the
-    // committed mirror imports) and a round published only through the §7
-    // comment path writes no event at all, so "no verdict in this ledger" is
-    // the common case rather than the exotic one. Such a PR falls through to
-    // the push rule below, which is debounced and reads the daemon's own
-    // recorded head — the record that actually exists.
+    // This branch is not debounced and nothing marks a response as consumed,
+    // so getting "already answered" wrong does not cost one wasted round — it
+    // costs one per poll, forever, each at round-1 price. It therefore
+    // measures against **every** record of having reviewed that the caller
+    // has, and fires only if the response is newer than all of them:
+    //
+    // - the ledger verdict, which exists only sometimes (verdicts do not cross
+    //   machines — GH-671 — and a round published through the §7 comment path
+    //   writes no event at all), and
+    // - the caller's own `--last-reviewed-at`, which is the record that does
+    //   exist for a round this daemon ran.
+    //
+    // With neither, there is nothing to be newer than and this is not a
+    // trigger: the PR falls through to the push rule below, which is debounced
+    // and reads the caller's recorded head.
     if config.enabled("response") {
-        if let (Some(response_at), Some(verdict_at)) = (facts.response_at, facts.last_verdict_at) {
-            if response_at > verdict_at {
+        let reviewed_at = match (facts.last_verdict_at, facts.last_reviewed_at) {
+            (Some(a), Some(b)) => Some(a.max(b)),
+            (only, None) | (None, only) => only,
+        };
+        if let (Some(response_at), Some(reviewed_at)) = (facts.response_at, reviewed_at) {
+            if response_at > reviewed_at {
                 return Due::Review("response".into());
             }
         }
@@ -260,7 +309,10 @@ pub(crate) fn decide(facts: &Facts, config: &DueConfig) -> Due {
     if settled_for >= debounce {
         Due::Review("push".into())
     } else {
-        Due::Skip(format!("debounce {}s", debounce - settled_for))
+        Due::Skip(format!(
+            "debounce {}s",
+            debounce.saturating_sub(settled_for)
+        ))
     }
 }
 
@@ -313,6 +365,11 @@ fn judge(args: DueArgs, cwd: &Path) -> Result<()> {
         .as_deref()
         .map(|value| epoch(value, "--response-at"))
         .transpose()?;
+    let last_reviewed_at = args
+        .last_reviewed_at
+        .as_deref()
+        .map(|value| epoch(value, "--last-reviewed-at"))
+        .transpose()?;
 
     // The repo is only needed once a PR number gives the ledger something to
     // look up, so the flag-only cases work outside a checkout.
@@ -346,6 +403,7 @@ fn judge(args: DueArgs, cwd: &Path) -> Result<()> {
             now,
             last_sha,
             last_verdict_at,
+            last_reviewed_at,
         },
         &config,
     );
@@ -355,11 +413,7 @@ fn judge(args: DueArgs, cwd: &Path) -> Result<()> {
             // A second round resumes the first round's session: the reviewer
             // already holds the diff, the spec and its own findings, which is
             // the difference between a $2 round and a $0.02 one.
-            let resume = match (history.rounds >= 1, history.first_session.as_deref()) {
-                (true, Some(session)) => format!(" --resume {session}"),
-                _ => String::new(),
-            };
-            println!("REVIEW {reason}{resume}");
+            println!("REVIEW {reason}{}", history.resume_suffix());
             println!("{}", history.cost_line());
             Ok(())
         }
@@ -389,7 +443,51 @@ mod tests {
             now: 10_000,
             last_sha: None,
             last_verdict_at: None,
+            last_reviewed_at: None,
         }
+    }
+
+    #[test]
+    fn a_response_older_than_the_callers_own_review_is_already_answered() {
+        // Round 2's P1: requiring a verdict to *exist* is not the same as
+        // requiring it to be *current*. `response` never reads the recorded
+        // head, so a PR the daemon has already reviewed still re-fired on
+        // every poll — undebounced, and nothing marks a response consumed.
+        let config = DueConfig::default();
+        let mut f = facts();
+        f.last_sha = Some(HEAD); // the daemon reviewed this very head
+        f.last_verdict_at = Some(1_000); // an old verdict exists
+        f.response_at = Some(2_000); // newer than the verdict...
+        f.last_reviewed_at = Some(3_000); // ...but older than the review
+        assert_eq!(decide(&f, &config), Due::Skip("reviewed".into()));
+    }
+
+    #[test]
+    fn a_response_newer_than_every_record_of_reviewing_still_fires() {
+        // The trigger has to survive its own hardening: this is the case it
+        // exists for — the implementer answered a round without pushing.
+        let config = DueConfig::default();
+        let mut f = facts();
+        f.last_sha = Some(HEAD);
+        f.last_verdict_at = Some(1_000);
+        f.last_reviewed_at = Some(3_000);
+        f.response_at = Some(3_001);
+        assert_eq!(decide(&f, &config), Due::Review("response".into()));
+    }
+
+    #[test]
+    fn the_callers_own_record_counts_even_with_no_verdict_at_all() {
+        // The common shape: a round published through the §7 comment path
+        // writes no ledger event, so the caller's record is the only one.
+        let config = DueConfig::default();
+        let mut f = facts();
+        f.last_sha = Some(HEAD);
+        f.last_verdict_at = None;
+        f.last_reviewed_at = Some(3_000);
+        f.response_at = Some(2_999);
+        assert_eq!(decide(&f, &config), Due::Skip("reviewed".into()));
+        f.response_at = Some(3_001);
+        assert_eq!(decide(&f, &config), Due::Review("response".into()));
     }
 
     #[test]
@@ -470,6 +568,127 @@ mod tests {
             matches!(decide(&f, &config), Due::Skip(reason) if reason.starts_with("debounce ")),
             "a saturating debounce must hold, never open"
         );
+    }
+
+    /// A `review_verdict` payload with only the fields this policy reads.
+    fn verdict_payload(pr: u64, round: u32, head: &str, session: &str) -> serde_json::Value {
+        serde_json::json!({
+            "schema": "review_verdict/0",
+            "subject": {
+                "base_sha": "base", "head_sha": head,
+                "files": 1, "lines": 1, "coverage": "full"
+            },
+            "refs": { "pr": pr, "round": round },
+            "spec": { "mode": "spec-backed", "source": "issue", "trust": "declared" },
+            "brief": { "core": "review-spec-v1" },
+            "reviewer": {
+                "agent": "claude", "transport": "cli",
+                "model_requested": "m", "model_observed": "m",
+                "observed_via": "test", "session_id": session,
+                "session_label": session, "tool_policy": "read-only"
+            },
+            "independence": "clean", "independence_policy": "session",
+            "gates": { "status": "green" }, "verdict": "lgtm", "outcome": "pass",
+            "qualified": true,
+            "cost": { "usd": 1.0, "measured": true, "duration_ms": 1 },
+            "parse": "ok"
+        })
+    }
+
+    /// Append `review_verdict` events to a throwaway ledger and read them back
+    /// through the real `history()`, so the round-selection and PR-scoping
+    /// rules are exercised rather than assumed.
+    fn ledger_history(events: &[(u64, u32, &str, &str)], pr: u64) -> (tempfile::TempDir, History) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().to_path_buf();
+        let ledger = edda_ledger::Ledger::open_or_init(&root).expect("ledger");
+        for (event_pr, round, head, session) in events {
+            let payload: edda_core::ReviewVerdictPayload =
+                serde_json::from_value(verdict_payload(*event_pr, *round, head, session))
+                    .expect("payload");
+            let event = edda_core::event::new_review_verdict_event(
+                "main",
+                ledger.last_event_hash().expect("hash").as_deref(),
+                &payload,
+                None,
+                None,
+                &[],
+            )
+            .expect("event");
+            ledger.append_event(&event).expect("append");
+        }
+        let history = history(&root, pr).expect("history");
+        (temp, history)
+    }
+
+    #[test]
+    fn the_session_to_resume_is_round_ones_by_number_not_by_ledger_position() {
+        // A machine that imported only later rounds would otherwise name
+        // whichever verdict happens to sit earliest in its own ledger. Round 1
+        // is the reviewer holding the whole subject; a later round holds a
+        // delta.
+        let (_temp, history) = ledger_history(
+            &[
+                (42, 2, "head2", "round-2-session"),
+                (42, 1, "head1", "round-1-session"),
+            ],
+            42,
+        );
+        assert_eq!(history.rounds, 2);
+        assert_eq!(history.resume_suffix(), " --resume round-1-session");
+    }
+
+    #[test]
+    fn another_prs_verdicts_are_not_this_prs_history() {
+        let (_temp, history) = ledger_history(
+            &[
+                (99, 1, "other", "other-session"),
+                (42, 1, "head1", "round-1-session"),
+            ],
+            42,
+        );
+        assert_eq!(history.rounds, 1);
+        assert_eq!(history.resume_suffix(), " --resume round-1-session");
+        assert_eq!(history.last_sha.as_deref(), Some("head1"));
+    }
+
+    #[test]
+    fn the_resume_suffix_names_round_ones_session_and_only_from_round_two() {
+        // Round 2's P1: dropping ` --resume {session}` from the decision line
+        // left every test green. The suffix is the whole point of the verb —
+        // a resumed round measured $0.02 against round 1's $1.28 — so its
+        // shape is pinned here rather than only in the ledger path.
+        let mut history = History {
+            rounds: 0,
+            first_session: None,
+            ..Default::default()
+        };
+        assert_eq!(
+            history.resume_suffix(),
+            "",
+            "no round yet, nothing to resume"
+        );
+        history.rounds = 1;
+        history.first_session = Some("round-1-session".into());
+        assert_eq!(history.resume_suffix(), " --resume round-1-session");
+        // A round that recorded no session id cannot be resumed by guessing.
+        history.first_session = None;
+        assert_eq!(history.resume_suffix(), "");
+    }
+
+    #[test]
+    fn a_ledger_without_round_one_resumes_the_lowest_round_it_has() {
+        // A machine that imported only later rounds still has a reviewer worth
+        // resuming; answering "no session" would pay round-1 price for want of
+        // an event this machine never received.
+        let (_temp, history) = ledger_history(
+            &[
+                (42, 3, "head3", "round-3-session"),
+                (42, 2, "head2", "round-2-session"),
+            ],
+            42,
+        );
+        assert_eq!(history.resume_suffix(), " --resume round-2-session");
     }
 
     #[test]

--- a/docs/guides/pr-review-watcher.md
+++ b/docs/guides/pr-review-watcher.md
@@ -140,7 +140,7 @@ sh scripts/test-pr-review-watch.sh         # 離線測試：審/跳過決策 + v
 
 | 檔案 | 內容 |
 |---|---|
-| `review-state.tsv` | `pr<TAB>reviewed_sha<TAB>round`——每張 PR 已審到哪個 head |
+| `review-state.tsv` | `pr<TAB>reviewed_sha<TAB>round<TAB>reviewed_at`——每張 PR 已審到哪個 head，以及那一輪的時間（`edda review due` 用它分辨 Review Response 是回應這一輪還是更早那輪；早期沒有這欄的列讀成「沒有記錄」）|
 | `review-pending.tsv` | `pr<TAB>round<TAB>sha<TAB>attempts<TAB>launched<TAB>postfails`——在途審查（attempts 0=首次派審，1=重試；postfails=判決貼文失敗次數）；**只在排程任務確認 Running 後才會寫入** |
 | `review-acks.tsv` | `pr<TAB>sha<TAB>attempts<TAB>status`——已啟動但 ack 未貼出的 head；成功即移除；3 次失敗 → 加 `review:post-failed`，條目標記 `post-failed`（終態）；label 呼叫也失敗則條目保留、下一輪重試 |
 | `review-fails.tsv` | `pr<TAB>sha<TAB>count`——連續啟動失敗次數（連續 3 次 → `review:unreviewed` 並停） |

--- a/docs/guides/pr-review-watcher.md
+++ b/docs/guides/pr-review-watcher.md
@@ -168,8 +168,9 @@ $1.28–$2.57，同一張 PR 續談的 delta 輪 $0.22 → $0.02。舊規則是�
 |---|---|---|
 | `draft` | — | 草稿不是審查對象，最先擋掉，任何設定都打不開 |
 | `ready` | 否 | 離開草稿是一次性事件，操作者正在等 |
-| `response` | 否 | `## Review Response: Round N` 晚於上一則判決才算 |
+| `response` | 否 | `## Review Response: Round N` 要**晚於每一份「審過了」的記錄**才算：帳本判決（§7 留言路徑不寫，且不跨機器）與 daemon 自己的 `--last-reviewed-at`。兩者都沒有就不算觸發，落到 push 規則 |
 | `push` | **是** | 只有 push 會重複，所以只有它要等 head 靜下來 |
+| `push`（拿不到 push 時間） | **是** | 呼叫端分不出「這張 PR 沒有 commit date」和「forge 呼叫失敗」，後者會一次關掉所有 PR 的開關，所以一律等：`SKIP debounce push-time-unknown` |
 
 預設 debounce 600 秒。改 `.edda/review/due.json`：
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1291,14 +1291,27 @@ The policy, in order — the first matching row wins:
 | `--draft` | `SKIP draft` |
 | `--unreviewed-label` and the head has not demonstrably moved | `SKIP review-unreviewed` |
 | `--ready` (the PR left draft this cycle) | `REVIEW ready` |
-| `--response-at` newer than the last verdict | `REVIEW response` |
+| `--response-at` newer than every record of having reviewed | `REVIEW response` |
 | head moved and the push has settled | `REVIEW push` |
 | head moved, still inside the debounce | `SKIP debounce <n>s` |
+| head moved, push time unknown | `SKIP debounce push-time-unknown` |
 | otherwise | `SKIP reviewed` |
 
 `ready` and `response` are one-time events the operator is waiting on, so
 neither is debounced; only `push` is, because only `push` repeats. A draft is
 refused first and cannot be enabled by any trigger.
+
+Two of those rows exist because `response` is *not* debounced, which makes a
+wrong "unanswered" answer cost one round per poll rather than one round. So it
+fires only when the response is newer than **both** records of having reviewed
+that may exist — the ledger verdict (`review_verdict`, which is absent for a
+round published through the §7 comment path, and does not cross machines) and
+the caller's own `--last-reviewed-at`. With neither, there is nothing to be
+newer than and the PR falls through to the debounced push rule.
+
+`SKIP debounce push-time-unknown` is the same caution: the caller cannot
+distinguish "this PR has no commit date" from "the forge call failed", and the
+second would otherwise open the switch for every PR at once.
 
 Facts come from the caller, and rounds from the ledger. `--last-reviewed`
 matters: a round published through the §7 comment path writes no

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -26,7 +26,7 @@
 #   PR_REVIEW_WATCH_ACKS       acks file override    (used by tests)
 #
 # State (under $EDDA_FLEET_SCRATCH, not in git):
-#   review-state.tsv     pr<TAB>reviewed_sha<TAB>round
+#   review-state.tsv     pr<TAB>reviewed_sha<TAB>round<TAB>reviewed_at
 #   review-pending.tsv   pr<TAB>round<TAB>sha<TAB>attempts<TAB>launched_epoch<TAB>postfails
 #   review-acks.tsv      pr<TAB>sha<TAB>attempts<TAB>status — heads launched but not
 #                        yet acked; the entry exists while the ack is pending
@@ -151,6 +151,10 @@ decide() {
     # event, so the daemon's own state is the only record that it happened.
     prev=$(awk -F'\t' -v n="$num" '$1 == n { last = $2 } END { print last }' \
       "$state" 2>/dev/null)
+    # Field 4 is when this daemon last reviewed the PR. Absent in rows written
+    # before it existed, which reads as "no record".
+    prev_at=$(awk -F'\t' -v n="$num" '$1 == n { last = $4 } END { print last }' \
+      "$state" 2>/dev/null)
 
     unreviewed=""
     case ",$labels," in *,review:unreviewed,*) unreviewed=--unreviewed-label ;; esac
@@ -170,7 +174,7 @@ decide() {
       ] | @tsv' 2>/dev/null); then
       :
     else
-      log "pr$num gh pr view failed; deciding without draft/push/response facts"
+      log "pr$num gh pr view failed; without a push time the verb holds this row"
       facts=""
     fi
     draft=$(printf '%s' "$facts" | cut -f1)
@@ -182,6 +186,7 @@ decide() {
     out=$SCRATCH/due.$num
     "${EDDA_BIN:-edda}" review due --head "$sha" --pr "$num" \
       ${prev:+--last-reviewed "$prev"} \
+      ${prev_at:+--last-reviewed-at "$prev_at"} \
       ${pushed_at:+--pushed-at "$pushed_at"} \
       ${response_at:+--response-at "$response_at"} \
       ${draft:+$draft} ${unreviewed:+$unreviewed} >"$out" 2>&1
@@ -499,8 +504,15 @@ pending_drop() {
 }
 
 state_set() { # $1=pr $2=sha $3=round
+  # Field 4 is when this review happened. `edda review due` needs it to tell a
+  # Review Response that arrived *after* a round from one that arrived before
+  # it: a ledger verdict answers the same question, but only when one exists,
+  # and a round published through the §7 comment path writes none (GH-763
+  # round 2). Rows written before this field existed read as empty, which the
+  # verb treats as "no record" — the behaviour they had already.
   awk -F'\t' -v pr="$1" '$1!=pr' "$STATE" > "$STATE.tmp"
-  printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$STATE.tmp"
+  printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" \
+    "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >> "$STATE.tmp"
   mv "$STATE.tmp" "$STATE"
 }
 

--- a/scripts/test-pr-review-watch.sh
+++ b/scripts/test-pr-review-watch.sh
@@ -296,7 +296,8 @@ pending_set() { # pr round sha attempts postfails
 }
 
 pending_get() { cat "$EDDA_FLEET_SCRATCH/review-pending.tsv" 2>/dev/null || true; }
-state_get()   { cat "$EDDA_FLEET_SCRATCH/review-state.tsv" 2>/dev/null || true; }
+state_get()   { cut -f1-3 "$EDDA_FLEET_SCRATCH/review-state.tsv" 2>/dev/null || true; }
+state_get_at() { cut -f4 "$EDDA_FLEET_SCRATCH/review-state.tsv" 2>/dev/null || true; }
 
 # --- decide -------------------------------------------------------------------
 # GH-763 moved the trigger rule into `edda review due`, so what the daemon owns
@@ -415,11 +416,49 @@ expect_decide_wired \
     '42\tabc123\t2\n' \
     '42\tdef456\t\t2026-09-02T00:00:00Z'
 case "$(cat "$PR_REVIEW_WATCH_LOG" 2>/dev/null)" in
-    *"gh pr view failed"*) ;;
+    *"gh pr view failed; without a push time the verb holds this row"*) ;;
     *) printf 'decide: a failed facts query was not logged, got:\n  %s\n' \
         "$(cat "$PR_REVIEW_WATCH_LOG" 2>/dev/null)" >&2; exit 1 ;;
 esac
 unset GH_FAIL_FACTS
+
+# The documented `decide` subcommand must work on a cold machine: the dispatch
+# runs before the daemon path creates $SCRATCH, so without its own mkdir the
+# redirect fails and every row prints an empty reason.
+rm -rf "$EDDA_FLEET_SCRATCH"
+expect_decide_wired     '''decide works when the scratch directory does not exist yet'''     '''REVIEW 42 def456'''     0 '''REVIEW push
+'''     ''''''     '''42	def456		2026-09-02T00:00:00Z'''
+
+# The decision line is the resume id's only consumer: the verb publishes
+# ` --resume <session>` on it from round 2 on, and nothing downstream parses
+# it. If the daemon stops logging the line, the id is written and deleted
+# unread — which is what round 1 filed (GH-763).
+: >"$PR_REVIEW_WATCH_LOG"
+expect_decide_wired \
+    'the decision line, carrying the resume id, is logged' \
+    'REVIEW 42 def456' \
+    0 'REVIEW response --resume round-1-session\n' \
+    '42\tabc123\t2\n' \
+    '42\tdef456\t\t2026-09-02T00:00:00Z'
+case "$(cat "$PR_REVIEW_WATCH_LOG" 2>/dev/null)" in
+    *"pr42 REVIEW response --resume round-1-session"*) ;;
+    *) printf 'decide: the decision line was not logged, got:\n  %s\n' \
+        "$(cat "$PR_REVIEW_WATCH_LOG" 2>/dev/null)" >&2; exit 1 ;;
+esac
+
+# The state row's review time reaches the verb, which is what lets it tell a
+# response that answers this round from one that predates it.
+expect_decide_wired \
+    'the recorded review time is handed to the verb' \
+    'REVIEW 42 def456' \
+    0 'REVIEW push\n' \
+    '42\tabc123\t2\t2026-09-01T00:00:00Z\n' \
+    '42\tdef456\t\t2026-09-02T00:00:00Z'
+case "$(cat "$DUE_ARGV" 2>/dev/null)" in
+    *"--last-reviewed-at 2026-09-01T00:00:00Z"*) ;;
+    *) printf 'decide: the verb was not handed --last-reviewed-at, got:\n  %s\n' \
+        "$(cat "$DUE_ARGV" 2>/dev/null)" >&2; exit 1 ;;
+esac
 
 expect_decide_wired \
     'a PR with no head is refused before the verb is asked' \
@@ -784,6 +823,14 @@ fi
 unset GH_FAIL_HEAD
 export GH_HEAD="$sha"
 run_watch_once >/dev/null 2>&1 || { printf 'live: watcher cycle failed (head recovered)\n' >&2; exit 1; }
+# Field 4 is what `--last-reviewed-at` is derived from: without it a Review
+# Response older than this round still reads as unanswered and re-fires every
+# poll (GH-763 round 2).
+case "$(state_get_at)" in
+    ????-??-??T??:??:??Z) ;;
+    *) printf 'live: the recorded review time is not RFC3339, got: %s\n' \
+        "$(state_get_at)" >&2; exit 1 ;;
+esac
 if [ "$(state_get)" != "$(printf '42\t%s\t1' "$sha")" ]; then
     printf 'live: head recovered should record reviewed, got:\n%s\n' "$(state_get)" >&2
     exit 1


### PR DESCRIPTION
Follow-up to #1070, which merged at `98ab748` while its round-2 review was still running. The review landed nine minutes after the merge and found three P1s; `main` carries all three today. This PR is those fixes plus round 3's.

Issue: #763

## Why this is a separate PR

#1070's head is frozen at `98ab748` and `refs/pull/1070/head` cannot move. The fixes were pushed to the branch after the merge, so they existed only there. Rebased onto current `main` (`--onto origin/main 98ab748`, dropping the two commits the squash already applied) and reopened here so they get exact-head CI and a review against the base they will actually merge into.

## What was on `main` and is fixed here

**The `response` trigger re-fires on a head already reviewed.** #1070's round-1 fix required a ledger verdict to *exist*, which is not the same as requiring it to be *current* — and `response` is the one rule that never reads the recorded head. Measured on `main`: head equal to the daemon's own `--last-reviewed`, an old verdict, a newer response → `REVIEW response`, exit 0, on every poll. The branch is undebounced and nothing marks a response consumed, so this is one round-1 price per cycle, indefinitely.

The rule now fires only when the response is newer than **every** record of having reviewed: the ledger verdict, and a new `--last-reviewed-at` fed from a new fourth column on the daemon's state row (`state_set` is its only writer; rows without it read as "no record", which is what they meant already).

**`--pushed-at`'s help states the behavior #1070 replaced** — "without it a moved head is due at once", when it now waits.

**The resume-id layer has no test.** Three separate mutations each left `main`'s suite green: deleting the daemon's decision-log line, changing round-1 selection to `Some(7)`, and dropping the ` --resume {session}` suffix. All three are pinned now, two through a ledger-backed fixture that appends real `review_verdict` events and reads them back through `history()`.

## Round 3's finding, also fixed here

The `refs.pr` pre-filter over-corrected. "Skip only what is positively another PR's" meant a verdict with `refs.pr` **absent** — what `edda review --base X --head Y` writes when no PR is named — counted as *every* PR's history: another subject's rounds, cost and resume session, and a `last_verdict_at` high enough to answer a genuine Review Response with `SKIP reviewed`. The raw gate stays a cheap pre-filter; the decision is now the typed equality check after deserializing, so an unreadable `refs.pr` still fails loudly rather than being silently attributed.

Also: `first_session` falls back when no event carries a round at all, and the operator guide documents the state row's fourth column — the script header was updated and the guide was not, which is the same drift class the round-2 review blocked on.

## Tests

| Test | Pins |
|---|---|
| `a_response_older_than_the_callers_own_review_is_already_answered` | The exact shape measured on `main`: an old verdict, a newer response, a head the daemon already reviewed |
| `the_callers_own_record_counts_even_with_no_verdict_at_all` | The common case — a §7-comment round writes no ledger event |
| `a_verdict_with_no_pr_belongs_to_no_pr` | A PR-less verdict contributes no rounds, no cost, no resume id, and cannot age this PR's verdict |
| `the_session_to_resume_is_round_ones_by_number_not_by_ledger_position` | Round 1 by `refs.round`, through a real ledger |
| `a_ledger_without_round_one_resumes_the_lowest_round_it_has` | A machine that imported only later rounds still resumes, rather than paying round-1 price |
| `the_resume_suffix_names_round_ones_session_and_only_from_round_two` | The emitted suffix |
| shell: decision line logged; `--last-reviewed-at` on the argv; state field 4 is RFC3339; cold-`$SCRATCH` `decide` | The wiring — each verified by deleting what it claims to pin |

Every fix in this PR was verified by re-running the reviewer's own mutation and confirming it now fails.

## Gates

L0 on Windows, `worker-1` lane: `cargo fmt --all --check`; `cargo clippy -p edda --all-targets -- -D warnings`; `cargo test -p edda`; `sh scripts/test-pr-review-watch.sh` clean and under six separate mutations; `scripts/lint-file-length.sh --tree`; `scripts/lint-markdown-content.sh`; `scripts/lint-doc-citations.sh --tree`; `sh -n` on both shell files.

`cmd_review::evidence::tests::deadline_stops_descendant_and_does_not_start_next_gate` is a known flake (#1071) in a file this PR does not touch — it now fails in most full-suite runs and passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
