### PR TITLE
chore(release): prepare v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-09-09
+
+### Added
+
+- **`edda review` in the product** — the review lifecycle moves from shell scripts into the CLI: `edda review` (#872), the union-gate window check (`edda review gate`, GH-769), the writing half with labels and the `Independent Review` status (`edda review deliver`, GH-1030), and the response trigger with the resume layer (`edda review due`, GH-763)
+- **Typed ratification** — `--evidence pr#N@sha` and `--by-rule cited-authority` give decisions cited, machine-checkable authority (GH-764, GH-761)
+- **`edda fleet order`** — a deterministic health-gated dispatch queue with per-file collision detection and in-product freshness (GH-1015)
+- **`edda fleet health`** — product-share/mechanism-rate health gate with GREEN/YELLOW/RED exit codes (GH-1014)
+- **ACP dispatch in the CLI** — edda-conductor dispatches through ACP with offline fake evidence for tests (GH-800)
+- **Thin TypeScript and Python SDKs** over MCP/HTTP with a shared task-action surface and a complete MCP client contract (GH-611)
+- **Cross-machine decision import** — `edda-ledger` imports committed-mirror decisions across machines (GH-671)
+- **Skill-less controller loop** — `next-issue.sh`, `next-review.sh`, and the pi controller runbook (GH-899)
+- **L0 rule runner** runs every marked REVIEW.md check block as one pass (#915)
+- **Brief tooling** — `brief-from-issue` renders the invariant brief skeleton from an issue body (GH-885) and a dry-run validator applies AUTHORED STEPS in a throwaway worktree at the pinned SHA before any lane launch (#945)
+- **Issue freshness gate** — `next-issue.sh` re-derives issue applicability at dispatch time (#938)
+- **Canary calibration runner** scripts the README recipe (GH-881); shadow-review compare script (GH-887)
+- **SessionStart renders the rail task** this session holds (GH-793)
+- **Pre-push guard** ships in the git-native installer: reads the remote ref and refuses tag moves (#976)
+- **Operator daily digest gains a clock** (GH-765)
+
+### Changed
+
+- SDK packages are made publishable (GH-611, #990)
+- Fleet rules R22–R27 codify engine authority, verdict shape, readiness, policy carrier, origin-first work, and transport (#921); the judgement tag is left to R2 with brief v2 and calibration v1 (GH-884)
+- Direct review is the default path; the watcher lane is the flash tier and the independence source (#1051)
+
+### Fixed
+
+- The dispatch claim guard gets its own window and one shared rule, bounds bare-CLI claims in time, and reconciles attempts by lease while preparing worktrees outside the workspace lock (GH-1018, GH-1047)
+- `merge-reviewed-pr.sh` asks the union gate, not the latest review (GH-1057); the review gate window sees renames with `--no-renames` on both diffs (GH-1062)
+- The Claude bridge's SessionStart writeback teaches the rule-based binding path instead of operator-only authority (GH-1063)
+- OpenClaw bridge redacts durable bridge event data (#876)
+- Verdict publication posts the report only; the watcher rejects transcript dumps, skips non-open PRs, and writes `Independent Review` only when the verdict engine is authoritative for the PR surface (R22, #947, #961)
+- `mergeStateStatus` is no longer treated as a readiness signal — a stacked PR with zero verdicts no longer reports CLEAN (GH-946)
+- The SDK contract is pinned to `SPEC_PIN.json` and red on spec drift (#973); pre-push guard and capability canaries hardened (#900, #929)
+- Review lane terminal lifecycle finished (#867); the release dry-run watches the whole `crates/` tree (#900)
+
+### Docs
+
+- The implementable adapter contract is published (#873); rules and runbooks updated (R22–R27, pi-controller-runbook)
+
 ## [0.5.0] - 2026-09-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "edda"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "edda-aggregate"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "edda-ask"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "edda-bridge-claude"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "edda-bridge-codex"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "edda-bridge-claude",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "edda-bridge-cursor"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "edda-bridge-claude",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "edda-bridge-hermes"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "edda-bridge-claude",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "edda-bridge-openclaw"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "edda-bridge-claude",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "edda-chronicle"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "edda-conductor"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "edda-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "edda-derive"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "edda-index"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "edda-store",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "edda-ingestion"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "edda-ledger"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "edda-mcp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "edda-ask",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "edda-notify"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "edda-ledger",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "edda-pack"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "edda-postmortem"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "edda-search-fts"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "edda-serve"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "edda-store"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "edda-transcript"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "edda-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 # Bisected 2026-09-04, not copied from the toolchain pin: 1.87 fails on
 # dependency floors (darling, instability, time all require 1.88), and

--- a/crates/edda-aggregate/Cargo.toml
+++ b/crates/edda-aggregate/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.5.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.5.0" }
-edda-store = { path = "../edda-store", version = "0.5.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
+edda-store = { path = "../edda-store", version = "0.6.0" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-ask/Cargo.toml
+++ b/crates/edda-ask/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-ledger = { path = "../edda-ledger", version = "0.5.0" }
-edda-core = { path = "../edda-core", version = "0.5.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/edda-bridge-claude/Cargo.toml
+++ b/crates/edda-bridge-claude/Cargo.toml
@@ -11,17 +11,17 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-aggregate = { path = "../edda-aggregate", version = "0.5.0" }
-edda-core = { path = "../edda-core", version = "0.5.0" }
-edda-store = { path = "../edda-store", version = "0.5.0" }
-edda-transcript = { path = "../edda-transcript", version = "0.5.0" }
-edda-index = { path = "../edda-index", version = "0.5.0" }
-edda-pack = { path = "../edda-pack", version = "0.5.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.5.0" }
-edda-search-fts = { path = "../edda-search-fts", version = "0.5.0" }
-edda-notify = { path = "../edda-notify", version = "0.5.0" }
-edda-postmortem = { path = "../edda-postmortem", version = "0.5.0" }
-edda-derive = { path = "../edda-derive", version = "0.5.0" }
+edda-aggregate = { path = "../edda-aggregate", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-store = { path = "../edda-store", version = "0.6.0" }
+edda-transcript = { path = "../edda-transcript", version = "0.6.0" }
+edda-index = { path = "../edda-index", version = "0.6.0" }
+edda-pack = { path = "../edda-pack", version = "0.6.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
+edda-search-fts = { path = "../edda-search-fts", version = "0.6.0" }
+edda-notify = { path = "../edda-notify", version = "0.6.0" }
+edda-postmortem = { path = "../edda-postmortem", version = "0.6.0" }
+edda-derive = { path = "../edda-derive", version = "0.6.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true
@@ -39,7 +39,7 @@ tempfile.workspace = true
 rusqlite = { version = "0.32", features = ["bundled"] }
 # Test-only: enables the thread-local store-root override used by
 # `isolated_store()` fixtures (GH-757). Not enabled for ordinary builds.
-edda-store = { path = "../edda-store", version = "0.5.0", features = [
+edda-store = { path = "../edda-store", version = "0.6.0", features = [
     "test-support",
 ] }
 

--- a/crates/edda-bridge-codex/Cargo.toml
+++ b/crates/edda-bridge-codex/Cargo.toml
@@ -11,13 +11,13 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.5.0" }
-edda-store = { path = "../edda-store", version = "0.5.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.5.0" }
-edda-pack = { path = "../edda-pack", version = "0.5.0" }
-edda-postmortem = { path = "../edda-postmortem", version = "0.5.0" }
-edda-derive = { path = "../edda-derive", version = "0.5.0" }
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.5.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-store = { path = "../edda-store", version = "0.6.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
+edda-pack = { path = "../edda-pack", version = "0.6.0" }
+edda-postmortem = { path = "../edda-postmortem", version = "0.6.0" }
+edda-derive = { path = "../edda-derive", version = "0.6.0" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.0" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-bridge-cursor/Cargo.toml
+++ b/crates/edda-bridge-cursor/Cargo.toml
@@ -11,11 +11,11 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.5.0" }
-edda-core = { path = "../edda-core", version = "0.5.0" }
-edda-pack = { path = "../edda-pack", version = "0.5.0" }
-edda-postmortem = { path = "../edda-postmortem", version = "0.5.0" }
-edda-store = { path = "../edda-store", version = "0.5.0" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-pack = { path = "../edda-pack", version = "0.6.0" }
+edda-postmortem = { path = "../edda-postmortem", version = "0.6.0" }
+edda-store = { path = "../edda-store", version = "0.6.0" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-bridge-hermes/Cargo.toml
+++ b/crates/edda-bridge-hermes/Cargo.toml
@@ -11,13 +11,13 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.5.0" }
-edda-store = { path = "../edda-store", version = "0.5.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.5.0" }
-edda-pack = { path = "../edda-pack", version = "0.5.0" }
-edda-postmortem = { path = "../edda-postmortem", version = "0.5.0" }
-edda-derive = { path = "../edda-derive", version = "0.5.0" }
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.5.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-store = { path = "../edda-store", version = "0.6.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
+edda-pack = { path = "../edda-pack", version = "0.6.0" }
+edda-postmortem = { path = "../edda-postmortem", version = "0.6.0" }
+edda-derive = { path = "../edda-derive", version = "0.6.0" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.0" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-bridge-openclaw/Cargo.toml
+++ b/crates/edda-bridge-openclaw/Cargo.toml
@@ -11,18 +11,18 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.5.0" }
-edda-store = { path = "../edda-store", version = "0.5.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.5.0" }
-edda-derive = { path = "../edda-derive", version = "0.5.0" }
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.5.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-store = { path = "../edda-store", version = "0.6.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
+edda-derive = { path = "../edda-derive", version = "0.6.0" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.0" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 time.workspace = true
 
 [dev-dependencies]
-edda-store = { path = "../edda-store", version = "0.5.0", features = ["test-support"] }
+edda-store = { path = "../edda-store", version = "0.6.0", features = ["test-support"] }
 tempfile.workspace = true
 
 [lints]

--- a/crates/edda-chronicle/Cargo.toml
+++ b/crates/edda-chronicle/Cargo.toml
@@ -11,13 +11,13 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.5.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.5.0" }
-edda-store = { path = "../edda-store", version = "0.5.0" }
-edda-transcript = { path = "../edda-transcript", version = "0.5.0" }
-edda-index = { path = "../edda-index", version = "0.5.0" }
-edda-search-fts = { path = "../edda-search-fts", version = "0.5.0" }
-edda-aggregate = { path = "../edda-aggregate", version = "0.5.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
+edda-store = { path = "../edda-store", version = "0.6.0" }
+edda-transcript = { path = "../edda-transcript", version = "0.6.0" }
+edda-index = { path = "../edda-index", version = "0.6.0" }
+edda-search-fts = { path = "../edda-search-fts", version = "0.6.0" }
+edda-aggregate = { path = "../edda-aggregate", version = "0.6.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/edda-cli/Cargo.toml
+++ b/crates/edda-cli/Cargo.toml
@@ -15,27 +15,27 @@ name = "edda"
 path = "src/main.rs"
 
 [dependencies]
-edda-aggregate = { path = "../edda-aggregate", version = "0.5.0" }
-edda-ask = { path = "../edda-ask", version = "0.5.0" }
-edda-chronicle = { path = "../edda-chronicle", version = "0.5.0" }
-edda-core = { path = "../edda-core", version = "0.5.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.5.0" }
-edda-derive = { path = "../edda-derive", version = "0.5.0" }
-edda-store = { path = "../edda-store", version = "0.5.0" }
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.5.0" }
-edda-bridge-codex = { path = "../edda-bridge-codex", version = "0.5.0" }
-edda-bridge-cursor = { path = "../edda-bridge-cursor", version = "0.5.0" }
-edda-bridge-hermes = { path = "../edda-bridge-hermes", version = "0.5.0" }
-edda-bridge-openclaw = { path = "../edda-bridge-openclaw", version = "0.5.0" }
-edda-transcript = { path = "../edda-transcript", version = "0.5.0" }
-edda-index = { path = "../edda-index", version = "0.5.0" }
-edda-pack = { path = "../edda-pack", version = "0.5.0" }
-edda-mcp = { path = "../edda-mcp", version = "0.5.0" }
-edda-serve = { path = "../edda-serve", version = "0.5.0" }
-edda-notify = { path = "../edda-notify", version = "0.5.0" }
-edda-postmortem = { path = "../edda-postmortem", version = "0.5.0" }
-edda-search-fts = { path = "../edda-search-fts", version = "0.5.0" }
-edda-conductor = { path = "../edda-conductor", version = "0.5.0" }
+edda-aggregate = { path = "../edda-aggregate", version = "0.6.0" }
+edda-ask = { path = "../edda-ask", version = "0.6.0" }
+edda-chronicle = { path = "../edda-chronicle", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
+edda-derive = { path = "../edda-derive", version = "0.6.0" }
+edda-store = { path = "../edda-store", version = "0.6.0" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.0" }
+edda-bridge-codex = { path = "../edda-bridge-codex", version = "0.6.0" }
+edda-bridge-cursor = { path = "../edda-bridge-cursor", version = "0.6.0" }
+edda-bridge-hermes = { path = "../edda-bridge-hermes", version = "0.6.0" }
+edda-bridge-openclaw = { path = "../edda-bridge-openclaw", version = "0.6.0" }
+edda-transcript = { path = "../edda-transcript", version = "0.6.0" }
+edda-index = { path = "../edda-index", version = "0.6.0" }
+edda-pack = { path = "../edda-pack", version = "0.6.0" }
+edda-mcp = { path = "../edda-mcp", version = "0.6.0" }
+edda-serve = { path = "../edda-serve", version = "0.6.0" }
+edda-notify = { path = "../edda-notify", version = "0.6.0" }
+edda-postmortem = { path = "../edda-postmortem", version = "0.6.0" }
+edda-search-fts = { path = "../edda-search-fts", version = "0.6.0" }
+edda-conductor = { path = "../edda-conductor", version = "0.6.0" }
 ratatui = { version = "0.29", optional = true }
 crossterm = { version = "0.28", optional = true }
 clap.workspace = true
@@ -68,7 +68,7 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 # `test_support::isolated_store()` (GH-757). Ordinary (non-test) builds of
 # this crate and of the `edda` binary never enable it, so production and
 # subprocess store resolution is unchanged.
-edda-store = { path = "../edda-store", version = "0.5.0", features = [
+edda-store = { path = "../edda-store", version = "0.6.0", features = [
     "test-support",
 ] }
 

--- a/crates/edda-conductor/Cargo.toml
+++ b/crates/edda-conductor/Cargo.toml
@@ -11,11 +11,11 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-store = { path = "../edda-store", version = "0.5.0" }
-edda-core = { path = "../edda-core", version = "0.5.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.5.0" }
-edda-derive = { path = "../edda-derive", version = "0.5.0" }
-edda-notify = { path = "../edda-notify", version = "0.5.0" }
+edda-store = { path = "../edda-store", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
+edda-derive = { path = "../edda-derive", version = "0.6.0" }
+edda-notify = { path = "../edda-notify", version = "0.6.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/edda-derive/Cargo.toml
+++ b/crates/edda-derive/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.5.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.5.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
 anyhow.workspace = true
 time.workspace = true
 serde.workspace = true

--- a/crates/edda-index/Cargo.toml
+++ b/crates/edda-index/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-store = { path = "../edda-store", version = "0.5.0" }
+edda-store = { path = "../edda-store", version = "0.6.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/edda-ingestion/Cargo.toml
+++ b/crates/edda-ingestion/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.5.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.5.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-ledger/Cargo.toml
+++ b/crates/edda-ledger/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.5.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/edda-mcp/Cargo.toml
+++ b/crates/edda-mcp/Cargo.toml
@@ -11,13 +11,13 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-ask = { path = "../edda-ask", version = "0.5.0" }
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.5.0" }
-edda-core = { path = "../edda-core", version = "0.5.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.5.0" }
-edda-derive = { path = "../edda-derive", version = "0.5.0" }
-edda-notify = { path = "../edda-notify", version = "0.5.0" }
-edda-store = { path = "../edda-store", version = "0.5.0" }
+edda-ask = { path = "../edda-ask", version = "0.6.0" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
+edda-derive = { path = "../edda-derive", version = "0.6.0" }
+edda-notify = { path = "../edda-notify", version = "0.6.0" }
+edda-store = { path = "../edda-store", version = "0.6.0" }
 rmcp = { version = "0.16", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 anyhow.workspace = true

--- a/crates/edda-notify/Cargo.toml
+++ b/crates/edda-notify/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-ledger = { path = "../edda-ledger", version = "0.5.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
 ureq = "3"
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-pack/Cargo.toml
+++ b/crates/edda-pack/Cargo.toml
@@ -11,10 +11,10 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.5.0" }
-edda-store = { path = "../edda-store", version = "0.5.0" }
-edda-index = { path = "../edda-index", version = "0.5.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.5.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-store = { path = "../edda-store", version = "0.6.0" }
+edda-index = { path = "../edda-index", version = "0.6.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/edda-postmortem/Cargo.toml
+++ b/crates/edda-postmortem/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.5.0" }
-edda-store = { path = "../edda-store", version = "0.5.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-store = { path = "../edda-store", version = "0.6.0" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-search-fts/Cargo.toml
+++ b/crates/edda-search-fts/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-store = { path = "../edda-store", version = "0.5.0" }
-edda-index = { path = "../edda-index", version = "0.5.0" }
-edda-core = { path = "../edda-core", version = "0.5.0" }
+edda-store = { path = "../edda-store", version = "0.6.0" }
+edda-index = { path = "../edda-index", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
 tantivy = { version = "0.25", default-features = false, features = ["mmap", "lz4-compression"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 fs2 = "0.4"

--- a/crates/edda-serve/Cargo.toml
+++ b/crates/edda-serve/Cargo.toml
@@ -11,14 +11,14 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-ask = { path = "../edda-ask", version = "0.5.0" }
-edda-core = { path = "../edda-core", version = "0.5.0" }
-edda-derive = { path = "../edda-derive", version = "0.5.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.5.0" }
-edda-aggregate = { path = "../edda-aggregate", version = "0.5.0" }
-edda-store = { path = "../edda-store", version = "0.5.0" }
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.5.0" }
-edda-ingestion = { path = "../edda-ingestion", version = "0.5.0" }
+edda-ask = { path = "../edda-ask", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-derive = { path = "../edda-derive", version = "0.6.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
+edda-aggregate = { path = "../edda-aggregate", version = "0.6.0" }
+edda-store = { path = "../edda-store", version = "0.6.0" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.0" }
+edda-ingestion = { path = "../edda-ingestion", version = "0.6.0" }
 axum = "0.8"
 tracing = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "time"] }

--- a/crates/edda-store/Cargo.toml
+++ b/crates/edda-store/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.5.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/edda-transcript/Cargo.toml
+++ b/crates/edda-transcript/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.5.0" }
-edda-store = { path = "../edda-store", version = "0.5.0" }
+edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-store = { path = "../edda-store", version = "0.6.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6,7 +6,7 @@ title: CLI Reference
 
 Complete reference for all `edda` commands.
 
-> Documented for edda 0.5 — the surface below is re-derived from the built binary by
+> Documented for edda 0.6 — the surface below is re-derived from the built binary by
 > binary, not copied from an older release. `scripts/check-cli-docs.sh`
 > enforces that every verb the binary exposes is documented here, either as a
 > full section or as a row in the [Internal / experimental](#internal--experimental-commands)


### PR DESCRIPTION
## Release prep v0.6.0

Prepares the workspace for the v0.6.0 release (69 commits since v0.5.0).

Issue: #1088

### Changes
- Workspace version `0.5.0` → `0.6.0` (root `Cargo.toml`)
- Internal dependency pins `"0.5.0"` → `"0.6.0"` in all 22 consumer crate manifests
- `cargo update -w` lockfile resync (all crates resolve at 0.6.0)
- CHANGELOG: new `## [0.6.0] - 2026-09-09` section (release-notes source for `create-release`), `[Unreleased]` kept empty

### Evidence
- `cargo package --workspace --locked --no-verify` — all 23 crates packaged from the clean release commit (`a72766e`)
- `cargo publish --dry-run --workspace --locked` — reaches `Uploading edda`, dependency order, all 23 crates
- `scripts/publish-crates-test.py` — 8/8 OK
- `scripts/check-cli-docs.sh` — OK, all 65 verbs verified
- pre-commit L0 hooks passed at commit

### Notes
- `crates_release_plan.py` no longer exists; local provenance proof is `scripts/publish-crates.py plan --tag` after the tag is created (per current release flow)
- Third-party `lz4_flex 0.11.5` is yanked upstream but pinned in `Cargo.lock`; packaging warning only, CI builds from the same lock