### PR TITLE
fix(edda-cli): doneWhen matchers accept the spacing axis — Done when parses everywhere (GH-1056)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -128,7 +128,7 @@ own linkage:
 ISSUES=$(gh pr view "$N" --json body --jq .body \
   | awk 'tolower($0) ~ /^issues?[[:space:]]*:/' | grep -Eo '#[0-9]+' | tr -d '#' | sort -u)
 for i in $ISSUES; do gh issue view "$i" --json body --jq .body \
-  | awk '/^## doneWhen/{f=1;next} /^## /{f=0} f'; done
+  | awk '/^## /{h=tolower($0);gsub(/[^a-z]/,"",h);f=(h=="donewhen")?1:0;next} f'; done
 ```
 # review-spec:check-end
 

--- a/crates/edda-cli/src/cmd_fleet_order.rs
+++ b/crates/edda-cli/src/cmd_fleet_order.rs
@@ -603,7 +603,8 @@ pub fn cites_red_run(body: &str) -> bool {
 ///
 /// * a path the issue itself declares under `## Predicted surface` WARNs
 ///   instead of FAILing when it is referenced again elsewhere in the body;
-/// * a `doneWhen` heading matches whatever its case;
+/// * a `doneWhen` heading matches whatever its case or spacing (`Done when`,
+///   `done-when`, `DONE_WHEN` all count, GH-1056);
 /// * a command that is to be built (mentioned under `doneWhen` or
 ///   `## Predicted surface`) or is evidence-cited WARNs instead of FAILing;
 /// * a reference to a genuinely deleted path still FAILs.
@@ -681,8 +682,13 @@ fn section_heading(line: &str) -> Option<String> {
     Some(rest.trim().to_ascii_lowercase())
 }
 
+/// `section` is already lowercased ([`section_heading`]); this additionally
+/// strips everything but ASCII letters before the prefix match, so the
+/// separating space in `Done when` (GH-1056) — and any hyphen or underscore
+/// spelling — collapses the same way the case axis already does.
 fn is_donewhen(section: &str) -> bool {
-    section.starts_with("donewhen")
+    let normalized: String = section.chars().filter(char::is_ascii_alphabetic).collect();
+    normalized.starts_with("donewhen")
 }
 
 /// Any `… surface` heading. Collision scoring reads only the canonical

--- a/crates/edda-cli/src/cmd_fleet_order/tests.rs
+++ b/crates/edda-cli/src/cmd_fleet_order/tests.rs
@@ -385,6 +385,30 @@ fn donewhen_headings_match_case_insensitively() {
     assert_eq!(verdict_for(empty, "## doneWhen"), Some(Verdict::Fail));
 }
 
+/// GH-1056: the case axis shipped in #1040 does not cover the separating
+/// space in `Done when` — `"done when".starts_with("donewhen")` is `false`.
+/// #953 and #970's own corpus spell the heading this way, so a fresh issue
+/// written `## Done when` was reported stale. Same fixture shape as
+/// `donewhen_headings_match_case_insensitively`, one axis over: space,
+/// double space, and hyphen/underscore spellings.
+#[test]
+fn donewhen_headings_match_the_spacing_axis() {
+    for heading in [
+        "## Done when",
+        "## done  when",
+        "## done-when",
+        "## Done_When",
+    ] {
+        let body = format!("## What happened\n\nprose.\n\n{heading}\n\n- delivered.\n");
+        assert!(
+            freshness(&body).is_empty(),
+            "{heading} should satisfy the doneWhen check"
+        );
+    }
+    let empty = "## What happened\n\nprose.\n\n## Done when\n\n";
+    assert_eq!(verdict_for(empty, "## doneWhen"), Some(Verdict::Fail));
+}
+
 /// A command the issue is about to build, or one cited with evidence that it
 /// ran, must not FAIL the gate; an unqualified reference to a verb that does
 /// not exist still does.

--- a/crates/edda-cli/src/cmd_fleet_order/tests.rs
+++ b/crates/edda-cli/src/cmd_fleet_order/tests.rs
@@ -519,6 +519,9 @@ fn a_future_tense_section_declares_rather_than_references() {
     // Prose sections that describe the delivery WARN.
     assert_eq!(declared("## 改哪裡"), Some(Verdict::Warn));
     assert_eq!(declared("## doneWhen"), Some(Verdict::Warn));
+    // GH-1056: the spacing axis reaches declares_future too, not just the
+    // freshness gate — a spaced doneWhen heading must WARN here as well.
+    assert_eq!(declared("## Done when"), Some(Verdict::Warn));
     // A surface section is pure declaration and is not scanned at all.
     assert_eq!(declared("## Suspected surface"), None);
     assert_eq!(declared("## Predicted surface"), None);

--- a/scripts/fleet/issue-freshness.sh
+++ b/scripts/fleet/issue-freshness.sh
@@ -133,9 +133,17 @@ for verb in $verbs; do
 done
 
 # 3. doneWhen: present and non-empty (blank lines do not count as content).
+# The heading is matched case- and spacing-insensitively (GH-1056): strip
+# everything but a-z from the lowercased heading text so "Done when",
+# "done-when" and "doneWhen" all collapse to "donewhen" the same way the
+# product gate's is_donewhen() does (crates/edda-cli/src/cmd_fleet_order.rs).
 section=$(printf '%s\n' "$body" | awk '
-    /^##[ \t]*doneWhen[ \t]*$/ { p = 1; next }
-    /^##[ \t]/ { p = 0 }
+    /^##[ \t]/ {
+        h = tolower($0)
+        gsub(/[^a-z]/, "", h)
+        p = (h == "donewhen") ? 1 : 0
+        next
+    }
     p { print }
 ')
 if [ -z "$(printf '%s' "$section" | tr -d '[:space:]')" ]; then

--- a/scripts/fleet/test-issue-freshness.sh
+++ b/scripts/fleet/test-issue-freshness.sh
@@ -82,6 +82,13 @@ cat >"$work/fixtures/issue-mention.json" <<'JSON'
 {"state":"OPEN","title":"feat(fleet): freshness mention","labels":[{"name":"fleet:ready"}],"comments":[],
  "body":"## doneWhen\n- `scripts/fleet/next-issue.sh`\n"}
 JSON
+# GH-1056: the spacing axis — "Done when" differs from "doneWhen" by a
+# space, not by case, and the pre-fix regex (`/^##[ \t]*doneWhen[ \t]*$/`)
+# rejected it.
+cat >"$work/fixtures/issue-donewhen-spaced.json" <<'JSON'
+{"state":"OPEN","title":"feat(fleet): freshness spaced donewhen","labels":[{"name":"fleet:ready"}],"comments":[],
+ "body":"## Predicted surface\n\nGate file `scripts/fleet/next-issue.sh` exists.\n\n## Done when\n- `edda ask` resolves\n"}
+JSON
 cat >"$work/fixtures/pr-list-hit.json" <<'JSON'
 [{"number":746,"state":"MERGED","title":"x","body":"Closes #993",
   "closingIssuesReferences":[{"number":993}]}]
@@ -132,6 +139,7 @@ case "$1 $2" in
             *\ 995\ *|*\ 995) resp=$(cat "$GH_FIXTURES/issue-barename.json") ;;
             *\ 996\ *|*\ 996) resp=$(cat "$GH_FIXTURES/issue-concept.json") ;;
             *\ 997\ *|*\ 997) resp=$(cat "$GH_FIXTURES/issue-mention.json") ;;
+            *\ 998\ *|*\ 998) resp=$(cat "$GH_FIXTURES/issue-donewhen-spaced.json") ;;
             *) resp=$(cat "$GH_FIXTURES/issue-ok.json") ;;
         esac ;;
     "issue edit")
@@ -265,6 +273,16 @@ if [ "$run_suite" -eq 1 ]; then
     grep -q '^PASS not delivered$' "$work/out-g.txt" ||
         fail "issue 997 must not treat a mention as delivery: $(cat "$work/out-g.txt")"
     echo "ok g mention is not delivery"
+
+    # h. GH-1056 spacing axis: "## Done when" (a space, not a case
+    # difference from "doneWhen") must PASS, not FAIL doneWhen-missing.
+    run_gated sh "$freshness" 998 >"$work/out-h.txt" 2>"$work/err-h.txt" ||
+        fail "issue 998 must pass: rc=$? err=$(cat "$work/err-h.txt")"
+    grep -q '^PASS doneWhen$' "$work/out-h.txt" ||
+        fail "issue 998 misses the doneWhen PASS line for '## Done when': $(cat "$work/out-h.txt")"
+    grep -q '^FAIL doneWhen' "$work/out-h.txt" &&
+        fail "issue 998 must not FAIL doneWhen for '## Done when': $(cat "$work/out-h.txt")"
+    echo "ok h '## Done when' (spacing axis) passes"
 
     echo "PASS: scripts/fleet/test-issue-freshness.sh"
     exit 0


### PR DESCRIPTION
Issue: #1056
Closes #1056

## What

Three more doneWhen matchers rejected the **spacing** axis — `## Done when`
differs from `## doneWhen` by a space, not by case, so #1040's case-axis fix
(`to_ascii_lowercase()` + a test literally named
`donewhen_headings_match_case_insensitively`) could not catch it:
`"done when".starts_with("donewhen")` is `false`.

- `crates/edda-cli/src/cmd_fleet_order.rs` — `is_donewhen()` now strips
  everything but ASCII letters from the already-lowercased heading before
  the prefix match, so `Done when`, `done  when`, `done-when`, and
  `Done_When` all collapse to `donewhen` the same way case already does.
  Both `donewhen_seen` and `declares_future` hang off this predicate, so the
  fix also restores future-declaring treatment for a `## Done when` section
  (the #970 false-FAIL shape).
- `scripts/fleet/issue-freshness.sh:135-146` — the shell gate's doneWhen
  section extractor now normalizes the same way (strip non-`a-z` from the
  lowercased heading, compare to `donewhen`) instead of the old
  `/^##[ \t]*doneWhen[ \t]*$/` regex, which was both case- and
  space-intolerant.
- `REVIEW.md` §1's `ISSUES` block (the awk one-liner a human reviewer runs
  by hand) carries the same normalization as the shell gate, so the spec and
  its automation no longer disagree. §7 (Output — the fixed format) is
  untouched.

**Surface named in the issue that no longer exists:** `scripts/review-pr.sh`
was deleted by GH-1061 before this PR started; the issue's proposed edit to
`scripts/review-pr.sh:779` therefore has no target. `REVIEW.md`'s own §1
block is the sole surviving instance of that pattern and is fixed here
instead.

## RAN

FAIL-first (Rust, `cmd_fleet_order.rs`): with `is_donewhen` unmodified,
the new test failed:

```
test cmd_fleet_order::tests::donewhen_headings_match_the_spacing_axis ... FAILED
thread '...' panicked at crates\edda-cli\src\cmd_fleet_order\tests.rs:403:9:
## Done when should satisfy the doneWhen check
```

After the fix, the same test and the existing case-axis test both pass:

```
test cmd_fleet_order::tests::donewhen_headings_match_case_insensitively ... ok
test cmd_fleet_order::tests::donewhen_headings_match_the_spacing_axis ... ok
```

FAIL-first (shell, `issue-freshness.sh`): with the awk pattern unmodified,
`scripts/fleet/test-issue-freshness.sh` case h (`## Done when` fixture,
issue 998) FAILed — `FAIL doneWhen missing or empty` instead of `PASS
doneWhen`. After the fix, the full suite passes, existing spellings
(`## doneWhen` etc.) stay green.

Gates (L0, focused on touched crates/scripts):

- `cargo fmt --all --check` — clean
- `cargo clippy -p edda --all-targets -- -D warnings` — clean
- `cargo test -p edda cmd_fleet_order` — all pass (including the two
  doneWhen tests above)
- `sh -n scripts/fleet/issue-freshness.sh` and `sh -n
  scripts/fleet/test-issue-freshness.sh` — clean
- `sh scripts/fleet/test-issue-freshness.sh` — full offline suite, including
  new case h for the `## Done when` fixture — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
