### PR TITLE
feat(fleet): sessions carry an explicit machine identity — label@machine, fleet label chain, collision warnings (GH-671)

### DIFF
--- a/crates/edda-bridge-claude/src/peers/heartbeat.rs
+++ b/crates/edda-bridge-claude/src/peers/heartbeat.rs
@@ -5,7 +5,7 @@ use crate::parse::now_rfc3339;
 use crate::signals::SessionSignals;
 
 use super::board::{compute_board_state, partition_requests_for_session};
-use super::helpers::{auto_label, parse_rfc3339_to_epoch, session_label_from_board};
+use super::helpers::{auto_label, fleet_session, parse_rfc3339_to_epoch, session_label_from_board};
 use super::{
     coordination_path, detect_git_branch_in, env_label, heartbeat_path, read_heartbeat, stale_secs,
     BindingConflict, CoordEvent, CoordEventType, SessionHeartbeat,
@@ -32,19 +32,7 @@ pub(crate) fn write_heartbeat(
     let derived_label = label
         .map(|s| s.to_string())
         .or_else(env_label)
-        .unwrap_or_else(|| {
-            let auto = auto_label(signals, Some(cwd));
-            if auto.is_empty() {
-                // Fresh session: no edits yet, so `auto_label` is empty. Fall back
-                // to the git branch so the peer stays identifiable in `edda watch`
-                // and can still receive `edda request` (#128). This is a presence
-                // signal on the heartbeat — never a scope claim, which is what
-                // used to block every peer under enforce_offlimits (#444).
-                branch.clone().unwrap_or_default()
-            } else {
-                auto
-            }
-        });
+        .unwrap_or_else(|| derive_label(project_id, session_id, signals, cwd, branch.as_deref()));
 
     let result = edda_store::update_heartbeat(project_id, session_id, |hb| {
         if hb.started_at.is_empty() {
@@ -83,6 +71,51 @@ pub(crate) fn write_heartbeat(
             &format!("{e:#}"),
         );
     }
+}
+
+/// The label to record when neither an explicit one nor `EDDA_SESSION_LABEL`
+/// supplied it (GH-671 identity half).
+///
+/// A fleet session (`EDDA_MACHINE` exported by the lane wrapper) owes an
+/// explicit identity: a claim label from the board counts, and past that the
+/// chain refuses to invent one — the branch/auto fallbacks are exactly what
+/// made three live fleet sessions all answer to `main`, indistinguishable to
+/// `edda request`. The last resort is the session id prefix: unique by
+/// construction, visibly derived (`sid-`), so a collision warning elsewhere
+/// in the render can stay a warning rather than a lie.
+///
+/// A bare local session keeps the permissive chain: focus-file auto label,
+/// then the git branch so the peer stays identifiable in `edda watch` and can
+/// still receive `edda request` (#128). This is a presence signal on the
+/// heartbeat — never a scope claim, which is what used to block every peer
+/// under enforce_offlimits (#444).
+fn derive_label(
+    project_id: &str,
+    session_id: &str,
+    signals: &SessionSignals,
+    cwd: &str,
+    branch: Option<&str>,
+) -> String {
+    if fleet_session() {
+        let claim = compute_board_state(project_id)
+            .claims
+            .iter()
+            .find(|c| c.session_id == session_id)
+            .map(|c| c.label.clone())
+            .filter(|l| !l.is_empty());
+        return claim.unwrap_or_else(|| sid_prefix(session_id));
+    }
+    let auto = auto_label(signals, Some(cwd));
+    if !auto.is_empty() {
+        return auto;
+    }
+    branch.unwrap_or_default().to_string()
+}
+
+/// The unambiguous fallback label: the session id's first segment, prefixed
+/// so a reader can tell a derived label from a chosen one.
+fn sid_prefix(session_id: &str) -> String {
+    format!("sid-{}", &session_id[..8.min(session_id.len())])
 }
 
 /// Lightweight heartbeat touch: only update last_heartbeat timestamp.

--- a/crates/edda-bridge-claude/src/peers/helpers.rs
+++ b/crates/edda-bridge-claude/src/peers/helpers.rs
@@ -1,6 +1,6 @@
 use super::board::{compute_board_state, partition_requests_for_session};
 use super::read_heartbeat;
-use super::{BoardState, RequestEntry};
+use super::{BoardState, PeerSummary, RequestEntry};
 use crate::signals::SessionSignals;
 
 /// Resolve a session's coordination label: an explicit claim wins, the
@@ -32,6 +32,63 @@ pub(crate) fn pending_requests_for_session(
 }
 
 // ── Helpers ──
+
+/// This machine's display identity (GH-671 identity half): `EDDA_MACHINE`
+/// when the fleet wrapper set it, else the OS host-name env vars, else none.
+///
+/// The chain matches `edda export md`'s provenance field so a session's
+/// `label@machine` and a mirror's "Exporting machine" cannot disagree about
+/// which machine they are on. None of this is a *credential*: the claim
+/// guard's machine identity (`--machine`/`EDDA_MACHINE`, hostname never
+/// guessed) stays explicit-only in `cmd_dispatch`; this resolver is for
+/// rendering, where a best-effort name beats silence but must never mint
+/// authority.
+pub fn machine_identity() -> Option<String> {
+    for key in ["EDDA_MACHINE", "COMPUTERNAME", "HOSTNAME"] {
+        if let Ok(value) = std::env::var(key) {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// A fleet-mode session (GH-671 identity half): the lane wrapper exports
+/// `EDDA_MACHINE` into the session's environment, so its presence is the
+/// opt-in that makes label discipline binding. A bare local session keeps
+/// the permissive label chain.
+pub(crate) fn fleet_session() -> bool {
+    std::env::var("EDDA_MACHINE")
+        .map(|v| !v.trim().is_empty())
+        .unwrap_or(false)
+}
+
+/// Labels shared by two or more **live** sessions (GH-671 identity half),
+/// with the live count each — `(label, count)`, sorted by label.
+///
+/// Requests address peers by label, so a shared label is an ambiguous
+/// address. Only live sessions collide: a dead heartbeat's label occupies
+/// nothing. Empty labels are not addressable and never reported. One
+/// implementation feeds both render surfaces (`edda peers` and the pack's
+/// peer block) so they cannot disagree about whether a label collides.
+pub fn colliding_labels<'a>(
+    peers: impl IntoIterator<Item = &'a PeerSummary>,
+) -> Vec<(String, usize)> {
+    use std::collections::BTreeMap;
+    let mut counts: BTreeMap<&'a str, usize> = BTreeMap::new();
+    for peer in peers.into_iter().filter(|p| p.is_live) {
+        if !peer.label.is_empty() {
+            *counts.entry(peer.label.as_str()).or_insert(0) += 1;
+        }
+    }
+    counts
+        .into_iter()
+        .filter(|(_, count)| *count >= 2)
+        .map(|(label, count)| (label.to_string(), count))
+        .collect()
+}
 
 /// True if a normalized path is absolute (`/...` or `C:/...`).
 pub(super) fn is_absolute_normalized(path: &str) -> bool {

--- a/crates/edda-bridge-claude/src/peers/helpers.rs
+++ b/crates/edda-bridge-claude/src/peers/helpers.rs
@@ -43,9 +43,14 @@ pub(crate) fn pending_requests_for_session(
 /// guessed) stays explicit-only in `cmd_dispatch`; this resolver is for
 /// rendering, where a best-effort name beats silence but must never mint
 /// authority.
+///
+/// Reads through [`crate::env_var`], this crate's single production read path
+/// for every env var a test configures (GH-757): in production that is a plain
+/// `std::env::var`, and in test builds a thread-scoped override map, so no
+/// test has to mutate the process environment to exercise these tiers.
 pub fn machine_identity() -> Option<String> {
     for key in ["EDDA_MACHINE", "COMPUTERNAME", "HOSTNAME"] {
-        if let Ok(value) = std::env::var(key) {
+        if let Some(value) = crate::env_var(key) {
             let trimmed = value.trim();
             if !trimmed.is_empty() {
                 return Some(trimmed.to_string());
@@ -59,10 +64,14 @@ pub fn machine_identity() -> Option<String> {
 /// `EDDA_MACHINE` into the session's environment, so its presence is the
 /// opt-in that makes label discipline binding. A bare local session keeps
 /// the permissive label chain.
+///
+/// Reads through [`crate::env_var`] for the same reason as
+/// [`machine_identity`], and one more: four pre-existing `write_heartbeat`
+/// tests pass `label: None` and so reach this predicate, while libtest runs
+/// every `#[test]` as a thread in one process — a test that set
+/// `EDDA_MACHINE` process-wide would flip their labels out from under them.
 pub(crate) fn fleet_session() -> bool {
-    std::env::var("EDDA_MACHINE")
-        .map(|v| !v.trim().is_empty())
-        .unwrap_or(false)
+    crate::env_var("EDDA_MACHINE").is_some_and(|v| !v.trim().is_empty())
 }
 
 /// Labels shared by two or more **live** sessions (GH-671 identity half),

--- a/crates/edda-bridge-claude/src/peers/helpers.rs
+++ b/crates/edda-bridge-claude/src/peers/helpers.rs
@@ -66,10 +66,12 @@ pub fn machine_identity() -> Option<String> {
 /// the permissive label chain.
 ///
 /// Reads through [`crate::env_var`] for the same reason as
-/// [`machine_identity`], and one more: four pre-existing `write_heartbeat`
-/// tests pass `label: None` and so reach this predicate, while libtest runs
-/// every `#[test]` as a thread in one process — a test that set
-/// `EDDA_MACHINE` process-wide would flip their labels out from under them.
+/// [`machine_identity`], and one more: three pre-existing tests in
+/// `peers::tests` call `write_heartbeat` with no label, across four call
+/// sites, and so reach this predicate — while libtest runs every test fn as
+/// a thread in one process, so a test that set `EDDA_MACHINE` process-wide
+/// would flip their labels out from under them. They are named in
+/// `tests_tail_gh671`'s first test, which is where that history is kept.
 pub(crate) fn fleet_session() -> bool {
     crate::env_var("EDDA_MACHINE").is_some_and(|v| !v.trim().is_empty())
 }

--- a/crates/edda-bridge-claude/src/peers/mod.rs
+++ b/crates/edda-bridge-claude/src/peers/mod.rs
@@ -58,10 +58,12 @@ fn protocol_budget() -> usize {
 const PEER_UPDATES_BUDGET: usize = 500;
 
 /// Session label from env var (set before launching Claude Code).
+///
+/// Through [`crate::env_var`] (GH-757): every `write_heartbeat` caller that
+/// passes `label: None` reads this, so a test exercising the tier must be able
+/// to configure it thread-locally rather than process-wide.
 fn env_label() -> Option<String> {
-    std::env::var("EDDA_SESSION_LABEL")
-        .ok()
-        .filter(|v| !v.is_empty())
+    crate::env_var("EDDA_SESSION_LABEL").filter(|v| !v.is_empty())
 }
 
 /// Detect git branch in a specific directory.

--- a/crates/edda-bridge-claude/src/peers/mod.rs
+++ b/crates/edda-bridge-claude/src/peers/mod.rs
@@ -281,7 +281,9 @@ pub use heartbeat::{
     write_binding, write_claim, write_claim_with_subject, write_heartbeat_minimal, write_request,
     write_request_ack, write_unclaim,
 };
+pub use helpers::colliding_labels;
 pub use helpers::format_age;
+pub use helpers::machine_identity;
 pub(crate) use helpers::{format_peer_suffix, pending_requests_for_session};
 pub use helpers::{resolve_session_label, session_label_from_board, timestamp_at_or_after};
 pub use liveness::{

--- a/crates/edda-bridge-claude/src/peers/render_coord.rs
+++ b/crates/edda-bridge-claude/src/peers/render_coord.rs
@@ -4,8 +4,8 @@ use super::autoclaim::derive_scope_from_files;
 use super::board::{compute_board_state, partition_requests_for_session};
 use super::discovery::discover_active_peers;
 use super::helpers::{
-    self, format_age, format_age_coarse, format_peer_suffix, session_label_from_board,
-    truncate_to_budget,
+    self, colliding_labels, format_age, format_age_coarse, format_peer_suffix,
+    session_label_from_board, truncate_to_budget,
 };
 use super::read_heartbeat;
 use super::{
@@ -369,6 +369,16 @@ pub(crate) fn render_peer_updates_with(
         } else {
             lines.push(format!("- {} ({age}){branch_suffix}", p.label));
         }
+    }
+
+    // GH-671 identity half: `edda request` addresses peers by label, so a
+    // label two live sessions share is an ambiguous address — the sender
+    // cannot tell which session answers. One warning line per colliding
+    // label, before the instructions below can teach a reader to use it.
+    for (label, count) in colliding_labels(peers) {
+        lines.push(format!(
+            "- ⚠ label \"{label}\" is shared by {count} live sessions — requests to it are ambiguous; set EDDA_SESSION_LABEL or claim a unique label"
+        ));
     }
 
     // Latest recorded decisions (coordination broadcasts, max 3). GH-401:

--- a/crates/edda-bridge-claude/src/peers/tests.rs
+++ b/crates/edda-bridge-claude/src/peers/tests.rs
@@ -1581,6 +1581,21 @@ fn git_repo_on_branch(branch: &str) -> tempfile::TempDir {
     tmp
 }
 
+/// Mask the two identity env vars for a test that calls `write_heartbeat`
+/// with `label: None` and then asserts on the derived label (GH-671).
+///
+/// Such a test walks the whole fallback chain, so it reads `env_label()` and
+/// `fleet_session()`. Both are ambient in this repo's own fleet lanes —
+/// `scripts/fleet/lane-launch.ps1` exports `EDDA_SESSION_LABEL` and
+/// `EDDA_MACHINE` into every lane wrapper — and an exported `EDDA_MACHINE`
+/// switches the chain to the fleet branch, where the answer is the sid prefix
+/// rather than the git branch. Masking them thread-locally (GH-757) keeps the
+/// expected label a property of the fixture instead of of the shell that
+/// happened to launch `cargo test`.
+fn fresh_session_identity_env() -> crate::test_config::Guard {
+    crate::test_config_guard(&[("EDDA_MACHINE", None), ("EDDA_SESSION_LABEL", None)])
+}
+
 #[test]
 fn auto_claim_writes_no_claim_for_a_fresh_session() {
     let _store = crate::isolated_store();
@@ -1642,6 +1657,7 @@ fn auto_claim_starts_claiming_once_files_are_edited() {
 #[test]
 fn heartbeat_label_falls_back_to_git_branch_for_a_fresh_session() {
     let _store = crate::isolated_store();
+    let _identity = fresh_session_identity_env();
     let pid = "test_hb_branch_label";
     let _ = edda_store::ensure_dirs(pid);
 
@@ -1668,6 +1684,7 @@ fn heartbeat_label_falls_back_to_git_branch_for_a_fresh_session() {
 #[test]
 fn fresh_session_receives_requests_addressed_to_its_branch() {
     let _store = crate::isolated_store();
+    let _identity = fresh_session_identity_env();
     let pid = "test_hb_branch_request";
     let _ = edda_store::ensure_dirs(pid);
     let _ = fs::remove_file(coordination_path(pid));
@@ -1705,6 +1722,7 @@ fn fresh_session_receives_requests_addressed_to_its_branch() {
 #[test]
 fn two_fresh_sessions_on_one_branch_do_not_block_each_other() {
     let _store = crate::isolated_store();
+    let _identity = fresh_session_identity_env();
     let pid = "test_two_fresh_no_block";
     let _ = edda_store::ensure_dirs(pid);
     let _ = fs::remove_file(coordination_path(pid));

--- a/crates/edda-bridge-claude/src/peers/tests.rs
+++ b/crates/edda-bridge-claude/src/peers/tests.rs
@@ -3543,3 +3543,6 @@ fn legacy_ackless_id_log_survives_compaction_without_swallowing_later_requests()
 
 #[path = "tests_tail_gh757.rs"]
 mod tests_tail_gh757;
+
+#[path = "tests_tail_gh671.rs"]
+mod tests_tail_gh671;

--- a/crates/edda-bridge-claude/src/peers/tests_tail_gh671.rs
+++ b/crates/edda-bridge-claude/src/peers/tests_tail_gh671.rs
@@ -13,11 +13,12 @@ use super::*;
 /// - `fresh_session_receives_requests_addressed_to_its_branch`
 /// - `two_fresh_sessions_on_one_branch_do_not_block_each_other`
 ///
-/// They are named rather than cited by line: adding the guards below shifted
-/// those line numbers once already, and a stale citation reads as a stale
-/// warning. Each reaches `env_label()` and `fleet_session()` on exactly the
-/// chain these tests drive, so a process-wide mutation here flipped two of
-/// them to the sid fallback whenever they were scheduled inside the window.
+/// They are named rather than cited by line: adding their guards in
+/// `peers/tests.rs` shifted those line numbers once already, and a stale
+/// citation reads as a stale warning. Each reaches `env_label()` and
+/// `fleet_session()` on exactly the chain these tests drive, so a
+/// process-wide mutation here flipped two of them to the sid fallback
+/// whenever they were scheduled inside the window.
 /// A thread-local override is invisible to them, and to every other thread
 /// in the binary.
 #[test]

--- a/crates/edda-bridge-claude/src/peers/tests_tail_gh671.rs
+++ b/crates/edda-bridge-claude/src/peers/tests_tail_gh671.rs
@@ -1,0 +1,171 @@
+use super::*;
+/// A fleet session (EDDA_MACHINE set) owes an explicit label: the chain is
+/// env label → claim label → sid prefix, and the branch/auto fallbacks that
+/// made three fleet sessions all answer to `main` are gone. The same fn
+/// covers `machine_identity` resolution — every tier runs inside ONE test
+/// because they all mutate EDDA_MACHINE, and separate #[test] fns doing
+/// that race each other in this binary (measured: a remove_var in one
+/// landed between set_var and write_heartbeat in the other, flipping the
+/// fleet chain to the branch fallback). Every pre-existing write_heartbeat
+/// test passes Some(label), which short-circuits before fleet_session() is
+/// ever read, so they cannot see these mutations.
+#[test]
+fn fleet_session_label_is_explicit_never_the_branch() {
+    let _store = crate::isolated_store();
+    let pid = "test_gh671_fleet_label";
+    let sid = "8-char-minimum-session-id";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    std::env::set_var("EDDA_MACHINE", "gh671-test-machine");
+    // No edits yet (auto label empty), cwd inside this git worktree — so the
+    // pre-fix chain would have written the branch name. The fleet chain must
+    // refuse it and fall back to the sid prefix instead.
+    write_heartbeat(pid, sid, &SessionSignals::default(), None, ".");
+    let hb = read_heartbeat(pid, sid).expect("heartbeat written");
+    assert_eq!(
+        hb.label, "sid-8-char-m",
+        "a fleet session without an explicit label must not inherit the branch: {:?}",
+        hb.label
+    );
+
+    // A claim label is explicit identity and wins over the sid fallback.
+    write_claim(pid, sid, "gh671-claimant", &["src/x/*".into()]);
+    write_heartbeat(pid, sid, &SessionSignals::default(), None, ".");
+    let hb = read_heartbeat(pid, sid).expect("heartbeat written");
+    assert_eq!(hb.label, "gh671-claimant");
+
+    // EDDA_SESSION_LABEL outranks the claim, matching the non-fleet chain.
+    std::env::set_var("EDDA_SESSION_LABEL", "gh671-env-label");
+    write_heartbeat(pid, sid, &SessionSignals::default(), None, ".");
+    let hb = read_heartbeat(pid, sid).expect("heartbeat written");
+    assert_eq!(hb.label, "gh671-env-label");
+
+    std::env::remove_var("EDDA_SESSION_LABEL");
+    std::env::remove_var("EDDA_MACHINE");
+
+    // The bare local session keeps the permissive chain: same inputs, no
+    // EDDA_MACHINE, and the branch fallback returns.
+    write_heartbeat(
+        pid,
+        "local-session-1",
+        &SessionSignals::default(),
+        None,
+        ".",
+    );
+    let hb = read_heartbeat(pid, "local-session-1").expect("heartbeat written");
+    assert_ne!(hb.label, "sid-local-", "local sessions keep the old chain");
+
+    // machine_identity: EDDA_MACHINE first, OS host name as the display
+    // fallback, and no guess past them — display identity, not a credential.
+    // The original host vars are saved and restored: they are ambient, and
+    // later readers in this binary deserve the machine they started with.
+    let real_computername = std::env::var("COMPUTERNAME").ok();
+    let real_hostname = std::env::var("HOSTNAME").ok();
+    std::env::set_var("EDDA_MACHINE", "gh671-m");
+    std::env::set_var("COMPUTERNAME", "gh671-c");
+    assert_eq!(machine_identity().as_deref(), Some("gh671-m"));
+    std::env::remove_var("EDDA_MACHINE");
+    assert_eq!(
+        machine_identity().as_deref(),
+        Some("gh671-c"),
+        "OS host name is the display fallback"
+    );
+    std::env::remove_var("COMPUTERNAME");
+    std::env::remove_var("HOSTNAME");
+    assert_eq!(machine_identity(), None, "nothing resolves: no guess");
+    if let Some(name) = real_computername {
+        std::env::set_var("COMPUTERNAME", name);
+    }
+    if let Some(name) = real_hostname {
+        std::env::set_var("HOSTNAME", name);
+    }
+
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+/// Only a label shared by two or more LIVE sessions collides: dead
+/// heartbeats occupy nothing, empty labels are not addressable.
+#[test]
+fn colliding_labels_counts_live_sessions_only() {
+    let peer = |id: &str, label: &str, live: bool| PeerSummary {
+        session_id: id.into(),
+        label: label.into(),
+        age_secs: 10,
+        is_live: live,
+        last_heartbeat: now_rfc3339(),
+        focus_files: vec![],
+        task_subjects: vec![],
+        files_modified_count: 0,
+        recent_commits: vec![],
+        claimed_paths: vec![],
+        claimed_subject: None,
+        branch: None,
+        current_phase: None,
+    };
+    let peers = vec![
+        peer("s1", "main", true),
+        peer("s2", "main", true),
+        peer("s3", "main", false), // dead: does not collide
+        peer("s4", "", true),      // unaddressable: never reported
+        peer("s5", "unique", true),
+    ];
+    assert_eq!(
+        colliding_labels(&peers),
+        vec![("main".to_string(), 2)],
+        "one live collision, counted live-only"
+    );
+
+    let distinct = vec![peer("s1", "auth", true), peer("s2", "billing", true)];
+    assert!(
+        colliding_labels(&distinct).is_empty(),
+        "distinct labels do not collide"
+    );
+}
+
+/// The pack's peer block warns when a label stops being an address.
+#[test]
+fn peer_block_warns_on_shared_label() {
+    let _store = crate::isolated_store();
+    let pid = "test_gh671_pack_collision";
+    let sid = "me";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    let peer = |id: &str, label: &str| PeerSummary {
+        session_id: id.into(),
+        label: label.into(),
+        age_secs: 10,
+        is_live: true,
+        last_heartbeat: now_rfc3339(),
+        focus_files: vec![],
+        task_subjects: vec![],
+        files_modified_count: 0,
+        recent_commits: vec![],
+        claimed_paths: vec![],
+        claimed_subject: None,
+        branch: None,
+        current_phase: None,
+    };
+    let board = BoardState::default();
+
+    let colliding = vec![peer("p1", "main"), peer("p2", "main")];
+    let out = render_peer_updates_with(&colliding, &board, pid, sid).unwrap();
+    assert!(
+        out.contains("shared by 2 live sessions"),
+        "the ambiguous address must be named: {out}"
+    );
+    assert!(
+        out.contains("label \"main\""),
+        "the colliding label must be named: {out}"
+    );
+
+    let distinct = vec![peer("p1", "auth"), peer("p2", "billing")];
+    let out = render_peer_updates_with(&distinct, &board, pid, sid).unwrap();
+    assert!(
+        !out.contains("shared by"),
+        "no collision, no warning: {out}"
+    );
+
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}

--- a/crates/edda-bridge-claude/src/peers/tests_tail_gh671.rs
+++ b/crates/edda-bridge-claude/src/peers/tests_tail_gh671.rs
@@ -5,13 +5,21 @@ use super::*;
 /// made three fleet sessions all answer to `main` are gone.
 ///
 /// Identity vars are installed through the GH-757 thread-scoped test
-/// configuration, never `std::env::set_var`. libtest runs every `#[test]` as
-/// a thread in ONE process, and four pre-existing `write_heartbeat` tests
-/// pass `label: None` (`peers/tests.rs:1650`, `:1680`, `:1715`, `:1716`), so
-/// they read `env_label()` and `fleet_session()` on exactly the chain these
-/// tests drive. A process-wide mutation here flipped two of them to the sid
-/// fallback whenever they were scheduled inside the window; a thread-local
-/// override is invisible to them, and to every other thread in the binary.
+/// configuration, never `std::env::set_var`. libtest runs every test fn as a
+/// thread in ONE process, and three pre-existing tests in `peers/tests.rs`
+/// call `write_heartbeat` with `label: None` across four call sites:
+///
+/// - `heartbeat_label_falls_back_to_git_branch_for_a_fresh_session`
+/// - `fresh_session_receives_requests_addressed_to_its_branch`
+/// - `two_fresh_sessions_on_one_branch_do_not_block_each_other`
+///
+/// They are named rather than cited by line: adding the guards below shifted
+/// those line numbers once already, and a stale citation reads as a stale
+/// warning. Each reaches `env_label()` and `fleet_session()` on exactly the
+/// chain these tests drive, so a process-wide mutation here flipped two of
+/// them to the sid fallback whenever they were scheduled inside the window.
+/// A thread-local override is invisible to them, and to every other thread
+/// in the binary.
 #[test]
 fn fleet_session_label_is_explicit_never_the_branch() {
     let _store = crate::isolated_store();

--- a/crates/edda-bridge-claude/src/peers/tests_tail_gh671.rs
+++ b/crates/edda-bridge-claude/src/peers/tests_tail_gh671.rs
@@ -1,14 +1,17 @@
 use super::*;
-/// A fleet session (EDDA_MACHINE set) owes an explicit label: the chain is
+
+/// A fleet session (`EDDA_MACHINE` set) owes an explicit label: the chain is
 /// env label → claim label → sid prefix, and the branch/auto fallbacks that
-/// made three fleet sessions all answer to `main` are gone. The same fn
-/// covers `machine_identity` resolution — every tier runs inside ONE test
-/// because they all mutate EDDA_MACHINE, and separate #[test] fns doing
-/// that race each other in this binary (measured: a remove_var in one
-/// landed between set_var and write_heartbeat in the other, flipping the
-/// fleet chain to the branch fallback). Every pre-existing write_heartbeat
-/// test passes Some(label), which short-circuits before fleet_session() is
-/// ever read, so they cannot see these mutations.
+/// made three fleet sessions all answer to `main` are gone.
+///
+/// Identity vars are installed through the GH-757 thread-scoped test
+/// configuration, never `std::env::set_var`. libtest runs every `#[test]` as
+/// a thread in ONE process, and four pre-existing `write_heartbeat` tests
+/// pass `label: None` (`peers/tests.rs:1650`, `:1680`, `:1715`, `:1716`), so
+/// they read `env_label()` and `fleet_session()` on exactly the chain these
+/// tests drive. A process-wide mutation here flipped two of them to the sid
+/// fallback whenever they were scheduled inside the window; a thread-local
+/// override is invisible to them, and to every other thread in the binary.
 #[test]
 fn fleet_session_label_is_explicit_never_the_branch() {
     let _store = crate::isolated_store();
@@ -17,7 +20,11 @@ fn fleet_session_label_is_explicit_never_the_branch() {
     let _ = edda_store::ensure_dirs(pid);
     let _ = fs::remove_file(coordination_path(pid));
 
-    std::env::set_var("EDDA_MACHINE", "gh671-test-machine");
+    let _fleet = crate::test_config_guard(&[
+        ("EDDA_MACHINE", Some("gh671-test-machine")),
+        ("EDDA_SESSION_LABEL", None),
+    ]);
+
     // No edits yet (auto label empty), cwd inside this git worktree — so the
     // pre-fix chain would have written the branch name. The fleet chain must
     // refuse it and fall back to the sid prefix instead.
@@ -36,52 +43,80 @@ fn fleet_session_label_is_explicit_never_the_branch() {
     assert_eq!(hb.label, "gh671-claimant");
 
     // EDDA_SESSION_LABEL outranks the claim, matching the non-fleet chain.
-    std::env::set_var("EDDA_SESSION_LABEL", "gh671-env-label");
-    write_heartbeat(pid, sid, &SessionSignals::default(), None, ".");
-    let hb = read_heartbeat(pid, sid).expect("heartbeat written");
-    assert_eq!(hb.label, "gh671-env-label");
+    {
+        let _env_label =
+            crate::test_config_guard(&[("EDDA_SESSION_LABEL", Some("gh671-env-label"))]);
+        write_heartbeat(pid, sid, &SessionSignals::default(), None, ".");
+        let hb = read_heartbeat(pid, sid).expect("heartbeat written");
+        assert_eq!(hb.label, "gh671-env-label");
+    }
 
-    std::env::remove_var("EDDA_SESSION_LABEL");
-    std::env::remove_var("EDDA_MACHINE");
+    let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
 
-    // The bare local session keeps the permissive chain: same inputs, no
-    // EDDA_MACHINE, and the branch fallback returns.
+/// The bare local session keeps the permissive chain: no `EDDA_MACHINE`, no
+/// edits, so the git branch still carries the identity (#128) and the fleet
+/// sid fallback stays out of its way.
+#[test]
+fn local_session_without_machine_keeps_the_branch_label() {
+    let _store = crate::isolated_store();
+    let pid = "test_gh671_local_label";
+    let _ = edda_store::ensure_dirs(pid);
+    let _ = fs::remove_file(coordination_path(pid));
+
+    let _local = crate::test_config_guard(&[("EDDA_MACHINE", None), ("EDDA_SESSION_LABEL", None)]);
+
+    let repo = git_repo_on_branch("gh671-local-branch");
     write_heartbeat(
         pid,
         "local-session-1",
         &SessionSignals::default(),
         None,
-        ".",
+        repo.path().to_str().unwrap(),
     );
     let hb = read_heartbeat(pid, "local-session-1").expect("heartbeat written");
-    assert_ne!(hb.label, "sid-local-", "local sessions keep the old chain");
-
-    // machine_identity: EDDA_MACHINE first, OS host name as the display
-    // fallback, and no guess past them — display identity, not a credential.
-    // The original host vars are saved and restored: they are ambient, and
-    // later readers in this binary deserve the machine they started with.
-    let real_computername = std::env::var("COMPUTERNAME").ok();
-    let real_hostname = std::env::var("HOSTNAME").ok();
-    std::env::set_var("EDDA_MACHINE", "gh671-m");
-    std::env::set_var("COMPUTERNAME", "gh671-c");
-    assert_eq!(machine_identity().as_deref(), Some("gh671-m"));
-    std::env::remove_var("EDDA_MACHINE");
     assert_eq!(
-        machine_identity().as_deref(),
-        Some("gh671-c"),
-        "OS host name is the display fallback"
+        hb.label, "gh671-local-branch",
+        "a local session keeps the branch fallback, not the fleet sid prefix"
     );
-    std::env::remove_var("COMPUTERNAME");
-    std::env::remove_var("HOSTNAME");
-    assert_eq!(machine_identity(), None, "nothing resolves: no guess");
-    if let Some(name) = real_computername {
-        std::env::set_var("COMPUTERNAME", name);
-    }
-    if let Some(name) = real_hostname {
-        std::env::set_var("HOSTNAME", name);
-    }
 
     let _ = fs::remove_dir_all(edda_store::project_dir(pid));
+}
+
+/// `machine_identity` resolves `EDDA_MACHINE` first, the OS host name as the
+/// display fallback, and refuses to guess past them — display identity, not a
+/// credential.
+///
+/// Same thread-scoped configuration, and here it also removes a save/restore
+/// dance: `COMPUTERNAME`/`HOSTNAME` are ambient, so mutating them
+/// process-wide handed every concurrent thread in the binary the wrong
+/// machine — or none — for the length of this test.
+#[test]
+fn machine_identity_prefers_edda_machine_then_host_then_nothing() {
+    {
+        let _cfg = crate::test_config_guard(&[
+            ("EDDA_MACHINE", Some("gh671-m")),
+            ("COMPUTERNAME", Some("gh671-c")),
+        ]);
+        assert_eq!(machine_identity().as_deref(), Some("gh671-m"));
+    }
+    {
+        let _cfg =
+            crate::test_config_guard(&[("EDDA_MACHINE", None), ("COMPUTERNAME", Some("gh671-c"))]);
+        assert_eq!(
+            machine_identity().as_deref(),
+            Some("gh671-c"),
+            "OS host name is the display fallback"
+        );
+    }
+    {
+        let _cfg = crate::test_config_guard(&[
+            ("EDDA_MACHINE", None),
+            ("COMPUTERNAME", None),
+            ("HOSTNAME", None),
+        ]);
+        assert_eq!(machine_identity(), None, "nothing resolves: no guess");
+    }
 }
 
 /// Only a label shared by two or more LIVE sessions collides: dead

--- a/crates/edda-cli/src/cmd_bridge/peers.rs
+++ b/crates/edda-cli/src/cmd_bridge/peers.rs
@@ -1,4 +1,5 @@
 use edda_bridge_claude::peers::liveness;
+use edda_bridge_claude::peers::{colliding_labels, machine_identity, PeerSummary};
 use std::path::Path;
 
 /// JSON board snapshot for `edda peers --json`.
@@ -78,11 +79,7 @@ pub fn peers(repo_root: &Path, json: bool) -> anyhow::Result<()> {
             (None, false) => format!(" [{}]", p.claimed_paths.join(", ")),
             (None, true) => String::new(),
         };
-        let label = if p.label.is_empty() {
-            "(no label)".to_string()
-        } else {
-            p.label.clone()
-        };
+        let label = peer_display_label(p, machine_identity().as_deref());
         println!(
             "  {} — {} ({age}){scope}",
             &p.session_id[..8.min(p.session_id.len())],
@@ -111,6 +108,14 @@ pub fn peers(repo_root: &Path, json: bool) -> anyhow::Result<()> {
             }
         }
     }
+    // GH-671 identity half: a label shared by live sessions is an ambiguous
+    // `edda request` address — say so where the operator is already reading
+    // the label, with the fix in the same breath.
+    for (label, count) in colliding_labels(active.iter().copied()) {
+        println!(
+            "\n  ⚠ label \"{label}\" is shared by {count} live sessions — requests to it are ambiguous; set EDDA_SESSION_LABEL or claim a unique label"
+        );
+    }
     if !stale.is_empty() {
         println!(
             "\n  (+{} stale session{} not shown)",
@@ -119,4 +124,21 @@ pub fn peers(repo_root: &Path, json: bool) -> anyhow::Result<()> {
         );
     }
     Ok(())
+}
+
+/// One session's label as `edda peers` shows it (GH-671 identity half):
+/// `label@machine`, or the bare label when no machine identity resolves.
+///
+/// Every session on this board runs on this machine — the heartbeat store is
+/// machine-local — so the machine suffix is resolved once per render rather
+/// than recorded per heartbeat. An unidentified session keeps its marker
+/// unchanged; `no label@machine` would read as a machine named "no label".
+pub(super) fn peer_display_label(peer: &PeerSummary, machine: Option<&str>) -> String {
+    if peer.label.is_empty() {
+        return "(no label)".to_string();
+    }
+    match machine {
+        Some(machine) => format!("{}@{machine}", peer.label),
+        None => peer.label.clone(),
+    }
 }

--- a/crates/edda-cli/src/cmd_bridge/peers.rs
+++ b/crates/edda-cli/src/cmd_bridge/peers.rs
@@ -70,6 +70,10 @@ pub fn peers(repo_root: &Path, json: bool) -> anyhow::Result<()> {
         return Ok(());
     }
 
+    // Every session on this board runs on this machine, so `peer_display_label`
+    // is documented to resolve the suffix once per render — do that literally,
+    // rather than re-reading the env chain for each peer.
+    let machine = machine_identity();
     println!("Active sessions ({}):\n", active.len());
     for p in &active {
         let age = edda_bridge_claude::peers::format_age(p.age_secs);
@@ -79,7 +83,7 @@ pub fn peers(repo_root: &Path, json: bool) -> anyhow::Result<()> {
             (None, false) => format!(" [{}]", p.claimed_paths.join(", ")),
             (None, true) => String::new(),
         };
-        let label = peer_display_label(p, machine_identity().as_deref());
+        let label = peer_display_label(p, machine.as_deref());
         println!(
             "  {} — {} ({age}){scope}",
             &p.session_id[..8.min(p.session_id.len())],

--- a/crates/edda-cli/src/cmd_bridge/tests.rs
+++ b/crates/edda-cli/src/cmd_bridge/tests.rs
@@ -1157,3 +1157,6 @@ fn peers_json_includes_sessions_and_full_board() {
     assert_eq!(json["requests"][0]["message"], "need auth");
     assert_eq!(json["acks"][0]["from_label"], "billing");
 }
+
+#[path = "tests_tail_gh671.rs"]
+mod tests_tail_gh671;

--- a/crates/edda-cli/src/cmd_bridge/tests_tail_gh671.rs
+++ b/crates/edda-cli/src/cmd_bridge/tests_tail_gh671.rs
@@ -1,0 +1,39 @@
+/// `edda peers` renders `label@machine`; an unidentified session keeps its
+/// marker, and a missing machine identity degrades to the bare label.
+#[test]
+fn peer_display_label_carries_the_machine_suffix() {
+    use super::peers::peer_display_label;
+    use edda_bridge_claude::peers::PeerSummary;
+
+    let peer = |label: &str| PeerSummary {
+        session_id: "s".into(),
+        label: label.into(),
+        age_secs: 5,
+        is_live: true,
+        last_heartbeat: String::new(),
+        focus_files: vec![],
+        task_subjects: vec![],
+        files_modified_count: 0,
+        recent_commits: vec![],
+        claimed_paths: vec![],
+        claimed_subject: None,
+        branch: None,
+        current_phase: None,
+    };
+
+    assert_eq!(
+        peer_display_label(&peer("main"), Some("docs")),
+        "main@docs",
+        "the render is label@machine"
+    );
+    assert_eq!(
+        peer_display_label(&peer("main"), None),
+        "main",
+        "no machine identity: bare label, no guess"
+    );
+    assert_eq!(
+        peer_display_label(&peer(""), Some("docs")),
+        "(no label)",
+        "the unidentified marker never gains a machine suffix"
+    );
+}

--- a/crates/edda-cli/src/cmd_export.rs
+++ b/crates/edda-cli/src/cmd_export.rs
@@ -370,25 +370,9 @@ fn resolve_machine(explicit: Option<&str>) -> String {
             return trimmed.to_string();
         }
     }
-    if let Ok(m) = std::env::var("EDDA_MACHINE") {
-        let trimmed = m.trim();
-        if !trimmed.is_empty() {
-            return trimmed.to_string();
-        }
-    }
-    if let Ok(m) = std::env::var("COMPUTERNAME") {
-        let trimmed = m.trim();
-        if !trimmed.is_empty() {
-            return trimmed.to_string();
-        }
-    }
-    if let Ok(m) = std::env::var("HOSTNAME") {
-        let trimmed = m.trim();
-        if !trimmed.is_empty() {
-            return trimmed.to_string();
-        }
-    }
-    "unknown".to_string()
+    // The env chain lives in one place (GH-671 identity half) so the mirror's
+    // "Exporting machine" and a session's `label@machine` cannot disagree.
+    edda_bridge_claude::peers::machine_identity().unwrap_or_else(|| "unknown".to_string())
 }
 
 fn now_rfc3339() -> String {

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -322,9 +322,28 @@ network protocol:
 - **Doorbell boundary.** The mirror is truth-layer replication: it rides git
   and delivers whenever the clone pulls, with no resident process. There is
   deliberately **no cross-platform doorbell** in this issue — live push over
-  Tailscale (`edda node` / `edda inbox`) is #685, as is session identity
-  (`label@machine`, collision warning). The mirror carries the *decisions*;
-  it does not implement them.
+  Tailscale (`edda node` / `edda inbox`) is #685. The mirror carries the
+  *decisions*; it does not implement them.
+- **Session identity (the other half of #671).** The label is the only part
+  of a session's identity that can cross machines at all, so in fleet mode
+  it is explicit or it is nobody's:
+  - `scripts/fleet/lane-launch.ps1` exports `EDDA_SESSION_LABEL` (the lane
+    name — unique per lane) and `EDDA_MACHINE` (the machine half of
+    `-Machine`) into the wrapper, so every fleet session, its hooks and its
+    children inherit an explicit identity; no hostname is guessed.
+  - A fleet session's heartbeat label chain is explicit label →
+    `EDDA_SESSION_LABEL` → claim label → `sid-<first 8>`. The branch/auto
+    fallbacks stay for bare local sessions only — they were what made three
+    live fleet sessions all answer to `main`.
+  - `edda peers` renders `label@machine` (machine resolved
+    `EDDA_MACHINE` → OS host name, same chain as the mirror's "Exporting
+    machine"), and **both render surfaces** — `edda peers` and the pack's
+    peer block — print a warning when two or more live sessions share a
+    label, because `edda request` addresses by label and a shared label is
+    an ambiguous address.
+  - Claims stay per-machine (`#656` owns the cross-machine mutex at the
+    issue layer); identity here makes each machine's board unambiguous, it
+    does not federate the board.
 
 ### Auditing a doneWhen that says 「決策 X 已在帳本」(`audit.ledger-donewhen`)
 

--- a/scripts/file-length-ceilings.txt
+++ b/scripts/file-length-ceilings.txt
@@ -13,7 +13,7 @@ crates/edda-bridge-claude/src/dispatch/session.rs 1006
 crates/edda-bridge-claude/src/dispatch/tests.rs 3238
 crates/edda-bridge-claude/src/peers/tests.rs 3588
 crates/edda-bridge-claude/src/signals.rs 2252
-crates/edda-cli/src/cmd_bridge/tests.rs 1159
+crates/edda-cli/src/cmd_bridge/tests.rs 1162
 crates/edda-cli/src/cmd_claim.rs 1732
 crates/edda-cli/src/cmd_dispatch.rs 2106
 crates/edda-cli/src/cmd_draft.rs 1705

--- a/scripts/fleet/lane-launch.ps1
+++ b/scripts/fleet/lane-launch.ps1
@@ -281,6 +281,17 @@ if ($BudgetUsd -gt 0) { $argLine += " --budget-usd $BudgetUsd" }
 # object, so the lane survives the session (fleet.lane-launch). __RUN__ is
 # the real dispatch pipeline; -DryRun swaps only that line for a trivial
 # real process so the launcher can be proven without agent spend.
+#
+# __IDENTITY_ENV__ (GH-671 identity half) exports the lane's explicit
+# session identity into every child process — dispatch, the agent, its
+# hooks: EDDA_SESSION_LABEL is the lane name (unique per lane, so fleet
+# sessions stop sharing branch-derived labels like three peers all named
+# 'main'), and EDDA_MACHINE is the machine half of -Machine when the lane
+# carries one, so `label@machine` renders without guessing hostnames.
+$identityEnv = "`$env:EDDA_SESSION_LABEL = $(PsQuote $Name)"
+if (-not [string]::IsNullOrWhiteSpace($Machine)) {
+  $identityEnv += "`r`n`$env:EDDA_MACHINE = $(PsQuote ($Machine -split '/', 2)[0])"
+}
 $wrapperText = @'
 [Console]::InputEncoding  = [System.Text.UTF8Encoding]::new($false)
 [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
@@ -288,6 +299,7 @@ $OutputEncoding = [System.Text.UTF8Encoding]::new($false)
 $env:HOME = $env:USERPROFILE
 # keep `git --help` from opening a browser inside the hidden task
 $env:GIT_CONFIG_PARAMETERS = "'help.format=man'"
+__IDENTITY_ENV__
 __LANEENV__
 $code = $null
 try {
@@ -417,6 +429,7 @@ if ($DryRun) {
   } else {
     $wrapperText = $wrapperText -replace '(?m)^.*__LANEENV__.*\r?\n', ''
   }
+  $wrapperText = $wrapperText.Replace('__IDENTITY_ENV__', $identityEnv)
   $wrapperText.Replace('__CWD__', (PsQuote $Cwd)).Replace('__LOG__', (PsQuote $Log)).Replace('__RUN__', $runDry).Replace('__DONE__', (PsQuote $Done)) |
     Set-Content -LiteralPath $Wrapper -Encoding utf8
   "dry-run wrapper=$Wrapper (identical to the real wrapper except __RUN__ runs the trivial process)"
@@ -511,6 +524,7 @@ if ($BuildLane) {
 } else {
   $wrapperText = $wrapperText -replace '(?m)^.*__LANEENV__.*\r?\n', ''
 }
+$wrapperText = $wrapperText.Replace('__IDENTITY_ENV__', $identityEnv)
 $wrapperText.Replace('__CWD__', (PsQuote $Cwd)).Replace('__LOG__', (PsQuote $Log)).Replace('__RUN__', $runReal).Replace('__DONE__', (PsQuote $Done)) |
   Set-Content -LiteralPath $Wrapper -Encoding utf8
 


### PR DESCRIPTION
Issue: #671 (identity half; the carrier half landed in #1017)

## What

The label is the only part of a session's identity that can cross machines at all, so in fleet mode it is explicit or it is nobody's. This closes the identity half of the #671 doneWhen:

- **Fleet sessions get an explicit identity at launch.** `scripts/fleet/lane-launch.ps1` now exports `EDDA_SESSION_LABEL` (the lane name — unique per lane) and `EDDA_MACHINE` (the machine half of `-Machine`, when the lane carries one) into the lane wrapper, so the session, its agent, and its hooks all inherit them. No hostname is guessed — matching the dispatch claim-guard's explicit-only rule.
- **The fleet label chain refuses to invent.** A session running under `EDDA_MACHINE` derives its heartbeat label as: explicit label → `EDDA_SESSION_LABEL` → claim label → `sid-<first 8>`. The branch/auto fallbacks stay for bare local sessions only — they were what made the issue's opening example (three live fleet sessions all answering to `main`) possible.
- **`label@machine` rendering.** `edda peers` shows `main@docs`, resolving the machine via the same chain the mirror's "Exporting machine" uses (`EDDA_MACHINE` → OS host name), now shared as `peers::machine_identity()` so the two surfaces cannot disagree. Unidentified sessions keep `(no label)` — `no label@machine` would read as a machine named "no label".
- **Collision warnings on both render surfaces.** `edda peers` and the pack's peer block warn when two or more **live** sessions share a label — `edda request` addresses by label, so a shared label is an ambiguous address. Dead heartbeats occupy nothing; empty labels are never reported.
- **Docs.** `docs/guides/multi-agent.md` replaces the "session identity is #685" pointer with the implemented behavior and its boundary: claims stay per-machine (#656 owns the cross-machine mutex at the issue layer); identity makes each machine's board unambiguous, it does not federate the board.

## Tests

- `fleet_session_label_is_explicit_never_the_branch` — the fleet chain (env label → claim → sid prefix, never the branch), the local chain unchanged. All env tiers in ONE test fn: separate fns mutating `EDDA_MACHINE` race in the same binary (measured — a `remove_var` landed between another test's `set_var` and its `write_heartbeat` and flipped the chain to the branch fallback; the red test caught it).
- `colliding_labels_counts_live_sessions_only` — live-only, empty-label-exempt.
- `peer_block_warns_on_shared_label` / `peer_display_label_carries_the_machine_suffix` — both render surfaces.
- Existing branch-fallback tests keep passing (bare local sessions keep the permissive chain).

## Gates (L0, Windows lane = worktree default target)

- RAN `cargo fmt --all --check` — PASS
- RAN `cargo clippy -p edda-bridge-claude -p edda --all-targets -- -D warnings` — PASS
- RAN `cargo test -p edda-bridge-claude -p edda` — PASS (24 suites, 0 failed)
- RAN `sh scripts/lint-file-length.sh --tree` — PASS (new tests split into `tests_tail_gh671.rs` modules, the GH-779 ratchet pattern)
- RAN `sh scripts/lint-markdown-content.sh` — PASS
- RAN `sh scripts/test-doc-citations.sh` — 21 checks PASS
- lane-launch.ps1 parse-checked; no scheduled-task dry run was executed locally (wrapper text change only; CI's Fleet shell tests cover the shell side)
- L1 = exact-head CI on this SHA. Windows CI covers 7 crates including `edda`; `edda-bridge-claude` tests ran locally above (C5).

## Surface (R22)

`crates/**` (出貨面) + `scripts/fleet/lane-launch.ps1` (閘門面). Authoritative review round required; glm-flash rounds are SHADOW only.