### PR TITLE
fix(review): REVIEW.md's diff surface enumeration — two-dot vs three-dot, and R3's file-order short-circuit (GH-1003, GH-992)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -23,7 +23,7 @@ classes:
 
 # REVIEW.md — the executable review spec
 
-- Spec version: `review-spec-v1.5`
+- Spec version: `review-spec-v1.6`
 - Audience: anyone — human or engine — reviewing a pull request in this
   repository, and any script that builds a review brief.
 - Status: this file is the **single source of truth** for how a PR is reviewed
@@ -174,6 +174,20 @@ For a delta round (a re-review after a fix push) the target is
 `git diff <previously-reviewed-sha>..<new-sha>` plus a RAN confirmation that
 each prior blocking finding is resolved. Do not re-review the whole PR
 (`loop` items 2 and 6).
+
+**Two-dot and three-dot are both intentional below, and mean different things
+to these two commands (GH-1003).** `git diff "origin/$BASE...$SHA"` (three-dot,
+§5's content enumerators) diffs from the merge base, so it reports what the PR
+changed even when `$SHA` is behind `$BASE`; two-dot there diffs tip-to-tip and
+folds in every commit `$BASE` gained after the branch point too. `git log
+"origin/$BASE..$SHA"` (two-dot, U2/U4/C2) lists commits reachable from `$SHA`
+but not `$BASE` — the PR's own commits; three-dot there is the symmetric
+difference and would pull in `$BASE`'s commits too, breaking the
+commit-message rules. Do not swap the two forms, and do not "fix" the `git
+log` lines to match a `git diff` line sitting next to them. A regression back
+to two-dot `git diff` is caught by `scripts/test-review-l0.sh`; check by hand
+with `git grep -nE 'git diff "origin/\$BASE\.\.\$SHA"' -- REVIEW.md` (must
+print nothing).
 
 ## 3. Step 3 — classify it
 
@@ -468,7 +482,7 @@ probe as that finding. This is mechanical routing, not reviewer discretion.
 
 # review-spec:check D1
 ```sh
-git diff "origin/$BASE..$SHA" | grep '^+' \
+git diff "origin/$BASE...$SHA" | grep '^+' \
   | grep -oE '`(edda|gh|git|cargo|pi|claude) [a-z][a-z0-9-]*' | tr -d '`' | sort -u \
   | while read -r c; do
       case "$c" in git\ *) flag=-h; want=129 ;; *) flag=--help; want=0 ;; esac
@@ -511,7 +525,7 @@ does not exist).
 # review-spec:check D3
 ```sh
 tops=$(git ls-files | cut -d/ -f1 | sort -u | tr '\n' '|' | sed 's/|$//')
-git diff "origin/$BASE..$SHA" | grep '^+' \
+git diff "origin/$BASE...$SHA" | grep '^+' \
   | grep -oE '`[^`]+`|\]\([^)]+\)' | sed 's/^`//;s/`$//;s/^](//;s/)$//' \
   | grep -E "^($tops)(/|$)" | sed 's/[ <*#\\].*$//;s#/$##' | sort -u \
   | while read -r p; do [ -e "$p" ] && echo "OK      $p" || echo "MISSING $p"; done
@@ -529,7 +543,7 @@ and lane worktree). A candidate with no such caveat is the finding (canary
 
 # review-spec:check D4
 ```sh
-git diff "origin/$BASE..$SHA" --unified=0 | grep -nE '^\+' \
+git diff "origin/$BASE...$SHA" --unified=0 | grep -nE '^\+' \
   | grep -E 'gh pr merge|--delete-branch|--admin|--no-verify|push --force|force-push'
 ```
 # review-spec:check-end
@@ -547,7 +561,7 @@ operator authority").
 
 # review-spec:check S1
 ```sh
-git diff "origin/$BASE..$SHA" -- '*SKILL.md' '.claude/**' 'skills/**' | grep '^+' \
+git diff "origin/$BASE...$SHA" -- '*SKILL.md' '.claude/**' 'skills/**' | grep '^+' \
   | grep -nEi 'merge|--delete-branch|self-review|skip (the )?review'
 ```
 # review-spec:check-end
@@ -573,7 +587,7 @@ adds:
 # review-spec:check C2
 ```sh
 git log --format=%s "origin/$BASE..$SHA"
-git diff "origin/$BASE..$SHA" -- 'crates/**' | grep -cE '^\+.*(#\[test\]|fn test_)'
+git diff "origin/$BASE...$SHA" -- 'crates/**' | grep -cE '^\+.*(#\[test\]|fn test_)'
 ```
 # review-spec:check-end
 
@@ -584,7 +598,7 @@ list; a candidate is N.A. only when the reported line is inside a
 
 # review-spec:check C3
 ```sh
-git diff "origin/$BASE..$SHA" -- 'crates/**' | grep -nE '^\+.*\.(unwrap|expect)\('
+git diff "origin/$BASE...$SHA" -- 'crates/**' | grep -nE '^\+.*\.(unwrap|expect)\('
 ```
 # review-spec:check-end
 
@@ -595,7 +609,7 @@ findings; empty output passes (`.claude/CLAUDE.md` §3.1–3.2). A targeted
 
 # review-spec:check C4
 ```sh
-git diff "origin/$BASE..$SHA" \
+git diff "origin/$BASE...$SHA" \
   | grep -nE '^\+.*(unsafe[[:space:]]*\{|#\[allow\(clippy::all\)\]|#!\[allow)'
 ```
 # review-spec:check-end
@@ -624,7 +638,7 @@ itself the finding.
 
 # review-spec:check R1
 ```sh
-git diff "origin/$BASE..$SHA" --unified=0 | grep -nE '^\+' \
+git diff "origin/$BASE...$SHA" --unified=0 | grep -nE '^\+' \
   | grep -E 'rm -rf|git clean|reset --hard|git rm|--delete-branch|--force|Remove-Item'
 ```
 # review-spec:check-end
@@ -646,18 +660,37 @@ writes the finding anyway, marks it `provisional`, and lists it under
 
 # review-spec:check R2
 ```sh
-git diff "origin/$BASE..$SHA" --unified=0 -- '*.sh' '*.bash' '*.ps1' '.github' \
+git diff "origin/$BASE...$SHA" --unified=0 -- '*.sh' '*.bash' '*.ps1' '.github' \
   | grep -nE '^\+' | grep -E '\|\|.*&&|&&.*\|\|'
 ```
 # review-spec:check-end
 
-**R3 — every changed shell script parses. P0.** Exit code is the signal.
+**R3 — every changed shell script parses. P0.** Exit code is the signal. A
+changed script that is simply absent from this working tree (GH-992 — e.g. a
+reviewer checked out at `$BASE` rather than `$SHA`) is reported but does not
+itself fail the rule; only a real `sh -n` non-zero, or finding zero of the
+named scripts present, does.
 
 # review-spec:check R3 no-pr-needed
 ```sh
-for f in $(if [ -n "${REVIEW_FILES:-}" ]; then cat "$REVIEW_FILES"; else gh pr diff "$N" --name-only; fi | grep -E '\.(sh|bash)$'); do
-  [ -f "$f" ] && { sh -n "$f"; echo "$f -> sh -n exit=$?"; }
+files=$(if [ -n "${REVIEW_FILES:-}" ]; then cat "$REVIEW_FILES"; else gh pr diff "$N" --name-only; fi | grep -E '\.(sh|bash)$')
+total=0; present=0
+for f in $files; do
+  total=$((total + 1))
+  [ -f "$f" ] && present=$((present + 1))
 done
+if [ "$total" -gt 0 ] && [ "$present" -eq 0 ]; then
+  echo "R3: 0 of $total changed shell script(s) present in working tree -- nothing checked"
+  exit 2
+fi
+for f in $files; do
+  if [ -f "$f" ]; then
+    sh -n "$f"; echo "$f -> sh -n exit=$?"
+  else
+    echo "$f -> not in working tree, skipped"
+  fi
+done
+exit 0
 ```
 # review-spec:check-end
 
@@ -761,7 +794,7 @@ One comment per round, pinned to the reviewed full SHA
 - model_requested: <the model dispatch asked for>
 - model_observed: <read from the system, or "unverified">
 - reviewer_session: <per-PR UUID the lane was launched with>
-- spec: review-spec-v1.5
+- spec: review-spec-v1.6
 - class: <code-risk | docs-skills>  (REVIEW.md classes: <docs|skills|code-plain|code-risk ...>)
 - escalations: <list of 需升級 items, or "none">
 - shadow: true|false  (documentation for a SHADOW round: true requires the heading suffix ` (SHADOW)` — `## Code Review: Round <N> (SHADOW) — PR #<n> @ <full 40-hex SHA>`; the suffix is the only marker, this field never substitutes for it; a SHADOW round is never a verdict — §8)
@@ -953,6 +986,25 @@ mechanical.
   brief tag moves to `brief-v2`. The #618 calibration is the evidence — glm's
   c1 parse tree and trigger conditions were entirely correct and the old rule
   forbade writing them up, scoring the P0 gate 1/2 (`design` §3 learning 1).
+- `review-spec-v1.6` (2026-09-09, issues #1003, #992): the nine content
+  enumerators in §5 (D1, D3, D4, S1, C2–C4, R1, R2) move from two-dot to
+  three-dot `git diff`, so a branch behind its base is diffed from the merge
+  base instead of tip-to-tip (#1003) — measured on a real PR at 39 files
+  reported for 3 actually changed. `scripts/wiring-scan.sh` carried the same
+  defect in its own two-argument form and gets the same fix. The three
+  `git log` commit enumerators (U2, U4, C2) are unchanged and stay two-dot —
+  §2 now states why the two commands take different forms, and
+  `scripts/test-review-l0.sh` greps this file for a regressed two-dot `git
+  diff` on every run. Separately, R3 no longer reports a false P0 when a
+  changed script the diff names is merely absent from the reviewer's working
+  tree (#992): the old `[ -f "$f" ] && { ... }` loop body let that file's
+  short-circuited exit status become the whole block's exit code whenever it
+  was the alphabetically-last file in the list, flipping a clean round to
+  FAIL on a file R3 never actually parsed. R3 now counts what it can and
+  cannot reach and reports a script's absence as text, not as a failing exit
+  code — except when every named script is absent, which is `ERROR`, not a
+  silent PASS, so a check that verified nothing is never mistaken for one
+  that passed (the #950 failure mode, in the opposite direction).
 
 Changing a rule here changes the line for every engine. Record the version in
 each verdict's `spec:` field so catch rates stay readable against the spec they

--- a/scripts/test-review-l0.sh
+++ b/scripts/test-review-l0.sh
@@ -16,9 +16,17 @@
 #     U2/U3/U6 stay N.A.(needs PR number);
 #   cjk fixture (GH-922) — an R1 evidence line far past the 160-byte cell
 #     cap; the capped cell must still decode as valid UTF-8.
+#   missing-file fixture (GH-992) — two changed .sh files, one clean and
+#     present, one committed on the branch then removed from disk (run under
+#     L0_SHA, so the file list comes from git history, not the working tree)
+#     with a name that sorts alphabetically last → R3 must stay PASS, not
+#     flip to FAIL from the short-circuit the missing file used to cause.
 #
 # It also proves the unmarked-block contract from a temp-modified spec copy:
 # a fenced sh block without markers → `UNMARKED <first line>`, exit 3.
+#
+# A final check greps REVIEW.md itself for a regressed two-dot `git diff`
+# enumerator (GH-1003) — static analysis on the spec, not a fixture run.
 #
 # Everything is written inside one mktemp directory; nothing outside it.
 #
@@ -125,6 +133,17 @@ STUB
     printf '# %s rm -r%s /tmp/fixture-cjk\n' "$cjk" f > "$fix/cjk.sh"
     echo cjk.sh > "$TMP/file-list"
     msg="feat(fleet): cjk fixture change"
+  elif [ "$mode" = missing ]; then
+    # GH-992: two changed .sh files, both committed on this branch — one
+    # stays on disk (clean), the other the caller removes from the working
+    # tree right after make_fixture returns (see the missing-file fixture
+    # below), simulating a reviewer whose checkout never fetched a file the
+    # PR added. "zzz-" sorts alphabetically last, the exact position R3's old
+    # `[ -f ] &&` short-circuit needed to flip a clean round to a false P0.
+    printf '#!/bin/sh\necho fixture-ok\n' > "$fix/aaa-exists.sh"
+    printf '#!/bin/sh\necho never fetched\n' > "$fix/zzz-added-by-pr.sh"
+    printf 'aaa-exists.sh\nzzz-added-by-pr.sh\n' > "$TMP/file-list"
+    msg="feat(fleet): missing-file fixture change"
   else
     printf '#!/bin/sh\necho fixture-ok\n' > "$fix/good.sh"
     echo good.sh > "$TMP/file-list"
@@ -138,14 +157,21 @@ run_l0() { # <fixture-dir> <spec> <out-file> [PR-number] — runner exit code vi
   # With no PR-number argument the runner runs in the pre-push shape
   # (GH-922): U1/C5/R3 must still run, from the runner's own file list.
   # L0_BASE overrides the <base> argument for the GH-950 cases; every other
-  # caller gets the ordinary origin/main shape.
+  # caller gets the ordinary origin/main shape. L0_SHA overrides the literal
+  # "HEAD" <head> argument (GH-992's missing-file fixture): passing a real
+  # commit switches the runner to its `git diff --name-only base...sha` file
+  # list (review-l0.sh's non-HEAD branch), which is computed from git history
+  # alone — the only way to make a file "changed" per that list while absent
+  # from this working tree, exactly the reviewer-behind-the-PR shape the bug
+  # needs. Every other caller gets the ordinary working-tree-vs-base shape.
   (cd "$1" \
     && PATH="$TMP/bin:$PATH" \
        GH_STUB_DIR="$TMP" \
        REVIEW_L0_SPEC="$2" \
-       sh "$RUNNER" "${L0_BASE:-origin/main}" HEAD ${4:-}) > "$3" 2>&1
+       sh "$RUNNER" "${L0_BASE:-origin/main}" "${L0_SHA:-HEAD}" ${4:-}) > "$3" 2>&1
 }
 L0_BASE=
+L0_SHA=
 
 # ---- 1. dirty fixture: R1 + R3 FAIL, exit 1 ---------------------------------
 make_fixture dirty
@@ -336,5 +362,38 @@ case "$u5" in
 esac
 [ "$rc" -eq 2 ] || fail "generic fatal: expected runner exit 2 (ERROR, no FAIL), got $rc"
 echo "generic fatal: an exit-0 block printing 'fatal:' is ERROR — OK"
+
+# ---- 8. R3 short-circuit: a changed .sh missing from the tree, sorting -----
+# alphabetically last, must not flip the block's own exit status (GH-992).
+# L0_SHA switches review-l0.sh to its base...sha (pure git-history) file
+# list, so "changed" comes from the commit and is independent of what this
+# rm leaves on disk — the real-world shape (a reviewer checked out at $BASE,
+# not at the PR's $SHA), not the working-tree-vs-base shape every other
+# fixture here runs under.
+make_fixture missing
+rm "$FIXDIR/zzz-added-by-pr.sh"
+L0_SHA=$(git -C "$FIXDIR" rev-parse HEAD)
+rc=0
+run_l0 "$FIXDIR" "$SPEC" "$TMP/missing.out" || rc=$?
+L0_SHA=
+[ "$rc" -eq 0 ] || fail "missing-file fixture: expected runner exit 0, got $rc: $(cat "$TMP/missing.out")"
+grep -Fq '| R3 | code-risk | P0 | FAIL' "$TMP/missing.out" \
+  && fail "missing-file fixture: R3 row is FAIL — the short-circuit regressed (GH-992)"
+grep -Fq '| R3 | code-risk | P0 | PASS' "$TMP/missing.out" \
+  || fail "missing-file fixture: R3 row is not PASS: $(grep -F '| R3 |' "$TMP/missing.out")"
+echo "missing-file fixture: R3 not FAIL when the alphabetically-last changed .sh is absent from the tree — OK"
+
+# ---- 9. two-dot git diff regression guard (GH-1003) -------------------------
+# REVIEW.md's content enumerators in §5 are three-dot (from the merge base);
+# only the git-log commit enumerators (U2, U4, C2 — REVIEW.md §2 explains
+# why) stay two-dot. A `git diff "origin/$BASE..$SHA"` regression silently
+# widens or narrows the reviewed surface on a branch behind its base. This
+# pattern cannot match the fixed three-dot form (the literal "BASE" and "SHA"
+# anchors on both sides of the dots make the two forms mutually exclusive
+# substrings — verified empirically, not just by inspection).
+twodot=$(grep -nE 'git diff "origin/\$BASE\.\.\$SHA"' "$SPEC" || true)
+[ -z "$twodot" ] \
+  || fail "two-dot git diff regression in $SPEC (GH-1003): $twodot"
+echo "two-dot git diff regression guard: no offending pattern in REVIEW.md — OK"
 
 echo "test-review-l0.sh: all fixture assertions held"

--- a/scripts/wiring-scan.sh
+++ b/scripts/wiring-scan.sh
@@ -15,6 +15,11 @@
 #
 # Human judgement is still required (false positives are expected) — this is
 # a reviewer RAN aid, not a CI gate.
+#
+# Both diffs below are three-dot (`"$BASE...$HEAD"`, from the merge base),
+# not tip-to-tip: a plain `git diff "$BASE" "$HEAD"` folds in every commit
+# <base> gained after the branch point, inflating the surface this scan
+# reports on a branch behind its base (GH-1003).
 
 set -u
 
@@ -42,7 +47,7 @@ echo "== New pub surfaces (${BASE}..${HEAD}) =="
 # visibility and the item keyword (e.g. pub(crate) async fn, pub const fn,
 # pub unsafe extern "C" fn). Item keywords: fn struct enum trait type const
 # static mod union. Fields (pub <name>: Type) handled separately below.
-surfaces=$(git diff "$BASE" "$HEAD" --unified=0 -- crates/ | awk '
+surfaces=$(git diff "$BASE...$HEAD" --unified=0 -- crates/ | awk '
   /^diff --git / { file = $NF; sub(/^b\//, "", file); next }
   /^\+\+\+/ { next }
   /^\+/ {
@@ -79,7 +84,7 @@ fi
 echo ""
 echo "== Swallow patterns on added lines =="
 
-git diff "$BASE" "$HEAD" --unified=0 | awk '
+git diff "$BASE...$HEAD" --unified=0 | awk '
   /^diff --git / { file = $NF; sub(/^b\//, "", file); next }
   /^\+\+\+/ { next }
   /^\+/ {


### PR DESCRIPTION
## Summary

Two defects in `REVIEW.md`'s own surface enumeration, on disjoint sections, bundled per the controller's brief (one fixture file covers both):

- **GH-1003**: `REVIEW.md`'s content-enumerating `git diff "origin/$BASE..$SHA"` calls used two-dot (tip-to-tip) instead of three-dot (from the merge base). On a branch behind its base, two-dot folds in every commit the base gained since the branch point, inflating the reviewed surface (measured on PR #988: 39 files reported for 3 actually changed). The three `git log "origin/$BASE..$SHA"` commit enumerators (U2, U4, C2) are correctly left two-dot — `git log` two-dot means something different (the PR's own commits) and three-dot there would pull in the base's commits too, breaking the commit-message rules.
- **GH-992**: `REVIEW.md`'s R3 block (every changed shell script parses, P0) short-circuited on `[ -f "$f" ] && { sh -n "$f"; ...; }` inside a `for` loop — when the *alphabetically last* changed `.sh` was simply absent from the reviewer's working tree (e.g. checked out at `$BASE`, not `$SHA`), the loop's own exit status flipped to 1 regardless of every other file parsing clean, reporting a P0 FAIL on a file R3 never actually checked, with the evidence column showing an unrelated clean file's `exit=0` line.

## Provenance — this PR is not one author's work

The first fix lane on these issues died with its edits on disk and nothing committed. The controller preserved that state verbatim as commit `3e22ee8c8a2d35b0aa421d1298d8ea25644ae629` ("wip(review): GH-1003 + GH-992 in progress — uncommitted lane work, preserved") and pushed it. That commit was explicitly unverified, ungated, and unreviewed — no gate had been run against it, and the lane that wrote it could not be asked to explain it.

I am the replacement lane. Before adding anything I read the whole diff against both issues' full `doneWhen` lists and re-derived every claim rather than trusting the preserved commit's own comments. **I made no code changes** — the preserved commit's substance held up under audit (see Verification below). This PR therefore carries only that one commit, which is the deviation from the original brief's "two commits, one per issue" instruction: R7 forbids amending or force-pushing a commit already on `origin`, and the preserved commit already bundled both issues' changes together (they touch the same two files — `REVIEW.md` and `scripts/test-review-l0.sh` — in the same hunks) before I had a chance to split it. Rewriting that history was not available to me; leaving it as one accurately-described commit was.

## What I verified (not just read)

- **The nine two-dot sites**: `git grep -nE 'git diff .*"origin/\$BASE\.\.\$SHA"' -- REVIEW.md` on `origin/main` (`bb60501`) matches exactly the nine sites the controller's fact block names (D1, D3, D4, S1, C2, C3, C4, R1, R2 — **not** D2, which uses `edda ask <decision-key>`, no `git diff` at all). All nine are three-dot on this branch; the same grep against this branch's `REVIEW.md` now matches nothing.
- **The three git-log sites stay two-dot**: U2 (`:338`), U4 (`:366`), and the `git log` line of C2 (`:589`) are untouched — confirmed by reading each block directly, including the exact case the fact block flagged (a `git log` line sitting immediately above a `git diff` line in C2, one kept, one converted).
- **`scripts/wiring-scan.sh`** carried the identical defect in its own two-argument form (`git diff "$BASE" "$HEAD"`, equivalent to two-dot) at two call sites; both now read `git diff "$BASE...$HEAD"`. A repo-wide grep outside the three files this lane may touch found no other script with the same shape.
- **`scripts/review-pr.sh`**, the third file GH-1003 predicted: confirmed gone (GH-1061 / PR #1082 retired the review shell branch).
- **R3's fix is order-independent by construction**: it counts `total`/`present` in one pass (no positional short-circuit), reports the block's own exit as `2` only when every named script is absent (`ERROR`, not a silent PASS — the GH-950 failure mode GH-992 explicitly warns against), and otherwise always reaches an unconditional `exit 0`. A genuine `sh -n` failure is still caught: `review-l0.sh`'s `run_block` scans every printed line for `exit=[1-9][0-9]*$` (the `badline` check, independent of the block's own `$?`), and the R3 block still prints `"$f -> sh -n exit=$?"` per present file — confirmed this path is unchanged and still fires via the existing "dirty fixture" test.
- **Full local gate run** (Windows, this worktree): `sh scripts/test-review-l0.sh` — all 9 fixture groups pass, exit 0. `sh -n` on both touched scripts — clean. `sh scripts/lint-markdown-content.sh`, `sh scripts/lint-doc-citations.sh`, `sh scripts/lint-file-length.sh --tree` — all exit 0.

### Falsifying evidence (both fixtures proven to actually catch their bug)

Per the brief's explicit demand, I reverted each fix in turn, on top of the new tests, and confirmed the suite goes red before restoring via `git checkout -- REVIEW.md`:

1. **GH-992**: reverted R3's block to the original `[ -f "$f" ] && { sh -n "$f"; echo ...; }` loop. `sh scripts/test-review-l0.sh` → **exit 1**, failing exactly at the new missing-file fixture: `test-review-l0.sh: missing-file fixture: expected runner exit 0, got 1`. The table dump shows `| R3 | code-risk | P0 | FAIL |` with evidence `aaa-exists.sh -> sh -n exit=0` — a clean file's line under a FAIL verdict, reproducing issue #992's exact reported symptom.
2. **GH-1003**: reverted the D1 site back to `git diff "origin/$BASE..$SHA"`. `sh scripts/test-review-l0.sh` → **exit 1**, failing exactly at the new regression guard: `two-dot git diff regression in REVIEW.md (GH-1003): 485:git diff "origin/$BASE..$SHA" | grep '^+' \`.

Both reverts were restored (`git checkout -- REVIEW.md`) before this PR was opened; the working tree is clean and matches `3e22ee8`.

## Surface and class

`REVIEW.md` is the review spec — 審判面 under `docs/fleet/rules.md` R22. This change affects every future review round's file-enumeration and R3 verdict; per `REVIEW.md`'s own classifier this PR is `docs-skills` (`*.md`) ∪ `code-risk` (`scripts/**`, `*.sh`), so the authoritative round should be Opus, glm SHADOW-only, per the repo's own `review.review-engine-model` convention.

## CI coverage note

`.github/workflows/ci.yml`'s `fleet-tests-windows` job ("Fleet shell tests (windows)") runs only `scripts/test-git-config-guard.sh` by explicit name plus the `scripts/fleet/test-*.ps1` glob — it does **not** run `scripts/test-review-l0.sh`. That script **is** covered by the Linux `fleet-tests` job via `scripts/fleet/run-fleet-tests.sh`'s `scripts/test-*.sh` glob (confirmed not on any quarantine list there), so CI will exercise both new fixtures on Linux automatically. My local Windows run in this worktree is the only Windows-side evidence for this change; no gate here needed a Cargo run (nothing under `crates/**` changed).

## Anything left undone

Nothing known. Both issues' full `doneWhen` lists are met and independently re-verified above, not just read from the preserved commit's own commit message.

Issue: #1003, #992
Closes #1003
Closes #992

🤖 Generated with [Claude Code](https://claude.com/claude-code)
