### PR TITLE
feat(fleet): reclaim-merged — batch deletes and verify by re-read (GH-1009)

### DIFF
--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -240,7 +240,7 @@ Brief 必含：assigned build lane、verification budget（L0 while iterating；
 | 操作者在場的小批量併行走 `/issue-pipeline`（in-session 子代理：開工先貼 `taking: <machine>/pipeline`、審查是 house review——審查者不修自己審的 PR、子代理隨 session 死，長時間無人值守改派 Task Scheduler lane）；一次最多兩張要編譯的單 | `fleet.parallel-modes=in-session-pipeline-when-operator-present-lanes-when-unattended` |
 | 審查釘 full SHA；**每次 push 使前一個判決失效**；一個 PR 一個審查者身分 | `fleet.review-protocol` |
 | 合併＝final current-head LGTM、P0=0/P1=0、required check「`CI Gate`」綠（`ci.merge-gate`）、SHA 窗檢查為空；docs-only PR 的 clippy／test job 顯示 skipped 而 `CI Gate` 仍綠＝`ci.path-filter` 正常跳過，不是漏跑 | `pr.merge-policy`、`ci.merge-gate` |
-| worktree／branch／source 永不刪；build cache 可清、按年齡回收 | CLAUDE.md Build lanes |
+| 未合併的 worktree／branch／source 永不刪；已合併的（PR MERGED）由控制者依第 9 步回收；build cache 可清、按年齡回收 | `fleet.merged-artifact-cleanup` |
 | 決策 recorded ≠ ratified；agent 不 ratify 自己的決策 | README 兩層授權 |
 | 審查 brief 用「驗證清單」框架（契約＋要確認的輸入形狀），不用攻擊計畫框架——後者會被 provider 拒收、燒掉一輪 | `fleet.review-brief-framing` |
 | brief 要先自己跑過一輪才交付（**非帳本決策**：來源是探索場 31 號第零條；edda 側尚無對應決策，要立法先開單） | — |

--- a/docs/guides/operator-runbook.md
+++ b/docs/guides/operator-runbook.md
@@ -174,7 +174,18 @@
 6. **收斂**：`/fleet-pr-loop` 的 bash driver 吐 `ACTION: REVIEW | FIX | DONE | BLOCKED`，照做到 LGTM；driver 不合併。走第 4 步直審路徑時不需要 driver：判決與修正在同一個 session 內來回。
 7. **合併**（有操作者授權時）：先執行 `sh scripts/merge-reviewed-pr.sh <PR>`，核對最新可信審查是目前完整 SHA 的 LGTM、P0=0/P1=0、無待升級項目且必要 CI 檢查通過；它另外會問一次聯集判決（GH-1057，經 `edda review deliver`），該 SHA 上只要還有一則站著的 Changes Requested，後來的 LGTM 也蓋不過（GH-742）。取得合併授權後使用 `sh scripts/merge-reviewed-pr.sh <PR> --merge`；它以 `--match-head-commit` 鎖定審查 SHA，避免最後一刻 push 越過判決。合併後對剩下的 PR 做 Layer-3 交集：不相交直接合，相交要 rebase → 判決失效 → 再一輪。
 8. **開單**：審查 exhaust、runtime 的傷、重複兩次的手動步驟，當場 `/issue-intake`／`/issue-create`（含四問接線審計）。不要留在對話裡。
-9. **收工**：`edda note "completed X; decided Y; next: Z" --tag session`；回報你：合了什麼、開了什麼、等你什麼。
+9. **回收**（wave 收尾，**控制者**跑，在 `C:\ai_agent\edda` 主 checkout 跑；GH-1009）：
+   先看 dry-run —— `sh scripts/fleet/reclaim-merged.sh`。每個 worktree／local branch／remote
+   branch 一行，附對應 PR、PR 狀態、dirty 與否，以及被留下的理由；確認 `RECLAIM` 那幾行就是
+   自己要清的，再 `sh scripts/fleet/reclaim-merged.sh --apply`，每移除一項留一行收據
+   （路徑、branch、PR#、squash SHA）。
+   它只動 `fleet.merged-artifact-cleanup` 授權內的東西：PR 已 MERGED、worktree 乾淨、ref 還停在
+   被合併的那顆 commit。closed-unmerged、open、dirty、無 PR、同名多 PR、locked、detached、
+   主 checkout 與 `.claude/worktrees/` 底下的 agent worktree 一律只列不碰（R7）；任何一項檢查
+   出錯就降級成只列。還在跑的 lane 用 `--protect <worktree 目錄名或分支名>` 保住（可重複）。
+   **lane 不跑這支**——§四第 3 條仍是「不刪分支、不刪 worktree」；回收是控制者的動作。
+   這支腳本是過渡載體，產品家在 `edda fleet reclaim`（腳本檔頭載明）。
+10. **收工**：`edda note "completed X; decided Y; next: Z" --tag session`；回報你：合了什麼、開了什麼、等你什麼。
 
 ---
 

--- a/scripts/fleet/reclaim-merged.sh
+++ b/scripts/fleet/reclaim-merged.sh
@@ -19,11 +19,12 @@
 # marks a new shell program with control flow as migration debt, and this is
 # one. It is accepted for this ticket as an explicitly-transitional carrier on
 # the condition it stays a thin loop: every per-item fact below comes from
-# `git` or `gh` directly, and the only processing applied to their output is
-# field extraction. The eventual product home is an `edda fleet reclaim` verb,
-# where the classification becomes typed and testable in Rust; this file is
-# expected to shrink to the one line that calls it. Do not grow judgement here
-# — take it to the verb.
+# `git` or `gh` directly, the only processing applied to their output is field
+# extraction and joining those fields onto one row per item, and the judgement
+# is the plain `if` ladder you can read in one screen. The eventual product
+# home is an `edda fleet reclaim` verb, where that ladder becomes typed and
+# unit-testable in Rust; this file is expected to shrink to the one line that
+# calls it. Do not grow judgement here — take it to the verb.
 #
 # usage:
 #   sh scripts/fleet/reclaim-merged.sh [--apply] [--protect <name>]...
@@ -68,16 +69,39 @@ trap 'rm -rf "$work"; exit 130' HUP INT TERM
 
 TAB=$(printf '\t')
 
-# ── the PR table ─────────────────────────────────────────────────────
+# Pure shell on purpose. The obvious `printf '%s\n' "$protect" | grep -qxF`
+# costs two processes, and this predicate is asked once per worktree and twice
+# per branch — on a workstation where a spawn measures ~2.7s that alone put a
+# 46-worktree, 229-branch dry run past forty minutes. `$protect` is a
+# newline-separated list, so a newline-delimited substring test IS the exact
+# match.
+protect_nl="$protect
+"
+is_protected() {
+    case $protect_nl in
+        *"
+$1
+"*) return 0 ;;
+    esac
+    return 1
+}
+
+is_nested() {
+    case $1 in "$2"/*) return 0 ;; *) return 1 ;; esac
+}
+
+# ── the fact tables ──────────────────────────────────────────────────
 #
-# One `gh` call for the whole repository rather than one per branch: with ~90
-# local branches the per-branch form spends a minute and a half on round trips
-# to learn what a single paginated list already says. `--jq` does the field
-# extraction, so nothing downstream parses JSON.
+# Four reads, each answering one question for the whole repository at once,
+# and then one join per pass. The per-item form of these — a `gh pr list
+# --head` and a `git rev-parse` inside the loop — costs one process per item
+# per question; on a workstation where a process spawn measures ~2.7s that is
+# twenty minutes of round trips to learn what four calls already say.
 #
 # `headRefOid` is carried because a PR's state alone does not license deleting
-# a ref: the branch must still point at the commit the PR was merged from. A
-# branch that has moved on carries work no PR ever saw.
+# a ref: the ref must still point at the commit the PR was merged from. A ref
+# that has moved on carries work no PR ever saw, and `refs/pull/N/head` does
+# not preserve it.
 if ! gh pr list --state all --limit "$pr_limit" \
         --json number,state,headRefName,headRefOid,mergeCommit \
         --jq '.[] | [.headRefName, (.number|tostring), .state, .headRefOid, (.mergeCommit.oid // "-")] | @tsv' \
@@ -86,32 +110,12 @@ if ! gh pr list --state all --limit "$pr_limit" \
     exit 3
 fi
 
-# The remote side of the same question, in one call. A missing or unreachable
-# `origin` leaves the table empty, which reads downstream as "no remote branch
-# to reclaim" — the conservative answer.
+# A missing or unreachable `origin` leaves this table empty, which reads
+# downstream as "no remote branch to reclaim" — the conservative answer.
 git ls-remote --heads origin 2>/dev/null \
     | sed "s|${TAB}refs/heads/|${TAB}|" >"$work/remote.tsv" || true
 
-# `pr_row <branch>` prints the single PR row for a branch, or nothing at all.
-# Printing nothing for two rows is deliberate: a branch name reused across PRs
-# has no single state, and a caller that saw the first row would act on the
-# wrong one. `pr_count` below tells the two empty answers apart.
-pr_row() {
-    awk -F"$TAB" -v b="$1" '$1 == b { rows[++n] = $0 } END { if (n == 1) print rows[1] }' \
-        "$work/prs.tsv"
-}
-
-pr_count() {
-    awk -F"$TAB" -v b="$1" '$1 == b { n++ } END { print n + 0 }' "$work/prs.tsv"
-}
-
-is_protected() {
-    printf '%s\n' "$protect" | grep -qxF -- "$1"
-}
-
-is_nested() {
-    case $1 in "$2"/*) return 0 ;; *) return 1 ;; esac
-}
+git worktree list --porcelain >"$work/wt.raw"
 
 # ── snapshot ─────────────────────────────────────────────────────────
 count_worktrees() { git worktree list | wc -l | tr -d ' '; }
@@ -128,9 +132,11 @@ printf '\n'
 #
 # `--porcelain` is the only stable shape: the human `git worktree list` packs
 # path, sha and branch into one padded line, and a path containing spaces
-# makes that unsplittable. The awk below turns each record into one TSV row
-# and extracts nothing else.
-git worktree list --porcelain >"$work/wt.raw"
+# makes that unsplittable. The first awk turns each record into one TSV row;
+# the second joins the PR table onto it by head branch. A branch that carries
+# two PR rows is left with a count and no fields — a name reused across PRs
+# has no single state, and a reader that took the first row would act on the
+# wrong one.
 awk -v OFS="$TAB" '
     function emit() { if (p != "") print p, (b == "" ? "-" : b), (h == "" ? "-" : h), lk, pn }
     /^worktree /  { emit(); p = substr($0, 10); b = ""; h = ""; lk = 0; pn = 0; next }
@@ -139,27 +145,39 @@ awk -v OFS="$TAB" '
     /^locked/     { lk = 1; next }
     /^prunable/   { pn = 1; next }
     END           { emit() }
-' "$work/wt.raw" >"$work/wt.tsv"
+' "$work/wt.raw" >"$work/wt.base"
 
-main_path=$(head -n 1 "$work/wt.tsv" | cut -f1)
+join_prs() { # <file-of-rows> <1-based field holding the branch name>
+    awk -F"$TAB" -v OFS="$TAB" -v prs="$work/prs.tsv" -v key="$2" '
+        FILENAME == prs {
+            c[$1]++
+            if (c[$1] == 1) { num[$1] = $2; st[$1] = $3; ho[$1] = $4; mo[$1] = $5 }
+            next
+        }
+        {
+            b = $key
+            one = (c[b] == 1)
+            print $0, c[b] + 0, (one ? num[b] : "-"), (one ? st[b] : "-"), \
+                  (one ? ho[b] : "-"), (one ? mo[b] : "-")
+        }
+    ' "$work/prs.tsv" "$1"
+}
+
+join_prs "$work/wt.base" 2 >"$work/wt.tsv"
+
+main_path=$(head -n 1 "$work/wt.base" | cut -f1)
 self_path=$(git rev-parse --show-toplevel)
 
 printf 'VERDICT\tKIND\tITEM\tBRANCH\tPR\tSTATE\tTREE/SHA\tREASON\n'
 
 : >"$work/wt.reclaim"
-while IFS="$TAB" read -r path branch head locked prunable; do
+while IFS="$TAB" read -r path branch head locked prunable prcount pr state head_oid merge_oid; do
     [ -n "$path" ] || continue
-    base=${path##*/}
-    row=$(pr_row "$branch")
-    pr='-'; state='-'; merge_oid='-'
-    if [ -n "$row" ]; then
-        pr='#'$(printf '%s' "$row" | cut -f2)
-        state=$(printf '%s' "$row" | cut -f3)
-        merge_oid=$(printf '%s' "$row" | cut -f5)
-    fi
+    [ "$pr" = '-' ] || pr="#$pr"
 
     # The tree state is read before any verdict so the printed row always
-    # reports it, even for items excluded for another reason first.
+    # reports it, which is what makes the dry run auditable rather than just
+    # a list of conclusions.
     tree='clean'
     if [ ! -d "$path" ]; then
         tree='missing'
@@ -180,18 +198,16 @@ while IFS="$TAB" read -r path branch head locked prunable; do
         reason='running-from-here'
     elif [ "$locked" = 1 ]; then
         reason='locked'
-    elif is_protected "$base" || { [ "$branch" != '-' ] && is_protected "$branch"; }; then
+    elif is_protected "${path##*/}" || { [ "$branch" != '-' ] && is_protected "$branch"; }; then
         reason='protected'
     elif [ "$prunable" = 1 ] || [ "$tree" = 'missing' ]; then
         reason='prunable — run git worktree prune'
     elif [ "$branch" = '-' ]; then
         reason='detached — no branch, no PR to judge by'
-    elif [ -z "$row" ]; then
-        if [ "$(pr_count "$branch")" -gt 0 ]; then
-            reason='pr-ambiguous — branch name reused across PRs'
-        else
-            reason='no-pr'
-        fi
+    elif [ "$prcount" -gt 1 ]; then
+        reason='pr-ambiguous — branch name reused across PRs'
+    elif [ "$prcount" -eq 0 ]; then
+        reason='no-pr'
     elif [ "$state" != 'MERGED' ]; then
         reason="pr-$state"
     elif [ "$tree" != 'clean' ]; then
@@ -225,64 +241,91 @@ fi
 #
 # After the worktree pass, because a branch checked out in a worktree cannot
 # be deleted until that worktree is gone — and under --apply some of them just
-# went. The list is therefore re-read rather than reused.
+# went, so the checked-out set is re-read rather than reused.
+#
+# The row set is the UNION of local and remote names: a merged PR's remote
+# branch left behind after its local ref was already deleted is half of what
+# the authority names, and iterating local refs alone never sees it.
+#
+# The checked-out set subtracts the worktrees the pass above just reclaimed.
+# Without that subtraction a dry run reports every reclaimable branch as
+# `checked-out` — true at the instant it looks, false by the time `--apply`
+# reaches the branch pass, and a dry run that does not predict `--apply` is
+# the one thing this script cannot be.
 printf '\n'
-git worktree list --porcelain | sed -n 's|^branch refs/heads/||p' >"$work/checkedout"
+git worktree list --porcelain | sed -n 's|^branch refs/heads/||p' >"$work/checkedout.all"
+awk -v gone="$work/wt.reclaim" -F"$TAB" '
+    FILENAME == gone { g[$2] = 1; next }
+    !($0 in g)       { print }
+' "$work/wt.reclaim" "$work/checkedout.all" >"$work/checkedout"
+git for-each-ref --format="%(refname:short)${TAB}%(objectname)" refs/heads >"$work/local.tsv"
 default=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
 default=${default:-main}
 
+awk -F"$TAB" -v OFS="$TAB" \
+    -v loc="$work/local.tsv" -v rem="$work/remote.tsv" -v co="$work/checkedout" '
+    FILENAME == loc { tip[$1] = $2; seen[$1] = 1; next }
+    FILENAME == rem { rsha[$2] = $1; seen[$2] = 1; next }
+    FILENAME == co  { out[$1] = 1; next }
+    END {
+        for (b in seen)
+            print b, (b in tip ? tip[b] : "-"), (b in rsha ? rsha[b] : "-"), (out[b] ? 1 : 0)
+    }
+' "$work/local.tsv" "$work/remote.tsv" "$work/checkedout" | sort >"$work/br.base"
+join_prs "$work/br.base" 1 >"$work/branches.tsv"
+
 : >"$work/br.reclaim"
 : >"$work/remote.reclaim"
-git for-each-ref --format="%(refname:short)${TAB}%(objectname)" refs/heads >"$work/branches.tsv"
-while IFS="$TAB" read -r branch tip; do
+while IFS="$TAB" read -r branch tip remote_sha checkedout prcount pr state head_oid merge_oid; do
     [ -n "$branch" ] || continue
-    row=$(pr_row "$branch")
-    pr='-'; state='-'; head_oid='-'; merge_oid='-'
-    if [ -n "$row" ]; then
-        pr='#'$(printf '%s' "$row" | cut -f2)
-        state=$(printf '%s' "$row" | cut -f3)
-        head_oid=$(printf '%s' "$row" | cut -f4)
-        merge_oid=$(printf '%s' "$row" | cut -f5)
-    fi
-    remote_sha=$(awk -F"$TAB" -v b="$branch" '$2 == b { print $1 }' "$work/remote.tsv")
+    [ "$pr" = '-' ] || pr="#$pr"
 
-    verdict='KEEP'
-    if [ "$branch" = "$default" ]; then
-        reason='default-branch'
-    elif grep -qxF "$branch" "$work/checkedout"; then
-        reason='checked-out'
-    elif is_protected "$branch"; then
-        reason='protected'
-    elif [ -z "$row" ]; then
-        if [ "$(pr_count "$branch")" -gt 0 ]; then
+    verdict=''
+    reason=''
+    if [ "$tip" != '-' ]; then
+        verdict='KEEP'
+        if [ "$branch" = "$default" ]; then
+            reason='default-branch'
+        elif [ "$checkedout" = 1 ]; then
+            reason='checked-out'
+        elif is_protected "$branch"; then
+            reason='protected'
+        elif [ "$prcount" -gt 1 ]; then
             reason='pr-ambiguous — branch name reused across PRs'
-        else
+        elif [ "$prcount" -eq 0 ]; then
             reason='no-pr'
+        elif [ "$state" != 'MERGED' ]; then
+            reason="pr-$state"
+        elif [ "$tip" != "$head_oid" ]; then
+            reason='local-ahead-of-pr'
+        else
+            verdict='RECLAIM'
+            reason='pr-merged, tip = merged head'
+            printf '%s\t%s\t%s\n' "$branch" "$pr" "$merge_oid" >>"$work/br.reclaim"
         fi
-    elif [ "$state" != 'MERGED' ]; then
-        reason="pr-$state"
-    elif [ "$tip" != "$head_oid" ]; then
-        # The PR is merged but the local ref has moved: whatever is on it now
-        # was never in that PR, so `refs/pull/N/head` does not preserve it.
-        reason='local-ahead-of-pr'
-    else
-        verdict='RECLAIM'
-        reason='pr-merged, tip = merged head'
-        printf '%s\t%s\t%s\n' "$branch" "$pr" "$merge_oid" >>"$work/br.reclaim"
+        printf '%s\tlocal-branch\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$verdict" "$branch" "$branch" "$pr" "$state" "$tip" "$reason"
     fi
-    printf '%s\tlocal-branch\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-        "$verdict" "$branch" "$branch" "$pr" "$state" "$tip" "$reason"
 
-    [ -n "$remote_sha" ] || continue
+    [ "$remote_sha" != '-' ] || continue
     rverdict='KEEP'
-    if is_protected "$branch"; then
+    if [ "$branch" = "$default" ]; then
+        rreason='default-branch'
+    elif is_protected "$branch"; then
         rreason='protected'
-    elif [ -z "$row" ]; then
+    elif [ "$prcount" -gt 1 ]; then
+        rreason='pr-ambiguous — branch name reused across PRs'
+    elif [ "$prcount" -eq 0 ]; then
         rreason='no-pr'
     elif [ "$state" != 'MERGED' ]; then
         rreason="pr-$state"
     elif [ "$remote_sha" != "$head_oid" ]; then
         rreason='remote-moved-since-merge'
+    elif [ -n "$verdict" ] && [ "$verdict" != 'RECLAIM' ]; then
+        # The local ref survived for some reason — a dirty lane, a ref ahead
+        # of its PR, an explicit protection. Whatever that reason was, it is
+        # also a reason to leave the operator somewhere to push it.
+        rreason="local-kept — $reason"
     else
         rverdict='RECLAIM'
         rreason='pr-merged, remote tip = merged head'

--- a/scripts/fleet/reclaim-merged.sh
+++ b/scripts/fleet/reclaim-merged.sh
@@ -1,0 +1,327 @@
+#!/bin/sh
+# GH-1009 — the executor for `fleet.merged-artifact-cleanup`.
+#
+# The authority already exists and is quoted in `.claude/CLAUDE.md` (Build
+# lanes, Verification cost): an artifact whose PR is MERGED — the merged PR's
+# remote branch and its lane worktree — may be reclaimed, because the squash
+# commit is on `main` and GitHub keeps `refs/pull/N/head`, so SHA-pinned
+# verdicts stay resolvable. Nothing executed it, so 57 worktrees and 345
+# branches accumulated (2026-09-06 measurement) and every triage round paid to
+# re-derive each branch's PR state by hand.
+#
+# R7 is the other half and is never crossed here: closed-unmerged, open, dirty,
+# ambiguous and no-PR items are LISTED and never touched. The default mode is
+# a dry run; `--apply` removes only the rows this script already printed as
+# RECLAIM. Every check that errors demotes its item to KEEP — an item whose
+# state could not be established is not a reclamation candidate.
+#
+# TRANSITIONAL CARRIER. `mechanism.shell-role=one-line-adapter-only` (ratified)
+# marks a new shell program with control flow as migration debt, and this is
+# one. It is accepted for this ticket as an explicitly-transitional carrier on
+# the condition it stays a thin loop: every per-item fact below comes from
+# `git` or `gh` directly, and the only processing applied to their output is
+# field extraction. The eventual product home is an `edda fleet reclaim` verb,
+# where the classification becomes typed and testable in Rust; this file is
+# expected to shrink to the one line that calls it. Do not grow judgement here
+# — take it to the verb.
+#
+# usage:
+#   sh scripts/fleet/reclaim-merged.sh [--apply] [--protect <name>]...
+#                                      [--pr-limit <n>]
+#
+# `--protect <name>` matches a worktree directory's basename or a branch name
+# exactly, and may be repeated; a protected item is always KEEP. The main
+# checkout, anything nested inside it (agent worktrees under
+# `.claude/worktrees/`), the worktree this script runs from, and locked
+# worktrees are protected unconditionally and need no flag.
+#
+# Exit codes: 0 = ran, 2 = usage, 3 = the PR table could not be read (without
+# it every item's PR state is unknown, so nothing may be reclaimed).
+set -eu
+
+usage() {
+    echo "usage: $0 [--apply] [--protect <name>]... [--pr-limit <n>]" >&2
+}
+
+apply=0
+pr_limit=2000
+protect=''
+while [ $# -gt 0 ]; do
+    case $1 in
+        --apply) apply=1; shift ;;
+        --protect) [ $# -ge 2 ] || { usage; exit 2; }; protect="$protect
+$2"; shift 2 ;;
+        --pr-limit) [ $# -ge 2 ] || { usage; exit 2; }; pr_limit=$2; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) usage; exit 2 ;;
+    esac
+done
+case $pr_limit in
+    '' | *[!0-9]*) usage; exit 2 ;;
+esac
+
+cd "$(git rev-parse --show-toplevel)"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/reclaim-merged.XXXXXX")
+trap 'rm -rf "$work"' 0
+trap 'rm -rf "$work"; exit 130' HUP INT TERM
+
+TAB=$(printf '\t')
+
+# ── the PR table ─────────────────────────────────────────────────────
+#
+# One `gh` call for the whole repository rather than one per branch: with ~90
+# local branches the per-branch form spends a minute and a half on round trips
+# to learn what a single paginated list already says. `--jq` does the field
+# extraction, so nothing downstream parses JSON.
+#
+# `headRefOid` is carried because a PR's state alone does not license deleting
+# a ref: the branch must still point at the commit the PR was merged from. A
+# branch that has moved on carries work no PR ever saw.
+if ! gh pr list --state all --limit "$pr_limit" \
+        --json number,state,headRefName,headRefOid,mergeCommit \
+        --jq '.[] | [.headRefName, (.number|tostring), .state, .headRefOid, (.mergeCommit.oid // "-")] | @tsv' \
+        >"$work/prs.tsv" 2>"$work/gh.err"; then
+    echo "reclaim-merged: gh pr list failed — $(head -n 1 "$work/gh.err")" >&2
+    exit 3
+fi
+
+# The remote side of the same question, in one call. A missing or unreachable
+# `origin` leaves the table empty, which reads downstream as "no remote branch
+# to reclaim" — the conservative answer.
+git ls-remote --heads origin 2>/dev/null \
+    | sed "s|${TAB}refs/heads/|${TAB}|" >"$work/remote.tsv" || true
+
+# `pr_row <branch>` prints the single PR row for a branch, or nothing at all.
+# Printing nothing for two rows is deliberate: a branch name reused across PRs
+# has no single state, and a caller that saw the first row would act on the
+# wrong one. `pr_count` below tells the two empty answers apart.
+pr_row() {
+    awk -F"$TAB" -v b="$1" '$1 == b { rows[++n] = $0 } END { if (n == 1) print rows[1] }' \
+        "$work/prs.tsv"
+}
+
+pr_count() {
+    awk -F"$TAB" -v b="$1" '$1 == b { n++ } END { print n + 0 }' "$work/prs.tsv"
+}
+
+is_protected() {
+    printf '%s\n' "$protect" | grep -qxF -- "$1"
+}
+
+is_nested() {
+    case $1 in "$2"/*) return 0 ;; *) return 1 ;; esac
+}
+
+# ── snapshot ─────────────────────────────────────────────────────────
+count_worktrees() { git worktree list | wc -l | tr -d ' '; }
+count_branches() { git for-each-ref --format='x' refs/heads | wc -l | tr -d ' '; }
+
+before_wt=$(count_worktrees)
+before_br=$(count_branches)
+printf 'reclaim-merged: before  worktrees=%s  branches=%s  prs=%s\n' \
+    "$before_wt" "$before_br" "$(wc -l <"$work/prs.tsv" | tr -d ' ')"
+[ "$apply" -eq 1 ] || printf 'reclaim-merged: dry run — nothing is removed without --apply\n'
+printf '\n'
+
+# ── worktree pass ────────────────────────────────────────────────────
+#
+# `--porcelain` is the only stable shape: the human `git worktree list` packs
+# path, sha and branch into one padded line, and a path containing spaces
+# makes that unsplittable. The awk below turns each record into one TSV row
+# and extracts nothing else.
+git worktree list --porcelain >"$work/wt.raw"
+awk -v OFS="$TAB" '
+    function emit() { if (p != "") print p, (b == "" ? "-" : b), (h == "" ? "-" : h), lk, pn }
+    /^worktree /  { emit(); p = substr($0, 10); b = ""; h = ""; lk = 0; pn = 0; next }
+    /^HEAD /      { h = substr($0, 6); next }
+    /^branch /    { b = substr($0, 8); sub(/^refs\/heads\//, "", b); next }
+    /^locked/     { lk = 1; next }
+    /^prunable/   { pn = 1; next }
+    END           { emit() }
+' "$work/wt.raw" >"$work/wt.tsv"
+
+main_path=$(head -n 1 "$work/wt.tsv" | cut -f1)
+self_path=$(git rev-parse --show-toplevel)
+
+printf 'VERDICT\tKIND\tITEM\tBRANCH\tPR\tSTATE\tTREE/SHA\tREASON\n'
+
+: >"$work/wt.reclaim"
+while IFS="$TAB" read -r path branch head locked prunable; do
+    [ -n "$path" ] || continue
+    base=${path##*/}
+    row=$(pr_row "$branch")
+    pr='-'; state='-'; merge_oid='-'
+    if [ -n "$row" ]; then
+        pr='#'$(printf '%s' "$row" | cut -f2)
+        state=$(printf '%s' "$row" | cut -f3)
+        merge_oid=$(printf '%s' "$row" | cut -f5)
+    fi
+
+    # The tree state is read before any verdict so the printed row always
+    # reports it, even for items excluded for another reason first.
+    tree='clean'
+    if [ ! -d "$path" ]; then
+        tree='missing'
+    elif ! git -C "$path" status --porcelain >"$work/status" 2>/dev/null; then
+        tree='error'
+    elif [ -s "$work/status" ]; then
+        tree='dirty'
+    fi
+
+    # Order matters: the unconditional protections come first, so a protected
+    # item is never even evaluated against its PR state.
+    verdict='KEEP'
+    if [ "$path" = "$main_path" ]; then
+        reason='main-checkout'
+    elif is_nested "$path" "$main_path"; then
+        reason='nested-in-main-checkout'
+    elif [ "$path" = "$self_path" ]; then
+        reason='running-from-here'
+    elif [ "$locked" = 1 ]; then
+        reason='locked'
+    elif is_protected "$base" || { [ "$branch" != '-' ] && is_protected "$branch"; }; then
+        reason='protected'
+    elif [ "$prunable" = 1 ] || [ "$tree" = 'missing' ]; then
+        reason='prunable — run git worktree prune'
+    elif [ "$branch" = '-' ]; then
+        reason='detached — no branch, no PR to judge by'
+    elif [ -z "$row" ]; then
+        if [ "$(pr_count "$branch")" -gt 0 ]; then
+            reason='pr-ambiguous — branch name reused across PRs'
+        else
+            reason='no-pr'
+        fi
+    elif [ "$state" != 'MERGED' ]; then
+        reason="pr-$state"
+    elif [ "$tree" != 'clean' ]; then
+        reason="tree-$tree"
+    else
+        verdict='RECLAIM'
+        reason='pr-merged, tree clean'
+        printf '%s\t%s\t%s\t%s\n' "$path" "$branch" "$pr" "$merge_oid" >>"$work/wt.reclaim"
+    fi
+    printf '%s\tworktree\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$verdict" "$path" "$branch" "$pr" "$state" "$tree" "$reason"
+done <"$work/wt.tsv"
+
+if [ "$apply" -eq 1 ] && [ -s "$work/wt.reclaim" ]; then
+    printf '\n'
+    while IFS="$TAB" read -r path branch pr merge_oid; do
+        # Never `--force`, and never `rm -rf`: a refusal means git sees state
+        # this script's own checks missed, and the correct response to that is
+        # to leave the worktree alone and say so.
+        if git worktree remove "$path" 2>"$work/rm.err"; then
+            printf 'reclaimed worktree\t%s\tbranch=%s\tpr=%s\tsquash=%s\n' \
+                "$path" "$branch" "$pr" "$merge_oid"
+        else
+            printf 'KEPT worktree\t%s\tgit worktree remove refused: %s\n' \
+                "$path" "$(head -n 1 "$work/rm.err")" >&2
+        fi
+    done <"$work/wt.reclaim"
+fi
+
+# ── branch pass ──────────────────────────────────────────────────────
+#
+# After the worktree pass, because a branch checked out in a worktree cannot
+# be deleted until that worktree is gone — and under --apply some of them just
+# went. The list is therefore re-read rather than reused.
+printf '\n'
+git worktree list --porcelain | sed -n 's|^branch refs/heads/||p' >"$work/checkedout"
+default=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
+default=${default:-main}
+
+: >"$work/br.reclaim"
+: >"$work/remote.reclaim"
+git for-each-ref --format="%(refname:short)${TAB}%(objectname)" refs/heads >"$work/branches.tsv"
+while IFS="$TAB" read -r branch tip; do
+    [ -n "$branch" ] || continue
+    row=$(pr_row "$branch")
+    pr='-'; state='-'; head_oid='-'; merge_oid='-'
+    if [ -n "$row" ]; then
+        pr='#'$(printf '%s' "$row" | cut -f2)
+        state=$(printf '%s' "$row" | cut -f3)
+        head_oid=$(printf '%s' "$row" | cut -f4)
+        merge_oid=$(printf '%s' "$row" | cut -f5)
+    fi
+    remote_sha=$(awk -F"$TAB" -v b="$branch" '$2 == b { print $1 }' "$work/remote.tsv")
+
+    verdict='KEEP'
+    if [ "$branch" = "$default" ]; then
+        reason='default-branch'
+    elif grep -qxF "$branch" "$work/checkedout"; then
+        reason='checked-out'
+    elif is_protected "$branch"; then
+        reason='protected'
+    elif [ -z "$row" ]; then
+        if [ "$(pr_count "$branch")" -gt 0 ]; then
+            reason='pr-ambiguous — branch name reused across PRs'
+        else
+            reason='no-pr'
+        fi
+    elif [ "$state" != 'MERGED' ]; then
+        reason="pr-$state"
+    elif [ "$tip" != "$head_oid" ]; then
+        # The PR is merged but the local ref has moved: whatever is on it now
+        # was never in that PR, so `refs/pull/N/head` does not preserve it.
+        reason='local-ahead-of-pr'
+    else
+        verdict='RECLAIM'
+        reason='pr-merged, tip = merged head'
+        printf '%s\t%s\t%s\n' "$branch" "$pr" "$merge_oid" >>"$work/br.reclaim"
+    fi
+    printf '%s\tlocal-branch\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$verdict" "$branch" "$branch" "$pr" "$state" "$tip" "$reason"
+
+    [ -n "$remote_sha" ] || continue
+    rverdict='KEEP'
+    if is_protected "$branch"; then
+        rreason='protected'
+    elif [ -z "$row" ]; then
+        rreason='no-pr'
+    elif [ "$state" != 'MERGED' ]; then
+        rreason="pr-$state"
+    elif [ "$remote_sha" != "$head_oid" ]; then
+        rreason='remote-moved-since-merge'
+    else
+        rverdict='RECLAIM'
+        rreason='pr-merged, remote tip = merged head'
+        printf '%s\t%s\t%s\n' "$branch" "$pr" "$merge_oid" >>"$work/remote.reclaim"
+    fi
+    printf '%s\tremote-branch\torigin/%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$rverdict" "$branch" "$branch" "$pr" "$state" "$remote_sha" "$rreason"
+done <"$work/branches.tsv"
+
+if [ "$apply" -eq 1 ]; then
+    printf '\n'
+    while IFS="$TAB" read -r branch pr merge_oid; do
+        if git branch -D "$branch" >/dev/null 2>"$work/rm.err"; then
+            printf 'reclaimed local branch\t%s\tpr=%s\tsquash=%s\n' \
+                "$branch" "$pr" "$merge_oid"
+        else
+            printf 'KEPT local branch\t%s\tgit branch -D refused: %s\n' \
+                "$branch" "$(head -n 1 "$work/rm.err")" >&2
+        fi
+    done <"$work/br.reclaim"
+    while IFS="$TAB" read -r branch pr merge_oid; do
+        if git push origin --delete "$branch" >/dev/null 2>"$work/rm.err"; then
+            printf 'reclaimed remote branch\torigin/%s\tpr=%s\tsquash=%s\n' \
+                "$branch" "$pr" "$merge_oid"
+        else
+            printf 'KEPT remote branch\torigin/%s\tpush --delete refused: %s\n' \
+                "$branch" "$(head -n 1 "$work/rm.err")" >&2
+        fi
+    done <"$work/remote.reclaim"
+fi
+
+printf '\n'
+if [ "$apply" -eq 1 ]; then
+    printf 'reclaim-merged: after   worktrees=%s  branches=%s (before: %s / %s)\n' \
+        "$(count_worktrees)" "$(count_branches)" "$before_wt" "$before_br"
+else
+    printf 'reclaim-merged: dry run — %s worktree(s), %s local branch(es), %s remote branch(es) would be reclaimed by --apply\n' \
+        "$(wc -l <"$work/wt.reclaim" | tr -d ' ')" \
+        "$(wc -l <"$work/br.reclaim" | tr -d ' ')" \
+        "$(wc -l <"$work/remote.reclaim" | tr -d ' ')"
+fi
+exit 0

--- a/scripts/fleet/reclaim-merged.sh
+++ b/scripts/fleet/reclaim-merged.sh
@@ -335,26 +335,81 @@ while IFS="$TAB" read -r branch tip remote_sha checkedout prcount pr state head_
         "$rverdict" "$branch" "$branch" "$pr" "$state" "$remote_sha" "$rreason"
 done <"$work/branches.tsv"
 
+# ── deletion ─────────────────────────────────────────────────────────
+#
+# Both ref deletions are BATCHED and then VERIFIED, rather than run one ref
+# per command and trusted by exit code. `git push origin --delete` accepts
+# many refs in one push, and one ref per push measured ~30s of round trip on
+# this workstation — 115 merged remote branches is most of two hours that way,
+# against one push batched. `git branch -D` batches for the same reason at
+# smaller stakes.
+#
+# The verification is what makes the batch honest: a partially applied batch
+# still deletes the refs it could, so the receipt cannot come from the exit
+# code. Each list is re-read from git afterwards and a receipt is printed only
+# for a ref that is actually gone; anything still standing gets a KEPT line
+# naming it. Chunked at 50 so no single command line grows unbounded.
+delete_batched() { # <reclaim-file> <"local"|"remote">
+    # Read both arguments out before the first `set --`: inside a function the
+    # positional parameters ARE the arguments, so building a batch in them
+    # destroys $1 and $2.
+    list=$1
+    kind=$2
+    [ -s "$list" ] || return 0
+    set --
+    n=0
+    while IFS="$TAB" read -r branch pr merge_oid; do
+        set -- "$@" "$branch"
+        n=$((n + 1))
+        if [ "$n" -ge 50 ]; then
+            if [ "$kind" = local ]; then
+                git branch -D "$@" >/dev/null 2>>"$work/del.err" || true
+            else
+                git push origin --delete "$@" >/dev/null 2>>"$work/del.err" || true
+            fi
+            set --
+            n=0
+        fi
+    done <"$list"
+    if [ "$n" -gt 0 ]; then
+        if [ "$kind" = local ]; then
+            git branch -D "$@" >/dev/null 2>>"$work/del.err" || true
+        else
+            git push origin --delete "$@" >/dev/null 2>>"$work/del.err" || true
+        fi
+    fi
+
+    if [ "$kind" = local ]; then
+        git for-each-ref --format='%(refname:short)' refs/heads >"$work/after.txt"
+        label='local branch'
+        prefix=''
+    else
+        git ls-remote --heads origin 2>/dev/null \
+            | sed "s|^.*${TAB}refs/heads/||" >"$work/after.txt" || true
+        label='remote branch'
+        prefix='origin/'
+    fi
+    awk -F"$TAB" -v OFS="$TAB" -v after="$work/after.txt" -v label="$label" \
+        -v prefix="$prefix" -v kept="$work/kept.txt" '
+        FILENAME == after { still[$1] = 1; next }
+        {
+            if ($1 in still)
+                print "KEPT " label, prefix $1, "still present after delete" >kept
+            else
+                print "reclaimed " label, prefix $1, "pr=" $2, "squash=" $3
+        }
+    ' "$work/after.txt" "$list"
+    if [ -s "$work/kept.txt" ]; then
+        cat "$work/kept.txt" >&2
+        : >"$work/kept.txt"
+    fi
+}
+
 if [ "$apply" -eq 1 ]; then
     printf '\n'
-    while IFS="$TAB" read -r branch pr merge_oid; do
-        if git branch -D "$branch" >/dev/null 2>"$work/rm.err"; then
-            printf 'reclaimed local branch\t%s\tpr=%s\tsquash=%s\n' \
-                "$branch" "$pr" "$merge_oid"
-        else
-            printf 'KEPT local branch\t%s\tgit branch -D refused: %s\n' \
-                "$branch" "$(head -n 1 "$work/rm.err")" >&2
-        fi
-    done <"$work/br.reclaim"
-    while IFS="$TAB" read -r branch pr merge_oid; do
-        if git push origin --delete "$branch" >/dev/null 2>"$work/rm.err"; then
-            printf 'reclaimed remote branch\torigin/%s\tpr=%s\tsquash=%s\n' \
-                "$branch" "$pr" "$merge_oid"
-        else
-            printf 'KEPT remote branch\torigin/%s\tpush --delete refused: %s\n' \
-                "$branch" "$(head -n 1 "$work/rm.err")" >&2
-        fi
-    done <"$work/remote.reclaim"
+    : >"$work/kept.txt"
+    delete_batched "$work/br.reclaim" local
+    delete_batched "$work/remote.reclaim" remote
 fi
 
 printf '\n'

--- a/scripts/fleet/reclaim-merged.sh
+++ b/scripts/fleet/reclaim-merged.sh
@@ -37,7 +37,9 @@
 # worktrees are protected unconditionally and need no flag.
 #
 # Exit codes: 0 = ran, 2 = usage, 3 = the PR table could not be read (without
-# it every item's PR state is unknown, so nothing may be reclaimed).
+# it every item's PR state is unknown, so nothing may be reclaimed), 4 = a
+# post-delete verification re-read failed — the affected refs are reported
+# KEPT/unverified on stderr, not receipted as reclaimed.
 set -eu
 
 usage() {
@@ -47,6 +49,7 @@ usage() {
 apply=0
 pr_limit=2000
 protect=''
+verify_failed=0
 while [ $# -gt 0 ]; do
     case $1 in
         --apply) apply=1; shift ;;
@@ -349,6 +352,15 @@ done <"$work/branches.tsv"
 # code. Each list is re-read from git afterwards and a receipt is printed only
 # for a ref that is actually gone; anything still standing gets a KEPT line
 # naming it. Chunked at 50 so no single command line grows unbounded.
+#
+# The re-read itself is verified too, not trusted by exit code either: an
+# unreachable origin here would otherwise read as "nothing survived the
+# delete" and receipt every ref in the batch as reclaimed — the exact
+# fail-open this script exists to close. `git ls-remote`'s own exit status is
+# checked directly (never the exit status of a pipeline it feeds), and on
+# failure the whole batch is reported KEPT/unverified with no receipt for any
+# ref in it; the run's exit code (4) reflects the failure instead of masking
+# it as a normal 0.
 delete_batched() { # <reclaim-file> <"local"|"remote">
     # Read both arguments out before the first `set --`: inside a function the
     # positional parameters ARE the arguments, so building a batch in them
@@ -384,8 +396,23 @@ delete_batched() { # <reclaim-file> <"local"|"remote">
         label='local branch'
         prefix=''
     else
-        git ls-remote --heads origin 2>/dev/null \
-            | sed "s|^.*${TAB}refs/heads/||" >"$work/after.txt" || true
+        if git ls-remote --heads origin >"$work/remote-after.raw" 2>"$work/lsremote.err"; then
+            sed "s|^.*${TAB}refs/heads/||" "$work/remote-after.raw" >"$work/after.txt"
+        else
+            # The re-read failed — network drop, token expiry, a 5xx, anything
+            # between the push above and this line. An empty after.txt here is
+            # indistinguishable from "origin now has no branches", and every
+            # ref in $list would read as gone. Do not let that manufacture a
+            # receipt: report every ref in this batch KEPT/unverified instead,
+            # on stderr, and fail the run's exit code rather than exit 0 on an
+            # unverified batch.
+            verify_failed=1
+            while IFS="$TAB" read -r branch pr merge_oid; do
+                printf 'KEPT remote branch\torigin/%s\tunverified — git ls-remote failed re-reading origin after delete: %s\n' \
+                    "$branch" "$(head -n 1 "$work/lsremote.err")" >&2
+            done <"$list"
+            return 0
+        fi
         label='remote branch'
         prefix='origin/'
     fi
@@ -421,5 +448,9 @@ else
         "$(wc -l <"$work/wt.reclaim" | tr -d ' ')" \
         "$(wc -l <"$work/br.reclaim" | tr -d ' ')" \
         "$(wc -l <"$work/remote.reclaim" | tr -d ' ')"
+fi
+if [ "$verify_failed" -eq 1 ]; then
+    echo 'reclaim-merged: a post-delete re-read could not be verified — see KEPT/unverified lines above' >&2
+    exit 4
 fi
 exit 0

--- a/scripts/fleet/test-reclaim-merged.sh
+++ b/scripts/fleet/test-reclaim-merged.sh
@@ -1,0 +1,265 @@
+#!/bin/sh
+# Offline self-test for scripts/fleet/reclaim-merged.sh (GH-1009).
+#
+# What is under test is the EXCLUSION boundary, not the removal: R7 says a
+# reclaimer that is merely usually right is a data-loss tool, so the cases
+# below are written from the keep side. A dirty worktree, an open PR, a
+# worktree nested in the main checkout, a local ref that has moved past the
+# merged head and a branch with no PR at all must survive `--apply` intact,
+# and the one item that satisfies every condition must actually go.
+#
+# Fully offline. `gh` is stubbed on PATH ahead of the real one and answers the
+# single `gh pr list` the script makes off a fixture table, so no network and
+# no GitHub credentials are touched. `git` is the real one, driving a
+# throwaway repository with a bare `origin` beside it — worktree registration,
+# `git worktree remove`'s own refusals and `git push --delete` are the
+# behavior under test, and a stub for them would test nothing.
+#
+# usage: sh scripts/fleet/test-reclaim-merged.sh
+set -eu
+
+cd "$(git rev-parse --show-toplevel)"
+script=$(pwd)/scripts/fleet/reclaim-merged.sh
+
+sh -n "$script" || { echo "FAIL: sh -n $script" >&2; exit 1; }
+sh -n "$0" || { echo "FAIL: sh -n $0" >&2; exit 1; }
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/test-reclaim-merged.XXXXXX")
+work=$(cd "$work" && pwd -P)
+cleanup() { chmod -R u+w "$work" 2>/dev/null || true; rm -rf "$work"; }
+trap cleanup 0
+trap 'cleanup; exit 130' HUP INT TERM
+
+TAB=$(printf '\t')
+
+fail() {
+    echo "FAIL: $1" >&2
+    [ ! -f "$work/out" ] || { echo '--- last run ---' >&2; cat "$work/out" >&2; }
+    exit 1
+}
+
+# ── the repository under test ────────────────────────────────────────
+
+mkdir -p "$work/bin"
+git init --quiet --bare "$work/origin.git"
+git init --quiet "$work/repo"
+repo=$work/repo
+cd "$repo"
+git symbolic-ref HEAD refs/heads/main
+git config user.email test@example.com
+git config user.name 'reclaim test'
+git config commit.gpgsign false
+echo seed >seed.txt
+git add seed.txt
+git commit --quiet -m seed
+base=$(git rev-parse HEAD)
+git remote add origin "$work/origin.git"
+
+for b in merged-clean merged-dirty open-clean nested-merged moved no-pr; do
+    git branch "$b" main
+done
+
+# `moved` is the ref that outran its own merged PR: one extra commit that no
+# PR ever saw, which `refs/pull/N/head` therefore does not preserve.
+git checkout --quiet moved
+echo later >later.txt
+git add later.txt
+git commit --quiet -m 'work the PR never saw'
+moved_tip=$(git rev-parse HEAD)
+git checkout --quiet main
+
+git push --quiet origin main merged-clean merged-dirty open-clean moved
+
+# Four linked worktrees. `nested` sits inside the main checkout on purpose —
+# that is the shape of the agent worktrees under `.claude/worktrees/`, and
+# removing one of those reaches into the operator's own checkout.
+git worktree add --quiet "$work/wt-merged-clean" merged-clean
+git worktree add --quiet "$work/wt-merged-dirty" merged-dirty
+git worktree add --quiet "$work/wt-open" open-clean
+git worktree add --quiet "$repo/nested" nested-merged
+echo scratch >"$work/wt-merged-dirty/uncommitted.txt"
+
+# A merged PR whose local ref is already gone but whose remote branch is not:
+# the half of the authority that iterating local refs alone never sees.
+git push --quiet origin "merged-clean:remote-only"
+
+# Paths are compared against what `git worktree list` prints, and git spells a
+# Windows path `C:/...` where the shell spells the same directory `/c/...`.
+# Asking git for each one keeps both sides in git's own spelling.
+g_repo=$(cd "$repo" && git rev-parse --show-toplevel)
+g_clean=$(cd "$work/wt-merged-clean" && git rev-parse --show-toplevel)
+g_dirty=$(cd "$work/wt-merged-dirty" && git rev-parse --show-toplevel)
+g_open=$(cd "$work/wt-open" && git rev-parse --show-toplevel)
+g_nested=$(cd "$repo/nested" && git rev-parse --show-toplevel)
+
+# ── the PR table the stub serves ─────────────────────────────────────
+#
+# Same five fields the script asks `gh pr list --jq` for: head branch, number,
+# state, head oid, merge oid. `moved`'s head oid is deliberately the base
+# commit — its local ref has since advanced.
+squash=1111111111111111111111111111111111111111
+{
+    printf 'merged-clean\t101\tMERGED\t%s\t%s\n' "$base" "$squash"
+    printf 'merged-dirty\t102\tMERGED\t%s\t%s\n' "$base" "$squash"
+    printf 'open-clean\t103\tOPEN\t%s\t-\n' "$base"
+    printf 'nested-merged\t104\tMERGED\t%s\t%s\n' "$base" "$squash"
+    printf 'moved\t105\tMERGED\t%s\t%s\n' "$base" "$squash"
+    printf 'remote-only\t106\tMERGED\t%s\t%s\n' "$base" "$squash"
+} >"$work/prs.tsv"
+
+cat >"$work/bin/gh" <<'STUB'
+#!/bin/sh
+printf 'gh %s\n' "$*" >>"$GH_CALLS"
+case "${1:-} ${2:-}" in
+    "pr list") cat "$STUB_PRS" ;;
+    *) echo "gh stub: unexpected invocation: $*" >&2; exit 1 ;;
+esac
+STUB
+chmod +x "$work/bin/gh"
+PATH="$work/bin:$PATH"
+export PATH
+STUB_PRS=$work/prs.tsv
+export STUB_PRS
+
+# ── harness ──────────────────────────────────────────────────────────
+
+case_no=0
+run() {
+    case_no=$((case_no + 1))
+    GH_CALLS=$work/gh-calls-$case_no
+    export GH_CALLS
+    : >"$GH_CALLS"
+    set +e
+    (cd "$repo" && sh "$script" "$@") >"$work/out" 2>"$work/err"
+    code=$?
+    set -e
+}
+
+# Rows are TSV: verdict, kind, item, branch, pr, state, tree/sha, reason.
+row() { awk -F"$TAB" -v k="$1" -v i="$2" '$2 == k && $3 == i { print }' "$work/out"; }
+
+# Verdict is the first field and reason the last, so both come out of the one
+# `row` call by parameter expansion. This matters: on the workstation this
+# runs on a process spawn measures ~2.7s, and a three-spawn assertion helper
+# called thirty times is two minutes of pure harness.
+expect() { # kind item verdict reason-substring label
+    got=$(row "$1" "$2")
+    [ -n "$got" ] || fail "$5: no row for $1 $2"
+    got_v=${got%%"$TAB"*}
+    got_r=${got##*"$TAB"}
+    [ "$got_v" = "$3" ] || fail "$5: $1 $2 is $got_v, expected $3 (reason: $got_r)"
+    case $got_r in
+        *"$4"*) : ;;
+        *) fail "$5: $1 $2 reason is '$got_r', expected to mention '$4'" ;;
+    esac
+}
+
+# ── case 1: the dry run classifies, and removes nothing ──────────────
+#
+# doneWhen bullet 1: every candidate listed with its worktree, branch, PR,
+# state and tree state, strictly scoped to merged PRs.
+
+wt_before=$(cd "$repo" && git worktree list | wc -l)
+run
+[ "$code" -eq 0 ] || fail "case 1: dry run exited $code: $(cat "$work/err")"
+grep -q 'pr list --state all' "$GH_CALLS" || fail "case 1: the PR table was never read"
+
+expect worktree "$g_clean" RECLAIM 'pr-merged' 'case 1'
+expect worktree "$g_dirty" KEEP 'tree-dirty' 'case 1'
+expect worktree "$g_open" KEEP 'pr-OPEN' 'case 1'
+expect worktree "$g_nested" KEEP 'nested-in-main-checkout' 'case 1'
+expect worktree "$g_repo" KEEP 'main-checkout' 'case 1'
+expect local-branch moved KEEP 'local-ahead-of-pr' 'case 1'
+expect local-branch no-pr KEEP 'no-pr' 'case 1'
+expect local-branch merged-dirty KEEP 'checked-out' 'case 1'
+expect local-branch nested-merged KEEP 'checked-out' 'case 1'
+expect local-branch main KEEP 'default-branch' 'case 1'
+# The dry run has to predict --apply: this branch is checked out only in the
+# worktree the same run already listed as RECLAIM.
+expect local-branch merged-clean RECLAIM 'pr-merged' 'case 1'
+expect remote-branch origin/moved KEEP 'remote-moved-since-merge' 'case 1'
+expect remote-branch origin/open-clean KEEP 'pr-OPEN' 'case 1'
+expect remote-branch origin/merged-dirty KEEP 'local-kept' 'case 1'
+expect remote-branch origin/merged-clean RECLAIM 'pr-merged' 'case 1'
+expect remote-branch origin/remote-only RECLAIM 'pr-merged' 'case 1'
+[ -z "$(row local-branch remote-only)" ] \
+    || fail 'case 1: a local row was invented for a branch that exists only on origin'
+
+# The dirty worktree's tree state has to be READ, not inferred from the
+# verdict: a row that says `clean` and keeps for some other reason would pass
+# a verdict-only assertion and still be the bug this test exists to catch.
+[ "$(row worktree "$g_dirty" | cut -f7)" = dirty ] \
+    || fail "case 1: the dirty worktree was not reported dirty"
+
+[ "$(cd "$repo" && git worktree list | wc -l)" -eq "$wt_before" ] \
+    || fail 'case 1: a dry run removed a worktree'
+[ -d "$work/wt-merged-clean" ] || fail 'case 1: a dry run removed the reclaim candidate'
+
+# ── case 2: --protect keeps an otherwise-qualifying item ─────────────
+
+run --protect wt-merged-clean
+expect worktree "$g_clean" KEEP 'protected' 'case 2'
+[ -d "$work/wt-merged-clean" ] || fail 'case 2: a protected worktree was removed'
+
+# ── case 3: --apply removes exactly the RECLAIM set ──────────────────
+#
+# doneWhen bullets 2 and 3: receipts for what went, and nothing dirty or
+# open-PR touched.
+
+run --apply
+[ "$code" -eq 0 ] || fail "case 3: --apply exited $code: $(cat "$work/err")"
+
+[ ! -d "$work/wt-merged-clean" ] || fail 'case 3: the merged clean worktree survived --apply'
+grep -q "reclaimed worktree.*wt-merged-clean.*pr=#101.*squash=$squash" "$work/out" \
+    || fail 'case 3: no receipt for the reclaimed worktree'
+
+[ -d "$work/wt-merged-dirty" ] || fail 'case 3: a DIRTY worktree was removed'
+[ -f "$work/wt-merged-dirty/uncommitted.txt" ] || fail 'case 3: uncommitted work was destroyed'
+[ -d "$work/wt-open" ] || fail 'case 3: an OPEN-PR worktree was removed'
+[ -d "$repo/nested" ] || fail 'case 3: a worktree nested in the main checkout was removed'
+[ -d "$repo/.git" ] || fail 'case 3: the main checkout was removed'
+
+cd "$repo"
+has_local() { git show-ref --verify --quiet "refs/heads/$1"; }
+has_remote() { [ -n "$(git ls-remote --heads origin "$1")" ]; }
+
+if has_local merged-clean; then fail 'case 3: the merged branch survived --apply'; fi
+grep -q "reclaimed local branch.*merged-clean.*pr=#101" "$work/out" \
+    || fail 'case 3: no receipt for the reclaimed local branch'
+has_local moved || fail 'case 3: a branch ahead of its PR was deleted'
+has_local no-pr || fail 'case 3: a branch with no PR was deleted'
+has_local merged-dirty || fail 'case 3: a checked-out branch was deleted'
+
+if has_remote merged-clean; then fail 'case 3: the merged remote branch survived --apply'; fi
+grep -q "reclaimed remote branch.*origin/merged-clean.*pr=#101" "$work/out" \
+    || fail 'case 3: no receipt for the reclaimed remote branch'
+if has_remote remote-only; then fail 'case 3: a remote-only merged branch survived --apply'; fi
+has_remote moved || fail 'case 3: a remote branch that moved past its merged head was deleted'
+has_remote open-clean || fail 'case 3: an OPEN-PR remote branch was deleted'
+has_remote merged-dirty || fail 'case 3: the remote of a kept dirty lane was deleted'
+
+grep -q 'reclaim-merged: after' "$work/out" || fail 'case 3: no before/after snapshot line'
+
+# ── case 4: a second --apply is a no-op ──────────────────────────────
+#
+# Everything left is excluded for a reason that does not decay, so a repeated
+# run must find nothing — a reclaimer that creeps outward on each pass is the
+# same defect as one that over-reaches on the first.
+
+run --apply
+[ "$code" -eq 0 ] || fail "case 4: second --apply exited $code: $(cat "$work/err")"
+if grep -q '^RECLAIM' "$work/out"; then fail 'case 4: a second pass found new candidates'; fi
+[ -d "$work/wt-merged-dirty" ] && [ -d "$work/wt-open" ] && [ -d "$repo/nested" ] \
+    || fail 'case 4: a second pass removed a kept worktree'
+
+# ── case 5: an unreadable PR table reclaims nothing ──────────────────
+#
+# Without PR state every item's state is unknown, and unknown is not merged.
+
+STUB_PRS=$work/does-not-exist
+export STUB_PRS
+run --apply
+[ "$code" -eq 3 ] || fail "case 5: expected exit 3 on an unreadable PR table, got $code"
+if grep -q 'reclaimed' "$work/out"; then fail 'case 5: something was removed without PR state'; fi
+
+echo 'PASS scripts/fleet/test-reclaim-merged.sh'

--- a/scripts/fleet/test-reclaim-merged.sh
+++ b/scripts/fleet/test-reclaim-merged.sh
@@ -311,4 +311,64 @@ if grep -q "reclaimed remote branch.*origin/partial-b" "$work/out"; then
     fail 'case 6: a ref the remote REJECTED was receipted as reclaimed — exit-code trust, not verification'
 fi
 
+# ── case 7: the remote re-read failing must not fabricate a receipt ──
+#
+# P1-1 (Round 1 review): `git ls-remote --heads origin | sed … || true` (the
+# remote arm's post-delete verification) discarded both the exit status and
+# stderr of `ls-remote`, so a re-read that failed left after.txt EMPTY —
+# indistinguishable from "origin now has zero branches" — and every ref in
+# the batch was receipted `reclaimed remote branch` anyway, on exit 0. This
+# reproduces the failure point directly: a `git` shim lets the FIRST
+# `ls-remote --heads origin` (fact-gathering, before any delete) through to
+# the real git, then fails every subsequent one — the shape of a network
+# drop or token expiry landing between the delete push and its verification
+# re-read. `has_remote`'s own 4-argument form (`ls-remote --heads origin
+# <branch>`) is a different argv and passes through the shim untouched.
+
+git branch verify-fail main
+git push --quiet origin verify-fail
+
+{
+    cat "$work/prs.tsv"
+    printf 'verify-fail\t301\tMERGED\t%s\t%s\n' "$base" "$squash"
+} >"$work/prs-case7.tsv"
+STUB_PRS=$work/prs-case7.tsv
+export STUB_PRS
+
+rm -f "$work/origin.git/hooks/update"
+
+real_git=$(command -v git)
+export REAL_GIT="$real_git"
+LSREMOTE_CALLS_FILE="$work/lsremote-calls"
+export LSREMOTE_CALLS_FILE
+printf '0\n' >"$LSREMOTE_CALLS_FILE"
+cat >"$work/bin/git" <<'GITSHIM'
+#!/bin/sh
+if [ "$1" = 'ls-remote' ] && [ "$2" = '--heads' ] && [ "$3" = 'origin' ] && [ $# -eq 3 ]; then
+    n=$(cat "$LSREMOTE_CALLS_FILE")
+    n=$((n + 1))
+    echo "$n" >"$LSREMOTE_CALLS_FILE"
+    if [ "$n" -gt 1 ]; then
+        echo 'git shim: origin unreachable' >&2
+        exit 128
+    fi
+fi
+exec "$REAL_GIT" "$@"
+GITSHIM
+chmod +x "$work/bin/git"
+
+run --apply
+[ "$code" -eq 4 ] || fail "case 7: expected exit 4 on an unverifiable remote re-read, got $code"
+
+grep -q "reclaimed local branch.*verify-fail.*pr=#301" "$work/out" \
+    || fail 'case 7: the local arm (unaffected by the shim) should still reclaim and receipt normally'
+
+if grep -q 'reclaimed remote branch.*verify-fail' "$work/out"; then
+    fail 'case 7: a receipt was fabricated for a batch whose re-read could not be verified'
+fi
+grep -q 'KEPT remote branch.*origin/verify-fail.*unverified' "$work/err" \
+    || fail 'case 7: no unverified/KEPT line for the ref whose re-read failed'
+
+rm -f "$work/bin/git"
+
 echo 'PASS scripts/fleet/test-reclaim-merged.sh'

--- a/scripts/fleet/test-reclaim-merged.sh
+++ b/scripts/fleet/test-reclaim-merged.sh
@@ -262,4 +262,53 @@ run --apply
 [ "$code" -eq 3 ] || fail "case 5: expected exit 3 on an unreadable PR table, got $code"
 if grep -q 'reclaimed' "$work/out"; then fail 'case 5: something was removed without PR state'; fi
 
+# ── case 6: a batch the remote only PARTIALLY accepts is verified, not
+#            trusted by the push's exit code ─────────────────────────
+#
+# `delete_batched` sends every remote reclaim of one run in ONE `git push
+# --delete`. A real remote can reject one ref out of that batch — a branch
+# protection rule, a ref that moved server-side — while still accepting the
+# rest of the same push, and the combined command exits non-zero either way.
+# That is exactly why the receipt comes from re-reading `git ls-remote`
+# afterwards instead of the push's exit code: an `update` hook that rejects
+# one ref out of two, offline, is the stand-in for that server behavior. Two
+# fresh remote-only branches keep this batch isolated from every branch the
+# earlier cases already resolved.
+
+git branch partial-a main
+git branch partial-b main
+git push --quiet origin partial-a partial-b
+git branch -D partial-a partial-b >/dev/null
+
+{
+    cat "$work/prs.tsv"
+    printf 'partial-a\t201\tMERGED\t%s\t%s\n' "$base" "$squash"
+    printf 'partial-b\t202\tMERGED\t%s\t%s\n' "$base" "$squash"
+} >"$work/prs-case6.tsv"
+STUB_PRS=$work/prs-case6.tsv
+export STUB_PRS
+
+cat >"$work/origin.git/hooks/update" <<'HOOK'
+#!/bin/sh
+case "$1" in
+    refs/heads/partial-b) echo "rejected by hook: $1" >&2; exit 1 ;;
+esac
+exit 0
+HOOK
+chmod +x "$work/origin.git/hooks/update"
+
+run --apply
+[ "$code" -eq 0 ] || fail "case 6: --apply exited $code: $(cat "$work/err")"
+
+if has_remote partial-a; then fail 'case 6: the ref the hook ACCEPTED survived the batch'; fi
+grep -q "reclaimed remote branch.*origin/partial-a.*pr=#201" "$work/out" \
+    || fail 'case 6: no receipt for the ref the hook accepted'
+
+has_remote partial-b || fail 'case 6: a ref the hook REJECTED was deleted anyway'
+grep -q "KEPT remote branch.*origin/partial-b.*still present after delete" "$work/err" \
+    || fail 'case 6: the rejected ref was not reported KEPT'
+if grep -q "reclaimed remote branch.*origin/partial-b" "$work/out"; then
+    fail 'case 6: a ref the remote REJECTED was receipted as reclaimed — exit-code trust, not verification'
+fi
+
 echo 'PASS scripts/fleet/test-reclaim-merged.sh'


### PR DESCRIPTION
Issue: #1009

Closes #1009

## Summary

- `scripts/fleet/reclaim-merged.sh` batches both the local `git branch -D`
  and the remote `git push origin --delete` (chunked at 50 refs) instead of
  one ref per command — a workstation where a process spawn measures ~2.7s
  turned 115 merged remote branches into most of two hours of round trips
  one-ref-at-a-time.
- The receipt for a batched delete now comes from **re-reading git**
  (`git for-each-ref` / `git ls-remote`) after the batch runs, never from the
  batch command's own exit code: a batched command can be fully rejected or
  only partially rejected, and the exit code alone cannot distinguish the
  two. A ref that is still present after the batch prints a `KEPT ...
  still present after delete` line (stderr) and is never receipted as
  reclaimed; a ref that is actually gone gets its `reclaimed ...` line.
- **Round 1 review fix (P1):** the re-read itself is now verified, not
  trusted by exit code either. `git ls-remote`'s own exit status is checked
  directly (not the exit status of a pipeline it used to feed via
  `| sed … || true`, which silently discarded both). When the re-read fails
  — network drop, token expiry, a 5xx between the delete push and the
  verification read — no ref in that batch is receipted `reclaimed`; every
  one is reported `KEPT ... unverified` on stderr instead, and the run
  exits 4 so the failure cannot be missed.
- This carries forward the prior commit's work unchanged: the dry run
  already predicts `--apply` (a branch only checked out in a worktree the
  same run reclaims reports RECLAIM, not checked-out), the runbook entry
  (`docs/guides/operator-runbook.md` §三 step 9), and R7's exclusion
  boundary (dirty tree, open PR, nested-in-main-checkout, no-PR, ref moved
  past its merged head — all KEEP, never touched).

## Test

`scripts/fleet/test-reclaim-merged.sh` is fully offline (`gh` stubbed off a
fixture PR table; a throwaway repo + bare `origin` drive real `git`) and now
carries 7 cases:

1. dry run classifies every candidate, scoped strictly to MERGED PRs, and
   removes nothing; the checked-out-branch prediction of `--apply` is
   asserted directly.
2. `--protect` keeps an otherwise-qualifying item.
3. `--apply` removes exactly the RECLAIM set: the dirty worktree, the
   open-PR worktree, the worktree nested in the main checkout, the branch
   ahead of its merged PR, and the branch with no PR all survive; the
   candidate that satisfies every condition is actually gone, with a
   receipt naming its PR number and squash SHA.
4. A second `--apply` is a no-op.
5. An unreadable PR table reclaims nothing (exit 3).
6. A batch the remote only *partially* accepts: two fresh remote-only
   merged branches go through `delete_batched` in one push while a
   fixture `update` hook on the bare origin rejects one of the two refs.
   This proves the receipt comes from re-reading `git ls-remote` and not
   from the push's exit code (which is non-zero regardless of which ref
   was rejected) — the accepted ref is gone and receipted, the rejected
   one survives and is reported KEPT, and the script itself still exits 0.
7. **New this round (Round 1 P1 fix)** — the remote re-read itself fails:
   a `git` shim lets the first `ls-remote --heads origin` (fact-gathering)
   through to the real git, then fails every subsequent one, reproducing a
   network drop or token expiry landing between the delete push and its
   verification re-read. Asserts no `reclaimed remote branch` receipt is
   printed for the ref in that batch, a `KEPT ... unverified` line is
   printed instead, and the run exits 4 — while the same run's local arm
   (unaffected by the shim) still reclaims and receipts normally, which is
   the asymmetry the review evidenced.

```
$ sh scripts/fleet/test-reclaim-merged.sh
PASS scripts/fleet/test-reclaim-merged.sh
```

## Gates run (L0 — shell script change, no Cargo gate)

- `sh -n scripts/fleet/reclaim-merged.sh`
- `sh -n scripts/fleet/test-reclaim-merged.sh`
- `sh scripts/fleet/test-reclaim-merged.sh` — PASS (7/7 cases)
- `bash scripts/lint-file-length.sh --tree` — clean (this ratchet only gates
  `*.rs`; run anyway per the repo's pre-commit checklist)

CI's `fleet-tests` job (ubuntu-latest, glob-driven over
`scripts/fleet/test-*.sh`) picks this test up without further wiring.

## Not in this PR

A live `--apply` against the real repository (the doneWhen bullet asking for
"the first real run's verbatim output") is deliberately deferred: this
worktree's brief is explicit that the main checkout and every existing
worktree/branch stay untouched. That run belongs to whoever next operates
`scripts/fleet/reclaim-merged.sh` for real, from the main checkout, per the
runbook entry already in place (§三 step 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
