### PR TITLE
fix(fleet): merge-reviewed-pr.sh asks the union gate, not the latest review (GH-1057)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -855,15 +855,27 @@ caller's verdict facts with `--verdicts`; it writes nothing, launches nothing,
 and never touches GitHub. Its exit codes and flags are in
 `docs/reference/cli.md`.
 
-No caller asks it today: the shell that posted the `Independent Review` commit
-status from its answer was retired with its status writer (GH-1061), and
-`review.merge-gate` had already taken that context out of the ruleset — verdict
-delivery for a dispatched round is `edda review deliver` (GH-1030). The merge
-step does not ask it either — `scripts/merge-reviewed-pr.sh` still requires the
-*latest* trusted
-review to be a qualifying LGTM, which an earlier standing Changes Requested on
-the same SHA does not survive contact with. GH-1057 wires it; until it lands,
-do not read this paragraph as a claim that merge already goes through the gate.
+**The merge step asks that rule** (GH-1057). `scripts/merge-reviewed-pr.sh`
+still requires the *latest* trusted review pinned to the head to be a
+qualifying LGTM with no unresolved escalation; on top of that it now refuses
+any head whose union is not a pass, so an earlier standing Changes Requested is
+no longer survived by a later LGTM there. It reaches the rule through
+`edda review deliver --pr <n> --sha <head> --json` (GH-1030) rather than
+`edda review gate` directly: verdicts do not cross machines in the ledger yet
+(`D8-debt(#671)`), so the §7 comments are the only source that answers
+correctly at a merge, and `deliver` is what reduces those comments and hands
+them to this same rule. A verdict comment the union could not read (a §7
+heading below line 1, #917) refuses too — a union reading `success` while a
+blocking round is invisible to it is not a pass. The shell that used to post
+the `Independent Review` commit status from the gate's answer was retired with
+its status writer (GH-1061), and `review.merge-gate` had already taken that
+context out of the ruleset, so the merge script — not a required check — is
+where the rule binds. What the merge step does **not** ask is the window check:
+`--base` needs both commits present locally and that entrypoint runs anywhere
+with `gh --repo`, so there `gh pr merge --match-head-commit` plus GitHub's own
+merge-state refusal covers the race at the moment it counts. Run
+`edda review gate <sha> --base <ref>` from a checkout for the stronger
+tree-level window check.
 
 ## 9. Provenance of the check commands
 

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -172,7 +172,7 @@
 
    **合併不在這一步**——仍在第 7 步、要操作者授權。
 6. **收斂**：`/fleet-pr-loop` 的 bash driver 吐 `ACTION: REVIEW | FIX | DONE | BLOCKED`，照做到 LGTM；driver 不合併。走第 4 步直審路徑時不需要 driver：判決與修正在同一個 session 內來回。
-7. **合併**（有操作者授權時）：先執行 `sh scripts/merge-reviewed-pr.sh <PR>`，核對最新可信審查是目前完整 SHA 的 LGTM、P0=0/P1=0、無待升級項目且必要 CI 檢查通過。取得合併授權後使用 `sh scripts/merge-reviewed-pr.sh <PR> --merge`；它以 `--match-head-commit` 鎖定審查 SHA，避免最後一刻 push 越過判決。合併後對剩下的 PR 做 Layer-3 交集：不相交直接合，相交要 rebase → 判決失效 → 再一輪。
+7. **合併**（有操作者授權時）：先執行 `sh scripts/merge-reviewed-pr.sh <PR>`，核對最新可信審查是目前完整 SHA 的 LGTM、P0=0/P1=0、無待升級項目且必要 CI 檢查通過；它另外會問一次聯集判決（GH-1057，經 `edda review deliver`），該 SHA 上只要還有一則站著的 Changes Requested，後來的 LGTM 也蓋不過（GH-742）。取得合併授權後使用 `sh scripts/merge-reviewed-pr.sh <PR> --merge`；它以 `--match-head-commit` 鎖定審查 SHA，避免最後一刻 push 越過判決。合併後對剩下的 PR 做 Layer-3 交集：不相交直接合，相交要 rebase → 判決失效 → 再一輪。
 8. **開單**：審查 exhaust、runtime 的傷、重複兩次的手動步驟，當場 `/issue-intake`／`/issue-create`（含四問接線審計）。不要留在對話裡。
 9. **收工**：`edda note "completed X; decided Y; next: Z" --tag session`；回報你：合了什麼、開了什麼、等你什麼。
 

--- a/scripts/merge-reviewed-pr.sh
+++ b/scripts/merge-reviewed-pr.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # Operator entrypoint. --merge must only be used with explicit operator authority.
-# Default is read-only validation; GitHub's match-head option closes the last race.
+# Default is validation only — no merge; GitHub's match-head option closes the
+# last race. The one write it can make is the union gate's own `edda review
+# deliver` publishing the label/status for the verdict it just read; see there.
 set -eu
 die() { echo "merge-reviewed-pr: $*" >&2; exit 1; }
 if [ "${1:-}" = --help ]; then
@@ -42,6 +44,59 @@ printf '%s\n' "$body" | grep -qE '^- escalations: none[[:space:]]*$' || die 'rev
 verdict=$(printf '%s\n' "$body" | awk '/^### Verdict[[:space:]]*$/{found=1;next} found && NF{print;exit}')
 printf '%s\n' "$verdict" | grep -qE '^LGTM \(P0=0, P1=0\)([[:space:]]|$)' || die 'latest review does not approve with P0=0/P1=0'
 case "$verdict" in *'Changes Requested'*|*provisional*) die 'provisional or conflicting verdict' ;; esac
+# The union gate (GH-1057) — an ADDITIONAL refusal, on top of everything above.
+#
+# Every check so far judges the *latest* trusted review pinned to this head.
+# REVIEW.md §8's rule is the *union* over every verdict pinned to it: a later
+# LGTM never overrides an earlier standing Changes Requested on the same SHA
+# (GH-742). PR #1055 was merged over exactly that shape on 2026-09-07.
+#
+# That rule has one implementation, `edda review gate` (GH-769), and one reader
+# of the §7 verdict comments that carry verdicts between machines,
+# `edda review deliver` (GH-1030), which feeds those comments to it. Verdicts
+# do not cross machines in the ledger yet (D8-debt(#671)), so the comment path
+# is the only source that answers correctly here. What follows is a call and a
+# field read: no verdict parsing and no union arithmetic live in this shell
+# (mechanism.shell-role=one-line-adapter-only).
+#
+# `--sha "$head"` pins the question to the head every check above accepted, and
+# skips deliver's own PR resolution, which fetches commits and would therefore
+# require a checkout. GH_REPO carries $repo to `gh` the way `--repo` does
+# above, so this step does not narrow where the script may run.
+#
+# Not read-only, and said plainly: deliver also publishes what it reads — the
+# `review:*` label and the `Independent Review` commit status the union
+# implies. It reads the current label and status first and writes nothing when
+# they already match, so on the ordinary path (the reviewing session delivered
+# its own round) this call makes zero GitHub writes. Where it does write, the
+# write is the union verdict for the very SHA about to be merged.
+#
+# The window step is deliberately NOT wired here. `edda review gate --base`
+# needs both commits present locally, which would turn this `gh --repo` script
+# into one that requires a checkout. At this entrypoint the forge already makes
+# the equivalent check at the moment it counts: `gh pr merge
+# --match-head-commit "$head"` below refuses if anything landed on the PR after
+# the reviewed SHA, and GitHub's own mergeStateStatus/branch protection refuses
+# a base the PR is behind. That is judged sufficient here; a reviewer wanting
+# the stronger tree-level window check should run `edda review gate <sha>
+# --base <ref>` from a checkout, which is what it is for.
+#
+# `edda review deliver` exits by *delivery* outcome (0 delivered, 1 partial,
+# 3 status withheld), not by the union — the union is `--json`'s `status`
+# field. So its exit code is deliberately not the gate. Exit 2 ("cannot judge")
+# prints no JSON at all, which the `jq -e` reads below turn into a refusal.
+report=$(GH_REPO="$repo" "${EDDA_BIN:-edda}" review deliver --pr "$pr" --sha "$head" --json) || true
+state=$(printf '%s\n' "$report" | jq -er '.status') \
+  || die "union gate gave no readable answer for $head; refusing"
+malformed=$(printf '%s\n' "$report" | jq -er '.malformed | length') \
+  || die "union gate gave no readable answer for $head; refusing"
+[ "$state" = success ] \
+  || die "union over every trusted review pinned to $head is '$state', not a pass; a later LGTM does not override an earlier Changes Requested (GH-742)"
+# A §7 heading below line 1 is a round the union never saw (GH-917), so the
+# union above can read `success` precisely because a blocking round is
+# invisible to it. Fail closed rather than merge on a verdict set with a hole.
+[ "$malformed" = 0 ] \
+  || die "$malformed verdict comment(s) on $head are malformed and outside the union; refusing"
 gh pr checks "$pr" --repo "$repo" --required || die 'required checks are not green'
 echo "review accepted: PR #$pr @ $head"
 if [ "$action" = --merge ]; then

--- a/scripts/merge-reviewed-pr.sh
+++ b/scripts/merge-reviewed-pr.sh
@@ -1,8 +1,14 @@
 #!/bin/sh
 # Operator entrypoint. --merge must only be used with explicit operator authority.
 # Default is validation only — no merge; GitHub's match-head option closes the
-# last race. The one write it can make is the union gate's own `edda review
-# deliver` publishing the label/status for the verdict it just read; see there.
+# last race. The union gate's own `edda review deliver` is the write surface
+# this script opens: it can publish the `review:*` label, the `Independent
+# Review` commit status, and — on a malformed §7 comment — a one-time notice
+# comment on the PR; see the comment above the `report=` assignment below.
+# Requires an `edda` binary built with `review deliver` (GH-1030,
+# post-2026-09-08); a stale or
+# missing binary is not detected separately here — it reports as a union
+# refusal (fail-closed). Check with `edda --version`.
 set -eu
 die() { echo "merge-reviewed-pr: $*" >&2; exit 1; }
 if [ "${1:-}" = --help ]; then
@@ -64,12 +70,17 @@ case "$verdict" in *'Changes Requested'*|*provisional*) die 'provisional or conf
 # require a checkout. GH_REPO carries $repo to `gh` the way `--repo` does
 # above, so this step does not narrow where the script may run.
 #
-# Not read-only, and said plainly: deliver also publishes what it reads — the
-# `review:*` label and the `Independent Review` commit status the union
-# implies. It reads the current label and status first and writes nothing when
-# they already match, so on the ordinary path (the reviewing session delivered
-# its own round) this call makes zero GitHub writes. Where it does write, the
-# write is the union verdict for the very SHA about to be merged.
+# Not read-only, and said plainly: deliver can make three kinds of GitHub
+# write — the `review:*` label, the `Independent Review` commit status the
+# union implies, and, when a §7 comment does not parse, a one-time `review:
+# malformed verdict comment <id>` notice on the PR (crates/edda-cli/src/
+# cmd_review/delivery.rs, `deliver()`'s notice loop; GH-917 / #917). It reads
+# the current label and status first and writes nothing when they already
+# match, so on the ordinary path (the reviewing session delivered its own
+# round, nothing malformed) this call makes zero GitHub writes. Where it does
+# write, the label/status write is the union verdict for the very SHA about
+# to be merged, and a malformed notice is posted under the operator's own
+# token — exactly the path the `$malformed` refusal below exists to serve.
 #
 # The window step is deliberately NOT wired here. `edda review gate --base`
 # needs both commits present locally, which would turn this `gh --repo` script
@@ -85,13 +96,42 @@ case "$verdict" in *'Changes Requested'*|*provisional*) die 'provisional or conf
 # 3 status withheld), not by the union — the union is `--json`'s `status`
 # field. So its exit code is deliberately not the gate. Exit 2 ("cannot judge")
 # prints no JSON at all, which the `jq -e` reads below turn into a refusal.
-report=$(GH_REPO="$repo" "${EDDA_BIN:-edda}" review deliver --pr "$pr" --sha "$head" --json) || true
-state=$(printf '%s\n' "$report" | jq -er '.status') \
+#
+# Not gating still means visible: `|| true` below keeps a nonzero delivery
+# exit from aborting the script (that decision stands — see above), but the
+# exit code and any individual failed write (`status_write`/`label`/
+# `label_removed` carrying outcome "failed") are still worth the operator's
+# attention, since a failed write means the label/status this refusal relies
+# on was never published. Report both, to stderr, without gating on them.
+report_exit=0
+report=$(GH_REPO="$repo" "${EDDA_BIN:-edda}" review deliver --pr "$pr" --sha "$head" --json) \
+  || report_exit=$?
+failed_writes=$(printf '%s\n' "$report" | jq -r '
+    [
+      {name: "status", w: .status_write},
+      {name: (.label.name // "label"), w: .label},
+      {name: (.label_removed.name // "label_removed"), w: .label_removed}
+    ]
+    | map(select(.w != null and .w.outcome == "failed") | .name)
+    | join(", ")
+  ' 2>/dev/null) || failed_writes=''
+if [ "$report_exit" -ne 0 ] || [ -n "$failed_writes" ]; then
+  echo "merge-reviewed-pr: warning: edda review deliver did not cleanly write for $head (exit $report_exit)${failed_writes:+; failed: $failed_writes}" >&2
+fi
+# `union_state` (not `state` — that name is already the PR's OPEN/CLOSED
+# state read above) is the union's own verdict; it alone decides the refusal
+# below, independent of the write-outcome warning above.
+union_state=$(printf '%s\n' "$report" | jq -er '.status') \
   || die "union gate gave no readable answer for $head; refusing"
-malformed=$(printf '%s\n' "$report" | jq -er '.malformed | length') \
+# `arrays` fails closed on a key-less or reshaped report: `.malformed | length`
+# reads a missing key as `null`, and `null | length` is `0`, which would pass
+# this check rather than refuse it. `arrays` only lets an actual array through,
+# so a missing/renamed key produces no output, `-e` sees nothing, and the
+# command fails into the `die` below — the same fail-closed shape as `.status`.
+malformed=$(printf '%s\n' "$report" | jq -er '.malformed | arrays | length') \
   || die "union gate gave no readable answer for $head; refusing"
-[ "$state" = success ] \
-  || die "union over every trusted review pinned to $head is '$state', not a pass; a later LGTM does not override an earlier Changes Requested (GH-742)"
+[ "$union_state" = success ] \
+  || die "union over every §7 verdict comment pinned to $head is '$union_state', not a pass; a later LGTM does not override an earlier Changes Requested (GH-742)"
 # A §7 heading below line 1 is a round the union never saw (GH-917), so the
 # union above can read `success` precisely because a blocking round is
 # invisible to it. Fail closed rather than merge on a verdict set with a hole.

--- a/scripts/test-merge-reviewed-pr.sh
+++ b/scripts/test-merge-reviewed-pr.sh
@@ -218,4 +218,29 @@ case $err in
     *) fail "case 4: expected a malformed-comment refusal, got: $err" ;;
 esac
 
+# ── case 5: exit code is not the gate, but it is not silent either ─────
+#
+# `edda review deliver` exits by delivery outcome (0/1/3), not by the union
+# (Round 1 review, P1-2 — the exit code was previously discarded with no
+# signal at all). Here deliver exits 1 (partially delivered) while the union
+# itself still reads `success`: the merge must still proceed — the union
+# `.status` field alone decides the refusal — but a warning naming the
+# nonzero exit must land on stderr so the operator can see the write did not
+# fully land.
+
+STUB_COMMENTS=$work/fixtures/lgtm-only.json
+STUB_DELIVER=$work/fixtures/deliver-success.json
+STUB_DELIVER_EXIT=1
+export STUB_COMMENTS STUB_DELIVER STUB_DELIVER_EXIT
+run_case
+[ "$code" -eq 0 ] || fail "case 5: a nonzero deliver exit with a union pass must not block the merge (exit $code): $err"
+[ "$out" = "review accepted: PR #$PR @ $HEAD_SHA" ] \
+    || fail "case 5: accept output changed: $out"
+grep -qF "pr checks $PR" "$GH_CALLS" \
+    || fail "case 5: --required checks were skipped: $(cat "$GH_CALLS")"
+case $err in
+    *warning*) : ;;
+    *) fail "case 5: expected a warning on stderr naming the failed write, got: $err" ;;
+esac
+
 echo "PASS scripts/test-merge-reviewed-pr.sh ($case_no cases)"

--- a/scripts/test-merge-reviewed-pr.sh
+++ b/scripts/test-merge-reviewed-pr.sh
@@ -1,0 +1,221 @@
+#!/bin/sh
+# Offline self-test for scripts/merge-reviewed-pr.sh's union gate (GH-1057).
+#
+# The defect this covers: the script selected the LATEST trusted review pinned
+# to the head and asked only that one for its verdict, so an earlier standing
+# `Changes Requested` stopped mattering the moment a later `LGTM (P0=0, P1=0)`
+# existed on the same SHA — exactly the failure the union rule (GH-742,
+# REVIEW.md §8) is written to prevent, on the operator's merge entrypoint.
+#
+# What is under test here is the WIRING, not the rule. The union rule has one
+# implementation, `edda review gate` (GH-769), reached over §7 verdict comments
+# by `edda review deliver` (GH-1030); both are covered by that crate's own
+# tests. This fixture stubs `edda` and asserts the script asks it about the
+# right head, refuses whatever it answers short of a union pass, and leaves the
+# pre-existing accept path byte-identical.
+#
+# Fully offline: `gh` and `edda` are stubbed on PATH ahead of the real ones and
+# every invocation is recorded, so no network, no repository and no GitHub
+# credentials are touched. `jq` is the real one — the script under test needs
+# it, and so does no assertion here.
+#
+# usage: sh scripts/test-merge-reviewed-pr.sh
+set -eu
+
+cd "$(git rev-parse --show-toplevel)"
+script=scripts/merge-reviewed-pr.sh
+
+sh -n "$script" || { echo "FAIL: sh -n $script" >&2; exit 1; }
+sh -n "$0" || { echo "FAIL: sh -n $0" >&2; exit 1; }
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/test-merge-reviewed-pr.XXXXXX")
+cleanup() { rm -rf "$work"; }
+trap cleanup 0 HUP INT TERM
+
+mkdir -p "$work/bin" "$work/fixtures"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+PR=4242
+HEAD_SHA=aaaaaaaabbbbbbbbccccccccdddddddd11112222
+
+# ── stubs ────────────────────────────────────────────────────────────
+#
+# `gh` answers exactly the three reads the script makes, off fixture files, and
+# records every call so a case can prove what was and was not reached. Anything
+# else is a hard error rather than a silent success: a stub that shrugs at an
+# unexpected call turns a wiring regression into a green test.
+
+cat >"$work/bin/gh" <<'STUB'
+#!/bin/sh
+printf 'gh %s\n' "$*" >>"$GH_CALLS"
+case "${1:-} ${2:-}" in
+    "pr view")   printf '%s\tOPEN\n' "$STUB_HEAD" ;;
+    "api --paginate") cat "$STUB_COMMENTS" ;;
+    "pr checks") exit "${STUB_CHECKS_EXIT:-0}" ;;
+    *) echo "gh stub: unexpected invocation: $*" >&2; exit 1 ;;
+esac
+STUB
+chmod +x "$work/bin/gh"
+
+# `edda` stands in for `edda review deliver --json`. STUB_DELIVER names the
+# report file; unset means the verb could not judge at all, which the real verb
+# signals by exiting 2 with nothing on stdout.
+cat >"$work/bin/edda" <<'STUB'
+#!/bin/sh
+printf 'edda %s\n' "$*" >>"$EDDA_CALLS"
+if [ -z "${STUB_DELIVER:-}" ]; then
+    echo 'edda review deliver: read comments of PR: gh: not authenticated' >&2
+    exit 2
+fi
+cat "$STUB_DELIVER"
+exit "${STUB_DELIVER_EXIT:-0}"
+STUB
+chmod +x "$work/bin/edda"
+
+PATH="$work/bin:$PATH"
+export PATH
+STUB_HEAD=$HEAD_SHA
+export STUB_HEAD
+
+# ── comment fixtures ─────────────────────────────────────────────────
+#
+# The REST issue-comments shape the script reads through `gh api --paginate
+# --slurp`: an array of pages, each an array of comments carrying
+# author_association, body, updated_at and a numeric id.
+
+sed "s/@SHA@/$HEAD_SHA/g" >"$work/fixtures/changes-then-lgtm.json" <<'JSON'
+[[
+  {
+    "id": 111,
+    "author_association": "OWNER",
+    "updated_at": "2026-09-08T10:00:00Z",
+    "body": "## Code Review: Round 1 — PR #4242 @ @SHA@\n\n- escalations: none\n\n### Verdict\n\nChanges Requested, P0=0, P1=1\n"
+  },
+  {
+    "id": 222,
+    "author_association": "OWNER",
+    "updated_at": "2026-09-08T11:00:00Z",
+    "body": "## Code Review: Round 2 — PR #4242 @ @SHA@\n\n- escalations: none\n\n### Verdict\n\nLGTM (P0=0, P1=0)\n"
+  }
+]]
+JSON
+
+sed "s/@SHA@/$HEAD_SHA/g" >"$work/fixtures/lgtm-only.json" <<'JSON'
+[[
+  {
+    "id": 222,
+    "author_association": "OWNER",
+    "updated_at": "2026-09-08T11:00:00Z",
+    "body": "## Code Review: Round 1 — PR #4242 @ @SHA@\n\n- escalations: none\n\n### Verdict\n\nLGTM (P0=0, P1=0)\n"
+  }
+]]
+JSON
+
+# ── deliver reports ──────────────────────────────────────────────────
+#
+# The `--json` shape of `edda review deliver` (crates/edda-cli/src/cmd_review/
+# deliver.rs): `status` is the union state — success / failure / error — and
+# `malformed` lists §7 comments the union could not read.
+
+cat >"$work/fixtures/deliver-failure.json" <<'JSON'
+{"pr":4242,"status":"failure","verdicts":["Changes Requested\t0\t1","LGTM\t0\t0"],"malformed":[],"shadow":[],"exit_code":0}
+JSON
+
+cat >"$work/fixtures/deliver-success.json" <<'JSON'
+{"pr":4242,"status":"success","verdicts":["LGTM\t0\t0"],"malformed":[],"shadow":[],"exit_code":0}
+JSON
+
+cat >"$work/fixtures/deliver-malformed.json" <<'JSON'
+{"pr":4242,"status":"success","verdicts":["LGTM\t0\t0"],"malformed":["5573431960"],"shadow":[],"exit_code":3}
+JSON
+
+# ── harness ──────────────────────────────────────────────────────────
+
+case_no=0
+run_case() {
+    case_no=$((case_no + 1))
+    GH_CALLS=$work/gh-calls-$case_no
+    EDDA_CALLS=$work/edda-calls-$case_no
+    export GH_CALLS EDDA_CALLS
+    : >"$GH_CALLS"
+    : >"$EDDA_CALLS"
+    set +e
+    out=$(sh "$script" "$PR" 2>"$work/err-$case_no")
+    code=$?
+    set -e
+    err=$(cat "$work/err-$case_no")
+}
+
+# ── case 1: an earlier Changes Requested under a later LGTM is refused ──
+#
+# doneWhen bullet 1. The latest trusted review pinned to this head IS a
+# qualifying LGTM — every pre-existing check passes — so this case fails
+# against the latest-review-wins script and can only pass once the union gate
+# stands.
+
+STUB_COMMENTS=$work/fixtures/changes-then-lgtm.json
+STUB_DELIVER=$work/fixtures/deliver-failure.json
+export STUB_COMMENTS STUB_DELIVER
+run_case
+[ "$code" -ne 0 ] || fail "case 1: a standing Changes Requested was merged over: $out"
+case $err in
+    *union*) : ;;
+    *) fail "case 1: the refusal must name the union, got: $err" ;;
+esac
+grep -qF "review deliver --pr $PR --sha $HEAD_SHA --json" "$EDDA_CALLS" \
+    || fail "case 1: the gate was not asked about this head: $(cat "$EDDA_CALLS")"
+if grep -q 'pr checks' "$GH_CALLS"; then
+    fail "case 1: required checks were queried after the union already refused"
+fi
+
+# ── case 2: a lone qualifying LGTM still merges — accept path unchanged ─
+#
+# doneWhen bullet 2. Same stdout line, same exit code, and the required-checks
+# call still made: the union gate is an ADDITIONAL refusal, never a
+# replacement for anything above it.
+
+STUB_COMMENTS=$work/fixtures/lgtm-only.json
+STUB_DELIVER=$work/fixtures/deliver-success.json
+export STUB_COMMENTS STUB_DELIVER
+run_case
+[ "$code" -eq 0 ] || fail "case 2: the accept path broke (exit $code): $err"
+[ "$out" = "review accepted: PR #$PR @ $HEAD_SHA" ] \
+    || fail "case 2: accept output changed: $out"
+grep -qF "pr checks $PR" "$GH_CALLS" \
+    || fail "case 2: --required checks were skipped: $(cat "$GH_CALLS")"
+
+# ── case 3: a gate that cannot judge refuses, it does not wave through ──
+#
+# `edda review deliver` exits 2 with no JSON when it cannot read the comments
+# at all. An unreadable answer is not an approval.
+
+STUB_COMMENTS=$work/fixtures/lgtm-only.json
+unset STUB_DELIVER
+run_case
+[ "$code" -ne 0 ] || fail "case 3: an unjudgeable head was accepted: $out"
+case $err in
+    *union*) : ;;
+    *) fail "case 3: expected a union-gate refusal, got: $err" ;;
+esac
+
+# ── case 4: a verdict comment the union could not read refuses ─────────
+#
+# A §7 heading below line 1 is a round the union never saw (GH-917). The
+# reported union is `success` here precisely because the blocking round is
+# invisible to it, which is why `malformed` has to be its own refusal.
+
+STUB_COMMENTS=$work/fixtures/lgtm-only.json
+STUB_DELIVER=$work/fixtures/deliver-malformed.json
+export STUB_COMMENTS STUB_DELIVER
+run_case
+[ "$code" -ne 0 ] || fail "case 4: a malformed verdict comment was ignored: $out"
+case $err in
+    *malformed*) : ;;
+    *) fail "case 4: expected a malformed-comment refusal, got: $err" ;;
+esac
+
+echo "PASS scripts/test-merge-reviewed-pr.sh ($case_no cases)"


### PR DESCRIPTION
Issue: #1057

Closes #1057

Decision: mechanism.shell-role

## What was wrong

`scripts/merge-reviewed-pr.sh` is the operator's merge entrypoint. Its verdict
selection was latest-trusted-review-wins:

```
$trusted | sort_by([.updated_at, .id]) | last | .body
```

so an earlier standing `Changes Requested` on the head stopped counting the
moment a later `LGTM (P0=0, P1=0)` existed on the same SHA — the exact failure
the union rule (GH-742, REVIEW.md §8) was written to prevent, and the shape PR
#1055 was merged over on 2026-09-07. The union did not reach it indirectly
either: ruleset 18852689 requires only `CI Gate`, so `Independent Review` never
reached `gh pr checks --required`.

## What this does

One additional refusal, wired to the product:

```sh
report=$(GH_REPO="$repo" "${EDDA_BIN:-edda}" review deliver --pr "$pr" --sha "$head" --json) || true
state=$(printf '%s\n' "$report" | jq -er '.status') || die ...
malformed=$(printf '%s\n' "$report" | jq -er '.malformed | length') || die ...
[ "$state" = success ] || die "union over every trusted review pinned to $head is '$state', not a pass; ..."
[ "$malformed" = 0 ] || die "$malformed verdict comment(s) on $head are malformed and outside the union; refusing"
```

Strictly tightening. Head-pinning, `escalations: none`, the latest-review LGTM
requirement and `gh pr checks --required` all stay; the union is checked before
the required-checks network call so a refused head costs nothing. The accept
path for a head whose only trusted review is a qualifying LGTM is
behavior-identical — same stdout line, same exit code, same `--required` call
(fixture case 2 asserts all three).

`malformed` is its own refusal because a §7 heading below line 1 (#917) is a
round the union never saw: the union can read `success` precisely because a
blocking round is invisible to it.

## Spec adaptation (stated, per the controller's adjudication)

The issue's "What to do" says to pipe `scripts/pr-review-watch.sh
collect-verdicts` into `edda review gate`. **That file no longer exists** —
GH-1061 deleted the review shell (merged today as 71e0654). It was not
resurrected and no third verdict parser was written in shell.

**`edda review deliver`, not `edda review gate` directly.** `gate` is the union
rule and the only implementation of it, but its *input contract* does not fit
this caller. Its default source is the ledger's `review_verdict` events, and
verdicts do not cross machines in the ledger yet (`D8-debt(#671)`, stated in
`gate.rs`'s own module doc) — a merge driven from a machine that did not run
the review would see no verdict at all. Its other source, `--verdicts`, wants
the tab-separated facts *someone else* derived from §7 comments, and deriving
them here is exactly the verdict parser `mechanism.shell-role` bans. `edda
review deliver` is the product's own reader of those comments: it pages the
REST issue-comments endpoint, reduces each §7 comment to the same
`gate::from_lines` shape, and hands it to `gate::union` — so the rule still has
one owner and this shell has no arithmetic in it. Its `--json` `status` field
*is* the union state.

Two consequences, both documented in the script rather than hidden:

- **The exit code is deliberately not the gate.** `deliver` exits by *delivery*
  outcome (0 delivered, 1 partial, 3 status withheld), not by the union. The
  gate is the `status` field. Exit 2 ("cannot judge") prints no JSON at all,
  which the `jq -e` reads turn into a refusal.
- **`--check` is no longer purely read-only.** `deliver` also publishes what it
  reads — the `review:*` label and the `Independent Review` commit status the
  union implies. It reads the current label/status first and writes nothing when
  they match, so on the ordinary path (the reviewing session already delivered)
  this makes zero GitHub writes; where it does write, the write is the union
  verdict for the very SHA about to be merged. The file header says so.

`GH_REPO="$repo"` carries the script's existing `EDDA_REPO` target to `gh` the
way `--repo` does for the other calls, and `--sha "$head"` skips `deliver`'s own
PR resolution (which fetches commits). So the union gate does not narrow where
this script may run — it still needs no checkout.

**The window step** (the issue leaves it open): decided the cheap way, with the
reasoning in a comment block in the script. `edda review gate --base` needs both
commits present locally, which would turn this `gh --repo` script into one that
requires a checkout — a contract change for a check the forge already makes at
the moment it counts. `gh pr merge --match-head-commit "$head"` refuses if
anything landed after the reviewed SHA, and GitHub's own
`mergeStateStatus`/branch protection refuses a base the PR is behind. A reviewer
wanting the stronger tree-level window check runs `edda review gate <sha> --base
<ref>` from a checkout, which is what it is for. No new contract.

**The fixture** goes in a new `scripts/test-merge-reviewed-pr.sh` — the issue
names `scripts/test-review-ownership.sh`, which GH-1061 also deleted. No edit to
`scripts/fleet/run-fleet-tests.sh` was needed: its group-2 glob is
`scripts/test-*.sh`, which is exactly the convention that file documents ("Tests
added later ... are picked up without editing this file or the workflow"), and
the run below shows it picked up.

**REVIEW.md §8**'s closing paragraph did claim the merge step does not ask the
gate ("until it lands, do not read this paragraph as a claim that merge already
goes through the gate"), so it was rewritten to describe what the merge step now
asks and how, including the window decision. **§7 is byte-untouched** (the only
REVIEW.md hunk is `@@ -858,9 +858,21 @@`, inside §8 at lines 809-879).
`docs/guides/operator-runbook.md` step 7 got the matching one-clause update.

## RAN

Workstation: Windows 11, Git Bash. L0 only — exact-head CI is the gate. No
cargo work: the diff is two shell files and two markdown files, no Rust.

**FAIL-first.** The fixture was written and committed red first
(`25070fd`, `test(fleet): fixture proving merge-reviewed-pr.sh merges over a
standing Changes Requested`), against the unmodified script:

```
$ sh scripts/test-merge-reviewed-pr.sh
FAIL: case 1: a standing Changes Requested was merged over: review accepted: PR #4242 @ aaaaaaaabbbbbbbbccccccccdddddddd11112222
EXIT=1
```

Case 1 is the doneWhen: a head carrying a Round 1 `Changes Requested` and a
later Round 2 `LGTM (P0=0, P1=0)`, where every pre-existing check passes.

Green at the head of this PR:

```
$ sh -n scripts/merge-reviewed-pr.sh && sh -n scripts/test-merge-reviewed-pr.sh
sh -n OK

$ sh scripts/test-merge-reviewed-pr.sh
PASS scripts/test-merge-reviewed-pr.sh (4 cases)
real    4m10.739s
user    0m2.477s
```

Four cases: (1) union refusal, message names the union, `--required` never
reached; (2) accept path unchanged, byte-identical stdout, `--required` still
called; (3) a gate that cannot judge refuses rather than waving through; (4) a
malformed verdict comment refuses.

`real 4m10s` against `user 2.5s` is this workstation's ~2.7 s/spawn AV tax on
~16 stubbed `gh`/`edda` invocations, not work — the same tax
`mechanism.shell-role` cites. The `fleet-tests` job that carries this glob runs
on ubuntu, where spawns are free; the Windows fleet job runs only the `.ps1`
group, so this adds nothing to it.

```
$ bash scripts/lint-doc-citations.sh --tree   # exit 0
$ bash scripts/lint-markdown-content.sh       # exit 0
$ bash scripts/lint-file-length.sh --staged   # exit 0 (pre-commit, both commits)
```

`scripts/lint-file-length.sh` covers `*.rs` only, so the two new/edited shell
files have no ceiling to raise.

Not run, deliberately: `cargo test`/`cargo clippy` (no Rust in the diff) and the
full `run-fleet-tests.sh` (its other groups are untouched and cost the same AV
tax per spawn across ~30 test files). Exact-head CI covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
