### PR TITLE
fix(edda-cli): fake-Codex handshake and periodic-renewal waits stop racing a load-calibrated ceiling (GH-1078, GH-1031)

### DIFF
--- a/crates/edda-cli/src/cmd_reconcile/tests/mod.rs
+++ b/crates/edda-cli/src/cmd_reconcile/tests/mod.rs
@@ -12,9 +12,48 @@ mod scheduler;
 
 #[cfg(windows)]
 pub(super) static FAKE_CODEX_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+/// A hang-safety-valve, not a tuned deadline. The waits that consume this
+/// budget (spawning `powershell.exe`, the JSON-RPC handshake, and recording
+/// the durable session under the workspace lock) are the same shape as
+/// `WORKSPACE_LOCK_WAIT_BUDGET` before GH-1047: a fixed ceiling sized as a
+/// multiple of idle-host timing. GH-1047's `git worktree add` was measured at
+/// 27.99 s and 64.8 s under contention against a 30 s budget — its fix did
+/// not raise that number, it moved the slow operation out of what the budget
+/// bounds. There is no equivalent move here (the wait's whole job is to
+/// observe this chain complete), so per GH-1078 ("spawn plus handshake
+/// exceeds the window") this constant is instead set to a magnitude that
+/// contention on this workstation is not expected to reach — comfortably
+/// above GH-1047's own worst measured single-subprocess figure for a chain
+/// with more steps than that one — so a slow host costs latency, never a
+/// failure, and only a genuinely wedged handshake still trips it.
 #[cfg(windows)]
 pub(super) const FAKE_CODEX_STARTUP_BUDGET: std::time::Duration =
-    std::time::Duration::from_secs(30);
+    std::time::Duration::from_secs(180);
+
+/// Poll `condition` every `poll` until it reports `true` or `budget` elapses.
+/// `budget` must be a hang-safety-valve (see `FAKE_CODEX_STARTUP_BUDGET`), not
+/// a value calibrated to idle-host timing — the anti-pattern this exists to
+/// replace let a load-calibrated ceiling double as the test's assertion, so
+/// exceeding it failed the test rather than merely arriving late. Returns
+/// whether the condition held before the deadline; the caller decides what
+/// "false" means (assert, bail, or something softer).
+#[cfg(windows)]
+pub(super) fn poll_until(
+    budget: std::time::Duration,
+    poll: std::time::Duration,
+    mut condition: impl FnMut() -> anyhow::Result<bool>,
+) -> anyhow::Result<bool> {
+    let deadline = std::time::Instant::now() + budget;
+    loop {
+        if condition()? {
+            return Ok(true);
+        }
+        if std::time::Instant::now() >= deadline {
+            return Ok(false);
+        }
+        std::thread::sleep(poll);
+    }
+}
 
 pub(super) static DOORBELL_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
@@ -157,25 +196,24 @@ pub(super) fn allow_fake_turn_after_durable_session(
     deny: std::path::PathBuf,
 ) -> std::thread::JoinHandle<anyhow::Result<()>> {
     std::thread::spawn(move || {
-        let deadline = std::time::Instant::now() + FAKE_CODEX_STARTUP_BUDGET;
-        while std::time::Instant::now() < deadline {
-            if challenge.exists() {
-                let view = Ledger::open(&repo)?
-                    .task_views()?
-                    .into_iter()
-                    .find(|view| view.task_id == task_id);
-                let valid = view.is_some_and(|view| {
-                    view.session_agent_kind.as_deref() == Some("codex")
-                        && view.session_attempt == Some(attempt)
-                        && view.session_id.as_deref() == Some("fake-thread")
-                });
-                std::fs::write(if valid { allow } else { deny }, "gate")?;
-                anyhow::ensure!(valid, "fake observed turn before durable current session");
-                return Ok(());
-            }
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        }
-        anyhow::bail!("fake never challenged turn gate")
+        let seen = poll_until(
+            FAKE_CODEX_STARTUP_BUDGET,
+            std::time::Duration::from_millis(10),
+            || Ok(challenge.exists()),
+        )?;
+        anyhow::ensure!(seen, "fake never challenged turn gate");
+        let view = Ledger::open(&repo)?
+            .task_views()?
+            .into_iter()
+            .find(|view| view.task_id == task_id);
+        let valid = view.is_some_and(|view| {
+            view.session_agent_kind.as_deref() == Some("codex")
+                && view.session_attempt == Some(attempt)
+                && view.session_id.as_deref() == Some("fake-thread")
+        });
+        std::fs::write(if valid { allow } else { deny }, "gate")?;
+        anyhow::ensure!(valid, "fake observed turn before durable current session");
+        Ok(())
     })
 }
 

--- a/crates/edda-cli/src/cmd_reconcile/tests/runner.rs
+++ b/crates/edda-cli/src/cmd_reconcile/tests/runner.rs
@@ -661,33 +661,33 @@ pub(super) fn periodic_renewal_stops_old_runner_before_failure_after_lease_repla
     let runner_config = config.clone();
     let runner = std::thread::spawn(move || run_task(&runner_repo, 1, 1, &runner_config, false));
 
-    let session_deadline = std::time::Instant::now() + FAKE_CODEX_STARTUP_BUDGET;
-    while std::time::Instant::now() < session_deadline {
-        if ledger
-            .task_events()?
-            .iter()
-            .any(|event| event.event_type == "task.session")
-        {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(25));
-    }
-    assert!(ledger
-        .task_events()?
-        .iter()
-        .any(|event| event.event_type == "task.session"));
+    let session_recorded = poll_until(
+        FAKE_CODEX_STARTUP_BUDGET,
+        std::time::Duration::from_millis(25),
+        || {
+            Ok(ledger
+                .task_events()?
+                .iter()
+                .any(|event| event.event_type == "task.session"))
+        },
+    )?;
+    assert!(session_recorded, "runner recorded the durable session");
     let after_session = ledger.task_lease(1)?.expect("session lease");
-    let mut saw_periodic_renewal = false;
-    for _ in 0..100 {
-        let current = ledger.task_lease(1)?.expect("current lease");
-        if current.heartbeat_at != after_session.heartbeat_at
-            || current.expires_at != after_session.expires_at
-        {
-            saw_periodic_renewal = true;
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(25));
-    }
+    // Same hang-safety-valve as FAKE_CODEX_STARTUP_BUDGET, not a tuned
+    // deadline: with lease_ttl_s = 1 the runner renews roughly once a second
+    // (`(ttl_s / 2).max(1)` in run_turn_with_renewals), but that tick shares
+    // the tokio runtime with the fake process's I/O, so a loaded host can
+    // stretch the wait well past its nominal interval without anything being
+    // wrong (GH-1031).
+    let saw_periodic_renewal = poll_until(
+        FAKE_CODEX_STARTUP_BUDGET,
+        std::time::Duration::from_millis(25),
+        || {
+            let current = ledger.task_lease(1)?.expect("current lease");
+            Ok(current.heartbeat_at != after_session.heartbeat_at
+                || current.expires_at != after_session.expires_at)
+        },
+    )?;
     assert!(
         saw_periodic_renewal,
         "runner crossed a periodic renewal interval"

--- a/crates/edda-cli/src/cmd_reconcile/tests/runner.rs
+++ b/crates/edda-cli/src/cmd_reconcile/tests/runner.rs
@@ -628,6 +628,13 @@ pub(super) fn fake_runner_records_session_in_main_ledger_before_turn_and_fails_w
 #[test]
 pub(super) fn periodic_renewal_stops_old_runner_before_failure_after_lease_replacement(
 ) -> anyhow::Result<()> {
+    // This test writes process env (`EDDA_FAKE_*`) to gate the fake turn
+    // below, so it takes the crate-wide env guard alongside its own
+    // fake-Codex lock — otherwise it races any other test in this binary
+    // that mutates process env, the same reason
+    // `fake_runner_resumes_current_attempt_after_slow_startup_before_turn`
+    // takes both.
+    let _env = crate::test_support::env_guard();
     let _fake = test_lock(&FAKE_CODEX_LOCK);
     let dir = tempfile::tempdir()?;
     let repo = dir.path().join("repo");
@@ -653,53 +660,104 @@ pub(super) fn periodic_renewal_stops_old_runner_before_failure_after_lease_repla
     )?)?;
     append_started(&ledger, 1, 1, 1)?;
     ledger.upsert_task_lease(&lease(1, 1, "2026-08-16T02:00:00Z"))?;
-    let fake = fake_codex(dir.path(), 2, false)?;
+    let fake = fake_codex(dir.path(), 0, false)?;
     let mut config = ReconcileConfig::test_defaults();
     config.lease_ttl_s = 1;
     config.codex_bin = fake;
+
+    // Gate the fake turn at the same EDDA_FAKE_CHALLENGE checkpoint
+    // `allow_fake_turn_after_durable_session` uses (tests/mod.rs): the fake
+    // process writes the challenge file and then blocks — bounded by
+    // FAKE_CODEX_STARTUP_BUDGET — until this test writes `allow` or `deny`.
+    // Without this, the turn resolves on `fake_codex`'s fixed `Start-Sleep`
+    // and `finish_runner` deletes the lease the moment it does, so the
+    // periodic-renewal tick this test waits for below has to land inside
+    // whatever is left of that fixed window: a race whose loss makes the
+    // condition permanently unobservable rather than merely late, which no
+    // poll budget can reach (GH-1031). Gating the turn means
+    // `run_turn_with_renewals`'s ~1s interval (`(ttl_s / 2).max(1)` with
+    // `lease_ttl_s = 1`, runner.rs:473-474) keeps ticking for as long as the
+    // gate stays shut, so the renewal below is an event this test waits on
+    // instead of a deadline it races.
+    let challenge = dir.path().join("renewal.challenge");
+    let allow = dir.path().join("renewal.allow");
+    let deny = dir.path().join("renewal.deny");
+    std::env::set_var("EDDA_FAKE_CHALLENGE", &challenge);
+    std::env::set_var("EDDA_FAKE_ALLOW", &allow);
+    std::env::set_var("EDDA_FAKE_DENY", &deny);
+
     let runner_repo = repo.clone();
     let runner_config = config.clone();
     let runner = std::thread::spawn(move || run_task(&runner_repo, 1, 1, &runner_config, false));
 
-    let session_recorded = poll_until(
-        FAKE_CODEX_STARTUP_BUDGET,
-        std::time::Duration::from_millis(25),
-        || {
-            Ok(ledger
-                .task_events()?
-                .iter()
-                .any(|event| event.event_type == "task.session"))
-        },
-    )?;
-    assert!(session_recorded, "runner recorded the durable session");
-    let after_session = ledger.task_lease(1)?.expect("session lease");
-    // Same hang-safety-valve as FAKE_CODEX_STARTUP_BUDGET, not a tuned
-    // deadline: with lease_ttl_s = 1 the runner renews roughly once a second
-    // (`(ttl_s / 2).max(1)` in run_turn_with_renewals), but that tick shares
-    // the tokio runtime with the fake process's I/O, so a loaded host can
-    // stretch the wait well past its nominal interval without anything being
-    // wrong (GH-1031).
-    let saw_periodic_renewal = poll_until(
-        FAKE_CODEX_STARTUP_BUDGET,
-        std::time::Duration::from_millis(25),
-        || {
-            let current = ledger.task_lease(1)?.expect("current lease");
-            Ok(current.heartbeat_at != after_session.heartbeat_at
-                || current.expires_at != after_session.expires_at)
-        },
-    )?;
-    assert!(
-        saw_periodic_renewal,
-        "runner crossed a periodic renewal interval"
-    );
-    ledger.upsert_task_lease(&TaskLease {
-        task_id: 1,
-        attempt: 2,
-        owner: "replacement".into(),
-        expires_at: "2026-08-16T03:00:00Z".into(),
-        heartbeat_at: "2026-08-16T01:00:00Z".into(),
-    })?;
-    runner.join().expect("runner thread")?;
+    let outcome = (|| -> anyhow::Result<()> {
+        let session_recorded = poll_until(
+            FAKE_CODEX_STARTUP_BUDGET,
+            std::time::Duration::from_millis(25),
+            || {
+                Ok(ledger
+                    .task_events()?
+                    .iter()
+                    .any(|event| event.event_type == "task.session"))
+            },
+        )?;
+        anyhow::ensure!(session_recorded, "runner recorded the durable session");
+        let after_session = ledger.task_lease(1)?.expect("session lease");
+
+        let challenge_seen = poll_until(
+            FAKE_CODEX_STARTUP_BUDGET,
+            std::time::Duration::from_millis(10),
+            || Ok(challenge.exists()),
+        )?;
+        anyhow::ensure!(challenge_seen, "fake never reached the turn gate");
+
+        // The turn is held at the gate now, so it cannot resolve out from
+        // under this poll: `finish_runner` cannot delete the lease until
+        // the gate opens below, which happens only after this observation
+        // succeeds.
+        let saw_periodic_renewal = poll_until(
+            FAKE_CODEX_STARTUP_BUDGET,
+            std::time::Duration::from_millis(25),
+            || {
+                let current = ledger.task_lease(1)?.expect("current lease");
+                Ok(current.heartbeat_at != after_session.heartbeat_at
+                    || current.expires_at != after_session.expires_at)
+            },
+        )?;
+        anyhow::ensure!(
+            saw_periodic_renewal,
+            "runner crossed a periodic renewal interval"
+        );
+
+        ledger.upsert_task_lease(&TaskLease {
+            task_id: 1,
+            attempt: 2,
+            owner: "replacement".into(),
+            expires_at: "2026-08-16T03:00:00Z".into(),
+            heartbeat_at: "2026-08-16T01:00:00Z".into(),
+        })?;
+        Ok(())
+    })();
+
+    // Release the gate unconditionally: allow if the observation above
+    // succeeded, deny otherwise, so a failed observation doesn't also make
+    // the fake process (and the join below) wait out its own copy of
+    // FAKE_CODEX_STARTUP_BUDGET on top of the one the failure already
+    // consumed.
+    let _ = std::fs::write(if outcome.is_ok() { &allow } else { &deny }, "gate");
+
+    // Whichever way the runner notices from here — the next renewal tick
+    // seeing it no longer owns the lease (runner.rs:480-484), or the turn
+    // completing and `finish_runner` reading the now-replaced lease —
+    // `finish_runner` re-reads current ownership rather than trusting a
+    // value captured earlier, so both paths land on the same outcome the
+    // assertions below check for.
+    let run_result = runner.join().expect("runner thread");
+    std::env::remove_var("EDDA_FAKE_CHALLENGE");
+    std::env::remove_var("EDDA_FAKE_ALLOW");
+    std::env::remove_var("EDDA_FAKE_DENY");
+    outcome?;
+    run_result?;
 
     assert_eq!(ledger.task_lease(1)?.expect("replacement").attempt, 2);
     assert!(ledger
@@ -735,17 +793,20 @@ pub(super) fn fake_runner_resumes_current_attempt_after_slow_startup_before_turn
     std::env::set_var("EDDA_FAKE_CHALLENGE", &challenge);
     std::env::set_var("EDDA_FAKE_ALLOW", &allow);
     std::env::set_var("EDDA_FAKE_DENY", &deny);
-    // The deliberate delay that simulates a slow runner startup happens
-    // before the observer starts polling, not after: the observer's budget
-    // exists to cover the handshake it is actually watching for, not time
-    // this test spends manufacturing "slow startup" on purpose. Sleeping
-    // after the observer was already running used to spend part of its
-    // hang-safety-valve on nothing observable — the unconditional-wait
-    // anti-pattern this reordering removes (GH-1078).
-    std::thread::sleep(std::time::Duration::from_millis(2_100));
-
     let observer =
         allow_fake_turn_after_durable_session(repo.clone(), 2, 1, challenge, allow, deny);
+
+    // The deliberate "slow startup" delay runs after the observer has
+    // already started polling, not before: that is what makes this a slow
+    // *startup* the observer has to wait through, rather than a delay that
+    // finishes before anything is watching and pins nothing. `84cbbdd`
+    // (2026-08-17) added this sleep in this position deliberately, in the
+    // same commit that renamed this test to `..._after_slow_startup_...`;
+    // it deliberately spends part of the observer's FAKE_CODEX_STARTUP_BUDGET
+    // hang-safety-valve on nothing observable, which is exactly what pins
+    // that the budget is generous enough to absorb a slow handshake and not
+    // merely a fast one.
+    std::thread::sleep(std::time::Duration::from_millis(2_100));
 
     let run_result = run_task(&repo, 2, 1, &config, false);
     let observer_result = observer.join();

--- a/crates/edda-cli/src/cmd_reconcile/tests/runner.rs
+++ b/crates/edda-cli/src/cmd_reconcile/tests/runner.rs
@@ -735,10 +735,17 @@ pub(super) fn fake_runner_resumes_current_attempt_after_slow_startup_before_turn
     std::env::set_var("EDDA_FAKE_CHALLENGE", &challenge);
     std::env::set_var("EDDA_FAKE_ALLOW", &allow);
     std::env::set_var("EDDA_FAKE_DENY", &deny);
+    // The deliberate delay that simulates a slow runner startup happens
+    // before the observer starts polling, not after: the observer's budget
+    // exists to cover the handshake it is actually watching for, not time
+    // this test spends manufacturing "slow startup" on purpose. Sleeping
+    // after the observer was already running used to spend part of its
+    // hang-safety-valve on nothing observable — the unconditional-wait
+    // anti-pattern this reordering removes (GH-1078).
+    std::thread::sleep(std::time::Duration::from_millis(2_100));
+
     let observer =
         allow_fake_turn_after_durable_session(repo.clone(), 2, 1, challenge, allow, deny);
-
-    std::thread::sleep(std::time::Duration::from_millis(2_100));
 
     let run_result = run_task(&repo, 2, 1, &config, false);
     let observer_result = observer.join();


### PR DESCRIPTION
## Summary

Two commits, one per issue, both in `crates/edda-cli/src/cmd_reconcile/tests/`:

- **GH-1078** (`1bbcbe7`): the fake-Codex handshake observer (`tests/mod.rs`) stops treating a load-calibrated 30s ceiling as its own assertion, and `fake_runner_resumes_current_attempt_after_slow_startup_before_turn`'s deliberate "slow startup" sleep no longer eats into that ceiling before the observer starts watching.
- **GH-1031** (`c01f073`): `periodic_renewal_stops_old_runner_before_failure_after_lease_replacement`'s two waits are converted to the same helper, closing the fixed-2.5s renewal-detection window that was the tightest instance of the same shape in this file.

## Round 1 fix (`47232b8`)

Round 1 review found the GH-1031 commit above did not fix GH-1031: widening a
poll budget cannot help when the polled condition (a lease renewal) is capped
by the runner's own turn lifetime, not by the budget — once the fake turn's
fixed `Start-Sleep` resolves, `finish_runner` deletes the lease and the
condition becomes permanently unobservable, not merely late. `47232b8` gates
the fake turn at the `EDDA_FAKE_CHALLENGE`/`ALLOW`/`DENY` checkpoint
`allow_fake_turn_after_durable_session` already uses, so the turn cannot
resolve until the test has already observed a renewal and released it — the
renewal becomes an event this test waits on instead of a deadline it races.
It also restores `fake_runner_resumes_current_attempt_after_slow_startup_before_turn`'s
"slow startup" sleep to the position `84cbbdd` deliberately placed it (after
the observer starts polling), which Round 1 found the first commit had moved
in a way that deleted the coverage it was added to pin. Full reasoning in the
`Review Response: Round 1` comment on this PR.

## Evidence standard: structural, not measured

Per the controller's own measurement at this SHA on this host, `cargo test -p edda --bin edda cmd_reconcile` was run 11 times and did not reproduce either report:

| condition | runs | failures among the three named tests | wall clock |
|---|---|---|---|
| idle host | 8 | **0** | 37–61 s |
| under a full-workspace rebuild **and** a PowerShell spawn storm | 3 | **0** | 80–137 s |

No local reproduction was attempted here (none was possible on this host, and the brief explicitly prohibited generating load or looping tests to try). Everything below argues from the code.

## The sites, sorted (six, not five)

The original count below inventoried five poll-with-deadline *sites*, all in
Rust. Round 1 correctly found a sixth *consumer of the constant* missing from
it — added at the end, in its own category since it isn't a Rust
poll-with-deadline site in the same sense as the other five.

- **`tests/mod.rs` observer loop** (`allow_fake_turn_after_durable_session`) — **anti-pattern, fixed.** It bailed with `"fake never challenged turn gate"` as soon as its own 30s deadline passed, even though nothing was necessarily broken: reaching the challenge file requires `Command::spawn` of `powershell.exe` plus the full JSON-RPC handshake plus `record_session_if_current` (workspace lock + ledger append) to have already completed. GH-1078's own diagnosis is "spawn plus handshake exceeds the window."
- **`runner.rs` session-deadline loop** (in the GH-1031 test) — **anti-pattern, fixed.** Same shape, same constant, same class of risk (it waits for the same `task.session` event the observer above waits to react to), and GH-1078 explicitly invites this: *"If #1031 shares the mechanism, it is closed by the same change or explicitly distinguished in the PR body."* It shares the mechanism.
- **`runner.rs` periodic-renewal loop** (the `for _ in 0..100 { sleep(25ms) }` in the same GH-1031 test) — **anti-pattern, fixed in the first commit but not resolved by it; genuinely fixed in `47232b8`.** This one isn't about spawn/handshake at all: with `lease_ttl_s = 1`, `run_turn_with_renewals` renews on a `tokio::time::interval` around 1s. The first commit converted the fixed `for` loop to `poll_until` with the same 180s ceiling as the other sites, which Round 1 showed does not touch the actual constraint: the renewal is capped by the fake turn's own fixed length, not by the poll budget. `47232b8` gates the turn instead, per the Round 1 fix section above.
- **`runner.rs:8` `await_gate`** — **sound, left alone.** Its 30s ceiling is a pure hang-safety-valve: on timeout it just returns (no `assert`/`bail` of its own), so a slow host costs the *simulated stall* some fidelity, never a false failure. Round 1 verified this characterization directly.
- **`runner.rs:526` `spawn_deadline`** (in `first_spawn_failure_does_not_prevent_later_plan_launch`) — **not sound; left alone on scope grounds, not soundness.** Round 1 caught this: `anyhow::ensure!(Instant::now() < spawn_deadline, ...)` fails the test on timeout, the identical deadline-as-assertion shape fixed at the other three sites above — the load-calibrated reasoning previously given here for leaving it alone (a trivial `.cmd` spawn, already tuned once for GH-524) is exactly the reasoning GH-1078 names as the anti-pattern, not a reason this site is structurally different. The only defensible reason to leave it untouched: neither issue names this test, it has no reported failure, and per `fleet.ci-flake-carrier=product-issue-per-test-no-registry` an unflaked test earns its own issue if and when it flakes, not a preemptive fix bundled into this PR.
- **`runner.rs:816` fake-Codex `STARTUP_BUDGET_MS` gate (PowerShell, substituted from `FAKE_CODEX_STARTUP_BUDGET`)** — the sixth consumer of the constant, missing from the count above. This is the fake process's own wait for `EDDA_FAKE_ALLOW`/`EDDA_FAKE_DENY` after it writes the challenge file (`tests/runner.rs:814-823`); its expiry is what produces the literal `unexpected EOF from Codex App Server` message GH-1078's own report names. It moved 30s to 180s alongside the Rust-side constant it shares a name with, so behavior stays consistent, but it bounds the fake's own gate loop rather than a Rust `Instant`-based poll, and belongs in this inventory regardless.

## Why widening the constant is not "the third instance"

`FAKE_CODEX_STARTUP_BUDGET` moved from 30s to 180s (`tests/mod.rs`), which superficially repeats the move GH-1078's own text calls out as insufficient by itself ("raising 30 s to 60 s would be the third instance, not a fix"). The distinguishing argument, not just a bigger number:

- The direct precedent in this codebase (`plan.rs:511-516`, `WORKSPACE_LOCK_WAIT_BUDGET`) shows what a *real* fix to this shape looks like: GH-1047's `git worktree add` was measured at 27.99s and 64.8s under contention against a 30s budget, and the fix did **not** raise that number — it moved the slow git I/O out of what the budget bounds, so the still-30s budget now only has to cover sub-10ms SQLite operations.
- There is no equivalent move available for the fake-Codex observer: its entire job is to *observe* the spawn+handshake+session-record chain complete, so nothing can be moved out from under it without changing what the test verifies.
- Given that, 180s is chosen to be a magnitude qualitatively different from a load-calibrated timeout — comfortably above GH-1047's own worst measured single-subprocess figure (64.8s) for a chain with more steps than that one (spawn *and* a multi-round-trip handshake *and* a lock-guarded ledger write) — so it functions as a hang detector (only a genuinely wedged handshake trips it) rather than a tuned assertion a busy-but-alive host can still lose to.

For the periodic-renewal wait specifically, this reasoning does not transfer — see the Round 1 fix section above and `47232b8`, which decouples that observation from the constant's size entirely rather than relying on it being large.

## Setting the pattern

Added `tests/mod.rs::poll_until` (Windows-gated, alongside `FAKE_CODEX_STARTUP_BUDGET`): poll a fallible condition on an interval until it holds or a budget elapses, returning whether it held rather than asserting itself. All three fixed sites above now go through it, so the next `cmd_reconcile` test with this shape has one place to reach for instead of a fourth hand-rolled deadline loop. The doc comments on both the constant and the helper spell out the distinction this PR is drawing (hang-safety-valve vs. load-calibrated ceiling) so it doesn't have to be re-derived.

Checked against the other four issues named in the brief as sharing this shape:

- **GH-1071** (`crates/edda-cli/src/cmd_review/evidence.rs`) — same crate, different module; `poll_until` is `pub(super)` inside `cmd_reconcile::tests` and doesn't reach it without promotion. GH-1071's own doneWhen also points at a different fix shape (an injected `--now`/`Facts` seam for a deadline *assertion*, not a spawn-observation poll), so the helper wouldn't be the right tool there even if visible.
- **GH-1085** (`crates/edda-bridge-claude`) — different crate and a different mechanism entirely (two independent clock reads straddling a wall-clock second boundary in a rendered string, not a poll-with-deadline). Doesn't transfer.
- **GH-924** (`crates/edda-search-fts`) — different crate; a Windows file-locking error (`os error 5`), not examined here. Not this shape as far as this PR's scope goes.
- **GH-1047** — closed already (`WORKSPACE_LOCK_WAIT_BUDGET`/`plan.rs`); it's the precedent cited above, not open work.

Not fixed here, per the brief.

## Gates (L0, touched crate only)

Lane: `worker-2` (`CARGO_TARGET_DIR=%LOCALAPPDATA%\fleet-workstation\lanes\worker-2`).

First two commits, run separately, each on the state at that commit:

- `cargo fmt --all --check` — clean
- `cargo clippy -p edda --all-targets -- -D warnings` — clean, 0 warnings
- `cargo test -p edda` — 749/749 unit tests passed (0 failed) both times, including all five touched `cmd_reconcile::tests::runner` tests by name; all `tests/*.rs` integration binaries green
- `sh scripts/lint-file-length.sh --tree` — clean

Round 1 fix commit `47232b8`, same lane, on top of the above:

- `cargo fmt --all --check` — clean
- `cargo clippy -p edda --all-targets -- -D warnings` — clean, 0 warnings
- `cargo test -p edda` — 749/749 unit tests passed (0 failed; test count unchanged, two existing tests modified), all `tests/*.rs` integration binaries green
- `sh scripts/lint-file-length.sh --tree` — clean

`cargo test --workspace` was not run on any commit (out of budget per the brief). The pre-commit hook's own `cargo fmt`/`clippy` re-ran outside the lane's `CARGO_TARGET_DIR` on the first two commits (known gap #1099) and left a stray `target/` in the worktree each time; deleted after each commit as instructed. The round 1 fix commit used the hook's own `SKIP_CLIPPY=1` escape hatch after running clippy warm in the lane, so it left no stray `target/`. No local reproduction loop was run on any commit's code, per the brief.

## Undone / left for the controller

- The written convention (hang-safety-valve vs. load-calibrated ceiling) and the `poll_until` shape are stated above for GH-1071/GH-924/GH-1085 to reuse, but no code in those crates was touched.
- Round 1's follow-up finding — `run_turn_with_renewals` performs blocking `Ledger::open` + `renew_lease` directly inside a `tokio::select!` arm rather than through `spawn_blocking` (`runner.rs:479-483`), which could delay a renewal tick under real lock contention independent of anything this PR touches — is evidenced but out of this PR's frozen surface (test files only) and was not examined or fixed here.
- CI run id for the round 1 fix head will follow once exact-head CI reports on this PR.

Issue: #1078, #1031
Closes #1078

🤖 Generated with [Claude Code](https://claude.com/claude-code)
