### PR TITLE
fix(edda-cli): diagnose required-check merge refusals

### DIFF
--- a/crates/edda-cli/src/cmd_review/github.rs
+++ b/crates/edda-cli/src/cmd_review/github.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Context, Result};
 use edda_core::ReviewSpec;
 use serde_json::Value;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Output};
 
 /// Set `GH_REPO` for one `gh` invocation from `EDDA_REPO`, when present.
 ///
@@ -39,8 +39,169 @@ fn command(repo: &Path, args: &[&str]) -> Command {
     command
 }
 
+/// Capture one `gh` invocation through the shared binary/repository seam.
+/// Callers that need to interpret an exit status or stdout shape use this
+/// rather than rebuilding a `Command` and losing `EDDA_GH_BIN` / `EDDA_REPO`.
+pub(crate) fn gh_capture(repo: &Path, args: &[&str]) -> Result<Output> {
+    command(repo, args).output().context("run gh")
+}
+
+/// One row from the structured reread used only to diagnose a refused plain
+/// required-check read.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RequiredCheckRow {
+    name: String,
+    state: String,
+    bucket: String,
+}
+
+/// Only `Green` satisfies the merge gate. Every diagnostic-only variant is a
+/// typed refusal, including a reread whose rows raced to passing/skipping.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RequiredChecks {
+    Green,
+    Absent,
+    Blocked(Vec<RequiredCheckRow>),
+    RacedNowGreen(Vec<RequiredCheckRow>),
+    Indeterminate(String),
+}
+
+impl RequiredChecks {
+    pub(crate) fn refusal(self, pr: u64) -> Option<(i32, String)> {
+        let rows = |rows: &[RequiredCheckRow]| {
+            rows.iter()
+                .map(|row| format!("{} (bucket={}, state={})", row.name, row.bucket, row.state))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        match self {
+            Self::Green => None,
+            Self::Absent => Some((
+                1,
+                format!(
+                    "no required-check rows are currently reported for PR #{pr}; wait for CI, or \
+                     check whether the PR base is covered by a ruleset; refusing"
+                ),
+            )),
+            Self::Blocked(checks) => Some((
+                1,
+                format!(
+                    "required checks are not green for PR #{pr}: {}; refusing",
+                    rows(&checks)
+                ),
+            )),
+            Self::RacedNowGreen(checks) => Some((
+                1,
+                format!(
+                    "required-check state changed during the read for PR #{pr}: diagnostic rows \
+                     are now all passing/skipping ({}); run `edda review merge` again; refusing",
+                    rows(&checks)
+                ),
+            )),
+            Self::Indeterminate(error) => Some((
+                2,
+                format!("cannot determine required checks for PR #{pr}: {error}; refusing"),
+            )),
+        }
+    }
+}
+
+fn required_checks_argv(pr: u64) -> Vec<String> {
+    vec![
+        "pr".into(),
+        "checks".into(),
+        pr.to_string(),
+        "--required".into(),
+    ]
+}
+
+fn required_checks_diagnostic_argv(pr: u64) -> Vec<String> {
+    let mut argv = required_checks_argv(pr);
+    argv.extend(["--json".into(), "name,state,bucket".into()]);
+    argv
+}
+
+/// Classify by exit status and structured stdout only — never gh's human
+/// stderr wording.
+fn classify_required_checks(exit: Option<i32>, stdout: &[u8]) -> RequiredChecks {
+    if stdout.is_empty() {
+        return RequiredChecks::Indeterminate(format!(
+            "diagnostic required-check read returned no structured report: stdout was empty \
+             (exit {exit:?}); retry after waiting for CI, and check GitHub connectivity and \
+             repository access"
+        ));
+    }
+    if !matches!(exit, Some(0 | 1 | 8)) {
+        return RequiredChecks::Indeterminate(format!(
+            "diagnostic `gh pr checks --required --json name,state,bucket` exited unexpectedly \
+             ({exit:?})"
+        ));
+    }
+    let rows: Vec<RequiredCheckRow> = match serde_json::from_slice(stdout) {
+        Ok(rows) => rows,
+        Err(error) => {
+            return RequiredChecks::Indeterminate(format!(
+                "diagnostic required-check JSON is malformed or has an unknown row shape: {error}"
+            ));
+        }
+    };
+    if rows.is_empty() {
+        return RequiredChecks::Absent;
+    }
+    if let Some(row) = rows.iter().find(|row| {
+        row.name.is_empty()
+            || row.state.is_empty()
+            || !matches!(
+                row.bucket.as_str(),
+                "pass" | "fail" | "pending" | "skipping" | "cancel"
+            )
+    }) {
+        return RequiredChecks::Indeterminate(format!(
+            "diagnostic required-check row has an unknown shape: name={:?}, state={:?}, \
+             bucket={:?}",
+            row.name, row.state, row.bucket
+        ));
+    }
+    if rows
+        .iter()
+        .all(|row| matches!(row.bucket.as_str(), "pass" | "skipping"))
+    {
+        RequiredChecks::RacedNowGreen(rows)
+    } else {
+        RequiredChecks::Blocked(rows)
+    }
+}
+
+/// Run the unchanged plain command as the sole Green authority. A nonzero
+/// result gets exactly one structured diagnostic reread; that reread can
+/// explain a refusal but never approve it.
+pub(crate) fn required_checks(repo: &Path, pr: u64) -> RequiredChecks {
+    let argv = required_checks_argv(pr);
+    let args: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let plain = match gh_capture(repo, &args) {
+        Ok(output) => output,
+        Err(error) => {
+            return RequiredChecks::Indeterminate(format!(
+                "authoritative plain required-check read failed to start: {error:#}"
+            ));
+        }
+    };
+    if plain.status.success() {
+        return RequiredChecks::Green;
+    }
+    let argv = required_checks_diagnostic_argv(pr);
+    let args: Vec<&str> = argv.iter().map(String::as_str).collect();
+    match gh_capture(repo, &args) {
+        Ok(output) => classify_required_checks(output.status.code(), &output.stdout),
+        Err(error) => RequiredChecks::Indeterminate(format!(
+            "diagnostic required-check read failed to start: {error:#}"
+        )),
+    }
+}
+
 pub(crate) fn gh(repo: &Path, args: &[&str]) -> Result<Value> {
-    let output = command(repo, args).output().context("run gh")?;
+    let output = gh_capture(repo, args)?;
     if !output.status.success() {
         bail!("gh: {}", String::from_utf8_lossy(&output.stderr));
     }
@@ -52,7 +213,7 @@ pub(crate) fn gh(repo: &Path, args: &[&str]) -> Result<Value> {
 /// none of them can go through [`gh`], which parses stdout as JSON. Only
 /// the exit status is meaningful here; stdout is discarded.
 pub(crate) fn gh_write(repo: &Path, args: &[&str]) -> Result<()> {
-    let output = command(repo, args).output().context("run gh")?;
+    let output = gh_capture(repo, args)?;
     if !output.status.success() {
         bail!("gh: {}", String::from_utf8_lossy(&output.stderr));
     }
@@ -275,6 +436,75 @@ pub(crate) fn load_spec(
 mod tests {
     use super::*;
     use crate::cmd_review::git::testrepo;
+
+    #[test]
+    fn required_check_argv_pins_the_pr_and_diagnostic_fields() {
+        assert_eq!(
+            required_checks_argv(4242),
+            ["pr", "checks", "4242", "--required"]
+        );
+        assert_eq!(
+            required_checks_diagnostic_argv(4242),
+            [
+                "pr",
+                "checks",
+                "4242",
+                "--required",
+                "--json",
+                "name,state,bucket"
+            ]
+        );
+    }
+
+    #[test]
+    fn required_check_output_is_classified_without_human_stderr() {
+        for exit in [Some(0), Some(1), Some(8), Some(9), None] {
+            let RequiredChecks::Indeterminate(message) = classify_required_checks(exit, b"") else {
+                panic!("empty output with {exit:?} must be indeterminate");
+            };
+            for expected in [
+                "no structured report",
+                "retry",
+                "waiting for CI",
+                "GitHub connectivity",
+                "repository access",
+            ] {
+                assert!(
+                    message.contains(expected),
+                    "missing {expected:?}: {message}"
+                );
+            }
+            assert!(!message.contains("no required-check rows"), "{message}");
+        }
+        assert_eq!(
+            classify_required_checks(Some(0), b"[]"),
+            RequiredChecks::Absent
+        );
+        let blocked = br#"[{"name":"build","state":"FAILURE","bucket":"fail"},
+            {"name":"test","state":"PENDING","bucket":"pending"}]"#;
+        assert!(matches!(
+            classify_required_checks(Some(0), blocked),
+            RequiredChecks::Blocked(rows)
+                if rows.iter().map(|row| row.bucket.as_str()).collect::<Vec<_>>()
+                    == ["fail", "pending"]
+        ));
+        let raced = br#"[{"name":"build","state":"SUCCESS","bucket":"pass"},
+            {"name":"docs","state":"SKIPPED","bucket":"skipping"}]"#;
+        assert!(matches!(
+            classify_required_checks(Some(1), raced),
+            RequiredChecks::RacedNowGreen(rows) if rows.len() == 2
+        ));
+        for result in [
+            classify_required_checks(Some(0), b"{"),
+            classify_required_checks(Some(9), b"[]"),
+            classify_required_checks(
+                Some(0),
+                br#"[{"name":"CI Gate","state":"SUCCESS","bucket":"mystery"}]"#,
+            ),
+        ] {
+            assert!(matches!(result, RequiredChecks::Indeterminate(_)));
+        }
+    }
 
     #[test]
     fn closing_keywords_ignore_mentions_and_use_first_closing_issue() {

--- a/crates/edda-cli/src/cmd_review/merge.rs
+++ b/crates/edda-cli/src/cmd_review/merge.rs
@@ -53,7 +53,7 @@ use super::deliver::{
 };
 use super::drift;
 use super::gate;
-use super::github::{gh, gh_write, gh_write_stdin};
+use super::github::{gh, gh_write_stdin, required_checks, RequiredChecks};
 use anyhow::{Context, Result};
 use std::path::Path;
 
@@ -95,8 +95,8 @@ pub(crate) trait Reads {
     /// prints every line of it and refuses on none of it (#1124): the subject
     /// PR's own hold is read from the subject, further down the stages.
     fn drift(&self) -> Result<drift::Report>;
-    /// Do the ruleset's required checks pass? (`gh pr checks --required`)
-    fn checks_green(&self, pr: u64) -> Result<bool>;
+    /// Authoritative plain required-check result plus its refusal diagnostic.
+    fn required_checks(&self, pr: u64) -> RequiredChecks;
     /// The `CI Gate` check-run URL for the receipt body, if resolvable.
     fn ci_gate_url(&self, sha: &str) -> Option<String>;
     /// Execute the squash merge with subject and body pinned (GH-1100).
@@ -527,17 +527,10 @@ pub(crate) fn merge_inner(args: &MergeArgs, reads: &dyn Reads) -> Result<i32> {
         return Ok(1);
     }
 
-    // 6. The forge's own required checks.
-    match reads.checks_green(args.pr) {
-        Ok(true) => {}
-        Ok(false) => {
-            eprintln!("required checks are not green");
-            return Ok(1);
-        }
-        Err(error) => {
-            eprintln!("cannot read required checks: {error:#}");
-            return Ok(2);
-        }
+    // 6. Only the original plain check's success is Green; JSON only diagnoses refusal.
+    if let Some((code, message)) = reads.required_checks(args.pr).refusal(args.pr) {
+        eprintln!("{message}");
+        return Ok(code);
     }
 
     // 7. The squash subject, derived from the PR title and validated
@@ -695,12 +688,8 @@ impl Reads for GhReads<'_> {
         )
     }
 
-    fn checks_green(&self, pr: u64) -> Result<bool> {
-        // `gh pr checks --required` exits nonzero both when a required check
-        // is red and when gh itself failed — the shell refused on either,
-        // without distinguishing, and this stays at that parity: nonzero
-        // reads as not green rather than as an unreadable answer.
-        Ok(gh_write(self.cwd, &["pr", "checks", &pr.to_string(), "--required"]).is_ok())
+    fn required_checks(&self, pr: u64) -> RequiredChecks {
+        required_checks(self.cwd, pr)
     }
 
     fn ci_gate_url(&self, sha: &str) -> Option<String> {
@@ -792,7 +781,7 @@ mod tests {
         comments: Vec<TimedComment>,
         drift: Result<drift::Report, String>,
         fail_comments: bool,
-        checks_green: bool,
+        required_checks: RequiredChecks,
         merged: RefCell<Vec<(u64, String, String, String)>>,
         /// Which PR each read was asked for — a `Fake` that shrugs at the
         /// argument is how the missing `--pr` selector stayed invisible to
@@ -812,7 +801,7 @@ mod tests {
                 comments,
                 drift: Ok(drift::Report::new(vec![], false)),
                 fail_comments: false,
-                checks_green: true,
+                required_checks: RequiredChecks::Green,
                 merged: RefCell::new(Vec::new()),
                 asked: RefCell::new(Vec::new()),
                 reached_comments: RefCell::new(false),
@@ -842,10 +831,10 @@ mod tests {
         fn drift(&self) -> Result<drift::Report> {
             self.drift.clone().map_err(anyhow::Error::msg)
         }
-        fn checks_green(&self, pr: u64) -> Result<bool> {
+        fn required_checks(&self, pr: u64) -> RequiredChecks {
             self.asked.borrow_mut().push(("checks", pr));
             *self.reached_checks.borrow_mut() = true;
-            Ok(self.checks_green)
+            self.required_checks.clone()
         }
         fn ci_gate_url(&self, _sha: &str) -> Option<String> {
             Some("https://github.com/fagemx/edda/runs/123".into())
@@ -1334,10 +1323,18 @@ Addressed in abc1234."
     }
 
     #[test]
-    fn required_checks_not_green_refuses() {
-        let mut fake = Fake::clean(lgtm());
-        fake.checks_green = false;
-        assert_eq!(merge_inner(&args(false), &fake).unwrap(), 1);
+    fn every_non_green_required_check_result_refuses_without_squashing() {
+        for (result, expected) in [
+            (RequiredChecks::Absent, 1),
+            (RequiredChecks::Blocked(vec![]), 1),
+            (RequiredChecks::RacedNowGreen(vec![]), 1),
+            (RequiredChecks::Indeterminate("unreadable".into()), 2),
+        ] {
+            let mut fake = Fake::clean(lgtm());
+            fake.required_checks = result;
+            assert_eq!(merge_inner(&args(true), &fake).unwrap(), expected);
+            assert!(fake.merged.borrow().is_empty(), "refusal reached squash");
+        }
     }
 
     // ---- GH-1100, folded in -------------------------------------------------

--- a/crates/edda-cli/tests/review_merge_advisory.rs
+++ b/crates/edda-cli/tests/review_merge_advisory.rs
@@ -69,6 +69,7 @@ struct Fixture {
     gh: PathBuf,
     repo: PathBuf,
     merged_marker: PathBuf,
+    calls_marker: PathBuf,
 }
 
 impl Fixture {
@@ -118,17 +119,35 @@ impl Fixture {
             std::fs::write(fixtures.join(name), text).expect("write fixture");
         }
 
+        std::fs::write(fixtures.join("checks.json"), "[]").expect("write checks fixture");
         let gh = stub(&bin);
         let merged_marker = fixtures.join("merged.txt");
+        let calls_marker = fixtures.join("calls.txt");
         Self {
             _dir: dir,
             gh,
             repo,
             merged_marker,
+            calls_marker,
         }
     }
 
     fn run(&self, extra: &[&str]) -> (i32, String, String) {
+        self.run_with_checks(extra, 0, 0, "[]")
+    }
+
+    fn run_with_checks(
+        &self,
+        extra: &[&str],
+        plain_exit: i32,
+        diagnostic_exit: i32,
+        diagnostic_stdout: &str,
+    ) -> (i32, String, String) {
+        std::fs::write(
+            self._dir.path().join("fixtures/checks.json"),
+            diagnostic_stdout,
+        )
+        .expect("write diagnostic checks fixture");
         let out = Command::new(env!("CARGO_BIN_EXE_edda"))
             .arg("review")
             .arg("merge")
@@ -138,7 +157,9 @@ impl Fixture {
             .current_dir(&self.repo)
             .env("EDDA_GH_BIN", &self.gh)
             .env("GH_FIXTURE_DIR", self._dir.path().join("fixtures"))
-            .env("GH_CHECKS_EXIT", "0")
+            .env("GH_CHECKS_EXIT", plain_exit.to_string())
+            .env("GH_CHECKS_JSON_EXIT", diagnostic_exit.to_string())
+            .env("EDDA_REPO", "fagemx/edda")
             .env("EDDA_STORE_ROOT", self._dir.path().join("store"))
             .env("EDDA_SESSION_ID", "review-merge-advisory-probe")
             .stdin(Stdio::null())
@@ -150,6 +171,10 @@ impl Fixture {
             String::from_utf8_lossy(&out.stderr).into_owned(),
         )
     }
+
+    fn calls(&self) -> String {
+        std::fs::read_to_string(&self.calls_marker).expect("read gh calls")
+    }
 }
 
 /// Write the stub `gh` the verb is pointed at with `EDDA_GH_BIN`. Anything
@@ -159,14 +184,19 @@ fn stub(bin: &Path) -> PathBuf {
     #[cfg(windows)]
     {
         let bat = r#"@echo off
+echo %*>>"%GH_FIXTURE_DIR%\calls.txt"
+if not "%GH_REPO%"=="fagemx/edda" ( echo GH_REPO not forwarded 1>&2 & exit /b 9 )
 if "%1 %2"=="pr view" ( type "%GH_FIXTURE_DIR%\pr-%3.json" & exit /b 0 )
 if "%1 %2"=="pr list" ( type "%GH_FIXTURE_DIR%\open.json" & exit /b 0 )
-if "%1 %2"=="pr checks" ( exit /b %GH_CHECKS_EXIT% )
+if "%1 %2"=="pr checks" goto checks
 if "%1 %2"=="pr merge" ( echo merged>"%GH_FIXTURE_DIR%\merged.txt" & exit /b 0 )
 if "%1 %2"=="api --paginate" goto comments
 if "%1"=="api" ( type "%GH_FIXTURE_DIR%\.check-runs.json" & exit /b 0 )
 echo unexpected gh call: %* 1>&2
 exit /b 9
+:checks
+if "%5"=="--json" ( type "%GH_FIXTURE_DIR%\checks.json" & exit /b %GH_CHECKS_JSON_EXIT% )
+exit /b %GH_CHECKS_EXIT%
 :comments
 for /f "tokens=5 delims=/" %%A in ("%3") do type "%GH_FIXTURE_DIR%\comments-%%A.json"
 exit /b 0
@@ -179,10 +209,17 @@ exit /b 0
     {
         use std::os::unix::fs::PermissionsExt;
         let sh = r#"#!/bin/sh
+printf '%s\n' "$*" >> "$GH_FIXTURE_DIR/calls.txt"
+[ "$GH_REPO" = 'fagemx/edda' ] || { echo 'GH_REPO not forwarded' >&2; exit 9; }
 case "$1 $2" in
   'pr view') cat "$GH_FIXTURE_DIR/pr-$3.json" ;;
   'pr list') cat "$GH_FIXTURE_DIR/open.json" ;;
-  'pr checks') exit "${GH_CHECKS_EXIT:-0}" ;;
+  'pr checks')
+    if [ "$5" = '--json' ]; then
+      cat "$GH_FIXTURE_DIR/checks.json"
+      exit "${GH_CHECKS_JSON_EXIT:-0}"
+    fi
+    exit "${GH_CHECKS_EXIT:-0}" ;;
   'pr merge') echo merged > "$GH_FIXTURE_DIR/merged.txt" ;;
   'api --paginate')
     n=$(printf '%s' "$3" | sed -n 's|.*/issues/\([0-9]*\)/comments$|\1|p')
@@ -227,6 +264,124 @@ fn a_dirty_neighbour_is_printed_and_does_not_refuse_the_green_subject() {
         stdout.contains(&format!("review accepted: PR #{SUBJECT} @ {HEAD}")),
         "{stdout}"
     );
+    let calls = f.calls();
+    let check_calls: Vec<String> = calls
+        .lines()
+        .filter(|line| line.starts_with("pr checks"))
+        .map(|line| line.replace('"', ""))
+        .collect();
+    assert_eq!(
+        check_calls,
+        [format!("pr checks {SUBJECT} --required")],
+        "plain success must be the sole Green authority and skip the diagnostic"
+    );
+}
+
+#[test]
+fn required_check_diagnostics_refuse_every_observed_shape_without_squashing() {
+    let blocked = r#"[{"name":"build","state":"FAILURE","bucket":"fail"},
+        {"name":"test","state":"PENDING","bucket":"pending"}]"#;
+    let raced = r#"[{"name":"build","state":"SUCCESS","bucket":"pass"},
+        {"name":"docs","state":"SKIPPED","bucket":"skipping"}]"#;
+    for (label, diagnostic_exit, diagnostic_stdout, expected_exit, messages) in [
+        (
+            "exit 1 empty stdout",
+            1,
+            "",
+            2,
+            &[
+                "no structured report",
+                "retry",
+                "waiting for CI",
+                "GitHub connectivity",
+                "repository access",
+            ][..],
+        ),
+        (
+            "exit 8 empty stdout",
+            8,
+            "",
+            2,
+            &[
+                "no structured report",
+                "retry",
+                "waiting for CI",
+                "GitHub connectivity",
+                "repository access",
+            ][..],
+        ),
+        (
+            "empty JSON array",
+            0,
+            "[]",
+            1,
+            &["no required-check rows"][..],
+        ),
+        (
+            "failed and pending rows despite JSON exit 0",
+            0,
+            blocked,
+            1,
+            &["build (bucket=fail", "test (bucket=pending"][..],
+        ),
+        (
+            "all-pass race",
+            0,
+            raced,
+            1,
+            &[
+                "state changed during the read",
+                "run `edda review merge` again",
+            ][..],
+        ),
+        ("malformed JSON", 0, "{", 2, &["JSON is malformed"][..]),
+        (
+            "API error shape",
+            1,
+            r#"{"message":"rate limit"}"#,
+            2,
+            &["unknown row shape"][..],
+        ),
+        ("unexpected exit", 9, "[]", 2, &["exited unexpectedly"][..]),
+    ] {
+        let f = Fixture::new(&open_set(), &lgtm_on_head());
+        let (code, stdout, stderr) =
+            f.run_with_checks(&["--merge"], 1, diagnostic_exit, diagnostic_stdout);
+        assert_eq!(
+            code, expected_exit,
+            "{label}: stdout: {stdout}\nstderr: {stderr}"
+        );
+        for message in messages {
+            assert!(
+                stderr.contains(message),
+                "{label}: missing {message:?}: {stderr}"
+            );
+        }
+        if diagnostic_stdout.is_empty() {
+            assert!(
+                !stderr.contains("no required-check rows are currently reported"),
+                "{label}: empty stdout falsely claimed absence: {stderr}"
+            );
+        }
+        assert!(
+            !f.merged_marker.exists(),
+            "{label}: a refusal issued gh pr merge"
+        );
+        let calls = f.calls();
+        let check_calls: Vec<String> = calls
+            .lines()
+            .filter(|line| line.starts_with("pr checks"))
+            .map(|line| line.replace('"', ""))
+            .collect();
+        assert_eq!(
+            check_calls,
+            [
+                format!("pr checks {SUBJECT} --required"),
+                format!("pr checks {SUBJECT} --required --json name,state,bucket"),
+            ],
+            "{label}: required-check argv did not preserve the exact PR and field order"
+        );
+    }
 }
 
 // Round 4's P0, measured the same way: the walk's own (creation) order reads a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1545,7 +1545,8 @@ edda review merge --pr 1105                  # --check is the default
 edda review merge --pr 1105 --merge --body-file .edda/merge-receipt.md
 ```
 
-The conditions run in order, and the first failure rejects with exit 1:
+The conditions run in order. A failed precondition rejects with exit 1;
+an unreadable or malformed answer rejects with exit 2:
 
 1. The PR is `OPEN` and its head is a 40-hex SHA.
 2. The latest trusted §7 review — ordered by `updated_at`, so an edited
@@ -1557,7 +1558,21 @@ The conditions run in order, and the first failure rejects with exit 1:
    Requested.
 4. Malformed §7 comments number zero (#917 — the union reads success
    precisely because a blocking round is invisible to it).
-5. Required checks are green.
+5. Required checks are green. The sole authority for green is a successful
+   plain `gh pr checks <PR> --required` invocation. If it refuses, Edda makes
+   one diagnostic read with `--required --json name,state,bucket`, but that
+   read can explain a refusal only; it can never approve the merge. A
+   successfully decoded empty array (`[]`) means no required-check rows are
+   reported and refuses with exit 1; its message tells the operator to wait
+   for CI or check whether the PR base is covered by a ruleset.
+   Failed/pending/cancelled rows and rows that raced to all passing/skipping
+   also refuse with exit 1, with the race asking for a fresh invocation.
+   Zero-byte diagnostic stdout on any exit means no structured report was
+   returned, not that rows are absent. It refuses as indeterminate with exit
+   2 and suggests retrying after waiting and checking GitHub connectivity and
+   repository access. Malformed JSON, an unknown row shape, an unexpected
+   exit, or a failed read also refuses as indeterminate with exit 2.
+   Classification never depends on gh's human stderr wording.
 6. The squash subject matches the commit convention
    `<type>(<scope>): <description>` (GH-1100): `type` is one of
    `feat|fix|docs|refactor|test|chore`, and a violation is rejected with the
@@ -1612,6 +1627,6 @@ may be passed explicitly.
 | Exit | Meaning |
 |---|---|
 | 0 | Accepted — merged, when `--merge` was given |
-| 1 | A precondition failed |
-| 2 | A read failed, or the invocation itself is malformed — an unreadable answer is never an approval |
+| 1 | A precondition failed, including a decoded empty required-check array, blocked rows, or raced rows |
+| 2 | A read failed or was indeterminate (including zero-byte diagnostic stdout on any exit), or the invocation itself is malformed — an unreadable answer is never an approval |
 


### PR DESCRIPTION
## Summary
- preserve plain `gh pr checks <PR> --required` as the sole green authority
- classify the structured diagnostic reread as absent, blocked, raced, or indeterminate without stderr matching
- cover exit/status/JSON shapes, exact argv, and no-squash refusals; document exit behavior

## Validation
- `cargo fmt --all --check`
- `cargo clippy -p edda --all-targets -- -D warnings`
- `cargo test -p edda`
- `bash scripts/check-cli-docs.sh`
- `sh scripts/lint-markdown-content.sh`
- `bash scripts/lint-doc-citations.sh --tree`
- `scripts/lint-file-length.sh --staged`

Issue: #1135

Closes #1135

## Review
- Round 1 Changes Requested at `e6b3ba11b7f8462a39dad16ed3ea37ce445a9d6e`: P0=1/P1=0
- Review Response Round 1: ambiguous empty output corrected under d-003
- Round 2 LGTM at `10865bdcf503d7296ed6749318f781b00001dc13`: P0=0/P1=0, exact-head CI `34581662226` green
