### PR TITLE
test(edda-cli): verify_contract OK checks match the authored marker, not a temp-path substring (GH-1033)

### DIFF
--- a/crates/edda-cli/tests/verify_contract.rs
+++ b/crates/edda-cli/tests/verify_contract.rs
@@ -8,6 +8,16 @@ use edda_ledger::Ledger;
 use serde_json::Value;
 use std::path::{Path, PathBuf};
 
+/// The exact success marker `cmd_verify::execute` prints on stdout for an
+/// intact chain (`crates/edda-cli/src/cmd_verify.rs`, the two `println!`
+/// arms `"ledger chain OK: empty ledger ..."` / `"ledger chain OK: {n}
+/// event(s), last event {id}"`). Negative assertions below must check for
+/// this authored text, never the bare substring `"OK"` — a bare substring
+/// also matches the letter pair inside a `tempfile`-generated temp
+/// directory name (GH-1033, e.g. `.tmpOKfVBd`), which makes the assertion
+/// depend on text the command never wrote.
+const VERIFY_OK_MARKER: &str = "ledger chain OK:";
+
 /// Path to the `edda` binary (`CARGO_BIN_EXE_edda`).
 fn edda_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_edda"))
@@ -159,12 +169,48 @@ fn verify_deleted_ledger_db_exits_2_and_is_not_recreated() {
         "must explain the ledger problem: {report:?}"
     );
     assert!(
-        !report.contains("OK"),
+        !report.contains(VERIFY_OK_MARKER),
         "must not report success for a vanished ledger: {report:?}"
     );
     assert!(
         !repo.path().join(".edda").join("ledger.db").exists(),
         "verify must never recreate the ledger database"
+    );
+}
+
+/// GH-1033 regression: a harness-generated path segment that happens to
+/// contain the letter pair "OK" must never be mistaken for the real
+/// success marker. `tempfile` names directories with random alphanumerics
+/// and did exactly this in the wild — PR #1016 CI hit `.tmpOKfVBd` on
+/// `macos-latest`. A random tempdir name is not reliable to reproduce on
+/// demand, so this test forces the same coupling deterministically by
+/// nesting the workspace under a directory whose name we choose to
+/// contain "OK" — `cmd_verify::execute` embeds that path directly in its
+/// "cannot open ledger at {path}" error text.
+#[test]
+fn verify_deleted_ledger_ok_in_workspace_path_is_not_mistaken_for_success() {
+    let base = tempfile::tempdir().expect("base tempdir");
+    let repo = base.path().join("workspaceOKdir");
+    std::fs::create_dir_all(&repo).expect("create OK-named workspace dir");
+    seeded_ledger(&repo);
+    std::fs::remove_file(repo.join(".edda").join("ledger.db"))
+        .expect("delete ledger.db, keeping .edda/");
+
+    let (code, stdout, stderr) = run_edda(&["verify"], &repo);
+    assert_eq!(
+        code, 2,
+        "missing ledger must exit 2, not rebuild an empty one: {stdout:?} {stderr:?}"
+    );
+    let report = format!("{stdout}{stderr}");
+    assert!(
+        report.contains("OK"),
+        "sanity: the workspace path must actually carry the bare substring \
+         this regression guards against, or the test proves nothing: {report:?}"
+    );
+    assert!(
+        !report.contains(VERIFY_OK_MARKER),
+        "must not report success for a vanished ledger just because its \
+         workspace path contains \"OK\": {report:?}"
     );
 }
 
@@ -293,7 +339,7 @@ fn verify_anchored_workspace_with_unopenable_ledger_exits_2_and_never_reports_ok
     assert_eq!(code, 2, "stdout={stdout:?} stderr={stderr:?}");
     let report = format!("{stdout}{stderr}");
     assert!(
-        !report.contains("OK"),
+        !report.contains(VERIFY_OK_MARKER),
         "must not report success on an unopenable ledger: {report:?}"
     );
     assert!(


### PR DESCRIPTION
`crates/edda-cli/tests/verify_contract.rs` had two `assert!(!report.contains("OK"), ...)` checks, both on `report = format!("{stdout}{stderr}")`. `stderr` embeds the workspace path (`repo_root.display()`), and `tempfile` names temp directories with random alphanumerics — so any run whose random suffix happens to contain the adjacent pair `OK` fails a correct run. Observed on `windows`/`macos` CI as `.tmpOKfVBd` (PR #1016, job `Test (macos-latest)`, run 34055854543).

## Fix

Added one constant, `VERIFY_OK_MARKER = "ledger chain OK:"` — the exact text `cmd_verify::execute` prints on stdout for an intact chain (`crates/edda-cli/src/cmd_verify.rs`, the two `println!` arms `"ledger chain OK: empty ledger ..."` / `"ledger chain OK: {n} event(s), last event {id}"`). Both negative assertions now check for that authored marker instead of the bare substring `"OK"`:

- `verify_deleted_ledger_db_exits_2_and_is_not_recreated` (was line 162)
- `verify_anchored_workspace_with_unopenable_ledger_exits_2_and_never_reports_ok` (was line 296)

I read the product code before choosing the marker rather than asserting one from memory — the exact printed prefix is what makes this fix precise in both directions: it can no longer false-fail on a path substring, and it cannot false-pass on stray output either, since `"ledger chain OK:"` is never emitted on any error branch (all four error branches in `cmd_verify.rs` print `"error: ..."` text that does not contain it).

## Why the second site (`:296`) is in scope

The issue names only `:161`–`:162`, in `verify_deleted_ledger_db_exits_2_and_is_not_recreated`, and asks that *neighbouring assertions in the same test* be reviewed for the same coupling. `:296` is a different test (`verify_anchored_workspace_with_unopenable_ledger_exits_2_and_never_reports_ok`), so a literal reading would route it to a follow-up issue. I did not: it is the identical `!report.contains("OK")` against the identical `stdout+stderr` blob, subject to the identical random-path failure — shipping a fix for one occurrence while its twin stays live is not a fix, it's a second issue waiting to be filed under a new number. Both are fixed here, from the same constant, in the same PR.

## The two positive sites (`:128`, `:139`) — reviewed, left unchanged

`verify_clean_ledger_is_ok_and_exits_0` and `verify_empty_ledger_is_ok_not_an_error` both assert `stdout.contains("OK")` — on `stdout` alone, not the `stdout+stderr` blob. I checked whether the success path ever puts a path on stdout: it does not. Both success branches in `cmd_verify.rs` (`report.events == 0` and the general case) print only the hardcoded `"ledger chain OK: ..."` text — neither interpolates `repo_root.display()` or any other path. Nothing else writes to stdout on this path either: `main.rs` sets up `tracing_subscriber` with `.with_writer(std::io::stderr)` and a default `"warn"` filter, and there is no `println!` anywhere between `main()` and `cmd_verify::execute` that could inject a path ahead of it. So a temp-path substring can never reach `stdout` on the success branch, and the coupling class this issue is about does not apply here. Left unchanged rather than churned for symmetry.

## doneWhen: neighbouring assertions reviewed for the same class

- `report.contains("ledger")` (next to the `:162` fix): the word "ledger" is part of the product's own authored error text on every path that reaches this assertion (`"error: cannot open ledger at ..."`), independent of whatever the random temp name is. It is not coupled to the accidental path content — it's there regardless of the path — so it is not an instance of this bug class. Left unchanged.
- The `.edda/ledger.db` existence check (same test): `Path::exists()`, not a `str::contains()` on process output. There is no text-authorship question to ask of a filesystem check — this bug class does not apply. Left unchanged.
- `report.contains("cannot open ledger")` (next to the `:296` fix, line ~346): already the correct, authored-text pattern — this is the existing "how to do it right" example in the same file that the `:296` fix now matches.

## Regression test (doneWhen #3)

Added `verify_deleted_ledger_ok_in_workspace_path_is_not_mistaken_for_success`. Waiting on `tempfile`'s randomness to reproduce the original flake on demand isn't reliable, so the test forces the same coupling deterministically: it nests the workspace under a directory whose name it chooses to contain "OK" (`workspaceOKdir`), then deletes `ledger.db` exactly like the sibling test. `cmd_verify::execute` embeds that path directly in `"error: cannot open ledger at {path}: ..."`, so the resulting `report` is guaranteed to contain the bare substring `"OK"` — every run, not just unlucky ones.

**Proof the test pins the failure.** I temporarily reverted just this new test's assertion to the pre-fix pattern (`!report.contains("OK")`) on the scratch worktree, ran it alone, and captured red:

```
running 1 test
test verify_deleted_ledger_ok_in_workspace_path_is_not_mistaken_for_success ... FAILED

---- verify_deleted_ledger_ok_in_workspace_path_is_not_mistaken_for_success stdout ----

thread 'verify_deleted_ledger_ok_in_workspace_path_is_not_mistaken_for_success' panicked at crates\edda-cli\tests\verify_contract.rs:210:5:
must not report success for a vanished ledger just because its workspace path contains "OK": "error: cannot open ledger at C:\\Users\\synvoke\\AppData\\Local\\Temp\\.tmpGgpvmb\\workspaceOKdir: ledger database not found: C:\\Users\\synvoke\\AppData\\Local\\Temp\\.tmpGgpvmb\\workspaceOKdir\\.edda\\ledger.db (run `edda init` to create a workspace)\n"

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 10 filtered out; finished in 4.31s
```

Exit code was 2 and the message was correct (`cannot open ledger`) — same shape as the issue's original report, reproduced on demand instead of by luck. I then restored the fixed assertion (`!report.contains(VERIFY_OK_MARKER)`); the same test passes as part of the full `cargo test -p edda` run reported below.

## Verification (L0, touched crate only — per brief)

```
cargo fmt --all --check                                  # clean, no diff
cargo clippy -p edda --all-targets -- -D warnings         # clean, zero warnings
cargo test -p edda                                        # full pass, all binaries green
                                                            # (includes verify_contract.rs: 11/11 ok)
sh scripts/lint-file-length.sh --tree                      # clean, no ceiling violations
```

`crates/edda-cli/tests/*.rs` are process-spawning integration tests (`env!("CARGO_BIN_EXE_edda")`), so `cargo test -p edda` (not `--bin edda`) is required to exercise this file at all — confirmed the new test actually ran as part of that command, not just in isolation.

`edda-cli` is inside CI's Windows 7-crate subset, so the C5 selector (focused Windows-gap run) is empty for this PR — no additional local run is owed beyond the L0 above; exact-head CI covers the rest.

Only `crates/edda-cli/tests/verify_contract.rs` was touched. No overlap with `crates/edda-cli/src/cmd_reconcile/**`, `crates/edda-cli/src/cmd_export.rs`, or `crates/edda-ledger/**`.

Issue: #1033
Closes #1033

🤖 Generated with [Claude Code](https://claude.com/claude-code)
