### PR TITLE
fix(edda-cli): tolerate absent required check output

### DIFF
--- a/crates/edda-cli/src/cmd_review/evidence/github.rs
+++ b/crates/edda-cli/src/cmd_review/evidence/github.rs
@@ -77,6 +77,9 @@ fn decode(output: &process::Output, allow_nonzero: bool) -> Result<Value> {
         !output.truncated,
         "GitHub evidence exceeds bounded JSON capture"
     );
+    if output.stdout.is_empty() && allow_nonzero && matches!(output.exit, 1 | 8) {
+        return Ok(Value::Array(vec![]));
+    }
     let value: Value = serde_json::from_slice(&output.stdout).context("GitHub evidence JSON")?;
     anyhow::ensure!(
         output.exit == 0 || (allow_nonzero && matches!(output.exit, 1 | 8) && value.is_array()),
@@ -151,6 +154,36 @@ mod tests {
             truncated: true,
         };
         assert!(decode(&output, true).is_err());
+    }
+
+    #[test]
+    fn empty_required_checks_are_tolerated_only_for_known_nonzero_exits() {
+        for exit in [1, 8] {
+            let output = process::Output {
+                exit,
+                timed_out: false,
+                stdout: vec![],
+                truncated: false,
+            };
+            assert_eq!(decode(&output, true).unwrap(), json!([]));
+            assert!(decode(&output, false).is_err());
+        }
+        for exit in [0, 2] {
+            let output = process::Output {
+                exit,
+                timed_out: false,
+                stdout: vec![],
+                truncated: false,
+            };
+            assert!(decode(&output, true).is_err());
+        }
+        let malformed = process::Output {
+            exit: 1,
+            timed_out: false,
+            stdout: b"not JSON".to_vec(),
+            truncated: false,
+        };
+        assert!(decode(&malformed, true).is_err());
     }
 
     #[test]

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1236,7 +1236,8 @@ round. With the flag the policy is `model` and any independence other than
 `verified` disqualifies it.
 
 Gates are READ from clean exact-SHA command receipts and required exact-SHA CI.
-Missing checks remain unverified; any red evidence wins. `--run-gates` opts in
+When GitHub reports no required checks yet, review still launches and CI evidence
+remains absent/unverified; any red evidence wins. `--run-gates` opts in
 to execution of trusted declared commands, bounded by `--max-ran-sec` (300 by
 default). Cargo gates require an existing `CARGO_TARGET_DIR` build lane.
 `--trust-spec` authorizes issue verify commands; explicit issue selection by


### PR DESCRIPTION
## Summary
- Treat empty stdout from `gh pr checks --required --json name` on tolerated exits 1/8 as no required checks currently reported, allowing the read-only reviewer to launch.
- Keep non-tolerated empty output, non-empty malformed JSON, bounded-capture failures, and exact-SHA API failures as errors.
- Document that absent required checks leave CI evidence absent/unverified rather than green.

This is the intentionally partial advisory-launch slice. `edda review merge` behavior and its absent-vs-red diagnostics remain later scope.

## Tests
- `cargo fmt --all --check`
- `cargo clippy -p edda --all-targets -- -D warnings`
- `cargo test -p edda`
- `bash scripts/lint-file-length.sh --tree`
- `sh scripts/lint-markdown-content.sh`
- `git diff --check`

Issue: #1135