### PR TITLE
feat(edda-cli): map declared gates to exact CI jobs

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -9,6 +9,16 @@ gates:
   - "cargo clippy --workspace --all-targets -- -D warnings"
   - "cargo test --workspace"
   - "sh scripts/lint-markdown-content.sh"
+ci_gates:
+  "cargo fmt --all --check": ["Format"]
+  "cargo clippy --workspace --all-targets -- -D warnings":
+    - "Clippy (ubuntu-latest)"
+    - "Clippy (windows-latest)"
+    - "Clippy (macos-latest)"
+  "cargo test --workspace":
+    - "Test (ubuntu-latest)"
+    - "Test (macos-latest)"
+  "sh scripts/lint-markdown-content.sh": ["Format"]
 ran_allowlist:
   - "edda "
   - "gh "
@@ -23,7 +33,7 @@ classes:
 
 # REVIEW.md — the executable review spec
 
-- Spec version: `review-spec-v1.6`
+- Spec version: `review-spec-v1.7`
 - Audience: anyone — human or engine — reviewing a pull request in this
   repository, and any script that builds a review brief.
 - Status: this file is the **single source of truth** for how a PR is reviewed
@@ -384,16 +394,33 @@ sh scripts/lint-markdown-content.sh; echo "exit=$?"
 # review-spec:check-end
 
 **U6 — gates: READ before RAN. P0 when CI is deterministically red.** The L1
-receipt is exact-head CI itself — `CI run <id> @ <sha>` — and the workspace
-Cargo `gates:` entries above are READ from its job results, never RAN by the
-reviewer (`ladder` L1: CI is the workspace gate; C5 is the only Cargo gate RAN
-here; non-Cargo gates such as U5 remain RAN where §5 routes them).
-RAN only what the CI jobs do not cover, and **state the reason for any rerun of
-a recorded gate** (`ladder`, L2 row). A coverage gap earns a focused check for
-that gap, not a full rerun; a full local rerun needs a stated reason (red or
-absent exact-head CI, or grounds to distrust it). Deterministically red CI
-already blocks the SHA — audit and request changes instead of spending a full
-run; if the red is environmental, rerun only the failed job.
+receipt is exact-head CI itself — `CI run <id> @ <sha>` — and `ci_gates:` maps
+each declared gate command to the exact check-run names that evidence it. One
+mapped row covers one declared gate only when every listed exact-head job
+succeeds; any mapped failure is red. A missing, pending, neutral, or skipped
+job leaves that row pending/unverified — skipped may satisfy the required `CI
+Gate`'s set-level path-filter rule, but it never becomes a green per-gate
+claim. A missing mapping remains visibly uncovered. Final status is a
+per-declared-gate union, not a coarse source-level lattice: any red receipt,
+required-CI row, mapped row, or non-timeout failed RAN is globally red.
+Otherwise every declared gate must have a green receipt or mapped row, or a
+successful stored non-timeout RAN for that same command. Different sources may
+cover different gates. A green required-CI row remains visible set-level
+evidence but covers no declared gate; any gate without eligible green evidence
+keeps the set unverified. Unknown evidence is advisory; deterministically red
+mapped or required CI remains blocking.
+
+The workspace Cargo `gates:` entries above are READ from those job results,
+never RAN by the reviewer (`ladder` L1: CI is the workspace gate; C5 is the
+only Cargo gate RAN here; non-Cargo gates such as U5 remain RAN where §5
+routes them). `ran_allowlist` is unchanged: reviewer execution capability is
+not a fallback for unavailable CI evidence. RAN only what the CI jobs do not
+cover, and **state the reason for any rerun of a recorded gate** (`ladder`, L2
+row). A coverage gap earns a focused check for that gap, not a full rerun; a
+full local rerun needs a stated reason (red or absent exact-head CI, or grounds
+to distrust it). Deterministically red CI already blocks the SHA — audit and
+request changes instead of spending a full run; if the red is environmental,
+rerun only the failed job.
 
 # review-spec:check U6
 ```sh
@@ -803,7 +830,7 @@ One comment per round, pinned to the reviewed full SHA
 - model_requested: <the model dispatch asked for>
 - model_observed: <read from the system, or "unverified">
 - reviewer_session: <per-PR UUID the lane was launched with>
-- spec: review-spec-v1.6
+- spec: review-spec-v1.7
 - class: <code-risk | docs-skills>  (REVIEW.md classes: <docs|skills|code-plain|code-risk ...>)
 - escalations: <list of 需升級 items, or "none">
 - shadow: true|false  (documentation for a SHADOW round: true requires the heading suffix ` (SHADOW)` — `## Code Review: Round <N> (SHADOW) — PR #<n> @ <full 40-hex SHA>`; the suffix is the only marker, this field never substitutes for it; a SHADOW round is never a verdict — §8)
@@ -859,6 +886,10 @@ rather than overwriting it.
   round is answered by a `Review Response: Round N` that names the new full SHA
   and the gates it ran (`loop` item 4).
 - P2 alone never blocks.
+- `gates.status = unverified` is visible advisory evidence, not by itself a
+  reason to withhold LGTM. `gates.status = red` or `undeclared` still prevents
+  a qualified LGTM; mapped red is blocking, and skipped is never a green
+  per-gate claim.
 - An LGTM with a non-empty `escalations:` field is provisional (§6.4).
 - Every push invalidates this verdict (`loop` item 5). A draft/ready flip, a
   label, or a status change is not a push and reruns nothing (`ladder`, L3).
@@ -1016,6 +1047,17 @@ mechanical.
   code — except when every named script is absent, which is `ERROR`, not a
   silent PASS, so a check that verified nothing is never mistaken for one
   that passed (the #950 failure mode, in the opposite direction).
+- `review-spec-v1.7` (2026-09-11, issue #1136 d-001): front matter gains the
+  generic `ci_gates` declared-command → exact check-name map. Exact-head mapped
+  jobs aggregate into one row per gate: all success is green, any failure is
+  red, and missing/pending/neutral/skipped is unverified. Final status unions
+  eligible green evidence per declared gate across receipts, mapped rows, and
+  successful stored non-timeout RAN; every gate must be covered, while any red
+  evidence globally dominates. Required checks stay visible as set-level
+  evidence, but required green covers no declared gate. Unverified gate
+  evidence becomes advisory; red and undeclared remain qualification blockers.
+  `ran_allowlist` is unchanged because execution capability is not a fallback
+  for unavailable evidence.
 
 Changing a rule here changes the line for every engine. Record the version in
 each verdict's `spec:` field so catch rates stay readable against the spec they

--- a/crates/edda-cli/src/cmd_review/brief.rs
+++ b/crates/edda-cli/src/cmd_review/brief.rs
@@ -24,6 +24,8 @@ pub(crate) struct FrontMatter {
     #[serde(default)]
     pub gates: Vec<String>,
     #[serde(default)]
+    pub ci_gates: BTreeMap<String, Vec<String>>,
+    #[serde(default)]
     pub ran_allowlist: Vec<String>,
     #[serde(default)]
     pub independence: Option<String>,
@@ -220,16 +222,27 @@ mod tests {
     fn current_and_old_frontmatter_keep_rules_and_verbatim_gates() {
         for version in [1, 2] {
             let text = format!(
-                "---\r\nedda_review: {version}\r\ngates: ['echo \"a  b\"']\r\n---\r\nRules"
+                "---\r\nedda_review: {version}\r\ngates: ['echo \"a  b\"']\r\nci_gates:\r\n  'echo \"a  b\"': [Linux, macOS]\r\n---\r\nRules"
             );
             let (fm, body, note) = parse_review_md(&text);
             assert_eq!(fm.gates, ["echo \"a  b\""]);
+            assert_eq!(fm.ci_gates["echo \"a  b\""], ["Linux", "macOS"]);
             assert_eq!(body, text);
             assert!(note.is_none());
         }
         assert!(parse_review_md("---\nedda_review: 99\n---\nRules")
             .2
             .is_some());
+    }
+
+    #[test]
+    fn malformed_ci_gate_mapping_empties_all_machine_fields() {
+        let (fm, _, note) = parse_review_md(
+            "---\nedda_review: 2\ngates: [test]\nci_gates: [not-a-map]\n---\nRules",
+        );
+        assert!(fm.gates.is_empty());
+        assert!(fm.ci_gates.is_empty());
+        assert!(note.is_some_and(|note| note.contains("machine fields empty")));
     }
     #[test]
     fn overlapping_code_is_protected_and_untrusted_contract_is_escaped() {

--- a/crates/edda-cli/src/cmd_review/evidence.rs
+++ b/crates/edda-cli/src/cmd_review/evidence.rs
@@ -4,13 +4,14 @@ mod probes;
 mod process;
 mod trust;
 
-pub(crate) use github::gh_required_checks;
+pub(crate) use github::{gh_required_checks, GitHubChecks};
 pub(crate) use probes::{extract_probe_verbs, run_probes, run_wiring_scan};
 pub(crate) use trust::{extract_verify, spec_trust, SpecOrigin};
 
 use super::brief::FrontMatter;
 use edda_core::types::{ReviewGateRan, ReviewGateRead, ReviewProbe};
 use edda_ledger::{paths::EddaPaths, Ledger};
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
@@ -91,14 +92,115 @@ pub(crate) fn read_gates(ledger: &Ledger, head: &str, gates: &GateSet) -> anyhow
     Ok((status.into(), read, uncovered))
 }
 
-/// One lattice for every independent evidence source; silence is neutral.
-pub(crate) fn combine_gate_status(current: &str, incoming: Option<&str>) -> String {
-    let incoming = incoming.unwrap_or("unverified");
-    if current == "undeclared" || incoming == "undeclared" {
-        "undeclared"
-    } else if current == "red" || incoming == "red" {
+pub(crate) fn read_ci(checks: &GitHubChecks) -> (Option<String>, Vec<ReviewGateRead>) {
+    if checks.required_names.is_empty() {
+        return (None, vec![]);
+    }
+    let read: Vec<_> = checks
+        .required_names
+        .iter()
+        .map(|name| {
+            let bucket = checks
+                .latest_runs
+                .get(name)
+                .map(String::as_str)
+                .unwrap_or("missing");
+            ReviewGateRead {
+                kind: "ci".into(),
+                r#ref: name.clone(),
+                cmd: name.clone(),
+                // Preserve the required-set path-filter rule: a skipped
+                // required check can still be accepted by its aggregate.
+                result: match bucket {
+                    "pass" | "skipped" => "green",
+                    "fail" => "red",
+                    _ => "pending",
+                }
+                .into(),
+            }
+        })
+        .collect();
+    let status = rows_status(&read);
+    (Some(status), read)
+}
+
+pub(crate) type MappedCiRead = (Option<String>, Vec<ReviewGateRead>, Vec<String>);
+
+/// Aggregate exact-name check runs into one row per mapped declared gate.
+/// The required-check set is the trust boundary: without it optional jobs
+/// are not fetched and this source remains silent.
+pub(crate) fn read_ci_job_map(
+    checks: &GitHubChecks,
+    gates: &GateSet,
+    mappings: &BTreeMap<String, Vec<String>>,
+) -> MappedCiRead {
+    if checks.required_names.is_empty() {
+        return (None, vec![], vec![]);
+    }
+    let mut rows = Vec::new();
+    let mut mapped = Vec::new();
+    for gate in &gates.cmds {
+        let Some(names) = mappings.get(gate) else {
+            continue;
+        };
+        mapped.push(gate.clone());
+        let statuses = names
+            .iter()
+            .map(|name| {
+                let bucket = checks
+                    .latest_runs
+                    .get(name)
+                    .map(String::as_str)
+                    .unwrap_or("missing");
+                (name, bucket)
+            })
+            .collect::<Vec<_>>();
+        let result = if statuses.iter().any(|(_, bucket)| *bucket == "fail") {
+            "red"
+        } else if !statuses.is_empty() && statuses.iter().all(|(_, bucket)| *bucket == "pass") {
+            "green"
+        } else {
+            // Missing, queued/in-progress/neutral, and skipped are not a
+            // per-gate success claim.
+            "pending"
+        };
+        let reference = if statuses.is_empty() {
+            "no mapped check names".into()
+        } else {
+            statuses
+                .iter()
+                .map(|(name, bucket)| format!("{name}={bucket}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        rows.push(ReviewGateRead {
+            kind: "ci-job-map".into(),
+            r#ref: reference,
+            cmd: gate.clone(),
+            result: result.into(),
+        });
+    }
+    if rows.is_empty() {
+        return (None, rows, mapped);
+    }
+    let status = if rows.iter().any(|row| row.result == "red") {
         "red"
-    } else if current == "verified" || incoming == "verified" {
+    } else if mapped.len() == gates.cmds.len() && rows.iter().all(|row| row.result == "green") {
+        "verified"
+    } else {
+        "unverified"
+    };
+    (Some(status.into()), rows, mapped)
+}
+
+pub(crate) fn remove_mapped_uncovered(uncovered: &mut Vec<String>, mapped: &[String]) {
+    uncovered.retain(|gate| !mapped.contains(gate));
+}
+
+fn rows_status(read: &[ReviewGateRead]) -> String {
+    if read.iter().any(|row| row.result == "red") {
+        "red"
+    } else if read.iter().all(|row| row.result == "green") {
         "verified"
     } else {
         "unverified"
@@ -106,49 +208,37 @@ pub(crate) fn combine_gate_status(current: &str, incoming: Option<&str>) -> Stri
     .into()
 }
 
-pub(crate) fn read_ci(checks: &[(String, String)]) -> (Option<String>, Vec<ReviewGateRead>) {
-    if checks.is_empty() {
-        return (None, vec![]);
+/// Derive the final set status from exact-head evidence after READ and RAN
+/// collection. Required CI is set-level evidence: its red is authoritative,
+/// but its green never covers an individual declared gate.
+pub(crate) fn gate_status(
+    gates: &[String],
+    read: &[ReviewGateRead],
+    ran: &[ReviewGateRan],
+) -> String {
+    if gates.is_empty() {
+        return "undeclared".into();
     }
-    let read: Vec<_> = checks
-        .iter()
-        .map(|(name, bucket)| ReviewGateRead {
-            kind: "ci".into(),
-            r#ref: name.clone(),
-            cmd: name.clone(),
-            result: match bucket.as_str() {
-                "pass" => "green",
-                "fail" | "cancel" => "red",
-                _ => "pending",
-            }
-            .into(),
+    if read.iter().any(|row| row.result == "red")
+        || ran.iter().any(|row| !row.timed_out && row.exit != 0)
+    {
+        return "red".into();
+    }
+    let all_covered = gates.iter().all(|gate| {
+        read.iter().any(|row| {
+            row.cmd == *gate
+                && row.result == "green"
+                && matches!(row.kind.as_str(), "cmd-event" | "ci-job-map")
+        }) || ran.iter().any(|row| {
+            row.cmd == *gate && row.exit == 0 && !row.timed_out && row.stdout_blob.is_some()
         })
-        .collect();
-    let status = if read.iter().any(|r| r.result == "red") {
-        "red"
-    } else if read.iter().all(|r| r.result == "green") {
+    });
+    if all_covered {
         "verified"
     } else {
         "unverified"
-    };
-    (Some(status.into()), read)
-}
-
-pub(crate) fn ran_status(gates: &[String], ran: &[ReviewGateRan]) -> Option<String> {
-    // A real failure remains red even if another command exceeded the budget.
-    if ran.iter().any(|r| !r.timed_out && r.exit != 0) {
-        return Some("red".into());
     }
-    if !gates.is_empty()
-        && gates.iter().all(|gate| {
-            ran.iter()
-                .any(|r| &r.cmd == gate && r.exit == 0 && !r.timed_out && r.stdout_blob.is_some())
-        })
-    {
-        Some("verified".into())
-    } else {
-        None
-    }
+    .into()
 }
 
 pub(crate) fn ran_gates(

--- a/crates/edda-cli/src/cmd_review/evidence/github.rs
+++ b/crates/edda-cli/src/cmd_review/evidence/github.rs
@@ -6,13 +6,15 @@ use std::path::Path;
 use std::process::Command;
 use std::time::{Duration, Instant};
 
+#[derive(Debug, Default)]
+pub(crate) struct GitHubChecks {
+    pub required_names: Vec<String>,
+    pub latest_runs: BTreeMap<String, String>,
+}
+
 /// gh pr checks legitimately exits 1 or 8 when its valid JSON describes red
 /// or pending checks. Required names come from it; results come ONLY from SHA.
-pub(crate) fn gh_required_checks(
-    repo: &Path,
-    pr: u64,
-    head_sha: &str,
-) -> Result<Vec<(String, String)>> {
+pub(crate) fn gh_required_checks(repo: &Path, pr: u64, head_sha: &str) -> Result<GitHubChecks> {
     anyhow::ensure!(
         head_sha.len() == 40 && head_sha.bytes().all(|b| b.is_ascii_hexdigit()),
         "CI requires a full head SHA"
@@ -51,7 +53,9 @@ pub(crate) fn gh_required_checks(
         })
         .collect::<Result<Vec<_>>>()?;
     if names.is_empty() {
-        return Ok(vec![]);
+        // No required set means no trustworthy boundary for optional jobs.
+        // Do not fetch them and never let one opportunistic success turn green.
+        return Ok(GitHubChecks::default());
     }
     let endpoint = format!("repos/{{owner}}/{{repo}}/commits/{head_sha}/check-runs?per_page=100");
     let pages = query(&["api", &endpoint, "--paginate", "--slurp"], false)?;
@@ -68,7 +72,10 @@ pub(crate) fn gh_required_checks(
                 .cloned(),
         );
     }
-    Ok(required_at_sha(&names, &checks, head_sha))
+    Ok(GitHubChecks {
+        required_names: names,
+        latest_runs: latest_at_sha(&checks, head_sha),
+    })
 }
 
 fn decode(output: &process::Output, allow_nonzero: bool) -> Result<Value> {
@@ -89,7 +96,7 @@ fn decode(output: &process::Output, allow_nonzero: bool) -> Result<Value> {
     Ok(value)
 }
 
-fn required_at_sha(names: &[String], runs: &[Value], sha: &str) -> Vec<(String, String)> {
+fn latest_at_sha(runs: &[Value], sha: &str) -> BTreeMap<String, String> {
     let mut latest: BTreeMap<&str, &Value> = BTreeMap::new();
     for run in runs {
         if run["head_sha"].as_str() != Some(sha) {
@@ -104,12 +111,13 @@ fn required_at_sha(names: &[String], runs: &[Value], sha: &str) -> Vec<(String, 
             }
         }
     }
-    names
-        .iter()
-        .map(|name| {
-            let bucket = match latest.get(name.as_str()) {
-                Some(run) if run["status"] == "completed" => match run["conclusion"].as_str() {
-                    Some("success" | "skipped") => "pass",
+    latest
+        .into_iter()
+        .map(|(name, run)| {
+            let bucket = match run["status"].as_str() {
+                Some("completed") => match run["conclusion"].as_str() {
+                    Some("success") => "pass",
+                    Some("skipped") => "skipped",
                     Some(
                         "failure" | "cancelled" | "timed_out" | "action_required"
                         | "startup_failure",
@@ -118,7 +126,7 @@ fn required_at_sha(names: &[String], runs: &[Value], sha: &str) -> Vec<(String, 
                 },
                 _ => "pending",
             };
-            (name.clone(), bucket.into())
+            (name.to_owned(), bucket.to_owned())
         })
         .collect()
 }
@@ -187,31 +195,27 @@ mod tests {
     }
 
     #[test]
-    fn missing_required_and_wrong_sha_cannot_disappear() {
-        let names = vec!["A".into(), "B".into(), "C".into()];
+    fn latest_attempt_wins_and_wrong_sha_is_excluded() {
         let runs = vec![
             json!({"name":"A","id":1,"head_sha":"head","status":"completed","conclusion":"success"}),
-            json!({"name":"B","id":2,"head_sha":"other","status":"completed","conclusion":"success"}),
+            json!({"name":"A","id":99,"head_sha":"other","status":"completed","conclusion":"success"}),
+            json!({"name":"A","id":2,"head_sha":"head","status":"completed","conclusion":"failure"}),
+            json!({"name":"OnlyOther","id":3,"head_sha":"other","status":"completed","conclusion":"success"}),
         ];
-        assert_eq!(
-            required_at_sha(&names, &runs, "head"),
-            vec![
-                ("A".into(), "pass".into()),
-                ("B".into(), "pending".into()),
-                ("C".into(), "pending".into())
-            ]
-        );
+        let latest = latest_at_sha(&runs, "head");
+        assert_eq!(latest.get("A").map(String::as_str), Some("fail"));
+        assert!(!latest.contains_key("OnlyOther"));
     }
 
     #[test]
-    fn latest_attempt_and_neutral_are_not_green() {
+    fn skipped_is_separate_and_neutral_is_pending() {
         let runs = vec![
             json!({"name":"A","id":2,"head_sha":"head","status":"completed","conclusion":"neutral"}),
             json!({"name":"A","id":1,"head_sha":"head","status":"completed","conclusion":"success"}),
+            json!({"name":"B","id":1,"head_sha":"head","status":"completed","conclusion":"skipped"}),
         ];
-        assert_eq!(
-            required_at_sha(&["A".into()], &runs, "head")[0].1,
-            "pending"
-        );
+        let latest = latest_at_sha(&runs, "head");
+        assert_eq!(latest.get("A").map(String::as_str), Some("pending"));
+        assert_eq!(latest.get("B").map(String::as_str), Some("skipped"));
     }
 }

--- a/crates/edda-cli/src/cmd_review/evidence/tests.rs
+++ b/crates/edda-cli/src/cmd_review/evidence/tests.rs
@@ -1,5 +1,16 @@
 use super::*;
 use edda_core::event::{new_cmd_event_with_git_context, CmdEventParams};
+use std::collections::BTreeMap;
+
+fn ci(required: &[&str], runs: &[(&str, &str)]) -> GitHubChecks {
+    GitHubChecks {
+        required_names: required.iter().map(|name| (*name).into()).collect(),
+        latest_runs: runs
+            .iter()
+            .map(|(name, bucket)| ((*name).into(), (*bucket).into()))
+            .collect(),
+    }
+}
 
 fn receipt(ledger: &Ledger, command: &[&str], sha: &str, dirty: bool, exit: i32) {
     let args = command.iter().map(|s| s.to_string()).collect::<Vec<_>>();
@@ -48,14 +59,14 @@ fn unreadable_ledger_is_an_error_not_uncovered_evidence() {
 }
 
 #[test]
-fn gate_lattice_is_exhaustive_and_silence_is_neutral() {
-    let states = ["undeclared", "red", "verified", "unverified"];
-    for (i, a) in states.iter().enumerate() {
-        for (j, b) in states.iter().enumerate() {
-            assert_eq!(combine_gate_status(a, Some(b)), states[i.min(j)]);
-        }
-        assert_eq!(combine_gate_status(a, None), *a);
-    }
+fn empty_gate_set_is_undeclared_even_when_evidence_exists() {
+    let read = vec![ReviewGateRead {
+        kind: "ci".into(),
+        r#ref: "CI Gate".into(),
+        cmd: "CI Gate".into(),
+        result: "red".into(),
+    }];
+    assert_eq!(gate_status(&[], &read, &[]), "undeclared");
 }
 
 #[test]
@@ -127,38 +138,191 @@ fn verify_section_preserves_quotes_and_stops_at_sibling_yaml_key() {
 }
 
 #[test]
-fn required_ci_is_independent_and_pending_is_neutral() {
-    assert_eq!(read_ci(&[]).0, None);
-    let green = read_ci(&[("Test".into(), "pass".into())]).0;
-    assert_eq!(
-        combine_gate_status("unverified", green.as_deref()),
-        "verified"
-    );
-    let pending = read_ci(&[("Test".into(), "pending".into())]).0;
-    assert_eq!(
-        combine_gate_status("verified", pending.as_deref()),
-        "verified"
-    );
+fn required_ci_rows_preserve_status_but_green_never_covers_a_gate() {
+    assert_eq!(read_ci(&GitHubChecks::default()).0, None);
+    let (green, rows) = read_ci(&ci(&["CI Gate"], &[("CI Gate", "pass")]));
+    assert_eq!(green.as_deref(), Some("verified"));
+    assert_eq!(rows[0].result, "green");
+    assert_eq!(gate_status(&["CI Gate".into()], &rows, &[]), "unverified");
+    let (pending, _) = read_ci(&ci(&["CI Gate"], &[("CI Gate", "pending")]));
+    assert_eq!(pending.as_deref(), Some("unverified"));
 }
 
 #[test]
-fn ran_requires_all_commands_and_blobs_and_timeout_is_silent() {
-    let gates: Vec<String> = vec!["echo hi".into()];
-    let mut ran = vec![ReviewGateRan {
+fn empty_required_names_never_use_a_successful_mapped_job() {
+    let gates = gate_set(&FrontMatter::default(), &["cargo test".into()], &[]);
+    let checks = ci(&[], &[("Test (ubuntu-latest)", "pass")]);
+    let mappings = BTreeMap::from([("cargo test".into(), vec!["Test (ubuntu-latest)".into()])]);
+    let (status, rows, mapped) = read_ci_job_map(&checks, &gates, &mappings);
+    assert!(status.is_none());
+    assert!(rows.is_empty());
+    assert!(mapped.is_empty());
+}
+
+#[test]
+fn mapped_gate_requires_all_exact_jobs_and_ref_lists_each_status() {
+    let gate = "cargo clippy --workspace";
+    let gates = gate_set(&FrontMatter::default(), &[gate.into()], &[]);
+    let mappings = BTreeMap::from([(
+        gate.into(),
+        vec!["Clippy (ubuntu)".into(), "Clippy (macos)".into()],
+    )]);
+    let checks = ci(
+        &["CI Gate"],
+        &[
+            ("CI Gate", "pass"),
+            ("Clippy (ubuntu)", "pass"),
+            ("Clippy (macos)", "pass"),
+        ],
+    );
+    let (status, rows, mapped) = read_ci_job_map(&checks, &gates, &mappings);
+    assert_eq!(status.as_deref(), Some("verified"));
+    assert_eq!(mapped, [gate]);
+    assert_eq!(rows[0].kind, "ci-job-map");
+    assert_eq!(rows[0].result, "green");
+    assert!(rows[0].r#ref.contains("Clippy (ubuntu)=pass"));
+    assert!(rows[0].r#ref.contains("Clippy (macos)=pass"));
+}
+
+#[test]
+fn mapped_failure_dominates_other_green_evidence() {
+    let gate = "cargo test";
+    let gates = gate_set(&FrontMatter::default(), &[gate.into()], &[]);
+    let mappings = BTreeMap::from([(gate.into(), vec!["Linux".into(), "macOS".into()])]);
+    let checks = ci(
+        &["CI Gate"],
+        &[("CI Gate", "pass"), ("Linux", "pass"), ("macOS", "fail")],
+    );
+    let (_, mut rows, _) = read_ci_job_map(&checks, &gates, &mappings);
+    assert_eq!(rows[0].result, "red");
+    rows.push(ReviewGateRead {
+        kind: "cmd-event".into(),
+        r#ref: "receipt".into(),
+        cmd: gate.into(),
+        result: "green".into(),
+    });
+    assert_eq!(gate_status(&gates.cmds, &rows, &[]), "red");
+}
+
+#[test]
+fn receipt_required_and_mapped_red_each_globally_dominate() {
+    let gates: Vec<String> = vec!["fmt".into(), "test".into()];
+    let green = vec![
+        ReviewGateRead {
+            kind: "cmd-event".into(),
+            r#ref: "receipt".into(),
+            cmd: gates[0].clone(),
+            result: "green".into(),
+        },
+        ReviewGateRead {
+            kind: "ci-job-map".into(),
+            r#ref: "Test=pass".into(),
+            cmd: gates[1].clone(),
+            result: "green".into(),
+        },
+    ];
+    for (kind, cmd) in [
+        ("cmd-event", gates[0].as_str()),
+        ("ci", "CI Gate"),
+        ("ci-job-map", gates[1].as_str()),
+    ] {
+        let mut read = green.clone();
+        read.push(ReviewGateRead {
+            kind: kind.into(),
+            r#ref: "failed evidence".into(),
+            cmd: cmd.into(),
+            result: "red".into(),
+        });
+        assert_eq!(gate_status(&gates, &read, &[]), "red", "{kind}");
+    }
+}
+
+#[test]
+fn partial_receipt_and_partial_mapped_green_collectively_verify() {
+    let gates = gate_set(&FrontMatter::default(), &["fmt".into(), "test".into()], &[]);
+    let dir = tempfile::tempdir().unwrap();
+    let ledger = Ledger::open_or_init(dir.path()).unwrap();
+    receipt(&ledger, &["fmt"], "head", false, 0);
+    let (_, mut read, _) = read_gates(&ledger, "head", &gates).unwrap();
+
+    let checks = ci(&["CI Gate"], &[("CI Gate", "pass"), ("Test", "pass")]);
+    read.extend(read_ci(&checks).1);
+    let mappings = BTreeMap::from([("test".into(), vec!["Test".into()])]);
+    read.extend(read_ci_job_map(&checks, &gates, &mappings).1);
+
+    assert_eq!(gate_status(&gates.cmds, &read, &[]), "verified");
+}
+
+#[test]
+fn missing_pending_and_skipped_mapped_jobs_are_unverified() {
+    let gate = "cargo test";
+    let gates = gate_set(&FrontMatter::default(), &[gate.into()], &[]);
+    for (label, runs) in [
+        ("missing", vec![]),
+        ("pending", vec![("Linux", "pending")]),
+        ("skipped", vec![("Linux", "skipped")]),
+    ] {
+        let mappings = BTreeMap::from([(gate.into(), vec!["Linux".into()])]);
+        let checks = ci(&["CI Gate"], &runs);
+        let (status, rows, _) = read_ci_job_map(&checks, &gates, &mappings);
+        assert_eq!(status.as_deref(), Some("unverified"), "{label}");
+        assert_eq!(rows[0].result, "pending", "{label}");
+        assert!(rows[0].r#ref.contains(label), "{label}: {}", rows[0].r#ref);
+    }
+}
+
+#[test]
+fn mapped_gate_is_not_also_uncovered_but_unmapped_gate_stays_visible() {
+    let mapped_gate = "cargo fmt";
+    let unmapped_gate = "custom lint";
+    let gates = gate_set(
+        &FrontMatter::default(),
+        &[mapped_gate.into(), unmapped_gate.into()],
+        &[],
+    );
+    let dir = tempfile::tempdir().unwrap();
+    let ledger = Ledger::open_or_init(dir.path()).unwrap();
+    let (_, mut read, mut uncovered) = read_gates(&ledger, "head", &gates).unwrap();
+    let mappings = BTreeMap::from([(mapped_gate.into(), vec!["Format".into()])]);
+    let checks = ci(&["CI Gate"], &[("Format", "pass")]);
+    let (_, mapped_rows, mapped) = read_ci_job_map(&checks, &gates, &mappings);
+    read.extend(mapped_rows);
+    remove_mapped_uncovered(&mut uncovered, &mapped);
+    assert_eq!(uncovered, [unmapped_gate]);
+    let text = evidence_text(&read, &uncovered, &[], &[], None);
+    assert!(text.contains("\"cargo fmt\": green (ci-job-map \"Format=pass\")"));
+    assert!(!text.contains("\"cargo fmt\": not covered"));
+    assert!(text.contains("\"custom lint\": not covered"));
+}
+
+#[test]
+fn ran_fills_only_a_remaining_gate_with_stored_success_before_timeout() {
+    let gates: Vec<String> = vec!["fmt".into(), "test".into()];
+    let read = vec![ReviewGateRead {
+        kind: "ci-job-map".into(),
+        r#ref: "Format=pass".into(),
         cmd: gates[0].clone(),
+        result: "green".into(),
+    }];
+    let mut ran = vec![ReviewGateRan {
+        cmd: gates[1].clone(),
         exit: 0,
         duration_ms: 1,
         stdout_blob: Some("blob".into()),
         timed_out: false,
     }];
-    assert_eq!(ran_status(&gates, &ran).as_deref(), Some("verified"));
+    assert_eq!(gate_status(&gates, &read, &ran), "verified");
+    ran[0].cmd = "other".into();
+    assert_eq!(gate_status(&gates, &read, &ran), "unverified");
+    ran[0].cmd = gates[1].clone();
     ran[0].stdout_blob = None;
-    assert_eq!(ran_status(&gates, &ran), None);
-    ran[0].exit = -1;
+    assert_eq!(gate_status(&gates, &read, &ran), "unverified");
+    ran[0].stdout_blob = Some("blob".into());
     ran[0].timed_out = true;
-    assert_eq!(ran_status(&gates, &ran), None);
+    assert_eq!(gate_status(&gates, &read, &ran), "unverified");
     ran[0].timed_out = false;
-    assert_eq!(ran_status(&gates, &ran).as_deref(), Some("red"));
+    ran[0].exit = 1;
+    assert_eq!(gate_status(&gates, &read, &ran), "red");
 }
 
 #[test]
@@ -214,7 +378,7 @@ fn failed_blob_write_is_loud_and_cannot_verify_ran() {
     assert_eq!(ran[0].exit, 0);
     assert!(ran[0].stdout_blob.is_none());
     assert!(notes.iter().any(|note| note.contains("not stored")));
-    assert_eq!(ran_status(&gates, &ran), None);
+    assert_eq!(gate_status(&gates, &[], &ran), "unverified");
 }
 
 #[test]

--- a/crates/edda-cli/src/cmd_review/prepare.rs
+++ b/crates/edda-cli/src/cmd_review/prepare.rs
@@ -128,13 +128,16 @@ pub(crate) fn collect_evidence(
         vec![]
     };
     let set = evidence::gate_set(&prepared.fm, &args.gates, &verify);
-    let (mut status, mut read, uncovered) =
+    let (_, mut read, mut uncovered) =
         evidence::read_gates(&prepared.ledger, &prepared.subject.head_sha, &set)?;
     if let Some(pr) = args.pr {
         let checks = evidence::gh_required_checks(&prepared.repo, pr, &prepared.subject.head_sha)?;
-        let (ci, rows) = evidence::read_ci(&checks);
-        status = evidence::combine_gate_status(&status, ci.as_deref());
-        read.extend(rows);
+        let (_, required_rows) = evidence::read_ci(&checks);
+        read.extend(required_rows);
+        let (_, mapped_rows, mapped_gates) =
+            evidence::read_ci_job_map(&checks, &set, &prepared.fm.ci_gates);
+        read.extend(mapped_rows);
+        evidence::remove_mapped_uncovered(&mut uncovered, &mapped_gates);
     }
     let (ran, notes) = if args.run_gates {
         evidence::ran_gates(
@@ -149,8 +152,7 @@ pub(crate) fn collect_evidence(
         (vec![], vec![])
     };
     prepared.notes.extend(notes);
-    status =
-        evidence::combine_gate_status(&status, evidence::ran_status(&set.cmds, &ran).as_deref());
+    let status = evidence::gate_status(&set.cmds, &read, &ran);
     let diff = git::git(
         &prepared.repo,
         &[

--- a/crates/edda-cli/src/cmd_review/verdict.rs
+++ b/crates/edda-cli/src/cmd_review/verdict.rs
@@ -139,7 +139,6 @@ pub(crate) fn qualify(payload: &mut ReviewVerdictPayload, engine: &Qualification
         (payload.verdict == "unreviewed", "unreviewed"),
         (payload.spec.mode != "spec-backed", "spec-convention-only"),
         (payload.gates.status == "undeclared", "gates-undeclared"),
-        (payload.gates.status == "unverified", "gates-unverified"),
         (payload.gates.status == "red", "gates-red"),
         (
             payload.reviewer.model_observed == "unknown",
@@ -342,6 +341,24 @@ mod tests {
         qualify(&mut payload, &engine(true));
         assert!(payload.disqualifiers.contains(&"escalation-pending".into()));
         assert_eq!(exit_code(&payload), 3);
+    }
+
+    #[test]
+    fn unverified_gate_evidence_is_advisory_but_red_and_undeclared_block() {
+        let mut advisory = qualified_payload_with_findings(vec![]);
+        advisory.gates.status = "unverified".into();
+        qualify(&mut advisory, &engine(true));
+        assert!(advisory.qualified, "{:?}", advisory.disqualifiers);
+        assert_eq!(exit_code(&advisory), 0);
+
+        for (status, reason) in [("red", "gates-red"), ("undeclared", "gates-undeclared")] {
+            let mut blocked = qualified_payload_with_findings(vec![]);
+            blocked.gates.status = status.into();
+            qualify(&mut blocked, &engine(true));
+            assert!(!blocked.qualified);
+            assert!(blocked.disqualifiers.contains(&reason.to_owned()));
+            assert_eq!(exit_code(&blocked), 3);
+        }
     }
 
     #[test]

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1236,12 +1236,25 @@ round. With the flag the policy is `model` and any independence other than
 `verified` disqualifies it.
 
 Gates are READ from clean exact-SHA command receipts and required exact-SHA CI.
-When GitHub reports no required checks yet, review still launches and CI evidence
-remains absent/unverified; any red evidence wins. `--run-gates` opts in
-to execution of trusted declared commands, bounded by `--max-ran-sec` (300 by
-default). Cargo gates require an existing `CARGO_TARGET_DIR` build lane.
-`--trust-spec` authorizes issue verify commands; explicit issue selection by
-itself does not. Local specification paths are operator-trusted.
+`REVIEW.md` may map a declared gate command under `ci_gates` to a list of exact
+check-run names. One `ci-job-map` row then reports that gate: every named job at
+the reviewed SHA must succeed for green; any failure is red; missing, pending,
+neutral, or skipped stays pending/unverified. Required-check rows remain visible
+set-level evidence, including their path-filter skip semantics, but required
+green covers no declared gate. Final status is computed per declared gate:
+every gate needs a green receipt or mapped row, or a successful stored
+non-timeout RAN for that same command; those sources may collectively cover the
+set. Unmapped gates remain uncovered. When GitHub reports no required checks
+yet, mapped jobs are not fetched or used, review still launches, and CI
+evidence remains absent/unverified. Unverified gate evidence is advisory for
+review qualification; `red` and `undeclared` still disqualify, and any red
+evidence wins across receipts, required CI, mapped CI, and non-timeout failed
+RAN. `ran_allowlist` is unchanged because reviewer execution capability is not
+the fallback for unavailable evidence. `--run-gates` opts in to execution
+of trusted declared commands, bounded by `--max-ran-sec` (300 by default).
+Cargo gates require an existing `CARGO_TARGET_DIR` build lane. `--trust-spec`
+authorizes issue verify commands; explicit issue selection by itself does not.
+Local specification paths are operator-trusted.
 
 | Exit | Meaning |
 |---|---|

--- a/docs/superpowers/specs/2026-09-02-edda-review-design.md
+++ b/docs/superpowers/specs/2026-09-02-edda-review-design.md
@@ -86,7 +86,7 @@ edda review [--base <ref>] [--head <ref>] [--pr <n>] [--spec <path|#n>] [--trust
 | `--timeout-sec` | 900 | 引擎回合上限 |
 | `--budget-usd` | 無 | pi 生效；codex 無法生效（沿用 dispatch 的警告） |
 | `--run-gates` | 關 | **RAN 唯一的開關**：跑全部宣告的閘門（§6.4）。不開就只 READ |
-| `--max-ran-sec` | 300 | RAN 總時長上限；超過即停，未跑完的閘門 RAN 對它沉默（回報 `None`），狀態依 §8 的格合成——既有的 `verified` 不會被降級 |
+| `--max-ran-sec` | 300 | RAN 總時長上限；超過即停，未跑完或 timeout 的 gate 不取得 RAN coverage；最終狀態依 §8 的 per-gate union 計算 |
 | `--keep-worktree` | 關 | 保留臨時 detached worktree 供除錯 |
 | `--json` | 關 | 印 `review_verdict` payload ＋ `event_id`（unstable；見 §7） |
 
@@ -174,6 +174,9 @@ edda_review: 1
 gates:                      # 宣告的閘門指令，逐字；READ 與 RAN 都以此為準
   - "cargo fmt --all --check"
   - "cargo test --workspace"
+ci_gates:                   # 宣告 gate → exact-head CI check-run 名單
+  "cargo fmt --all --check": ["Format"]
+  "cargo test --workspace": ["Test (ubuntu-latest)", "Test (macos-latest)"]
 ran_allowlist:              # edda 可額外執行的指令前綴（只用於 --help 探測與 --run-gates）
   - "edda "
 independence: session       # session（預設）：session 隔離即獨立；model：要求不同模型且可驗證
@@ -335,12 +338,12 @@ maintainer}` 時）spec 的 `verify` 段逐行。在臨時 worktree **逐字**�
 duration_ms / stdout 尾段 blob`。總時長 `--max-ran-sec` 是**硬期限**：每條閘門以剩餘時間
 spawn、輪詢 `try_wait`，到期就砍**整棵程序樹**——Unix 用 `CommandExt::process_group(0)` 開
 新 process group 並 `kill -9 -- -<pgid>`；Windows 用 `taskkill /PID <pid> /T /F`；只殺 `sh`
-本身不算兌現期限。被殺的閘門記 exit `-1` 與 `timed_out`，剩下的閘門記「未跑」；RAN 對
-未跑完的閘門沉默（回報 `None`）、對實際失敗回報 `red`，狀態依 §8 的格合成——既有的
-`verified` 不會被降級——`notes` 說明。stdout 尾段寫 blob 失敗是**大聲的**：該 RAN 條目
-`stdout_blob = null`、`notes` 記一行，而且這條 RAN 條目不作為 `verified` 的證據——
-`ReviewGateRan` 沒有 per-gate 的結果欄位，任一條目的 blob 存不進去，整個 RAN 就沉默
-（回報 `None`）——最終狀態仍由格合成。
+本身不算兌現期限。被殺的閘門記 exit `-1` 與 `timed_out`，剩下的閘門記「未跑」；未跑完
+或 timeout 的 gate 不取得 RAN coverage，非 timeout 的實際失敗使整個 gate set 為 `red`，
+`notes` 說明。stdout 尾段寫 blob 失敗是**大聲的**：該 RAN 條目
+`stdout_blob = null`、`notes` 記一行，而且這條 RAN 條目不取得 coverage。只有 exit 0、
+`timed_out = false` 且 stdout blob 已成功儲存的 RAN 才覆蓋同 command 的 declared gate；
+最終狀態由 §8 的 per-gate union 計算。
 
 - 白名單裡**沒有** `git *`；edda 自己需要的 git 都是程序內固定子命令。
 - cargo 類閘門（指令以 `cargo ` 開頭）只在環境有 `CARGO_TARGET_DIR` 時執行；沒有就跳過並記
@@ -405,7 +408,7 @@ codex 不回報 usage，預算閘永遠不會觸發——這件事要說出來�
   "independence_policy": "session | model",
   "gates": {"status": "verified | unverified | red | undeclared",
             "declared_by": ["REVIEW.md", "--gate"],
-            "read": [{"kind": "cmd-event | ci", "ref": "evt_… | check-name", "cmd": "cargo test --workspace",
+            "read": [{"kind": "cmd-event | ci | ci-job-map", "ref": "evt_… | check-name | exact-name=status, …", "cmd": "cargo test --workspace",
                       "result": "green | red | pending"}],
             "ran": [{"cmd": "cargo test -p edda-core", "exit": 0, "duration_ms": 41200, "stdout_blob": "… | null", "timed_out": false}]},
   "probes": [{"cmd": "edda wave --help", "exit": 2}],
@@ -424,10 +427,12 @@ codex 不回報 usage，預算閘永遠不會觸發——這件事要說出來�
 ```
 
 - `qualified` 由 edda 計算：`verdict ≠ unreviewed` ∧ `spec.mode = spec-backed` ∧
-  `gates.status = verified` ∧ `model_observed ≠ unknown` ∧ `parse = ok` ∧ `coverage = full` ∧
-  `tool_policy = hard` ∧ 無 `model-mismatch` ∧（僅當 `independence_policy = model` 時）
-  `independence = verified`。不成立的條件逐一列在 `disqualifiers`（`spec-convention-only`、
-  `gates-undeclared`、`gates-unverified`、`gates-red`、`model-unknown`、`model-mismatch`、
+  `gates.status ∉ {undeclared, red}` ∧ `model_observed ≠ unknown` ∧ `parse = ok` ∧
+  `coverage = full` ∧ `tool_policy = hard` ∧ 無 `model-mismatch` ∧（僅當
+  `independence_policy = model` 時）`independence = verified`。`unverified` 保留在
+  `gates.status`、rows、uncovered 與 notes，屬 advisory，不再自動產生 disqualifier。
+  其他不成立條件逐一列在 `disqualifiers`（`spec-convention-only`、
+  `gates-undeclared`、`gates-red`、`model-unknown`、`model-mismatch`、
   `coverage-partial`、`tool-policy-none`；`model` 政策下另有 `independence-unverified`、
   `independence-same-model`）。
 - finding 在 payload 裡的 `id` 是事件內的 `fN`（事件 id 在寫入前不存在，無法內嵌）；
@@ -455,31 +460,41 @@ vacuous verified——不然沒寫 `REVIEW.md` 的 repo 免費拿到 verified。
 exit 0 → `green`；非 0 → `red`；沒有 → 該 gate 未涵蓋。全部 green → `verified`；
 任一 red → `red`；有未涵蓋（且 `--run-gates` 沒補上）→ `unverified`，輸出印
 「run `edda run -- <gate>` at <head12> on a clean tree, or pass --run-gates」。
-`--pr` 時另讀 exact-head CI，**釘在 `head_sha`**：`gh api repos/{o}/{r}/commits/<head_sha>/check-runs`
-取該 SHA 的 check-runs（name / status / conclusion），再用 `gh pr checks <n> --required --json name`
-取 required 名單做交集；PR 在解析後被 push 也不會把新 head 的綠記到受審 SHA 上。required
-全部 `completed` + `success`（或 `skipped`）→ verified；任一 `failure` / `cancelled` / `timed_out`
-→ red；有 `in_progress` / `queued` → `pending`（`read[].result` 的合法值：`green | red | pending`），
-CI 對這件事的回報是 `unverified`——它在格上是中性的，不改變其他來源已建立的結論。`neutral` **不算綠**——它的語意是「這個 check 放棄判定」。required 名單為空時
-CI 對本 head 沒有任何主張，直接不貢獻（**不可**退回「所有 optional check 都算」，否則沒設分支
-保護的 repo 用任何一個碰巧綠的 job 就買到 verified）。
+`--pr` 時另讀 exact-head CI，**釘在 `head_sha`**：先用
+`gh pr checks <n> --required --json name` 取 required 名單；名單非空才以
+`gh api repos/{o}/{r}/commits/<head_sha>/check-runs` 取該 SHA 的 check-runs
+（name / status / conclusion），同名重跑取最大 id。PR 在解析後被 push 也不會把新
+head 的綠記到受審 SHA 上。required rows 保留為 set-level evidence：全部
+`completed` + `success`（或既有 path-filter 語意接受的 `skipped`）→ verified；任一
+`failure` / `cancelled` / `timed_out` → red；其他 → pending/unverified。
 
-**三個證據來源，一條格（lattice）**：閘門集合非空時，本地收據、exact-head required CI、
-`--run-gates` 的 RAN 是對同一件事的三個獨立來源，合成規則只有一條，三者共用：
+front matter 的 `ci_gates` 是 gate command → exact check-run name list。只為已宣告且
+有 mapping 的 gate 產一筆 `kind = ci-job-map` row；所有列名在 exact head 都是
+`success` 才 green，任一 failure 就 red，missing / pending / neutral / skipped 都是
+pending/unverified。`ref` 逐一列出 exact name 與 bucket，不能用 glob 或推斷配對。
+有 mapped row 的 gate 不再同時列作 uncovered；沒有 mapping 的 gate 仍 uncovered。
+required 名單為空時不 fetch、不使用 mapped jobs，CI 完全不貢獻（**不可**退回「所有
+optional check 都算」，否則沒設分支保護的 repo 用任何一個碰巧綠的 job 就買到
+verified）。API、JSON、bounded capture、pagination 或 SHA 驗證失敗都 fail closed。
+`neutral` 不算綠；`skipped` 可被 required set-level 規則接受，但永不成為綠色 per-gate row。
+`ran_allowlist` 不變：reviewer 的執行能力不是 CI 證據不可用時的 fallback。
+
+**最終狀態採 per-declared-gate union**，不是把四個來源各自先壓成 set-level status 再做
+coarse lattice。規則依序為：
 
 | 規則 | 說明 |
 |---|---|
-| `undeclared` 吸收一切 | 沒宣告 gate 就沒有東西可證；CI 再綠、RAN 再乾淨都蓋不過去 |
-| 任一 `red` 即 `red` | 任何一處失敗就是失敗 |
-| 否則任一 `verified` 即 `verified` | 獨立來源指向同一事實，擇一即可 |
-| 否則 `unverified` | |
-| **沉默的來源不改變狀態** | 某來源「沒話說」（RAN 因無 build lane 或期限而跳過、`--pr` 之外沒有 CI）時，狀態原封不動——**任何來源都不得把別的來源已建立的結論降級** |
+| 空 gate set → `undeclared` | 沒宣告 gate 就沒有東西可證；CI 再綠、RAN 再乾淨都不能變成 verified |
+| 任一 red → `red` | 任一 local receipt、required-CI row、mapped row，或非 timeout 的 RAN 失敗都 globally dominate |
+| 每個 declared gate 都有 eligible green → `verified` | 同 command 的 green `cmd-event`、green `ci-job-map`，或 exit 0 + stored stdout + non-timeout RAN 可覆蓋該 gate；不同來源可各自覆蓋一部分 gate |
+| 其餘 → `unverified` | missing/pending/skipped、無 mapping、timeout、未執行或 RAN blob 未儲存都不提供 coverage |
 
-要求兩者同時 verified 會讓「CI 全綠但作者沒在本機留收據」的 PR 讀成 unverified，那是把
-證據當儀式（Round 5 P1）；而讓跳過的 RAN 把 verified 降成 unverified 是同一個錯誤的另一面
-（Round 6 P1）。實作上這條規則寫成**單一函式** `combine_gate_status(current, incoming)`——
-本地 READ 是 accumulator 的**初值**（`read_gates` 直接回傳起始 status），CI 與 RAN 各呼叫
-它一次——這條規則被分別重述兩次，就被破壞了兩次。
+required-CI row 是 set-level 可見證據：red 仍 globally dominate，但 green **永遠不覆蓋任何
+單一 declared gate**，即使 required check name 恰好等於 gate command。mapped row 的既有
+聚合不變：所有 exact names pass 才 green，任一 fail 為 red，其餘 pending。這使 partial
+receipt green 加 partial mapped green 可以合起來驗證整個集合，也使成功且有 blob 的 RAN
+只補上仍缺 coverage 的同名 gate，而不替其他 gate 背書。實作上由單一 `gate_status(gates,
+read, ran)` 在 READ 與 RAN 都收集後計算，避免 set-level green 偽造整組 coverage。
 
 PR body 裡的散文 L1 receipt 不解析；fleet 在一個迭代內改用 `edda run -- <gate>` 產收據。
 
@@ -497,11 +512,13 @@ PR body 裡的散文 L1 receipt 不解析；fleet 在一個迭代內改用 `edda
 | provider 過載 | 不換模型（`fleet.review-provider-overload`），`outcome = overload`，exit 2 |
 | diff 超預算 | 按類別優先截，`coverage = partial`，不合格；`code-risk` 本身超預算 → exit 2 |
 | 閘門集合為空 | `gates.status = undeclared`，不合格，印宣告方式 |
+| gate 證據 missing / pending / neutral / skipped | `gates.status = unverified` 並保留 rows/uncovered；advisory，單獨不使 LGTM 不合格；skipped 不是綠色 per-gate claim |
+| mapped 或 required CI 任一 red | `gates.status = red`，不合格；其他來源的綠不能蓋過 |
 | `model_observed` 拿不到 | 照審，`unknown`，不合格 |
 | 同模型不同 session | 照審，`same-model`；預設政策合格，`model` 政策不合格 |
 | 模型寫法對照表不認得 | 該來源 `unverified`；絕不記 `verified`；只在 `model` 政策下不合格 |
-| `--run-gates` 但 cargo 閘門而無 `CARGO_TARGET_DIR` | 該閘門跳過並說明（RAN 對它沉默，回報 `None`），狀態依 §8 的格合成 |
-| RAN 超時 | RAN 對未跑完的閘門沉默（回報 `None`），狀態依 §8 的格合成，既有的 `verified` 不會被降級；說明哪些沒跑 |
+| `--run-gates` 但 cargo 閘門而無 `CARGO_TARGET_DIR` | 該閘門跳過並說明；RAN 不提供該 gate 的 coverage，狀態依 §8 的 per-gate union 計算 |
+| RAN 超時 | timeout 與未跑完的 gate 不取得 RAN coverage；其他 eligible green 仍可覆蓋它，否則 `unverified`；說明哪些沒跑 |
 | spec 來自 `untrusted` issue | 照審；`verify` 欄不執行 |
 | 臨時 worktree 移除失敗 | 警告＋`notes`，判決不受影響 |
 
@@ -515,7 +532,9 @@ PR body 裡的散文 L1 receipt 不解析；fleet 在一個迭代內改用 `edda
   history_rewritten（tempfile git repo 造分支、rebase；**main 上有 verdict 的 commit 不得
   成為新分支的 supersedes**）；`qualified` 真值表（每個 disqualifier 各一列）；輸出區塊解析
   （合法、缺區塊、壞 JSON、非法 verdict、`subject_seen` 不符）；`cmd` 事件收據比對
-  （sha 不符、tree dirty、argv 正規化、exit 非 0）；front matter 解析（缺、版本不認得、壞 YAML）；
+  （sha 不符、tree dirty、argv 正規化、exit 非 0）；per-gate evidence union（required green
+  不提供 coverage、receipt/mapped/RAN 可分別補齊、任一 red globally dominate、RAN 必須
+  exit 0 + stored stdout + non-timeout）；front matter 解析（缺、版本不認得、壞 YAML）；
   **`canonical_model_id()` 每對來源一個測試**（trailer × modelUsage × pi session × 收據），
   以及不認得的寫法回 `unverified`；exit code 四值；`spec.trust` 三級與 `verify` 欄是否進白名單；
   diff 截斷保留 `code-risk`；base 解析鏈。


### PR DESCRIPTION
Issue: #1136

## Summary
- implement controller ruling d-001 with a generic declared-gate to exact CI check-run map
- aggregate green evidence per declared gate across receipts, mapped CI, and stored successful RAN
- keep required green visibility-only, red evidence globally dominant, and unverified advisory
- update REVIEW.md to review-spec-v1.7 and align CLI/design documentation

## Scope
This is d-001 only. The closing keyword is intentionally omitted because #1136's dirty-path receipt relevance and fixtures remain for the later slice.

REVIEW.md is read from the base SHA, so this PR is reviewed under the base REVIEW.md and its new mapping cannot be used by `edda review` until it lands on `main`. Per d-001, the live mapped-gate measurement is deferred until then.

## Validation
- `CARGO_TARGET_DIR=C:/Users/fagem/AppData/Local/fleet-workstation/lanes/worker-1 cargo test -p edda cmd_review::brief::tests`
- `CARGO_TARGET_DIR=C:/Users/fagem/AppData/Local/fleet-workstation/lanes/worker-1 cargo test -p edda cmd_review::evidence::`
- `CARGO_TARGET_DIR=C:/Users/fagem/AppData/Local/fleet-workstation/lanes/worker-1 cargo test -p edda cmd_review::verdict::tests`
- `CARGO_TARGET_DIR=C:/Users/fagem/AppData/Local/fleet-workstation/lanes/worker-1 cargo clippy -p edda --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=C:/Users/fagem/AppData/Local/fleet-workstation/lanes/worker-1 cargo fmt --all --check`
- `sh scripts/test-review-l0.sh`
- `sh scripts/lint-markdown-content.sh`
- `bash scripts/lint-doc-citations.sh --tree`
- `sh scripts/lint-file-length.sh --tree`
- `git diff --check`

Exact-head CI is L1; no full workspace gate was run locally.