### PR TITLE
fix(edda-cli): ratify cited-authority stops inferring supersession from a mention (GH-1066)

### DIFF
--- a/crates/edda-cli/src/cmd_ratify/mod.rs
+++ b/crates/edda-cli/src/cmd_ratify/mod.rs
@@ -178,19 +178,54 @@ fn append_ratify(
 /// deliberately, so the threshold does not apply once either is given.
 const RATIFY_THRESHOLD: usize = 20;
 
-/// `--since <date>` must be `YYYY-MM-DD`: cheap to check at the boundary, so
-/// a typo is a usage error (exit 2) rather than a silently-wrong comparison.
-fn validate_since(s: &str) -> String {
+/// True when `s` is a real calendar date in `YYYY-MM-DD` form — not merely
+/// shaped like one (PR #1098 Round 1 P2): the original shape-only check
+/// accepted `2026-99-99`. The `--since` comparison itself stays
+/// lexicographic and was never unsafe on a malformed value, but the flag
+/// advertises a date it should actually parse.
+fn is_valid_since_date(s: &str) -> bool {
     let bytes = s.as_bytes();
-    let ok = bytes.len() == 10
-        && bytes[4] == b'-'
-        && bytes[7] == b'-'
-        && bytes.iter().enumerate().all(|(i, b)| match i {
-            4 | 7 => true,
-            _ => b.is_ascii_digit(),
-        });
-    if !ok {
-        usage_exit(&format!("--since must be YYYY-MM-DD — got '{s}'"));
+    if bytes.len() != 10 || bytes[4] != b'-' || bytes[7] != b'-' {
+        return false;
+    }
+    if !bytes
+        .iter()
+        .enumerate()
+        .all(|(i, b)| matches!(i, 4 | 7) || b.is_ascii_digit())
+    {
+        return false;
+    }
+    let Ok(year) = s[0..4].parse::<i32>() else {
+        return false;
+    };
+    let Ok(month) = s[5..7].parse::<u32>() else {
+        return false;
+    };
+    let Ok(day) = s[8..10].parse::<u32>() else {
+        return false;
+    };
+    if !(1..=12).contains(&month) {
+        return false;
+    }
+    let leap = (year % 4 == 0 && year % 100 != 0) || year % 400 == 0;
+    let max_day = match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if leap => 29,
+        2 => 28,
+        _ => unreachable!("month already bounded to 1..=12"),
+    };
+    (1..=max_day).contains(&day)
+}
+
+/// `--since <date>` must be a real `YYYY-MM-DD` calendar date: cheap to
+/// check at the boundary, so a typo is a usage error (exit 2) rather than a
+/// silently-wrong comparison.
+fn validate_since(s: &str) -> String {
+    if !is_valid_since_date(s) {
+        usage_exit(&format!(
+            "--since must be a real YYYY-MM-DD date — got '{s}'"
+        ));
     }
     s.to_string()
 }

--- a/crates/edda-cli/src/cmd_ratify/mod.rs
+++ b/crates/edda-cli/src/cmd_ratify/mod.rs
@@ -319,16 +319,17 @@ fn collect(
         });
     }
     candidates.sort_by_key(|c| c.order);
-    // Every active row reaches the rule, same-key predecessors included:
-    // `active_decisions` can return more than one active row for a `(branch,
-    // key)` — `Ledger::ratified_decisions_map` groups them for exactly that
-    // reason. Before GH-1066 this function collapsed to "keep only the
-    // latest row per key" so an older row was invisible to the rule and its
-    // supersession was silently assumed rather than shown; now the rule's
-    // own same-key check (rule.rs) holds every predecessor explicitly and
-    // names why, and only the newest row in a same-key chain can ever clear
-    // that check and reach the citation check — so the write loop below
-    // still appends at most one ratify event per key.
+    // `active_decisions` never returns two rows for one `(branch, key)`: the
+    // ledger deactivates a key's prior row in the same write that appends a
+    // same-key successor (`UPDATE decisions SET is_active = FALSE ... WHERE
+    // key = ? AND branch = ?`, sqlite_store/events.rs) — a redecided key's
+    // old value is gone from this candidate set before the rule ever runs,
+    // not merely held by it. `evaluate`'s own same-key check
+    // (rule.rs::same_key_superseded) stays correct regardless and is
+    // exercised directly there with hand-built same-key candidates, so it
+    // still guards the pure function itself if a future caller ever feeds it
+    // a candidate set that is not pre-deduplicated this way. Either way, the
+    // write loop below appends at most one ratify event per key.
     Ok((candidates, binding))
 }
 

--- a/crates/edda-cli/src/cmd_ratify/mod.rs
+++ b/crates/edda-cli/src/cmd_ratify/mod.rs
@@ -53,6 +53,21 @@ pub struct RatifyArgs {
     /// With --by-rule: print the table without writing anything
     #[arg(long = "dry-run", requires = "by_rule")]
     pub dry_run: bool,
+    /// With --by-rule: only judge these keys (repeatable). Bounds the sweep
+    /// (GH-1066) — with this set, the unbounded-sweep size refusal below
+    /// does not apply.
+    #[arg(long = "key", requires = "by_rule")]
+    pub keys: Vec<String>,
+    /// With --by-rule: only judge decisions recorded on or after this date
+    /// (`YYYY-MM-DD`). Bounds the sweep the same way `--key` does (GH-1066).
+    #[arg(long, requires = "by_rule")]
+    pub since: Option<String>,
+    /// With --by-rule and neither --key nor --since: proceed even though the
+    /// ratify set exceeds the safety threshold (GH-1066). Without it, an
+    /// unbounded sweep that would ratify more than the threshold prints the
+    /// table and counts, and writes nothing.
+    #[arg(long, requires = "by_rule")]
+    pub yes: bool,
     /// Session ID (uses EDDA_SESSION_ID; --session required when identity is ambiguous)
     #[arg(long)]
     pub session: Option<String>,
@@ -156,23 +171,77 @@ fn append_ratify(
     Ok(())
 }
 
+/// Default cap on an unbounded `--by-rule` sweep's ratify count before it
+/// refuses without `--yes` (GH-1066): a sweep nobody scoped is a sweep
+/// nobody dares run, so the default protects against acting on more than a
+/// screenful of decisions sight-unseen. `--key`/`--since` bound the sweep
+/// deliberately, so the threshold does not apply once either is given.
+const RATIFY_THRESHOLD: usize = 20;
+
+/// `--since <date>` must be `YYYY-MM-DD`: cheap to check at the boundary, so
+/// a typo is a usage error (exit 2) rather than a silently-wrong comparison.
+fn validate_since(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let ok = bytes.len() == 10
+        && bytes[4] == b'-'
+        && bytes[7] == b'-'
+        && bytes.iter().enumerate().all(|(i, b)| match i {
+            4 | 7 => true,
+            _ => b.is_ascii_digit(),
+        });
+    if !ok {
+        usage_exit(&format!("--since must be YYYY-MM-DD — got '{s}'"));
+    }
+    s.to_string()
+}
+
 /// `--by-rule <RULE>`: evaluate every active decision on this branch and
 /// print one row per unratified key. `--dry-run` prints the same table and
 /// writes nothing, so the operator can read what the machine is about to do
 /// on their behalf before it does it.
+///
+/// `--key`/`--since` bound *which* verdicts are shown and acted on, not what
+/// the rule sees while deciding: same-key and domain-guard comparisons
+/// (rule.rs) still see every active decision on the branch, so scoping a
+/// sweep can never blind it to an older, still-relevant ruling.
 fn sweep(repo_root: &Path, rule_name: &str, args: &RatifyArgs) -> anyhow::Result<()> {
     if rule_name != RULE_CITED_AUTHORITY {
         usage_exit(&format!(
             "unknown rule '{rule_name}' — known rules: {RULE_CITED_AUTHORITY}"
         ));
     }
+    let since = args.since.as_deref().map(validate_since);
 
     let ledger = edda_ledger::Ledger::open(repo_root).context("cmd_ratify: opening ledger")?;
     let _lock = edda_ledger::lock::WorkspaceLock::acquire(&ledger.paths)?;
     let branch = ledger.head_branch()?;
 
     let (candidates, binding) = collect(&ledger, &branch)?;
-    let verdicts = evaluate(&candidates, &binding);
+    let dates: HashMap<&str, &str> = candidates
+        .iter()
+        .map(|c| (c.key.as_str(), c.date.as_str()))
+        .collect();
+    let all_verdicts = evaluate(&candidates, &binding);
+
+    let bounded = !args.keys.is_empty() || since.is_some();
+    let verdicts: Vec<Verdict> = all_verdicts
+        .into_iter()
+        .filter(|v| args.keys.is_empty() || args.keys.iter().any(|k| k == &v.key))
+        .filter(|v| {
+            since
+                .as_deref()
+                .is_none_or(|s| dates.get(v.key.as_str()).is_some_and(|d| *d >= s))
+        })
+        .collect();
+
+    let ratify_count = verdicts.iter().filter(|v| v.is_ratify()).count();
+    if !args.dry_run && !bounded && !args.yes && ratify_count > RATIFY_THRESHOLD {
+        print_table(&verdicts, rule_name, true);
+        println!(
+            "refusing: {ratify_count} decisions would ratify unscoped (threshold {RATIFY_THRESHOLD}) — bound with --key/--since, or pass --yes; nothing written."
+        );
+        return Ok(());
+    }
 
     print_table(&verdicts, rule_name, args.dry_run);
 
@@ -244,19 +313,22 @@ fn collect(
             cites: cites_by_event.remove(&d.event_id).unwrap_or_default(),
             ratified: ratified.contains_key(&d.event_id),
             order: ledger.rowid_for_event_id(&d.event_id)?.unwrap_or(0),
+            date: d.ts.clone().unwrap_or_default(),
             key: d.key,
             reason: d.reason,
         });
     }
     candidates.sort_by_key(|c| c.order);
-    // One row per key: `active_decisions` can return more than one active row
-    // for a `(branch, key)` — `Ledger::ratified_decisions_map` groups them for
-    // exactly that reason — and two rows would otherwise write two ratify
-    // events for one key. The later row is the current value, so keep it.
-    let mut seen = BTreeSet::new();
-    candidates.reverse();
-    candidates.retain(|c| seen.insert(c.key.clone()));
-    candidates.reverse();
+    // Every active row reaches the rule, same-key predecessors included:
+    // `active_decisions` can return more than one active row for a `(branch,
+    // key)` — `Ledger::ratified_decisions_map` groups them for exactly that
+    // reason. Before GH-1066 this function collapsed to "keep only the
+    // latest row per key" so an older row was invisible to the rule and its
+    // supersession was silently assumed rather than shown; now the rule's
+    // own same-key check (rule.rs) holds every predecessor explicitly and
+    // names why, and only the newest row in a same-key chain can ever clear
+    // that check and reach the citation check — so the write loop below
+    // still appends at most one ratify event per key.
     Ok((candidates, binding))
 }
 

--- a/crates/edda-cli/src/cmd_ratify/rule.rs
+++ b/crates/edda-cli/src/cmd_ratify/rule.rs
@@ -38,6 +38,11 @@ pub struct Candidate {
     pub ratified: bool,
     /// Ledger insertion order. Only ever compared, never displayed.
     pub order: i64,
+    /// Ledger timestamp (RFC3339), for `--since` bounding (GH-1066). Empty
+    /// when unknown. `evaluate` never reads this field — `--since` filters
+    /// the caller's output (`mod.rs::sweep`), not a verdict here, so an
+    /// empty date never changes what this pure function decides.
+    pub date: String,
 }
 
 /// What the rule decided, and why. The why is not decoration: it is the
@@ -109,28 +114,99 @@ fn verdict_for(c: &Candidate, all: &[Candidate], binding_keys: &BTreeSet<String>
             why: format!("held domain '{prefix}' — operator ratifies these"),
         };
     }
-    if let Some(later) = superseding(c, all) {
+    // Supersession is explicit, never inferred from a mention (GH-1066): a
+    // decision that merely comes up while explaining something else has not
+    // overtaken it. Only two things count as "superseded" now, checked in
+    // this order because same-key is unambiguous and free, and an explicit
+    // marker is still cheaper to trust than reading the domain guard below.
+    if same_key_superseded(c, all) {
         return Outcome::Hold {
-            why: format!("superseded — a later decision '{later}' names it"),
+            why: format!(
+                "superseded-by-same-key — a later decision recorded under '{}' replaces it",
+                c.key
+            ),
+        };
+    }
+    if let Some(newer) = all
+        .iter()
+        .filter(|o| o.order > c.order)
+        .find(|o| names_explicit_supersession(&o.reason, &c.key))
+    {
+        return Outcome::Hold {
+            why: format!("superseded-explicit — '{}' marks it superseded", newer.key),
+        };
+    }
+    // Domain guard (GH-1066): a valid citation is not immunity. A newer,
+    // *binding* ruling in the same governance domain can have overtaken this
+    // one in substance even though it never names it — decision.auto-ratify's
+    // "contradicts no binding decision" clause, approximated the only way
+    // that does not require reading prose.
+    if let Some(later) = domain_superseded_by(c, all) {
+        return Outcome::Hold {
+            why: format!(
+                "older-than-binding-in-domain — '{later}' is binding and newer in domain '{}'",
+                domain_of(&c.key)
+            ),
         };
     }
     match citation(c, binding_keys) {
         Some(citation) => Outcome::Ratify { citation },
         None => Outcome::Hold {
-            why: "no citation — add --cite operator:<when> | issue:#<n> | decision:<key>"
+            why: "no-citation — add --cite operator:<when> | issue:#<n> | decision:<key>"
                 .to_string(),
         },
     }
 }
 
-/// The key of a later decision whose reason names `c`, if any. This is the
-/// soft supersede the ledger's own `supersedes` edge does not catch: a new
-/// decision that explains itself by pointing at an older one has already
-/// overtaken it, whatever its key.
-fn superseding(c: &Candidate, all: &[Candidate]) -> Option<String> {
+/// True when a later decision was recorded under the identical key — the
+/// most explicit supersession there is: nothing needs inferring when the
+/// ledger already carries a newer value for the same key.
+fn same_key_superseded(c: &Candidate, all: &[Candidate]) -> bool {
+    all.iter().any(|o| o.key == c.key && o.order > c.order)
+}
+
+/// Marker tokens this rule reads as an *explicit* supersession claim in a
+/// decision's own reason — never inferred from a mention anywhere in the
+/// prose, only from the target key appearing immediately after one of these
+/// tokens. `supersedes:` is the canonical form this rule writes going
+/// forward (GH-1066 doneWhen); `SUPERSEDES` (bare, all-caps) and `顯式取代`
+/// are phrasings already on the ledger before this rule existed — recognised
+/// so existing decisions need no migration, and never rewritten.
+const SUPERSEDES_MARKERS: [&str; 3] = ["supersedes:", "SUPERSEDES", "顯式取代"];
+
+/// True when `reason` explicitly names `target_key` as superseded: one of
+/// `SUPERSEDES_MARKERS`, immediately followed (after optional separator
+/// whitespace or a colon) by `target_key` at a word boundary. `target_key`
+/// appearing anywhere else in the sentence does not count — that is the
+/// exact shape of the GH-1066 bug this replaces.
+fn names_explicit_supersession(reason: &str, target_key: &str) -> bool {
+    SUPERSEDES_MARKERS.iter().any(|marker| {
+        reason.find(marker).is_some_and(|idx| {
+            let after = reason[idx + marker.len()..].trim_start_matches([' ', ':', '\t', '　']);
+            after.strip_prefix(target_key).is_some_and(|rest| {
+                rest.chars()
+                    .next()
+                    .is_none_or(|ch| !(ch.is_alphanumeric() || matches!(ch, '_' | '-' | '.')))
+            })
+        })
+    })
+}
+
+/// The domain segment of a key: everything before the first `.` — the same
+/// split the ledger uses to populate `decisions.domain`.
+fn domain_of(key: &str) -> &str {
+    key.split('.').next().unwrap_or(key)
+}
+
+/// The key of a later, **binding** decision in the same domain, if any
+/// (GH-1066 domain guard). Only a ratified sibling counts: an unratified
+/// newer decision in the same domain has no more authority than `c` itself
+/// yet, so it cannot be what overtook it.
+fn domain_superseded_by(c: &Candidate, all: &[Candidate]) -> Option<String> {
+    let domain = domain_of(&c.key);
     all.iter()
-        .filter(|o| o.order > c.order && o.key != c.key)
-        .find(|o| o.reason.contains(&c.key))
+        .filter(|o| o.ratified && o.order > c.order && o.key != c.key)
+        .find(|o| domain_of(&o.key) == domain)
         .map(|o| o.key.clone())
 }
 
@@ -206,6 +282,7 @@ mod tests {
             cites: Vec::new(),
             ratified: false,
             order,
+            date: String::new(),
         }
     }
 
@@ -239,14 +316,19 @@ mod tests {
     }
 
     #[test]
-    fn decision_named_by_a_later_reason_is_held() {
+    fn mention_alone_no_longer_holds_it() {
+        // GH-1066: this is the exact shape of the bug. `review.pool`'s
+        // reason names `review.engine` in passing (it builds on it, it does
+        // not replace it), so a later decision *mentioning* an earlier key
+        // must not hold it — only a same-key redecision or an explicit
+        // marker does. `review.engine` has a real citation and nothing
+        // superseded it, so it ratifies.
         let mut old = cand("review.engine", "cited in issue #900", 1);
         old.cites = vec!["issue:#900".to_string()];
         let newer = cand("review.pool", "replaces review.engine after the window", 2);
         let v = evaluate(&[old, newer], &none());
-        let held = v.iter().find(|x| x.key == "review.engine").unwrap();
-        assert!(!held.is_ratify());
-        assert!(held.columns().1.contains("superseded"), "{held:?}");
+        let engine = v.iter().find(|x| x.key == "review.engine").unwrap();
+        assert!(engine.is_ratify(), "{engine:?}");
     }
 
     #[test]
@@ -260,11 +342,163 @@ mod tests {
         assert!(v.iter().find(|x| x.key == "b.two").unwrap().is_ratify());
     }
 
+    // ── same-key supersession (GH-1066) ─────────────────────────────────
+
+    #[test]
+    fn same_key_later_decision_holds_the_older_row() {
+        let mut old = cand("db.engine", "postgres, per #1", 1);
+        old.cites = vec!["issue:#1".to_string()];
+        let mut newer = cand("db.engine", "sqlite instead, embedded is simpler", 2);
+        newer.cites = vec!["issue:#2".to_string()];
+        let v = evaluate(&[old, newer], &none());
+        // Both verdicts share the key "db.engine" here — same-key chains are
+        // exactly the case where key alone cannot disambiguate — so pick out
+        // each side by outcome instead. Both rows carry a valid citation, so
+        // only same-key supersession explains why one is held.
+        assert_eq!(v.len(), 2);
+        let held = v.iter().find(|x| !x.is_ratify()).unwrap();
+        assert!(
+            held.columns().1.starts_with("superseded-by-same-key"),
+            "{held:?}"
+        );
+        assert!(v.iter().any(|x| x.is_ratify()), "{v:?}");
+    }
+
+    #[test]
+    fn newest_row_in_a_same_key_chain_still_reaches_citation() {
+        let old = cand("db.engine", "postgres", 1);
+        let mut newer = cand("db.engine", "sqlite instead", 2);
+        newer.cites = vec!["issue:#2".to_string()];
+        let v = evaluate(&[old, newer], &none());
+        // Two candidates share one key here (mod.rs::collect no longer
+        // dedups before the rule sees them — GH-1066), so `evaluate` returns
+        // two verdicts under the same key; the newest one must ratify.
+        assert_eq!(v.len(), 2);
+        assert!(v.iter().any(|x| x.is_ratify()), "{v:?}");
+        assert!(v.iter().any(|x| !x.is_ratify()), "{v:?}");
+    }
+
+    // ── explicit-marker supersession (GH-1066) ──────────────────────────
+
+    #[test]
+    fn explicit_canonical_marker_holds_the_named_key() {
+        let mut old = cand("review.old-gate", "cited in issue #900", 1);
+        old.cites = vec!["issue:#900".to_string()];
+        let newer = cand(
+            "review.new-gate",
+            "supersedes:review.old-gate — the gate moved to the aggregate check",
+            2,
+        );
+        let v = evaluate(&[old, newer], &none());
+        let held = v.iter().find(|x| x.key == "review.old-gate").unwrap();
+        assert!(!held.is_ratify());
+        assert!(
+            held.columns().1.starts_with("superseded-explicit"),
+            "{held:?}"
+        );
+    }
+
+    #[test]
+    fn legacy_all_caps_supersedes_marker_is_recognized() {
+        // The exact phrasing already on the ledger before this rule existed
+        // (fleet.merge-authority's own reason text): `SUPERSEDES <key>` with
+        // no colon. Recognised, not migrated.
+        let mut old = cand("fleet.old-policy", "per #12", 1);
+        old.cites = vec!["issue:#12".to_string()];
+        let newer = cand(
+            "fleet.new-policy",
+            "SUPERSEDES fleet.old-policy=old-value ONLY in its gate clause",
+            2,
+        );
+        let v = evaluate(&[old, newer], &none());
+        let held = v.iter().find(|x| x.key == "fleet.old-policy").unwrap();
+        assert!(!held.is_ratify());
+        assert!(
+            held.columns().1.starts_with("superseded-explicit"),
+            "{held:?}"
+        );
+    }
+
+    #[test]
+    fn legacy_chinese_explicit_marker_is_recognized() {
+        let mut old = cand("review.old-carrier", "per #7", 1);
+        old.cites = vec!["issue:#7".to_string()];
+        let newer = cand(
+            "review.new-carrier",
+            "顯式取代review.old-carrier，理由如下",
+            2,
+        );
+        let v = evaluate(&[old, newer], &none());
+        let held = v.iter().find(|x| x.key == "review.old-carrier").unwrap();
+        assert!(!held.is_ratify());
+        assert!(
+            held.columns().1.starts_with("superseded-explicit"),
+            "{held:?}"
+        );
+    }
+
+    #[test]
+    fn explicit_marker_key_must_be_a_whole_word_not_a_prefix() {
+        // `review.merge-gate` must not be caught by a marker that actually
+        // names the longer key `review.merge-gate-v2` — the whole point of
+        // GH-1066 is that a partial textual match never counts as explicit.
+        let mut short = cand("review.merge-gate", "per #55", 1);
+        short.cites = vec!["issue:#55".to_string()];
+        let newer = cand(
+            "review.merge-gate-v2",
+            "supersedes:review.merge-gate-v2 — restates the v1 record",
+            2,
+        );
+        let v = evaluate(&[short, newer], &none());
+        let short_verdict = v.iter().find(|x| x.key == "review.merge-gate").unwrap();
+        assert!(short_verdict.is_ratify(), "{short_verdict:?}");
+    }
+
+    // ── domain guard (GH-1066) ───────────────────────────────────────────
+
+    #[test]
+    fn domain_guard_holds_older_candidate_behind_a_later_binding_sibling() {
+        let mut old = cand("review.legacy-gate", "per #100", 1);
+        old.cites = vec!["issue:#100".to_string()];
+        let mut newer = cand("review.auto-merge", "gate is now mechanical, per Tim", 2);
+        newer.ratified = true;
+        let v = evaluate(&[old, newer], &none());
+        let held = v.iter().find(|x| x.key == "review.legacy-gate").unwrap();
+        assert!(!held.is_ratify());
+        assert!(
+            held.columns().1.starts_with("older-than-binding-in-domain"),
+            "{held:?}"
+        );
+    }
+
+    #[test]
+    fn domain_guard_does_not_cross_domains() {
+        let mut old = cand("fleet.legacy-gate", "per #100", 1);
+        old.cites = vec!["issue:#100".to_string()];
+        let mut newer = cand("review.auto-merge", "gate is now mechanical", 2);
+        newer.ratified = true;
+        let v = evaluate(&[old, newer], &none());
+        let verdict = v.iter().find(|x| x.key == "fleet.legacy-gate").unwrap();
+        assert!(verdict.is_ratify(), "{verdict:?}");
+    }
+
+    #[test]
+    fn domain_guard_requires_the_sibling_to_be_binding_not_merely_newer() {
+        // An unratified newer decision in the same domain has no more
+        // authority than the candidate itself — it must not hold it.
+        let mut old = cand("review.legacy-gate", "per #100", 1);
+        old.cites = vec!["issue:#100".to_string()];
+        let newer = cand("review.auto-merge", "gate is now mechanical", 2); // not ratified
+        let v = evaluate(&[old, newer], &none());
+        let verdict = v.iter().find(|x| x.key == "review.legacy-gate").unwrap();
+        assert!(verdict.is_ratify(), "{verdict:?}");
+    }
+
     #[test]
     fn uncited_decision_is_held() {
         let v = evaluate(&[cand("cache.ttl", "seems about right", 1)], &none());
         assert!(!v[0].is_ratify());
-        assert!(v[0].columns().1.contains("no citation"));
+        assert!(v[0].columns().1.contains("no-citation"));
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_ratify/rule.rs
+++ b/crates/edda-cli/src/cmd_ratify/rule.rs
@@ -179,9 +179,14 @@ const SUPERSEDES_MARKERS: [&str; 3] = ["supersedes:", "SUPERSEDES", "顯式取�
 /// whitespace or a colon) by `target_key` at a word boundary. `target_key`
 /// appearing anywhere else in the sentence does not count — that is the
 /// exact shape of the GH-1066 bug this replaces.
+///
+/// Checks **every** occurrence of each marker, not only the first (PR #1098
+/// Round 1 P2): a reason superseding two keys with the same marker —
+/// `"supersedes:a.one and supersedes:b.two"` — must hold both, and a
+/// single `str::find` only ever sees the first one.
 fn names_explicit_supersession(reason: &str, target_key: &str) -> bool {
     SUPERSEDES_MARKERS.iter().any(|marker| {
-        reason.find(marker).is_some_and(|idx| {
+        reason.match_indices(marker).any(|(idx, _)| {
             let after = reason[idx + marker.len()..].trim_start_matches([' ', ':', '\t', '　']);
             after.strip_prefix(target_key).is_some_and(|rest| {
                 rest.chars()
@@ -438,6 +443,28 @@ mod tests {
     }
 
     #[test]
+    fn explicit_marker_used_twice_holds_both_named_keys() {
+        // PR #1098 Round 1 P2: `reason.find(marker)` located only the first
+        // "supersedes:" occurrence, so a reason superseding two keys with
+        // the same marker held only the first-named one. `match_indices`
+        // checks every occurrence.
+        let mut a = cand("a.one", "cited a", 1);
+        a.cites = vec!["issue:#1".to_string()];
+        let mut b = cand("b.two", "cited b", 2);
+        b.cites = vec!["issue:#2".to_string()];
+        let newer = cand("c.three", "supersedes:a.one and supersedes:b.two", 3);
+        let v = evaluate(&[a, b, newer], &none());
+        for key in ["a.one", "b.two"] {
+            let held = v.iter().find(|x| x.key == key).unwrap();
+            assert!(!held.is_ratify(), "{key}: {held:?}");
+            assert!(
+                held.columns().1.starts_with("superseded-explicit"),
+                "{key}: {held:?}"
+            );
+        }
+    }
+
+    #[test]
     fn explicit_marker_key_must_be_a_whole_word_not_a_prefix() {
         // `review.merge-gate` must not be caught by a marker that actually
         // names the longer key `review.merge-gate-v2` — the whole point of
@@ -491,6 +518,38 @@ mod tests {
         let newer = cand("review.auto-merge", "gate is now mechanical", 2); // not ratified
         let v = evaluate(&[old, newer], &none());
         let verdict = v.iter().find(|x| x.key == "review.legacy-gate").unwrap();
+        assert!(verdict.is_ratify(), "{verdict:?}");
+    }
+
+    // The two tests above prove the domain guard on `review.` keys sharing a
+    // domain. PR #1098 Round 2 (controller amendment to GH-1066 doneWhen
+    // bullet 5, 2026-09-09) requires the same positive/negative pair proven
+    // on a second, genuinely shared domain — `fleet.` — rather than relying
+    // on `domain_guard_does_not_cross_domains` below, which is a cross-domain
+    // negative and proves a different property.
+
+    #[test]
+    fn domain_guard_holds_older_fleet_candidate_behind_a_later_binding_fleet_sibling() {
+        let mut old = cand("fleet.legacy-gate", "per #100", 1);
+        old.cites = vec!["issue:#100".to_string()];
+        let mut newer = cand("fleet.rollout-gate", "dispatch is now mechanical", 2);
+        newer.ratified = true;
+        let v = evaluate(&[old, newer], &none());
+        let held = v.iter().find(|x| x.key == "fleet.legacy-gate").unwrap();
+        assert!(!held.is_ratify());
+        assert!(
+            held.columns().1.starts_with("older-than-binding-in-domain"),
+            "{held:?}"
+        );
+    }
+
+    #[test]
+    fn domain_guard_requires_the_fleet_sibling_to_be_binding_not_merely_newer() {
+        let mut old = cand("fleet.legacy-gate", "per #100", 1);
+        old.cites = vec!["issue:#100".to_string()];
+        let newer = cand("fleet.rollout-gate", "dispatch is now mechanical", 2); // not ratified
+        let v = evaluate(&[old, newer], &none());
+        let verdict = v.iter().find(|x| x.key == "fleet.legacy-gate").unwrap();
         assert!(verdict.is_ratify(), "{verdict:?}");
     }
 

--- a/crates/edda-cli/src/cmd_ratify/tests.rs
+++ b/crates/edda-cli/src/cmd_ratify/tests.rs
@@ -369,29 +369,52 @@ fn mention_alone_does_not_hold_it_through_the_cli() {
 // Reconstructs the shape of the real 2026-09-07 `--by-rule cited-authority
 // --dry-run` sweep the issue reports (176 rows, 97 ratify / 79 hold): five
 // real, plain-flow rulings the old rule held only because a later decision
-// happened to name them while building on them, and four real 2026-08
-// rail-closeout entries (`d-013`..`d-034`) that a blind sweep would have
-// re-ratified because nothing named them, even though a later, binding
-// ruling (`review.auto-merge`) had already overtaken the whole merge-
-// authority area in substance. Keys, relative order, and citations are
-// drawn from the real ledger (verified read-only against this project's own
+// happened to name them while building on or referencing them, and four
+// real 2026-08 rail-closeout entries (`d-013`..`d-034`) that an *unbounded*
+// sweep still ratifies today. Keys, relative order, and citations are drawn
+// from the real ledger (verified read-only against this project's own
 // `.edda` while diagnosing GH-1066, before any code changed); reasons are
-// paraphrased, not quoted verbatim.
+// paraphrased, not quoted verbatim — and two of the five plain-flow reasons
+// below are edited from that paraphrase to *name* the key they are built to
+// trip (see the per-decision comments): a paraphrase that happened to drop
+// the name would prove nothing about the bug this fixture exists to catch.
 //
-// One thing this fixture does *not* claim: that the four `d-NNN.*` keys
-// share a domain with `review.auto-merge`, or with each other. Each `d-NNN`
-// key is its own historical identifier — a `d-032` decision and a `d-034`
-// decision are never in the same domain by construction, the same way
-// `d-032` is never in the same domain as `review.*`. The domain guard
-// (proven separately above, and via `four_case_ledger`'s case 3) cannot
-// mechanically connect them without inferring a relationship the ledger
-// never recorded, which is the exact kind of inference GH-1066 removes. The
-// `--since` date guard is what actually keeps this specific 2026-08 batch
-// out of an unscoped sweep — proven below — and is the mechanism the issue
-// titles "No domain OR date guard" (bullet 2): either guard protecting a
-// given row is sufficient; this batch is protected by the date guard. That
-// guard only works if the four rows genuinely carry an old date, so they are
-// stamped via `decide_at` rather than `decide` (which would record "now").
+// Controller amendment to GH-1066 doneWhen bullet 5 (PR #1098 Round 1,
+// 2026-09-09 — see the issue's newest comment): the original bullet also
+// asked the four `d-NNN.*` rows to become `hold: older-than-binding-in-
+// domain`. That is mechanically impossible and was withdrawn —
+// `extract_domain` is `key.split('.').next()`, so `d-033` and `review`
+// share no domain, and nothing in this fixture claims otherwise.
+// `review.auto-merge`'s ratification does *not* domain-guard the four rows
+// below; its role here is limited to (a) being the later, binding decision
+// this file's own domain-guard shape is modeled on (mirrored, on a
+// genuinely shared domain, by the `fleet.`-domain pair in `rule.rs`), and
+// (b) naming `fleet.lane-launch` in its own reason — this fixture's
+// mention-inference trip for that key.
+//
+// The amended bullet is outcome-oriented for the four rows instead: an
+// unbounded sweep must not silently ratify them.
+// `gh1066_without_since_the_rail_closeout_batch_would_have_ratified` below
+// proves the residual honestly — they *do* ratify unbounded, because each
+// row's own reason happens to carry a PR/task number the reason-fallback
+// citation reads (a real quirk, out of GH-1066's scope) — and
+// `gh1066_since_bound_keeps_the_rail_closeout_batch_out_of_the_sweep` proves
+// `--since` is what keeps them out. `unbounded_sweep_refuses_past_the_
+// threshold_without_yes`, elsewhere in this file, is the other accepted
+// half: the real table's 97 ratifies exceed the default cap of 20, so a
+// truly unscoped sweep refuses and prints the table rather than writing
+// silently, even without `--since`. That guard only works if the four rows
+// genuinely carry an old date, so they are stamped via `decide_at` rather
+// than `decide` (which would record "now").
+//
+// The domain guard itself is proven on keys that genuinely share a domain —
+// not on this fixture's cross-domain `d-NNN`/`review` pairing — by four
+// unit tests in `rule.rs`: `domain_guard_holds_older_candidate_behind_a_
+// later_binding_sibling` / `domain_guard_requires_the_sibling_to_be_
+// binding_not_merely_newer` (domain `review`), and their fleet-domain
+// counterparts `domain_guard_holds_older_fleet_candidate_behind_a_later_
+// binding_fleet_sibling` / `domain_guard_requires_the_fleet_sibling_to_be_
+// binding_not_merely_newer`.
 fn gh1066_snapshot_ledger() -> (std::path::PathBuf, edda_ledger::Ledger) {
     let (tmp, ledger) = setup_workspace();
 
@@ -431,20 +454,30 @@ fn gh1066_snapshot_ledger() -> (std::path::PathBuf, edda_ledger::Ledger) {
         Some("2026-08-15T09:00:00Z"),
     );
 
-    // 2026-09-02/03: fleet.lane-launch, then the ruling that supersedes the
-    // whole 2026-08 merge-authority regime in substance, never by name.
+    // 2026-09-02/03: fleet.lane-launch, then the ruling that follows it.
+    // `fleet.lane-launch` carries a real citation, so under the fixed
+    // engine it ratifies on its own citation once mention alone can no
+    // longer hold it. Before this fix (Round 1 P0-2) it carried no
+    // citation at all, held as `no-citation` regardless of the bug, and
+    // was silently left out of the acceptance assertion below.
     decide(
         &ledger,
         "fleet.lane-launch",
         "profile-a",
         "per the lane launcher design",
-        &[],
+        &["operator:2026-09-02"],
     );
+    // Reason names `fleet.lane-launch` (paraphrased, not the real wording)
+    // — this fixture's mention-inference trip for that key: the pre-
+    // GH-1066 rule held anything a later reason merely named, so without
+    // this mention the fifth key would prove nothing about the bug. This
+    // ratification does not, and is not claimed to, domain-guard the four
+    // `d-NNN.*` rows above — see the file-level comment.
     decide(
         &ledger,
         "review.auto-merge",
         "gate-green-merges-by-machine",
-        "Tim: merge authority moves to the gate",
+        "Tim: merge authority moves to the gate, keeping fleet.lane-launch's rollout order",
         &["operator:2026-09-03"],
     );
     run(&tmp, &args(Some("review.auto-merge"))).unwrap();
@@ -479,11 +512,15 @@ fn gh1066_snapshot_ledger() -> (std::path::PathBuf, edda_ledger::Ledger) {
         "Tim 2026-09-07",
         &["operator:2026-09-07"],
     );
+    // Reason now names all four plain-flow keys above (paraphrased): the
+    // fixture must trip the old mention-inference bug for all four, not
+    // only two, or two of the four assertions below pass identically on
+    // the unfixed engine (Round 1 P0-2).
     decide(
         &ledger,
         "review.shell-branch",
         "controller-owned",
-        "builds on review.default-path and review.watcher",
+        "builds on review.readonly-proof, review.merge-gate, review.default-path and review.watcher",
         &[],
     );
 
@@ -492,6 +529,15 @@ fn gh1066_snapshot_ledger() -> (std::path::PathBuf, edda_ledger::Ledger) {
 
 #[test]
 fn gh1066_plain_flow_rulings_ratify_despite_being_named_by_a_later_decision() {
+    // All five held keys the issue reports (bullet 5, controller-amended
+    // 2026-09-09): each is named by a later decision's reason above, which
+    // the pre-GH-1066 rule alone would have held (see PR #1098 Round 2's
+    // Review Response for the scratch-copy proof: reverting just that
+    // inference turns every assertion below red). Asserting all five, not
+    // a subset, is the Round 1 P0-2 fix — two of the previous four
+    // assertions passed identically on the unfixed engine because nothing
+    // actually named them, and the fifth key was silently omitted from
+    // both the fixture's citation and this test.
     let (tmp, ledger) = gh1066_snapshot_ledger();
     let branch = ledger.head_branch().unwrap();
     let (candidates, binding) = collect(&ledger, &branch).unwrap();
@@ -502,6 +548,7 @@ fn gh1066_plain_flow_rulings_ratify_despite_being_named_by_a_later_decision() {
         "review.merge-gate",
         "review.default-path",
         "review.watcher",
+        "fleet.lane-launch",
     ] {
         let v = verdicts.iter().find(|v| v.key == key).unwrap();
         assert!(v.is_ratify(), "{key}: {v:?}");

--- a/crates/edda-cli/src/cmd_ratify/tests.rs
+++ b/crates/edda-cli/src/cmd_ratify/tests.rs
@@ -19,6 +19,23 @@ fn setup_workspace() -> (std::path::PathBuf, edda_ledger::Ledger) {
 /// Write a decision the way `edda decide` writes one, including the
 /// structured `cites` field when given.
 fn decide(ledger: &edda_ledger::Ledger, key: &str, value: &str, reason: &str, cites: &[&str]) {
+    decide_at(ledger, key, value, reason, cites, None)
+}
+
+/// Same as `decide`, but stamped with `ts` (RFC3339) instead of "now" when
+/// given. Every plain `decide()` call in one test run lands within the same
+/// wall-clock second, so a fixture that needs `--since` to see genuinely
+/// distinct dates (GH-1066) must override `ts` explicitly — a narrative
+/// comment claiming a row is "2026-08-14" does not make the ledger record
+/// that date.
+fn decide_at(
+    ledger: &edda_ledger::Ledger,
+    key: &str,
+    value: &str,
+    reason: &str,
+    cites: &[&str],
+    ts: Option<&str>,
+) {
     let branch = ledger.head_branch().unwrap();
     let parent_hash = ledger.last_event_hash().unwrap();
     let dp = edda_core::types::DecisionPayload {
@@ -38,8 +55,15 @@ fn decide(ledger: &edda_ledger::Ledger, key: &str, value: &str, reason: &str, ci
             Some(cites.iter().map(|c| (*c).to_string()).collect())
         },
     };
-    let event = edda_core::event::new_decision_event(&branch, parent_hash.as_deref(), "agent", &dp)
-        .unwrap();
+    let mut event =
+        edda_core::event::new_decision_event(&branch, parent_hash.as_deref(), "agent", &dp)
+            .unwrap();
+    if let Some(t) = ts {
+        // The hash covers `ts`, so a caller-supplied date must be finalized
+        // again rather than poked in after the fact.
+        event.ts = t.to_string();
+        edda_core::event::finalize_event(&mut event).unwrap();
+    }
     ledger.append_event(&event).unwrap();
 }
 
@@ -365,40 +389,46 @@ fn mention_alone_does_not_hold_it_through_the_cli() {
 // `--since` date guard is what actually keeps this specific 2026-08 batch
 // out of an unscoped sweep — proven below — and is the mechanism the issue
 // titles "No domain OR date guard" (bullet 2): either guard protecting a
-// given row is sufficient; this batch is protected by the date guard.
+// given row is sufficient; this batch is protected by the date guard. That
+// guard only works if the four rows genuinely carry an old date, so they are
+// stamped via `decide_at` rather than `decide` (which would record "now").
 fn gh1066_snapshot_ledger() -> (std::path::PathBuf, edda_ledger::Ledger) {
     let (tmp, ledger) = setup_workspace();
 
     // 2026-08-14/15: a PR-rail closeout batch. Each key is its own
-    // historical `d-NNN` identifier, never revisited under that exact key
-    // except d-033 (below) — so each is alone in its own domain.
-    decide(
+    // historical `d-NNN` identifier, never revisited under that exact key —
+    // so each is alone in its own domain.
+    decide_at(
         &ledger,
         "d-013.final_gate",
         "task22",
         "verifier gate per task #22",
         &[],
+        Some("2026-08-14T09:00:00Z"),
     );
-    decide(
+    decide_at(
         &ledger,
         "d-032.fresh_premerge_gate",
         "pass",
         "integration rerun per PRs #459/#460/#461",
         &[],
+        Some("2026-08-14T10:00:00Z"),
     );
-    decide(
+    decide_at(
         &ledger,
         "d-033.merge_authority",
         "required",
         "no merge without explicit delegation, per PR #459",
         &[],
+        Some("2026-08-14T11:00:00Z"),
     );
-    decide(
+    decide_at(
         &ledger,
         "d-034.merge_authority",
         "granted",
         "operator authorized the merge order per PR #459",
         &[],
+        Some("2026-08-15T09:00:00Z"),
     );
 
     // 2026-09-02/03: fleet.lane-launch, then the ruling that supersedes the
@@ -457,16 +487,6 @@ fn gh1066_snapshot_ledger() -> (std::path::PathBuf, edda_ledger::Ledger) {
         &[],
     );
 
-    // The real stopgap the operator recorded once GH-1066 was diagnosed: a
-    // same-key redecision of d-033, so the engine can see it without a fix.
-    decide(
-        &ledger,
-        "d-033.merge_authority",
-        "superseded-by-review.auto-merge",
-        "housekeeping under review.auto-merge and review.merge-gate",
-        &[],
-    );
-
     (tmp, ledger)
 }
 
@@ -490,26 +510,6 @@ fn gh1066_plain_flow_rulings_ratify_despite_being_named_by_a_later_decision() {
 }
 
 #[test]
-fn gh1066_same_key_stopgap_holds_the_original_d033_row() {
-    let (tmp, ledger) = gh1066_snapshot_ledger();
-    let branch = ledger.head_branch().unwrap();
-    let (candidates, binding) = collect(&ledger, &branch).unwrap();
-    let verdicts = evaluate(&candidates, &binding);
-
-    let d033: Vec<_> = verdicts
-        .iter()
-        .filter(|v| v.key == "d-033.merge_authority")
-        .collect();
-    assert_eq!(d033.len(), 2, "two rows share this key: {d033:?}");
-    let held = d033.iter().find(|v| !v.is_ratify()).unwrap();
-    assert!(
-        held.columns().1.starts_with("superseded-by-same-key"),
-        "{held:?}"
-    );
-    let _ = std::fs::remove_dir_all(&tmp);
-}
-
-#[test]
 fn gh1066_since_bound_keeps_the_rail_closeout_batch_out_of_the_sweep() {
     // The date guard (GH-1066): without a same-key or same-domain signal
     // available, `--since` is what an operator who knows this batch is
@@ -522,6 +522,7 @@ fn gh1066_since_bound_keeps_the_rail_closeout_batch_out_of_the_sweep() {
     for key in [
         "d-013.final_gate",
         "d-032.fresh_premerge_gate",
+        "d-033.merge_authority",
         "d-034.merge_authority",
     ] {
         assert!(
@@ -538,9 +539,11 @@ fn gh1066_since_bound_keeps_the_rail_closeout_batch_out_of_the_sweep() {
 fn gh1066_without_since_the_rail_closeout_batch_would_have_ratified() {
     // The negative control for the test above: proves --since is load-
     // bearing here, not incidental — without it, these PR/task-number
-    // "citations" (real quirk, out of GH-1066's scope) let d-034 through.
+    // "citations" (real quirk, out of GH-1066's scope) let the whole 2026-08
+    // batch through, d-033 included.
     let (tmp, ledger) = gh1066_snapshot_ledger();
     run(&tmp, &rule_args(false)).unwrap();
+    assert!(is_binding(&ledger, "d-033.merge_authority"));
     assert!(is_binding(&ledger, "d-034.merge_authority"));
     let _ = std::fs::remove_dir_all(&tmp);
 }

--- a/crates/edda-cli/src/cmd_ratify/tests.rs
+++ b/crates/edda-cli/src/cmd_ratify/tests.rs
@@ -619,6 +619,25 @@ fn well_formed_since_passes_through_unchanged() {
     assert_eq!(validate_since("2026-08-20"), "2026-08-20");
 }
 
+#[test]
+fn since_calendar_validity_rejects_impossible_dates() {
+    // PR #1098 Round 1 P2: the old shape-only check accepted `2026-99-99`.
+    // The exit-2 boundary itself is covered end to end by
+    // ratify_exit_codes.rs::since_with_an_impossible_calendar_date_exits_2
+    // (same reason `well_formed_since_passes_through_unchanged` above
+    // cannot exercise `usage_exit` in-process); this checks the pure
+    // predicate that boundary now calls.
+    assert!(!is_valid_since_date("2026-99-99"));
+    assert!(!is_valid_since_date("2026-02-30")); // February never has 30 days
+    assert!(!is_valid_since_date("2026-04-31")); // April has 30 days
+    assert!(!is_valid_since_date("2026-00-10")); // month 0
+    assert!(is_valid_since_date("2026-02-28"));
+    assert!(is_valid_since_date("2024-02-29")); // 2024 is a leap year
+    assert!(!is_valid_since_date("2026-02-29")); // 2026 is not
+    assert!(!is_valid_since_date("1900-02-29")); // divisible by 100, not 400
+    assert!(is_valid_since_date("2000-02-29")); // divisible by 400
+}
+
 // ── through `edda decide` — these mutate process env, so they take the
 //    shared guard in `crate::test_support` (one test binary, one lock) ──
 

--- a/crates/edda-cli/src/cmd_ratify/tests.rs
+++ b/crates/edda-cli/src/cmd_ratify/tests.rs
@@ -51,6 +51,9 @@ fn args(key: Option<&str>) -> RatifyArgs {
         evidence: None,
         by_rule: None,
         dry_run: false,
+        keys: Vec::new(),
+        since: None,
+        yes: false,
         session: None,
     }
 }
@@ -148,7 +151,13 @@ fn ratify_records_a_separate_event_never_a_mutation() {
 
 // ── rule form (GH-761) ──────────────────────────────────────────────
 
-/// The four cases named in GH-761's doneWhen, on one fixture ledger.
+/// The four cases named in GH-761's original doneWhen, on one fixture
+/// ledger. Case 3 used to be "a later decision's reason names it" — that
+/// was the GH-1066 bug itself (see `mention_alone_does_not_hold_it_through_the_cli`
+/// below for the proof it no longer holds), so this fixture now demonstrates
+/// the domain guard that replaced it: `review.auto-merge` is ratified
+/// *before* the sweep runs, so it is already binding when the sweep judges
+/// `review.old-gate`.
 fn four_case_ledger() -> (std::path::PathBuf, edda_ledger::Ledger) {
     let (tmp, ledger) = setup_workspace();
     // 1. cited → ratified
@@ -161,15 +170,23 @@ fn four_case_ledger() -> (std::path::PathBuf, edda_ledger::Ledger) {
         "pricing",
         &["operator:2026-09-03"],
     );
-    // 3. superseded → held (a later decision's reason names it)
+    // 3. domain guard (GH-1066) → held: a later, binding ruling in the same
+    // domain overtook it in substance, even though nothing names it.
     decide(
         &ledger,
-        "review.engine",
-        "opus",
+        "review.old-gate",
+        "manual",
         "per #900",
         &["issue:#900"],
     );
-    decide(&ledger, "review.pool", "two", "replaces review.engine", &[]);
+    decide(
+        &ledger,
+        "review.auto-merge",
+        "mechanical",
+        "the gate is now automatic",
+        &["operator:2026-09-03"],
+    );
+    run(&tmp, &args(Some("review.auto-merge"))).unwrap();
     // 4. no citation → held
     decide(&ledger, "cache.ttl", "60s", "seems about right", &[]);
     (tmp, ledger)
@@ -183,6 +200,9 @@ fn rule_args(dry_run: bool) -> RatifyArgs {
         evidence: None,
         by_rule: Some(RULE_CITED_AUTHORITY.to_string()),
         dry_run,
+        keys: Vec::new(),
+        since: None,
+        yes: false,
         session: None,
     }
 }
@@ -194,7 +214,10 @@ fn rule_ratifies_only_the_cited_unheld_decision() {
 
     assert!(is_binding(&ledger, "db.engine"), "cited → ratified");
     assert!(!is_binding(&ledger, "product.tier"), "product.* → held");
-    assert!(!is_binding(&ledger, "review.engine"), "superseded → held");
+    assert!(
+        !is_binding(&ledger, "review.old-gate"),
+        "domain guard → held"
+    );
     assert!(!is_binding(&ledger, "cache.ttl"), "no citation → held");
     let _ = std::fs::remove_dir_all(&tmp);
 }
@@ -202,8 +225,13 @@ fn rule_ratifies_only_the_cited_unheld_decision() {
 #[test]
 fn dry_run_writes_nothing() {
     let (tmp, ledger) = four_case_ledger();
+    let before = ratify_events(&ledger).len();
     run(&tmp, &rule_args(true)).unwrap();
-    assert!(ratify_events(&ledger).is_empty());
+    assert_eq!(
+        ratify_events(&ledger).len(),
+        before,
+        "dry run must write nothing new"
+    );
     assert!(!is_binding(&ledger, "db.engine"));
     let _ = std::fs::remove_dir_all(&tmp);
 }
@@ -216,17 +244,20 @@ fn rule_ratifications_are_distinguishable_from_operator_ones() {
     run(&tmp, &rule_args(false)).unwrap();
 
     let events = ratify_events(&ledger);
-    assert_eq!(events.len(), 1);
+    let db_engine = events
+        .iter()
+        .find(|e| e.payload["key"] == "db.engine")
+        .expect("the rule ratifies db.engine");
     assert_eq!(
-        events[0].payload["ratified_by"],
+        db_engine.payload["ratified_by"],
         format!("rule:{RULE_CITED_AUTHORITY}")
     );
     assert!(
-        events[0].payload["note"]
+        db_engine.payload["note"]
             .as_str()
             .is_some_and(|n| n.contains("issue:#742")),
         "the matched citation rides along: {:?}",
-        events[0].payload["note"]
+        db_engine.payload["note"]
     );
     let _ = std::fs::remove_dir_all(&tmp);
 }
@@ -234,9 +265,16 @@ fn rule_ratifications_are_distinguishable_from_operator_ones() {
 #[test]
 fn a_second_sweep_is_a_no_op() {
     let (tmp, ledger) = four_case_ledger();
+    let before = ratify_events(&ledger).len();
     run(&tmp, &rule_args(false)).unwrap();
+    let after_first = ratify_events(&ledger).len();
+    assert_eq!(after_first, before + 1, "sweep ratifies exactly db.engine");
     run(&tmp, &rule_args(false)).unwrap();
-    assert_eq!(ratify_events(&ledger).len(), 1);
+    assert_eq!(
+        ratify_events(&ledger).len(),
+        after_first,
+        "second sweep must not append"
+    );
     let _ = std::fs::remove_dir_all(&tmp);
 }
 
@@ -277,6 +315,305 @@ fn sweeping_an_empty_ledger_is_not_an_error() {
     let (tmp, _ledger) = setup_workspace();
     run(&tmp, &rule_args(true)).unwrap();
     let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn mention_alone_does_not_hold_it_through_the_cli() {
+    // GH-1066, end to end through `run`: `review.pool` mentions
+    // `review.engine` in passing while explaining itself. Before this fix
+    // that alone held `review.engine` — the exact bug the issue reports at
+    // scale (the operator's plain-flow rulings held, the mentions ratified).
+    let (tmp, ledger) = setup_workspace();
+    decide(
+        &ledger,
+        "review.engine",
+        "opus",
+        "per #900",
+        &["issue:#900"],
+    );
+    decide(&ledger, "review.pool", "two", "replaces review.engine", &[]);
+    run(&tmp, &rule_args(false)).unwrap();
+    assert!(
+        is_binding(&ledger, "review.engine"),
+        "a mention must not hold a validly cited decision"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+// ── GH-1066 acceptance scenario ──────────────────────────────────────
+//
+// Reconstructs the shape of the real 2026-09-07 `--by-rule cited-authority
+// --dry-run` sweep the issue reports (176 rows, 97 ratify / 79 hold): five
+// real, plain-flow rulings the old rule held only because a later decision
+// happened to name them while building on them, and four real 2026-08
+// rail-closeout entries (`d-013`..`d-034`) that a blind sweep would have
+// re-ratified because nothing named them, even though a later, binding
+// ruling (`review.auto-merge`) had already overtaken the whole merge-
+// authority area in substance. Keys, relative order, and citations are
+// drawn from the real ledger (verified read-only against this project's own
+// `.edda` while diagnosing GH-1066, before any code changed); reasons are
+// paraphrased, not quoted verbatim.
+//
+// One thing this fixture does *not* claim: that the four `d-NNN.*` keys
+// share a domain with `review.auto-merge`, or with each other. Each `d-NNN`
+// key is its own historical identifier — a `d-032` decision and a `d-034`
+// decision are never in the same domain by construction, the same way
+// `d-032` is never in the same domain as `review.*`. The domain guard
+// (proven separately above, and via `four_case_ledger`'s case 3) cannot
+// mechanically connect them without inferring a relationship the ledger
+// never recorded, which is the exact kind of inference GH-1066 removes. The
+// `--since` date guard is what actually keeps this specific 2026-08 batch
+// out of an unscoped sweep — proven below — and is the mechanism the issue
+// titles "No domain OR date guard" (bullet 2): either guard protecting a
+// given row is sufficient; this batch is protected by the date guard.
+fn gh1066_snapshot_ledger() -> (std::path::PathBuf, edda_ledger::Ledger) {
+    let (tmp, ledger) = setup_workspace();
+
+    // 2026-08-14/15: a PR-rail closeout batch. Each key is its own
+    // historical `d-NNN` identifier, never revisited under that exact key
+    // except d-033 (below) — so each is alone in its own domain.
+    decide(
+        &ledger,
+        "d-013.final_gate",
+        "task22",
+        "verifier gate per task #22",
+        &[],
+    );
+    decide(
+        &ledger,
+        "d-032.fresh_premerge_gate",
+        "pass",
+        "integration rerun per PRs #459/#460/#461",
+        &[],
+    );
+    decide(
+        &ledger,
+        "d-033.merge_authority",
+        "required",
+        "no merge without explicit delegation, per PR #459",
+        &[],
+    );
+    decide(
+        &ledger,
+        "d-034.merge_authority",
+        "granted",
+        "operator authorized the merge order per PR #459",
+        &[],
+    );
+
+    // 2026-09-02/03: fleet.lane-launch, then the ruling that supersedes the
+    // whole 2026-08 merge-authority regime in substance, never by name.
+    decide(
+        &ledger,
+        "fleet.lane-launch",
+        "profile-a",
+        "per the lane launcher design",
+        &[],
+    );
+    decide(
+        &ledger,
+        "review.auto-merge",
+        "gate-green-merges-by-machine",
+        "Tim: merge authority moves to the gate",
+        &["operator:2026-09-03"],
+    );
+    run(&tmp, &args(Some("review.auto-merge"))).unwrap();
+
+    // 2026-09-06/07: the operator's plain-flow rulings, each cited by date,
+    // and a later decision that only *builds on* them by mentioning them.
+    decide(
+        &ledger,
+        "review.readonly-proof",
+        "watcher-only",
+        "Tim 2026-09-06",
+        &["operator:2026-09-06"],
+    );
+    decide(
+        &ledger,
+        "review.merge-gate",
+        "single-aggregate",
+        "Tim 2026-09-07",
+        &["operator:2026-09-07"],
+    );
+    decide(
+        &ledger,
+        "review.default-path",
+        "watch-first",
+        "Tim 2026-09-07",
+        &["operator:2026-09-07"],
+    );
+    decide(
+        &ledger,
+        "review.watcher",
+        "poll-interval",
+        "Tim 2026-09-07",
+        &["operator:2026-09-07"],
+    );
+    decide(
+        &ledger,
+        "review.shell-branch",
+        "controller-owned",
+        "builds on review.default-path and review.watcher",
+        &[],
+    );
+
+    // The real stopgap the operator recorded once GH-1066 was diagnosed: a
+    // same-key redecision of d-033, so the engine can see it without a fix.
+    decide(
+        &ledger,
+        "d-033.merge_authority",
+        "superseded-by-review.auto-merge",
+        "housekeeping under review.auto-merge and review.merge-gate",
+        &[],
+    );
+
+    (tmp, ledger)
+}
+
+#[test]
+fn gh1066_plain_flow_rulings_ratify_despite_being_named_by_a_later_decision() {
+    let (tmp, ledger) = gh1066_snapshot_ledger();
+    let branch = ledger.head_branch().unwrap();
+    let (candidates, binding) = collect(&ledger, &branch).unwrap();
+    let verdicts = evaluate(&candidates, &binding);
+
+    for key in [
+        "review.readonly-proof",
+        "review.merge-gate",
+        "review.default-path",
+        "review.watcher",
+    ] {
+        let v = verdicts.iter().find(|v| v.key == key).unwrap();
+        assert!(v.is_ratify(), "{key}: {v:?}");
+    }
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn gh1066_same_key_stopgap_holds_the_original_d033_row() {
+    let (tmp, ledger) = gh1066_snapshot_ledger();
+    let branch = ledger.head_branch().unwrap();
+    let (candidates, binding) = collect(&ledger, &branch).unwrap();
+    let verdicts = evaluate(&candidates, &binding);
+
+    let d033: Vec<_> = verdicts
+        .iter()
+        .filter(|v| v.key == "d-033.merge_authority")
+        .collect();
+    assert_eq!(d033.len(), 2, "two rows share this key: {d033:?}");
+    let held = d033.iter().find(|v| !v.is_ratify()).unwrap();
+    assert!(
+        held.columns().1.starts_with("superseded-by-same-key"),
+        "{held:?}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn gh1066_since_bound_keeps_the_rail_closeout_batch_out_of_the_sweep() {
+    // The date guard (GH-1066): without a same-key or same-domain signal
+    // available, `--since` is what an operator who knows this batch is
+    // legacy actually uses to keep it out of an unscoped sweep.
+    let (tmp, ledger) = gh1066_snapshot_ledger();
+    let mut a = rule_args(false);
+    a.since = Some("2026-08-20".to_string());
+    run(&tmp, &a).unwrap();
+
+    for key in [
+        "d-013.final_gate",
+        "d-032.fresh_premerge_gate",
+        "d-034.merge_authority",
+    ] {
+        assert!(
+            !is_binding(&ledger, key),
+            "{key} must stay out of a --since-bound sweep"
+        );
+    }
+    assert!(is_binding(&ledger, "review.default-path"));
+    assert!(is_binding(&ledger, "review.watcher"));
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn gh1066_without_since_the_rail_closeout_batch_would_have_ratified() {
+    // The negative control for the test above: proves --since is load-
+    // bearing here, not incidental — without it, these PR/task-number
+    // "citations" (real quirk, out of GH-1066's scope) let d-034 through.
+    let (tmp, ledger) = gh1066_snapshot_ledger();
+    run(&tmp, &rule_args(false)).unwrap();
+    assert!(is_binding(&ledger, "d-034.merge_authority"));
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+// ── sweep bounding and the unbounded-sweep threshold (GH-1066) ─────────
+
+#[test]
+fn unbounded_sweep_refuses_past_the_threshold_without_yes() {
+    let (tmp, ledger) = setup_workspace();
+    for i in 0..=RATIFY_THRESHOLD {
+        decide(
+            &ledger,
+            &format!("k.item{i}"),
+            "v",
+            &format!("per #{i}"),
+            &[],
+        );
+    }
+    run(&tmp, &rule_args(false)).unwrap();
+    assert!(
+        ratify_events(&ledger).is_empty(),
+        "must refuse and write nothing past the threshold"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn unbounded_sweep_proceeds_past_the_threshold_with_yes() {
+    let (tmp, ledger) = setup_workspace();
+    for i in 0..=RATIFY_THRESHOLD {
+        decide(
+            &ledger,
+            &format!("k.item{i}"),
+            "v",
+            &format!("per #{i}"),
+            &[],
+        );
+    }
+    let mut a = rule_args(false);
+    a.yes = true;
+    run(&tmp, &a).unwrap();
+    assert_eq!(ratify_events(&ledger).len(), RATIFY_THRESHOLD + 1);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn key_bound_sweep_ignores_the_threshold() {
+    let (tmp, ledger) = setup_workspace();
+    for i in 0..=RATIFY_THRESHOLD {
+        decide(
+            &ledger,
+            &format!("k.item{i}"),
+            "v",
+            &format!("per #{i}"),
+            &[],
+        );
+    }
+    let mut a = rule_args(false);
+    a.keys = vec!["k.item0".to_string()];
+    run(&tmp, &a).unwrap();
+    assert_eq!(ratify_events(&ledger).len(), 1);
+    assert!(is_binding(&ledger, "k.item0"));
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn well_formed_since_passes_through_unchanged() {
+    // `usage_exit` on the malformed path calls `std::process::exit(2)`
+    // directly (documented in `ratify_exit_codes.rs`) — not a panic, so it
+    // cannot be exercised from an in-process unit test without aborting the
+    // whole test binary. `ratify_exit_codes.rs::malformed_since_exits_2`
+    // covers that path through a spawned binary instead.
+    assert_eq!(validate_since("2026-08-20"), "2026-08-20");
 }
 
 // ── through `edda decide` — these mutate process env, so they take the
@@ -353,6 +690,9 @@ fn ratify_records_separate_event_and_makes_decision_binding() {
             evidence: None,
             by_rule: None,
             dry_run: false,
+            keys: Vec::new(),
+            since: None,
+            yes: false,
             session: None,
         },
     )
@@ -395,6 +735,9 @@ fn ratify_unknown_key_errors() {
             evidence: None,
             by_rule: None,
             dry_run: false,
+            keys: Vec::new(),
+            since: None,
+            yes: false,
             session: None,
         },
     )

--- a/crates/edda-cli/tests/ratify_exit_codes.rs
+++ b/crates/edda-cli/tests/ratify_exit_codes.rs
@@ -102,6 +102,26 @@ fn malformed_since_exits_2() {
 }
 
 #[test]
+fn since_with_an_impossible_calendar_date_exits_2() {
+    // PR #1098 Round 1 P2: the shape-only check accepted `2026-99-99` (right
+    // length, dashes in the right places) even though no such date exists.
+    let env = TestEnv::new();
+    let (code, stdout, stderr) = env.run_edda(&[
+        "ratify",
+        "--by-rule",
+        "cited-authority",
+        "--since",
+        "2026-99-99",
+    ]);
+
+    assert_eq!(code, 2, "stdout={stdout:?} stderr={stderr:?}");
+    assert!(
+        stderr.contains("--since"),
+        "stderr should name the malformed flag, got: {stderr:?}"
+    );
+}
+
+#[test]
 fn since_without_by_rule_exits_2() {
     let env = TestEnv::new();
     let (code, stdout, stderr) = env.run_edda(&["ratify", "db.engine", "--since", "2026-09-01"]);

--- a/crates/edda-cli/tests/ratify_exit_codes.rs
+++ b/crates/edda-cli/tests/ratify_exit_codes.rs
@@ -84,6 +84,32 @@ fn unknown_rule_exits_2() {
 }
 
 #[test]
+fn malformed_since_exits_2() {
+    let env = TestEnv::new();
+    let (code, stdout, stderr) = env.run_edda(&[
+        "ratify",
+        "--by-rule",
+        "cited-authority",
+        "--since",
+        "not-a-date",
+    ]);
+
+    assert_eq!(code, 2, "stdout={stdout:?} stderr={stderr:?}");
+    assert!(
+        stderr.contains("--since"),
+        "stderr should name the malformed flag, got: {stderr:?}"
+    );
+}
+
+#[test]
+fn since_without_by_rule_exits_2() {
+    let env = TestEnv::new();
+    let (code, stdout, stderr) = env.run_edda(&["ratify", "db.engine", "--since", "2026-09-01"]);
+
+    assert_eq!(code, 2, "stdout={stdout:?} stderr={stderr:?}");
+}
+
+#[test]
 fn key_together_with_by_rule_exits_2() {
     let env = TestEnv::new();
     let (code, stdout, stderr) =

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -233,6 +233,9 @@ edda ratify --by-rule <RULE> [--dry-run] [OPTIONS]
 | `--evidence pr#N@SHA` | The merged PR that made this decision binding. The SHA is a full 40-hex commit; an abbreviated one is refused |
 | `--by-rule RULE` | Sweep every active, unratified decision with a named rule. Today: `cited-authority` |
 | `--dry-run` | With `--by-rule`: print the table and write nothing |
+| `--key KEY` | With `--by-rule`: only judge this key (repeatable). Bounds the sweep (GH-1066) — with this set, the unbounded-sweep size refusal below does not apply |
+| `--since DATE` | With `--by-rule`: only judge decisions recorded on or after `DATE` — a real calendar date, `YYYY-MM-DD`; a malformed or impossible one (e.g. `2026-99-99`) exits 2. Bounds the sweep the same way `--key` does (GH-1066) |
+| `--yes` | With `--by-rule`, and neither `--key` nor `--since` given: proceed even though the sweep's ratify count exceeds the safety threshold (20). Without it, an unscoped sweep that would ratify more than the threshold prints the table and refuses, writing nothing (GH-1066) |
 | `--session ID` | Session ID (uses `EDDA_SESSION_ID`; `--session` required when identity is ambiguous) |
 
 Exit codes (`claim-check.exit-codes=0/1/2`): **0** success, including the no-op
@@ -261,8 +264,17 @@ or the word "operator" in its reason. It holds:
 
 - keys under `product.`, `commercial.` and `spend.` — these bind money or
   product promises, and a cited issue is not authority for either;
-- anything a later decision's reason names, which has already been overtaken;
-- anything with no citation at all.
+- a decision superseded by a later one recorded under the identical key
+  (`superseded-by-same-key`);
+- a decision a later reason **explicitly** marks as superseded —
+  `supersedes:<key>`, bare `SUPERSEDES <key>`, or `顯式取代<key>` immediately
+  naming it, never merely mentioning it elsewhere in the prose
+  (`superseded-explicit`; GH-1066 removed the old mention-based inference,
+  which held anything a later reason happened to name);
+- a decision whose governance domain (its key up to the first `.`) has a
+  later ruling that is already binding — `older-than-binding-in-domain`, the
+  GH-1066 domain guard;
+- anything with no citation at all (`no-citation`).
 
 `--dry-run` prints the same table it would act on, so the sweep can be read
 before it runs:
@@ -271,9 +283,24 @@ before it runs:
 key                action  why
 db.engine          ratify  issue:#742
 product.tier       hold    held domain 'product.' — operator ratifies these
-review.engine      hold    superseded — a later decision 'review.pool' names it
-cache.ttl          hold    no citation — add --cite operator:<when> | issue:#<n> | decision:<key>
+review.old-gate    hold    older-than-binding-in-domain — 'review.auto-merge' is binding and newer in domain 'review'
+cache.ttl          hold    no-citation — add --cite operator:<when> | issue:#<n> | decision:<key>
 dry run — would ratify 1, hold 3 (rule: cited-authority); nothing written.
+```
+
+By default the sweep is unscoped: `--by-rule` alone judges every active,
+unratified decision on the branch, and writing more than 20 ratifications
+this way is refused unless `--yes` is also given (GH-1066) — the table above
+still prints so the refusal is never silent. `--key`/`--since` bound *which*
+verdicts are shown and written, without changing what the rule sees while
+judging same-key or domain-guard supersession: an older, still-relevant
+ruling stays visible to the rule even when the sweep's own output is scoped
+away from it.
+
+```bash
+edda ratify --by-rule cited-authority --key db.engine --key review.old-gate
+edda ratify --by-rule cited-authority --since 2026-09-01
+edda ratify --by-rule cited-authority --yes
 ```
 
 Ratification is per decision event, not per key: re-deciding a key resets it to


### PR DESCRIPTION
## Summary

`edda ratify --by-rule cited-authority` used to infer supersession from a
name mention: if a later decision's reason merely *named* an earlier key
while building on it, the earlier (correctly-cited) key was held. On the
2026-09-07 sweep (176 rows) this held the operator's five most-cited,
plain-flow rulings and would have ratified four rows of a superseded
merge-authority regime that a later, binding decision had overtaken in
substance but never named.

- Supersession is now explicit, never inferred from a mention: only a
  later decision under the **same key**, or one carrying an **explicit**
  `supersedes:<key>` marker (plus the pre-existing `SUPERSEDES` / `顯式取代`
  phrasings already on the ledger — recognised, not migrated), counts.
- Four distinguishable hold reasons: `superseded-by-same-key`,
  `superseded-explicit`, `no-citation`, `older-than-binding-in-domain`
  (the new domain guard: an unratified decision whose key shares a domain
  prefix with a later **binding** decision is held and shown, never
  auto-ratified).
- `--by-rule` now accepts `--key <KEY>` (repeatable) and `--since <date>`
  to bound a sweep; the unbounded form refuses past a 20-ratify threshold
  without `--yes`.

## This PR carries two authors' work — here is the split

The first fix lane on this issue died with its edits uncommitted. The
controller preserved that state as commit `de79b22` (683 insertions / 36
deletions across `cmd_ratify/{mod,rule,tests}.rs` and
`tests/ratify_exit_codes.rs`) and pushed it — **not verified, not gated,
not reviewed; no test had ever been run against it.** I picked up from
there as a replacement lane, per the addendum's instruction to audit
before adding anything.

**`cargo test -p edda` on the preserved commit: 744 passed, 2 failed.**
Both failures were real bugs in the fixture, not flakiness:

1. `gh1066_same_key_stopgap_holds_the_original_d033_row` assumed
   `active_decisions()` can return two active rows for one `(branch,
   key)`. It cannot — the ledger deactivates a key's prior row in the
   same write that appends a same-key successor (`UPDATE decisions SET
   is_active = FALSE ... WHERE key = ? AND branch = ?`,
   `sqlite_store/events.rs:136-141`), which predates GH-1066 entirely.
   The fixture's fabricated "same-key stopgap" scenario for
   `d-033.merge_authority` could never produce the two rows the test
   expected. I removed the fabricated block (its target coverage — one
   ratify event per re-decided key — was already proven by the
   pre-existing `a_re_decided_key_is_ratified_once_not_once_per_row`)
   and corrected the stale `collect()` comment that stated the false
   premise.
2. `gh1066_since_bound_keeps_the_rail_closeout_batch_out_of_the_sweep`
   asserted `--since 2026-08-20` keeps the 2026-08 rail-closeout batch
   out of the sweep, but the fixture's `decide()` helper always stamps
   `ts` as real wall-clock "now" — every row in the fixture carried
   *today's* date regardless of its narrative comment, so `--since`
   filtered nothing. Added a `decide_at` test helper that stamps a
   caller-given RFC3339 timestamp (re-finalizing the event, since the
   hash covers `ts`) and used it for the four 2026-08 rows.

Fixed and pushed as a second commit on this branch; `rule.rs` and
`evidence.rs` were untouched by either lane.

## One doneWhen nuance for review

The issue's acceptance bullet says the four old-constitution rows
(`d-013.final_gate`, `d-032.fresh_premerge_gate`, `d-033.merge_authority`,
`d-034.merge_authority`) become `hold: older-than-binding-in-domain`.
In this fixture they do not — they are kept out of an *unscoped* sweep by
the `--since` date guard instead, and ratify (via the existing
issue-number citation fallback, out of this issue's scope) when `--since`
is omitted. Reason: `domain` is `text before the first '.'` throughout
the codebase (`edda_core::decision::extract_domain`, mirrored here by
`rule.rs::domain_of`), so `d-013`/`d-032`/`d-033`/`d-034` are each their
own domain — none of them is `review`. Connecting them to
`review.auto-merge` would mean inferring a relationship the ledger never
recorded, which is the exact kind of inference GH-1066 removes. The
issue's own bullet title is "No domain **or** date guard" — this batch is
the case the date guard covers; the domain guard is proven separately
(`domain_guard_holds_older_candidate_behind_a_later_binding_sibling` and
`four_case_ledger`'s case 3) against keys that do share a real domain
prefix with a later binding sibling.

Flagging this rather than silently reinterpreting the doneWhen text or
fabricating a domain match in the fixture — this is the "supersession
semantics are the judgment" call the issue itself predicted.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p edda --all-targets -- -D warnings` — clean
- [x] `cargo test -p edda` — 745 unit tests + all `edda-cli` integration
      binaries (including `tests/ratify_exit_codes.rs`, which never ran
      against the preserved commit because `cargo test` stops after the
      first failing binary) — 0 failed
- [x] `scripts/lint-file-length.sh --tree` — clean
- [x] `supersede_only_looks_forward` and the other pre-existing
      `rule.rs` tests pass unmodified

Issue: #1066
Closes #1066

🤖 Generated with [Claude Code](https://claude.com/claude-code)
