### PR TITLE
fix(release): enforce portable release assets

### DIFF
--- a/.claude/skills/edda-release/SKILL.md
+++ b/.claude/skills/edda-release/SKILL.md
@@ -263,8 +263,9 @@ gh run watch <RUN_ID> --exit-status
 ### Step 2: Verify every CI job did its job
 
 Require all five logical stages green — currently nine concrete jobs because
-`build-release` expands to five matrix legs. A green aggregate with a skipped
-required stage or leg is BLOCKED. Read `conclusion` and each job result; do not
+`build-linux-release` and `build-non-linux-release` expand to five legs total.
+A green aggregate with a skipped required stage or leg is BLOCKED. Read
+`conclusion` and each job result; do not
 classify arbitrary warning/error-looking lines from `gh run watch` output as a
 workflow failure:
 

--- a/.claude/skills/edda-release/SKILL.md
+++ b/.claude/skills/edda-release/SKILL.md
@@ -12,9 +12,13 @@ release-critical commands. A GitHub Release alone is not success.
 Since GH-648 (PR #847) the repository automates crates.io publication inside
 `.github/workflows/release.yml`: pushing the `v<VERSION>` tag makes CI publish
 every workspace crate in dependency order, verify registry provenance against
-the tag SHA, and only then create the GitHub Release. Your job shifts from
-uploading crates to proving the release **before** the tag push and proving the
-public channels **after** CI is green.
+the tag SHA, and only then create the GitHub Release. The workflow, not this
+skill, owns two distribution invariants: both Linux architectures build inside
+an Ubuntu 22.04 userspace and reject requirements above `GLIBC_2.35`, and every
+checksum sidecar is one exact ASCII line ending in LF. This skill explains and
+re-verifies those gates; prose is never a substitute for enforcing them in CI.
+Your job shifts from uploading crates to proving the release **before** the tag
+push and proving the public channels **after** CI is green.
 
 ## Usage
 
@@ -274,8 +278,8 @@ gh run view <RUN_ID> --json conclusion,jobs \
 | `prepare-crates` | `enabled=true` (secret present); tag/plan validation passed |
 | `publish-crates` | `SUCCESS: all <N> workspace versions verified` |
 | `create-release` | parity gate `verify --tag` passed; draft release created from the CHANGELOG section |
-| `build-release` (5 jobs) | every platform matrix leg green; all five archives + `.sha256` uploaded to the draft |
-| `publish-release` | exact 10-asset set, no empty assets, checksums verified, native binary canary without credentials (version core after stripping the optional build identity suffix), release published `--latest` |
+| `build-linux-release` + `build-non-linux-release` (5 jobs total) | every platform leg green; Linux x86_64/aarch64 built in Ubuntu 22.04, ABI cap and critical CLI canaries passed; all five archives + `.sha256` uploaded to the draft |
+| `publish-release` | exact 10-asset set, no empty assets, each checksum sidecar is exact ASCII+LF and matches its archive, native binary canary without credentials (version core after stripping the optional build identity suffix), release published `--latest` |
 
 Never repair a failed run by moving the tag.
 
@@ -320,12 +324,18 @@ curl -sSf https://raw.githubusercontent.com/fagemx/edda/main/install.sh \
 <LATEST_DIR>/bin/edda verdict --help
 ```
 
-Both binaries must report the intended version. Also prove the downloaded Linux
-asset on the repository's documented minimum Linux/glibc baseline. If no floor
-is documented, test at least a mainstream older baseline (for example Ubuntu
-22.04) and report the highest `GLIBC_x.y` from `readelf --version-info`. An
-`ubuntu-latest` build that starts only on the newest runner is not portable;
-`GLIBC_x.y not found` is a product failure, never an environmental retry.
+Both binaries must report the intended version. The release-asset compatibility
+baseline is Ubuntu 22.04: CI builds both Linux architectures inside that
+userspace and rejects a highest `readelf --version-info` requirement above
+`GLIBC_2.35`. Post-publication verification must still download the public
+asset, run it on Ubuntu 22.04, and report its observed highest `GLIBC_x.y`;
+checking the build directory or trusting the runner label is insufficient. An
+asset that fails there is a product failure, never an environmental retry.
+
+Download all ten public assets and run GNU `sha256sum -c` against every
+sidecar. A sidecar containing CRLF, a missing final LF, extra lines, a non-ASCII
+payload, or anything other than `<64 lowercase hex><two spaces><archive>\n` is
+a distribution failure even when the digest value itself is correct.
 
 After crates.io publication is verified, generate the Homebrew formula from the
 immutable crates.io source package. The generator downloads and hashes the
@@ -447,7 +457,7 @@ Use the decision table below, then resume at the earliest missing safe step.
 | Tag pushed, run failed at `publish-crates` | Rerun failed jobs (`gh run rerun <id> --failed`); verified crates are NO-OP |
 | Run failed at `create-release` (parity) | Inspect registry with `verify --tag`; rerun only after the cause is gone |
 | Run failed at `create-release` (CHANGELOG section missing) | BLOCKED; repair means a new commit and tag — operator decision, never move the tag |
-| Run failed at `build-release`/`publish-release` | Rerun failed jobs; draft uploads are clobber-safe and re-verified |
+| Run failed at `build-linux-release`/`build-non-linux-release`/`publish-release` | Rerun failed jobs; draft uploads are clobber-safe and re-verified |
 | Registry provenance differs from tag SHA | BLOCKED; do not yank or move tag without operator decision |
 | Public release exists but a channel is stale | Repair that channel without changing immutable crate/tag identity |
 
@@ -501,10 +511,15 @@ lag. After three failures with the same stable cause, stop and report
     detached tag worktree; never retarget silently when main advances.
 19. **Watch-log diagnosis**: trust run/job conclusions and required success
     markers, not an alarming tail line from `gh run watch`.
-20. **Newest-runner Linux means portable Linux**: measure the glibc floor and
-    run the release asset on the documented/older baseline.
+20. **Newest-runner Linux means portable Linux**: the host CPU label does not
+    define the userspace. Keep both Linux builds in the Ubuntu 22.04 container,
+    enforce the `GLIBC_2.35` cap before upload, and run the downloaded asset on
+    that baseline after publication.
 21. **Fresh `brew reinstall`**: install first, then reinstall; final proof reads
     the remote tap, not only a locally mounted formula.
+22. **Normalize checksum files only in the verifier**: accepting CRLF by
+    stripping `\r` hides a broken public sidecar. Producers emit ASCII+LF and
+    `publish-release` rejects any other byte shape before publishing.
 
 ## References
 

--- a/.github/workflows/publish-crates-check.yml
+++ b/.github/workflows/publish-crates-check.yml
@@ -6,6 +6,7 @@ on:
       - '.github/workflows/release.yml'
       - '.github/workflows/publish-crates-check.yml'
       - 'scripts/publish-crates*'
+      - 'scripts/verify-release-checksum.sh'
       - 'Cargo.toml'
       - 'Cargo.lock'
       # Whole crate tree, not just manifests: include_str! resources, build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,6 +280,7 @@ jobs:
     needs: [create-release, build-linux-release, build-non-linux-release]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
       - name: Verify release assets
         shell: bash
         run: |
@@ -325,20 +326,8 @@ jobs:
             cd "$asset_dir"
             for checksum in *.sha256; do
               archive="${checksum%.sha256}"
-              actual_hash="$(sha256sum "$archive" | awk '{ print $1 }')"
-              expected_line="$actual_hash  $archive"
-              actual_line="$(cat "$checksum")"
-              line_count="$(awk 'END { print NR }' "$checksum")"
-              final_byte="$(tail -c 1 "$checksum" | od -An -t u1 | tr -d '[:space:]')"
-              if grep -q $'\r' "$checksum"; then
-                echo "::error::Checksum sidecar contains CRLF: $checksum"
-                exit 1
-              fi
-              if [ "$line_count" != "1" ] || [ "$final_byte" != "10" ] \
-                || [ "$actual_line" != "$expected_line" ]; then
-                echo "::error::Checksum sidecar must be one exact ASCII LF line: $checksum"
-                exit 1
-              fi
+              "$GITHUB_WORKSPACE/scripts/verify-release-checksum.sh" \
+                "$archive" "$checksum"
             done
           )
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,6 +281,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Verify release assets
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,97 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  build-release:
+  build-linux-release:
+    name: Build (${{ matrix.name }})
+    needs: create-release
+    runs-on: ${{ matrix.os }}
+    container:
+      # Both Linux architectures build in the same older userspace. The host
+      # label selects CPU architecture; the container owns the glibc floor.
+      image: ubuntu:22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+          - name: linux-aarch64
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+    steps:
+      - name: Install Linux build dependencies
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            build-essential ca-certificates curl gh git pkg-config libssl-dev zstd
+
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        shell: bash
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --profile minimal --default-toolchain none
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Resolve pinned Rust toolchain
+        shell: bash
+        run: |
+          rustup show
+          rustup target add ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}-ubuntu-22.04
+
+      - name: Build release binary
+        run: cargo build --locked --release --target ${{ matrix.target }} -p edda
+
+      - name: Verify Linux ABI floor and critical CLI surfaces
+        shell: bash
+        run: |
+          binary="target/${{ matrix.target }}/release/edda"
+          highest_glibc="$(readelf --version-info "$binary" \
+            | grep -o 'GLIBC_[0-9.]*' | sort -Vu | tail -1)"
+          if [ -z "$highest_glibc" ]; then
+            echo "::error::Could not determine the GLIBC requirement for $binary"
+            exit 1
+          fi
+          if [ "$(printf '%s\n' "$highest_glibc" GLIBC_2.35 | sort -Vu | tail -1)" != "GLIBC_2.35" ]; then
+            echo "::error::$binary requires $highest_glibc; release assets must not exceed GLIBC_2.35"
+            exit 1
+          fi
+          echo "Linux ABI floor: $highest_glibc"
+          "$binary" --version
+          "$binary" dispatch --help >/dev/null
+          "$binary" verdict --help >/dev/null
+
+      - name: Prepare Linux archive
+        shell: bash
+        run: |
+          TAG="${{ needs.create-release.outputs.tag }}"
+          ARCHIVE="edda-${TAG}-${{ matrix.target }}"
+          mkdir "$ARCHIVE"
+          cp target/${{ matrix.target }}/release/edda "$ARCHIVE/"
+          cp LICENSE-MIT LICENSE-APACHE "$ARCHIVE/"
+          tar czf "${ARCHIVE}.tar.gz" "$ARCHIVE"
+          sha256sum "${ARCHIVE}.tar.gz" > "${ARCHIVE}.tar.gz.sha256"
+          echo "ASSET=${ARCHIVE}.tar.gz" >> "$GITHUB_ENV"
+
+      - name: Verify draft release and upload assets
+        shell: bash
+        run: |
+          tag="${{ needs.create-release.outputs.tag }}"
+          if [ "$(gh release view "$tag" --json isDraft --jq '.isDraft')" != "true" ]; then
+            echo "::error::Release $tag is no longer a draft; refusing to replace assets"
+            exit 1
+          fi
+          gh release upload "$tag" "${{ env.ASSET }}" "${{ env.ASSET }}.sha256" --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-non-linux-release:
     name: Build (${{ matrix.name }})
     needs: create-release
     runs-on: ${{ matrix.os }}
@@ -114,19 +204,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: linux-x86_64
-            os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            archive: tar.gz
-          - name: linux-aarch64
-            os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
-            archive: tar.gz
           - name: macos-x86_64
             os: macos-latest
             target: x86_64-apple-darwin
             archive: tar.gz
-            cross: true
           - name: macos-aarch64
             os: macos-latest
             target: aarch64-apple-darwin
@@ -138,10 +219,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Linux native deps
-        if: contains(matrix.target, 'linux-gnu')
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
-
       - name: Install Rust
         run: |
           rustup show
@@ -151,10 +228,10 @@ jobs:
         with:
           key: release-${{ matrix.target }}
 
-      - name: Build release binaries
+      - name: Build release binary
         run: cargo build --locked --release --target ${{ matrix.target }} -p edda
 
-      - name: Prepare archive (unix)
+      - name: Prepare archive (macOS)
         if: matrix.archive == 'tar.gz'
         run: |
           TAG="${{ needs.create-release.outputs.tag }}"
@@ -166,7 +243,7 @@ jobs:
           shasum -a 256 "${ARCHIVE}.tar.gz" > "${ARCHIVE}.tar.gz.sha256"
           echo "ASSET=${ARCHIVE}.tar.gz" >> "$GITHUB_ENV"
 
-      - name: Prepare archive (windows)
+      - name: Prepare archive (Windows)
         if: matrix.archive == 'zip'
         shell: pwsh
         run: |
@@ -178,7 +255,12 @@ jobs:
           Copy-Item "LICENSE-APACHE" "$ARCHIVE\"
           Compress-Archive -Path "$ARCHIVE\*" -DestinationPath "${ARCHIVE}.zip"
           $hash = (Get-FileHash "${ARCHIVE}.zip" -Algorithm SHA256).Hash.ToLower()
-          "$hash  ${ARCHIVE}.zip" | Out-File -Encoding ASCII "${ARCHIVE}.zip.sha256"
+          $checksum = "$hash  ${ARCHIVE}.zip`n"
+          [System.IO.File]::WriteAllText(
+            (Join-Path (Get-Location) "${ARCHIVE}.zip.sha256"),
+            $checksum,
+            [System.Text.Encoding]::ASCII
+          )
           echo "ASSET=${ARCHIVE}.zip" >> $env:GITHUB_ENV
 
       - name: Verify draft release and upload assets
@@ -195,7 +277,7 @@ jobs:
 
   publish-release:
     name: Publish Release
-    needs: [create-release, build-release]
+    needs: [create-release, build-linux-release, build-non-linux-release]
     runs-on: ubuntu-latest
     steps:
       - name: Verify release assets
@@ -243,14 +325,21 @@ jobs:
             cd "$asset_dir"
             for checksum in *.sha256; do
               archive="${checksum%.sha256}"
-              expected_hash="$(awk '{ print tolower($1) }' "$checksum" | tr -d '\r\n')"
               actual_hash="$(sha256sum "$archive" | awk '{ print $1 }')"
-              if [[ ! "$expected_hash" =~ ^[0-9a-f]{64}$ ]] || [ "$actual_hash" != "$expected_hash" ]; then
-                echo "::error::Checksum mismatch for $archive"
+              expected_line="$actual_hash  $archive"
+              actual_line="$(cat "$checksum")"
+              line_count="$(awk 'END { print NR }' "$checksum")"
+              final_byte="$(tail -c 1 "$checksum" | od -An -t u1 | tr -d '[:space:]')"
+              if grep -q $'\r' "$checksum"; then
+                echo "::error::Checksum sidecar contains CRLF: $checksum"
+                exit 1
+              fi
+              if [ "$line_count" != "1" ] || [ "$final_byte" != "10" ] \
+                || [ "$actual_line" != "$expected_line" ]; then
+                echo "::error::Checksum sidecar must be one exact ASCII LF line: $checksum"
                 exit 1
               fi
             done
-
           )
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/publish-crates-test.py
+++ b/scripts/publish-crates-test.py
@@ -122,7 +122,8 @@ class PublisherTests(unittest.TestCase):
         text = workflow.read_text()
         prepare = text.split("  prepare-crates:", 1)[1].split("  publish-crates:", 1)[0]
         publish = text.split("  publish-crates:", 1)[1].split("  create-release:", 1)[0]
-        create = text.split("  create-release:", 1)[1].split("  build-release:", 1)[0]
+        create = text.split("  create-release:", 1)[1].split(
+            "  build-linux-release:", 1)[0]
         self.assertIn('echo "enabled=false"', prepare)
         self.assertIn("::notice::CARGO_REGISTRY_TOKEN is absent", prepare)
         self.assertIn("needs.prepare-crates.outputs.enabled == 'true'", publish)

--- a/scripts/publish-crates-test.py
+++ b/scripts/publish-crates-test.py
@@ -130,6 +130,30 @@ class PublisherTests(unittest.TestCase):
         self.assertIn("needs: publish-crates", create)
         self.assertIn("publish-crates.py verify", create)
 
+    def test_workflow_enforces_portable_linux_and_lf_checksums(self):
+        workflow = Path(__file__).resolve().parents[1] / ".github/workflows/release.yml"
+        text = workflow.read_text()
+        linux = text.split("  build-linux-release:", 1)[1].split(
+            "  build-non-linux-release:", 1)[0]
+        non_linux = text.split("  build-non-linux-release:", 1)[1].split(
+            "  publish-release:", 1)[0]
+        publish = text.split("  publish-release:", 1)[1]
+
+        self.assertIn("image: ubuntu:22.04", linux)
+        self.assertEqual(linux.count("target: "), 2)
+        self.assertIn("release assets must not exceed GLIBC_2.35", linux)
+        self.assertIn('"$binary" dispatch --help', linux)
+        self.assertIn('"$binary" verdict --help', linux)
+        self.assertIn("[System.IO.File]::WriteAllText", non_linux)
+        self.assertIn('${ARCHIVE}.zip`n', non_linux)
+        self.assertNotIn("Out-File", non_linux)
+        self.assertIn("Checksum sidecar contains CRLF", publish)
+        self.assertIn("Checksum sidecar must be one exact ASCII LF line", publish)
+        self.assertIn(
+            "needs: [create-release, build-linux-release, build-non-linux-release]",
+            publish,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/publish-crates-test.py
+++ b/scripts/publish-crates-test.py
@@ -134,7 +134,8 @@ class PublisherTests(unittest.TestCase):
         self.assertIn("publish-crates.py verify", create)
 
     def test_workflow_enforces_portable_linux_and_lf_checksums(self):
-        workflow = Path(__file__).resolve().parents[1] / ".github/workflows/release.yml"
+        root = Path(__file__).resolve().parents[1]
+        workflow = root / ".github/workflows/release.yml"
         text = workflow.read_text()
         linux = text.split("  build-linux-release:", 1)[1].split(
             "  build-non-linux-release:", 1)[0]
@@ -150,8 +151,16 @@ class PublisherTests(unittest.TestCase):
         self.assertIn("[System.IO.File]::WriteAllText", non_linux)
         self.assertIn('${ARCHIVE}.zip`n', non_linux)
         self.assertNotIn("Out-File", non_linux)
-        self.assertIn("uses: actions/checkout@v6", publish)
+        self.assertIn(
+            "uses: actions/checkout@v6\n        with:\n"
+            "          persist-credentials: false",
+            publish,
+        )
         self.assertIn("scripts/verify-release-checksum.sh", publish)
+        publication_check = (
+            root / ".github/workflows/publish-crates-check.yml"
+        ).read_text()
+        self.assertIn("- 'scripts/verify-release-checksum.sh'", publication_check)
         self.assertIn(
             "needs: [create-release, build-linux-release, build-non-linux-release]",
             publish,

--- a/scripts/publish-crates-test.py
+++ b/scripts/publish-crates-test.py
@@ -5,9 +5,11 @@ import hashlib
 import importlib.util
 import io
 import json
+import os
 from pathlib import Path
 import subprocess
 import tarfile
+import tempfile
 import unittest
 from unittest.mock import patch
 import urllib.error
@@ -148,12 +150,59 @@ class PublisherTests(unittest.TestCase):
         self.assertIn("[System.IO.File]::WriteAllText", non_linux)
         self.assertIn('${ARCHIVE}.zip`n', non_linux)
         self.assertNotIn("Out-File", non_linux)
-        self.assertIn("Checksum sidecar contains CRLF", publish)
-        self.assertIn("Checksum sidecar must be one exact ASCII LF line", publish)
+        self.assertIn("uses: actions/checkout@v6", publish)
+        self.assertIn("scripts/verify-release-checksum.sh", publish)
         self.assertIn(
             "needs: [create-release, build-linux-release, build-non-linux-release]",
             publish,
         )
+
+    def test_release_checksum_helper_rejects_non_exact_bytes(self):
+        script = Path(__file__).with_name("verify-release-checksum.sh")
+        bash = "bash"
+        if os.name == "nt":
+            bash = str(Path(os.environ["PROGRAMFILES"]) / "Git/bin/bash.exe")
+            if not Path(bash).is_file():
+                self.skipTest("Git Bash is unavailable")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            archive_path = temp / "edda-v1.2.3-test.tar.gz"
+            checksum_path = temp / f"{archive_path.name}.sha256"
+            archive_path.write_bytes(b"release archive")
+            digest = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+            valid = f"{digest}  {archive_path.name}\n".encode("ascii")
+            malformed = {
+                "empty": b"",
+                "wrong-digest": b"0" * 64 + valid[64:],
+                "wrong-spacing": valid.replace(b"  ", b" ", 1),
+                "nul": valid[:-1] + b"\0\n",
+                "crlf": valid[:-1] + b"\r\n",
+                "missing-final-lf": valid[:-1],
+                "extra-line": valid + b"unexpected\n",
+                "bom": b"\xef\xbb\xbf" + valid,
+                "non-ascii": valid[:-1] + b"\xc3\xa9\n",
+            }
+
+            checksum_path.write_bytes(valid)
+            accepted = subprocess.run(
+                [bash, script.as_posix(), archive_path.name, checksum_path.name],
+                cwd=temp,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+
+            for name, contents in malformed.items():
+                with self.subTest(name=name):
+                    checksum_path.write_bytes(contents)
+                    rejected = subprocess.run(
+                        [bash, script.as_posix(), archive_path.name, checksum_path.name],
+                        cwd=temp,
+                        capture_output=True,
+                        text=True,
+                    )
+                    self.assertNotEqual(rejected.returncode, 0)
+                    self.assertIn("::error::Checksum sidecar", rejected.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/verify-release-checksum.sh
+++ b/scripts/verify-release-checksum.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: verify-release-checksum.sh <archive> <checksum>" >&2
+  exit 2
+fi
+
+archive="$1"
+checksum="$2"
+
+if [ ! -f "$archive" ] || [ ! -f "$checksum" ]; then
+  echo "::error::Missing release archive or checksum: $archive / $checksum" >&2
+  exit 1
+fi
+
+actual_hash="$(sha256sum "$archive" | awk '{ print $1 }')"
+
+if grep -q $'\r' "$checksum"; then
+  echo "::error::Checksum sidecar contains CRLF: $checksum" >&2
+  exit 1
+fi
+
+# Compare bytes directly. Command substitution cannot be used here because Bash
+# discards embedded NUL bytes before a string comparison.
+if ! printf '%s  %s\n' "$actual_hash" "$archive" | cmp -s - "$checksum"; then
+  echo "::error::Checksum sidecar must be one exact ASCII LF line: $checksum" >&2
+  exit 1
+fi


### PR DESCRIPTION
Issue: #1107
Decision: release.linux-asset-baseline, release.checksum-sidecar

## Summary

- build both Linux release architectures inside an Ubuntu 22.04 userspace
- reject Linux binaries requiring newer than `GLIBC_2.35` before upload and run critical CLI canaries there
- emit the Windows checksum sidecar as explicit ASCII+LF
- reject CRLF, embedded NUL, BOM, missing final LF, extra lines, or any checksum bytes other than the exact archive digest line before publishing
- check out the tag-pinned verifier without persisting repository credentials, and trigger its behavioral gate on helper-only changes
- document workflow ownership and public re-verification in the `edda-release` skill

## Why

During the v0.6.1 release (#1107), `ubuntu-latest` produced x86_64 and aarch64 assets requiring `GLIBC_2.39`; they failed on Ubuntu 22.04 and had to be rebuilt from the immutable tag. The Windows `.sha256` sidecar also used CRLF and failed GNU `sha256sum -c`. This moves both manually proven repairs into the release gate.

The five build legs are split across two matrix job definitions, but the release workflow remains five logical stages and nine concrete jobs.

## Validation

- `python scripts/publish-crates-test.py` — 10 passed, including behavior-level malformed-sidecar cases
- `python .claude/skills/edda-release/scripts/test_crates_release_plan.py` — 6 passed
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release.yml` — passed
- YAML parse — 6 job definitions
- `sh scripts/lint-doc-citations.sh` — passed
- `sh scripts/lint-markdown-content.sh` — passed
- `git diff --check` — passed
- Ubuntu 22.04 packaged `gh` supports `release upload --clobber`
- the exact PowerShell `WriteAllText(..., ASCII)` pattern emitted byte `0a` and passed GNU `sha256sum -c`
- Ubuntu 22.04 behavior probe accepted the exact sidecar and rejected the same bytes with an embedded NUL

## Release evidence

The repaired public v0.6.1 x86_64 and aarch64 artifacts were built with the same Ubuntu 22.04 baseline, reported highest requirement `GLIBC_2.34`, and passed `--version`, `dispatch --help`, and `verdict --help` on Ubuntu 22.04.
