### PR TITLE
feat(edda-cli): add path-aware dirty receipts

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -33,7 +33,7 @@ classes:
 
 # REVIEW.md — the executable review spec
 
-- Spec version: `review-spec-v1.7`
+- Spec version: `review-spec-v1.8`
 - Audience: anyone — human or engine — reviewing a pull request in this
   repository, and any script that builds a review brief.
 - Status: this file is the **single source of truth** for how a PR is reviewed
@@ -409,6 +409,19 @@ cover different gates. A green required-CI row remains visible set-level
 evidence but covers no declared gate; any gate without eligible green evidence
 keeps the set unverified. Unknown evidence is advisory; deterministically red
 mapped or required CI remains blocking.
+
+Exact-head local receipts are relevant/scoped, not clean-only. A legacy receipt
+with `tree_dirty=false` and no `tree_dirty_paths` remains eligible. A path-aware
+dirty receipt is eligible, and visibly reads as `cmd-event-scoped`, only when
+its tracked list is empty and every untracked root-relative Git `/` path is
+outside the reviewed subject and matches this measured inert positive
+allowlist: `docs/archive/**`, `.tmp-fleet/**`, `codereviews/**`, or root
+`edda_tmp_*.txt`. Tracked dirt always rejects, even outside the subject.
+Unknown, null, malformed, inconsistent, empty, absolute, parent-traversing,
+control-character, source/control, and all other untracked paths reject. A
+legacy dirty receipt remains ineligible. These rejected states provide no
+evidence rather than being inferred safe from the PR file list; a scoped
+receipt's command exit still decides green (0) or red (nonzero).
 
 The workspace Cargo `gates:` entries above are READ from those job results,
 never RAN by the reviewer (`ladder` L1: CI is the workspace gate; C5 is the
@@ -830,7 +843,7 @@ One comment per round, pinned to the reviewed full SHA
 - model_requested: <the model dispatch asked for>
 - model_observed: <read from the system, or "unverified">
 - reviewer_session: <per-PR UUID the lane was launched with>
-- spec: review-spec-v1.7
+- spec: review-spec-v1.8
 - class: <code-risk | docs-skills>  (REVIEW.md classes: <docs|skills|code-plain|code-risk ...>)
 - escalations: <list of 需升級 items, or "none">
 - shadow: true|false  (documentation for a SHADOW round: true requires the heading suffix ` (SHADOW)` — `## Code Review: Round <N> (SHADOW) — PR #<n> @ <full 40-hex SHA>`; the suffix is the only marker, this field never substitutes for it; a SHADOW round is never a verdict — §8)
@@ -1058,6 +1071,14 @@ mechanical.
   evidence becomes advisory; red and undeclared remain qualification blockers.
   `ran_allowlist` is unchanged because execution capability is not a fallback
   for unavailable evidence.
+- `review-spec-v1.8` (2026-09-11, issue #1136 d-002): exact-head command
+  receipts become path-aware without treating ambient inputs as clean. Legacy
+  clean receipts remain compatible. Dirty receipts cover a gate only as
+  visible `cmd-event-scoped` evidence when tracked dirt is empty and every
+  untracked path is outside the subject and in the four measured inert
+  patterns named by U6. Tracked, control/source, unknown, malformed, or
+  inconsistent dirt never becomes evidence. CI mapping and advisory-unverified
+  semantics from v1.7, and the unchanged `ran_allowlist`, remain intact.
 
 Changing a rule here changes the line for every engine. Record the version in
 each verdict's `spec:` field so catch rates stay readable against the spec they

--- a/crates/edda-cli/src/cmd_review/evidence.rs
+++ b/crates/edda-cli/src/cmd_review/evidence.rs
@@ -49,7 +49,12 @@ pub(crate) fn gate_set(fm: &FrontMatter, cli: &[String], verify: &[String]) -> G
 
 pub(crate) type GateRead = (String, Vec<ReviewGateRead>, Vec<String>);
 
-pub(crate) fn read_gates(ledger: &Ledger, head: &str, gates: &GateSet) -> anyhow::Result<GateRead> {
+pub(crate) fn read_gates(
+    ledger: &Ledger,
+    head: &str,
+    gates: &GateSet,
+    subject_files: &[String],
+) -> anyhow::Result<GateRead> {
     if gates.cmds.is_empty() {
         return Ok(("undeclared".into(), vec![], vec![]));
     }
@@ -57,18 +62,21 @@ pub(crate) fn read_gates(ledger: &Ledger, head: &str, gates: &GateSet) -> anyhow
     let mut read = Vec::new();
     let mut uncovered = Vec::new();
     for gate in &gates.cmds {
-        let best = events.iter().rev().find(|event| {
+        let best = events.iter().rev().find_map(|event| {
             let payload = &event.payload;
-            payload["git_sha"].as_str() == Some(head)
-                && payload["tree_dirty"].as_bool() == Some(false)
-                && payload["argv"]
-                    .as_array()
-                    .and_then(|args| args.iter().map(|a| a.as_str()).collect::<Option<Vec<_>>>())
-                    .is_some_and(|args| normalize_cmd(&args.join(" ")) == normalize_cmd(gate))
+            let command_matches = payload["argv"]
+                .as_array()
+                .and_then(|args| args.iter().map(|a| a.as_str()).collect::<Option<Vec<_>>>())
+                .is_some_and(|args| normalize_cmd(&args.join(" ")) == normalize_cmd(gate));
+            if payload["git_sha"].as_str() == Some(head) && command_matches {
+                eligible_receipt_kind(payload, subject_files).map(|kind| (event, kind))
+            } else {
+                None
+            }
         });
-        if let Some(event) = best {
+        if let Some((event, kind)) = best {
             read.push(ReviewGateRead {
-                kind: "cmd-event".into(),
+                kind: kind.into(),
                 r#ref: event.event_id.clone(),
                 cmd: gate.clone(),
                 result: if event.payload["exit_code"].as_i64() == Some(0) {
@@ -90,6 +98,87 @@ pub(crate) fn read_gates(ledger: &Ledger, head: &str, gates: &GateSet) -> anyhow
         "unverified"
     };
     Ok((status.into(), read, uncovered))
+}
+
+fn eligible_receipt_kind(
+    payload: &serde_json::Value,
+    subject_files: &[String],
+) -> Option<&'static str> {
+    let dirty = payload.get("tree_dirty")?.as_bool()?;
+    let Some(paths_value) = payload.get("tree_dirty_paths") else {
+        return (!dirty).then_some("cmd-event");
+    };
+    let object = paths_value.as_object()?;
+    if object.len() != 2 {
+        return None;
+    }
+    let tracked = strict_path_array(object.get("tracked")?)?;
+    let untracked = strict_path_array(object.get("untracked")?)?;
+    let has_paths = !tracked.is_empty() || !untracked.is_empty();
+    if dirty != has_paths || !tracked.is_empty() {
+        return None;
+    }
+    if !dirty {
+        return Some("cmd-event");
+    }
+    let subjects = subject_files
+        .iter()
+        .map(|path| path.replace('\\', "/"))
+        .collect::<Vec<_>>();
+    untracked
+        .iter()
+        .all(|path| {
+            inert_untracked_path(path)
+                && !subjects
+                    .iter()
+                    .any(|subject| git_paths_intersect(path, subject))
+        })
+        .then_some("cmd-event-scoped")
+}
+
+fn strict_path_array(value: &serde_json::Value) -> Option<Vec<&str>> {
+    let paths = value
+        .as_array()?
+        .iter()
+        .map(serde_json::Value::as_str)
+        .collect::<Option<Vec<_>>>()?;
+    if paths.iter().any(|path| !valid_git_path(path))
+        || paths.windows(2).any(|pair| pair[0] >= pair[1])
+    {
+        return None;
+    }
+    Some(paths)
+}
+
+fn valid_git_path(path: &str) -> bool {
+    !path.is_empty()
+        && !path.starts_with('/')
+        && !path.contains('\\')
+        && !path.chars().any(char::is_control)
+        && !matches!(path.as_bytes().get(1), Some(b':'))
+        && path
+            .split('/')
+            .all(|component| !component.is_empty() && !matches!(component, "." | ".."))
+}
+
+fn inert_untracked_path(path: &str) -> bool {
+    ["docs/archive/", ".tmp-fleet/", "codereviews/"]
+        .iter()
+        .any(|prefix| {
+            path.strip_prefix(prefix)
+                .is_some_and(|tail| !tail.is_empty())
+        })
+        || (!path.contains('/') && path.starts_with("edda_tmp_") && path.ends_with(".txt"))
+}
+
+fn git_paths_intersect(left: &str, right: &str) -> bool {
+    left == right
+        || left
+            .strip_prefix(right)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+        || right
+            .strip_prefix(left)
+            .is_some_and(|suffix| suffix.starts_with('/'))
 }
 
 pub(crate) fn read_ci(checks: &GitHubChecks) -> (Option<String>, Vec<ReviewGateRead>) {
@@ -228,7 +317,10 @@ pub(crate) fn gate_status(
         read.iter().any(|row| {
             row.cmd == *gate
                 && row.result == "green"
-                && matches!(row.kind.as_str(), "cmd-event" | "ci-job-map")
+                && matches!(
+                    row.kind.as_str(),
+                    "cmd-event" | "cmd-event-scoped" | "ci-job-map"
+                )
         }) || ran.iter().any(|row| {
             row.cmd == *gate && row.exit == 0 && !row.timed_out && row.stdout_blob.is_some()
         })
@@ -306,7 +398,8 @@ pub(crate) fn evidence_text(
     probes: &[ReviewProbe],
     wiring_scan: Option<&str>,
 ) -> String {
-    let mut text = String::from("### Gates READ (exact head, clean tree receipts / required CI)\n");
+    let mut text =
+        String::from("### Gates READ (exact-head relevant/scoped receipts and required CI)\n");
     for r in read {
         text.push_str(&format!(
             "- {:?}: {} ({} {:?})\n",

--- a/crates/edda-cli/src/cmd_review/evidence/tests.rs
+++ b/crates/edda-cli/src/cmd_review/evidence/tests.rs
@@ -1,5 +1,8 @@
 use super::*;
-use edda_core::event::{new_cmd_event_with_git_context, CmdEventParams};
+use edda_core::event::{
+    finalize_event, new_cmd_event_with_git_context, new_cmd_event_with_git_context_and_dirty_paths,
+    CmdEventParams,
+};
 use std::collections::BTreeMap;
 
 fn ci(required: &[&str], runs: &[(&str, &str)]) -> GitHubChecks {
@@ -32,18 +35,252 @@ fn receipt(ledger: &Ledger, command: &[&str], sha: &str, dirty: bool, exit: i32)
     ledger.append_event(&event).unwrap();
 }
 
+fn path_receipt(
+    ledger: &Ledger,
+    command: &[&str],
+    sha: &str,
+    dirty: Option<bool>,
+    tracked: &[&str],
+    untracked: &[&str],
+    exit: i32,
+) {
+    let args = command.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+    let tracked = tracked.iter().map(|s| (*s).to_owned()).collect::<Vec<_>>();
+    let untracked = untracked
+        .iter()
+        .map(|s| (*s).to_owned())
+        .collect::<Vec<_>>();
+    let event = new_cmd_event_with_git_context_and_dirty_paths(
+        &CmdEventParams {
+            branch: "main",
+            parent_hash: ledger.last_event_hash().unwrap().as_deref(),
+            argv: &args,
+            cwd: "/repo",
+            exit_code: exit,
+            duration_ms: 1,
+            stdout_blob: "",
+            stderr_blob: "",
+        },
+        Some(sha),
+        dirty,
+        Some((&tracked, &untracked)),
+    )
+    .unwrap();
+    ledger.append_event(&event).unwrap();
+}
+
+fn malformed_path_receipt(ledger: &Ledger, dirty: Option<bool>, paths: serde_json::Value) {
+    let args = vec!["gate".to_owned()];
+    let mut event = new_cmd_event_with_git_context(
+        &CmdEventParams {
+            branch: "main",
+            parent_hash: ledger.last_event_hash().unwrap().as_deref(),
+            argv: &args,
+            cwd: "/repo",
+            exit_code: 0,
+            duration_ms: 1,
+            stdout_blob: "",
+            stderr_blob: "",
+        },
+        Some("head"),
+        dirty,
+    )
+    .unwrap();
+    event.payload["tree_dirty_paths"] = paths;
+    finalize_event(&mut event).unwrap();
+    ledger.append_event(&event).unwrap();
+}
+
 #[test]
-fn receipt_matching_requires_exact_clean_head_and_latest_event() {
+fn legacy_receipts_require_exact_clean_head_and_use_latest_eligible_event() {
     let dir = tempfile::tempdir().unwrap();
     let ledger = Ledger::open_or_init(dir.path()).unwrap();
     let gates = gate_set(&FrontMatter::default(), &["cargo  test -p x".into()], &[]);
     receipt(&ledger, &["cargo", "test", "-p", "x"], "other", false, 0);
     receipt(&ledger, &["cargo", "test", "-p", "x"], "head", true, 0);
-    assert_eq!(read_gates(&ledger, "head", &gates).unwrap().0, "unverified");
+    assert_eq!(
+        read_gates(&ledger, "head", &gates, &[]).unwrap().0,
+        "unverified"
+    );
     receipt(&ledger, &["cargo", "test", "-p", "x"], "head", false, 0);
-    assert_eq!(read_gates(&ledger, "head", &gates).unwrap().0, "verified");
+    receipt(&ledger, &["cargo", "test", "-p", "x"], "head", true, 1);
+    assert_eq!(
+        read_gates(&ledger, "head", &gates, &[]).unwrap().0,
+        "verified"
+    );
     receipt(&ledger, &["cargo", "test", "-p", "x"], "head", false, 1);
-    assert_eq!(read_gates(&ledger, "head", &gates).unwrap().0, "red");
+    assert_eq!(read_gates(&ledger, "head", &gates, &[]).unwrap().0, "red");
+}
+
+#[test]
+fn scoped_untracked_receipt_is_visible_and_subject_sensitive() {
+    let dir = tempfile::tempdir().unwrap();
+    let ledger = Ledger::open_or_init(dir.path()).unwrap();
+    let gates = gate_set(&FrontMatter::default(), &["gate".into()], &[]);
+    path_receipt(
+        &ledger,
+        &["gate"],
+        "head",
+        Some(true),
+        &[],
+        &[".tmp-fleet/probe.txt"],
+        0,
+    );
+    let (_, rows, _) = read_gates(&ledger, "head", &gates, &["crates/x.rs".into()]).unwrap();
+    assert_eq!(rows[0].kind, "cmd-event-scoped");
+    assert_eq!(rows[0].result, "green");
+    assert_eq!(
+        read_gates(&ledger, "head", &gates, &[".tmp-fleet/probe.txt".into()])
+            .unwrap()
+            .0,
+        "unverified"
+    );
+}
+
+#[test]
+fn only_measured_inert_untracked_patterns_are_eligible() {
+    let dir = tempfile::tempdir().unwrap();
+    let ledger = Ledger::open_or_init(dir.path()).unwrap();
+    let gates = gate_set(&FrontMatter::default(), &["gate".into()], &[]);
+    path_receipt(
+        &ledger,
+        &["gate"],
+        "head",
+        Some(true),
+        &[],
+        &[
+            ".tmp-fleet/a",
+            "codereviews/a.txt",
+            "docs/archive/a.md",
+            "edda_tmp_a.txt",
+        ],
+        0,
+    );
+    assert_eq!(
+        read_gates(&ledger, "head", &gates, &["src/lib.rs".into()])
+            .unwrap()
+            .0,
+        "verified"
+    );
+}
+
+#[test]
+fn tracked_and_control_source_or_unknown_untracked_paths_are_rejected() {
+    let gates = gate_set(&FrontMatter::default(), &["gate".into()], &[]);
+    for (label, tracked, untracked) in [
+        ("tracked", vec!["README.md"], vec![]),
+        ("control", vec![], vec![".cargo/config.toml"]),
+        ("source", vec![], vec!["crates/edda/src/main.rs"]),
+        ("unknown", vec![], vec!["notes/probe.txt"]),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Ledger::open_or_init(dir.path()).unwrap();
+        path_receipt(
+            &ledger,
+            &["gate"],
+            "head",
+            Some(true),
+            &tracked,
+            &untracked,
+            0,
+        );
+        assert_eq!(
+            read_gates(&ledger, "head", &gates, &["subject.rs".into()])
+                .unwrap()
+                .0,
+            "unverified",
+            "{label}"
+        );
+    }
+}
+
+#[test]
+fn malformed_and_inconsistent_path_payloads_are_rejected() {
+    let gates = gate_set(&FrontMatter::default(), &["gate".into()], &[]);
+    let cases = [
+        (Some(true), serde_json::Value::Null),
+        (Some(false), serde_json::Value::Null),
+        (
+            Some(true),
+            serde_json::json!({"tracked": [], "untracked": []}),
+        ),
+        (
+            Some(false),
+            serde_json::json!({"tracked": [], "untracked": [".tmp-fleet/x"]}),
+        ),
+        (None, serde_json::json!({"tracked": [], "untracked": []})),
+        (Some(true), serde_json::json!({"tracked": []})),
+        (
+            Some(true),
+            serde_json::json!({"tracked": [], "untracked": ".tmp-fleet/x"}),
+        ),
+        (
+            Some(true),
+            serde_json::json!({"tracked": [], "untracked": [".tmp-fleet/x"], "extra": []}),
+        ),
+        (
+            Some(true),
+            serde_json::json!({"tracked": [], "untracked": [".tmp-fleet/z", ".tmp-fleet/a"]}),
+        ),
+        (
+            Some(true),
+            serde_json::json!({"tracked": [], "untracked": [".tmp-fleet/a", ".tmp-fleet/a"]}),
+        ),
+    ];
+    for (dirty, paths) in cases {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Ledger::open_or_init(dir.path()).unwrap();
+        malformed_path_receipt(&ledger, dirty, paths);
+        assert_eq!(
+            read_gates(&ledger, "head", &gates, &[]).unwrap().0,
+            "unverified"
+        );
+    }
+}
+
+#[test]
+fn unsafe_path_shapes_never_become_scoped_evidence() {
+    let gates = gate_set(&FrontMatter::default(), &["gate".into()], &[]);
+    for path in [
+        "",
+        "/docs/archive/x",
+        "docs/archive/../x",
+        "docs/archive/control\n.txt",
+        "docs\\archive\\x",
+        "C:/docs/archive/x",
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Ledger::open_or_init(dir.path()).unwrap();
+        path_receipt(&ledger, &["gate"], "head", Some(true), &[], &[path], 0);
+        assert_eq!(
+            read_gates(&ledger, "head", &gates, &[]).unwrap().0,
+            "unverified",
+            "{path:?}"
+        );
+    }
+}
+
+#[test]
+fn known_clean_path_receipt_is_normal_and_scoped_failure_is_red() {
+    let dir = tempfile::tempdir().unwrap();
+    let ledger = Ledger::open_or_init(dir.path()).unwrap();
+    let gates = gate_set(&FrontMatter::default(), &["gate".into()], &[]);
+    path_receipt(&ledger, &["gate"], "head", Some(false), &[], &[], 0);
+    let (_, rows, _) = read_gates(&ledger, "head", &gates, &[]).unwrap();
+    assert_eq!(rows[0].kind, "cmd-event");
+    path_receipt(
+        &ledger,
+        &["gate"],
+        "head",
+        Some(true),
+        &[],
+        &["codereviews/failure.txt"],
+        7,
+    );
+    let (status, rows, _) = read_gates(&ledger, "head", &gates, &[]).unwrap();
+    assert_eq!(status, "red");
+    assert_eq!(rows[0].kind, "cmd-event-scoped");
+    assert_eq!(rows[0].result, "red");
 }
 
 #[test]
@@ -55,7 +292,7 @@ fn unreadable_ledger_is_an_error_not_uncovered_evidence() {
         .execute("ALTER TABLE events RENAME TO unavailable_events", [])
         .unwrap();
     let gates = gate_set(&FrontMatter::default(), &["echo hi".into()], &[]);
-    assert!(read_gates(&ledger, "head", &gates).is_err());
+    assert!(read_gates(&ledger, "head", &gates, &[]).is_err());
 }
 
 #[test]
@@ -81,7 +318,8 @@ fn gate_commands_preserve_semantic_whitespace() {
         read_gates(
             &ledger,
             "head",
-            &gate_set(&FrontMatter::default(), &[], &[])
+            &gate_set(&FrontMatter::default(), &[], &[]),
+            &[],
         )
         .unwrap()
         .0,
@@ -238,12 +476,21 @@ fn receipt_required_and_mapped_red_each_globally_dominate() {
 }
 
 #[test]
-fn partial_receipt_and_partial_mapped_green_collectively_verify() {
+fn scoped_receipt_and_partial_mapped_green_collectively_verify() {
     let gates = gate_set(&FrontMatter::default(), &["fmt".into(), "test".into()], &[]);
     let dir = tempfile::tempdir().unwrap();
     let ledger = Ledger::open_or_init(dir.path()).unwrap();
-    receipt(&ledger, &["fmt"], "head", false, 0);
-    let (_, mut read, _) = read_gates(&ledger, "head", &gates).unwrap();
+    path_receipt(
+        &ledger,
+        &["fmt"],
+        "head",
+        Some(true),
+        &[],
+        &["docs/archive/receipt.txt"],
+        0,
+    );
+    let (_, mut read, _) = read_gates(&ledger, "head", &gates, &["crates/x.rs".into()]).unwrap();
+    assert_eq!(read[0].kind, "cmd-event-scoped");
 
     let checks = ci(&["CI Gate"], &[("CI Gate", "pass"), ("Test", "pass")]);
     read.extend(read_ci(&checks).1);
@@ -282,7 +529,7 @@ fn mapped_gate_is_not_also_uncovered_but_unmapped_gate_stays_visible() {
     );
     let dir = tempfile::tempdir().unwrap();
     let ledger = Ledger::open_or_init(dir.path()).unwrap();
-    let (_, mut read, mut uncovered) = read_gates(&ledger, "head", &gates).unwrap();
+    let (_, mut read, mut uncovered) = read_gates(&ledger, "head", &gates, &[]).unwrap();
     let mappings = BTreeMap::from([(mapped_gate.into(), vec!["Format".into()])]);
     let checks = ci(&["CI Gate"], &[("Format", "pass")]);
     let (_, mapped_rows, mapped) = read_ci_job_map(&checks, &gates, &mappings);

--- a/crates/edda-cli/src/cmd_review/prepare.rs
+++ b/crates/edda-cli/src/cmd_review/prepare.rs
@@ -128,8 +128,12 @@ pub(crate) fn collect_evidence(
         vec![]
     };
     let set = evidence::gate_set(&prepared.fm, &args.gates, &verify);
-    let (_, mut read, mut uncovered) =
-        evidence::read_gates(&prepared.ledger, &prepared.subject.head_sha, &set)?;
+    let (_, mut read, mut uncovered) = evidence::read_gates(
+        &prepared.ledger,
+        &prepared.subject.head_sha,
+        &set,
+        &prepared.subject.files,
+    )?;
     if let Some(pr) = args.pr {
         let checks = evidence::gh_required_checks(&prepared.repo, pr, &prepared.subject.head_sha)?;
         let (_, required_rows) = evidence::read_ci(&checks);
@@ -265,4 +269,48 @@ pub(crate) fn assemble(
         classes,
         qualified,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmd_review::git::testrepo;
+    use edda_core::event::{new_cmd_event_with_git_context_and_dirty_paths, CmdEventParams};
+
+    #[test]
+    fn evidence_selection_receives_the_reviewed_subject_files() {
+        let (_temp, root) = testrepo::init();
+        testrepo::run(&root, &["checkout", "-qb", "feature"]);
+        std::fs::create_dir_all(root.join("docs/archive")).expect("archive dir");
+        let subject_path = "docs/archive/probe.txt";
+        let head = testrepo::commit_file(&root, subject_path, "subject\n", "feature change");
+        let ledger = Ledger::open_or_init(&root).expect("ledger");
+        let argv = vec!["gate".to_owned()];
+        let untracked = vec![subject_path.to_owned()];
+        let event = new_cmd_event_with_git_context_and_dirty_paths(
+            &CmdEventParams {
+                branch: "main",
+                parent_hash: ledger.last_event_hash().expect("parent").as_deref(),
+                argv: &argv,
+                cwd: root.to_str().expect("utf8 root"),
+                exit_code: 0,
+                duration_ms: 1,
+                stdout_blob: "",
+                stderr_blob: "",
+            },
+            Some(&head),
+            Some(true),
+            Some((&[], &untracked)),
+        )
+        .expect("receipt");
+        ledger.append_event(&event).expect("append receipt");
+        let args = ReviewArgs {
+            gates: vec!["gate".into()],
+            ..Default::default()
+        };
+        let mut prepared = prepare(&args, &root).expect("prepare");
+        let (gates, _, _) = collect_evidence(&mut prepared, &args, &root).expect("evidence");
+        assert_eq!(gates.status, "unverified");
+        assert!(gates.read.is_empty());
+    }
 }

--- a/crates/edda-cli/src/cmd_review/render.rs
+++ b/crates/edda-cli/src/cmd_review/render.rs
@@ -19,7 +19,7 @@ pub(crate) fn render(p: &ReviewVerdictPayload, event: &str) -> String {
             "spec-convention-only" => "pass --spec <path|#issue>",
             "gates-undeclared" => "declare gates in REVIEW.md or pass --gate",
             "gates-unverified" => {
-                "record edda run -- <gate> at this SHA on a clean tree, or pass --run-gates"
+                "record edda run -- <gate> at this SHA with an eligible relevant/scoped tree, or pass --run-gates"
             }
             "gates-red" => "fix the failing gate and review the new SHA",
             "model-unknown" | "tool-policy-none" => {
@@ -139,8 +139,12 @@ mod tests {
 
     #[test]
     fn render_includes_the_actual_escalation() {
-        let text = render(&payload(), "evt_01");
+        let mut payload = payload();
+        payload.disqualifiers.push("gates-unverified".into());
+        let text = render(&payload, "evt_01");
         assert!(text.contains("escalation: missing exact-head CI receipt"));
         assert!(text.contains("escalation-pending → resolve the listed review escalations"));
+        assert!(text.contains("eligible relevant/scoped tree"));
+        assert!(!text.contains("on a clean tree"));
     }
 }

--- a/crates/edda-cli/src/cmd_run.rs
+++ b/crates/edda-cli/src/cmd_run.rs
@@ -1,9 +1,10 @@
-use edda_core::event::{new_cmd_event_with_git_context, CmdEventParams};
+use edda_core::event::{new_cmd_event_with_git_context_and_dirty_paths, CmdEventParams};
 use edda_ledger::blob_store::blob_put;
 use edda_ledger::lock::WorkspaceLock;
 use edda_ledger::Ledger;
+use std::collections::BTreeSet;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub fn execute(repo_root: &Path, argv: &[String]) -> anyhow::Result<()> {
     execute_in(repo_root, &std::env::current_dir()?, argv)
@@ -17,7 +18,7 @@ pub fn execute_in(repo_root: &Path, cwd: &Path, argv: &[String]) -> anyhow::Resu
     }
 
     let ledger = Ledger::open(repo_root)?;
-    let before = git_context(cwd);
+    let before = git_snapshot(cwd);
     let start = std::time::Instant::now();
 
     let output = std::process::Command::new(&argv[0])
@@ -28,16 +29,8 @@ pub fn execute_in(repo_root: &Path, cwd: &Path, argv: &[String]) -> anyhow::Resu
 
     let duration_ms = start.elapsed().as_millis() as u64;
     let exit_code = output.status.code().unwrap_or(-1);
-    let after = git_context(cwd);
-    // A command that changes the checkout cannot certify the original clean
-    // SHA. Git failures remain unknown; they never buy a clean receipt.
-    let tree_dirty = if before.0 != after.0 || before.1 == Some(true) || after.1 == Some(true) {
-        Some(true)
-    } else if before.1 == Some(false) && after.1 == Some(false) {
-        Some(false)
-    } else {
-        None
-    };
+    let after = git_snapshot(cwd);
+    let git_context = combine_git_snapshots(before, after);
 
     let _lock = WorkspaceLock::acquire(&ledger.paths)?;
 
@@ -48,7 +41,11 @@ pub fn execute_in(repo_root: &Path, cwd: &Path, argv: &[String]) -> anyhow::Resu
     let parent_hash = ledger.last_event_hash()?;
     let cwd = cwd.to_string_lossy().to_string();
 
-    let event = new_cmd_event_with_git_context(
+    let dirty_paths = git_context
+        .dirty_paths
+        .as_ref()
+        .map(|paths| (paths.tracked.as_slice(), paths.untracked.as_slice()));
+    let event = new_cmd_event_with_git_context_and_dirty_paths(
         &CmdEventParams {
             branch: &branch,
             parent_hash: parent_hash.as_deref(),
@@ -59,8 +56,9 @@ pub fn execute_in(repo_root: &Path, cwd: &Path, argv: &[String]) -> anyhow::Resu
             stdout_blob: &stdout_blob,
             stderr_blob: &stderr_blob,
         },
-        before.0.as_deref(),
-        tree_dirty,
+        git_context.sha.as_deref(),
+        git_context.tree_dirty,
+        dirty_paths,
     )?;
     ledger.append_event(&event)?;
 
@@ -72,27 +70,168 @@ pub fn execute_in(repo_root: &Path, cwd: &Path, argv: &[String]) -> anyhow::Resu
     Ok(())
 }
 
-fn git_context(cwd: &Path) -> (Option<String>, Option<bool>) {
-    let output = |args: &[&str]| {
-        std::process::Command::new("git")
-            .args(args)
-            .current_dir(cwd)
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct DirtyPaths {
+    tracked: Vec<String>,
+    untracked: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct GitSnapshot {
+    sha: Option<String>,
+    dirty_paths: Option<DirtyPaths>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct GitContext {
+    sha: Option<String>,
+    tree_dirty: Option<bool>,
+    dirty_paths: Option<DirtyPaths>,
+}
+
+fn git_snapshot(cwd: &Path) -> GitSnapshot {
+    let sha = git_output(cwd, &["rev-parse", "--verify", "HEAD^{commit}"])
+        .and_then(|bytes| one_git_line(&bytes));
+    let dirty_paths = git_output(cwd, &["rev-parse", "--show-toplevel"])
+        .and_then(|bytes| one_git_line(&bytes))
+        .map(PathBuf::from)
+        .and_then(|root| {
+            git_output(
+                &root,
+                &[
+                    "status",
+                    "--porcelain=v1",
+                    "-z",
+                    "--untracked-files=all",
+                    "--ignore-submodules=none",
+                ],
+            )
+        })
+        .and_then(|bytes| parse_porcelain_v1_z(&bytes));
+    GitSnapshot { sha, dirty_paths }
+}
+
+fn git_output(cwd: &Path, args: &[&str]) -> Option<Vec<u8>> {
+    std::process::Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| output.stdout)
+}
+
+fn one_git_line(bytes: &[u8]) -> Option<String> {
+    let text = std::str::from_utf8(bytes).ok()?;
+    let text = text.strip_suffix('\n').unwrap_or(text);
+    let text = text.strip_suffix('\r').unwrap_or(text);
+    (!text.is_empty() && !text.chars().any(char::is_control)).then(|| text.to_owned())
+}
+
+fn parse_porcelain_v1_z(bytes: &[u8]) -> Option<DirtyPaths> {
+    let mut tracked = BTreeSet::new();
+    let mut untracked = BTreeSet::new();
+    let mut offset = 0;
+    while offset < bytes.len() {
+        let record = take_nul_record(bytes, &mut offset)?;
+        if record.len() < 4 || record[2] != b' ' || !valid_status(record[0], record[1]) {
+            return None;
+        }
+        let path = parse_status_path(&record[3..])?;
+        let destination = if record[0] == b'?' && record[1] == b'?' {
+            &mut untracked
+        } else {
+            &mut tracked
+        };
+        destination.insert(path);
+        if matches!(record[0], b'R' | b'C') || matches!(record[1], b'R' | b'C') {
+            destination.insert(parse_status_path(take_nul_record(bytes, &mut offset)?)?);
+        }
+    }
+    Some(DirtyPaths {
+        tracked: tracked.into_iter().collect(),
+        untracked: untracked.into_iter().collect(),
+    })
+}
+
+fn valid_status(index: u8, worktree: u8) -> bool {
+    if (index, worktree) == (b'?', b'?') {
+        return true;
+    }
+    let ordinary = |status| {
+        matches!(
+            status,
+            b' ' | b'M' | b'T' | b'A' | b'D' | b'R' | b'C' | b'U'
+        )
     };
-    let sha = output(&["rev-parse", "--verify", "HEAD^{commit}"])
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty());
-    let dirty = output(&[
-        "status",
-        "--porcelain=v1",
-        "--untracked-files=all",
-        "--ignore-submodules=none",
-    ])
-    .map(|o| !o.stdout.is_empty());
-    (sha, dirty)
+    ordinary(index) && ordinary(worktree) && (index, worktree) != (b' ', b' ')
+}
+
+fn take_nul_record<'a>(bytes: &'a [u8], offset: &mut usize) -> Option<&'a [u8]> {
+    let length = bytes.get(*offset..)?.iter().position(|byte| *byte == 0)?;
+    let end = offset.checked_add(length)?;
+    let record = bytes.get(*offset..end)?;
+    *offset = end.checked_add(1)?;
+    Some(record)
+}
+
+fn parse_status_path(bytes: &[u8]) -> Option<String> {
+    (!bytes.is_empty())
+        .then_some(bytes)
+        .and_then(|path| std::str::from_utf8(path).ok())
+        .map(str::to_owned)
+}
+
+fn combine_git_snapshots(before: GitSnapshot, after: GitSnapshot) -> GitContext {
+    let sha = before.sha.clone();
+    match (before.sha.as_deref(), after.sha.as_deref()) {
+        (Some(before_sha), Some(after_sha)) if before_sha != after_sha => GitContext {
+            sha,
+            tree_dirty: Some(true),
+            dirty_paths: None,
+        },
+        (Some(_), Some(_)) => match (before.dirty_paths, after.dirty_paths) {
+            (Some(before_paths), Some(after_paths)) => {
+                let dirty_paths = union_dirty_paths(before_paths, after_paths);
+                GitContext {
+                    sha,
+                    tree_dirty: Some(
+                        !dirty_paths.tracked.is_empty() || !dirty_paths.untracked.is_empty(),
+                    ),
+                    dirty_paths: Some(dirty_paths),
+                }
+            }
+            _ => GitContext {
+                sha,
+                tree_dirty: None,
+                dirty_paths: None,
+            },
+        },
+        _ => GitContext {
+            sha,
+            tree_dirty: None,
+            dirty_paths: None,
+        },
+    }
+}
+
+fn union_dirty_paths(before: DirtyPaths, after: DirtyPaths) -> DirtyPaths {
+    DirtyPaths {
+        tracked: before
+            .tracked
+            .into_iter()
+            .chain(after.tracked)
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect(),
+        untracked: before
+            .untracked
+            .into_iter()
+            .chain(after.untracked)
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect(),
+    }
 }
 
 #[cfg(test)]
@@ -117,9 +256,48 @@ mod tests {
     }
 
     #[test]
-    fn git_context_distinguishes_clean_dirty_untracked_and_non_git() {
+    fn strict_porcelain_parser_covers_paths_and_rejects_bad_records() {
+        assert_eq!(parse_porcelain_v1_z(b""), Some(DirtyPaths::default()));
+        assert_eq!(
+            parse_porcelain_v1_z(
+                " M z tracked.rs\0A  staged file.rs\0?? untracked space.txt\0?? 文档.txt\0"
+                    .as_bytes()
+            ),
+            Some(DirtyPaths {
+                tracked: vec!["staged file.rs".into(), "z tracked.rs".into()],
+                untracked: vec!["untracked space.txt".into(), "文档.txt".into()],
+            })
+        );
+        assert_eq!(
+            parse_porcelain_v1_z(b"R  new name\0old name\0C  copy\0source\0"),
+            Some(DirtyPaths {
+                tracked: vec![
+                    "copy".into(),
+                    "new name".into(),
+                    "old name".into(),
+                    "source".into()
+                ],
+                untracked: vec![],
+            })
+        );
+        for malformed in [
+            b" M missing-nul".as_slice(),
+            b"M bad-status-width\0",
+            b"?? \0",
+            b"?M mixed-question\0",
+            b"R  missing-second\0",
+            b" M valid\0\0",
+            b"!! ignored\0",
+            b" M non-utf8-\xff\0",
+        ] {
+            assert!(parse_porcelain_v1_z(malformed).is_none(), "{malformed:?}");
+        }
+    }
+
+    #[test]
+    fn git_snapshot_distinguishes_clean_tracked_untracked_and_non_git() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        assert_eq!(git_context(tmp.path()), (None, None));
+        assert_eq!(git_snapshot(tmp.path()), GitSnapshot::default());
         git(tmp.path(), &["init"]);
         git(tmp.path(), &["config", "user.name", "Test"]);
         git(tmp.path(), &["config", "user.email", "test@example.com"]);
@@ -127,13 +305,58 @@ mod tests {
         git(tmp.path(), &["add", "tracked"]);
         git(tmp.path(), &["commit", "-m", "initial"]);
         let sha = git(tmp.path(), &["rev-parse", "HEAD"]);
-        assert_eq!(git_context(tmp.path()), (Some(sha.clone()), Some(false)));
+        assert_eq!(
+            git_snapshot(tmp.path()),
+            GitSnapshot {
+                sha: Some(sha.clone()),
+                dirty_paths: Some(DirtyPaths::default()),
+            }
+        );
         std::fs::write(tmp.path().join("tracked"), "two").expect("file");
-        assert_eq!(git_context(tmp.path()), (Some(sha.clone()), Some(true)));
+        assert_eq!(
+            git_snapshot(tmp.path())
+                .dirty_paths
+                .expect("known status")
+                .tracked,
+            ["tracked"]
+        );
         git(tmp.path(), &["checkout", "--", "tracked"]);
         git(tmp.path(), &["config", "status.showUntrackedFiles", "no"]);
         std::fs::write(tmp.path().join("untracked"), "new").expect("file");
-        assert_eq!(git_context(tmp.path()), (Some(sha), Some(true)));
+        let snapshot = git_snapshot(tmp.path());
+        assert_eq!(snapshot.sha.as_deref(), Some(sha.as_str()));
+        assert_eq!(
+            snapshot.dirty_paths.expect("known status").untracked,
+            ["untracked"]
+        );
+    }
+
+    #[test]
+    fn before_after_paths_are_a_sorted_deduplicated_union() {
+        let context = combine_git_snapshots(
+            GitSnapshot {
+                sha: Some("head".into()),
+                dirty_paths: Some(DirtyPaths {
+                    tracked: vec!["z".into(), "same".into()],
+                    untracked: vec!["old".into()],
+                }),
+            },
+            GitSnapshot {
+                sha: Some("head".into()),
+                dirty_paths: Some(DirtyPaths {
+                    tracked: vec!["a".into(), "same".into()],
+                    untracked: vec!["new".into()],
+                }),
+            },
+        );
+        assert_eq!(context.tree_dirty, Some(true));
+        assert_eq!(
+            context.dirty_paths,
+            Some(DirtyPaths {
+                tracked: vec!["a".into(), "same".into(), "z".into()],
+                untracked: vec!["new".into(), "old".into()],
+            })
+        );
     }
 
     #[test]
@@ -175,8 +398,22 @@ mod tests {
         let event = events.last().expect("receipt");
         assert_eq!(event.payload["git_sha"], sha);
         assert_eq!(event.payload["tree_dirty"], false);
+        assert_eq!(
+            event.payload["tree_dirty_paths"],
+            serde_json::json!({"tracked": [], "untracked": []})
+        );
         assert_eq!(event.payload["cwd"], nested.to_string_lossy().as_ref());
         assert!(!worktree.join(".edda").exists());
+
+        std::fs::write(worktree.join("root-only"), "untracked").expect("root file");
+        assert_eq!(
+            git_snapshot(&nested)
+                .dirty_paths
+                .expect("root-relative status")
+                .untracked,
+            ["root-only"]
+        );
+        std::fs::remove_file(worktree.join("root-only")).expect("remove root file");
 
         execute_in(
             &repo,
@@ -188,5 +425,27 @@ mod tests {
         let event = events.last().expect("receipt");
         assert_eq!(event.payload["git_sha"], sha);
         assert_eq!(event.payload["tree_dirty"], true);
+        assert_eq!(event.payload["tree_dirty_paths"]["tracked"][0], "tracked");
+
+        execute_in(
+            &repo,
+            &worktree,
+            &[
+                "git".into(),
+                "-c".into(),
+                "user.name=Test".into(),
+                "-c".into(),
+                "user.email=test@example.com".into(),
+                "commit".into(),
+                "-m".into(),
+                "move head".into(),
+            ],
+        )
+        .expect("head-mutating run");
+        let events = ledger.iter_events().expect("events");
+        let event = events.last().expect("receipt");
+        assert_eq!(event.payload["git_sha"], sha);
+        assert_eq!(event.payload["tree_dirty"], true);
+        assert!(event.payload["tree_dirty_paths"].is_null());
     }
 }

--- a/crates/edda-core/src/cmd_event.rs
+++ b/crates/edda-core/src/cmd_event.rs
@@ -27,7 +27,27 @@ pub fn new_cmd_event_with_git_context(
     git_sha: Option<&str>,
     tree_dirty: Option<bool>,
 ) -> anyhow::Result<Event> {
-    let payload = serde_json::json!({
+    build_cmd_event(params, git_sha, tree_dirty, None)
+}
+
+/// Create a SHA-bound receipt with the tracked and untracked paths observed
+/// around command execution. `None` records an explicitly unknown path state.
+pub fn new_cmd_event_with_git_context_and_dirty_paths(
+    params: &CmdEventParams<'_>,
+    git_sha: Option<&str>,
+    tree_dirty: Option<bool>,
+    tree_dirty_paths: Option<(&[String], &[String])>,
+) -> anyhow::Result<Event> {
+    build_cmd_event(params, git_sha, tree_dirty, Some(tree_dirty_paths))
+}
+
+fn build_cmd_event(
+    params: &CmdEventParams<'_>,
+    git_sha: Option<&str>,
+    tree_dirty: Option<bool>,
+    tree_dirty_paths: Option<Option<(&[String], &[String])>>,
+) -> anyhow::Result<Event> {
+    let mut payload = serde_json::json!({
         "argv": params.argv,
         "cwd": params.cwd,
         "exit_code": params.exit_code,
@@ -37,6 +57,15 @@ pub fn new_cmd_event_with_git_context(
         "git_sha": git_sha,
         "tree_dirty": tree_dirty,
     });
+    if let Some(paths) = tree_dirty_paths {
+        payload["tree_dirty_paths"] = match paths {
+            Some((tracked, untracked)) => serde_json::json!({
+                "tracked": tracked,
+                "untracked": untracked,
+            }),
+            None => serde_json::Value::Null,
+        };
+    }
 
     let mut blob_refs = Vec::new();
     if !params.stdout_blob.is_empty() {

--- a/crates/edda-core/src/event.rs
+++ b/crates/edda-core/src/event.rs
@@ -344,7 +344,10 @@ pub fn new_review_verdict_event(
     Ok(event)
 }
 
-pub use crate::cmd_event::{new_cmd_event, new_cmd_event_with_git_context, CmdEventParams};
+pub use crate::cmd_event::{
+    new_cmd_event, new_cmd_event_with_git_context, new_cmd_event_with_git_context_and_dirty_paths,
+    CmdEventParams,
+};
 
 /// Parameters for creating a `commit` event.
 pub struct CommitEventParams<'a> {

--- a/crates/edda-core/src/review_tests.rs
+++ b/crates/edda-core/src/review_tests.rs
@@ -1,5 +1,6 @@
 use crate::event::{
-    new_cmd_event, new_cmd_event_with_git_context, new_review_verdict_event, CmdEventParams,
+    compute_event_hash, new_cmd_event, new_cmd_event_with_git_context,
+    new_cmd_event_with_git_context_and_dirty_paths, new_review_verdict_event, CmdEventParams,
 };
 use crate::ReviewVerdictPayload;
 
@@ -47,7 +48,7 @@ fn review_verdict_event_roundtrip_taxonomy_and_refs() {
 }
 
 #[test]
-fn cmd_receipt_writes_context_and_preserves_unknown_as_null() {
+fn cmd_receipt_constructors_preserve_legacy_payload_and_finalize_paths() {
     let argv = vec!["cargo".into(), "test".into()];
     let params = CmdEventParams {
         branch: "main",
@@ -62,12 +63,46 @@ fn cmd_receipt_writes_context_and_preserves_unknown_as_null() {
     let old = new_cmd_event(&params).expect("legacy constructor");
     assert!(old.payload.get("git_sha").expect("sha key").is_null());
     assert!(old.payload.get("tree_dirty").expect("dirty key").is_null());
-    for dirty in [false, true] {
-        let receipt = new_cmd_event_with_git_context(&params, Some(&"a".repeat(40)), Some(dirty))
-            .expect("receipt");
-        assert_eq!(receipt.payload["git_sha"], "a".repeat(40));
-        assert_eq!(receipt.payload["tree_dirty"], dirty);
-        assert_eq!(receipt.refs.blobs, ["out", "err"]);
-        assert_eq!(receipt.event_family.as_deref(), Some("signal"));
-    }
+    assert!(old.payload.get("tree_dirty_paths").is_none());
+
+    let legacy_context = new_cmd_event_with_git_context(&params, Some(&"a".repeat(40)), Some(true))
+        .expect("legacy context constructor");
+    assert!(legacy_context.payload.get("tree_dirty_paths").is_none());
+
+    let tracked = vec!["crates/a.rs".into()];
+    let untracked = vec!["docs/archive/probe.txt".into()];
+    let receipt = new_cmd_event_with_git_context_and_dirty_paths(
+        &params,
+        Some(&"a".repeat(40)),
+        Some(true),
+        Some((&tracked, &untracked)),
+    )
+    .expect("path-aware receipt");
+    assert_eq!(receipt.payload["git_sha"], "a".repeat(40));
+    assert_eq!(receipt.payload["tree_dirty"], true);
+    assert_eq!(
+        receipt.payload["tree_dirty_paths"]["tracked"][0],
+        tracked[0]
+    );
+    assert_eq!(
+        receipt.payload["tree_dirty_paths"]["untracked"][0],
+        untracked[0]
+    );
+    assert_eq!(receipt.refs.blobs, ["out", "err"]);
+    assert_eq!(receipt.event_family.as_deref(), Some("signal"));
+
+    let mut value = serde_json::to_value(&receipt).expect("serialize event");
+    let object = value.as_object_mut().expect("event object");
+    object.remove("hash");
+    object.remove("digests");
+    object.remove("schema_version");
+    assert_eq!(
+        compute_event_hash(&value).expect("recompute hash"),
+        receipt.hash
+    );
+
+    let unknown =
+        new_cmd_event_with_git_context_and_dirty_paths(&params, Some(&"a".repeat(40)), None, None)
+            .expect("unknown path receipt");
+    assert!(unknown.payload["tree_dirty_paths"].is_null());
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -366,6 +366,12 @@ edda run -- cargo test
 edda run -- npm run build
 ```
 
+In a Git checkout the receipt records the before-command HEAD plus a strict
+before/after union of tracked and untracked root-relative paths. A moved HEAD
+or an unreadable/malformed status records unknown path state; it is never
+silently treated as clean. `edda review` applies its narrower scoped-evidence
+allowlist described below.
+
 ---
 
 ## Coordination (multi-agent)
@@ -1235,7 +1241,17 @@ author and reviewer on the same model are recorded in the receipt as
 round. With the flag the policy is `model` and any independence other than
 `verified` disqualifies it.
 
-Gates are READ from clean exact-SHA command receipts and required exact-SHA CI.
+Gates are READ from exact-SHA relevant/scoped command receipts and required
+exact-SHA CI. Legacy clean receipts (`tree_dirty=false` with no path field)
+remain compatible. A dirty receipt is visible as `cmd-event-scoped` and can
+cover its exact command only when it reports no tracked path and every
+untracked root-relative Git `/` path is outside the reviewed subject and in the
+explicit measured inert corpus: `docs/archive/**`, `.tmp-fleet/**`,
+`codereviews/**`, or root `edda_tmp_*.txt`. Tracked dirt always rejects, even
+outside the subject. Legacy dirty, unknown/null, malformed or inconsistent path
+state, and empty, absolute, parent-traversing, control-character,
+source/control, or any other untracked path never become evidence.
+
 `REVIEW.md` may map a declared gate command under `ci_gates` to a list of exact
 check-run names. One `ci-job-map` row then reports that gate: every named job at
 the reviewed SHA must succeed for green; any failure is red; missing, pending,

--- a/docs/superpowers/specs/2026-09-02-edda-review-design.md
+++ b/docs/superpowers/specs/2026-09-02-edda-review-design.md
@@ -408,7 +408,7 @@ codex 不回報 usage，預算閘永遠不會觸發——這件事要說出來�
   "independence_policy": "session | model",
   "gates": {"status": "verified | unverified | red | undeclared",
             "declared_by": ["REVIEW.md", "--gate"],
-            "read": [{"kind": "cmd-event | ci | ci-job-map", "ref": "evt_… | check-name | exact-name=status, …", "cmd": "cargo test --workspace",
+            "read": [{"kind": "cmd-event | cmd-event-scoped | ci | ci-job-map", "ref": "evt_… | check-name | exact-name=status, …", "cmd": "cargo test --workspace",
                       "result": "green | red | pending"}],
             "ran": [{"cmd": "cargo test -p edda-core", "exit": 0, "duration_ms": 41200, "stdout_blob": "… | null", "timed_out": false}]},
   "probes": [{"cmd": "edda wave --help", "exit": 2}],
@@ -447,19 +447,32 @@ codex 不回報 usage，預算閘永遠不會觸發——這件事要說出來�
 
 ## 8. 本地收據：`cmd` 事件擴充（`review.local-receipt`）
 
-`edda run` 在 `cmd` payload 加兩個 additive 欄位：`git_sha`（執行時的 HEAD；非 git repo
-為 null）與 `tree_dirty`（`git status --porcelain` 非空）。
+`edda run` 在 `cmd` payload 保留 additive 欄位 `git_sha`（執行前的 HEAD；非 git repo
+為 null）與 `tree_dirty`，並新增 `tree_dirty_paths`：已知時為
+`{"tracked":[…],"untracked":[…]}`，未知時為 null。它在 command 前後固定執行
+`git status --porcelain=v1 -z --untracked-files=all --ignore-submodules=none`；嚴格解析 NUL
+framing、rename/copy 的第二路徑與 UTF-8，路徑皆為 repo-root-relative Git `/` 路徑，前後集合
+排序、去重後聯集。status 失敗、malformed 或 non-UTF-8 是 unknown。前後 HEAD 若確定不同，
+`tree_dirty=true` 且 path state 為 null；任何一邊曾 staged/modified 的路徑都在 `tracked`。
+舊 constructor 與舊 payload 保持不變；path-aware constructor 在完整 payload 組好後才 hash。
 
 閘門集合＝`REVIEW.md` front matter 的 `gates` ∪ `--gate`。**集合為空 →
 `gates.status = undeclared`**，disqualifier `gates-undeclared`，人讀輸出印
 「to qualify: declare gates in REVIEW.md front matter or pass --gate」。空集合不是
 vacuous verified——不然沒寫 `REVIEW.md` 的 repo 免費拿到 verified。
 
-集合非空時的 READ 規則：對每條 gate，找 `git_sha == head_sha` ∧ `tree_dirty == false`
-∧ `argv.join(" ")` 經空白正規化後**與 gate 字串完全相等**的 `cmd` 事件，取最新一筆：
-exit 0 → `green`；非 0 → `red`；沒有 → 該 gate 未涵蓋。全部 green → `verified`；
-任一 red → `red`；有未涵蓋（且 `--run-gates` 沒補上）→ `unverified`，輸出印
-「run `edda run -- <gate>` at <head12> on a clean tree, or pass --run-gates」。
+集合非空時的 READ 規則：對每條 gate，先限定 `git_sha == head_sha` 且
+`argv.join(" ")` 經空白正規化後**與 gate 字串完全相等**，再取最新 eligible receipt。
+舊事件只有 `tree_dirty == false` 且沒有 `tree_dirty_paths` 才 eligible；舊 dirty 仍拒絕。
+新事件的 clean state 必須是 `tree_dirty == false` 加兩個空陣列。新 dirty state 只有在 tracked
+陣列為空，且每個 untracked path 都不與明示傳入的 `subject.files` 相交、又命中封閉的量測
+inert positive allowlist 時才 eligible：`docs/archive/**`、`.tmp-fleet/**`、`codereviews/**`、
+root `edda_tmp_*.txt`。這種 row 顯示為 `kind = cmd-event-scoped`，不是把 dirty 改稱 clean。
+任何 tracked path 即使在 subject 外也拒絕；null、malformed、排序/去重不一致、
+`tree_dirty` 與集合不一致、empty/absolute/parent-traversal/control-character 路徑，以及
+`.cargo`、toolchain、manifest、`build.rs`、`crates`、`scripts`、test/spec fixture、workflow
+等 source/control 或未知 untracked path 都拒絕。只由上述四個 pattern 正面接受，不從 PR
+paths 推論其他位置安全。exit 0 → `green`；非 0 → `red`；沒有 eligible event → 未涵蓋。
 `--pr` 時另讀 exact-head CI，**釘在 `head_sha`**：先用
 `gh pr checks <n> --required --json name` 取 required 名單；名單非空才以
 `gh api repos/{o}/{r}/commits/<head_sha>/check-runs` 取該 SHA 的 check-runs
@@ -486,7 +499,7 @@ coarse lattice。規則依序為：
 |---|---|
 | 空 gate set → `undeclared` | 沒宣告 gate 就沒有東西可證；CI 再綠、RAN 再乾淨都不能變成 verified |
 | 任一 red → `red` | 任一 local receipt、required-CI row、mapped row，或非 timeout 的 RAN 失敗都 globally dominate |
-| 每個 declared gate 都有 eligible green → `verified` | 同 command 的 green `cmd-event`、green `ci-job-map`，或 exit 0 + stored stdout + non-timeout RAN 可覆蓋該 gate；不同來源可各自覆蓋一部分 gate |
+| 每個 declared gate 都有 eligible green → `verified` | 同 command 的 green `cmd-event` / `cmd-event-scoped`、green `ci-job-map`，或 exit 0 + stored stdout + non-timeout RAN 可覆蓋該 gate；不同來源可各自覆蓋一部分 gate |
 | 其餘 → `unverified` | missing/pending/skipped、無 mapping、timeout、未執行或 RAN blob 未儲存都不提供 coverage |
 
 required-CI row 是 set-level 可見證據：red 仍 globally dominate，但 green **永遠不覆蓋任何
@@ -561,7 +574,7 @@ PR body 裡的散文 L1 receipt 不解析；fleet 在一個迭代內改用 `edda
 |---|---|---|---|---|
 | `edda review` 動詞 | CLI；stdout 人讀 ＋ `--json` | 人、CI（`if edda review`）、fleet-review skill（切片 2 前用 `--json` 貼回） | exit 0/1/2/3；`unreviewed` 帶 `outcome`；不合格 LGTM 回 3，絕不假 approve | CLI → conductor launcher → ledger |
 | `review_verdict` 事件 | `edda review` 唯一寫端；`refs.events` 放 supersedes；寫進作者 repo 的帳本 | `edda log --type review_verdict`、#580、#582、#632 | `model_observed` 缺 → 不合格；寫入失敗 → exit 2 且 stderr | ledger（unstable） |
-| `cmd` 事件 `git_sha` / `tree_dirty` | `edda run` | §8 的 READ；#647 將新增的 verify 動詞（今日不存在）之後可用它檢視 receipt | 非 git repo → null；不影響既有讀者（additive） | CLI → ledger |
+| `cmd` 事件 `git_sha` / `tree_dirty` / `tree_dirty_paths` | `edda run` | §8 的 READ；#647 將新增的 verify 動詞（今日不存在）之後可用它檢視 receipt | status/HEAD/path unknown → null；tracked/control/source/unknown dirt never evidences；舊 clean receipt 仍相容（additive） | CLI → ledger |
 | `REVIEW.md` front matter reader | `edda review` 讀 `base_sha` 版 | brief 組裝、閘門集合、探測前綴 | 缺／版本不認得／壞 YAML → 機器欄位空 ＋ `notes` 一行，不擋 | CLI |
 | `canonical_model_id()` | edda-core 純函式 ＋ 對照表 | §6.3 獨立性比對、#580 | 不認得 → `unverified`（永不 `verified`）；每對來源有測試 | library |
 | `probes[]` 與 `.edda-review-subject` | edda 執行探測、寫標記檔 | 證據段 ⑥、引擎 checklist、`subject_seen` 檢查 | 探測非 0 是 finding 素材；標記不符 → `subject-mismatch` | CLI → worktree → ledger |


### PR DESCRIPTION
## Summary

- implement controller ruling d-002 with strict before/after porcelain-v1 NUL parsing and hashed `tree_dirty_paths`
- preserve legacy constructors and clean-receipt compatibility while rejecting tracked, control/source, malformed, and unknown dirt
- accept only unrelated untracked paths in the four measured inert patterns, visibly as `cmd-event-scoped`
- update REVIEW.md to v1.8 plus CLI/design references without changing v1.7 CI mapping, advisory-unverified behavior, or `ran_allowlist`

Issue: #1136

Closes #1136

Ruling: [d-002](https://github.com/fagemx/edda/issues/1136#issuecomment-5630491343)

## Worker receipt

- frozen SHA: `25e881b0c5c5891dd653dc040e85e7f5003c1c66`
- lane: `C:/Users/fagem/AppData/Local/fleet-workstation/lanes/worker-2`
- `cargo test -p edda-core` — pass (207 tests)
- `cargo test -p edda` — pass (846 unit tests plus integration suites)
- `cargo clippy -p edda-core --all-targets -- -D warnings` — pass
- `cargo clippy -p edda --all-targets -- -D warnings` — pass
- `cargo fmt --all --check` — pass
- `sh scripts/test-review-l0.sh` — pass
- markdown content fixtures, doc citation checks, file-length ratchet, CLI docs, and `git diff --check` — pass

## Live measurement and review

- scoped receipt `evt_01m27n5pet1sr86xpmhpgeptsp`: exact head/argv, `tracked=[]`, sole untracked owned probe `docs/archive/gh1136-scoped-receipt-probe.txt`, exit 0; probe removed afterward
- live `edda review`: scoped receipt plus all four mapped declared gate rows green, `gates.status=verified`
- focused Windows C5 receipt `evt_01m27nnmgmpp1d0hc6p075w0mn`: `cargo test -p edda-core`, 207 passed
- independent task #116 audit: LGTM, P0=0/P1=0; base-v1.7 `REVIEW.md` self-change escalation adjudicated safe

## Exact-head CI receipt

- `CI run 34572575624 @ 25e881b0c5c5891dd653dc040e85e7f5003c1c66` — green, including Format, MSRV, Clippy on Linux/macOS/Windows, full workspace tests on Linux/macOS, and the Windows 7-crate subset
- exact-head contract run `34572575636` — green
- exact-head workspace publish dry-run `34572575668` — green
