### PR TITLE
feat(edda-cli): edda review deliver — the writing half: verdict comment, labels, Independent Review status (GH-1030)

### DIFF
--- a/crates/edda-cli/src/cmd_review/deliver.rs
+++ b/crates/edda-cli/src/cmd_review/deliver.rs
@@ -358,6 +358,9 @@ fn deliver_inner(args: &DeliverArgs, cwd: &Path) -> Result<i32> {
                 "label": result.label.as_ref().map(|(name, w)| serde_json::json!({
                     "name": name, "outcome": w.tag(), "reason": w.reason(),
                 })),
+                "label_removed": result.label_removed.as_ref().map(|(name, w)| serde_json::json!({
+                    "name": name, "outcome": w.tag(), "reason": w.reason(),
+                })),
                 "exit_code": exit_code,
             })
         );
@@ -389,6 +392,16 @@ fn deliver_inner(args: &DeliverArgs, cwd: &Path) -> Result<i32> {
         if let Some((name, outcome)) = &result.label {
             println!(
                 "label {name} {}{}",
+                outcome.tag(),
+                outcome
+                    .reason()
+                    .map(|r| format!(" ({r})"))
+                    .unwrap_or_default()
+            );
+        }
+        if let Some((name, outcome)) = &result.label_removed {
+            println!(
+                "label_removed {name} {}{}",
                 outcome.tag(),
                 outcome
                     .reason()

--- a/crates/edda-cli/src/cmd_review/deliver.rs
+++ b/crates/edda-cli/src/cmd_review/deliver.rs
@@ -16,7 +16,15 @@
 //! The extracted lines are the tab-separated shape `gate::from_lines` already
 //! parses, so the union rule stays in one place (GH-769) and this module never
 //! re-decides what a verdict means.
+//!
+//! [`extract`] above is the read half (GH-1030 part 1, PR #1077). [`run`]
+//! below is the write half: it feeds `extract`'s output to
+//! [`super::delivery::deliver`], which performs the `review:*` label, the
+//! `Independent Review` commit status, and the malformed-comment notice —
+//! see that module's own doc comment for what it deliberately does not do
+//! (post the primary verdict comment) and why.
 
+use super::delivery;
 use super::gate;
 use super::github::gh;
 use anyhow::{Context, Result};
@@ -53,6 +61,13 @@ pub(crate) struct Extracted {
     pub lines: Vec<String>,
     /// Ids of comments that carry a §7 heading somewhere other than line 1.
     pub malformed: Vec<String>,
+    /// Ids of comments that are well-formed, sha-pinned §7 verdicts, self-
+    /// declared ` (SHADOW)` (REVIEW.md §8, rules.md R22). Distinct from a
+    /// SHA carrying no verdict at all: [`super::delivery`] performs zero
+    /// GitHub writes when this is the only signal standing, rather than
+    /// writing the `error` state [`super::gate::Union::None`] means for an
+    /// unreviewed SHA.
+    pub shadow: Vec<String>,
 }
 
 /// Does this line open a §7 verdict comment?
@@ -109,6 +124,35 @@ fn pinned_to(line: &str, sha: &str) -> bool {
     };
     let rest = rest.trim_start_matches(|c: char| c.is_ascii_digit());
     rest.strip_prefix(" @ ").is_some_and(|tail| tail == sha)
+}
+
+/// Is this heading a §7 verdict for `sha`, self-declared SHADOW?
+///
+/// Same shape [`pinned_to`] pins, but — unlike it — accepts the ` (SHADOW)`
+/// suffix in either recorded position (REVIEW.md §7/§8, rules.md R22): a
+/// self-declared SHADOW round names its SHA exactly like any other verdict,
+/// only decorated. [`pinned_to`] must keep refusing this shape (a SHADOW
+/// round never enters the union); this is the delivery module's separate
+/// signal for "well-formed, pinned here, but R22 says zero writes" —
+/// distinguishing a SHADOW round from "nothing pinned to this SHA at all",
+/// which [`pinned_to`] alone cannot do since both read as "not pinned".
+fn shadow_pinned_to(line: &str, sha: &str) -> bool {
+    let Some(rest) = line.strip_prefix("## Code Review: Round ") else {
+        return false;
+    };
+    let rest = rest.trim_start_matches(|c: char| c.is_ascii_digit());
+    let round_shadow = rest.starts_with(" (SHADOW)");
+    let rest = rest.strip_prefix(" (SHADOW)").unwrap_or(rest);
+    let Some(rest) = rest.strip_prefix(" — PR #") else {
+        return false;
+    };
+    let rest = rest.trim_start_matches(|c: char| c.is_ascii_digit());
+    let Some(tail) = rest.strip_prefix(" @ ") else {
+        return false;
+    };
+    let tail_shadow = tail.ends_with(" (SHADOW)");
+    let tail = tail.strip_suffix(" (SHADOW)").unwrap_or(tail);
+    (round_shadow || tail_shadow) && tail == sha
 }
 
 /// The verdict word and its counts, from the `### Verdict` section.
@@ -174,6 +218,9 @@ pub(crate) fn extract(sha: &str, comments: &[Comment]) -> Extracted {
             continue;
         }
         if !pinned_to(first, sha) {
+            if shadow_pinned_to(first, sha) {
+                out.shadow.push(comment.id.clone());
+            }
             continue;
         }
         let Some(vline) = verdict_line(&normalized) else {
@@ -205,7 +252,7 @@ pub(crate) fn extract(sha: &str, comments: &[Comment]) -> Extracted {
 /// sees it (verified live against this repo, forcing multiple pages with
 /// `per_page=2`), so a comment list longer than one page is never silently
 /// truncated on the merge-gate path.
-fn comments(repo: &Path, pr: u64) -> Result<Vec<Comment>> {
+pub(crate) fn comments(repo: &Path, pr: u64) -> Result<Vec<Comment>> {
     let value = gh(
         repo,
         &[
@@ -237,15 +284,31 @@ fn parse_comments(value: &serde_json::Value) -> Vec<Comment> {
         .collect()
 }
 
-/// `edda review deliver --pr <N>` — what the §7 comments on the reviewed SHA
-/// amount to, and what a deliverer would therefore publish.
+/// `edda review deliver --pr <N>` — deliver what the §7 comments on the
+/// reviewed SHA amount to: the `review:*` label, the `Independent Review`
+/// commit status, and a one-shot notice for any malformed comment.
 ///
-/// This is the read half. It moves the watcher's `verdict_body_lines` awk into
-/// the product and answers with the union rule GH-769 owns; the GitHub writes
-/// (comment, `review:*` labels, `Independent Review` status), their idempotency
-/// and their exit-code contract are the next step of GH-1030 and are not
-/// performed here. Nothing in this path writes to GitHub or to the ledger.
+/// Moves the watcher's `verdict_body_lines` awk into the product and answers
+/// with the union rule GH-769 owns; [`delivery::deliver`] performs the
+/// writes that rule implies, over the real `gh`-backed [`delivery::GhCli`].
+/// An unreadable comment list or an invalid `--sha` never reaches that far:
+/// both leave through exit 2, the same "could not judge" contract
+/// `edda review gate` uses, because nothing was delivered either way.
 pub fn run(args: DeliverArgs, cwd: &Path) -> Result<()> {
+    match deliver_inner(&args, cwd) {
+        Ok(0) => Ok(()),
+        Ok(code) => std::process::exit(code),
+        Err(error) => {
+            eprintln!("edda review deliver: {error:#}");
+            std::process::exit(2);
+        }
+    }
+}
+
+/// The read, decide, and write sequence; returns the exit code `run` should
+/// use on success (0 delivered, 1 partially delivered — never returned as
+/// an `Err`, since something WAS delivered).
+fn deliver_inner(args: &DeliverArgs, cwd: &Path) -> Result<i32> {
     let sha = match &args.sha {
         Some(sha) => sha.clone(),
         None => super::github::resolve_pr(cwd, args.pr)?.head,
@@ -254,13 +317,26 @@ pub fn run(args: DeliverArgs, cwd: &Path) -> Result<()> {
         is_full_sha(&sha),
         "--sha must be a full 40-character lowercase hex commit"
     );
-    let extracted = extract(&sha, &comments(cwd, args.pr)?);
+    let existing_comments = comments(cwd, args.pr)?;
+    let extracted = extract(&sha, &existing_comments);
     let union = gate::union(&gate::from_lines(&extracted.lines.join("\n")));
     let state = match union {
         gate::Union::Pass => "success",
         gate::Union::Fail => "failure",
         gate::Union::None => "error",
     };
+
+    let gh_client = delivery::GhCli { repo: cwd };
+    let result = delivery::deliver(
+        &gh_client,
+        args.pr,
+        &sha,
+        &existing_comments,
+        &extracted,
+        union,
+    );
+    let exit_code = result.exit_code();
+
     if args.json {
         println!(
             "{}",
@@ -270,6 +346,17 @@ pub fn run(args: DeliverArgs, cwd: &Path) -> Result<()> {
                 "status": state,
                 "verdicts": extracted.lines,
                 "malformed": extracted.malformed,
+                "shadow": extracted.shadow,
+                "notices": result.notices.iter().map(|(id, w)| serde_json::json!({
+                    "comment_id": id, "outcome": w.tag(), "reason": w.reason(),
+                })).collect::<Vec<_>>(),
+                "status_write": result.status.as_ref().map(|w| serde_json::json!({
+                    "outcome": w.tag(), "reason": w.reason(),
+                })),
+                "label": result.label.as_ref().map(|(name, w)| serde_json::json!({
+                    "name": name, "outcome": w.tag(), "reason": w.reason(),
+                })),
+                "exit_code": exit_code,
             })
         );
     } else {
@@ -277,8 +364,38 @@ pub fn run(args: DeliverArgs, cwd: &Path) -> Result<()> {
         for id in &extracted.malformed {
             println!("malformed {id}");
         }
+        for (id, outcome) in &result.notices {
+            println!(
+                "notice {id} {}{}",
+                outcome.tag(),
+                outcome
+                    .reason()
+                    .map(|r| format!(" ({r})"))
+                    .unwrap_or_default()
+            );
+        }
+        if let Some(outcome) = &result.status {
+            println!(
+                "status {state} {}{}",
+                outcome.tag(),
+                outcome
+                    .reason()
+                    .map(|r| format!(" ({r})"))
+                    .unwrap_or_default()
+            );
+        }
+        if let Some((name, outcome)) = &result.label {
+            println!(
+                "label {name} {}{}",
+                outcome.tag(),
+                outcome
+                    .reason()
+                    .map(|r| format!(" ({r})"))
+                    .unwrap_or_default()
+            );
+        }
     }
-    Ok(())
+    Ok(exit_code)
 }
 
 #[cfg(test)]
@@ -346,7 +463,23 @@ mod tests {
                 got.malformed.is_empty(),
                 "SHADOW reported malformed: {heading}"
             );
+            // Distinct from "nothing pinned here at all": the delivery
+            // module needs this to tell "SHADOW is the only signal" apart
+            // from "no verdict exists" (R22 — zero writes vs. the `error`
+            // status an unreviewed SHA gets).
+            assert_eq!(got.shadow, vec!["1"], "SHADOW not surfaced: {heading}");
         }
+    }
+
+    #[test]
+    fn a_shadow_round_for_another_sha_is_not_this_shas_shadow() {
+        let body = format!(
+            "## Code Review: Round 1 (SHADOW) — PR #1030 @ {OTHER}\n\n### Verdict\n\nLGTM (P0=0, P1=0)\n"
+        );
+        let got = extract(SHA, &[comment("1", &body)]);
+        assert!(got.lines.is_empty());
+        assert!(got.malformed.is_empty());
+        assert!(got.shadow.is_empty());
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_review/deliver.rs
+++ b/crates/edda-cli/src/cmd_review/deliver.rs
@@ -306,8 +306,10 @@ pub fn run(args: DeliverArgs, cwd: &Path) -> Result<()> {
 }
 
 /// The read, decide, and write sequence; returns the exit code `run` should
-/// use on success (0 delivered, 1 partially delivered — never returned as
-/// an `Err`, since something WAS delivered).
+/// use on success (0 delivered, 1 partially delivered, 2 failed, 3 a due
+/// status/label withheld under R23/#917 — never returned as an `Err`, since
+/// something either succeeded or was deliberately withheld this round; see
+/// [`delivery::Delivery::exit_code`]).
 fn deliver_inner(args: &DeliverArgs, cwd: &Path) -> Result<i32> {
     let sha = match &args.sha {
         Some(sha) => sha.clone(),

--- a/crates/edda-cli/src/cmd_review/delivery.rs
+++ b/crates/edda-cli/src/cmd_review/delivery.rs
@@ -135,6 +135,15 @@ pub(crate) struct Delivery {
     /// `(label, outcome)`; `None` when the union is `Union::None` (no label
     /// is due either way).
     pub label: Option<(String, Write)>,
+    /// `(sibling_label, outcome)` for the best-effort cleanup that follows a
+    /// due `label` (GH-1081 Round 2 P1): removing the *other* `review:*`
+    /// label so the two never stand together on one SHA (ratified
+    /// `review.same-sha-multiple-verdicts`). `None` when no sibling stood,
+    /// or when `label` itself was never due/attempted this run. Unlike the
+    /// Round 1 shape this replaces, a failed removal is recorded here as
+    /// `Write::Failed` — never swallowed via `let _ =` — so it reaches
+    /// stdout/JSON and `exit_code()` the same as any other write.
+    pub label_removed: Option<(String, Write)>,
 }
 
 impl Delivery {
@@ -157,6 +166,7 @@ impl Delivery {
             .map(|(_, w)| w)
             .chain(self.status.iter())
             .chain(self.label.iter().map(|(_, w)| w))
+            .chain(self.label_removed.iter().map(|(_, w)| w))
             .collect();
         let attempted = outcomes
             .iter()
@@ -253,7 +263,20 @@ pub(crate) fn deliver(
             const REASON: &str = "withheld: new malformed notice posted this run (R23/#917)";
             out.status = Some(Write::Withheld(REASON));
             if let Some(label) = label_for(union) {
-                out.label = Some((label.to_owned(), Write::Withheld(REASON)));
+                // GH-1081 Round 2 P2: the label is only actually due when
+                // the PR's current head still matches the reviewed SHA —
+                // exactly the gate the main branch below applies
+                // (`Skipped("head moved")`). Reporting `Withheld` here
+                // without that check told a moved head a label was held
+                // back that was never due this run. A head-read failure
+                // stays conservative (`Withheld`, as before this fix) since
+                // it cannot positively confirm the head has moved.
+                let outcome = match gh.head(pr) {
+                    Ok(current) if current == sha => Write::Withheld(REASON),
+                    Ok(_moved) => Write::Skipped("head moved"),
+                    Err(_) => Write::Withheld(REASON),
+                };
+                out.label = Some((label.to_owned(), outcome));
             }
         }
         return out;
@@ -285,12 +308,18 @@ pub(crate) fn deliver(
     });
 
     if let Some(label) = label_for(union) {
-        // The sibling review:* label (GH-1081/P1-1): the shell this verb
-        // replaces removes it right after a successful add
-        // (`pr-review-watch.sh:925-928`) so a later verdict on the same SHA
-        // never leaves both labels standing. Only a freshly applied label
-        // triggers the removal — an "already applied" rerun makes zero new
-        // calls (GH-1030 doneWhen: idempotent rerun, zero new writes).
+        // The sibling review:* label (GH-1081/P1-1, tightened in Round 2
+        // P1): the shell this verb replaces removes it right after a
+        // successful add (`pr-review-watch.sh:925-928`) so a later verdict
+        // on the same SHA never leaves both labels standing. The sibling
+        // condition is now evaluated independently of whether `label` was
+        // freshly added or already applied — Round 1's fix only reached the
+        // removal from the fresh-add arm, so a single transient
+        // `remove_label` failure (or any split state left by an older
+        // writer) could never self-heal: every later rerun took the
+        // `Skipped("already applied")` arm and never looked at the sibling
+        // again. A clean state (desired label present, sibling absent)
+        // still makes zero new calls either way.
         let sibling = if label == LABEL_LGTM {
             LABEL_CHANGES
         } else {
@@ -298,21 +327,37 @@ pub(crate) fn deliver(
         };
         let outcome = match gh.head(pr) {
             Ok(current) if current == sha => match gh.labels(pr) {
-                Ok(existing) if existing.iter().any(|l| l == label) => {
-                    Write::Skipped("already applied")
-                }
-                Ok(existing) => match gh.add_label(pr, label) {
-                    Ok(()) => {
-                        if existing.iter().any(|l| l == sibling) {
-                            // Best-effort, like the shell's `|| true`: a
-                            // failed removal must not turn a delivered
-                            // label into a failed write.
-                            let _ = gh.remove_label(pr, sibling);
+                Ok(existing) => {
+                    let sibling_stands = existing.iter().any(|l| l == sibling);
+                    let label_outcome = if existing.iter().any(|l| l == label) {
+                        Write::Skipped("already applied")
+                    } else {
+                        match gh.add_label(pr, label) {
+                            Ok(()) => Write::Done,
+                            Err(error) => Write::Failed(error.to_string()),
                         }
-                        Write::Done
+                    };
+                    // Only attempt the removal when the desired label
+                    // itself did not just fail — a failed add changed
+                    // nothing about the PR's label state, so there is
+                    // nothing new to clean up on top of an already-failed
+                    // round.
+                    if sibling_stands && !matches!(label_outcome, Write::Failed(_)) {
+                        // GH-1081 Round 2 P1: no longer `let _ =` — a
+                        // failed removal is recorded as `Write::Failed` so
+                        // it surfaces on stdout/JSON and contributes to
+                        // `exit_code()`, instead of a delivered label
+                        // silently leaving both `review:*` labels standing.
+                        out.label_removed = Some((
+                            sibling.to_owned(),
+                            match gh.remove_label(pr, sibling) {
+                                Ok(()) => Write::Done,
+                                Err(error) => Write::Failed(error.to_string()),
+                            },
+                        ));
                     }
-                    Err(error) => Write::Failed(error.to_string()),
-                },
+                    label_outcome
+                }
                 Err(error) => Write::Failed(format!("read labels: {error}")),
             },
             Ok(_moved) => Write::Skipped("head moved"),
@@ -436,6 +481,7 @@ mod tests {
         fail_add_label: bool,
         fail_post_status: bool,
         fail_post_comment: bool,
+        fail_remove_label: bool,
 
         label_calls: RefCell<Vec<(u64, String)>>,
         status_calls: RefCell<Vec<(String, String, String)>>,
@@ -452,6 +498,7 @@ mod tests {
                 fail_add_label: false,
                 fail_post_status: false,
                 fail_post_comment: false,
+                fail_remove_label: false,
                 label_calls: RefCell::new(Vec::new()),
                 status_calls: RefCell::new(Vec::new()),
                 comment_calls: RefCell::new(Vec::new()),
@@ -477,6 +524,7 @@ mod tests {
             self.remove_label_calls
                 .borrow_mut()
                 .push((pr, label.to_owned()));
+            anyhow::ensure!(!self.fail_remove_label, "simulated remove_label failure");
             self.labels.borrow_mut().retain(|l| l != label);
             Ok(())
         }
@@ -575,22 +623,98 @@ mod tests {
     }
 
     #[test]
-    fn reapplying_the_same_label_makes_zero_new_remove_calls() {
-        // A rerun where the target label is already applied must not touch
-        // the sibling either — it takes the "already applied" Skipped path
-        // entirely, never reaching add_label, so there is nothing to clean
-        // up after (GH-1030 doneWhen: idempotent rerun, zero new writes).
+    fn reapplying_the_same_label_in_a_clean_state_makes_zero_new_writes() {
+        // Clean-state rerun (GH-1081 Round 2 P1 fixture c): the target label
+        // is already applied and the sibling is absent — idempotency must
+        // still hold, exactly like before the Round 2 fix, just now also
+        // covering the new `label_removed` field (GH-1030 doneWhen:
+        // idempotent rerun, zero new writes).
         let gh = FakeGh::new(SHA);
         let ext = extracted(&["LGTM\t0\t0"]);
         let d1 = deliver(&gh, 1, SHA, &[], &ext, union_of(&ext));
         assert_eq!(d1.label, Some((LABEL_LGTM.to_owned(), Write::Done)));
+        assert_eq!(d1.label_removed, None);
 
         let d2 = deliver(&gh, 1, SHA, &[], &ext, union_of(&ext));
         assert_eq!(
             d2.label,
             Some((LABEL_LGTM.to_owned(), Write::Skipped("already applied")))
         );
+        assert_eq!(d2.label_removed, None);
         assert!(gh.remove_label_calls.borrow().is_empty());
+    }
+
+    #[test]
+    fn a_rerun_with_the_desired_label_applied_and_the_sibling_still_standing_removes_it_gh1081_round2_p1(
+    ) {
+        // GH-1081 Round 2 P1 fixture (b): Round 1's fix only reached the
+        // sibling from the fresh-add arm, so a rerun where the desired
+        // label was already applied (e.g. an earlier removal attempt
+        // failed, or some other writer left both labels standing) could
+        // never retry the cleanup — `Skipped("already applied")` at :302
+        // returned before the sibling was even looked at. The condition
+        // must now be evaluated independently of freshness.
+        let gh = FakeGh::new(SHA);
+        gh.labels.borrow_mut().push(LABEL_LGTM.to_owned());
+        gh.labels.borrow_mut().push(LABEL_CHANGES.to_owned());
+        let ext = extracted(&["LGTM\t0\t0"]);
+
+        let d = deliver(&gh, 1, SHA, &[], &ext, union_of(&ext));
+        assert_eq!(
+            d.label,
+            Some((LABEL_LGTM.to_owned(), Write::Skipped("already applied"))),
+            "the desired label was already standing — no add_label call"
+        );
+        assert!(gh.label_calls.borrow().is_empty());
+        assert_eq!(
+            d.label_removed,
+            Some((LABEL_CHANGES.to_owned(), Write::Done)),
+            "the still-standing sibling must be removed even on the already-applied path"
+        );
+        assert_eq!(
+            gh.remove_label_calls.borrow().as_slice(),
+            [(1, LABEL_CHANGES.to_owned())]
+        );
+        assert_eq!(gh.labels.borrow().as_slice(), [LABEL_LGTM.to_owned()]);
+        assert_eq!(d.exit_code(), 0);
+    }
+
+    #[test]
+    fn a_failed_sibling_removal_is_recorded_and_makes_the_exit_code_non_zero_gh1081_round2_p1() {
+        // GH-1081 Round 2 P1 fixture (a): Round 1 discarded the removal's
+        // Result via `let _ =` — a failed `gh pr edit --remove-label` still
+        // reported the label `Write::Done` and exit 0, with nothing on
+        // stdout/JSON to say the sibling never came off. The removal must
+        // now be recorded as its own `Write::Failed` and count toward
+        // `exit_code()` like any other attempted write.
+        let gh = FakeGh {
+            fail_remove_label: true,
+            ..FakeGh::new(SHA)
+        };
+        gh.labels.borrow_mut().push(LABEL_CHANGES.to_owned());
+        let ext = extracted(&["LGTM\t0\t0"]);
+
+        let d = deliver(&gh, 1, SHA, &[], &ext, union_of(&ext));
+        assert_eq!(
+            d.label,
+            Some((LABEL_LGTM.to_owned(), Write::Done)),
+            "the desired label itself was freshly, successfully applied"
+        );
+        assert!(
+            matches!(&d.label_removed, Some((sib, Write::Failed(_))) if sib == LABEL_CHANGES),
+            "the failed removal must be recorded, not swallowed: {:?}",
+            d.label_removed
+        );
+        assert_eq!(
+            gh.labels.borrow().as_slice(),
+            [LABEL_CHANGES.to_owned(), LABEL_LGTM.to_owned()],
+            "a failed removal must not be reflected as removed"
+        );
+        assert_ne!(
+            d.exit_code(),
+            0,
+            "a failed write must never read as fully delivered"
+        );
     }
 
     #[test]
@@ -727,6 +851,38 @@ mod tests {
             3,
             "withheld is its own outcome, distinct from partial (1) or full (2) failure"
         );
+    }
+
+    #[test]
+    fn a_new_malformed_notice_on_a_moved_head_does_not_report_the_label_withheld_gh1081_round2_p2()
+    {
+        // GH-1081 Round 2 P2: the main branch gates the label on
+        // `gh.head(pr) == sha`, answering `Skipped("head moved")` rather
+        // than attempting anything. The withhold branch (a new malformed
+        // notice posted this run) used to report the label `Withheld`
+        // unconditionally, telling a moved head a label was held back that
+        // was never due this run at all.
+        let gh = FakeGh::new("ffffffffffffffffffffffffffffffffffffffff"); // current head != reviewed sha
+        let ext = Extracted {
+            lines: vec!["LGTM\t0\t0".to_owned()],
+            malformed: vec!["42".to_owned()],
+            shadow: vec![],
+        };
+        let d = deliver(&gh, 7, SHA, &[], &ext, union_of(&ext));
+        assert_eq!(d.notices, vec![("42".to_owned(), Write::Done)]);
+        assert!(
+            matches!(d.status, Some(Write::Withheld(_))),
+            "status is unconditional on head — still withheld: {:?}",
+            d.status
+        );
+        assert_eq!(
+            d.label,
+            Some((LABEL_LGTM.to_owned(), Write::Skipped("head moved"))),
+            "the label was never due this run on a moved head — not Withheld: {:?}",
+            d.label
+        );
+        assert!(gh.label_calls.borrow().is_empty());
+        assert!(gh.remove_label_calls.borrow().is_empty());
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_review/delivery.rs
+++ b/crates/edda-cli/src/cmd_review/delivery.rs
@@ -66,6 +66,11 @@ pub(crate) trait Gh {
     /// itself, so a fake's call log is the truth for "zero new writes";
     /// this method is not required to be idempotent on its own.
     fn add_label(&self, pr: u64, label: &str) -> Result<()>;
+    /// Remove one label. Deliver only calls this as a best-effort sibling
+    /// cleanup right after a successful `add_label` — mirroring
+    /// `pr-review-watch.sh`'s `gh pr edit --remove-label ... || true` — so a
+    /// failure here must never turn a delivered label into a failed write.
+    fn remove_label(&self, pr: u64, label: &str) -> Result<()>;
     /// The latest `Independent Review` status state on `sha`, if that
     /// context has ever been posted there (`None` otherwise).
     fn latest_status(&self, sha: &str) -> Result<Option<String>>;
@@ -85,6 +90,13 @@ pub(crate) enum Write {
     Done,
     /// The call was made and failed; the message is the `gh` failure.
     Failed(String),
+    /// No call was made this round, but — unlike `Skipped` — the write WAS
+    /// due: R23 (#917) withholds status/label for any run that posts a new
+    /// malformed-comment notice, mirroring `pr-review-watch.sh`'s
+    /// `post_review_status` returning 3 ("status withheld this poll") to
+    /// tell its caller to come back. A withheld write must read as
+    /// outstanding, never as delivered — see [`Delivery::exit_code`].
+    Withheld(&'static str),
 }
 
 impl Write {
@@ -93,6 +105,7 @@ impl Write {
             Write::Skipped(_) => "skipped",
             Write::Done => "done",
             Write::Failed(_) => "failed",
+            Write::Withheld(_) => "withheld",
         }
     }
 
@@ -100,6 +113,7 @@ impl Write {
         match self {
             Write::Skipped(r) => Some(r),
             Write::Failed(e) => Some(e.as_str()),
+            Write::Withheld(r) => Some(r),
             Write::Done => None,
         }
     }
@@ -111,8 +125,12 @@ impl Write {
 pub(crate) struct Delivery {
     /// One entry per malformed comment id, in `Extracted::malformed` order.
     pub notices: Vec<(String, Write)>,
-    /// `None` only when withheld by rule: a new notice was just posted this
-    /// run, or the only standing signal on the SHA is SHADOW.
+    /// `None` only when nothing was due at all: the only standing signal on
+    /// the SHA is SHADOW, or a malformed notice failed to post (already
+    /// non-zero via the notice's own `Write::Failed`). A status that WAS due
+    /// but got deferred by a new, successfully posted malformed notice
+    /// (R23/#917) is `Some(Write::Withheld(_))`, never `None` — see
+    /// `Write::Withheld` and `exit_code`.
     pub status: Option<Write>,
     /// `(label, outcome)`; `None` when the union is `Union::None` (no label
     /// is due either way).
@@ -120,12 +138,18 @@ pub(crate) struct Delivery {
 }
 
 impl Delivery {
-    /// 0 delivered, 1 partially delivered, 2 failed — the exit-code
-    /// contract doneWhen requires: nothing here is silently dropped, every
-    /// attempted write's outcome feeds this. A run whose intended action
-    /// (a notice, or a status+label) fully succeeds, or whose intended
-    /// action was correctly "nothing" (SHADOW-only, an idempotent rerun),
-    /// is `delivered`.
+    /// 0 delivered, 1 partially delivered, 2 failed, 3 withheld — the
+    /// exit-code contract doneWhen requires: nothing here is silently
+    /// dropped, every attempted write's outcome feeds this. A run whose
+    /// intended action (a notice, or a status+label) fully succeeds, or
+    /// whose intended action was correctly "nothing" (SHADOW-only, an
+    /// idempotent rerun), is `delivered`. A run that withholds a due
+    /// status/label under R23 (#917) — a new malformed notice standing
+    /// alongside a real verdict — is never `delivered` even when the
+    /// notice itself posted cleanly: `Write::Withheld` must outrank 0, the
+    /// same way the shell's `post_review_status` returns 3 rather than 0
+    /// so the caller comes back. `Withheld` outcomes never count toward
+    /// `attempted`/`failed` — they were not attempted, deliberately.
     pub(crate) fn exit_code(&self) -> i32 {
         let outcomes: Vec<&Write> = self
             .notices
@@ -136,18 +160,22 @@ impl Delivery {
             .collect();
         let attempted = outcomes
             .iter()
-            .filter(|w| !matches!(w, Write::Skipped(_)))
+            .filter(|w| !matches!(w, Write::Skipped(_) | Write::Withheld(_)))
             .count();
         let failed = outcomes
             .iter()
             .filter(|w| matches!(w, Write::Failed(_)))
             .count();
-        if failed == 0 {
-            0
-        } else if attempted > 0 && failed == attempted {
-            2
+        if failed > 0 {
+            if attempted > 0 && failed == attempted {
+                2
+            } else {
+                1
+            }
+        } else if outcomes.iter().any(|w| matches!(w, Write::Withheld(_))) {
+            3
         } else {
-            1
+            0
         }
     }
 }
@@ -197,13 +225,40 @@ pub(crate) fn deliver(
                 .push((id.clone(), Write::Failed(error.to_string()))),
         }
     }
-    if new_notice {
-        return out;
-    }
+
     // The only standing signal on this SHA is a self-declared SHADOW round
     // (or a malformed comment already noticed on an earlier run): R22 /
-    // REVIEW.md §8 — zero further writes.
-    if extracted.lines.is_empty() && !extracted.shadow.is_empty() {
+    // REVIEW.md §8 — zero further writes, whether or not a notice was just
+    // posted.
+    let shadow_only = extracted.lines.is_empty() && !extracted.shadow.is_empty();
+
+    if new_notice {
+        // R23 (#917): a run that posts a new malformed-comment notice
+        // withholds status/label for THIS run regardless of `extracted.lines`
+        // — mirroring pr-review-watch.sh's `post_review_status`, whose
+        // `new_notice=1` sits outside the if/else on the `gh pr comment`
+        // call and whose caller returns 3 ("status withheld this poll") so
+        // the next poll retries. A failed notice post already withholds
+        // (this branch fires either way) and already reports non-zero via
+        // the notice's own `Write::Failed`, so status/label there stay
+        // `None` (nothing to add) rather than `Withheld`; a successfully
+        // posted notice must still not read as fully delivered when a real
+        // status (and, per the union, a label) was due — see
+        // `Delivery::exit_code`.
+        let notice_failed = out
+            .notices
+            .iter()
+            .any(|(_, w)| matches!(w, Write::Failed(_)));
+        if !notice_failed && !shadow_only {
+            const REASON: &str = "withheld: new malformed notice posted this run (R23/#917)";
+            out.status = Some(Write::Withheld(REASON));
+            if let Some(label) = label_for(union) {
+                out.label = Some((label.to_owned(), Write::Withheld(REASON)));
+            }
+        }
+        return out;
+    }
+    if shadow_only {
         return out;
     }
 
@@ -229,19 +284,33 @@ pub(crate) fn deliver(
         Err(error) => Write::Failed(format!("read latest status: {error}")),
     });
 
-    let label_target = match union {
-        Union::Pass => Some(LABEL_LGTM),
-        Union::Fail => Some(LABEL_CHANGES),
-        Union::None => None,
-    };
-    if let Some(label) = label_target {
+    if let Some(label) = label_for(union) {
+        // The sibling review:* label (GH-1081/P1-1): the shell this verb
+        // replaces removes it right after a successful add
+        // (`pr-review-watch.sh:925-928`) so a later verdict on the same SHA
+        // never leaves both labels standing. Only a freshly applied label
+        // triggers the removal — an "already applied" rerun makes zero new
+        // calls (GH-1030 doneWhen: idempotent rerun, zero new writes).
+        let sibling = if label == LABEL_LGTM {
+            LABEL_CHANGES
+        } else {
+            LABEL_LGTM
+        };
         let outcome = match gh.head(pr) {
             Ok(current) if current == sha => match gh.labels(pr) {
                 Ok(existing) if existing.iter().any(|l| l == label) => {
                     Write::Skipped("already applied")
                 }
-                Ok(_) => match gh.add_label(pr, label) {
-                    Ok(()) => Write::Done,
+                Ok(existing) => match gh.add_label(pr, label) {
+                    Ok(()) => {
+                        if existing.iter().any(|l| l == sibling) {
+                            // Best-effort, like the shell's `|| true`: a
+                            // failed removal must not turn a delivered
+                            // label into a failed write.
+                            let _ = gh.remove_label(pr, sibling);
+                        }
+                        Write::Done
+                    }
                     Err(error) => Write::Failed(error.to_string()),
                 },
                 Err(error) => Write::Failed(format!("read labels: {error}")),
@@ -253,6 +322,15 @@ pub(crate) fn deliver(
     }
 
     out
+}
+
+/// The `review:*` label the union rule calls for, if any.
+fn label_for(union: Union) -> Option<&'static str> {
+    match union {
+        Union::Pass => Some(LABEL_LGTM),
+        Union::Fail => Some(LABEL_CHANGES),
+        Union::None => None,
+    }
 }
 
 /// The real `gh`-backed [`Gh`]. `head`/`labels`/`latest_status` are reads;
@@ -286,6 +364,13 @@ impl Gh for GhCli<'_> {
         github::gh_write(
             self.repo,
             &["pr", "edit", &pr.to_string(), "--add-label", label],
+        )
+    }
+
+    fn remove_label(&self, pr: u64, label: &str) -> Result<()> {
+        github::gh_write(
+            self.repo,
+            &["pr", "edit", &pr.to_string(), "--remove-label", label],
         )
     }
 
@@ -355,6 +440,7 @@ mod tests {
         label_calls: RefCell<Vec<(u64, String)>>,
         status_calls: RefCell<Vec<(String, String, String)>>,
         comment_calls: RefCell<Vec<(u64, String)>>,
+        remove_label_calls: RefCell<Vec<(u64, String)>>,
     }
 
     impl FakeGh {
@@ -369,6 +455,7 @@ mod tests {
                 label_calls: RefCell::new(Vec::new()),
                 status_calls: RefCell::new(Vec::new()),
                 comment_calls: RefCell::new(Vec::new()),
+                remove_label_calls: RefCell::new(Vec::new()),
             }
         }
     }
@@ -384,6 +471,13 @@ mod tests {
             self.label_calls.borrow_mut().push((pr, label.to_owned()));
             anyhow::ensure!(!self.fail_add_label, "simulated add_label failure");
             self.labels.borrow_mut().push(label.to_owned());
+            Ok(())
+        }
+        fn remove_label(&self, pr: u64, label: &str) -> Result<()> {
+            self.remove_label_calls
+                .borrow_mut()
+                .push((pr, label.to_owned()));
+            self.labels.borrow_mut().retain(|l| l != label);
             Ok(())
         }
         fn latest_status(&self, _sha: &str) -> Result<Option<String>> {
@@ -451,6 +545,55 @@ mod tests {
     }
 
     #[test]
+    fn a_later_changes_requested_on_the_same_sha_removes_the_standing_lgtm_label_gh1081_p1_1() {
+        // GH-1081 Round 1 P1-1: the label carrier used to be add-only. Run 1
+        // delivers a lone LGTM (review:lgtm applied). A Changes Requested
+        // comment then lands on the SAME sha, so run 2's union flips to
+        // Fail (GH-742) and must apply review:changes-requested — and, per
+        // pr-review-watch.sh:925-928, remove the now-stale review:lgtm
+        // sibling so the two labels never stand together.
+        let gh = FakeGh::new(SHA);
+        let ext1 = extracted(&["LGTM\t0\t0"]);
+        let d1 = deliver(&gh, 1, SHA, &[], &ext1, union_of(&ext1));
+        assert_eq!(d1.label, Some((LABEL_LGTM.to_owned(), Write::Done)));
+        assert_eq!(gh.labels.borrow().as_slice(), [LABEL_LGTM.to_owned()]);
+        assert!(gh.remove_label_calls.borrow().is_empty());
+
+        let ext2 = extracted(&["LGTM\t0\t0", "Changes Requested\t0\t1"]);
+        let d2 = deliver(&gh, 1, SHA, &[], &ext2, union_of(&ext2));
+        assert_eq!(d2.label, Some((LABEL_CHANGES.to_owned(), Write::Done)));
+        assert_eq!(
+            gh.remove_label_calls.borrow().as_slice(),
+            [(1, LABEL_LGTM.to_owned())],
+            "the sibling review:lgtm must be removed, not left standing"
+        );
+        assert_eq!(
+            gh.labels.borrow().as_slice(),
+            [LABEL_CHANGES.to_owned()],
+            "only the new label stands after the removal"
+        );
+    }
+
+    #[test]
+    fn reapplying_the_same_label_makes_zero_new_remove_calls() {
+        // A rerun where the target label is already applied must not touch
+        // the sibling either — it takes the "already applied" Skipped path
+        // entirely, never reaching add_label, so there is nothing to clean
+        // up after (GH-1030 doneWhen: idempotent rerun, zero new writes).
+        let gh = FakeGh::new(SHA);
+        let ext = extracted(&["LGTM\t0\t0"]);
+        let d1 = deliver(&gh, 1, SHA, &[], &ext, union_of(&ext));
+        assert_eq!(d1.label, Some((LABEL_LGTM.to_owned(), Write::Done)));
+
+        let d2 = deliver(&gh, 1, SHA, &[], &ext, union_of(&ext));
+        assert_eq!(
+            d2.label,
+            Some((LABEL_LGTM.to_owned(), Write::Skipped("already applied")))
+        );
+        assert!(gh.remove_label_calls.borrow().is_empty());
+    }
+
+    #[test]
     fn no_verdicts_at_all_posts_error_and_applies_no_label() {
         let gh = FakeGh::new(SHA);
         let ext = extracted(&[]);
@@ -512,7 +655,7 @@ mod tests {
         assert_eq!(d.label, Some((LABEL_LGTM.to_owned(), Write::Done)));
     }
 
-    // ---- malformed heading: one notice, no status, no label -----------------
+    // ---- malformed heading: one notice, status/label withheld ---------------
 
     #[test]
     fn malformed_heading_posts_one_notice_and_withholds_status_and_label() {
@@ -529,10 +672,61 @@ mod tests {
             "review: malformed verdict comment 42"
         );
         assert_eq!(d.notices, vec![("42".to_owned(), Write::Done)]);
-        assert_eq!(d.status, None);
-        assert_eq!(d.label, None);
+        // No lines stood on this SHA, but an "error" status was still due
+        // (see no_verdicts_at_all_posts_error_and_applies_no_label) — R23
+        // withholds it rather than skipping it outright, so exit_code must
+        // say "come back", not "delivered" (GH-1081 P1-2).
+        assert!(matches!(d.status, Some(Write::Withheld(_))));
+        assert_eq!(d.label, None, "Union::None calls for no label either way");
         assert!(gh.status_calls.borrow().is_empty());
-        assert_eq!(d.exit_code(), 0);
+        assert_eq!(d.exit_code(), 3);
+    }
+
+    #[test]
+    fn malformed_notice_alongside_a_standing_verdict_withholds_status_and_label_gh1081_p1_2() {
+        // GH-1081 Round 1 P1-2: a not-yet-noticed malformed id used to take
+        // an early return regardless of `extracted.lines`, so a standing
+        // LGTM got no status that run, yet exit_code() answered 0
+        // ("delivered"). pr-review-watch.sh's post_review_status returns 3
+        // ("status withheld this poll") in exactly this case, which is what
+        // makes its caller come back on the next poll instead of treating
+        // the SHA as settled.
+        let gh = FakeGh::new(SHA);
+        let ext = Extracted {
+            lines: vec!["LGTM\t0\t0".to_owned()],
+            malformed: vec!["42".to_owned()],
+            shadow: vec![],
+        };
+        let d = deliver(&gh, 7, SHA, &[], &ext, union_of(&ext));
+        assert_eq!(d.notices, vec![("42".to_owned(), Write::Done)]);
+        assert!(
+            matches!(d.status, Some(Write::Withheld(_))),
+            "a standing LGTM makes the status due, not merely absent: {:?}",
+            d.status
+        );
+        assert!(
+            matches!(d.label, Some((_, Write::Withheld(_)))),
+            "the union (LGTM) calls for review:lgtm, withheld not skipped: {:?}",
+            d.label
+        );
+        assert!(
+            gh.status_calls.borrow().is_empty(),
+            "no status call — withheld means no gh write, not a failed one"
+        );
+        assert!(
+            gh.label_calls.borrow().is_empty(),
+            "no label call — withheld means no gh write, not a failed one"
+        );
+        assert_ne!(
+            d.exit_code(),
+            0,
+            "a withheld status must not read as delivered"
+        );
+        assert_eq!(
+            d.exit_code(),
+            3,
+            "withheld is its own outcome, distinct from partial (1) or full (2) failure"
+        );
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_review/delivery.rs
+++ b/crates/edda-cli/src/cmd_review/delivery.rs
@@ -1,0 +1,636 @@
+//! The write half of `edda review deliver` (GH-1030): given the §7 verdict
+//! facts the read half ([`super::deliver::extract`]) already reduced
+//! GitHub's comments to, perform exactly the writes the ratified semantics
+//! call for — the malformed notice, the `review:*` label, and the
+//! `Independent Review` commit status — and nothing else.
+//!
+//! ## What this module does not do
+//!
+//! It does not post the primary §7 verdict comment. In the architecture the
+//! parsing half (GH-1030 part 1, PR #1077) landed, that comment is read as
+//! already present on GitHub — posted by whatever ran the review, today
+//! `scripts/pr-review-watch.sh`'s `settle_pending`. The issue's own list of
+//! what the follow-up adapter PR converts into calls on this verb —
+//! `post_review_status`, `settle_pending`, `verdict_body_lines` — never
+//! names the shell's `gh pr comment --body-file` verdict post, so that call
+//! stays exactly where it is; this module owns only the writes derived from
+//! a verdict once one exists to read. See the PR body for the fuller
+//! discussion of this divergence from the issue's original "What".
+//!
+//! ## SHADOW and non-authoritative engines (R22)
+//!
+//! REVIEW.md §8 and rules.md R22 are explicit that the ` (SHADOW)` heading
+//! suffix is the *only* SHADOW marker a reviewer emits — including for an
+//! engine that R22 does not make authoritative on the PR's touched surface;
+//! R22 itself routes that case through the same suffix, not a second
+//! channel ("SHADOW 輪次標題尾加 (SHADOW)"). This module honors exactly that
+//! marker, via [`super::deliver::Extracted::shadow`], and performs zero
+//! writes when it is the only signal standing on the SHA. It does not
+//! additionally re-derive engine/surface authority from the PR's changed
+//! files the way `pr-review-watch.sh`'s `verdict_engine` / `classify_surface`
+//! / `verdict_surface_ok` do as defense-in-depth against a reviewer that
+//! fails to self-declare — that independent server-side cross-check is a
+//! separate, larger feature (a new `gh` read of the PR's changed files, plus
+//! the R22 path table) and is not implemented here; see the PR body.
+//!
+//! ## Status is unconditional on the current head
+//!
+//! Only the `review:*` label is gated on `current head == reviewed sha`
+//! (doneWhen's own moved-head bullet names only the label). The issue's
+//! "Independent Review commit status on the reviewed SHA by the union rule"
+//! carries no head-equality clause either. `pr-review-watch.sh`'s
+//! `finish_verdict` happens to skip both together, but that is a side effect
+//! of its early-return control flow, not a stated rule — so this module
+//! writes the status regardless of whether the PR has since moved past the
+//! reviewed SHA.
+
+use super::deliver::{Comment, Extracted};
+use super::gate::Union;
+use super::github;
+use anyhow::Result;
+use std::path::Path;
+
+pub(crate) const LABEL_LGTM: &str = "review:lgtm";
+pub(crate) const LABEL_CHANGES: &str = "review:changes-requested";
+const STATUS_CONTEXT: &str = "Independent Review";
+
+/// What `edda review deliver` needs GitHub to do, factored out so union,
+/// idempotency and failure-contract fixtures never touch the network
+/// (GH-1030 doneWhen: "injectable gh, no network").
+pub(crate) trait Gh {
+    /// The PR's current head SHA.
+    fn head(&self, pr: u64) -> Result<String>;
+    /// Labels currently on the PR.
+    fn labels(&self, pr: u64) -> Result<Vec<String>>;
+    /// Add one label. Deliver only calls this after checking `labels`
+    /// itself, so a fake's call log is the truth for "zero new writes";
+    /// this method is not required to be idempotent on its own.
+    fn add_label(&self, pr: u64, label: &str) -> Result<()>;
+    /// The latest `Independent Review` status state on `sha`, if that
+    /// context has ever been posted there (`None` otherwise).
+    fn latest_status(&self, sha: &str) -> Result<Option<String>>;
+    /// Post the `Independent Review` commit status.
+    fn post_status(&self, sha: &str, state: &str, description: &str) -> Result<()>;
+    /// Post a plain-text PR comment (used only for the malformed notice).
+    fn post_comment(&self, pr: u64, body: &str) -> Result<()>;
+}
+
+/// The outcome of one attempted write.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Write {
+    /// No call was made: the desired state already held, or a rule (moved
+    /// head) says this write must not happen.
+    Skipped(&'static str),
+    /// The call was made and succeeded.
+    Done,
+    /// The call was made and failed; the message is the `gh` failure.
+    Failed(String),
+}
+
+impl Write {
+    pub(crate) fn tag(&self) -> &'static str {
+        match self {
+            Write::Skipped(_) => "skipped",
+            Write::Done => "done",
+            Write::Failed(_) => "failed",
+        }
+    }
+
+    pub(crate) fn reason(&self) -> Option<&str> {
+        match self {
+            Write::Skipped(r) => Some(r),
+            Write::Failed(e) => Some(e.as_str()),
+            Write::Done => None,
+        }
+    }
+}
+
+/// Every write `edda review deliver` attempted or deliberately withheld for
+/// one `(pr, sha)` pair.
+#[derive(Debug, Default)]
+pub(crate) struct Delivery {
+    /// One entry per malformed comment id, in `Extracted::malformed` order.
+    pub notices: Vec<(String, Write)>,
+    /// `None` only when withheld by rule: a new notice was just posted this
+    /// run, or the only standing signal on the SHA is SHADOW.
+    pub status: Option<Write>,
+    /// `(label, outcome)`; `None` when the union is `Union::None` (no label
+    /// is due either way).
+    pub label: Option<(String, Write)>,
+}
+
+impl Delivery {
+    /// 0 delivered, 1 partially delivered, 2 failed — the exit-code
+    /// contract doneWhen requires: nothing here is silently dropped, every
+    /// attempted write's outcome feeds this. A run whose intended action
+    /// (a notice, or a status+label) fully succeeds, or whose intended
+    /// action was correctly "nothing" (SHADOW-only, an idempotent rerun),
+    /// is `delivered`.
+    pub(crate) fn exit_code(&self) -> i32 {
+        let outcomes: Vec<&Write> = self
+            .notices
+            .iter()
+            .map(|(_, w)| w)
+            .chain(self.status.iter())
+            .chain(self.label.iter().map(|(_, w)| w))
+            .collect();
+        let attempted = outcomes
+            .iter()
+            .filter(|w| !matches!(w, Write::Skipped(_)))
+            .count();
+        let failed = outcomes
+            .iter()
+            .filter(|w| matches!(w, Write::Failed(_)))
+            .count();
+        if failed == 0 {
+            0
+        } else if attempted > 0 && failed == attempted {
+            2
+        } else {
+            1
+        }
+    }
+}
+
+/// The malformed-notice text, exact and stable so a notice posted by either
+/// `edda review deliver` or `pr-review-watch.sh` (during the transition
+/// before the follow-up adapter PR) is recognized by the other — no local
+/// marker file, no ledger row, just this string read back from GitHub.
+fn notice_text(id: &str) -> String {
+    format!("review: malformed verdict comment {id}")
+}
+
+/// Perform (or correctly withhold) every write for one `(pr, sha)` round.
+///
+/// `union` is the caller's own `gate::union(gate::from_lines(...))` over
+/// `extracted.lines` — computed once by the caller and threaded through
+/// rather than recomputed here, so this module never re-decides what a
+/// verdict means (GH-769 stays the union rule's only owner).
+pub(crate) fn deliver(
+    gh: &dyn Gh,
+    pr: u64,
+    sha: &str,
+    comments: &[Comment],
+    extracted: &Extracted,
+    union: Union,
+) -> Delivery {
+    let mut out = Delivery::default();
+
+    let mut new_notice = false;
+    for id in &extracted.malformed {
+        let text = notice_text(id);
+        if comments.iter().any(|c| c.body.trim() == text) {
+            out.notices
+                .push((id.clone(), Write::Skipped("already noticed")));
+            continue;
+        }
+        // Attempting a not-yet-noticed id withholds status/label for this
+        // run regardless of whether the post itself succeeds — mirroring
+        // pr-review-watch.sh, whose `new_notice=1` sits outside the
+        // if/else on the `gh pr comment` call. A failed post must not be
+        // masked by a status write that proceeds as if nothing happened.
+        new_notice = true;
+        match gh.post_comment(pr, &text) {
+            Ok(()) => out.notices.push((id.clone(), Write::Done)),
+            Err(error) => out
+                .notices
+                .push((id.clone(), Write::Failed(error.to_string()))),
+        }
+    }
+    if new_notice {
+        return out;
+    }
+    // The only standing signal on this SHA is a self-declared SHADOW round
+    // (or a malformed comment already noticed on an earlier run): R22 /
+    // REVIEW.md §8 — zero further writes.
+    if extracted.lines.is_empty() && !extracted.shadow.is_empty() {
+        return out;
+    }
+
+    let state = match union {
+        Union::Pass => "success",
+        Union::Fail => "failure",
+        Union::None => "error",
+    };
+    let description = match union {
+        Union::Pass => format!("LGTM · {} verdict(s) on this SHA", extracted.lines.len()),
+        Union::Fail => format!(
+            "Changes Requested · {} verdict(s) on this SHA",
+            extracted.lines.len()
+        ),
+        Union::None => "no verdict on this SHA".to_owned(),
+    };
+    out.status = Some(match gh.latest_status(sha) {
+        Ok(Some(current)) if current == state => Write::Skipped("already applied"),
+        Ok(_) => match gh.post_status(sha, state, &description) {
+            Ok(()) => Write::Done,
+            Err(error) => Write::Failed(error.to_string()),
+        },
+        Err(error) => Write::Failed(format!("read latest status: {error}")),
+    });
+
+    let label_target = match union {
+        Union::Pass => Some(LABEL_LGTM),
+        Union::Fail => Some(LABEL_CHANGES),
+        Union::None => None,
+    };
+    if let Some(label) = label_target {
+        let outcome = match gh.head(pr) {
+            Ok(current) if current == sha => match gh.labels(pr) {
+                Ok(existing) if existing.iter().any(|l| l == label) => {
+                    Write::Skipped("already applied")
+                }
+                Ok(_) => match gh.add_label(pr, label) {
+                    Ok(()) => Write::Done,
+                    Err(error) => Write::Failed(error.to_string()),
+                },
+                Err(error) => Write::Failed(format!("read labels: {error}")),
+            },
+            Ok(_moved) => Write::Skipped("head moved"),
+            Err(error) => Write::Failed(format!("read current head: {error}")),
+        };
+        out.label = Some((label.to_owned(), outcome));
+    }
+
+    out
+}
+
+/// The real `gh`-backed [`Gh`]. `head`/`labels`/`latest_status` are reads;
+/// `add_label`/`post_status`/`post_comment` are writes via
+/// [`github::gh_write`] — `gh`'s own stdout for these is a bare URL or
+/// nothing, never JSON, so they cannot go through [`github::gh`].
+pub(crate) struct GhCli<'a> {
+    pub repo: &'a Path,
+}
+
+impl Gh for GhCli<'_> {
+    fn head(&self, pr: u64) -> Result<String> {
+        github::pr_head(self.repo, pr)
+    }
+
+    fn labels(&self, pr: u64) -> Result<Vec<String>> {
+        let value = github::gh(
+            self.repo,
+            &["pr", "view", &pr.to_string(), "--json", "labels"],
+        )?;
+        Ok(value["labels"]
+            .as_array()
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|label| label["name"].as_str().map(str::to_owned))
+            .collect())
+    }
+
+    fn add_label(&self, pr: u64, label: &str) -> Result<()> {
+        github::gh_write(
+            self.repo,
+            &["pr", "edit", &pr.to_string(), "--add-label", label],
+        )
+    }
+
+    fn latest_status(&self, sha: &str) -> Result<Option<String>> {
+        let value = github::gh(
+            self.repo,
+            &[
+                "api",
+                &format!("repos/{{owner}}/{{repo}}/commits/{sha}/status"),
+            ],
+        )?;
+        Ok(value["statuses"]
+            .as_array()
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .find(|status| status["context"].as_str() == Some(STATUS_CONTEXT))
+            .and_then(|status| status["state"].as_str())
+            .map(str::to_owned))
+    }
+
+    fn post_status(&self, sha: &str, state: &str, description: &str) -> Result<()> {
+        github::gh_write(
+            self.repo,
+            &[
+                "api",
+                &format!("repos/{{owner}}/{{repo}}/statuses/{sha}"),
+                "-f",
+                &format!("state={state}"),
+                "-f",
+                &format!("context={STATUS_CONTEXT}"),
+                "-f",
+                &format!("description={description}"),
+            ],
+        )
+    }
+
+    fn post_comment(&self, pr: u64, body: &str) -> Result<()> {
+        github::gh_write(
+            self.repo,
+            &["pr", "comment", &pr.to_string(), "--body", body],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    const SHA: &str = "0123456789abcdef0123456789abcdef01234567";
+
+    /// An injectable, network-free [`Gh`]: every read is pre-seeded, every
+    /// write is recorded (so a test can assert "zero new writes") and can be
+    /// made to fail (the gh-failure-contract fixture).
+    ///
+    /// No `#[derive(Default)]`: `Result<String, String>` is not `Default`,
+    /// so [`FakeGh::new`] lists every field explicitly instead.
+    struct FakeGh {
+        head: RefCell<Result<String, String>>,
+        labels: RefCell<Vec<String>>,
+        latest_status: RefCell<Result<Option<String>, String>>,
+        fail_add_label: bool,
+        fail_post_status: bool,
+        fail_post_comment: bool,
+
+        label_calls: RefCell<Vec<(u64, String)>>,
+        status_calls: RefCell<Vec<(String, String, String)>>,
+        comment_calls: RefCell<Vec<(u64, String)>>,
+    }
+
+    impl FakeGh {
+        fn new(head: &str) -> Self {
+            Self {
+                head: RefCell::new(Ok(head.to_owned())),
+                labels: RefCell::new(Vec::new()),
+                latest_status: RefCell::new(Ok(None)),
+                fail_add_label: false,
+                fail_post_status: false,
+                fail_post_comment: false,
+                label_calls: RefCell::new(Vec::new()),
+                status_calls: RefCell::new(Vec::new()),
+                comment_calls: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl Gh for FakeGh {
+        fn head(&self, _pr: u64) -> Result<String> {
+            self.head.borrow().clone().map_err(anyhow::Error::msg)
+        }
+        fn labels(&self, _pr: u64) -> Result<Vec<String>> {
+            Ok(self.labels.borrow().clone())
+        }
+        fn add_label(&self, pr: u64, label: &str) -> Result<()> {
+            self.label_calls.borrow_mut().push((pr, label.to_owned()));
+            anyhow::ensure!(!self.fail_add_label, "simulated add_label failure");
+            self.labels.borrow_mut().push(label.to_owned());
+            Ok(())
+        }
+        fn latest_status(&self, _sha: &str) -> Result<Option<String>> {
+            self.latest_status
+                .borrow()
+                .clone()
+                .map_err(anyhow::Error::msg)
+        }
+        fn post_status(&self, sha: &str, state: &str, description: &str) -> Result<()> {
+            self.status_calls.borrow_mut().push((
+                sha.to_owned(),
+                state.to_owned(),
+                description.to_owned(),
+            ));
+            anyhow::ensure!(!self.fail_post_status, "simulated post_status failure");
+            *self.latest_status.borrow_mut() = Ok(Some(state.to_owned()));
+            Ok(())
+        }
+        fn post_comment(&self, pr: u64, body: &str) -> Result<()> {
+            self.comment_calls.borrow_mut().push((pr, body.to_owned()));
+            anyhow::ensure!(!self.fail_post_comment, "simulated post_comment failure");
+            Ok(())
+        }
+    }
+
+    fn extracted(lines: &[&str]) -> Extracted {
+        Extracted {
+            lines: lines.iter().map(|s| (*s).to_owned()).collect(),
+            malformed: vec![],
+            shadow: vec![],
+        }
+    }
+
+    fn union_of(extracted: &Extracted) -> Union {
+        super::super::gate::union(&super::super::gate::from_lines(&extracted.lines.join("\n")))
+    }
+
+    // ---- union-rule matrix drives the posted status state -------------------
+
+    #[test]
+    fn lgtm_only_posts_success_and_applies_the_lgtm_label() {
+        let gh = FakeGh::new(SHA);
+        let ext = extracted(&["LGTM\t0\t0"]);
+        let d = deliver(&gh, 1, SHA, &[], &ext, union_of(&ext));
+        assert_eq!(gh.status_calls.borrow()[0].1, "success");
+        assert_eq!(d.label, Some((LABEL_LGTM.to_owned(), Write::Done)));
+        assert_eq!(d.exit_code(), 0);
+    }
+
+    #[test]
+    fn lgtm_then_changes_requested_same_sha_posts_failure_gh742() {
+        // GH-742: a later LGTM never overrides an earlier Changes Requested.
+        let gh = FakeGh::new(SHA);
+        let ext = extracted(&["LGTM\t0\t0", "Changes Requested\t0\t1"]);
+        let d = deliver(&gh, 1, SHA, &[], &ext, union_of(&ext));
+        assert_eq!(gh.status_calls.borrow()[0].1, "failure");
+        assert_eq!(d.label, Some((LABEL_CHANGES.to_owned(), Write::Done)));
+
+        // Order reversed: still failure, never re-flipped to success.
+        let gh2 = FakeGh::new(SHA);
+        let ext2 = extracted(&["Changes Requested\t0\t1", "LGTM\t0\t0"]);
+        let d2 = deliver(&gh2, 1, SHA, &[], &ext2, union_of(&ext2));
+        assert_eq!(gh2.status_calls.borrow()[0].1, "failure");
+        assert_eq!(d2.label, Some((LABEL_CHANGES.to_owned(), Write::Done)));
+    }
+
+    #[test]
+    fn no_verdicts_at_all_posts_error_and_applies_no_label() {
+        let gh = FakeGh::new(SHA);
+        let ext = extracted(&[]);
+        let d = deliver(&gh, 1, SHA, &[], &ext, union_of(&ext));
+        assert_eq!(gh.status_calls.borrow()[0].1, "error");
+        assert_eq!(d.label, None);
+        assert!(gh.label_calls.borrow().is_empty());
+    }
+
+    // ---- moved head: label withheld, status still written -------------------
+
+    #[test]
+    fn moved_head_withholds_the_label_but_still_posts_status() {
+        let gh = FakeGh::new("ffffffffffffffffffffffffffffffffffffffff"); // current head != reviewed sha
+        let ext = extracted(&["LGTM\t0\t0"]);
+        let d = deliver(&gh, 1, SHA, &[], &ext, union_of(&ext));
+        assert_eq!(gh.status_calls.borrow()[0].1, "success");
+        assert_eq!(
+            d.label,
+            Some((LABEL_LGTM.to_owned(), Write::Skipped("head moved")))
+        );
+        assert!(gh.label_calls.borrow().is_empty());
+        assert_eq!(d.exit_code(), 0);
+    }
+
+    // ---- SHADOW: zero writes when it is the only signal ---------------------
+
+    #[test]
+    fn shadow_only_round_performs_zero_github_writes() {
+        let gh = FakeGh::new(SHA);
+        let ext = Extracted {
+            lines: vec![],
+            malformed: vec![],
+            shadow: vec!["9".to_owned()],
+        };
+        let d = deliver(&gh, 1, SHA, &[], &ext, union_of(&ext));
+        assert_eq!(d.status, None);
+        assert_eq!(d.label, None);
+        assert!(d.notices.is_empty());
+        assert!(gh.status_calls.borrow().is_empty());
+        assert!(gh.label_calls.borrow().is_empty());
+        assert!(gh.comment_calls.borrow().is_empty());
+        assert_eq!(d.exit_code(), 0);
+    }
+
+    #[test]
+    fn a_real_verdict_alongside_a_shadow_comment_still_delivers_normally() {
+        // SHADOW contributes nothing to `lines`, but must not poison a real,
+        // authoritative verdict standing on the same SHA (REVIEW.md §8: a
+        // SHADOW round is calibration evidence, not a gate on its own SHA).
+        let gh = FakeGh::new(SHA);
+        let ext = Extracted {
+            lines: vec!["LGTM\t0\t0".to_owned()],
+            malformed: vec![],
+            shadow: vec!["9".to_owned()],
+        };
+        let d = deliver(&gh, 1, SHA, &[], &ext, union_of(&ext));
+        assert_eq!(gh.status_calls.borrow()[0].1, "success");
+        assert_eq!(d.label, Some((LABEL_LGTM.to_owned(), Write::Done)));
+    }
+
+    // ---- malformed heading: one notice, no status, no label -----------------
+
+    #[test]
+    fn malformed_heading_posts_one_notice_and_withholds_status_and_label() {
+        let gh = FakeGh::new(SHA);
+        let ext = Extracted {
+            lines: vec![],
+            malformed: vec!["42".to_owned()],
+            shadow: vec![],
+        };
+        let d = deliver(&gh, 7, SHA, &[], &ext, union_of(&ext));
+        assert_eq!(gh.comment_calls.borrow().len(), 1);
+        assert_eq!(
+            gh.comment_calls.borrow()[0].1,
+            "review: malformed verdict comment 42"
+        );
+        assert_eq!(d.notices, vec![("42".to_owned(), Write::Done)]);
+        assert_eq!(d.status, None);
+        assert_eq!(d.label, None);
+        assert!(gh.status_calls.borrow().is_empty());
+        assert_eq!(d.exit_code(), 0);
+    }
+
+    #[test]
+    fn a_previously_noticed_malformed_comment_does_not_block_a_later_real_verdict() {
+        // Once the one-shot notice for a malformed id already exists on
+        // GitHub, a later run with a real, well-formed verdict alongside it
+        // must proceed to status/label — matching pr-review-watch.sh's
+        // "next poll proceeds with the malformed comment permanently
+        // excluded".
+        let gh = FakeGh::new(SHA);
+        let existing = [Comment {
+            id: "1".into(),
+            body: "review: malformed verdict comment 42".into(),
+        }];
+        let ext = Extracted {
+            lines: vec!["LGTM\t0\t0".to_owned()],
+            malformed: vec!["42".to_owned()],
+            shadow: vec![],
+        };
+        let d = deliver(&gh, 7, SHA, &existing, &ext, union_of(&ext));
+        assert!(gh.comment_calls.borrow().is_empty(), "no NEW notice");
+        assert_eq!(
+            d.notices,
+            vec![("42".to_owned(), Write::Skipped("already noticed"))]
+        );
+        assert_eq!(gh.status_calls.borrow()[0].1, "success");
+        assert_eq!(d.label, Some((LABEL_LGTM.to_owned(), Write::Done)));
+    }
+
+    // ---- idempotency: re-running an already-delivered verdict -------------
+
+    #[test]
+    fn rerunning_an_already_delivered_verdict_performs_zero_new_writes() {
+        let gh = FakeGh::new(SHA);
+        gh.labels.borrow_mut().push(LABEL_LGTM.to_owned());
+        *gh.latest_status.borrow_mut() = Ok(Some("success".to_owned()));
+        let ext = extracted(&["LGTM\t0\t0"]);
+        let d = deliver(&gh, 1, SHA, &[], &ext, union_of(&ext));
+        assert!(gh.status_calls.borrow().is_empty(), "no new status call");
+        assert!(gh.label_calls.borrow().is_empty(), "no new label call");
+        assert_eq!(d.status, Some(Write::Skipped("already applied")));
+        assert_eq!(
+            d.label,
+            Some((LABEL_LGTM.to_owned(), Write::Skipped("already applied")))
+        );
+        assert_eq!(d.exit_code(), 0);
+    }
+
+    // ---- gh failure contract: delivered / partially-delivered / failed ------
+
+    #[test]
+    fn a_status_post_failure_alone_is_a_full_failure() {
+        let gh = FakeGh {
+            fail_post_status: true,
+            ..FakeGh::new(SHA)
+        };
+        let ext = extracted(&["LGTM\t0\t0"]);
+        // Head unknown => label is Skipped, not attempted, so the ONLY
+        // attempted write is the status, and it fails: exit 2.
+        *gh.head.borrow_mut() = Err("gh: rate limited".into());
+        let d = deliver(&gh, 1, SHA, &[], &ext, union_of(&ext));
+        assert!(matches!(d.status, Some(Write::Failed(_))));
+        assert!(matches!(d.label, Some((_, Write::Failed(_)))));
+        assert_eq!(d.exit_code(), 2, "nothing was delivered");
+    }
+
+    #[test]
+    fn a_label_failure_alongside_a_successful_status_is_partial() {
+        let gh = FakeGh {
+            fail_add_label: true,
+            ..FakeGh::new(SHA)
+        };
+        let ext = extracted(&["LGTM\t0\t0"]);
+        let d = deliver(&gh, 1, SHA, &[], &ext, union_of(&ext));
+        assert_eq!(d.status, Some(Write::Done));
+        assert!(matches!(d.label, Some((_, Write::Failed(_)))));
+        assert_eq!(d.exit_code(), 1, "status delivered, label did not");
+    }
+
+    #[test]
+    fn a_malformed_notice_post_failure_withholds_status_and_label_and_is_a_full_failure() {
+        let gh = FakeGh {
+            fail_post_comment: true,
+            ..FakeGh::new(SHA)
+        };
+        let ext = Extracted {
+            lines: vec![],
+            malformed: vec!["42".to_owned()],
+            shadow: vec![],
+        };
+        let d = deliver(&gh, 7, SHA, &[], &ext, union_of(&ext));
+        assert!(matches!(d.notices[0].1, Write::Failed(_)));
+        // Attempting an as-yet-unnoticed id withholds status/label this run
+        // even when the post itself fails — a failed notice must not be
+        // masked by a status write that proceeds as if nothing happened.
+        assert_eq!(d.status, None);
+        assert_eq!(d.label, None);
+        assert!(gh.status_calls.borrow().is_empty());
+        assert_eq!(d.exit_code(), 2, "the only attempted write failed");
+    }
+}

--- a/crates/edda-cli/src/cmd_review/github.rs
+++ b/crates/edda-cli/src/cmd_review/github.rs
@@ -18,6 +18,40 @@ pub(crate) fn gh(repo: &Path, args: &[&str]) -> Result<Value> {
     Ok(serde_json::from_slice(&output.stdout)?)
 }
 
+/// Run `gh` for a write whose stdout is not JSON — a label edit, a comment
+/// post, and a status post each print a bare URL or nothing on success, so
+/// none of them can go through [`gh`], which parses stdout as JSON. Only
+/// the exit status is meaningful here; stdout is discarded.
+pub(crate) fn gh_write(repo: &Path, args: &[&str]) -> Result<()> {
+    let output = Command::new("gh")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .context("run gh")?;
+    if !output.status.success() {
+        bail!("gh: {}", String::from_utf8_lossy(&output.stderr));
+    }
+    Ok(())
+}
+
+/// The PR's current head SHA — a lighter read than [`resolve_pr`], which
+/// also fetches the head and base commits into private refs for `edda
+/// review`'s own diffing. `edda review deliver`'s moved-head check only
+/// ever compares this string; it has no need to make the commit locally
+/// resolvable.
+pub(crate) fn pr_head(repo: &Path, number: u64) -> Result<String> {
+    let value = gh(
+        repo,
+        &["pr", "view", &number.to_string(), "--json", "headRefOid"],
+    )?;
+    let head = value["headRefOid"].as_str().context("PR head missing")?;
+    anyhow::ensure!(
+        head.len() == 40 && head.bytes().all(|b| b.is_ascii_hexdigit()),
+        "invalid PR head SHA"
+    );
+    Ok(head.to_owned())
+}
+
 pub(crate) struct PrSubject {
     pub head: String,
     pub base: String,

--- a/crates/edda-cli/src/cmd_review/mod.rs
+++ b/crates/edda-cli/src/cmd_review/mod.rs
@@ -3,6 +3,7 @@ mod args;
 mod brief;
 mod config;
 mod deliver;
+mod delivery;
 mod due;
 mod evidence;
 mod gate;
@@ -54,9 +55,12 @@ pub enum ReviewCmd {
         #[command(flatten)]
         args: GateArgs,
     },
-    /// What the §7 verdict comments on a reviewed SHA amount to (GH-1030)
+    /// Deliver the §7 verdict comments on a reviewed SHA to GitHub (GH-1030)
     ///
-    /// Reads only for now: the GitHub writes are the next step of GH-1030.
+    /// Writes the `review:*` label and the `Independent Review` commit
+    /// status by the union rule (`edda review gate`, GH-769); a malformed
+    /// verdict comment gets a one-shot notice instead. Exit: 0 delivered,
+    /// 1 partially delivered, 2 failed or cannot judge.
     Deliver {
         #[command(flatten)]
         args: DeliverArgs,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1361,8 +1361,12 @@ A comment is a verdict when its **first** line is the §7 heading. A heading
 anywhere else in the body is a transcript dump, not a verdict: it contributes
 nothing to the union, and its comment id gets a one-shot `review: malformed
 verdict comment <id>` notice — posted once (a later run recognizes the
-existing notice text and does not repeat it) — with no status and no label
-that run. A round whose heading carries ` (SHADOW)` — in either recorded
+existing notice text and does not repeat it). Posting a *new* notice
+withholds status and label for that run, regardless of whether a real
+verdict also stands on the SHA (R23, #917); a withheld write reports outcome
+`withheld` (not `skipped`) and the run's exit code says so too (see the exit
+code table below), so a poller comes back rather than treating the round as
+settled. A round whose heading carries ` (SHADOW)` — in either recorded
 position — is well formed and contributes nothing to the union, because a
 SHADOW round is calibration evidence, never a gate (REVIEW.md §8, rules.md
 R22); when it is the only signal standing on the SHA, deliver performs **zero
@@ -1379,7 +1383,9 @@ The `Independent Review` status is written for the union's state —
 of whether the PR's current head has since moved past the reviewed SHA. The
 `review:*` label is different: it is applied **only** while the current head
 still equals the reviewed SHA. A moved head still gets the status; it never
-gets the label.
+gets the label. Applying a label removes its sibling when present — a later
+Changes Requested on the same SHA removes a standing `review:lgtm`, and vice
+versa — so the two never stand together.
 
 Every write is idempotent by construction: deliver reads the label already on
 the PR, the latest `Independent Review` state already posted for the SHA, and
@@ -1390,13 +1396,15 @@ Stdout is one line — the union state, the SHA, and the number of verdicts
 standing — followed by one `malformed <id>` line per malformed comment, one
 `notice <id> <outcome>` line per notice attempted, and a `status`/`label`
 line for each of those writes. `--json` emits the same as an object, with an
-`outcome` of `done`, `skipped`, or `failed` (with a `reason`) for each write.
+`outcome` of `done`, `skipped`, `withheld`, or `failed` (with a `reason`) for
+each write.
 
 | Exit | Meaning |
 |---|---|
 | 0 | Delivered — every write this round called for succeeded, or none was due |
 | 1 | Partially delivered — some writes succeeded, at least one failed |
 | 2 | Failed — no write succeeded, the comment list was unreadable, or `--sha` was invalid |
+| 3 | Withheld — a new malformed-comment notice posted this run held back a status/label that was due (R23, #917); rerun to retry |
 
 Launching reviews (`edda review`), the trigger policy (`edda review due`,
 GH-763), verdict semantics (`edda review gate`, GH-769), and merging

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1342,10 +1342,11 @@ switch they believe they threw.
 
 #### `edda review deliver`
 
-Reads the §7 verdict comments GitHub holds for a pull request and reports what
-they amount to on one reviewed SHA. It is the product's half of the delivery
-path: the extraction the watcher did in awk (`verdict_body_lines`) plus the
-union rule `edda review gate` owns, in one call.
+Reads the §7 verdict comments GitHub holds for a pull request, reports what
+they amount to on one reviewed SHA, and delivers the writes that follow: the
+`review:lgtm` / `review:changes-requested` label, the `Independent Review`
+commit status, and — for a malformed verdict comment — a one-shot notice.
+This is `edda review`'s only subcommand that touches GitHub.
 
 ```bash
 edda review deliver --pr 1030
@@ -1358,21 +1359,46 @@ verdict comment counts only when it is pinned to that SHA.
 
 A comment is a verdict when its **first** line is the §7 heading. A heading
 anywhere else in the body is a transcript dump, not a verdict: it contributes
-nothing and is reported as `malformed <comment id>` so the round is not lost
-silently. A round whose heading carries ` (SHADOW)` — in either recorded
-position — is well formed and contributes nothing, because a SHADOW round is
-calibration evidence and never enters the union (REVIEW.md §8).
+nothing to the union, and its comment id gets a one-shot `review: malformed
+verdict comment <id>` notice — posted once (a later run recognizes the
+existing notice text and does not repeat it) — with no status and no label
+that run. A round whose heading carries ` (SHADOW)` — in either recorded
+position — is well formed and contributes nothing to the union, because a
+SHADOW round is calibration evidence, never a gate (REVIEW.md §8, rules.md
+R22); when it is the only signal standing on the SHA, deliver performs **zero
+GitHub writes** rather than reporting the SHA unreviewed.
 
 The verdict word is read in order: `Changes Requested` first, then the
 `Provisional — …` line written for an unqualified LGTM, then plain `LGTM`. A
 `P0=`/`P1=` count that is absent stays absent, and the union rule reads an
-unstated count as non-zero.
+unstated count as non-zero. A later LGTM never overrides an earlier Changes
+Requested standing on the same SHA (GH-742).
 
-Stdout is one line — `success`, `failure` or `error`, the SHA, and the number
-of verdicts standing — followed by one `malformed <id>` line per malformed
-comment. `--json` emits the same as an object with the verdict lines and the
-malformed ids.
+The `Independent Review` status is written for the union's state —
+`success`, `failure`, or `error` when no verdict stands at all — regardless
+of whether the PR's current head has since moved past the reviewed SHA. The
+`review:*` label is different: it is applied **only** while the current head
+still equals the reviewed SHA. A moved head still gets the status; it never
+gets the label.
 
-This verb **writes nothing**: no comment, no label, no commit status, no
-ledger event. Publishing those is the remaining half of GH-1030.
+Every write is idempotent by construction: deliver reads the label already on
+the PR, the latest `Independent Review` state already posted for the SHA, and
+the comments already present, before writing anything, so re-running deliver
+for an already-delivered verdict performs zero new GitHub calls.
+
+Stdout is one line — the union state, the SHA, and the number of verdicts
+standing — followed by one `malformed <id>` line per malformed comment, one
+`notice <id> <outcome>` line per notice attempted, and a `status`/`label`
+line for each of those writes. `--json` emits the same as an object, with an
+`outcome` of `done`, `skipped`, or `failed` (with a `reason`) for each write.
+
+| Exit | Meaning |
+|---|---|
+| 0 | Delivered — every write this round called for succeeded, or none was due |
+| 1 | Partially delivered — some writes succeeded, at least one failed |
+| 2 | Failed — no write succeeded, the comment list was unreadable, or `--sha` was invalid |
+
+Launching reviews (`edda review`), the trigger policy (`edda review due`,
+GH-763), verdict semantics (`edda review gate`, GH-769), and merging
+(`edda prs check-merge`; GATE-01 — deliver never merges) stay out of scope.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1383,9 +1383,15 @@ The `Independent Review` status is written for the union's state —
 of whether the PR's current head has since moved past the reviewed SHA. The
 `review:*` label is different: it is applied **only** while the current head
 still equals the reviewed SHA. A moved head still gets the status; it never
-gets the label. Applying a label removes its sibling when present — a later
-Changes Requested on the same SHA removes a standing `review:lgtm`, and vice
-versa — so the two never stand together.
+gets the label — and a withheld run (a new malformed notice) reports the
+label the same way, `skipped (head moved)` rather than `withheld`, when the
+head has moved. Whenever the desired label stands (freshly applied, or
+already applied from an earlier run) and its sibling is still standing too,
+the sibling is removed — a later Changes Requested on the same SHA removes a
+standing `review:lgtm`, and vice versa — so the two never stand together;
+this cleanup retries on every run until it succeeds, and a failed removal is
+its own reported write (`label_removed`), not swallowed into the label's own
+outcome.
 
 Every write is idempotent by construction: deliver reads the label already on
 the PR, the latest `Independent Review` state already posted for the SHA, and
@@ -1394,10 +1400,10 @@ for an already-delivered verdict performs zero new GitHub calls.
 
 Stdout is one line — the union state, the SHA, and the number of verdicts
 standing — followed by one `malformed <id>` line per malformed comment, one
-`notice <id> <outcome>` line per notice attempted, and a `status`/`label`
-line for each of those writes. `--json` emits the same as an object, with an
-`outcome` of `done`, `skipped`, `withheld`, or `failed` (with a `reason`) for
-each write.
+`notice <id> <outcome>` line per notice attempted, and a `status`/`label`/
+`label_removed` line for each of those writes. `--json` emits the same as an
+object, with an `outcome` of `done`, `skipped`, `withheld`, or `failed` (with
+a `reason`) for each write.
 
 | Exit | Meaning |
 |---|---|


### PR DESCRIPTION
Issue: #1030

This is the **write half** of `edda review deliver` (GH-1030). The read half — turning §7 verdict comments into the verdict facts the union rule consumes — merged as #1077 / 8d838e5e. This PR performs the GitHub writes that follow: the `review:*` label, the `Independent Review` commit status, and the malformed-comment notice.

## What it does

```
$ edda review deliver --pr 1030
success 65f135b66305a815a80bc195e5958a9dc63d4137 verdicts=1
status success done
label review:lgtm done
```

`delivery::deliver` performs, or correctly withholds, three kinds of write over the SHA the read half already extracted:

- **The `Independent Review` commit status**, by the union rule (`edda review gate`, GH-769) — `success` for a clean qualifying LGTM, `failure` while any non-qualifying verdict stands (GH-742: a later LGTM never overrides an earlier Changes Requested on the same SHA), `error` when no verdict stands at all. Written regardless of whether the PR's current head has since moved past the reviewed SHA.
- **The `review:lgtm` / `review:changes-requested` label**, matching the same union state — but **only** while the current head still equals the reviewed SHA. A moved head still gets the status; it never gets the label.
- **A one-shot `review: malformed verdict comment <id>` notice**, for a comment whose §7 heading is not on line 1 (#867/#917) — with no status and no label that run.

A round whose only standing signal is a self-declared ` (SHADOW)` verdict (REVIEW.md §8, rules.md R22) gets **zero GitHub writes** — not even the `error` status an unreviewed SHA would get, because a SHADOW round is calibration evidence, not a judgement to erase.

Every write is idempotent by construction, not by a local marker file: `deliver` reads the label already on the PR, the latest `Independent Review` state already posted for the SHA, and the comments already present, before writing anything — so re-running deliver for an already-delivered verdict performs zero new GitHub calls, from any machine, with no local state to go stale.

## The seam

`cmd_review::delivery::Gh` is a small trait — `head`, `labels`, `add_label`, `latest_status`, `post_status`, `post_comment` — implemented for real by `GhCli` (over two new `github.rs` primitives, `gh_write` for the non-JSON write calls and `pr_head` for a head-only PR read) and by an in-module `FakeGh` for tests. Every doneWhen fixture is a `deliver()` call against `FakeGh`; none touch the network.

## Two divergences from the issue's original "What" — stated, not silently resolved

**1. The verdict source is comments, not the ledger** (inherited from #1077, restated here because it now also shapes the write half). The issue's What says deliver "reads the `review_verdict` events for the PR's head SHA from the ledger"; #1077 reads §7 comments from GitHub instead, because a round published only through the comment path writes no ledger event at all (`review_verdict` is not among the event types the committed mirror imports — `D8-debt(#671)`). This PR follows that architecture rather than re-litigating it.

**2. This module does not post the primary §7 verdict comment.** The issue's What also lists "Post the §7 verdict comment verbatim, heading on line 1" as something deliver does. Once the verdict source is "comments already on GitHub" (divergence 1), that comment has to already exist for `deliver` to read it in the first place — so this PR treats it as posted by whatever ran the review (today `pr-review-watch.sh`'s `settle_pending`, via `gh pr comment --body-file`), not by `deliver` itself. Two things point at this being the intended shape rather than a shortcut:
   - The issue's own list of what the follow-up adapter PR converts into calls on this verb — `post_review_status`, `settle_pending`, `verdict_body_lines` — never names the shell's verdict-comment `gh pr comment --body-file` call. Only the derived writes (status, label, malformed notice) move.
   - The doneWhen fixtures are all about derived writes (the union matrix's status, the moved-head label, the SHADOW zero-writes, the malformed notice, idempotency, the failure contract). None of them exercise "post a fresh verdict comment from a caller-supplied carrier."

   "Post the §7 verdict comment verbatim, heading on line 1" is honored as a **read-time validation** instead: [`super::deliver::extract`] only accepts a comment as a verdict when its heading is line 1, and refuses (routes to the malformed notice) anything else. It is not honored as a write action in this PR. Flagging this explicitly because it's exactly the class of silent misreading #1056 was burned by.

**3. (Minor, same family) The status write is unconditional on head.** `pr-review-watch.sh`'s `finish_verdict` happens to skip both the status and the label together on a moved head — but that's a side effect of its early-return control flow, not a stated rule: the issue's own wording for the status ("Independent Review commit status on the reviewed SHA by the union rule") carries no head-equality clause, and doneWhen's moved-head bullet names only the label ("Label applied only when head == reviewed SHA"). This PR writes the status regardless of head movement and gates only the label — see `delivery.rs`'s module doc comment for the fuller reasoning.

## What's deliberately not here

Per the issue's Out of scope and my brief: launching reviews (`edda review`), the trigger policy (`edda review due`, #763), verdict semantics (`edda review gate`, #769), the `--sha` PR-vs-issue validation and the read-path argv guard (a separate issue), the watcher adapter itself, and any merging (GATE-01 — `deliver` never merges).

One more explicit gap, named rather than silently skipped: rules.md R22's engine-authority check (`verdict_engine` / `classify_surface` / `verdict_surface_ok` in `pr-review-watch.sh`) is a **second, independent** defense against a reviewer that fails to self-declare SHADOW — it re-derives authority from the PR's changed files and the R22 path table. This PR honors only the primary mechanism R22 itself names (the ` (SHADOW)` heading suffix — REVIEW.md §8 calls it "the only SHADOW marker"). The independent cross-check is a separate, larger feature (a new `gh` read of the PR's changed files, plus the R22 path table kept in sync with `pr-review-watch.sh`'s copy) and is not implemented here.

## doneWhen → fixture map

| doneWhen bullet | Fixture(s) in `delivery.rs` |
|---|---|
| Union matrix: LGTM-only → success | `lgtm_only_posts_success_and_applies_the_lgtm_label` |
| LGTM + Changes Requested same SHA → failure; later-LGTM-never-overrides (GH-742) | `lgtm_then_changes_requested_same_sha_posts_failure_gh742` (both orderings) |
| none → error | `no_verdicts_at_all_posts_error_and_applies_no_label` |
| Label applied only when head == reviewed SHA (moved-head: comment posted [pre-existing], no label) | `moved_head_withholds_the_label_but_still_posts_status` |
| SHADOW / non-authoritative-engine fixtures: zero GitHub writes | `shadow_only_round_performs_zero_github_writes`, `a_real_verdict_alongside_a_shadow_comment_still_delivers_normally` |
| Malformed-heading fixture: one notice, no status, no label | `malformed_heading_posts_one_notice_and_withholds_status_and_label`, `a_previously_noticed_malformed_comment_does_not_block_a_later_real_verdict` |
| Idempotent: zero new writes on rerun | `rerunning_an_already_delivered_verdict_performs_zero_new_writes` |
| gh failure contract: delivered / partially-delivered / failed | `a_status_post_failure_alone_is_a_full_failure`, `a_label_failure_alongside_a_successful_status_is_partial`, `a_malformed_notice_post_failure_withholds_status_and_label_and_is_a_full_failure` |
| Tests written FAIL-first | Written against stub bodies (`Delivery::default()`) first, confirmed red, then implemented |

Two supporting fixtures in `deliver.rs` extend the read half's own `Extracted` (a new `shadow: Vec<String>` field, needed to distinguish "SHADOW is the only signal" from "nothing pinned to this SHA at all"): `a_shadow_round_is_well_formed_and_contributes_nothing` (extended) and `a_shadow_round_for_another_sha_is_not_this_shas_shadow` (new).

## Gates (L0, touched crates)

Lane: `worker-2` (`$env:CARGO_TARGET_DIR = "$env:LOCALAPPDATA\fleet-workstation\lanes\worker-2"`).

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | exit 0 |
| `cargo clippy -p edda --all-targets -- -D warnings` | exit 0 |
| `cargo test -p edda cmd_review` | 109 passed, 5 failed (all pre-existing — see below), 601 filtered out |

The pre-existing failures in `cmd_review::evidence::tests` and `cmd_review::tests::mutating_ran_gate_persists_unreviewed_proof_failure_before_engine_launch` are unrelated to this change — verified directly: with this work `git stash`ed away, the identical 5 tests fail identically against unmodified `origin/main` (same assertions, same `sh` not found in PATH). #1077 documented the same class of failure for the same reason (wall-clock/spawn-sensitive tests on a workstation running several sessions at once).

L1 (exact-head CI) will run on push; this PR carries no `Cargo.lock`/toolchain change, so the full CI matrix applies as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
