### PR TITLE
chore(release): prepare v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`fleet reclaim-merged` executor** — reclaims merged lane worktrees and local/remote branches with dry-run-first receipts and fail-closed remote verification (GH-1009, #1091)
+- **Merged-lane cleanup executor** — `scripts/fleet/reclaim-merged.sh` reclaims merged lane worktrees and local/remote branches with dry-run-first receipts and fail-closed remote verification (GH-1009, #1091)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-09-10
+
+### Added
+
+- **`fleet reclaim-merged` executor** — reclaims merged lane worktrees and local/remote branches with dry-run-first receipts and fail-closed remote verification (GH-1009, #1091)
+
+### Changed
+
+- **Merge governance follows the rule gate** — loaded policy carriers now describe the current-head LGTM, zero-blocker, CI, union, and base-window conditions instead of assigning merge to a named operator; shared checkouts remain on main and reviewers fetch private refs (GH-1064, #1101)
+- **Fleet review rules are complete** — R18–R20 restore Independent Review semantics, review-dispatch pre-claim, and L1 ownership while repairing R21/R22 citations (GH-966, #1095)
+- **Release operations are hardened** — Homebrew formulas build the immutable crates.io source package to avoid Linux glibc-runner coupling (#1090), and the release skill records the slower `0.6.x` patch cadence plus v0.6.0 operational lessons (#1106)
+
+### Fixed
+
+- **Review merge safety** — orphan Review Responses now block merge, untrusted public comments cannot create or clear drift, and failed remote verification no longer looks like a clean result (GH-993, #1102)
+- **`ratify --by-rule` guards** — supersession is no longer inferred from a key mention; same-key, explicit-marker, domain/date, and bounded-sweep guards preserve binding decisions (GH-1066, #1098)
+- **Review diff and shell parsing** — content checks use three-dot PR ranges, and shell-parse evidence reads reviewed blobs without depending on working-tree file presence (GH-1003, GH-992, #1097)
+- **doneWhen parsing** accepts the documented spacing variants across issue/spec matchers (GH-1056, #1089)
+- **`edda review deliver` read path** has an argv-level regression guard and validates PR-vs-issue identity before reducing comments (GH-1079, #1086)
+
 ## [0.6.0] - 2026-09-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Merged-lane cleanup executor** — `scripts/fleet/reclaim-merged.sh` reclaims merged lane worktrees and local/remote branches with dry-run-first receipts and fail-closed remote verification (GH-1009, #1091)
+- **Merged-lane cleanup script** — `scripts/fleet/reclaim-merged.sh` reclaims merged lane worktrees and local/remote branches with dry-run-first receipts and fail-closed remote verification (GH-1009, #1091)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "edda"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "edda-aggregate"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "edda-ask"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "edda-bridge-claude"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "edda-bridge-codex"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "edda-bridge-claude",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "edda-bridge-cursor"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "edda-bridge-claude",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "edda-bridge-hermes"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "edda-bridge-claude",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "edda-bridge-openclaw"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "edda-bridge-claude",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "edda-chronicle"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "edda-conductor"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "edda-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "edda-derive"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "edda-index"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "edda-store",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "edda-ingestion"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "edda-ledger"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "edda-mcp"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "edda-ask",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "edda-notify"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "edda-ledger",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "edda-pack"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "edda-postmortem"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "edda-search-fts"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "edda-core",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "edda-serve"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "edda-store"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "edda-transcript"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "edda-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 # Bisected 2026-09-04, not copied from the toolchain pin: 1.87 fails on
 # dependency floors (darling, instability, time all require 1.88), and

--- a/crates/edda-aggregate/Cargo.toml
+++ b/crates/edda-aggregate/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.6.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
-edda-store = { path = "../edda-store", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.1" }
+edda-store = { path = "../edda-store", version = "0.6.1" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-ask/Cargo.toml
+++ b/crates/edda-ask/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
-edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.1" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/edda-bridge-claude/Cargo.toml
+++ b/crates/edda-bridge-claude/Cargo.toml
@@ -11,17 +11,17 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-aggregate = { path = "../edda-aggregate", version = "0.6.0" }
-edda-core = { path = "../edda-core", version = "0.6.0" }
-edda-store = { path = "../edda-store", version = "0.6.0" }
-edda-transcript = { path = "../edda-transcript", version = "0.6.0" }
-edda-index = { path = "../edda-index", version = "0.6.0" }
-edda-pack = { path = "../edda-pack", version = "0.6.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
-edda-search-fts = { path = "../edda-search-fts", version = "0.6.0" }
-edda-notify = { path = "../edda-notify", version = "0.6.0" }
-edda-postmortem = { path = "../edda-postmortem", version = "0.6.0" }
-edda-derive = { path = "../edda-derive", version = "0.6.0" }
+edda-aggregate = { path = "../edda-aggregate", version = "0.6.1" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
+edda-store = { path = "../edda-store", version = "0.6.1" }
+edda-transcript = { path = "../edda-transcript", version = "0.6.1" }
+edda-index = { path = "../edda-index", version = "0.6.1" }
+edda-pack = { path = "../edda-pack", version = "0.6.1" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.1" }
+edda-search-fts = { path = "../edda-search-fts", version = "0.6.1" }
+edda-notify = { path = "../edda-notify", version = "0.6.1" }
+edda-postmortem = { path = "../edda-postmortem", version = "0.6.1" }
+edda-derive = { path = "../edda-derive", version = "0.6.1" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true
@@ -39,7 +39,7 @@ tempfile.workspace = true
 rusqlite = { version = "0.32", features = ["bundled"] }
 # Test-only: enables the thread-local store-root override used by
 # `isolated_store()` fixtures (GH-757). Not enabled for ordinary builds.
-edda-store = { path = "../edda-store", version = "0.6.0", features = [
+edda-store = { path = "../edda-store", version = "0.6.1", features = [
     "test-support",
 ] }
 

--- a/crates/edda-bridge-codex/Cargo.toml
+++ b/crates/edda-bridge-codex/Cargo.toml
@@ -11,13 +11,13 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.6.0" }
-edda-store = { path = "../edda-store", version = "0.6.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
-edda-pack = { path = "../edda-pack", version = "0.6.0" }
-edda-postmortem = { path = "../edda-postmortem", version = "0.6.0" }
-edda-derive = { path = "../edda-derive", version = "0.6.0" }
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
+edda-store = { path = "../edda-store", version = "0.6.1" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.1" }
+edda-pack = { path = "../edda-pack", version = "0.6.1" }
+edda-postmortem = { path = "../edda-postmortem", version = "0.6.1" }
+edda-derive = { path = "../edda-derive", version = "0.6.1" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.1" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-bridge-cursor/Cargo.toml
+++ b/crates/edda-bridge-cursor/Cargo.toml
@@ -11,11 +11,11 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.0" }
-edda-core = { path = "../edda-core", version = "0.6.0" }
-edda-pack = { path = "../edda-pack", version = "0.6.0" }
-edda-postmortem = { path = "../edda-postmortem", version = "0.6.0" }
-edda-store = { path = "../edda-store", version = "0.6.0" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.1" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
+edda-pack = { path = "../edda-pack", version = "0.6.1" }
+edda-postmortem = { path = "../edda-postmortem", version = "0.6.1" }
+edda-store = { path = "../edda-store", version = "0.6.1" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-bridge-hermes/Cargo.toml
+++ b/crates/edda-bridge-hermes/Cargo.toml
@@ -11,13 +11,13 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.6.0" }
-edda-store = { path = "../edda-store", version = "0.6.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
-edda-pack = { path = "../edda-pack", version = "0.6.0" }
-edda-postmortem = { path = "../edda-postmortem", version = "0.6.0" }
-edda-derive = { path = "../edda-derive", version = "0.6.0" }
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
+edda-store = { path = "../edda-store", version = "0.6.1" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.1" }
+edda-pack = { path = "../edda-pack", version = "0.6.1" }
+edda-postmortem = { path = "../edda-postmortem", version = "0.6.1" }
+edda-derive = { path = "../edda-derive", version = "0.6.1" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.1" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-bridge-openclaw/Cargo.toml
+++ b/crates/edda-bridge-openclaw/Cargo.toml
@@ -11,18 +11,18 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.6.0" }
-edda-store = { path = "../edda-store", version = "0.6.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
-edda-derive = { path = "../edda-derive", version = "0.6.0" }
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
+edda-store = { path = "../edda-store", version = "0.6.1" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.1" }
+edda-derive = { path = "../edda-derive", version = "0.6.1" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.1" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 time.workspace = true
 
 [dev-dependencies]
-edda-store = { path = "../edda-store", version = "0.6.0", features = ["test-support"] }
+edda-store = { path = "../edda-store", version = "0.6.1", features = ["test-support"] }
 tempfile.workspace = true
 
 [lints]

--- a/crates/edda-chronicle/Cargo.toml
+++ b/crates/edda-chronicle/Cargo.toml
@@ -11,13 +11,13 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.6.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
-edda-store = { path = "../edda-store", version = "0.6.0" }
-edda-transcript = { path = "../edda-transcript", version = "0.6.0" }
-edda-index = { path = "../edda-index", version = "0.6.0" }
-edda-search-fts = { path = "../edda-search-fts", version = "0.6.0" }
-edda-aggregate = { path = "../edda-aggregate", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.1" }
+edda-store = { path = "../edda-store", version = "0.6.1" }
+edda-transcript = { path = "../edda-transcript", version = "0.6.1" }
+edda-index = { path = "../edda-index", version = "0.6.1" }
+edda-search-fts = { path = "../edda-search-fts", version = "0.6.1" }
+edda-aggregate = { path = "../edda-aggregate", version = "0.6.1" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/edda-cli/Cargo.toml
+++ b/crates/edda-cli/Cargo.toml
@@ -15,27 +15,27 @@ name = "edda"
 path = "src/main.rs"
 
 [dependencies]
-edda-aggregate = { path = "../edda-aggregate", version = "0.6.0" }
-edda-ask = { path = "../edda-ask", version = "0.6.0" }
-edda-chronicle = { path = "../edda-chronicle", version = "0.6.0" }
-edda-core = { path = "../edda-core", version = "0.6.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
-edda-derive = { path = "../edda-derive", version = "0.6.0" }
-edda-store = { path = "../edda-store", version = "0.6.0" }
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.0" }
-edda-bridge-codex = { path = "../edda-bridge-codex", version = "0.6.0" }
-edda-bridge-cursor = { path = "../edda-bridge-cursor", version = "0.6.0" }
-edda-bridge-hermes = { path = "../edda-bridge-hermes", version = "0.6.0" }
-edda-bridge-openclaw = { path = "../edda-bridge-openclaw", version = "0.6.0" }
-edda-transcript = { path = "../edda-transcript", version = "0.6.0" }
-edda-index = { path = "../edda-index", version = "0.6.0" }
-edda-pack = { path = "../edda-pack", version = "0.6.0" }
-edda-mcp = { path = "../edda-mcp", version = "0.6.0" }
-edda-serve = { path = "../edda-serve", version = "0.6.0" }
-edda-notify = { path = "../edda-notify", version = "0.6.0" }
-edda-postmortem = { path = "../edda-postmortem", version = "0.6.0" }
-edda-search-fts = { path = "../edda-search-fts", version = "0.6.0" }
-edda-conductor = { path = "../edda-conductor", version = "0.6.0" }
+edda-aggregate = { path = "../edda-aggregate", version = "0.6.1" }
+edda-ask = { path = "../edda-ask", version = "0.6.1" }
+edda-chronicle = { path = "../edda-chronicle", version = "0.6.1" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.1" }
+edda-derive = { path = "../edda-derive", version = "0.6.1" }
+edda-store = { path = "../edda-store", version = "0.6.1" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.1" }
+edda-bridge-codex = { path = "../edda-bridge-codex", version = "0.6.1" }
+edda-bridge-cursor = { path = "../edda-bridge-cursor", version = "0.6.1" }
+edda-bridge-hermes = { path = "../edda-bridge-hermes", version = "0.6.1" }
+edda-bridge-openclaw = { path = "../edda-bridge-openclaw", version = "0.6.1" }
+edda-transcript = { path = "../edda-transcript", version = "0.6.1" }
+edda-index = { path = "../edda-index", version = "0.6.1" }
+edda-pack = { path = "../edda-pack", version = "0.6.1" }
+edda-mcp = { path = "../edda-mcp", version = "0.6.1" }
+edda-serve = { path = "../edda-serve", version = "0.6.1" }
+edda-notify = { path = "../edda-notify", version = "0.6.1" }
+edda-postmortem = { path = "../edda-postmortem", version = "0.6.1" }
+edda-search-fts = { path = "../edda-search-fts", version = "0.6.1" }
+edda-conductor = { path = "../edda-conductor", version = "0.6.1" }
 ratatui = { version = "0.29", optional = true }
 crossterm = { version = "0.28", optional = true }
 clap.workspace = true
@@ -68,7 +68,7 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 # `test_support::isolated_store()` (GH-757). Ordinary (non-test) builds of
 # this crate and of the `edda` binary never enable it, so production and
 # subprocess store resolution is unchanged.
-edda-store = { path = "../edda-store", version = "0.6.0", features = [
+edda-store = { path = "../edda-store", version = "0.6.1", features = [
     "test-support",
 ] }
 

--- a/crates/edda-conductor/Cargo.toml
+++ b/crates/edda-conductor/Cargo.toml
@@ -11,11 +11,11 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-store = { path = "../edda-store", version = "0.6.0" }
-edda-core = { path = "../edda-core", version = "0.6.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
-edda-derive = { path = "../edda-derive", version = "0.6.0" }
-edda-notify = { path = "../edda-notify", version = "0.6.0" }
+edda-store = { path = "../edda-store", version = "0.6.1" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.1" }
+edda-derive = { path = "../edda-derive", version = "0.6.1" }
+edda-notify = { path = "../edda-notify", version = "0.6.1" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/edda-derive/Cargo.toml
+++ b/crates/edda-derive/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.6.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.1" }
 anyhow.workspace = true
 time.workspace = true
 serde.workspace = true

--- a/crates/edda-index/Cargo.toml
+++ b/crates/edda-index/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-store = { path = "../edda-store", version = "0.6.0" }
+edda-store = { path = "../edda-store", version = "0.6.1" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/edda-ingestion/Cargo.toml
+++ b/crates/edda-ingestion/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.6.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.1" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-ledger/Cargo.toml
+++ b/crates/edda-ledger/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/edda-mcp/Cargo.toml
+++ b/crates/edda-mcp/Cargo.toml
@@ -11,13 +11,13 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-ask = { path = "../edda-ask", version = "0.6.0" }
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.0" }
-edda-core = { path = "../edda-core", version = "0.6.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
-edda-derive = { path = "../edda-derive", version = "0.6.0" }
-edda-notify = { path = "../edda-notify", version = "0.6.0" }
-edda-store = { path = "../edda-store", version = "0.6.0" }
+edda-ask = { path = "../edda-ask", version = "0.6.1" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.1" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.1" }
+edda-derive = { path = "../edda-derive", version = "0.6.1" }
+edda-notify = { path = "../edda-notify", version = "0.6.1" }
+edda-store = { path = "../edda-store", version = "0.6.1" }
 rmcp = { version = "0.16", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 anyhow.workspace = true

--- a/crates/edda-notify/Cargo.toml
+++ b/crates/edda-notify/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.1" }
 ureq = "3"
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-pack/Cargo.toml
+++ b/crates/edda-pack/Cargo.toml
@@ -11,10 +11,10 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.6.0" }
-edda-store = { path = "../edda-store", version = "0.6.0" }
-edda-index = { path = "../edda-index", version = "0.6.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
+edda-store = { path = "../edda-store", version = "0.6.1" }
+edda-index = { path = "../edda-index", version = "0.6.1" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.1" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/edda-postmortem/Cargo.toml
+++ b/crates/edda-postmortem/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.6.0" }
-edda-store = { path = "../edda-store", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
+edda-store = { path = "../edda-store", version = "0.6.1" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/edda-search-fts/Cargo.toml
+++ b/crates/edda-search-fts/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-store = { path = "../edda-store", version = "0.6.0" }
-edda-index = { path = "../edda-index", version = "0.6.0" }
-edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-store = { path = "../edda-store", version = "0.6.1" }
+edda-index = { path = "../edda-index", version = "0.6.1" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
 tantivy = { version = "0.25", default-features = false, features = ["mmap", "lz4-compression"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 fs2 = "0.4"

--- a/crates/edda-serve/Cargo.toml
+++ b/crates/edda-serve/Cargo.toml
@@ -11,14 +11,14 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-ask = { path = "../edda-ask", version = "0.6.0" }
-edda-core = { path = "../edda-core", version = "0.6.0" }
-edda-derive = { path = "../edda-derive", version = "0.6.0" }
-edda-ledger = { path = "../edda-ledger", version = "0.6.0" }
-edda-aggregate = { path = "../edda-aggregate", version = "0.6.0" }
-edda-store = { path = "../edda-store", version = "0.6.0" }
-edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.0" }
-edda-ingestion = { path = "../edda-ingestion", version = "0.6.0" }
+edda-ask = { path = "../edda-ask", version = "0.6.1" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
+edda-derive = { path = "../edda-derive", version = "0.6.1" }
+edda-ledger = { path = "../edda-ledger", version = "0.6.1" }
+edda-aggregate = { path = "../edda-aggregate", version = "0.6.1" }
+edda-store = { path = "../edda-store", version = "0.6.1" }
+edda-bridge-claude = { path = "../edda-bridge-claude", version = "0.6.1" }
+edda-ingestion = { path = "../edda-ingestion", version = "0.6.1" }
 axum = "0.8"
 tracing = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "time"] }

--- a/crates/edda-store/Cargo.toml
+++ b/crates/edda-store/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/edda-transcript/Cargo.toml
+++ b/crates/edda-transcript/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-edda-core = { path = "../edda-core", version = "0.6.0" }
-edda-store = { path = "../edda-store", version = "0.6.0" }
+edda-core = { path = "../edda-core", version = "0.6.1" }
+edda-store = { path = "../edda-store", version = "0.6.1" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Issue: #1107

## Summary

- bump all 23 workspace crates and internal dependency pins to 0.6.1
- rebuild Cargo.lock at 0.6.1
- reconstruct CHANGELOG from the complete `v0.6.0..main` range (10 commits)
- keep the CLI reference on documented major/minor 0.6; verify it against a freshly built 0.6.1 binary

## Validation

- workspace metadata audit: 23 packages, zero bad versions, zero bad internal pins
- `cargo fmt --all --check`
- `cargo test -p edda --locked` (749 unit + 71 integration tests)
- freshly built `target/debug/edda.exe --version` -> 0.6.1
- `EDDA_BIN=target/debug/edda.exe bash scripts/check-cli-docs.sh` -> 65 verbs and flags covered
- `cargo package --workspace --locked --no-verify` -> 23 packages
- skill-local `test_crates_release_plan.py` -> 6/6
- local archive provenance -> PASS, 23/23 archives at `830ff4765c7a6f793ccf953981b3901ca99ee48a`
- `cargo publish --dry-run --workspace --locked` -> reached simulated upload for all 23 crates, including final `edda`
- markdown content, doc citation, file-length, and pre-commit focused clippy gates pass

## Known non-blocking warning

Cargo packaging reports the existing locked `lz4_flex 0.11.5` is yanked. The lockfile dependency is unchanged by this release, package verification succeeds for all consumers, and this PR intentionally avoids an unrelated dependency update.