### PR TITLE
fix(edda-ledger): escape_field escapes backticks, closing the last hole in the round-trip encoding (GH-1044)

### DIFF
--- a/crates/edda-bridge-claude/src/mirror_import.rs
+++ b/crates/edda-bridge-claude/src/mirror_import.rs
@@ -17,12 +17,13 @@
 //!    ledger is opened, so the steady-state cost is one `is_file` plus two
 //!    small reads. A project with no `docs/decisions/INDEX.md` — every
 //!    single-machine project — pays only the `is_file`.
-//! 3. **Never fails or delays session start.** Every fallible step degrades to
-//!    `None`. A broken mirror must not cost anyone a session; the import is
-//!    convenience, and the manual `edda sync --from-mirror` still reports the
-//!    real error.
+//! 3. **Never fails or delays session start.** Every fallible step degrades —
+//!    the locating steps to `None`, the import itself to a warning line. A
+//!    broken mirror must not cost anyone a session; the import is convenience.
 //! 4. **Visible.** An import that happened silently is indistinguishable from
 //!    one that did not, so the caller injects the returned line into the pack.
+//!    A mirror file the importer *refuses* is the sharper case (GH-1044): it
+//!    recurs every session and no other reader reports it, so it renders too.
 
 use edda_ledger::sync::{sync_from_mirror, MirrorSource};
 use std::path::{Path, PathBuf};
@@ -33,8 +34,9 @@ use std::path::{Path, PathBuf};
 const MIRROR_DIR: &str = "docs/decisions";
 
 /// Import the committed mirror if it moved since the last session, and return
-/// the line describing what happened. `None` means nothing to say: no mirror
-/// in this repo, an unchanged stamp, or a failure that must stay silent.
+/// the line describing what happened. `None` means there was nothing to do —
+/// no mirror in this repo, an unchanged stamp, or a peer session already
+/// importing. A mirror that *failed* is never `None`; it is a warning line.
 pub fn import_on_session_start(cwd: &str, project_id: &str) -> Option<String> {
     let root = edda_ledger::EddaPaths::find_root(Path::new(cwd))?;
     let mirror_dir = root.join(MIRROR_DIR);
@@ -59,7 +61,20 @@ pub fn import_on_session_start(cwd: &str, project_id: &str) -> Option<String> {
     let _claim = Claim::take(&state.with_extension("lock"))?;
 
     let ledger = edda_ledger::Ledger::open(&root).ok()?;
-    let result = sync_from_mirror(&ledger, &MirrorSource { mirror_dir }, false).ok()?;
+    let result = match sync_from_mirror(&ledger, &MirrorSource { mirror_dir }, false) {
+        Ok(result) => result,
+        // GH-1044: this used to be `.ok()?`. Property 3 still holds — the
+        // session starts either way — but a whole-mirror failure discarded
+        // here reaches nobody: no line is rendered, the stamp is not written,
+        // and every later session repeats the same failure just as quietly.
+        // Cross-machine sync is then dead and no one is told. Say it instead.
+        Err(e) => {
+            let hint = format!("run `edda sync --from-mirror {MIRROR_DIR}`");
+            return Some(format!(
+                "## Cross-machine mirror\n\n⚠ Mirror import FAILED, nothing imported: {e} — {hint}."
+            ));
+        }
+    };
 
     // Recorded only after a successful import: a failed run must retry next
     // session rather than mark the stamp seen and go quiet forever.
@@ -148,7 +163,7 @@ fn write_state(path: &Path, stamp: &str) {
 /// stamp moved but carried no decision this ledger did not already have, and
 /// a line saying "imported 0" every morning is how a signal stops being read.
 fn render_line(result: &edda_ledger::sync::SyncResult, stamp: &str) -> Option<String> {
-    if result.imported.is_empty() && result.conflicts.is_empty() {
+    if result.imported.is_empty() && result.conflicts.is_empty() && result.errors.is_empty() {
         return None;
     }
     let machine = result
@@ -167,6 +182,22 @@ fn render_line(result: &edda_ledger::sync::SyncResult, stamp: &str) -> Option<St
         line.push_str(&format!(
             " {} conflicted with a local decision and were imported **inactive** — resolve with `edda ask <key>`.",
             result.conflicts.len()
+        ));
+    }
+    if !result.errors.is_empty() {
+        // GH-1044: the importer refuses a file it cannot classify rather than
+        // guess at it. That refusal reaches nobody unless it is said here —
+        // `edda sync --from-mirror` prints it, but nobody runs it to find out
+        // a hook went quiet, so an unheard refusal is sync silently dead.
+        let files: Vec<&str> = result
+            .errors
+            .iter()
+            .map(|e| e.project_name.as_str())
+            .collect();
+        line.push_str(&format!(
+            " ⚠ {} mirror file(s) refused and NOT imported ({}) — run `edda sync --from-mirror {MIRROR_DIR}` for the reason.",
+            result.errors.len(),
+            files.join(", ")
         ));
     }
     if result
@@ -293,6 +324,23 @@ mod tests {
     }
 
     #[test]
+    fn a_refused_mirror_file_is_named_even_when_nothing_else_happened() {
+        // The whole point of GH-1044 F13: `import_on_session_start` discards
+        // the importer's error with `.ok()?`, so if `render_line` also stays
+        // quiet, a mirror file that never imports is reported by nobody, ever.
+        let mut r = SyncResult::default();
+        r.errors.push(edda_ledger::sync::SourceError {
+            project_name: "legacy".to_string(),
+            error: "malformed mirror heading: ## `legacy".to_string(),
+        });
+        r.mirror = Some(meta(Some("2026-09-07T03:00:00Z"), Some(1.0)));
+        let line = render_line(&r, "2026-09-07T03:00:00Z").expect("a refusal must be visible");
+        assert!(line.contains("1 mirror file(s) refused"), "{line}");
+        assert!(line.contains("legacy"), "{line}");
+        assert!(line.contains("edda sync --from-mirror"), "{line}");
+    }
+
+    #[test]
     fn a_stale_mirror_says_so_even_when_the_import_worked() {
         let mut r = SyncResult::default();
         r.imported.push(imported("db.engine"));
@@ -404,17 +452,43 @@ mod tests {
         )
         .expect("index");
         // A decision section with no `event_id` line — `finish_mirror_decision`
-        // rejects the whole run.
+        // rejects this file.
         std::fs::write(
             decisions.join("fleet.md"),
             "# Domain: `fleet`\n\n## `fleet.broken`\n\n- **Value**: `x`\n",
         )
         .expect("domain file");
 
-        assert_eq!(
-            import_on_session_start(repo.to_str().expect("utf-8 path"), project_id),
-            None,
-            "a broken mirror is silence, never a failed session start"
-        );
+        // This assertion used to demand `None`. That was the GH-1044 F13
+        // defect written down as a requirement: the session does not fail
+        // (still asserted — we got a value back, not a panic or an `Err`), but
+        // "does not fail" was being met by saying nothing at all, forever.
+        let line = import_on_session_start(repo.to_str().expect("utf-8 path"), project_id)
+            .expect("a broken mirror is reported, never silent");
+        assert!(line.contains("refused"), "{line}");
+        assert!(line.contains("fleet"), "{line}");
+    }
+
+    #[test]
+    fn a_mirror_that_fails_outright_is_reported_not_swallowed() {
+        // The residual swallow F13 named: `sync_from_mirror` failing as a
+        // whole (here: an INDEX.md with no `decisions/` beside it) was
+        // discarded by `.ok()?`, so the hook went quiet and stayed quiet.
+        let _store = crate::isolated_store();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(repo.join("docs").join("decisions")).expect("mirror dir");
+        edda_ledger::Ledger::open_or_init(&repo).expect("ledger");
+        std::fs::write(
+            repo.join("docs").join("decisions").join("INDEX.md"),
+            "# Ledger\n\n- **Exported at**: 2026-09-07T02:00:00Z\n",
+        )
+        .expect("index");
+
+        let line =
+            import_on_session_start(repo.to_str().expect("utf-8 path"), "mirror_import_dead")
+                .expect("a failed import is reported, never silent");
+        assert!(line.contains("FAILED"), "{line}");
+        assert!(line.contains("edda sync --from-mirror"), "{line}");
     }
 }

--- a/crates/edda-cli/src/cmd_export.rs
+++ b/crates/edda-cli/src/cmd_export.rs
@@ -15,14 +15,16 @@
 //!   the committed-mirror import in `edda-ledger::sync` needs those fields to
 //!   restore the row faithfully (original actor included). Every
 //!   caller-supplied component of that encoding — the `## `key`` header and
-//!   the `- **Field**: value` lines alike — is escaped (`\` and newline) by
-//!   [`escape_field`], so a multi-line reason or a newline in any other field
-//!   survives the single-line markdown encoding losslessly instead of emitting
-//!   a line the importer would read as another field. Only the branch name and
-//!   the timestamp ride raw; both are machine-constrained, and the reason is
-//!   recorded at the `- **Branch/ts**:` line itself. Cites (GH-761) is read
-//!   from the decision event payload, not the projected row — see
-//!   [`collect_cites`].
+//!   the `- **Field**: value` lines alike — is escaped (`\`, newline and
+//!   backtick, GH-1044) by [`escape_field`], so a multi-line reason or a
+//!   newline in any other field survives the single-line markdown encoding
+//!   losslessly instead of emitting a line the importer would read as another
+//!   field, and a backtick inside a Tags/Affected paths/Cites item survives
+//!   instead of colliding with that list's `` `, ` `` separator or wrapping
+//!   delimiters. Only the branch name and the timestamp ride raw; both are
+//!   machine-constrained, and the reason is recorded at the
+//!   `- **Branch/ts**:` line itself. Cites (GH-761) is read from the decision
+//!   event payload, not the projected row — see [`collect_cites`].
 //! - Layout:
 //!   <out>/INDEX.md             — table of contents with freshness metadata
 //!   <out>/decisions/<domain>.md — one file per domain (active decisions)
@@ -353,14 +355,25 @@ fn render_index(
 }
 
 /// Escape a field for single-line markdown (GH-671 round trip): backslash
-/// first, then newline. Inverse lives in `edda-ledger::sync::unescape_field`.
+/// first, then newline, then backtick (GH-1044) — in that order, so the
+/// escape backslashes the later two passes insert are never themselves
+/// re-escaped by the first. Inverse lives in
+/// `edda-ledger::sync::unescape_field`.
 ///
-/// Applied to every caller-supplied component of the encoding. The pair is
-/// only sound when both halves are total — escaping a field on write without
-/// unescaping it on read hands the importer a literal `\n`, which is a quieter
-/// corruption than the injected line it replaced, not a fix.
+/// Applied to every caller-supplied component of the encoding, including
+/// each item of a backtick-wrapped list (Tags, Affected paths, Cites) before
+/// `` `{item}` `` wraps it. Without the backtick pass, an item containing a
+/// raw backtick is indistinguishable from the list's own `` `, ` `` item
+/// separator or its wrapping delimiters, so `backtick_list` either splits one
+/// item into two (GH-1044) or mis-trims the wrapping backtick off an item
+/// that itself starts or ends with one. The pair is only sound when both
+/// halves are total — escaping a field on write without unescaping it on
+/// read hands the importer a literal `\n` or `` \` ``, which is a quieter
+/// corruption than the injected line or split it replaced, not a fix.
 fn escape_field(s: &str) -> String {
-    s.replace('\\', "\\\\").replace('\n', "\\n")
+    s.replace('\\', "\\\\")
+        .replace('\n', "\\n")
+        .replace('`', "\\`")
 }
 
 fn resolve_machine(explicit: Option<&str>) -> String {
@@ -518,6 +531,22 @@ mod tests {
             !md.contains("a\nb"),
             "raw newline must not leak into the file"
         );
+    }
+
+    /// GH-1044: a backtick must survive `escape_field` too, in the same
+    /// backslash-escape scheme as newline — not just the one reported
+    /// character (a lone backtick, one leading, one trailing, and the
+    /// two-character separator `backtick_list` splits on), since the reader
+    /// is a single shared function and every caller-supplied field rides it.
+    #[test]
+    fn escape_field_escapes_backticks() {
+        assert_eq!(escape_field("a`b"), "a\\`b");
+        assert_eq!(escape_field("`lead"), "\\`lead");
+        assert_eq!(escape_field("trail`"), "trail\\`");
+        assert_eq!(escape_field("a`, `b"), "a\\`, \\`b");
+        // Backslash-first ordering: a literal backslash immediately before a
+        // backtick must not be read back as one already-escaped unit.
+        assert_eq!(escape_field("a\\`b"), "a\\\\\\`b");
     }
 
     #[test]
@@ -861,6 +890,99 @@ mod tests {
             after.source_event_id.as_deref(),
             Some(before.event_id.as_str())
         );
+    }
+
+    /// GH-1044: `escape_field` left backticks raw, so a Tags/Affected
+    /// paths/Cites item containing the list's own two-character separator
+    /// `` `, `` split into two items after a mirror round trip — the one
+    /// hole `export_import_round_trip_is_total_for_newlines_and_backslashes`
+    /// (PR #1017) left in the "encoding is total" property. Property, not
+    /// the one reported character: this payload also covers a tag that
+    /// starts with a backtick and one that ends with one, both of which
+    /// `backtick_list`'s old `trim_matches('`')` (a greedy strip, not the
+    /// one-at-a-time `strip_prefix`/`strip_suffix` this fix switches to)
+    /// would mis-trim once backticks are escaped, by eating the escaped
+    /// backtick's bare half along with the list's real wrapping delimiter.
+    ///
+    /// Round trip, not render inspection, same shape as the sibling test
+    /// above: A decides, A exports, B imports, B's row must equal A's field
+    /// for field — `tags` above all, since that is where GH-1044 lived, but
+    /// also the scalar fields the same shared `escape_field` touches.
+    #[test]
+    fn export_import_round_trip_is_total_for_backticks() {
+        let dir = tempfile::tempdir().unwrap();
+        let a_root = dir.path().join("machine-a");
+        let b_root = dir.path().join("machine-b");
+        fs::create_dir_all(&a_root).unwrap();
+        fs::create_dir_all(&b_root).unwrap();
+
+        let a = Ledger::open_or_init(&a_root).unwrap();
+        let dp = edda_core::types::DecisionPayload {
+            key: "esc.backtick`key".to_string(),
+            value: "a`, `b".to_string(),
+            reason: Some("see `escape_field`, the reader".to_string()),
+            scope: None,
+            authority: Some("`agent".to_string()),
+            affected_paths: Some(vec!["crates/a`b/**".to_string()]),
+            tags: Some(vec![
+                // The exact GH-1044 defect: a single tag that IS the list's
+                // own item separator, embedded.
+                "a`, `b".to_string(),
+                // The secondary hole a naive "just escape the backtick" fix
+                // still leaves: an item whose escaped form ends up adjacent
+                // to the wrapping delimiter on one edge only.
+                "`leading".to_string(),
+                "trailing`".to_string(),
+                "plain".to_string(),
+            ]),
+            review_after: None,
+            reversibility: Some("hard`".to_string()),
+            village_id: None,
+            cites: None,
+        };
+        let ev = edda_core::event::new_decision_event("main", None, "system", &dp).unwrap();
+        a.append_event(&ev).unwrap();
+        let source = a.active_decisions(None, None, None, None).unwrap();
+        assert_eq!(source.len(), 1, "one decision on machine A");
+        drop(a);
+
+        let mirror = a_root.join("docs").join("decisions");
+        execute(&a_root, &mirror, false, Some("host-a")).unwrap();
+
+        let b = Ledger::open_or_init(&b_root).unwrap();
+        let imported = edda_ledger::sync::sync_from_mirror(
+            &b,
+            &edda_ledger::sync::MirrorSource {
+                mirror_dir: mirror.clone(),
+            },
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            imported.imported.len(),
+            1,
+            "exactly one decision crosses the mirror"
+        );
+
+        let landed = b.active_decisions(None, None, None, None).unwrap();
+        assert_eq!(landed.len(), 1, "one decision on machine B: {landed:#?}");
+        let (before, after) = (&source[0], &landed[0]);
+
+        assert_eq!(after.key, before.key, "key rides the `## `key`` header");
+        assert_eq!(after.value, before.value);
+        assert_eq!(after.reason, before.reason);
+        assert_eq!(after.authority, before.authority);
+        assert_eq!(after.reversibility, before.reversibility);
+        assert_eq!(after.affected_paths, before.affected_paths);
+        // The core GH-1044 assertion: four tags in, four tags out,
+        // byte-identical — none split, none truncated at an edge backtick.
+        assert_eq!(
+            after.tags.len(),
+            4,
+            "a tag containing `, ` must not split the list: {:?}",
+            after.tags
+        );
+        assert_eq!(after.tags, before.tags);
     }
 
     #[test]

--- a/crates/edda-cli/src/cmd_sync.rs
+++ b/crates/edda-cli/src/cmd_sync.rs
@@ -132,6 +132,13 @@ fn execute_from_mirror(repo_root: &Path, mirror: &str, dry_run: bool) -> anyhow:
         }
     }
 
+    // GH-1044: a domain file the importer refuses is skipped, not fatal — but
+    // it prints before the summary and before the up-to-date early return,
+    // because "already up to date" over a refused file is the lie that hides it.
+    if let Some(warning) = refused_files_warning(&result.errors) {
+        eprintln!("{warning}\n");
+    }
+
     if result.imported.is_empty() && result.conflicts.is_empty() {
         println!("Already up to date ({} skipped).", result.skipped);
         return Ok(());
@@ -171,6 +178,19 @@ fn execute_from_mirror(repo_root: &Path, mirror: &str, dry_run: bool) -> anyhow:
     }
 
     Ok(())
+}
+
+/// The visible refusal signal (GH-1044): every mirror file the importer would
+/// not parse, named with its reason, so the operator can fix or delete it.
+fn refused_files_warning(errors: &[edda_ledger::sync::SourceError]) -> Option<String> {
+    if errors.is_empty() {
+        return None;
+    }
+    let mut out = format!("Refused {} mirror file(s) — NOT imported:", errors.len());
+    for e in errors {
+        out.push_str(&format!("\n  {}.md: {}", e.project_name, e.error));
+    }
+    Some(out)
 }
 
 /// Resolve the mirror directory: absolute as-is, otherwise relative to the
@@ -217,6 +237,22 @@ mod tests {
     use super::*;
     use edda_ledger::Ledger;
     use std::fs;
+
+    #[test]
+    fn a_refused_mirror_file_is_named_with_its_reason() {
+        // GH-1044 F13: the importer now contains a refusal instead of aborting
+        // the mirror, so `--from-mirror` must print what it refused. Silence
+        // here would trade a loud abort for a quiet skip, which is worse.
+        assert_eq!(refused_files_warning(&[]), None, "no refusal ⇒ no noise");
+        let errors = [edda_ledger::sync::SourceError {
+            project_name: "legacy".to_string(),
+            error: "malformed mirror heading: ## `legacy".to_string(),
+        }];
+        let warning = refused_files_warning(&errors).expect("a refusal must be visible");
+        assert!(warning.contains("Refused 1 mirror file(s)"), "{warning}");
+        assert!(warning.contains("legacy.md"), "{warning}");
+        assert!(warning.contains("malformed mirror heading"), "{warning}");
+    }
 
     /// The verbatim value and six-point reason the binding carrier demands:
     /// `fleet.lane-profile` quotes the operator ruling, never the

--- a/crates/edda-ledger/src/sync.rs
+++ b/crates/edda-ledger/src/sync.rs
@@ -580,16 +580,28 @@ enum MirrorEncoding {
     Escaped,
 }
 
-/// PR #1017 introduced escaping and the required Scope/Authority lines in
-/// the same writer change. Those lines are therefore the existing format
-/// discriminator for generated domain mirrors; a partial or mixed file is
-/// ambiguous and must fail closed instead of selecting a lossy decoder.
+/// Return the content of an exact backtick-wrapped mirror heading. Once a
+/// structural prefix appears, a missing wrapper or empty value is malformed,
+/// not prose that the encoding detector and parser may interpret differently.
+fn mirror_heading<'a>(line: &'a str, prefix: &str) -> anyhow::Result<Option<&'a str>> {
+    let Some(rest) = line.strip_prefix(prefix) else {
+        return Ok(None);
+    };
+    let value = rest
+        .strip_suffix('`')
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| anyhow::anyhow!("malformed mirror heading: {line}"))?;
+    Ok(Some(value))
+}
+
+/// PR #1017 introduced escaping and required Scope/Authority lines in the
+/// same writer change. Partial or mixed generated shapes fail closed.
 fn detect_mirror_encoding(text: &str) -> anyhow::Result<MirrorEncoding> {
     let mut detected = None;
     let mut section = None;
 
     for line in text.lines() {
-        if line.starts_with("## `") {
+        if mirror_heading(line, "## `")?.is_some() {
             if let Some((scope, authority)) = section.replace((false, false)) {
                 record_section_encoding(scope, authority, &mut detected)?;
             }
@@ -634,22 +646,17 @@ fn parse_domain_markdown(file_domain: &str, text: &str) -> anyhow::Result<Vec<Mi
     let mut current: Option<MirrorDecision> = None;
 
     for line in text.lines() {
-        if let Some(rest) = line.strip_prefix("# Domain: `") {
-            header_domain = rest
-                .strip_suffix('`')
-                .map(|value| decode_mirror_field(value, encoding));
+        if let Some(domain) = mirror_heading(line, "# Domain: `")? {
+            header_domain = Some(decode_mirror_field(domain, encoding));
             continue;
         }
-        if let Some(rest) = line.strip_prefix("## `") {
+        if let Some(key) = mirror_heading(line, "## `")? {
             if let Some(done) = current.take() {
                 finish_mirror_decision(done, &mut out)?;
             }
             // Trim before decoding, never after: decoding first can produce a
             // trailing newline that `trim` would then eat.
-            let key = decode_mirror_field(rest.strip_suffix('`').unwrap_or(rest).trim(), encoding);
-            if key.is_empty() {
-                continue;
-            }
+            let key = decode_mirror_field(key.trim(), encoding);
             let domain = header_domain
                 .clone()
                 .unwrap_or_else(|| file_domain.to_string());

--- a/crates/edda-ledger/src/sync.rs
+++ b/crates/edda-ledger/src/sync.rs
@@ -736,18 +736,44 @@ fn backtick_list_to_json(s: &str) -> String {
 
 /// `` `a`, `b` `` → `vec!["a", "b"]`, each item unescaped.
 ///
-/// The export escapes every item (`cmd_export::escape_field`), so a tag or a
-/// citation containing a backslash or a newline survives the single-line
-/// encoding instead of splitting the list or truncating the value.
+/// The export escapes every item, backtick included (GH-1044:
+/// `cmd_export::escape_field`), so a tag or a citation containing a
+/// backslash, a newline, or a backtick — including the two-character
+/// sequence `` `, `` that would otherwise read as this list's own item
+/// separator — survives the single-line encoding instead of splitting the
+/// list or truncating a value.
+///
+/// The list's own outer wrapping backticks are stripped exactly once, from
+/// the *whole* string, before splitting — never per fragment (GH-1044). One
+/// pass over the joined string already shows why: `split("`, `")` finds and
+/// consumes every INTERIOR delimiter pair as part of its match (the
+/// preceding item's closing backtick together with the next item's opening
+/// one), so once the two outer delimiters are gone, nothing left in any
+/// fragment is ever a genuine wrapping backtick — every backtick still there
+/// is escaped content (`` \` ``) bound for [`unescape_field`]. A middle item
+/// whose own value ends in a backtick is the case that breaks a per-fragment
+/// strip: it renders as `` ...\``` `` at that item's boundary (the escaped
+/// backtick's own closing backtick immediately followed by the real
+/// delimiter), `split` correctly consumes only the real delimiter as part of
+/// the *next* match, and a fragment-local `strip_suffix('`')` — unable to
+/// tell the two apart from inside one fragment — then strips the escaped
+/// backtick's bare half too, corrupting the item. Stripping the outer pair
+/// once, before any fragment exists, removes the ambiguity instead of
+/// guessing at it.
 fn backtick_list(s: &str) -> Vec<String> {
-    s.split("`, `")
-        .map(|p| unescape_field(p.trim_matches('`').trim()))
+    let inner = s.strip_prefix('`').unwrap_or(s);
+    let inner = inner.strip_suffix('`').unwrap_or(inner);
+    inner
+        .split("`, `")
+        .map(|p| unescape_field(p.trim()))
         .filter(|p| !p.is_empty())
         .collect()
 }
 
 /// Inverse of `edda-cli::cmd_export::escape_field` — a left-to-right scan so
-/// `\\n` (escaped backslash followed by `n`) never collapses into a newline.
+/// `\\n` (escaped backslash followed by `n`) never collapses into a newline,
+/// and (GH-1044) an escaped backslash followed by a raw backtick never
+/// collapses into an unescaped one either.
 ///
 /// Older mirrors wrote some fields raw. An *unknown* escape is passed through
 /// unchanged (`\p` stays `\p`), so most raw text survives — but this is not
@@ -755,7 +781,13 @@ fn backtick_list(s: &str) -> Vec<String> {
 /// and a raw `\\` halves. Reachability is narrow (the fields that carried
 /// backslashes in practice — `affected_paths`, tags — were already unescaped
 /// before the encoding was made total), which is why the round trip is
-/// preferred over a version-tagged mirror format.
+/// preferred over a version-tagged mirror format. The same argument covers
+/// the new backtick arm: every backslash run in mirror text written before
+/// GH-1044 came only from doubling a raw `\` (`.replace('\\', "\\\\")`), so
+/// every such run has even length and this scan always pairs it off
+/// completely — an escaped-backtick two-char sequence can therefore never
+/// appear by accident in a pre-GH-1044 mirror, only be introduced by this
+/// fix's own writer.
 fn unescape_field(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut chars = s.chars();
@@ -764,6 +796,7 @@ fn unescape_field(s: &str) -> String {
             match chars.next() {
                 Some('n') => out.push('\n'),
                 Some('\\') => out.push('\\'),
+                Some('`') => out.push('`'),
                 Some(other) => {
                     out.push('\\');
                     out.push(other);

--- a/crates/edda-ledger/src/sync.rs
+++ b/crates/edda-ledger/src/sync.rs
@@ -744,30 +744,62 @@ fn backtick_list_to_json(s: &str) -> String {
 /// list or truncating a value.
 ///
 /// The list's own outer wrapping backticks are stripped exactly once, from
-/// the *whole* string, before splitting — never per fragment (GH-1044). One
-/// pass over the joined string already shows why: `split("`, `")` finds and
-/// consumes every INTERIOR delimiter pair as part of its match (the
-/// preceding item's closing backtick together with the next item's opening
-/// one), so once the two outer delimiters are gone, nothing left in any
-/// fragment is ever a genuine wrapping backtick — every backtick still there
-/// is escaped content (`` \` ``) bound for [`unescape_field`]. A middle item
-/// whose own value ends in a backtick is the case that breaks a per-fragment
-/// strip: it renders as `` ...\``` `` at that item's boundary (the escaped
-/// backtick's own closing backtick immediately followed by the real
-/// delimiter), `split` correctly consumes only the real delimiter as part of
-/// the *next* match, and a fragment-local `strip_suffix('`')` — unable to
-/// tell the two apart from inside one fragment — then strips the escaped
-/// backtick's bare half too, corrupting the item. Stripping the outer pair
-/// once, before any fragment exists, removes the ambiguity instead of
-/// guessing at it.
+/// the *whole* string, before splitting (GH-1044) — never per fragment: a
+/// fragment-local `strip_suffix('`')` cannot tell an escaped content
+/// backtick's bare half and a genuine wrapping delimiter apart, so it would
+/// sometimes strip the wrong one.
+///
+/// The split itself has to be escape-aware (GH-1044 Round 1 P0 —
+/// `split_unescaped_backtick_comma` below). A plain `split("`, `")` matches
+/// four literal bytes and never looks at what precedes them, so an item
+/// whose value *ends* in exactly backtick, comma, space — escaped by the
+/// writer to `` \`,  `` — still supplies the delimiter's opening half from
+/// its own escaped content, one byte before the genuine wrapper backtick
+/// that follows it. Because a plain split is leftmost and non-overlapping,
+/// that false match consumes the real delimiter's opening half too,
+/// corrupting both the item that ends there and the one after it.
 fn backtick_list(s: &str) -> Vec<String> {
     let inner = s.strip_prefix('`').unwrap_or(s);
     let inner = inner.strip_suffix('`').unwrap_or(inner);
-    inner
-        .split("`, `")
+    split_unescaped_backtick_comma(inner)
+        .into_iter()
         .map(|p| unescape_field(p.trim()))
         .filter(|p| !p.is_empty())
         .collect()
+}
+
+/// Split `inner` on the list's item delimiter `` `, ` ``, treating a
+/// backtick as delimiter material only when it is not itself escaped
+/// content (GH-1044 Round 1 P0).
+///
+/// Walks `inner` left to right the same way [`unescape_field`] does: a `\`
+/// and whatever character follows it are consumed together as one unit and
+/// can never begin a delimiter match. `escape_field` escapes every content
+/// backtick, so the only backtick this scan ever reaches as a fresh,
+/// unconsumed character is a genuine item wrapper — an escaped content
+/// backtick is always the second half of a pair the backslash branch has
+/// already stepped over. A fresh backtick not immediately followed by
+/// `` , ` `` is left in place rather than treated as an error, the same
+/// leniency `backtick_list` has always extended to malformed input.
+fn split_unescaped_backtick_comma(inner: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0usize;
+    let mut chars = inner.char_indices();
+    while let Some((i, c)) = chars.next() {
+        if c == '\\' {
+            chars.next(); // escaped unit — cannot itself begin a delimiter
+            continue;
+        }
+        if c == '`' && inner[i..].starts_with("`, `") {
+            parts.push(&inner[start..i]);
+            for _ in 0..3 {
+                chars.next(); // ',', ' ', the delimiter's closing '`'
+            }
+            start = i + "`, `".len();
+        }
+    }
+    parts.push(&inner[start..]);
+    parts
 }
 
 /// Inverse of `edda-cli::cmd_export::escape_field` — a left-to-right scan so
@@ -782,12 +814,21 @@ fn backtick_list(s: &str) -> Vec<String> {
 /// backslashes in practice — `affected_paths`, tags — were already unescaped
 /// before the encoding was made total), which is why the round trip is
 /// preferred over a version-tagged mirror format. The same argument covers
-/// the new backtick arm: every backslash run in mirror text written before
-/// GH-1044 came only from doubling a raw `\` (`.replace('\\', "\\\\")`), so
-/// every such run has even length and this scan always pairs it off
-/// completely — an escaped-backtick two-char sequence can therefore never
-/// appear by accident in a pre-GH-1044 mirror, only be introduced by this
-/// fix's own writer.
+/// the new backtick arm, but not because every pre-GH-1044 backslash run has
+/// even length — it doesn't: the pre-fix writer's newline pass
+/// (`.replace('\n', "\\n")`) also emits a single backslash, so a raw `\`
+/// immediately before a raw newline encodes to three backslashes then `n`,
+/// an odd-length run. What actually holds is that this scan is
+/// self-synchronising over the old escape alphabet: every backslash it
+/// meets in pre-GH-1044 text is the first character of either a doubled
+/// backslash (`.replace('\\', "\\\\")`) or a newline escape
+/// (`.replace('\n', "\\n")`), and both are consumed as one unit — so
+/// regardless of the run's length or parity, the scan always lands back on
+/// a fresh, unpaired position immediately after it, never mid-run, and so
+/// never pairs a leftover backslash with a raw backtick that happens to
+/// follow. An escaped-backtick two-char sequence can therefore never appear
+/// by accident in a pre-GH-1044 mirror, only be introduced by this fix's own
+/// writer.
 fn unescape_field(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut chars = s.chars();

--- a/crates/edda-ledger/src/sync.rs
+++ b/crates/edda-ledger/src/sync.rs
@@ -347,7 +347,7 @@ pub fn sync_from_mirror(
         freshness,
     });
 
-    let decisions = parse_mirror(&source.mirror_dir)?;
+    let decisions = parse_mirror(&source.mirror_dir, &mut result)?;
     let branch = target.head_branch()?;
 
     for md in &decisions {
@@ -544,8 +544,10 @@ fn mirror_freshness(meta: &MirrorIndexMeta, threshold_hours: i64) -> MirrorFresh
     }
 }
 
-/// Parse every `decisions/*.md` file of a mirror into importable rows.
-fn parse_mirror(mirror_dir: &Path) -> anyhow::Result<Vec<MirrorDecision>> {
+/// Parse every `decisions/*.md` file of a mirror into importable rows. A file
+/// this parser refuses is reported in `result.errors` — never guessed at, never
+/// fatal to the mirror's other domains, and never silent (GH-1044).
+fn parse_mirror(mirror_dir: &Path, result: &mut SyncResult) -> anyhow::Result<Vec<MirrorDecision>> {
     let decisions_dir = mirror_dir.join("decisions");
     if !decisions_dir.is_dir() {
         anyhow::bail!(
@@ -562,14 +564,16 @@ fn parse_mirror(mirror_dir: &Path) -> anyhow::Result<Vec<MirrorDecision>> {
 
     let mut out = Vec::new();
     for f in files {
-        let stem = f
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("")
-            .to_string();
+        let stem = f.file_stem().and_then(|s| s.to_str()).unwrap_or("");
         let text = std::fs::read_to_string(&f)
             .with_context(|| format!("read mirror file {}", f.display()))?;
-        out.extend(parse_domain_markdown(&stem, &text)?);
+        match parse_domain_markdown(stem, &text) {
+            Ok(rows) => out.extend(rows),
+            Err(e) => result.errors.push(SourceError {
+                project_name: stem.to_string(),
+                error: e.to_string(),
+            }),
+        }
     }
     Ok(out)
 }
@@ -636,9 +640,8 @@ fn record_section_encoding(
     Ok(())
 }
 
-/// Parse one domain file of the mirror format (the exact shape
-/// `edda export md` renders) into decisions. Missing optional lines fall
-/// back to conservative defaults so pre-GH-671 mirrors still import.
+/// Parse one domain file of the mirror format (the exact shape `edda export md`
+/// renders). Missing optional lines default; an unclassifiable shape errors.
 fn parse_domain_markdown(file_domain: &str, text: &str) -> anyhow::Result<Vec<MirrorDecision>> {
     let encoding = detect_mirror_encoding(text)?;
     let mut out: Vec<MirrorDecision> = Vec::new();

--- a/crates/edda-ledger/src/sync.rs
+++ b/crates/edda-ledger/src/sync.rs
@@ -574,27 +574,79 @@ fn parse_mirror(mirror_dir: &Path) -> anyhow::Result<Vec<MirrorDecision>> {
     Ok(out)
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MirrorEncoding {
+    Raw,
+    Escaped,
+}
+
+/// PR #1017 introduced escaping and the required Scope/Authority lines in
+/// the same writer change. Those lines are therefore the existing format
+/// discriminator for generated domain mirrors; a partial or mixed file is
+/// ambiguous and must fail closed instead of selecting a lossy decoder.
+fn detect_mirror_encoding(text: &str) -> anyhow::Result<MirrorEncoding> {
+    let mut detected = None;
+    let mut section = None;
+
+    for line in text.lines() {
+        if line.starts_with("## `") {
+            if let Some((scope, authority)) = section.replace((false, false)) {
+                record_section_encoding(scope, authority, &mut detected)?;
+            }
+        } else if let Some((scope, authority)) = section.as_mut() {
+            *scope |= line.starts_with("- **Scope**: ");
+            *authority |= line.starts_with("- **Authority**: ");
+        }
+    }
+    if let Some((scope, authority)) = section {
+        record_section_encoding(scope, authority, &mut detected)?;
+    }
+
+    Ok(detected.unwrap_or(MirrorEncoding::Raw))
+}
+
+fn record_section_encoding(
+    has_scope: bool,
+    has_authority: bool,
+    detected: &mut Option<MirrorEncoding>,
+) -> anyhow::Result<()> {
+    let encoding = match (has_scope, has_authority) {
+        (false, false) => MirrorEncoding::Raw,
+        (true, true) => MirrorEncoding::Escaped,
+        _ => anyhow::bail!(
+            "ambiguous mirror encoding: decision must contain both Scope and Authority or neither"
+        ),
+    };
+    if detected.is_some_and(|previous| previous != encoding) {
+        anyhow::bail!("ambiguous mirror encoding: raw and escaped decision shapes are mixed");
+    }
+    *detected = Some(encoding);
+    Ok(())
+}
+
 /// Parse one domain file of the mirror format (the exact shape
 /// `edda export md` renders) into decisions. Missing optional lines fall
 /// back to conservative defaults so pre-GH-671 mirrors still import.
 fn parse_domain_markdown(file_domain: &str, text: &str) -> anyhow::Result<Vec<MirrorDecision>> {
+    let encoding = detect_mirror_encoding(text)?;
     let mut out: Vec<MirrorDecision> = Vec::new();
     let mut header_domain: Option<String> = None;
     let mut current: Option<MirrorDecision> = None;
 
     for line in text.lines() {
         if let Some(rest) = line.strip_prefix("# Domain: `") {
-            header_domain = rest.strip_suffix('`').map(unescape_field);
+            header_domain = rest
+                .strip_suffix('`')
+                .map(|value| decode_mirror_field(value, encoding));
             continue;
         }
         if let Some(rest) = line.strip_prefix("## `") {
             if let Some(done) = current.take() {
                 finish_mirror_decision(done, &mut out)?;
             }
-            // Trim before unescaping, never after: unescaping first can
-            // produce a trailing newline that `trim` would then eat, silently
-            // shortening the very key this escape exists to carry whole.
-            let key = unescape_field(rest.strip_suffix('`').unwrap_or(rest).trim());
+            // Trim before decoding, never after: decoding first can produce a
+            // trailing newline that `trim` would then eat.
+            let key = decode_mirror_field(rest.strip_suffix('`').unwrap_or(rest).trim(), encoding);
             if key.is_empty() {
                 continue;
             }
@@ -632,7 +684,7 @@ fn parse_domain_markdown(file_domain: &str, text: &str) -> anyhow::Result<Vec<Mi
         let Some(decision) = current.as_mut() else {
             continue;
         };
-        parse_mirror_field_line(line, decision);
+        parse_mirror_field_line(line, decision, encoding);
     }
     if let Some(done) = current.take() {
         finish_mirror_decision(done, &mut out)?;
@@ -670,19 +722,19 @@ fn finish_mirror_decision(
 /// Match one `- **Field**: value` line inside a decision section.
 /// Unrecognized lines (headers, prose, gloss) are ignored.
 ///
-/// Every caller-supplied field is unescaped here, because `cmd_export` escapes
-/// every caller-supplied field on write — the two halves are one encoding and
-/// only work as a pair. Branch and ts are the exception on both sides: a
-/// branch name is restricted to `[A-Za-z0-9._/-]` by
+/// Every caller-supplied field is decoded here according to the domain file's
+/// writer era: post-#1017 fields are unescaped, while raw-era bytes are kept
+/// literal. Branch and ts are the exception on both sides: a branch name is
+/// restricted to `[A-Za-z0-9._/-]` by
 /// [`crate::validate_branch_name`] and a ts is a machine RFC3339 stamp, so
 /// neither can carry an escape to undo.
-fn parse_mirror_field_line(line: &str, decision: &mut MirrorDecision) {
+fn parse_mirror_field_line(line: &str, decision: &mut MirrorDecision, encoding: MirrorEncoding) {
     let row = &mut decision.row;
     if let Some(v) = line.strip_prefix("- **Value**: `") {
         let v = v.strip_suffix('`').unwrap_or(v);
-        row.value = unescape_field(v);
+        row.value = decode_mirror_field(v, encoding);
     } else if let Some(v) = line.strip_prefix("- **Reason**: ") {
-        row.reason = unescape_field(v.trim_end());
+        row.reason = decode_mirror_field(v.trim_end(), encoding);
     } else if let Some(v) = line.strip_prefix("- **Branch/ts**: `") {
         if let Some((branch, ts)) = v.split_once("` · ") {
             row.branch = branch.trim().to_string();
@@ -695,46 +747,46 @@ fn parse_mirror_field_line(line: &str, decision: &mut MirrorDecision) {
                 // ratification` records the mirror, not this string — but it
                 // is quoted into that event's note, so it is carried exactly
                 // rather than half-decoded.
-                decision.ratified_by = Some(unescape_field(who.trim()));
+                decision.ratified_by = Some(decode_mirror_field(who.trim(), encoding));
                 decision.ratified_at = Some(ts.trim().to_string());
             }
         } else if let Some(rest) = v.strip_prefix("unratified (") {
             let auth = rest.strip_suffix(')').unwrap_or(rest).trim();
             if !auth.is_empty() {
-                row.authority = unescape_field(auth);
+                row.authority = decode_mirror_field(auth, encoding);
             }
         }
     } else if let Some(v) = line.strip_prefix("- **Scope**: ") {
-        row.scope = unescape_field(v.trim());
+        row.scope = decode_mirror_field(v.trim(), encoding);
     } else if let Some(v) = line.strip_prefix("- **Authority**: ") {
-        row.authority = unescape_field(v.trim());
+        row.authority = decode_mirror_field(v.trim(), encoding);
     } else if let Some(v) = line.strip_prefix("- **Affected paths**: ") {
-        row.affected_paths = backtick_list_to_json(v);
+        row.affected_paths = backtick_list_to_json(v, encoding);
     } else if let Some(v) = line.strip_prefix("- **Tags**: ") {
-        row.tags = backtick_list_to_json(v);
+        row.tags = backtick_list_to_json(v, encoding);
     } else if let Some(v) = line.strip_prefix("- **Review after**: ") {
-        row.review_after = Some(unescape_field(v.trim()));
+        row.review_after = Some(decode_mirror_field(v.trim(), encoding));
     } else if let Some(v) = line.strip_prefix("- **Reversibility**: ") {
-        row.reversibility = unescape_field(v.trim());
+        row.reversibility = decode_mirror_field(v.trim(), encoding);
     } else if let Some(v) = line.strip_prefix("- **Village**: ") {
-        row.village_id = Some(unescape_field(v.trim()));
+        row.village_id = Some(decode_mirror_field(v.trim(), encoding));
     } else if let Some(v) = line.strip_prefix("- **Cites**: ") {
         // GH-761 citations ride the mirror as a backtick list, same encoding
         // as Tags and Affected paths. Dropping them would make the mirror lie
         // by omission about what authority a decision rests on.
-        decision.cites = backtick_list(v);
+        decision.cites = backtick_list(v, encoding);
     } else if let Some(v) = line.strip_prefix("- **event_id**: `") {
         let v = v.strip_suffix('`').unwrap_or(v);
-        row.event_id = unescape_field(v.trim());
+        row.event_id = decode_mirror_field(v.trim(), encoding);
     }
 }
 
 /// `` `a`, `b` `` → `["a","b"]` as a JSON array string.
-fn backtick_list_to_json(s: &str) -> String {
-    serde_json::to_string(&backtick_list(s)).unwrap_or_else(|_| "[]".to_string())
+fn backtick_list_to_json(s: &str, encoding: MirrorEncoding) -> String {
+    serde_json::to_string(&backtick_list(s, encoding)).unwrap_or_else(|_| "[]".to_string())
 }
 
-/// `` `a`, `b` `` → `vec!["a", "b"]`, each item unescaped.
+/// `` `a`, `b` `` → `vec!["a", "b"]`, decoded for its writer era.
 ///
 /// The export escapes every item, backtick included (GH-1044:
 /// `cmd_export::escape_field`), so a tag or a citation containing a
@@ -759,19 +811,20 @@ fn backtick_list_to_json(s: &str) -> String {
 /// that false match consumes the real delimiter's opening half too,
 /// corrupting both the item that ends there and the one after it.
 ///
-/// Known, accepted limitation (GH-1044 Round 2, not fixable by a cleverer
-/// scan — see [`unescape_field`]'s doc comment for the full argument): a
-/// mirror written before PR #1017 (`3306c1a`, 2026-09-07), whose item
-/// values were never escaped at all, can lose an item *boundary* — not just
-/// value content — when a value ends in an odd-length run of raw
-/// backslashes right before the wrapper. Recovering that needs a mirror
-/// format/version marker; routed as GH-1113.
-fn backtick_list(s: &str) -> Vec<String> {
+/// Raw pre-#1017 mirrors use their historical plain split and preserve field
+/// bytes. Escaped mirrors use the escape-aware split. Selecting the rule from
+/// the domain-file shape prevents raw trailing backslashes from swallowing a
+/// wrapper while retaining GH-1044's current-writer round trip.
+fn backtick_list(s: &str, encoding: MirrorEncoding) -> Vec<String> {
     let inner = s.strip_prefix('`').unwrap_or(s);
     let inner = inner.strip_suffix('`').unwrap_or(inner);
-    split_unescaped_backtick_comma(inner)
+    let parts = match encoding {
+        MirrorEncoding::Raw => inner.split("`, `").collect(),
+        MirrorEncoding::Escaped => split_unescaped_backtick_comma(inner),
+    };
+    parts
         .into_iter()
-        .map(|p| unescape_field(p.trim()))
+        .map(|p| decode_mirror_field(p.trim(), encoding))
         .filter(|p| !p.is_empty())
         .collect()
 }
@@ -790,15 +843,8 @@ fn backtick_list(s: &str) -> Vec<String> {
 /// `` , ` `` is left in place rather than treated as an error, the same
 /// leniency `backtick_list` has always extended to malformed input.
 ///
-/// Both guarantees above are scoped to text `escape_field` itself produced.
-/// [`unescape_field`]'s doc comment has the full two-era argument; in short,
-/// the backslash branch is safe from PR #1017 onward (every backslash this
-/// scan meets is already paired) but can eat a genuine wrapper on a
-/// pre-#1017 mirror (GH-1044 Round 2, known, accepted, GH-1113), and a fresh
-/// backtick is only guaranteed genuine for current-writer text — a raw
-/// backtick in *any* older text can still look like delimiter material,
-/// which is GH-1044's original defect, unchanged, on files already written
-/// that way.
+/// This function is used only for [`MirrorEncoding::Escaped`]. Raw mirrors
+/// retain the historical plain split in [`backtick_list`].
 fn split_unescaped_backtick_comma(inner: &str) -> Vec<&str> {
     let mut parts = Vec::new();
     let mut start = 0usize;
@@ -820,64 +866,16 @@ fn split_unescaped_backtick_comma(inner: &str) -> Vec<&str> {
     parts
 }
 
-/// Inverse of `edda-cli::cmd_export::escape_field` — a left-to-right scan so
-/// `\\n` (escaped backslash followed by `n`) never collapses into a newline,
-/// and (GH-1044) an escaped backslash followed by a raw backtick never
-/// collapses into an unescaped one either.
-///
-/// GH-1044 Round 2: "older mirrors" is not one era, and the back-compat
-/// argument below covers only the more recent of the two. `edda export md`
-/// has written mirrors since `f3e5e97` (2026-07-08):
-///
-/// - **Raw era** (`f3e5e97`..`3306c1a^`, up to 2026-09-07, ~2 months): list
-///   items were rendered with **no escaping at all**
-///   (`format!("`{}`", p)` — `3306c1a^:crates/edda-cli/src/cmd_export.rs:150`).
-///   A raw backslash had no structural meaning and could appear singly,
-///   anywhere.
-/// - **Escaped era** (`3306c1a`, PR #1017, onward until this fix):
-///   `escape_field` existed and doubled every backslash and escaped every
-///   newline (`.replace('\\', "\\\\").replace('\n', "\\n")`), but did not
-///   yet escape backtick — the GH-1044 defect this PR closes. Every
-///   backslash this era's writer emits is therefore already paired.
-///
-/// For the escaped era (and the current one, which adds a third,
-/// same-shaped backtick pass), this scan is self-synchronising: every
-/// backslash it meets is the first of a doubled backslash or a newline
-/// escape, both consumed as one unit, so the scan always lands back on a
-/// fresh position after it, never mid-run — a claim about the *backslash*
-/// branch only, not that escaped-era text always round-trips. Neither older
-/// era ever escaped backtick (that is this PR), so a **raw backtick in an
-/// escaped- or raw-era value** is GH-1044's own original defect, unchanged
-/// by this PR, still live on any mirror already written that way — distinct
-/// from, and not fixed or worsened by, anything below.
-///
-/// The raw era has no backslash guarantee at all, and is lossy in two
-/// distinct ways beyond the shared raw-backtick issue above. An *unknown*
-/// escape (this scan's fallback arm) passes through unchanged (`\p` stays
-/// `\p`), so most raw text still survives, but not losslessly:
-///
-/// - **Value content** (already accepted, unchanged by this PR): a raw
-///   `C:\notes` decodes to `C:` + newline + `otes`, and a raw `\\` halves.
-///   Reachability is narrow (the fields that carried backslashes in
-///   practice — `affected_paths`, tags — were already unescaped before the
-///   encoding was made total), which is why the round trip is preferred
-///   over a version-tagged mirror format.
-/// - **List structure** (new with this PR's escape-aware split,
-///   [`split_unescaped_backtick_comma`] — base and the pre-Round-1 code
-///   here did not have this failure mode): when a raw-era value ends in an
-///   odd-length run of backslashes immediately before that item's own
-///   closing wrapper backtick, the split consumes the wrapper as escaped
-///   content and the two items either side of it silently merge. Provably
-///   irreducible from the bytes alone, not a bug fixable by a cleverer
-///   scan: a raw-era single item whose value is literally `` a`, `b `` and
-///   a current two-item list `["a", "b"]` render to the identical bytes
-///   `` `a`, `b` `` — no decoder operating on bytes alone can be correct
-///   for both origins of that string. A format/version marker would settle
-///   it; out of GH-1044's own stated scope (mirror directory layout /
-///   `INDEX.md`), routed as GH-1113. Accepted and pinned, not silently
-///   introduced: see
-///   `backtick_list_merges_a_raw_pre_1017_item_ending_in_an_odd_backslash_run`
-///   in `sync/tests.rs`.
+fn decode_mirror_field(s: &str, encoding: MirrorEncoding) -> String {
+    match encoding {
+        MirrorEncoding::Raw => s.to_string(),
+        MirrorEncoding::Escaped => unescape_field(s),
+    }
+}
+
+/// Inverse of `edda-cli::cmd_export::escape_field` for escaped-era mirrors.
+/// Raw-era fields bypass this function so literal `\\`, `\\n`, and `` \\` ``
+/// sequences are preserved rather than reinterpreted as escapes.
 fn unescape_field(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut chars = s.chars();

--- a/crates/edda-ledger/src/sync.rs
+++ b/crates/edda-ledger/src/sync.rs
@@ -758,6 +758,14 @@ fn backtick_list_to_json(s: &str) -> String {
 /// that follows it. Because a plain split is leftmost and non-overlapping,
 /// that false match consumes the real delimiter's opening half too,
 /// corrupting both the item that ends there and the one after it.
+///
+/// Known, accepted limitation (GH-1044 Round 2, not fixable by a cleverer
+/// scan — see [`unescape_field`]'s doc comment for the full argument): a
+/// mirror written before PR #1017 (`3306c1a`, 2026-09-07), whose item
+/// values were never escaped at all, can lose an item *boundary* — not just
+/// value content — when a value ends in an odd-length run of raw
+/// backslashes right before the wrapper. Recovering that needs a mirror
+/// format/version marker; routed as GH-1113.
 fn backtick_list(s: &str) -> Vec<String> {
     let inner = s.strip_prefix('`').unwrap_or(s);
     let inner = inner.strip_suffix('`').unwrap_or(inner);
@@ -781,6 +789,16 @@ fn backtick_list(s: &str) -> Vec<String> {
 /// already stepped over. A fresh backtick not immediately followed by
 /// `` , ` `` is left in place rather than treated as an error, the same
 /// leniency `backtick_list` has always extended to malformed input.
+///
+/// Both guarantees above are scoped to text `escape_field` itself produced.
+/// [`unescape_field`]'s doc comment has the full two-era argument; in short,
+/// the backslash branch is safe from PR #1017 onward (every backslash this
+/// scan meets is already paired) but can eat a genuine wrapper on a
+/// pre-#1017 mirror (GH-1044 Round 2, known, accepted, GH-1113), and a fresh
+/// backtick is only guaranteed genuine for current-writer text — a raw
+/// backtick in *any* older text can still look like delimiter material,
+/// which is GH-1044's original defect, unchanged, on files already written
+/// that way.
 fn split_unescaped_backtick_comma(inner: &str) -> Vec<&str> {
     let mut parts = Vec::new();
     let mut start = 0usize;
@@ -807,28 +825,59 @@ fn split_unescaped_backtick_comma(inner: &str) -> Vec<&str> {
 /// and (GH-1044) an escaped backslash followed by a raw backtick never
 /// collapses into an unescaped one either.
 ///
-/// Older mirrors wrote some fields raw. An *unknown* escape is passed through
-/// unchanged (`\p` stays `\p`), so most raw text survives — but this is not
-/// lossless in general: a raw `C:\notes` decodes to `C:` + newline + `otes`,
-/// and a raw `\\` halves. Reachability is narrow (the fields that carried
-/// backslashes in practice — `affected_paths`, tags — were already unescaped
-/// before the encoding was made total), which is why the round trip is
-/// preferred over a version-tagged mirror format. The same argument covers
-/// the new backtick arm, but not because every pre-GH-1044 backslash run has
-/// even length — it doesn't: the pre-fix writer's newline pass
-/// (`.replace('\n', "\\n")`) also emits a single backslash, so a raw `\`
-/// immediately before a raw newline encodes to three backslashes then `n`,
-/// an odd-length run. What actually holds is that this scan is
-/// self-synchronising over the old escape alphabet: every backslash it
-/// meets in pre-GH-1044 text is the first character of either a doubled
-/// backslash (`.replace('\\', "\\\\")`) or a newline escape
-/// (`.replace('\n', "\\n")`), and both are consumed as one unit — so
-/// regardless of the run's length or parity, the scan always lands back on
-/// a fresh, unpaired position immediately after it, never mid-run, and so
-/// never pairs a leftover backslash with a raw backtick that happens to
-/// follow. An escaped-backtick two-char sequence can therefore never appear
-/// by accident in a pre-GH-1044 mirror, only be introduced by this fix's own
-/// writer.
+/// GH-1044 Round 2: "older mirrors" is not one era, and the back-compat
+/// argument below covers only the more recent of the two. `edda export md`
+/// has written mirrors since `f3e5e97` (2026-07-08):
+///
+/// - **Raw era** (`f3e5e97`..`3306c1a^`, up to 2026-09-07, ~2 months): list
+///   items were rendered with **no escaping at all**
+///   (`format!("`{}`", p)` — `3306c1a^:crates/edda-cli/src/cmd_export.rs:150`).
+///   A raw backslash had no structural meaning and could appear singly,
+///   anywhere.
+/// - **Escaped era** (`3306c1a`, PR #1017, onward until this fix):
+///   `escape_field` existed and doubled every backslash and escaped every
+///   newline (`.replace('\\', "\\\\").replace('\n', "\\n")`), but did not
+///   yet escape backtick — the GH-1044 defect this PR closes. Every
+///   backslash this era's writer emits is therefore already paired.
+///
+/// For the escaped era (and the current one, which adds a third,
+/// same-shaped backtick pass), this scan is self-synchronising: every
+/// backslash it meets is the first of a doubled backslash or a newline
+/// escape, both consumed as one unit, so the scan always lands back on a
+/// fresh position after it, never mid-run — a claim about the *backslash*
+/// branch only, not that escaped-era text always round-trips. Neither older
+/// era ever escaped backtick (that is this PR), so a **raw backtick in an
+/// escaped- or raw-era value** is GH-1044's own original defect, unchanged
+/// by this PR, still live on any mirror already written that way — distinct
+/// from, and not fixed or worsened by, anything below.
+///
+/// The raw era has no backslash guarantee at all, and is lossy in two
+/// distinct ways beyond the shared raw-backtick issue above. An *unknown*
+/// escape (this scan's fallback arm) passes through unchanged (`\p` stays
+/// `\p`), so most raw text still survives, but not losslessly:
+///
+/// - **Value content** (already accepted, unchanged by this PR): a raw
+///   `C:\notes` decodes to `C:` + newline + `otes`, and a raw `\\` halves.
+///   Reachability is narrow (the fields that carried backslashes in
+///   practice — `affected_paths`, tags — were already unescaped before the
+///   encoding was made total), which is why the round trip is preferred
+///   over a version-tagged mirror format.
+/// - **List structure** (new with this PR's escape-aware split,
+///   [`split_unescaped_backtick_comma`] — base and the pre-Round-1 code
+///   here did not have this failure mode): when a raw-era value ends in an
+///   odd-length run of backslashes immediately before that item's own
+///   closing wrapper backtick, the split consumes the wrapper as escaped
+///   content and the two items either side of it silently merge. Provably
+///   irreducible from the bytes alone, not a bug fixable by a cleverer
+///   scan: a raw-era single item whose value is literally `` a`, `b `` and
+///   a current two-item list `["a", "b"]` render to the identical bytes
+///   `` `a`, `b` `` — no decoder operating on bytes alone can be correct
+///   for both origins of that string. A format/version marker would settle
+///   it; out of GH-1044's own stated scope (mirror directory layout /
+///   `INDEX.md`), routed as GH-1113. Accepted and pinned, not silently
+///   introduced: see
+///   `backtick_list_merges_a_raw_pre_1017_item_ending_in_an_odd_backslash_run`
+///   in `sync/tests.rs`.
 fn unescape_field(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut chars = s.chars();

--- a/crates/edda-ledger/src/sync/tests.rs
+++ b/crates/edda-ledger/src/sync/tests.rs
@@ -437,6 +437,59 @@ fn mirror_parse_unescapes_value_and_reason() {
     );
 }
 
+#[test]
+fn mirror_parse_preserves_raw_pre_1017_backslash_shapes() {
+    // Direct raw-era fixture: no Scope/Authority lines, exactly as the writer
+    // before #1017 emitted it. The value's literal backslash+backtick must not
+    // be consumed as a new escape, and the first path's trailing backslash
+    // must not hide its wrapper and merge the second path.
+    let raw = concat!(
+        "# Domain: `legacy`\n\n",
+        "## `legacy.raw`\n\n",
+        "- **Value**: `literal\\`tick`\n",
+        "- **Reason**: raw bytes\n",
+        "- **Branch/ts**: `main` · 2026-09-01T00:00:00Z\n",
+        "- **Governance**: unratified (agent)\n",
+        "- **Affected paths**: `a\\`, `b`\n",
+        "- **event_id**: `evt_legacy`\n",
+    );
+    let parsed = parse_domain_markdown("legacy", raw).unwrap();
+
+    assert_eq!(parsed[0].row.value, "literal\\`tick");
+    let paths: Vec<String> = serde_json::from_str(&parsed[0].row.affected_paths).unwrap();
+    assert_eq!(paths, vec!["a\\".to_string(), "b".to_string()]);
+}
+
+#[test]
+fn mirror_parse_uses_shape_to_disambiguate_the_same_field_bytes() {
+    // In an escaped-era file these bytes encode a content backtick. The
+    // required post-#1017 fields distinguish this from the raw fixture above,
+    // where the same bytes mean a literal backslash followed by a backtick.
+    let escaped = concat!(
+        "## `escaped`\n\n",
+        "- **Value**: `literal\\`tick`\n",
+        "- **Scope**: local\n",
+        "- **Authority**: agent\n",
+        "- **event_id**: `evt_escaped`\n",
+    );
+    let parsed = parse_domain_markdown("escaped", escaped).unwrap();
+    assert_eq!(parsed[0].row.value, "literal`tick");
+}
+
+#[test]
+fn mirror_parse_fails_closed_on_partial_encoding_shape() {
+    let ambiguous = concat!(
+        "## `ambiguous`\n\n",
+        "- **Value**: `literal\\`tick`\n",
+        "- **Scope**: local\n",
+        "- **event_id**: `evt_ambiguous`\n",
+    );
+    let error = parse_domain_markdown("ambiguous", ambiguous)
+        .err()
+        .expect("partial discriminator must fail closed");
+    assert!(error.to_string().contains("ambiguous mirror encoding"));
+}
+
 /// Every caller-supplied field in its escaped form (GH-671 R5) — not only
 /// Value and Reason. `\n` here is the two-character escape the export writes,
 /// never a real line break; a real one would make the line below it a
@@ -722,14 +775,20 @@ fn mirror_list(items: &[&str]) -> String {
 fn backtick_list_ordinary_items_unchanged() {
     // Regression: no backticks involved, must split exactly as before.
     assert_eq!(
-        backtick_list(&mirror_list(&["sqlite", "postgres"])),
+        backtick_list(
+            &mirror_list(&["sqlite", "postgres"]),
+            MirrorEncoding::Escaped,
+        ),
         vec!["sqlite".to_string(), "postgres".to_string()]
     );
     assert_eq!(
-        backtick_list(&mirror_list(&["solo"])),
+        backtick_list(&mirror_list(&["solo"]), MirrorEncoding::Escaped),
         vec!["solo".to_string()]
     );
-    assert_eq!(backtick_list(""), Vec::<String>::new());
+    assert_eq!(
+        backtick_list("", MirrorEncoding::Escaped),
+        Vec::<String>::new()
+    );
 }
 
 #[test]
@@ -738,7 +797,10 @@ fn backtick_list_does_not_split_on_embedded_separator_sequence() {
     // `a`, `b` — i.e. it contains the raw four-byte sequence "`, `" that
     // `backtick_list` splits list items on. One item in, one item out.
     let item = "a`, `b";
-    assert_eq!(backtick_list(&mirror_list(&[item])), vec![item.to_string()]);
+    assert_eq!(
+        backtick_list(&mirror_list(&[item]), MirrorEncoding::Escaped),
+        vec![item.to_string()]
+    );
 }
 
 #[test]
@@ -748,11 +810,11 @@ fn backtick_list_recovers_leading_and_trailing_backtick_items() {
     // have that delimiter's greedy removal eat the escaped backtick's bare
     // half too.
     assert_eq!(
-        backtick_list(&mirror_list(&["`leading"])),
+        backtick_list(&mirror_list(&["`leading"]), MirrorEncoding::Escaped),
         vec!["`leading".to_string()]
     );
     assert_eq!(
-        backtick_list(&mirror_list(&["trailing`"])),
+        backtick_list(&mirror_list(&["trailing`"]), MirrorEncoding::Escaped),
         vec!["trailing`".to_string()]
     );
 }
@@ -764,7 +826,7 @@ fn backtick_list_multi_item_mixes_edge_and_embedded_backticks() {
     // backtick, and one plain item as a control.
     let items = ["a`, `b", "`leading", "trailing`", "plain"];
     assert_eq!(
-        backtick_list(&mirror_list(&items)),
+        backtick_list(&mirror_list(&items), MirrorEncoding::Escaped),
         items.iter().map(|s| s.to_string()).collect::<Vec<_>>()
     );
 }
@@ -804,7 +866,7 @@ fn backtick_list_item_ending_in_backtick_comma_space_does_not_corrupt_the_next_i
     // something this test conflates with the split corruption above.
     let items = ["a`, ", "b"];
     assert_eq!(
-        backtick_list(&mirror_list(&items)),
+        backtick_list(&mirror_list(&items), MirrorEncoding::Escaped),
         vec!["a`,".to_string(), "b".to_string()]
     );
 }
@@ -831,33 +893,21 @@ fn backtick_list_reads_a_raw_pre_1017_item_whose_backslash_is_not_at_the_trailin
     // which this does NOT hold for.
     let raw_legacy_line = "`a\\b`, `c`";
     assert_eq!(
-        backtick_list(raw_legacy_line),
+        backtick_list(raw_legacy_line, MirrorEncoding::Raw),
         vec!["a\\b".to_string(), "c".to_string()]
     );
 }
 
 #[test]
-fn backtick_list_merges_a_raw_pre_1017_item_ending_in_an_odd_backslash_run() {
-    // Known, accepted limitation (GH-1044 Round 2 finding F6) — pinned here
-    // so a future change to this function changes this behavior on
-    // purpose, not by accident. Item 1's raw value is `a\` (a, backslash):
-    // the writer rendered the two items as the 9-byte line `` `a\`, `b` ``.
-    // After the outer strip, `inner = a \ ` , ␣ ` b`. The escape-aware walk
-    // hits the backslash at inner[1] and consumes inner[2] — the item's own
-    // *genuine* closing wrapper — as if it were escaped content, so that
-    // backtick is never tested as delimiter material. No further delimiter
-    // exists in the rest of the line, so both items come back as one,
-    // silently (`split_unescaped_backtick_comma` has no error channel).
-    //
-    // This is not fixable by a cleverer scan: a raw-era single item whose
-    // value is literally `` a`, `b `` renders to the identical bytes
-    // `` `a`, `b` `` that a *current* two-item list `["a", "b"]` also
-    // renders to — no decoder operating on bytes alone can be correct for
-    // both origins of that string. Recovering it needs a mirror
-    // format/version marker (GH-1113), out of GH-1044's own stated scope
-    // (mirror directory layout / `INDEX.md`).
+fn backtick_list_preserves_a_raw_pre_1017_item_ending_in_an_odd_backslash_run() {
+    // GH-1044 Round 3 P0: the raw writer rendered `a\` and `b` exactly as
+    // `` `a\`, `b` ``. Raw mode must use the historical plain split: treating
+    // backslash+wrapper as an escaped unit silently merges the two items.
     let raw_legacy_line = "`a\\`, `b`";
-    assert_eq!(backtick_list(raw_legacy_line), vec!["a`, `b".to_string()]);
+    assert_eq!(
+        backtick_list(raw_legacy_line, MirrorEncoding::Raw),
+        vec!["a\\".to_string(), "b".to_string()]
+    );
 }
 
 #[test]
@@ -879,9 +929,8 @@ fn unescape_field_inverts_escaped_backtick() {
 
 #[test]
 fn unescape_field_unknown_escape_passes_through_unchanged() {
-    // Back-compat (doneWhen #3): a mirror written before GH-1044 never
-    // produced `` \` `` (escape_field did not escape backticks), so this arm
-    // only ever fires on mirrors written by the fixed writer. An unrelated
-    // unknown escape must still pass through unchanged, exactly as before.
+    // Escaped-era back-compat (doneWhen #3): an unrelated unknown escape
+    // must still pass through unchanged. Raw-era fields bypass unescaping
+    // entirely, as the direct legacy fixture above verifies.
     assert_eq!(unescape_field("\\p"), "\\p");
 }

--- a/crates/edda-ledger/src/sync/tests.rs
+++ b/crates/edda-ledger/src/sync/tests.rs
@@ -682,3 +682,115 @@ fn mirror_dry_run_writes_nothing() {
 
     let _ = std::fs::remove_dir_all(&tmp_tgt);
 }
+
+// ── GH-1044: `backtick_list` / `unescape_field` backtick handling ──────
+//
+// `edda-ledger` cannot call the real `cmd_export::escape_field` (it lives in
+// `edda-cli`, which depends on `edda-ledger`, not the reverse), so
+// `mirror_escape` below is a deliberate, documented duplicate of it, used
+// only to CONSTRUCT test input the same way the real writer would — every
+// assertion is still against `backtick_list`/`unescape_field`, the read
+// side. Building `rendered` with this helper (rather than hand-encoded
+// string literals) keeps each test's intent checkable by inspection instead
+// of by counting backslashes. The full write-then-read pipeline is
+// exercised end-to-end by `export_import_round_trip_is_total_for_backticks`
+// in `edda-cli::cmd_export`; these pin the read side alone, in isolation, so
+// a failure here points at `backtick_list`/`unescape_field` directly rather
+// than somewhere in the round trip.
+
+/// Duplicate of `edda-cli::cmd_export::escape_field` — see the module
+/// comment above for why this crate cannot call the original directly. Keep
+/// in sync with it by hand; a divergence here would make these tests assert
+/// against a writer the real code no longer has.
+fn mirror_escape(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('\n', "\\n")
+        .replace('`', "\\`")
+}
+
+/// `["a", "b", ...]` → the exact `` `a`, `b` `` markdown `backtick_list`
+/// reads, each item escaped and wrapped the way `render_domain` does.
+fn mirror_list(items: &[&str]) -> String {
+    items
+        .iter()
+        .map(|it| format!("`{}`", mirror_escape(it)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[test]
+fn backtick_list_ordinary_items_unchanged() {
+    // Regression: no backticks involved, must split exactly as before.
+    assert_eq!(
+        backtick_list(&mirror_list(&["sqlite", "postgres"])),
+        vec!["sqlite".to_string(), "postgres".to_string()]
+    );
+    assert_eq!(
+        backtick_list(&mirror_list(&["solo"])),
+        vec!["solo".to_string()]
+    );
+    assert_eq!(backtick_list(""), Vec::<String>::new());
+}
+
+#[test]
+fn backtick_list_does_not_split_on_embedded_separator_sequence() {
+    // GH-1044, the exact reported defect: a single tag whose value is
+    // `a`, `b` — i.e. it contains the raw four-byte sequence "`, `" that
+    // `backtick_list` splits list items on. One item in, one item out.
+    let item = "a`, `b";
+    assert_eq!(backtick_list(&mirror_list(&[item])), vec![item.to_string()]);
+}
+
+#[test]
+fn backtick_list_recovers_leading_and_trailing_backtick_items() {
+    // GH-1044's secondary hole: once backticks are escaped, an item whose
+    // escaped form is adjacent to the list's own wrapping delimiter must not
+    // have that delimiter's greedy removal eat the escaped backtick's bare
+    // half too.
+    assert_eq!(
+        backtick_list(&mirror_list(&["`leading"])),
+        vec!["`leading".to_string()]
+    );
+    assert_eq!(
+        backtick_list(&mirror_list(&["trailing`"])),
+        vec!["trailing`".to_string()]
+    );
+}
+
+#[test]
+fn backtick_list_multi_item_mixes_edge_and_embedded_backticks() {
+    // Four items in one list, each exercising a different edge of the
+    // GH-1044 hole: embedded separator-lookalike, leading backtick, trailing
+    // backtick, and one plain item as a control.
+    let items = ["a`, `b", "`leading", "trailing`", "plain"];
+    assert_eq!(
+        backtick_list(&mirror_list(&items)),
+        items.iter().map(|s| s.to_string()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn unescape_field_inverts_escaped_backtick() {
+    for original in ["a`b", "`lead", "trail`", "``double``"] {
+        assert_eq!(
+            unescape_field(&mirror_escape(original)),
+            original,
+            "round trip for {original:?}"
+        );
+    }
+    // Backslash-first ordering (matches `escape_field`): a real backslash
+    // immediately before a real backtick — `mirror_escape` doubles the
+    // backslash before it escapes the backtick — must round-trip whole, not
+    // be misread as one already-escaped unit that swallows the backtick.
+    let original = "a\\`b"; // a, backslash, backtick, b
+    assert_eq!(unescape_field(&mirror_escape(original)), original);
+}
+
+#[test]
+fn unescape_field_unknown_escape_passes_through_unchanged() {
+    // Back-compat (doneWhen #3): a mirror written before GH-1044 never
+    // produced `` \` `` (escape_field did not escape backticks), so this arm
+    // only ever fires on mirrors written by the fixed writer. An unrelated
+    // unknown escape must still pass through unchanged, exactly as before.
+    assert_eq!(unescape_field("\\p"), "\\p");
+}

--- a/crates/edda-ledger/src/sync/tests.rs
+++ b/crates/edda-ledger/src/sync/tests.rs
@@ -770,6 +770,46 @@ fn backtick_list_multi_item_mixes_edge_and_embedded_backticks() {
 }
 
 #[test]
+fn backtick_list_item_ending_in_backtick_comma_space_does_not_corrupt_the_next_item() {
+    // GH-1044 Round 1 P0 (re-derived independently from the review, not
+    // copied): escaping a content backtick makes it distinguishable *to
+    // `unescape_field`* — it is preceded by a backslash — but does nothing
+    // for a plain `split`, which matches four literal bytes and never looks
+    // at what precedes them. An item whose value ends in exactly backtick,
+    // comma, space renders (escaped) as `` a\`,  `` — so the escaped
+    // backtick's own bare half sits immediately before that same item's
+    // trailing ", " and the wrapper's closing backtick, and a leftmost,
+    // non-overlapping `split("`, `")` matches one byte too early, starting
+    // at the *content* backtick instead of the wrapper one.
+    //
+    // Two items, `` a`, `` (a, backtick, comma, space) and `b` — rendered:
+    //
+    //   ` a \ ` ,  ` , ` b `
+    //   0 1 2 3 4 5 6 7 8 9 10 11        (12 bytes)
+    //         ^wrap-open(3=esc.bt)  ^wrap-close(6)   ^wrap-open(9)
+    //
+    // After the outer strip, `inner = a \ ` , ␣ ` , ␣ ` b`. The leftmost
+    // `` `,  ` `` match starts at inner[2] (the escaped content backtick),
+    // consuming inner[2..6] — the item's own ", " *and* the wrapper's
+    // closing backtick — before the genuine delimiter at inner[5..9] is
+    // ever reached. Pre-fix this produced `["a\\", ", `b"]`: item 1 loses
+    // its trailing comma and gains a dangling backslash, item 2 gains a
+    // leading ", `" stolen from item 1. Both values land corrupted in the
+    // ledger import payload — silently, since `backtick_list` cannot fail.
+    //
+    // The expected value below is `"a`,"`, not `"a`, "`: `backtick_list`'s
+    // own `.trim()` drops the trailing space regardless of this fix — a
+    // separate, pre-existing whitespace-loss limitation tracked outside
+    // GH-1044 (see the reviewer's FOLLOW-UP ISSUE on PR #1108 Round 1), not
+    // something this test conflates with the split corruption above.
+    let items = ["a`, ", "b"];
+    assert_eq!(
+        backtick_list(&mirror_list(&items)),
+        vec!["a`,".to_string(), "b".to_string()]
+    );
+}
+
+#[test]
 fn unescape_field_inverts_escaped_backtick() {
     for original in ["a`b", "`lead", "trail`", "``double``"] {
         assert_eq!(

--- a/crates/edda-ledger/src/sync/tests.rs
+++ b/crates/edda-ledger/src/sync/tests.rs
@@ -809,6 +809,57 @@ fn backtick_list_item_ending_in_backtick_comma_space_does_not_corrupt_the_next_i
     );
 }
 
+// The two tests below read a mirror line shaped the way a mirror committed
+// before PR #1017 (`3306c1a`, 2026-09-07) actually looks on disk: that
+// writer applied no escaping at all
+// (`3306c1a^:crates/edda-cli/src/cmd_export.rs:150`,
+// `.map(|p| format!("`{}`", p))`). Hand-constructed as literal string
+// slices below, NOT through `mirror_list`/`mirror_escape` — those two
+// helpers duplicate the *current* writer, which is exactly the writer this
+// input predates. GH-1044 Round 2 (re-derived independently, not copied
+// from the review): see `unescape_field`'s doc comment for the full
+// raw-era-vs-escaped-era argument these two tests pin.
+
+#[test]
+fn backtick_list_reads_a_raw_pre_1017_item_whose_backslash_is_not_at_the_trailing_edge() {
+    // Item 1's raw value is `a\b` — a backslash, but not immediately before
+    // the item's own closing wrapper backtick. The escape-aware split still
+    // finds the genuine `` `,  ` `` delimiter correctly here, and this
+    // particular value even round-trips byte-for-byte (`\b` is not a
+    // recognised escape target, so `unescape_field`'s fallback arm passes
+    // it through unchanged). Contrast with the odd-trailing-run case below,
+    // which this does NOT hold for.
+    let raw_legacy_line = "`a\\b`, `c`";
+    assert_eq!(
+        backtick_list(raw_legacy_line),
+        vec!["a\\b".to_string(), "c".to_string()]
+    );
+}
+
+#[test]
+fn backtick_list_merges_a_raw_pre_1017_item_ending_in_an_odd_backslash_run() {
+    // Known, accepted limitation (GH-1044 Round 2 finding F6) — pinned here
+    // so a future change to this function changes this behavior on
+    // purpose, not by accident. Item 1's raw value is `a\` (a, backslash):
+    // the writer rendered the two items as the 9-byte line `` `a\`, `b` ``.
+    // After the outer strip, `inner = a \ ` , ␣ ` b`. The escape-aware walk
+    // hits the backslash at inner[1] and consumes inner[2] — the item's own
+    // *genuine* closing wrapper — as if it were escaped content, so that
+    // backtick is never tested as delimiter material. No further delimiter
+    // exists in the rest of the line, so both items come back as one,
+    // silently (`split_unescaped_backtick_comma` has no error channel).
+    //
+    // This is not fixable by a cleverer scan: a raw-era single item whose
+    // value is literally `` a`, `b `` renders to the identical bytes
+    // `` `a`, `b` `` that a *current* two-item list `["a", "b"]` also
+    // renders to — no decoder operating on bytes alone can be correct for
+    // both origins of that string. Recovering it needs a mirror
+    // format/version marker (GH-1113), out of GH-1044's own stated scope
+    // (mirror directory layout / `INDEX.md`).
+    let raw_legacy_line = "`a\\`, `b`";
+    assert_eq!(backtick_list(raw_legacy_line), vec!["a`, `b".to_string()]);
+}
+
 #[test]
 fn unescape_field_inverts_escaped_backtick() {
     for original in ["a`b", "`lead", "trail`", "``double``"] {

--- a/crates/edda-ledger/src/sync/tests.rs
+++ b/crates/edda-ledger/src/sync/tests.rs
@@ -529,14 +529,57 @@ fn mirror_import_fails_closed_on_partial_or_mixed_encoding_before_writes() {
         std::fs::write(mirror.join("decisions/test.md"), text).unwrap();
 
         let source = MirrorSource { mirror_dir: mirror };
-        let error = sync_from_mirror(&target, &source, false).unwrap_err();
-        assert!(error.to_string().contains("ambiguous mirror encoding"));
+        // The refusal is now contained to the file and reported (GH-1044 F13)
+        // rather than aborting the import — but it is still a refusal: not one
+        // row of an unclassifiable shape reaches the ledger.
+        let r = sync_from_mirror(&target, &source, false).unwrap();
+        assert_eq!(r.errors.len(), 1, "the refusal is reported, not swallowed");
+        assert!(r.errors[0].error.contains("ambiguous mirror encoding"));
+        assert!(r.imported.is_empty());
         assert!(target
             .active_decisions(None, None, None, None)
             .unwrap()
             .is_empty());
         let _ = std::fs::remove_dir_all(tmp);
     }
+}
+
+#[test]
+fn mirror_import_contains_one_unparseable_file_instead_of_aborting_the_mirror() {
+    // The raw (pre-#1017) writer rendered the heading as `## `{key}`` with the
+    // key verbatim (`3306c1a^:crates/edda-cli/src/cmd_export.rs:125`), so a
+    // legacy key holding a newline emits a heading with no closing backtick.
+    // Before this fix `parse_mirror`'s `?` let that one file abort every other
+    // domain in the mirror, and SessionStart's `.ok()?` swallowed the error —
+    // cross-machine sync died silently and retried identically forever.
+    let (tmp, target) = setup_workspace();
+    let index = index_body_with_stamp("2026-09-09T00:00:00Z", "4090");
+    let mirror = write_mirror_tree(&tmp.join("_mirror"), &index);
+    // Sorts before `fleet.md`, so the refusal is reached first.
+    std::fs::write(
+        mirror.join("decisions/aaa-legacy.md"),
+        "## `legacy\nkey`\n- **Value**: `v`\n- **event_id**: `evt_legacy`\n",
+    )
+    .unwrap();
+
+    let source = MirrorSource { mirror_dir: mirror };
+    let r = sync_from_mirror(&target, &source, false).unwrap();
+
+    assert_eq!(r.imported.len(), 2, "the parseable domain still imports");
+    assert_eq!(r.errors.len(), 1, "the refusal is reported, not swallowed");
+    assert_eq!(r.errors[0].project_name, "aaa-legacy");
+    assert!(r.errors[0].error.contains("malformed mirror heading"));
+    // Base read this heading as `strip_suffix('`').unwrap_or(rest)` and would
+    // have imported the truncated key. Refusing means refusing, not guessing.
+    assert!(
+        target
+            .sqlite
+            .find_active_decision("main", "legacy")
+            .unwrap()
+            .is_none(),
+        "nothing from the refused file is imported as if it parsed"
+    );
+    let _ = std::fs::remove_dir_all(tmp);
 }
 
 /// Every caller-supplied field in its escaped form (GH-671 R5) — not only

--- a/crates/edda-ledger/src/sync/tests.rs
+++ b/crates/edda-ledger/src/sync/tests.rs
@@ -438,24 +438,27 @@ fn mirror_parse_unescapes_value_and_reason() {
 }
 
 #[test]
-fn mirror_parse_preserves_raw_pre_1017_backslash_shapes() {
-    // Direct raw-era fixture: no Scope/Authority lines, exactly as the writer
-    // before #1017 emitted it. The value's literal backslash+backtick must not
-    // be consumed as a new escape, and the first path's trailing backslash
-    // must not hide its wrapper and merge the second path.
+fn mirror_parse_preserves_raw_pre_1017_literal_backslash_backtick() {
+    // b10c392 unescaped these bytes and returned `literal`tick`, losing `\`.
     let raw = concat!(
-        "# Domain: `legacy`\n\n",
-        "## `legacy.raw`\n\n",
+        "## `legacy.raw`\n",
         "- **Value**: `literal\\`tick`\n",
-        "- **Reason**: raw bytes\n",
-        "- **Branch/ts**: `main` · 2026-09-01T00:00:00Z\n",
-        "- **Governance**: unratified (agent)\n",
+        "- **event_id**: `evt_legacy`\n",
+    );
+    let parsed = parse_domain_markdown("legacy", raw).unwrap();
+    assert_eq!(parsed[0].row.value, "literal\\`tick");
+}
+
+#[test]
+fn mirror_parse_preserves_raw_pre_1017_trailing_backslash_list_item() {
+    // b10c392's escape-aware split returned one merged item: `` a`, `b ``.
+    let raw = concat!(
+        "## `legacy.raw`\n",
+        "- **Value**: `raw`\n",
         "- **Affected paths**: `a\\`, `b`\n",
         "- **event_id**: `evt_legacy`\n",
     );
     let parsed = parse_domain_markdown("legacy", raw).unwrap();
-
-    assert_eq!(parsed[0].row.value, "literal\\`tick");
     let paths: Vec<String> = serde_json::from_str(&parsed[0].row.affected_paths).unwrap();
     assert_eq!(paths, vec!["a\\".to_string(), "b".to_string()]);
 }
@@ -477,17 +480,63 @@ fn mirror_parse_uses_shape_to_disambiguate_the_same_field_bytes() {
 }
 
 #[test]
-fn mirror_parse_fails_closed_on_partial_encoding_shape() {
-    let ambiguous = concat!(
-        "## `ambiguous`\n\n",
+fn mirror_parse_ignores_prose_when_detecting_encoding() {
+    let raw = concat!(
+        "## Prose about `mirror fields`\n",
+        "- **Scope**: prose, not a decision field\n",
+        "- **Authority**: prose, not a decision field\n",
+        "## `legacy.raw`\n",
         "- **Value**: `literal\\`tick`\n",
-        "- **Scope**: local\n",
-        "- **event_id**: `evt_ambiguous`\n",
+        "- **event_id**: `evt_legacy`\n",
     );
-    let error = parse_domain_markdown("ambiguous", ambiguous)
-        .err()
-        .expect("partial discriminator must fail closed");
-    assert!(error.to_string().contains("ambiguous mirror encoding"));
+    assert_eq!(
+        parse_domain_markdown("legacy", raw).unwrap()[0].row.value,
+        "literal\\`tick"
+    );
+}
+
+#[test]
+fn mirror_parse_rejects_malformed_headings() {
+    for malformed in [
+        "# Domain: `broken\n## `key`\n- **Value**: `v`\n- **event_id**: `e`\n",
+        "## `broken\n- **Value**: `v`\n- **event_id**: `e`\n",
+    ] {
+        let error = parse_domain_markdown("legacy", malformed)
+            .err()
+            .expect("malformed heading must fail closed");
+        assert!(error.to_string().contains("malformed mirror heading"));
+    }
+}
+
+#[test]
+fn mirror_import_fails_closed_on_partial_or_mixed_encoding_before_writes() {
+    let shapes = [
+        concat!(
+            "## `partial`\n- **Value**: `v`\n- **Scope**: local\n",
+            "- **event_id**: `evt_partial`\n",
+        ),
+        concat!(
+            "## `raw`\n- **Value**: `v`\n- **event_id**: `evt_raw`\n",
+            "## `escaped`\n- **Value**: `v`\n- **Scope**: local\n",
+            "- **Authority**: agent\n- **event_id**: `evt_escaped`\n",
+        ),
+    ];
+    for (n, text) in shapes.into_iter().enumerate() {
+        let (tmp, target) = setup_workspace();
+        let mirror = tmp.join(format!("mixed-{n}"));
+        std::fs::create_dir_all(mirror.join("decisions")).unwrap();
+        std::fs::write(mirror.join("INDEX.md"), "- **Exporting machine**: test\n").unwrap();
+        std::fs::write(mirror.join("decisions/test.md"), text).unwrap();
+
+        let source = MirrorSource { mirror_dir: mirror };
+        let error = sync_from_mirror(&target, &source, false).unwrap_err();
+        assert!(error.to_string().contains("ambiguous mirror encoding"));
+        assert!(target
+            .active_decisions(None, None, None, None)
+            .unwrap()
+            .is_empty());
+        let _ = std::fs::remove_dir_all(tmp);
+    }
 }
 
 /// Every caller-supplied field in its escaped form (GH-671 R5) — not only
@@ -868,45 +917,6 @@ fn backtick_list_item_ending_in_backtick_comma_space_does_not_corrupt_the_next_i
     assert_eq!(
         backtick_list(&mirror_list(&items), MirrorEncoding::Escaped),
         vec!["a`,".to_string(), "b".to_string()]
-    );
-}
-
-// The two tests below read a mirror line shaped the way a mirror committed
-// before PR #1017 (`3306c1a`, 2026-09-07) actually looks on disk: that
-// writer applied no escaping at all
-// (`3306c1a^:crates/edda-cli/src/cmd_export.rs:150`,
-// `.map(|p| format!("`{}`", p))`). Hand-constructed as literal string
-// slices below, NOT through `mirror_list`/`mirror_escape` — those two
-// helpers duplicate the *current* writer, which is exactly the writer this
-// input predates. GH-1044 Round 2 (re-derived independently, not copied
-// from the review): see `unescape_field`'s doc comment for the full
-// raw-era-vs-escaped-era argument these two tests pin.
-
-#[test]
-fn backtick_list_reads_a_raw_pre_1017_item_whose_backslash_is_not_at_the_trailing_edge() {
-    // Item 1's raw value is `a\b` — a backslash, but not immediately before
-    // the item's own closing wrapper backtick. The escape-aware split still
-    // finds the genuine `` `,  ` `` delimiter correctly here, and this
-    // particular value even round-trips byte-for-byte (`\b` is not a
-    // recognised escape target, so `unescape_field`'s fallback arm passes
-    // it through unchanged). Contrast with the odd-trailing-run case below,
-    // which this does NOT hold for.
-    let raw_legacy_line = "`a\\b`, `c`";
-    assert_eq!(
-        backtick_list(raw_legacy_line, MirrorEncoding::Raw),
-        vec!["a\\b".to_string(), "c".to_string()]
-    );
-}
-
-#[test]
-fn backtick_list_preserves_a_raw_pre_1017_item_ending_in_an_odd_backslash_run() {
-    // GH-1044 Round 3 P0: the raw writer rendered `a\` and `b` exactly as
-    // `` `a\`, `b` ``. Raw mode must use the historical plain split: treating
-    // backslash+wrapper as an escaped unit silently merges the two items.
-    let raw_legacy_line = "`a\\`, `b`";
-    assert_eq!(
-        backtick_list(raw_legacy_line, MirrorEncoding::Raw),
-        vec!["a\\".to_string(), "b".to_string()]
     );
 }
 


### PR DESCRIPTION
Issue: #1044
Closes #1044

## What was broken

`escape_field` (`crates/edda-cli/src/cmd_export.rs`) escaped backslash and
newline (PR #1017) but left backtick raw. The read side, `backtick_list`
(`crates/edda-ledger/src/sync.rs`), splits `Tags` / `Affected paths` / `Cites`
list fields on the literal 4-byte sequence `` `, ` ``. A list item whose value
itself contained that sequence — e.g. a tag literally equal to `` a`, `b `` —
split into two items after a mirror export/import round trip, and an item that
merely started or ended with a backtick lost that character. This was the one
hole PR #1017 left in the "encoding is total" property it established for
newlines and backslashes.

These fields carry arbitrary user text: `--paths` and `--cite` are repeatable
`Vec<String>` with no `value_delimiter` (`main.rs:129,137`), stored verbatim by
`cmd_bridge/decide.rs:123-126`. The defect is reachable from the shipped CLI.

## What this PR delivers

Four things, in the order the review rounds forced them out. All four are in
the head; none of the intermediate designs are.

**1. The write side escapes backtick.** `escape_field` gains a third
`.replace()`: backtick → `` \` ``, applied **after** backslash-doubling and the
newline pass, so the escape backslashes those passes insert are never
themselves re-escaped. `unescape_field` gains the matching arm.

**2. The read side splits escape-aware.** Escaping alone was not enough:
`split` matches four literal bytes and never looks at what precedes them, so an
escaped content backtick could still supply the *opening* half of a delimiter
match. `split_unescaped_backtick_comma` walks the string with the same pairing
rule `unescape_field` uses — a `\` and whatever follows it are consumed as one
unit and can never begin a delimiter match — and `backtick_list` strips the
list's own outer wrapping backticks once, from the whole string, before
splitting rather than per fragment.

**3. A writer-era discriminator, because "pre-GH-1044 text" is not one era.**
`escape_field` did not exist before PR #1017 (`3306c1a`, 2026-09-07); before
it, `edda export md` (live since `f3e5e97`, 2026-07-08) applied **no escaping
at all** (`3306c1a^:crates/edda-cli/src/cmd_export.rs:150`). An escape-aware
walk is correct for what the current writer produces and *wrong* for raw-era
bytes, where a backslash has no structural pairing: raw items `a\` and `b`,
written as `` `a\`, `b` ``, had their wrapper eaten and merged into one item.

The bytes alone cannot distinguish the two eras — raw `` a\`b `` and current
`` a`b `` are the same 5 bytes inside their wrappers — so the discriminator
reads a signal from *outside* the field. `3306c1a` introduced `escape_field` in
the same writer change that made every generated decision emit both
`- **Scope**:` and `- **Authority**:`; the raw writer emitted neither.
`detect_mirror_encoding` (`sync.rs`) classifies each domain file `Raw` when
every decision section lacks both and `Escaped` when every section has both.
Raw files take the historical plain split and bypass `unescape_field` entirely,
preserving literal `\`, `\n` and `` \` `` bytes. A partial or mixed shape is
refused rather than guessed at.

This is what finally delivers doneWhen #1's "reading **both** old and new
mirrors correctly", instead of trading one era's correctness for the other's.

**4. A refusal is contained and reported, never fatal and never silent.**
Item 3 added two hard-error paths to a parse that previously could not fail,
and the surrounding plumbing turned that into an operational regression:
`parse_mirror` propagated with `?` from inside its per-file loop, so one
unparseable `decisions/<domain>.md` aborted every other domain in the mirror;
and the only unattended consumer, `import_on_session_start`
(`crates/edda-bridge-claude/src/mirror_import.rs`), discarded the error with
`.ok()?` — no line rendered, stamp not written — so the failure repeated
identically and silently every session, forever.

Both triggers are reachable on raw-era mirrors specifically, because that
writer escaped nothing: it rendered the heading as `` ## `{key}` `` with the
key verbatim, so a legacy key containing a newline emits a heading with no
closing backtick; and a newline in Value or Reason whose continuation begins
`- **Scope**: ` or `- **Authority**: ` gives a section exactly one of the pair.
PR #1017's own round-trip test uses precisely those payloads
(`cmd_export.rs:830`, `:834`) and its doc comment states that no validation
rejects a newline in any of these fields.

The refusal itself is kept — on a hash-chained ledger, refusing to import what
you cannot parse is the right posture, and not one row of an unclassifiable
shape reaches the ledger. What changed is blast radius and reporting:

- `parse_mirror` takes `&mut SyncResult` and pushes a per-file refusal into
  `result.errors` instead of `?`-ing out — the same carrier `sync_from_sources`
  has always used for per-source failures. The mirror's other domains import.
- `import_on_session_start` renders a whole-mirror failure instead of
  swallowing it, and `render_line` names refused files even when nothing else
  happened. A refusal is never `None`.
- `edda sync --from-mirror` prints refused files before the summary and before
  the up-to-date early return, so containment cannot become a quieter failure
  than the abort it replaces.

## What this PR does not do

- **It does not recover a raw, unescaped backtick positioned like a delimiter
  in a file already written that way.** Neither writer era escaped backtick
  before this fix, so that ambiguity was baked in at write time and no reader
  change recovers it retroactively. That is GH-1044's own write-side defect on
  historical files, unaffected by this PR in either direction.
- **It does not record which era a row was decoded under.** `MirrorDecision`
  carries no era field, so a misclassification leaves nothing to audit against
  after the fact. Correct-by-construction for every *generated* file, since the
  current writer emits Scope and Authority unconditionally
  (`cmd_export.rs:224`, `:228`) and the raw writer emitted neither — but
  hand-edited or forged content is outside that guarantee. Routed as a
  follow-up, not fixed here.
- **It does not add an explicit format marker.** #1113 remains worth having,
  but its rationale has changed: it is no longer the only way to select a
  parsing rule per era, it is the way to make that selection *explicit* rather
  than inferred from decision shape. Whoever picks it up should read the
  discriminator first.
- **It does not test the CLI print wiring end-to-end.** `refused_files_warning`
  is unit-tested and its call site is a five-line `eprintln!` block; there is no
  integration test asserting `edda sync --from-mirror` stderr. The unattended
  consumer — the one F13 was actually about — *is* covered end-to-end through
  the real `import_on_session_start`.
- It does not touch the mirror directory layout or the `INDEX.md` format
  (GH-1044's stated Out of scope), and it does not fix `backtick_list`'s
  `p.trim()` edge-whitespace loss, `backtick_list_to_json`'s `unwrap_or_else`
  folding a serialization failure into `"[]"`, or `mirror_escape`'s hand-copy
  of `escape_field` in the test module. All routed as follow-ups.

## Why the closing keyword is back

Restored deliberately, having been removed in Round 3 when it rested on a
claim that has since been withdrawn. All three doneWhen items hold at head:

1. "reading both old and new mirrors correctly" — delivered by the
   discriminator (item 3), not by favouring one era over the other.
2. round-trip totality — `export_import_round_trip_is_total_for_backticks`
   (`cmd_export.rs:912`) runs through the real writer.
3. "mirrors written before the fix still parse, unknown escapes pass through
   unchanged" — delivered twice over: raw fields bypass `unescape_field`
   entirely, and escaped-era unknown escapes still fall through.

The residual write-side ambiguity above is not a doneWhen failure: it is the
state of files already on disk, which no reader change can alter.

## Scope

`crates/edda-cli/src/cmd_export.rs`, `crates/edda-cli/src/cmd_sync.rs`,
`crates/edda-ledger/src/sync.rs`, `crates/edda-ledger/src/sync/tests.rs`,
`crates/edda-bridge-claude/src/mirror_import.rs`. No new files.
`crates/edda-cli/src/cmd_reconcile/**` and
`crates/edda-cli/tests/verify_contract.rs` (peer lanes) — untouched.

`crates/edda-ledger/src/sync.rs` is at 999 lines against the GH-779 ceiling of
1000. The `stem` binding in `parse_mirror` was collapsed to one line (same
semantics, `&str` instead of `String`) to stay under it without raising the
ceiling or splitting the module.

## Tests

Every behaviour change owes a test that fails without it. Round 4's additions,
each mutation-checked — the fix broken, the case confirmed red, the fix
restored:

| Test | Crate | Red when |
|---|---|---|
| `mirror_import_contains_one_unparseable_file_instead_of_aborting_the_mirror` | `edda-ledger` | `parse_mirror` restored to `?` |
| `mirror_import_fails_closed_on_partial_or_mixed_encoding_before_writes` | `edda-ledger` | same |
| `a_mirror_that_fails_outright_is_reported_not_swallowed` | `edda-bridge-claude` | `.ok()?` restored |
| `a_refused_mirror_file_is_named_even_when_nothing_else_happened` | `edda-bridge-claude` | `render_line`'s error block removed |
| `a_broken_mirror_does_not_fail_session_start` | `edda-bridge-claude` | same |
| `a_refused_mirror_file_is_named_with_its_reason` | `edda` | `refused_files_warning` guard inverted |

`a_broken_mirror_does_not_fail_session_start` previously asserted `None` on a
broken mirror. That assertion was the defect written down as a requirement —
"does not fail session start" was being satisfied by saying nothing at all,
forever. The property it names is preserved and still asserted; only the
silence it also demanded is gone.

`mirror_import_round_trip_then_dedups_on_second_run` stayed green under every
mutation, so the new tests are not artifacts of the new code.

## Gates (L0, touched crates only)

```
cargo fmt --all --check                                        -> pass
cargo clippy -p edda-ledger -p edda-bridge-claude -p edda
  --all-targets -- -D warnings                                 -> pass, 0 warnings
cargo test -p edda-ledger                                      -> 270 passed, 0 failed
cargo test -p edda-bridge-claude                               -> 661 passed, 0 failed
cargo test -p edda                                             -> 861 passed, 0 failed
sh scripts/lint-file-length.sh --tree                          -> exit 0
```

All three touched crates — `edda-ledger`, `edda-bridge-claude` and `edda` —
are inside CI's Windows 7-crate subset, so the C5 selector is empty on this SHA
and no focused Windows-gap run is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
