### PR TITLE
fix(fleet): a review round posted by a subagent reaches no one (GH-993)

### DIFF
--- a/scripts/fleet/daily-digest.sh
+++ b/scripts/fleet/daily-digest.sh
@@ -163,6 +163,20 @@ open_rows=$(gh pr list --repo "$EDDA_REPO" --state open --limit "$open_pr_limit"
 # takes the same failure path as a gh failure below. GH_OPEN_JSON is cleared
 # for the subprocess so a test fixture written for this script's own
 # post-jq `gh pr list` output is not re-parsed as raw JSON by the drift check.
+#
+# GH-993: verdict-drift.sh may now also append `orphan-response=Round-<N>`
+# — a Review Response answering a round that was never posted (the failure
+# #974/#976/#980/#981 shipped: a completed review whose report reached no
+# one but the implementer's answer to it). No parsing change was needed
+# here for it: it is one more trailing token on the same line, and the awk
+# pass below already forwards every field past the state ($5..$NF)
+# verbatim into the digest row. This digest still only REPORTS — it has
+# always captured drift_rc without blocking on it, by design, since GH-765:
+# a digest that refused to post because the fleet was imperfect would be
+# less useful than the report itself. The caller that now BLOCKS on this
+# same check is scripts/merge-reviewed-pr.sh, run before any --check or
+# --merge; see the comment above its own call for why that entrypoint and
+# not this one.
 drift_out="$tmp/drift.txt"
 drift_rc=0
 GH_OPEN_JSON= EDDA_OPEN_PR_LIMIT="$open_pr_limit" sh "$self_dir/verdict-drift.sh" >"$drift_out" 2>"$tmp/drift.err" || drift_rc=$?

--- a/scripts/fleet/test-daily-digest.sh
+++ b/scripts/fleet/test-daily-digest.sh
@@ -272,6 +272,25 @@ limits=$(grep -- '--state open' "$GH_STUB_LOG" | sed -n 's/.*--limit \([0-9]*\).
     || fail "case 3c: digest and verdict-drift enumerate different --limit values: $(printf '%s' "$limits" | tr '\n' ' ')"
 unset GH_DRIFT_OPEN_JSON GH_DRIFT_COMMENTS_JSON
 
+# --- case 3d: an orphan Review Response (GH-993) passes through unchanged -----
+# verdict-drift.sh may append `orphan-response=Round-<N>` to a drift line.
+# This proves the digest needs no parsing change for it: it is only more
+# trailing text on the same line, and the awk pass-through above already
+# forwards $5..$NF verbatim into the 擋住什麼 row.
+reset_stubs
+SHA80=8080808080808080808080808080808080808080
+printf '[{"number":80,"title":"Orphan response","mergeStateStatus":"CLEAN","headRefOid":"%s"}]\n' "$SHA80" >"$tmp/open-orphan.json"
+printf '[{"number":80,"headRefOid":"%s","baseRefName":"main","mergeable":"MERGEABLE"}]\n' "$SHA80" >"$tmp/drift-open-orphan.json"
+printf '{"comments":[{"body":"## Review Response: Round 1\\n\\nNew head: %s"}]}\n' "$SHA80" >"$tmp/drift-comments-orphan.json"
+export GH_OPEN_JSON="$tmp/open-orphan.json"
+export GH_DRIFT_OPEN_JSON="$tmp/drift-open-orphan.json"
+export GH_DRIFT_COMMENTS_JSON="$tmp/drift-comments-orphan.json"
+export EDDA_RECAP_FILE="$RECAP_CANNED"
+out=$(run_digest --dry-run 2>&1) || fail 'case 3d: daily-digest.sh exited non-zero'
+printf '%s\n' "$out" | grep -qF -- '- #80 Orphan response — no verdict on head orphan-response=Round-1' \
+    || fail "case 3d: orphan-response annotation missing from 擋住什麼, got: $(printf '%s' "$out" | grep '#80' || true)"
+unset GH_DRIFT_OPEN_JSON GH_DRIFT_COMMENTS_JSON
+
 # --- case 4: board comment with needs-operator lands under 例外 ----------------
 reset_stubs
 printf 'https://github.com/fagemx/edda/issues/613#issuecomment-1\tstatus header\nhttps://github.com/fagemx/edda/issues/613#issuecomment-1\tneeds-operator: relogin gh on 4090\nhttps://github.com/fagemx/edda/issues/613#issuecomment-1\tother details\n' >"$tmp/board.md"

--- a/scripts/fleet/test-daily-digest.sh
+++ b/scripts/fleet/test-daily-digest.sh
@@ -277,11 +277,17 @@ unset GH_DRIFT_OPEN_JSON GH_DRIFT_COMMENTS_JSON
 # This proves the digest needs no parsing change for it: it is only more
 # trailing text on the same line, and the awk pass-through above already
 # forwards $5..$NF verbatim into the 擋住什麼 row.
+#
+# `authorAssociation":"OWNER"` is required since Round 1 review's P1 fix:
+# verdict-drift.sh now trusts only OWNER/MEMBER/COLLABORATOR comments, so an
+# unannotated comment here would read as invisible rather than orphan —
+# see scripts/fleet/test-verdict-drift.sh cases 16-18 for the trust-filter
+# fixtures themselves.
 reset_stubs
 SHA80=8080808080808080808080808080808080808080
 printf '[{"number":80,"title":"Orphan response","mergeStateStatus":"CLEAN","headRefOid":"%s"}]\n' "$SHA80" >"$tmp/open-orphan.json"
 printf '[{"number":80,"headRefOid":"%s","baseRefName":"main","mergeable":"MERGEABLE"}]\n' "$SHA80" >"$tmp/drift-open-orphan.json"
-printf '{"comments":[{"body":"## Review Response: Round 1\\n\\nNew head: %s"}]}\n' "$SHA80" >"$tmp/drift-comments-orphan.json"
+printf '{"comments":[{"body":"## Review Response: Round 1\\n\\nNew head: %s","authorAssociation":"OWNER"}]}\n' "$SHA80" >"$tmp/drift-comments-orphan.json"
 export GH_OPEN_JSON="$tmp/open-orphan.json"
 export GH_DRIFT_OPEN_JSON="$tmp/drift-open-orphan.json"
 export GH_DRIFT_COMMENTS_JSON="$tmp/drift-comments-orphan.json"

--- a/scripts/fleet/test-verdict-drift.sh
+++ b/scripts/fleet/test-verdict-drift.sh
@@ -184,4 +184,56 @@ grep -q 'hit its limit' "$tmp/err" ||
 echo "PASS 11"
 unset GH_ARGV_LOG
 
+# --- case 12: an orphan Review Response holds the PR (GH-993) ------------------
+# The observed defect, as a fixture: PRs #974/#976/#980/#981 each carried a
+# `## Review Response: Round 1` and no `## Code Review: Round 1` at all —
+# real body captured 2026-09-06T06:19:40Z via `gh api .../issues/974/comments`.
+SHA7=7777777777777777777777777777777777777777
+printf '[{"number":12,"headRefOid":"%s","baseRefName":"main"}]\n' "$SHA7" >"$tmp/prs.json"
+printf '{"comments":[{"body":"## Review Response: Round 1\\n\\nNew head: `%s`\\n\\n### f1 — fixed"}]}\n' "$SHA7" >"$tmp/comments-12.json"
+run_drift
+expect 12 1 "#12 777777777777 main no verdict on head orphan-response=Round-1"
+
+# --- case 13: a response answering a round that was really posted is clean ----
+# Ordinary Changes-Requested flow: Round 1 posted, pinned to head, the
+# implementer answers it. No orphan annotation. (The base state itself does
+# not hold the PR here — see the existing "else" branch above: a head
+# verdict that resolves Changes Requested is a visible signal, not drift.)
+SHA8=8888888888888888888888888888888888888888
+printf '[{"number":13,"headRefOid":"%s","baseRefName":"main"}]\n' "$SHA8" >"$tmp/prs.json"
+printf '{"comments":[{"body":"## Code Review: Round 1 — PR #13 @ %s\\n\\n### Verdict\\nChanges Requested, P0=0, P1=1"},{"body":"## Review Response: Round 1\\n\\nNew head: unchanged"}]}\n' "$SHA8" >"$tmp/comments-13.json"
+run_drift
+expect 13 0 "#13 888888888888 main Changes Requested"
+
+# --- case 14: the #974 repair shape — an old orphan does not re-trigger -------
+# Round 1's response is answered by nothing, permanently (the repair chosen
+# for #974/#976/#980/#981 never backfills a Round 1 Code Review — it jumps
+# straight to Round 2, each recording that Round 1's report is absent). Only
+# the NEWEST response is judged, and it is Round 2's, which IS paired — so a
+# PR that recovered this way must read clean, or this check would have
+# permanently blocked the very PRs GH-993's own repair produced. Sequence
+# mirrors the real PR #974 comment order exactly: Response 1, Review 2,
+# Response 2, Review 3 (LGTM, pinned to head).
+SHA9=9999999999999999999999999999999999999999
+SHAMID=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+printf '[{"number":14,"headRefOid":"%s","baseRefName":"main"}]\n' "$SHA9" >"$tmp/prs.json"
+{
+    printf '{"comments":['
+    printf '{"body":"## Review Response: Round 1\\n\\nNew head: %s"},' "$SHAMID"
+    printf '{"body":"## Code Review: Round 2 — PR #14 @ %s\\n\\n### Verdict\\nChanges Requested, P0=0, P1=1"},' "$SHAMID"
+    printf '{"body":"## Review Response: Round 2\\n\\nNew head: %s"},' "$SHA9"
+    printf '{"body":"## Code Review: Round 3 — PR #14 @ %s\\n\\n### Verdict\\nLGTM (P0=0, P1=0)"}' "$SHA9"
+    printf ']}\n'
+} >"$tmp/comments-14.json"
+run_drift
+expect 14 0 "#14 999999999999 main LGTM"
+
+# --- case 15: a Review Response heading not on the first line is not a --------
+# trigger, symmetric with case 6's identical rule for Code Review headings.
+SHA10=cccccccccccccccccccccccccccccccccccccccc
+printf '[{"number":15,"headRefOid":"%s","baseRefName":"main"}]\n' "$SHA10" >"$tmp/prs.json"
+printf '{"comments":[{"body":"note first\\n## Review Response: Round 1\\n\\nignored"}]}\n' >"$tmp/comments-15.json"
+run_drift
+expect 15 1 "#15 cccccccccccc main no verdict on head"
+
 echo "verdict-drift fixtures passed"

--- a/scripts/fleet/test-verdict-drift.sh
+++ b/scripts/fleet/test-verdict-drift.sh
@@ -92,13 +92,13 @@ SHAOLD=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 # --- case 1: verdict pinned to head, LGTM → exit 0 -----------------------------
 printf '[{"number":1,"headRefOid":"%s","baseRefName":"main"}]\n' "$SHA1" >"$tmp/prs.json"
-printf '{"comments":[{"body":"## Code Review: Round 1 — PR #1 @ %s\\n\\n### Verdict\\nLGTM (P0=0, P1=0)"}]}\n' "$SHA1" >"$tmp/comments-1.json"
+printf '{"comments":[{"body":"## Code Review: Round 1 — PR #1 @ %s\\n\\n### Verdict\\nLGTM (P0=0, P1=0)","authorAssociation":"OWNER"}]}\n' "$SHA1" >"$tmp/comments-1.json"
 run_drift
 expect 1 0 "#1 111111111111 main LGTM"
 
 # --- case 2: verdict pinned to an older SHA → stale, exit 1 (#899 regression) --
 printf '[{"number":2,"headRefOid":"%s","baseRefName":"main"}]\n' "$SHA2" >"$tmp/prs.json"
-printf '{"comments":[{"body":"## Code Review: Round 1 — PR #2 @ %s\\n\\n### Verdict\\nLGTM (P0=0, P1=0)"}]}\n' "$SHAOLD" >"$tmp/comments-2.json"
+printf '{"comments":[{"body":"## Code Review: Round 1 — PR #2 @ %s\\n\\n### Verdict\\nLGTM (P0=0, P1=0)","authorAssociation":"OWNER"}]}\n' "$SHAOLD" >"$tmp/comments-2.json"
 run_drift
 expect 2 1 "#2 222222222222 main stale from aaaaaaaaaaaa"
 
@@ -110,7 +110,7 @@ expect 3 1 "#3 333333333333 main no verdict on head"
 
 # --- case 4: only a (SHADOW) verdict on head → SHADOW only, exit 0 --------------
 printf '[{"number":4,"headRefOid":"%s","baseRefName":"main"}]\n' "$SHA4" >"$tmp/prs.json"
-printf '{"comments":[{"body":"## Code Review: Round 2 (SHADOW) — PR #4 @ %s\\n- shadow: true\\n\\n### Verdict\\nLGTM (P0=0, P1=0)"}]}\n' "$SHA4" >"$tmp/comments-4.json"
+printf '{"comments":[{"body":"## Code Review: Round 2 (SHADOW) — PR #4 @ %s\\n- shadow: true\\n\\n### Verdict\\nLGTM (P0=0, P1=0)","authorAssociation":"OWNER"}]}\n' "$SHA4" >"$tmp/comments-4.json"
 run_drift
 expect 4 0 "#4 444444444444 main SHADOW only"
 
@@ -123,7 +123,7 @@ expect 5 1 \
 
 # --- case 6: R23 heading mid-body is not a verdict (the #867 shape) -------------
 printf '[{"number":6,"headRefOid":"%s","baseRefName":"main"}]\n' "$SHA6" >"$tmp/prs.json"
-printf '{"comments":[{"body":"narration first\\n## Code Review: Round 3 — PR #867 @ %s\\nLGTM (P0=0, P1=0)"}]}\n' "$SHA6" >"$tmp/comments-6.json"
+printf '{"comments":[{"body":"narration first\\n## Code Review: Round 3 — PR #867 @ %s\\nLGTM (P0=0, P1=0)","authorAssociation":"OWNER"}]}\n' "$SHA6" >"$tmp/comments-6.json"
 run_drift
 expect 6 1 "#6 666666666666 main no verdict on head"
 
@@ -144,7 +144,7 @@ echo "PASS 7"
 # before says ready. R24's third field does not, and used to be left to the
 # digest's DIRTY row — invisible whenever this check ran standalone.
 printf '[{"number":8,"headRefOid":"%s","baseRefName":"main","mergeable":"CONFLICTING"}]\n' "$SHA1" >"$tmp/prs.json"
-printf '{"comments":[{"body":"## Code Review: Round 1 — PR #8 @ %s\\n\\n### Verdict\\nLGTM (P0=0, P1=0)"}]}\n' "$SHA1" >"$tmp/comments-8.json"
+printf '{"comments":[{"body":"## Code Review: Round 1 — PR #8 @ %s\\n\\n### Verdict\\nLGTM (P0=0, P1=0)","authorAssociation":"OWNER"}]}\n' "$SHA1" >"$tmp/comments-8.json"
 run_drift
 expect 8 1 "#8 111111111111 main LGTM mergeable=CONFLICTING"
 
@@ -152,7 +152,7 @@ expect 8 1 "#8 111111111111 main LGTM mergeable=CONFLICTING"
 # GitHub has not computed the merge yet; that is a transient answer, not a
 # verdict, so it is annotated and the exit code stays 0.
 printf '[{"number":9,"headRefOid":"%s","baseRefName":"main","mergeable":"UNKNOWN"}]\n' "$SHA2" >"$tmp/prs.json"
-printf '{"comments":[{"body":"## Code Review: Round 1 — PR #9 @ %s\\n\\n### Verdict\\nLGTM (P0=0, P1=0)"}]}\n' "$SHA2" >"$tmp/comments-9.json"
+printf '{"comments":[{"body":"## Code Review: Round 1 — PR #9 @ %s\\n\\n### Verdict\\nLGTM (P0=0, P1=0)","authorAssociation":"OWNER"}]}\n' "$SHA2" >"$tmp/comments-9.json"
 run_drift
 expect 9 0 "#9 222222222222 main LGTM mergeable=UNKNOWN"
 
@@ -160,7 +160,7 @@ expect 9 0 "#9 222222222222 main LGTM mergeable=UNKNOWN"
 # digest (GH-958). The two scripts hardcoded 200 and 100, so a PR past the
 # digest's 100 got a line here that could never reach a digest row.
 printf '[{"number":10,"headRefOid":"%s","baseRefName":"main","mergeable":"MERGEABLE"}]\n' "$SHA3" >"$tmp/prs.json"
-printf '{"comments":[{"body":"## Code Review: Round 1 — PR #10 @ %s\\n\\n### Verdict\\nLGTM (P0=0, P1=0)"}]}\n' "$SHA3" >"$tmp/comments-10.json"
+printf '{"comments":[{"body":"## Code Review: Round 1 — PR #10 @ %s\\n\\n### Verdict\\nLGTM (P0=0, P1=0)","authorAssociation":"OWNER"}]}\n' "$SHA3" >"$tmp/comments-10.json"
 : >"$tmp/gh-argv.log"
 GH_ARGV_LOG="$tmp/gh-argv.log"
 export GH_ARGV_LOG
@@ -190,7 +190,7 @@ unset GH_ARGV_LOG
 # real body captured 2026-09-06T06:19:40Z via `gh api .../issues/974/comments`.
 SHA7=7777777777777777777777777777777777777777
 printf '[{"number":12,"headRefOid":"%s","baseRefName":"main"}]\n' "$SHA7" >"$tmp/prs.json"
-printf '{"comments":[{"body":"## Review Response: Round 1\\n\\nNew head: `%s`\\n\\n### f1 — fixed"}]}\n' "$SHA7" >"$tmp/comments-12.json"
+printf '{"comments":[{"body":"## Review Response: Round 1\\n\\nNew head: `%s`\\n\\n### f1 — fixed","authorAssociation":"OWNER"}]}\n' "$SHA7" >"$tmp/comments-12.json"
 run_drift
 expect 12 1 "#12 777777777777 main no verdict on head orphan-response=Round-1"
 
@@ -201,7 +201,7 @@ expect 12 1 "#12 777777777777 main no verdict on head orphan-response=Round-1"
 # verdict that resolves Changes Requested is a visible signal, not drift.)
 SHA8=8888888888888888888888888888888888888888
 printf '[{"number":13,"headRefOid":"%s","baseRefName":"main"}]\n' "$SHA8" >"$tmp/prs.json"
-printf '{"comments":[{"body":"## Code Review: Round 1 — PR #13 @ %s\\n\\n### Verdict\\nChanges Requested, P0=0, P1=1"},{"body":"## Review Response: Round 1\\n\\nNew head: unchanged"}]}\n' "$SHA8" >"$tmp/comments-13.json"
+printf '{"comments":[{"body":"## Code Review: Round 1 — PR #13 @ %s\\n\\n### Verdict\\nChanges Requested, P0=0, P1=1","authorAssociation":"OWNER"},{"body":"## Review Response: Round 1\\n\\nNew head: unchanged","authorAssociation":"OWNER"}]}\n' "$SHA8" >"$tmp/comments-13.json"
 run_drift
 expect 13 0 "#13 888888888888 main Changes Requested"
 
@@ -219,10 +219,10 @@ SHAMID=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 printf '[{"number":14,"headRefOid":"%s","baseRefName":"main"}]\n' "$SHA9" >"$tmp/prs.json"
 {
     printf '{"comments":['
-    printf '{"body":"## Review Response: Round 1\\n\\nNew head: %s"},' "$SHAMID"
-    printf '{"body":"## Code Review: Round 2 — PR #14 @ %s\\n\\n### Verdict\\nChanges Requested, P0=0, P1=1"},' "$SHAMID"
-    printf '{"body":"## Review Response: Round 2\\n\\nNew head: %s"},' "$SHA9"
-    printf '{"body":"## Code Review: Round 3 — PR #14 @ %s\\n\\n### Verdict\\nLGTM (P0=0, P1=0)"}' "$SHA9"
+    printf '{"body":"## Review Response: Round 1\\n\\nNew head: %s","authorAssociation":"OWNER"},' "$SHAMID"
+    printf '{"body":"## Code Review: Round 2 — PR #14 @ %s\\n\\n### Verdict\\nChanges Requested, P0=0, P1=1","authorAssociation":"OWNER"},' "$SHAMID"
+    printf '{"body":"## Review Response: Round 2\\n\\nNew head: %s","authorAssociation":"OWNER"},' "$SHA9"
+    printf '{"body":"## Code Review: Round 3 — PR #14 @ %s\\n\\n### Verdict\\nLGTM (P0=0, P1=0)","authorAssociation":"OWNER"}' "$SHA9"
     printf ']}\n'
 } >"$tmp/comments-14.json"
 run_drift
@@ -232,8 +232,47 @@ expect 14 0 "#14 999999999999 main LGTM"
 # trigger, symmetric with case 6's identical rule for Code Review headings.
 SHA10=cccccccccccccccccccccccccccccccccccccccc
 printf '[{"number":15,"headRefOid":"%s","baseRefName":"main"}]\n' "$SHA10" >"$tmp/prs.json"
-printf '{"comments":[{"body":"note first\\n## Review Response: Round 1\\n\\nignored"}]}\n' >"$tmp/comments-15.json"
+printf '{"comments":[{"body":"note first\\n## Review Response: Round 1\\n\\nignored","authorAssociation":"OWNER"}]}\n' >"$tmp/comments-15.json"
 run_drift
 expect 15 1 "#15 cccccccccccc main no verdict on head"
+
+# --- case 16: an untrusted-author verdict does not silence the check -----------
+# (Round 1 review, P1). This repo is PUBLIC: without an author filter, a §7-
+# shaped comment from ANY commenter would read as a real LGTM and clear the
+# PR. Byte-identical to case 1's LGTM-on-head shape — only the author trust
+# differs — so this isolates the filter rather than testing a new rule.
+# "NONE" is GitHub's real authorAssociation value for a user with no
+# relationship to the repo.
+SHA11=dddddddddddddddddddddddddddddddddddddddd
+printf '[{"number":16,"headRefOid":"%s","baseRefName":"main"}]\n' "$SHA11" >"$tmp/prs.json"
+printf '{"comments":[{"body":"## Code Review: Round 1 — PR #16 @ %s\\n\\n### Verdict\\nLGTM (P0=0, P1=0)","authorAssociation":"NONE"}]}\n' "$SHA11" >"$tmp/comments-16.json"
+run_drift
+expect 16 1 "#16 dddddddddddd main no verdict on head"
+
+# --- case 17: an untrusted-author Review Response does not hold the PR ---------
+# (Round 1 review, P1) — the other direction of the same finding: on a
+# public repo, anyone could otherwise post any `## Review Response: Round
+# N` (no SHA, no matching PR number required) and refuse every
+# --check/--merge in the fleet. Byte-identical to case 12's shape, only the
+# author trust differs: no orphan-response annotation, because the comment
+# is invisible to the check — not because it was judged and cleared.
+SHA12=eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+printf '[{"number":17,"headRefOid":"%s","baseRefName":"main"}]\n' "$SHA12" >"$tmp/prs.json"
+printf '{"comments":[{"body":"## Review Response: Round 9\\n\\nNew head: `%s`","authorAssociation":"NONE"}]}\n' "$SHA12" >"$tmp/comments-17.json"
+run_drift
+expect 17 1 "#17 eeeeeeeeeeee main no verdict on head"
+
+# --- case 18: a missing authorAssociation fails closed, same as an untrusted --
+# one (Round 1 review, P1) — "absent or unreadable" must not be treated as a
+# verdict either. Distinct from case 16: there the field is present and
+# untrusted; here the key is absent entirely, exercising jq's `null` path
+# (reading `.authorAssociation` off an object that never had the key), which
+# must compare unequal to every trusted value, not error and not default
+# open.
+SHA13=ffffffffffffffffffffffffffffffffffffffff
+printf '[{"number":18,"headRefOid":"%s","baseRefName":"main"}]\n' "$SHA13" >"$tmp/prs.json"
+printf '{"comments":[{"body":"## Code Review: Round 1 — PR #18 @ %s\\n\\n### Verdict\\nLGTM (P0=0, P1=0)"}]}\n' "$SHA13" >"$tmp/comments-18.json"
+run_drift
+expect 18 1 "#18 ffffffffffff main no verdict on head"
 
 echo "verdict-drift fixtures passed"

--- a/scripts/fleet/verdict-drift.sh
+++ b/scripts/fleet/verdict-drift.sh
@@ -7,11 +7,23 @@
 # reports CLEAN with zero verdicts.
 #
 # Output, one line per open PR:
-#   #<n> <head12> <base> <state> [ mergeable=<v> ] [ base=<branch> (...) ]
+#   #<n> <head12> <base> <state> [ mergeable=<v> ] [ base=<branch> (...) ] [ orphan-response=Round-<N> ]
 # with <state> one of:
 #   no verdict on head | stale from <sha12> | SHADOW only | LGTM | Changes Requested
 # The base annotation is appended when the PR's base is not `main`, whose
 # status contexts are the only ones any ruleset enforces.
+#
+# GH-993: `orphan-response=Round-<N>` is appended when the newest
+# `## Review Response: Round N` comment on the PR answers a round that was
+# never posted — a completed review whose report reached no one but the
+# implementer's answer to it (the observed failure: PRs #974/#976/#980/#981
+# each carried a `Review Response: Round 1` and no `Code Review: Round 1`).
+# Matching is by round NUMBER only, not SHA — a response answering an old,
+# superseded round is still answering a round that is really there. Only the
+# NEWEST response is judged, so a PR that recovered by moving straight to a
+# later, properly paired round (the #974 repair shape: Round 1's response
+# stays permanently unanswered, but Round 2 is posted and paired) reads
+# clean. This annotation holds the PR (not_ready=1) independent of <state>.
 #
 # GH-958: R24 names THREE readiness fields, and this check now covers all
 # three — (1) the newest verdict's SHA equals the head, (2) the
@@ -26,10 +38,12 @@
 # digest's 100 got a drift line here that could never reach a digest row —
 # invisible in the one artefact R24 calls the report.
 #
-# Exit 0 every PR carries a verdict on its head and is not CONFLICTING;
-# exit 1 when any PR has `no verdict on head`, is `stale from ...`, or is
-# CONFLICTING; exit 2 when a gh read fails — a check that could not read
-# must never print nothing and exit 0.
+# Exit 0 every PR carries a verdict on its head, is not CONFLICTING, and its
+# newest Review Response (if any) answers a round that was actually posted;
+# exit 1 when any PR has `no verdict on head`, is `stale from ...`, is
+# CONFLICTING, or carries an orphan Review Response (GH-993); exit 2 when a
+# gh read fails — a check that could not read must never print nothing and
+# exit 0.
 # Read-only: no posting, no labels, no merges, no ledger writes.
 set -eu
 
@@ -50,6 +64,17 @@ open_rows=$(gh pr list --repo "$repo" --state open --limit "$open_limit" \
     --json number,headRefOid,baseRefName,mergeable \
     --jq '.[] | [.number, .headRefOid, .baseRefName, .mergeable] | @tsv' \
 ) || fail_read "pr list"
+# Defensive: strip any stray CR (`tr -d`, not a trailing-only trim — none of
+# these fields are free-form text, so a bare CR never belongs in one). Found
+# while adding the GH-993 fields below: an external jq.exe on at least one
+# Windows dev box emits CRLF for redirected output, and `read`'s last
+# variable absorbs a trailing \r as data, silently breaking any comparison
+# or interpolation of that field (`mergeable = CONFLICTING` and the R23
+# fields the same way — this predates GH-993 and just had no field that both
+# echoed into output and drove a comparison until now). Harmless no-op
+# against the real `gh --jq`, which filters through an embedded jq library,
+# not a spawned binary.
+open_rows=$(printf '%s' "$open_rows" | tr -d '\r')
 if [ "$(printf %s "$open_rows" | grep -c .)" -ge "$open_limit" ]; then
     echo "verdict-drift: the open-PR enumeration hit its limit of $open_limit; PRs past it were not examined (raise EDDA_OPEN_PR_LIMIT)" >&2
 fi
@@ -57,38 +82,75 @@ fi
 not_ready=0
 while IFS="$(printf '\t')" read -r num head base mergeable; do
     [ -n "$num" ] || continue
+    # GH-993: one tagged pass over `.comments` so the drift check keeps its
+    # one-call-per-PR cost. Each comment yields at most one row: "v" (an R23
+    # verdict — same regex and fields as before, plus its own round number)
+    # or "r" (a first-line `## Review Response: Round N` heading, round
+    # number only). A comment can match only one shape; most match neither
+    # and yield nothing (`empty`).
     verdicts=$(gh pr view "$num" --repo "$repo" --json comments --jq '
         .comments[]
         | (.body) as $b
         | ($b | split("\n")[0]) as $fl
-        | select($fl | test("^## Code Review: Round [0-9]+( \\(SHADOW\\))? — PR #[0-9]+ @ [0-9a-f]{40}( \\(SHADOW\\))?$"))
-        | [
-            ($fl | capture("@ (?<sha>[0-9a-f]{40})") | .sha),
-            (if ($fl | test("\\(SHADOW\\)")) or ($b | test("(?m)^- shadow: true$")) then "s" else "a" end),
-            (if ($b | test("(?m)^LGTM")) then "lgtm"
-             elif ($b | test("(?m)^Changes Requested")) then "cr"
-             else "unknown" end)
-          ]
+        | if ($fl | test("^## Code Review: Round [0-9]+( \\(SHADOW\\))? — PR #[0-9]+ @ [0-9a-f]{40}( \\(SHADOW\\))?$")) then
+            [
+              "v",
+              ($fl | capture("Round (?<r>[0-9]+)") | .r),
+              ($fl | capture("@ (?<sha>[0-9a-f]{40})") | .sha),
+              (if ($fl | test("\\(SHADOW\\)")) or ($b | test("(?m)^- shadow: true$")) then "s" else "a" end),
+              (if ($b | test("(?m)^LGTM")) then "lgtm"
+               elif ($b | test("(?m)^Changes Requested")) then "cr"
+               else "unknown" end)
+            ]
+          elif ($fl | test("^## Review Response: Round [0-9]+")) then
+            ["r", ($fl | capture("Round (?<r>[0-9]+)") | .r)]
+          else
+            empty
+          end
         | @tsv' \
     ) || fail_read "pr view $num (comments)"
+    verdicts=$(printf '%s' "$verdicts" | tr -d '\r')  # see the note above open_rows
 
     newest=
     newest_sha=
     newest_resolve=
     authoritative_present=0
     authoritative_resolve=
-    while IFS="$(printf '\t')" read -r v_sha v_kind v_resolve; do
-        [ -n "$v_sha" ] || continue
-        newest=1
-        newest_sha=$v_sha
-        newest_resolve=$v_resolve
-        if [ "$v_kind" = "a" ] && [ "$v_sha" = "$head" ]; then
-            authoritative_present=1
-            authoritative_resolve=$v_resolve
+    code_review_rounds=","
+    response_round=
+    while IFS="$(printf '\t')" read -r row_tag f1 f2 f3 f4; do
+        [ -n "$row_tag" ] || continue
+        if [ "$row_tag" = v ]; then
+            v_round=$f1; v_sha=$f2; v_kind=$f3; v_resolve=$f4
+            code_review_rounds="$code_review_rounds$v_round,"
+            newest=1
+            newest_sha=$v_sha
+            newest_resolve=$v_resolve
+            if [ "$v_kind" = "a" ] && [ "$v_sha" = "$head" ]; then
+                authoritative_present=1
+                authoritative_resolve=$v_resolve
+            fi
+        else
+            # row_tag = r. Only the newest response (last in comment order)
+            # is judged — see the GH-993 note above the Output doc comment.
+            response_round=$f1
         fi
     done <<EOF
 $verdicts
 EOF
+
+    # GH-993: does the newest Review Response answer a round that was
+    # actually posted? Round-number membership only (see note above); the
+    # leading/trailing commas make the case pattern an exact-element match
+    # rather than a substring match on the number itself (so round "1" does
+    # not accidentally match inside "11").
+    orphan_response=
+    if [ -n "$response_round" ]; then
+        case "$code_review_rounds" in
+            *",$response_round,"*) ;;
+            *) orphan_response=$response_round ;;
+        esac
+    fi
 
     head12=$(printf '%s' "$head" | cut -c1-12)
     if [ -z "$newest" ]; then
@@ -120,6 +182,10 @@ EOF
     fi
     if [ "$base" != "main" ]; then
         line="$line base=$base (status contexts not enforced)"
+    fi
+    if [ -n "$orphan_response" ]; then
+        line="$line orphan-response=Round-$orphan_response"
+        not_ready=1
     fi
     printf '%s\n' "$line"
 done <<EOF

--- a/scripts/fleet/verdict-drift.sh
+++ b/scripts/fleet/verdict-drift.sh
@@ -88,8 +88,30 @@ while IFS="$(printf '\t')" read -r num head base mergeable; do
     # or "r" (a first-line `## Review Response: Round N` heading, round
     # number only). A comment can match only one shape; most match neither
     # and yield nothing (`empty`).
+    #
+    # Round 1 review (P1): both row shapes are gated on `authorAssociation`
+    # first. This repo is PUBLIC, so an unfiltered read let any commenter
+    # either *hold* the PR (post any `## Review Response: Round N`, no SHA
+    # required — every --check/--merge in the fleet then refuses) or
+    # *silence* this check (post a §7-shaped `## Code Review: Round N`
+    # pinned to head, waving through the exact "the round never reached the
+    # PR" case this script exists to catch). Trusted set mirrors
+    # merge-reviewed-pr.sh:72 exactly — OWNER, MEMBER, COLLABORATOR — so the
+    # two scripts do not carry two definitions of trust for the same comment
+    # class. Fails closed by construction, not by a separate check: jq's
+    # `==`/`!=` never errors across mismatched types (verified directly
+    # against jq — a missing key, `null`, or a wrong-shaped value are all
+    # simply unequal to every trusted string), so an absent or unreadable
+    # `authorAssociation` makes the `select` below drop the comment, and it
+    # falls through to the same `empty` a comment matching neither heading
+    # already produces — neither a verdict nor a response. The product-side
+    # counterpart of this same gap — `edda review deliver`'s `Comment`
+    # struct carries no author at all, and it is what writes the
+    # `Independent Review` status — is filed separately as #1103; not fixed
+    # here.
     verdicts=$(gh pr view "$num" --repo "$repo" --json comments --jq '
         .comments[]
+        | select(.authorAssociation == "OWNER" or .authorAssociation == "MEMBER" or .authorAssociation == "COLLABORATOR")
         | (.body) as $b
         | ($b | split("\n")[0]) as $fl
         | if ($fl | test("^## Code Review: Round [0-9]+( \\(SHADOW\\))? — PR #[0-9]+ @ [0-9a-f]{40}( \\(SHADOW\\))?$")) then

--- a/scripts/merge-reviewed-pr.sh
+++ b/scripts/merge-reviewed-pr.sh
@@ -9,18 +9,52 @@
 # post-2026-09-08); a stale or
 # missing binary is not detected separately here — it reports as a union
 # refusal (fail-closed). Check with `edda --version`.
+# GH-993: also refuses, for both --check and --merge, unless
+# scripts/fleet/verdict-drift.sh exits 0 across every open PR — see the
+# comment above that call, below.
 set -eu
 die() { echo "merge-reviewed-pr: $*" >&2; exit 1; }
 if [ "${1:-}" = --help ]; then
   echo 'usage: merge-reviewed-pr.sh PR [--merge] (merge requires operator authority)'
   exit 0
 fi
+self_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 pr=${1:-}; action=${2:---check}
 printf '%s\n' "$pr" | grep -qE '^[1-9][0-9]*$' || die 'invalid PR'
 case "$action" in --check|--merge) ;; *) die 'expected --check or --merge' ;; esac
 [ "$#" -le 2 ] || die 'too many arguments'
 repo=${EDDA_REPO:-fagemx/edda}
 printf '%s\n' "$repo" | grep -qE '^[A-Za-z0-9_-]+/[A-Za-z0-9_.-]+$' || die 'invalid repository'
+# GH-993: a completed review round must reach the PR regardless of transport
+# — the observed failure was a `Review Response: Round N` comment with no
+# matching `Code Review: Round N` anywhere on the PR (a subagent's report
+# that was never posted). verdict-drift.sh already detects that, plus "no
+# verdict on head", a stale verdict, and CONFLICTING mergeability, across
+# every open PR (GH-914/958) — but its only prior caller (daily-digest.sh)
+# captures the exit code and reports it without blocking (by design — see
+# the comment there). This is the "declare a PR done" entrypoint
+# docs/guides/pi-controller-runbook.md:128 already names as the place to
+# run verdict-drift.sh, by policy; wiring it here enforces that policy
+# instead of relying on an operator remembering it, for --check and --merge
+# alike (nothing above this point branches on $action, so both share this
+# code path). The whole open-PR set is checked, not just $pr: a fleet-wide
+# check scoped down to one PR would stop being the check GH-958 shares with
+# daily-digest.sh, and this is deliberately the same blocking scope
+# pi-controller-runbook.md already names, not a narrower one invented here.
+#
+# `drift_rc` is read directly from `$?` of the substitution on the next
+# line — nothing pipes into or out of it, so there is no stage for the exit
+# code to hide behind (the near-miss the issue's own author records:
+# `verdict-drift.sh | head -20; echo $?` reads `head`'s exit code, not
+# verdict-drift.sh's — GH-993). Every nonzero exit refuses, not only exit 1
+# (drift found): exit 2 (verdict-drift.sh could not read PR state at all)
+# must refuse too, or a broken read would wave every merge through clean.
+drift_rc=0
+drift_out=$(EDDA_REPO="$repo" sh "$self_dir/fleet/verdict-drift.sh" 2>&1) || drift_rc=$?
+if [ "$drift_rc" -ne 0 ]; then
+  printf '%s\n' "$drift_out" >&2
+  die "verdict-drift.sh is not clean across the open PR set (exit $drift_rc) — refusing until every open PR carries a verdict on its head (output above)"
+fi
 facts=$(gh pr view "$pr" --repo "$repo" --json headRefOid,state --jq '[.headRefOid,.state]|@tsv') || die 'cannot read PR head'
 head=$(printf '%s\n' "$facts" | cut -f1)
 state=$(printf '%s\n' "$facts" | cut -f2)

--- a/scripts/merge-reviewed-pr.sh
+++ b/scripts/merge-reviewed-pr.sh
@@ -33,7 +33,7 @@ printf '%s\n' "$repo" | grep -qE '^[A-Za-z0-9_-]+/[A-Za-z0-9_.-]+$' || die 'inva
 # every open PR (GH-914/958) — but its only prior caller (daily-digest.sh)
 # captures the exit code and reports it without blocking (by design — see
 # the comment there). This is the "declare a PR done" entrypoint
-# docs/guides/pi-controller-runbook.md:128 already names as the place to
+# docs/guides/pi-controller-runbook.md:125 already names as the place to
 # run verdict-drift.sh, by policy; wiring it here enforces that policy
 # instead of relying on an operator remembering it, for --check and --merge
 # alike (nothing above this point branches on $action, so both share this

--- a/scripts/test-merge-reviewed-pr.sh
+++ b/scripts/test-merge-reviewed-pr.sh
@@ -334,11 +334,19 @@ fi
 # own doneWhen calls out as needing a real fixture instead. This is that
 # fixture: one populated, healthy open PR, distinct from $PR itself, with a
 # real LGTM pinned to its head. The accept path stays byte-identical.
+#
+# `authorAssociation":"OWNER"` is required on this comment since Round 1
+# review's P1 fix: verdict-drift.sh now trusts only OWNER/MEMBER/
+# COLLABORATOR comments (scripts/fleet/verdict-drift.sh), mirroring the
+# union gate's own filter five lines below in this script. The trust-filter
+# logic itself is unit-tested in scripts/fleet/test-verdict-drift.sh (cases
+# 16-18); this fixture only needs to stay trusted so this wiring case keeps
+# proving what it always proved.
 
 OTHER_SHA=eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
 printf '[{"number":9002,"headRefOid":"%s","baseRefName":"main","mergeable":"MERGEABLE"}]\n' "$OTHER_SHA" >"$work/fixtures/drift-clean-prs.json"
 sed "s/@SHA@/$OTHER_SHA/g" >"$work/fixtures/drift-clean-comments.json" <<'JSON'
-{"comments":[{"body":"## Code Review: Round 1 — PR #9002 @ @SHA@\n\n### Verdict\nLGTM (P0=0, P1=0)"}]}
+{"comments":[{"body":"## Code Review: Round 1 — PR #9002 @ @SHA@\n\n### Verdict\nLGTM (P0=0, P1=0)","authorAssociation":"OWNER"}]}
 JSON
 STUB_DRIFT_PRS=$work/fixtures/drift-clean-prs.json
 STUB_DRIFT_COMMENTS=$work/fixtures/drift-clean-comments.json

--- a/scripts/test-merge-reviewed-pr.sh
+++ b/scripts/test-merge-reviewed-pr.sh
@@ -44,16 +44,53 @@ HEAD_SHA=aaaaaaaabbbbbbbbccccccccdddddddd11112222
 
 # ── stubs ────────────────────────────────────────────────────────────
 #
-# `gh` answers exactly the three reads the script makes, off fixture files, and
+# `gh` answers exactly the reads the script makes, off fixture files, and
 # records every call so a case can prove what was and was not reached. Anything
 # else is a hard error rather than a silent success: a stub that shrugs at an
 # unexpected call turns a wiring regression into a green test.
+#
+# GH-993 adds two more calls, made by the verdict-drift.sh subprocess the
+# script now runs before anything else: `pr list` (the open-PR enumeration)
+# and a second, differently-shaped `pr view --json comments` (per-PR
+# comments — distinguished from the script's own `pr view --json
+# headRefOid,state` by that flag, since both start with the same two argv
+# words). Both apply the caller's real `--jq` filter via real jq, the way
+# scripts/fleet/test-verdict-drift.sh's stub already does, so the R23/R993
+# regexes in verdict-drift.sh are exercised, not assumed. Unset
+# STUB_DRIFT_PRS defaults `pr list` to `[]` (zero open PRs) so cases 1-5,
+# which predate GH-993 and set no drift fixture, see a vacuously clean
+# fleet and are unaffected; unset STUB_DRIFT_COMMENTS defaults a drift
+# `pr view` to empty comments (no verdict — the not-ready shape).
 
 cat >"$work/bin/gh" <<'STUB'
 #!/bin/sh
 printf 'gh %s\n' "$*" >>"$GH_CALLS"
+jqfilter=
+prevarg=
+for a in "$@"; do
+    [ "$prevarg" = "--jq" ] && jqfilter=$a
+    prevarg=$a
+done
 case "${1:-} ${2:-}" in
-    "pr view")   printf '%s\tOPEN\n' "$STUB_HEAD" ;;
+    "pr view")
+        case "$*" in
+            *"--json comments"*)
+                src=${STUB_DRIFT_COMMENTS:-}
+                if [ -n "$src" ] && [ -f "$src" ]; then jq -r "$jqfilter" <"$src"
+                else printf '{"comments":[]}\n' | jq -r "$jqfilter"; fi
+                ;;
+            *) printf '%s\tOPEN\n' "$STUB_HEAD" ;;
+        esac
+        ;;
+    "pr list")
+        if [ "${STUB_DRIFT_LIST_FAIL:-0}" = 1 ]; then
+            echo "gh stub: simulated pr list failure" >&2
+            exit 1
+        fi
+        src=${STUB_DRIFT_PRS:-}
+        if [ -n "$src" ] && [ -f "$src" ]; then jq -r "$jqfilter" <"$src"
+        else printf '[]\n' | jq -r "$jqfilter"; fi
+        ;;
     "api --paginate") cat "$STUB_COMMENTS" ;;
     "pr checks") exit "${STUB_CHECKS_EXIT:-0}" ;;
     *) echo "gh stub: unexpected invocation: $*" >&2; exit 1 ;;
@@ -242,5 +279,78 @@ case $err in
     *warning*) : ;;
     *) fail "case 5: expected a warning on stderr naming the failed write, got: $err" ;;
 esac
+
+# ── case 6: an unrelated open PR with no verdict refuses everything (GH-993) ──
+#
+# The fleet-wide drift gate (scripts/fleet/verdict-drift.sh) now runs before
+# any of the checks above. It is deliberately whole-open-set, not scoped to
+# $PR — the same scope daily-digest.sh already shares with it via
+# EDDA_OPEN_PR_LIMIT — so an unrelated PR's missing verdict blocks this PR's
+# --check/--merge too, and blocks it before the union gate or required
+# checks are even asked.
+
+DRIFT_SHA=dddddddddddddddddddddddddddddddddddddddd
+printf '[{"number":9001,"headRefOid":"%s","baseRefName":"main"}]\n' "$DRIFT_SHA" >"$work/fixtures/drift-dirty-prs.json"
+STUB_DRIFT_PRS=$work/fixtures/drift-dirty-prs.json
+export STUB_DRIFT_PRS
+run_case
+unset STUB_DRIFT_PRS
+[ "$code" -ne 0 ] || fail "case 6: an unrelated PR with no verdict did not block: $out"
+case $err in
+    *verdict-drift*) : ;;
+    *) fail "case 6: expected a verdict-drift refusal, got: $err" ;;
+esac
+if grep -q 'api --paginate' "$GH_CALLS"; then
+    fail "case 6: the union gate was reached after drift already refused: $(cat "$GH_CALLS")"
+fi
+if grep -q 'pr checks' "$GH_CALLS"; then
+    fail "case 6: required checks were queried after drift already refused: $(cat "$GH_CALLS")"
+fi
+
+# ── case 7: verdict-drift.sh itself failing to read also refuses (GH-993) ──
+#
+# The fail-closed proof the issue requires: not only "drift was found"
+# (case 6) but "the check that looks for drift could not even run" must
+# block too — exit 2, not only exit 1 — or a broken read would wave every
+# merge through clean.
+
+STUB_DRIFT_LIST_FAIL=1
+export STUB_DRIFT_LIST_FAIL
+run_case
+unset STUB_DRIFT_LIST_FAIL
+[ "$code" -ne 0 ] || fail "case 7: a failed drift read did not block: $out"
+case $err in
+    *verdict-drift*) : ;;
+    *) fail "case 7: expected a verdict-drift refusal, got: $err" ;;
+esac
+if grep -q 'api --paginate' "$GH_CALLS"; then
+    fail "case 7: the union gate was reached after the drift read failed: $(cat "$GH_CALLS")"
+fi
+
+# ── case 8: a genuinely clean, non-vacuous drift state does not block ──────
+#
+# Cases 1-5 all run under the drift gate's vacuous default (zero open PRs
+# in STUB_DRIFT_PRS) — clean, but the empty-set kind of clean the issue's
+# own doneWhen calls out as needing a real fixture instead. This is that
+# fixture: one populated, healthy open PR, distinct from $PR itself, with a
+# real LGTM pinned to its head. The accept path stays byte-identical.
+
+OTHER_SHA=eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+printf '[{"number":9002,"headRefOid":"%s","baseRefName":"main","mergeable":"MERGEABLE"}]\n' "$OTHER_SHA" >"$work/fixtures/drift-clean-prs.json"
+sed "s/@SHA@/$OTHER_SHA/g" >"$work/fixtures/drift-clean-comments.json" <<'JSON'
+{"comments":[{"body":"## Code Review: Round 1 — PR #9002 @ @SHA@\n\n### Verdict\nLGTM (P0=0, P1=0)"}]}
+JSON
+STUB_DRIFT_PRS=$work/fixtures/drift-clean-prs.json
+STUB_DRIFT_COMMENTS=$work/fixtures/drift-clean-comments.json
+STUB_COMMENTS=$work/fixtures/lgtm-only.json
+STUB_DELIVER=$work/fixtures/deliver-success.json
+export STUB_DRIFT_PRS STUB_DRIFT_COMMENTS STUB_COMMENTS STUB_DELIVER
+run_case
+unset STUB_DRIFT_PRS STUB_DRIFT_COMMENTS
+[ "$code" -eq 0 ] || fail "case 8: a healthy, non-vacuous open set was refused (exit $code): $err"
+[ "$out" = "review accepted: PR #$PR @ $HEAD_SHA" ] \
+    || fail "case 8: accept output changed: $out"
+grep -qF "pr checks $PR" "$GH_CALLS" \
+    || fail "case 8: --required checks were skipped: $(cat "$GH_CALLS")"
 
 echo "PASS scripts/test-merge-reviewed-pr.sh ($case_no cases)"


### PR DESCRIPTION
## What GH-993 asked for, and what has changed since it was filed

GH-993 was filed 2026-09-06. Verified against `origin/main` before starting (controller-supplied fact block, confirmed independently below):

- **Two thirds of the predicted surface is gone.** `scripts/pr-review-watch.sh`, `scripts/review-pr.sh`, and `docs/guides/pr-review-watcher.md` were deleted by PR #1082 (GH-1061). Confirmed with `git ls-tree -r origin/main --name-only` (not `cat-file`): none of the three appear in the tree.
- **One doneWhen bullet is already delivered.** 「The record for #974, #976, #980, #981 is repaired」 — confirmed independently via `gh pr view` / `gh api .../comments`: all four are `MERGED`, and each now carries exactly **two** published `## Code Review: Round N` comments (the repair skips straight to a properly-paired Round 2 rather than backfilling Round 1 — see the verdict-drift.sh comment below for why that shape matters). Not redone here; no rounds posted to merged PRs.
- **`edda review deliver` (GH-1030) landed** and is now the `review:*` label / `Independent Review` status writer, reading §7 verdict comments on a SHA. It does not close this gap — it can only deliver a comment that already exists on the PR. `scripts/merge-reviewed-pr.sh` already calls it (pre-existing); this PR does not change that call.

## What was still live, and what this PR does about it

`scripts/fleet/verdict-drift.sh` already detected "no verdict on head" correctly (GH-914/958) but had exactly one caller, `daily-digest.sh:168`, which captures the exit code and reports it without blocking — by design, since a digest that refused to post because the fleet wasn't perfect would be less useful than the report itself. Nothing made *posting* part of a completed round, and nothing ran the check at a moment that blocks.

**doneWhen bullet 1** offers a choice between a generator (make posting automatic) and a refusal check (catch the orphan after the fact). I chose the **refusal check**: reviews are dispatched as subagents now, in-process, with no single "review shell" script left to hook a "post automatically" step into (GH-1061 retired the last one) — a generator would need a new home in every dispatch path, which is out of scope for a `scripts/**`-only fix lane and speculative about what that home should be. A refusal check is cheap, has one home (verdict-drift.sh, which already reads every open PR's comments), and catches exactly the observed defect.

**`scripts/fleet/verdict-drift.sh`** now also flags a `## Review Response: Round N` comment that answers a round never posted — the precise shape #974/#976/#980/#981 shipped, confirmed against the real PR #974 comment history (`gh api repos/fagemx/edda/issues/974/comments`, fetched during this work). Matching is by round number, not SHA, and only the *newest* response is judged — so a PR that recovers by moving straight to a properly-paired later round (the repair shape above: Round 1's response stays permanently unanswered, Round 2 is posted and paired) reads clean rather than being permanently blocked by its own repair. New annotation: `orphan-response=Round-<N>`, holds the PR the same way `no verdict on head` does. See the doc comment at the top of the script for the full contract.

**doneWhen bullet 2** — where verdict-drift.sh runs at a moment that blocks. I chose **`scripts/merge-reviewed-pr.sh`**, run before both `--check` and `--merge`, over the two other candidates the brief named:
- *A CI job* would need to run the same whole-open-set check on every push to every PR, turning one PR's drift into every other PR's red CI, and would need branch-protection admin action to become "required" — out of a `scripts/**`-only PR's reach, and expensive (repeats the same fleet-wide `gh` reads on every push instead of once per merge attempt).
- *A lefthook `pre-push` hook* runs on every local push to every branch, unrelated to whether that push is "declaring a PR done" — it would block routine WIP pushes over drift on some unrelated PR.
- `scripts/merge-reviewed-pr.sh` is specifically the "declare this PR done" entrypoint — and `docs/guides/pi-controller-runbook.md:125` **already** names running `verdict-drift.sh` before declaring any PR complete as mandatory policy: 「宣稱任何一張 PR 完成之前先跑 `sh scripts/fleet/verdict-drift.sh`；它 exit 1 就沒有一張 PR 可以被稱作完成。」 This PR turns that manually-run rule into an enforced one, at the one entrypoint that already means what the rule requires — with no branch-protection config needed and no cost added to routine pushes.

The check is deliberately **whole-open-set**, not narrowed to the one PR being merged: that is the scope `daily-digest.sh` already shares with `verdict-drift.sh` via `EDDA_OPEN_PR_LIMIT` (GH-958), and it is what the runbook rule above actually asks for ("before declaring *any* PR done"). See "Known limitations" below for what that scope costs in practice — recorded by Round 1 review, not a change to the choice.

**doneWhen bullet 4** — "from a caller that cannot mask the exit code behind a pipeline," read literally per the brief: the new caller reads `drift_rc` directly from `$?` immediately after the substitution, nothing pipes into or out of it (unlike the near-miss the issue's own author records: `verdict-drift.sh | head -20; echo $?`, which reads `head`'s exit code). **Every nonzero exit refuses** — not only exit 1 (drift found) but exit 2 (verdict-drift.sh itself could not read PR state). Proven, not just asserted: `scripts/test-merge-reviewed-pr.sh` case 7 sets `STUB_DRIFT_LIST_FAIL=1` (verdict-drift.sh's own `gh pr list` fails) and asserts the merge is refused — the fail-closed case the brief calls out as required, distinct from case 6 (drift found on an unrelated PR, also refused, also before the union gate or required checks are even reached).

**"Vacuous evidence" callout** — the brief warned that with zero open PRs, "verdict-drift.sh exits 0 across the open set" would be vacuously true, and asked for a fixture instead of relying on that. Two things: `scripts/test-merge-reviewed-pr.sh` case 8 is that fixture (a populated, non-empty open-PR set with a real LGTM verdict, proving the gate doesn't false-positive on a healthy fleet). Separately, by the time this PR was first ready, the live repo was no longer vacuous — `sh scripts/fleet/verdict-drift.sh` against `origin/main`:
```
#1101 d4252ad27f3a main Changes Requested
rc=0
```
One real open PR, genuinely non-vacuous, exit 0. (That snapshot predates this PR itself being open; Round 1 review re-ran the same command and got `rc=1` — see "Known limitations" below. The offline fixture, not this line, is the durable evidence.)

## Round 1 fix: comment author trust (P1)

Round 1 review found the gate this PR installs decided on comment text read with **no author filter**, on a repo that is **PUBLIC**: `scripts/fleet/verdict-drift.sh` selected `## Code Review: Round N` and `## Review Response: Round N` straight off `.comments[]`, while `scripts/merge-reviewed-pr.sh:69-74` already filters the very same comment class on `author_association` five lines below its own call into that script. Concretely, that gap let any commenter either *hold* the merge entrypoint (post any `## Review Response: Round N`, no SHA or matching PR number required — every `--check`/`--merge` in the fleet then refuses) or *silence* it (post a §7-shaped `## Code Review: Round N` pinned to head, waving through the exact "the round never reached the PR" case this script exists to catch).

Fixed by applying the identical trusted set `merge-reviewed-pr.sh` already uses — `OWNER`, `MEMBER`, `COLLABORATOR` — via one jq `select` in `verdict-drift.sh`, mirroring `merge-reviewed-pr.sh:72` exactly, so the two scripts share one definition of trust instead of two. Fails closed by construction rather than by a bolted-on check: jq's `==`/`!=` never errors across mismatched types (verified directly against jq before relying on it), so a missing, `null`, or wrong-shaped `authorAssociation` is simply unequal to every trusted value and the comment is excluded — the same `empty` a comment matching neither heading already produces. Three new fixtures (`test-verdict-drift.sh` cases 16-18) prove the fix itself, not just the happy path: an untrusted verdict does not silence the check, an untrusted Review Response does not hold the PR, and a comment whose `authorAssociation` key is entirely absent fails closed the same way as an untrusted one. Every pre-existing comment fixture across the three affected test files (`test-verdict-drift.sh`, `test-merge-reviewed-pr.sh` case 8, `test-daily-digest.sh` case 3d) gained a trusted `authorAssociation` so the happy path keeps proving exactly what it proved before.

The product-side counterpart of this same gap is filed separately as **#1103**: `edda review deliver`'s `Comment` struct carries no author at all, and it is what writes the `Independent Review` status. Not fixed here. If #1103 lands with a different trusted set than OWNER/MEMBER/COLLABORATOR, the two should be reconciled rather than left disagreeing.

## Known limitations (Round 1 review, recorded here rather than fixed)

Round 1 review upheld `scripts/merge-reviewed-pr.sh` as the blocking point and did not ask for the whole-open-set scope to change — the runbook rule at `docs/guides/pi-controller-runbook.md:125` (corrected above from a stale `:128`, inherited from when #993 was filed) reads literally as "before declaring *any* PR done." But it measured two facts that qualify what that wiring achieves in practice, and asked that both be recorded:

- **`rc=1` is the *ordinary* state of a parallel fleet, not the exceptional one.** Live during Round 1 review, with only two open PRs (#1101, #1102 itself) both mid-loop: `sh scripts/fleet/verdict-drift.sh` printed `no verdict on head` / `stale from …` for both, `rc=1`. Under this fleet's own operating model (parallel lanes, WIP cap 3), a PR sits at `no verdict on head` from opening until its first round and returns to `stale from …` after every fix push — so a fully LGTM'd, CI-green PR can be refused by an unrelated PR's mid-loop state, and the blocked party is not the party who caused it. **What the operator does about it today:** run `sh scripts/fleet/verdict-drift.sh` to see which open PR(s) are holding the set; there is no per-PR override in this PR. That is deliberate — narrowing the scope to one PR would stop being the check `daily-digest.sh` shares with this script (GH-958) — but it means the steady state of a healthy, busy fleet is "refuse," not "clean."
- **Issue #1100 (open) is a prerequisite for this gate to bind in practice.** It records, in the repo's own words, that recent merges bypassed `merge-reviewed-pr.sh` specifically because the script takes no merge subject/body, so merges continued to go through `gh pr merge` by hand — a path this PR's gate does not sit on. #1100 should be linked from #993 so that dependency stays visible; this PR does not close it.

Neither is a doneWhen miss — bullet 2 asks for a deliberate choice with a stated reason, and gets one — so neither blocks. Whether to narrow the scan from whole-open-set to the PR being merged plus a *reported* fleet state is a separate design decision for the controller, not reopened here.

## The rules.md sentence (not in this diff)

GH-1064 is live across `docs/fleet/rules.md`, `docs/guides/**`, `REVIEW.md`, `.claude/**`, `AGENTS.md`, `README.md` this wave — my brief marks all of it off-limits, even for a one-word touch. The proposed rule is below for the controller to land after GH-1064 merges; it is not part of this diff.

<!-- LIFTABLE: docs/fleet/rules.md addition, land after GH-1064 merges -->
```
- **R30 判決要送達，不是完成**：一輪審查完成不等於它「存在」於 PR 上——存在的定義是 PR 留言區有一則 `## Code Review: Round <N>`（R23 形狀）。子代理／in-process 審查把報告吐在對話裡，不會自動貼上 PR；沒有腳本幫它貼，這一輪就只活在那次對話裡，PR 上什麼都沒有。內部驗證報告、任務收據、CI 都不能替代 PR 留言（`.claude/CLAUDE.md`）。`## Review Response: Round <N>` 貼在一張沒有對應 `Code Review: Round <N>` 的 PR 上是這個缺口的症狀，不是巧合——`scripts/fleet/verdict-drift.sh`（GH-993）把它標成 `orphan-response=Round-<N>` 並判為未就緒（比對只看輪數不看 SHA，且只判最新一則回應：用改編號補救的 PR，如 #974/#976/#980/#981，補上配對的 Round 2 之後即視為乾淨，不會因為 Round 1 永遠沒人補而卡死；且只信任 OWNER/MEMBER/COLLABORATOR 留言者，repo 是 PUBLIC，見 #993 Round 1 review）。宣稱／合併任何一張 PR 之前，`scripts/merge-reviewed-pr.sh` 現在會先掃過整個 open set 跑 `verdict-drift.sh`，非零退出一律拒絕——不論是找到 drift（exit 1）還是這個檢查本身讀不到（exit 2）；把 `docs/guides/pi-controller-runbook.md:125` 原本要操作者手動記得的規則，變成這個入口自動擋住。來源：#993、R23、R24。
```

## Surface

`scripts/fleet/daily-digest.sh` is named 審判面 in R22 explicitly; `scripts/merge-reviewed-pr.sh` also qualifies independently under R22's catch-all ("以及任何會貼 status 或執行合併的腳本" — it calls `gh pr merge`). So this PR is **審判面**, via two paths. It does not touch `.github/**` or `lefthook.yml`, so it is not 閘門面.

Touched:
- `scripts/fleet/verdict-drift.sh` — orphan-response detection, plus the Round 1 author-trust filter (內部工具面 on its own, but the PR's surface class is set by the 審判面 files below)
- `scripts/fleet/daily-digest.sh` — doc comment only, no behavior change (審判面, named explicitly in R22)
- `scripts/fleet/test-verdict-drift.sh`, `scripts/fleet/test-daily-digest.sh` — new fixtures (內部工具面, `scripts/test-*.sh`/`scripts/fleet/**` other files)
- `scripts/merge-reviewed-pr.sh` — the new blocking call, plus the `:125` citation fix (審判面, R22 catch-all)
- `scripts/test-merge-reviewed-pr.sh` — new fixtures (內部工具面)

## Gates run

- `sh -n` on every touched script — clean.
- `sh scripts/fleet/test-verdict-drift.sh` — 18/18 cases pass (11 pre-existing + 4 GH-993 + 3 new in Round 1's P1 fix: cases 16-18), run 6× total for determinism.
- `sh scripts/fleet/test-daily-digest.sh` — all cases pass including case 3d, re-run after the Round 1 fixture update.
- `sh scripts/test-merge-reviewed-pr.sh` — 8/8 cases pass (5 pre-existing, unmodified + 3 from GH-993; case 8's fixture updated for the Round 1 trust filter), re-run after the fixture update.
- `sh scripts/lint-file-length.sh --tree` — ran; it is a `*.rs`-only ratchet (per its own header comment) and this PR touches no Rust, so it is a no-op here but was run per the brief.
- No `crates/**` change, so no Cargo gate.
- Exact-head CI: see below.

**Windows-only local finding, worth naming:** while adding the original GH-993 fixtures, the offline test stub's external `jq.exe` (chocolatey install, used only to emulate `gh --jq` for offline testing — the real `gh` filters through an embedded Go jq library, not a spawned binary) intermittently emitted CRLF for some redirected invocations on this box, and POSIX `read`'s last field silently absorbed the trailing `\r` as data. This broke a case that both echoes a field into output and pattern-matches it — the first time either code path had, since the pre-existing fields were only ever compared against fixed strings. Fixed defensively in `verdict-drift.sh` (`tr -d '\r'` on both TSV captures, documented inline) rather than chased further upstream: it's a no-op against clean input and closes the class of bug regardless of root cause.

**CI note per the brief:** CI's `Fleet shell tests (windows)` job carries only the `.ps1` group (per `.github/workflows/ci.yml`); none of the `.sh` tests touched or added here run on Windows in CI. The runs above, on this Windows box, are the only Windows evidence for this change.

**CI flake, established environmental (Round 1 review):** exact-head CI on the pre-fix SHA (`c585457…`, run 34362712884) was red solely from `Test (macos-latest)`, established by Round 1 review as environmental and not caused by this PR — zero Rust in the diff, Ubuntu/Windows/Fleet-shell/Format/MSRV/Clippy×3 all passed on that SHA, base `main` was macOS-green, and the failing test is `simultaneous_reconciles`, the exact mechanism named in issue #1047.

## Mechanized

- Worktree: `C:/ai_agent/edda-wt-gh993`, branch `fix/gh993-review-round-delivery`. Repo main checkout (`C:\ai_agent\edda`) untouched, still on `main`.
- Three commits, each pushed immediately: verdict-drift.sh detection + daily-digest.sh doc note (`c957c00`), merge-reviewed-pr.sh wiring (`c585457`), then the Round 1 P1 author-trust fix (`d7d6197`).

Issue: #993
Closes #993

🤖 Generated with [Claude Code](https://claude.com/claude-code)
