### PR TITLE
fix(release): generate portable Homebrew formulas

### DIFF
--- a/.claude/skills/edda-release/SKILL.md
+++ b/.claude/skills/edda-release/SKILL.md
@@ -233,10 +233,14 @@ Run the one-line installer twice in disposable directories: once pinned
 (`--version v<VERSION>`) and once through its default “latest” path. Both
 binaries must report the same version and expose `dispatch` and `verdict`.
 
-After the release is published, generate the Homebrew formula from the release
-checksums:
+After crates.io publication is verified, generate the Homebrew formula from the
+immutable crates.io source package. The generator downloads and hashes the
+`.crate` itself and emits a source-build formula; do not point Linuxbrew back at
+a GitHub binary built on `ubuntu-latest`, because its glibc floor can exceed the
+Homebrew host's:
 
 ```bash
+sh scripts/test-update-homebrew.sh
 ./scripts/update-homebrew.sh <VERSION> <HOME_BREW_TAP_CHECKOUT>
 brew audit --strict fagemx/tap/edda
 brew reinstall fagemx/tap/edda
@@ -245,9 +249,10 @@ edda dispatch --help
 edda verdict --help
 ```
 
-Commit and push the tap formula only after its diff names the intended version
-and hashes. If no macOS/Linux Homebrew verifier is available, the release cannot
-claim full `DONE`; report `DONE_WITH_CONCERNS` with the missing public canary.
+Commit and push the tap formula only after its diff names the intended static
+crates.io URL, source hash, and build dependencies. If no macOS/Linux Homebrew
+verifier is available, the release cannot claim full `DONE`; report
+`DONE_WITH_CONCERNS` with the missing public canary.
 
 ### Step 5: Record the release receipt
 

--- a/scripts/test-update-homebrew.sh
+++ b/scripts/test-update-homebrew.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin" "$TMP/tap/Formula"
+
+cat > "$TMP/bin/curl" <<'EOF'
+#!/bin/sh
+set -eu
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output)
+      out=$2
+      shift 2
+      ;;
+    --retry|--user-agent)
+      shift 2
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      url=$1
+      shift
+      ;;
+  esac
+done
+[ "$url" = "https://static.crates.io/crates/edda/edda-9.8.7.crate" ]
+[ -n "$out" ]
+printf 'homebrew-source-fixture' > "$out"
+EOF
+chmod +x "$TMP/bin/curl"
+
+PATH="$TMP/bin:$PATH" bash "$ROOT/scripts/update-homebrew.sh" 9.8.7 "$TMP/tap" >/dev/null
+FORMULA="$TMP/tap/Formula/edda.rb"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  EXPECTED=$(printf 'homebrew-source-fixture' | sha256sum | awk '{print $1}')
+else
+  EXPECTED=$(printf 'homebrew-source-fixture' | shasum -a 256 | awk '{print $1}')
+fi
+
+grep -F 'url "https://static.crates.io/crates/edda/edda-9.8.7.crate"' "$FORMULA" >/dev/null
+grep -F "sha256 \"$EXPECTED\"" "$FORMULA" >/dev/null
+grep -F 'depends_on "pkgconf" => :build' "$FORMULA" >/dev/null
+grep -F 'depends_on "rust" => :build' "$FORMULA" >/dev/null
+grep -F 'depends_on "openssl@3"' "$FORMULA" >/dev/null
+grep -F 'system "cargo", "install", *std_cargo_args' "$FORMULA" >/dev/null
+
+if grep -Eq '^[[:space:]]+version "' "$FORMULA"; then
+  echo "test-update-homebrew: explicit version is redundant with the URL" >&2
+  exit 1
+fi
+if grep -F 'releases/download' "$FORMULA" >/dev/null; then
+  echo "test-update-homebrew: generated formula still uses glibc-bound binaries" >&2
+  exit 1
+fi
+if PATH="$TMP/bin:$PATH" bash "$ROOT/scripts/update-homebrew.sh" v9.8.7 "$TMP/tap" >/dev/null 2>&1; then
+  echo "test-update-homebrew: accepted a version with a leading v" >&2
+  exit 1
+fi
+
+bash -n "$ROOT/scripts/update-homebrew.sh"
+echo "test-update-homebrew: OK"

--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -1,69 +1,65 @@
 #!/usr/bin/env bash
-# Update the Homebrew formula in fagemx/homebrew-tap with SHA256 hashes
-# from a GitHub Release.
+# Update the Homebrew formula in fagemx/homebrew-tap from the published
+# crates.io source package. Building inside Homebrew avoids tying Linux users
+# to the glibc version of GitHub's release runner.
 #
 # Usage:
-#   ./scripts/update-homebrew.sh 0.1.0
-#   ./scripts/update-homebrew.sh 0.1.0 /path/to/homebrew-tap
+#   ./scripts/update-homebrew.sh 0.6.0
+#   ./scripts/update-homebrew.sh 0.6.0 /path/to/homebrew-tap
 
 set -euo pipefail
 
 VERSION="${1:?Usage: update-homebrew.sh <version> [tap-dir]}"
-TAG="v${VERSION}"
-REPO="fagemx/edda"
 TAP_DIR="${2:-}"
 FORMULA_OUT=""
 
-# Fetch SHA256 for a given target
-fetch_hash() {
-  local target="$1"
-  local asset="edda-${TAG}-${target}.tar.gz.sha256"
-  gh release download "$TAG" --repo "$REPO" --pattern "$asset" --output - | awk '{print $1}'
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: version must be a bare semantic version (for example 0.6.0)" >&2
+  exit 2
+fi
+
+CRATE_URL="https://static.crates.io/crates/edda/edda-${VERSION}.crate"
+CRATE_FILE=$(mktemp)
+cleanup() {
+  rm -f "$CRATE_FILE"
 }
+trap cleanup EXIT
 
-echo "Fetching SHA256 hashes for ${TAG}..."
+curl -fsSL --retry 3 --user-agent "edda-homebrew-updater/1.0" \
+  --output "$CRATE_FILE" "$CRATE_URL"
 
-HASH_MACOS_ARM=$(fetch_hash "aarch64-apple-darwin")
-HASH_MACOS_X86=$(fetch_hash "x86_64-apple-darwin")
-HASH_LINUX_ARM=$(fetch_hash "aarch64-unknown-linux-gnu")
-HASH_LINUX_X86=$(fetch_hash "x86_64-unknown-linux-gnu")
+if command -v sha256sum >/dev/null 2>&1; then
+  SOURCE_HASH=$(sha256sum "$CRATE_FILE" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+  SOURCE_HASH=$(shasum -a 256 "$CRATE_FILE" | awk '{print $1}')
+else
+  echo "error: sha256sum or shasum is required" >&2
+  exit 1
+fi
 
-echo "  macOS arm64:  ${HASH_MACOS_ARM}"
-echo "  macOS x86_64: ${HASH_MACOS_X86}"
-echo "  Linux arm64:  ${HASH_LINUX_ARM}"
-echo "  Linux x86_64: ${HASH_LINUX_X86}"
+if [[ ! "$SOURCE_HASH" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "error: invalid SHA256 for ${CRATE_URL}" >&2
+  exit 1
+fi
 
-# Generate formula
+echo "Source: ${CRATE_URL}"
+echo "SHA256: ${SOURCE_HASH}"
+
 generate_formula() {
 cat <<RUBY
 class Edda < Formula
   desc "Decision memory for coding agents"
   homepage "https://github.com/fagemx/edda"
-  version "${VERSION}"
+  url "${CRATE_URL}"
+  sha256 "${SOURCE_HASH}"
   license any_of: ["MIT", "Apache-2.0"]
 
-  on_macos do
-    if Hardware::CPU.arm?
-      url "https://github.com/fagemx/edda/releases/download/v#{version}/edda-v#{version}-aarch64-apple-darwin.tar.gz"
-      sha256 "${HASH_MACOS_ARM}"
-    else
-      url "https://github.com/fagemx/edda/releases/download/v#{version}/edda-v#{version}-x86_64-apple-darwin.tar.gz"
-      sha256 "${HASH_MACOS_X86}"
-    end
-  end
-
-  on_linux do
-    if Hardware::CPU.arm?
-      url "https://github.com/fagemx/edda/releases/download/v#{version}/edda-v#{version}-aarch64-unknown-linux-gnu.tar.gz"
-      sha256 "${HASH_LINUX_ARM}"
-    else
-      url "https://github.com/fagemx/edda/releases/download/v#{version}/edda-v#{version}-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "${HASH_LINUX_X86}"
-    end
-  end
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+  depends_on "openssl@3"
 
   def install
-    bin.install "edda"
+    system "cargo", "install", *std_cargo_args
   end
 
   test do
@@ -76,7 +72,6 @@ RUBY
 if [ -n "$TAP_DIR" ]; then
   FORMULA_OUT="${TAP_DIR}/Formula/edda.rb"
   generate_formula > "$FORMULA_OUT"
-  echo ""
   echo "Formula written to: ${FORMULA_OUT}"
 else
   echo ""


### PR DESCRIPTION
## Summary

The v0.6.0 Homebrew canary exposed two independent defects in the generated formula:

1. `brew audit --strict` rejected the explicit `version` as redundant with the URL.
2. After correcting that, the GitHub Linux binary failed in the official Linuxbrew container because it requires `GLIBC_2.39` while the host loader is older.

This changes `scripts/update-homebrew.sh` to generate a portable source-build formula from the immutable crates.io `.crate`, with an independently computed SHA256 and explicit Rust/pkgconf/OpenSSL dependencies. It also adds an offline regression test.

Issue: #1088
Decision: release.homebrew-distribution

## Evidence

- Public tap formula repaired and pushed: `fagemx/homebrew-tap@2d744d01733ca554feb5b6fb5d8d0aaef9031397`
- Official `homebrew/brew:latest` container, remote tap at that exact SHA:
  - `brew audit --strict fagemx/tap/edda` — PASS
  - `brew install fagemx/tap/edda` — PASS
  - `brew reinstall fagemx/tap/edda` — PASS
  - `edda --version` → `edda 0.6.0 (unknown)`
  - `dispatch --help`, `verdict --help`, `brew test` — PASS
- `sh scripts/test-update-homebrew.sh` — PASS
- Generated 0.6.0 formula matches the public tap formula byte-for-byte
- `bash -n scripts/update-homebrew.sh`; `sh -n scripts/test-update-homebrew.sh` — PASS
- markdown/content and staged file-length lints — PASS

## Root-cause evidence

`readelf --version-info` on `edda-v0.6.0-x86_64-unknown-linux-gnu` reports `GLIBC_2.39`; the original public Homebrew install failed with:

```text
edda: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

No tag, crate, or GitHub Release identity was changed.