### PR TITLE
refactor(edda-cli): converge legacy merge check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Legacy merge-check compatibility converges on the product gate** — live `edda prs check-merge` forwards to `edda review merge`, while its retained host-agnostic scalar forms are explicitly deprecated advisory diagnostics and cannot merge (GH-1145)
+
 ## [0.6.1] - 2026-09-10
 
 ### Added

--- a/crates/edda-cli/src/cmd_prs.rs
+++ b/crates/edda-cli/src/cmd_prs.rs
@@ -20,7 +20,8 @@ pub enum PrsCmd {
         #[arg(long, default_value = "all")]
         state: String,
     },
-    /// Evaluate merge preconditions for a PR (current-head LGTM, green CI, SHA window)
+    /// Deprecated compatibility: live PRs forward to `edda review merge`;
+    /// --input/direct facts are advisory scalar diagnostics, not R6 evidence
     CheckMerge(merge_gate::CheckMergeArgs),
 }
 

--- a/crates/edda-cli/src/cmd_prs/merge_gate.rs
+++ b/crates/edda-cli/src/cmd_prs/merge_gate.rs
@@ -4,65 +4,73 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::Read;
 use std::path::Path;
-use std::process::Command;
 
-/// Command line arguments for `edda prs check-merge`
+const ADVISORY_NOTICE: &str = "Deprecated advisory scalar diagnostics only; not trusted R6 evidence. Use `edda review merge --pr <PR>` for live merge readiness.";
+
+/// Arguments for deprecated `edda prs check-merge` compatibility.
+///
+/// A positional PR without `--input` forwards to `edda review merge`. The
+/// `--input` and direct-fact forms remain advisory scalar diagnostics only.
 #[derive(Debug, Clone, Args, Default)]
 pub struct CheckMergeArgs {
-    /// PR number to evaluate (queries GitHub via `gh` CLI)
+    /// PR number. Without --input, forward to canonical `edda review merge`
     #[arg(value_name = "PR")]
     pub pr: Option<u64>,
 
-    /// Explicit head commit SHA
+    /// Advisory direct-fact head commit SHA (deprecated)
     #[arg(long)]
     pub head_sha: Option<String>,
 
-    /// Explicit verdict commit SHA
+    /// Advisory direct-fact verdict commit SHA (deprecated)
     #[arg(long)]
     pub verdict_sha: Option<String>,
 
-    /// Explicit verdict (e.g. "lgtm", "changes-requested")
+    /// Advisory direct-fact verdict: exactly "lgtm" or "approved" (deprecated)
     #[arg(long)]
     pub verdict: Option<String>,
 
-    /// Optional author of the review verdict
+    /// Optional advisory author of the direct-fact verdict (deprecated)
     #[arg(long)]
     pub verdict_author: Option<String>,
 
-    /// Count of P0 blocking findings
+    /// Advisory count of P0 blocking findings (deprecated)
     #[arg(long, default_value_t = 0)]
     pub p0: usize,
 
-    /// Count of P1 blocking findings
+    /// Advisory count of P1 blocking findings (deprecated)
     #[arg(long, default_value_t = 0)]
     pub p1: usize,
 
-    /// Mark required CI checks as green
+    /// Advisory assertion that required CI checks are green (deprecated)
     #[arg(long)]
     pub ci_green: bool,
 
-    /// Optional list of allowed reviewer usernames
+    /// Unsupported for live PR forwarding; canonical trust uses GitHub
+    /// author_association (OWNER, MEMBER, or COLLABORATOR)
     #[arg(long, value_delimiter = ',')]
     pub allowed_reviewers: Option<Vec<String>>,
 
-    /// Path to JSON file containing MergeGateInput (or '-' for stdin)
+    /// Advisory MergeGateInput JSON file, or '-' for stdin (deprecated)
     #[arg(long, value_name = "FILE")]
     pub input: Option<String>,
 
-    /// Execute `gh pr merge <PR> --squash` if preconditions pass
+    /// Forward a live PR to canonical `edda review merge --merge`; forbidden
+    /// for advisory --input/direct-fact modes
     #[arg(long)]
     pub merge: bool,
 
-    /// Output evaluation report as JSON
+    /// Output canonical live JSON, or the advisory compatibility result as JSON
     #[arg(long)]
     pub json: bool,
 
-    /// Override process claim held by another session (GH-581)
+    /// Override an active process claim in advisory --input/direct-fact modes
+    /// only; unsupported for a forwarded live PR (GH-581)
     #[arg(long)]
     pub force: bool,
 }
 
-/// Host-agnostic input for evaluating merge preconditions.
+/// Deprecated host-agnostic advisory scalar input. This schema is retained for
+/// compatibility; it is not trusted-comment union or R6 evidence.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MergeGateInput {
     pub head_sha: String,
@@ -88,7 +96,8 @@ pub struct MergeGateInput {
     pub force: bool,
 }
 
-/// Evaluation outcome for merge preconditions.
+/// Deprecated advisory scalar result. The shape remains compatible, but
+/// `can_merge` is not trusted R6 merge-readiness evidence.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct MergeGateResult {
     pub can_merge: bool,
@@ -115,11 +124,13 @@ pub fn is_valid_40_hex_sha(sha: &str) -> bool {
     s.len() == 40 && s.chars().all(|c| c.is_ascii_hexdigit())
 }
 
-/// Pure evaluation function without host or network dependencies.
+/// Pure deprecated advisory evaluation without host or network dependencies.
+///
+/// This deliberately evaluates only caller-supplied scalar facts. It cannot
+/// establish the trusted-comment union and is never R6 evidence.
 pub fn evaluate_merge_preconditions(input: &MergeGateInput) -> MergeGateResult {
     let mut reasons = Vec::new();
 
-    // 1. Validate head SHA shape
     let h_clean = input.head_sha.trim();
     if !is_valid_40_hex_sha(h_clean) {
         reasons.push(format!(
@@ -127,22 +138,18 @@ pub fn evaluate_merge_preconditions(input: &MergeGateInput) -> MergeGateResult {
         ));
     }
 
-    // 2. Verdict presence & state
     match &input.verdict {
-        None => {
-            reasons.push("no review verdict found on PR".to_string());
-        }
+        None => reasons.push("no review verdict found on PR".to_string()),
         Some(v) => {
             let v_clean = v.trim().to_lowercase();
             if v_clean.is_empty() || v_clean == "none" || v_clean == "unreviewed" {
                 reasons.push("no review verdict found on PR".to_string());
-            } else if v_clean != "lgtm" && !v_clean.contains("lgtm") && v_clean != "approved" {
+            } else if !matches!(v_clean.as_str(), "lgtm" | "approved") {
                 reasons.push(format!("review verdict is not LGTM (found '{v}')"));
             }
         }
     }
 
-    // 3. Blocking findings (P0=0 and P1=0)
     if input.p0_count > 0 || input.p1_count > 0 {
         reasons.push(format!(
             "blocking findings present: {} P0, {} P1 (both must be 0)",
@@ -150,7 +157,6 @@ pub fn evaluate_merge_preconditions(input: &MergeGateInput) -> MergeGateResult {
         ));
     }
 
-    // 4. SHA window check (verdict SHA must match current PR head exactly)
     if let Some(v_sha) = &input.verdict_sha {
         let v_clean = v_sha.trim();
         if !is_valid_40_hex_sha(v_clean) {
@@ -166,8 +172,12 @@ pub fn evaluate_merge_preconditions(input: &MergeGateInput) -> MergeGateResult {
         reasons.push("review verdict is not pinned to any commit SHA".to_string());
     }
 
-    // 5. Required CI checks
-    if !input.required_ci_green {
+    if input.required_ci_green && !input.failed_checks.is_empty() {
+        reasons.push(format!(
+            "required_ci_green=true contradicts nonempty failed_checks: {}",
+            input.failed_checks.join(", ")
+        ));
+    } else if !input.required_ci_green {
         if input.failed_checks.is_empty() {
             reasons.push("required CI check(s) are not green".to_string());
         } else {
@@ -178,7 +188,6 @@ pub fn evaluate_merge_preconditions(input: &MergeGateInput) -> MergeGateResult {
         }
     }
 
-    // 6. Process object claim protection (GH-581)
     if let Some(holder) = &input.claimed_by {
         if !input.force {
             reasons.push(format!(
@@ -203,416 +212,20 @@ pub fn evaluate_merge_preconditions(input: &MergeGateInput) -> MergeGateResult {
     }
 }
 
-// GitHub API / `gh` structures
-#[derive(Debug, Clone, Deserialize)]
-pub struct GhViewPr {
-    #[serde(rename = "headRefOid")]
-    pub head_ref_oid: String,
-    pub author: Option<GhAuthor>,
-    #[serde(default)]
-    pub comments: Vec<GhComment>,
-    #[serde(default)]
-    pub reviews: Vec<GhReviewItem>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct GhAuthor {
-    pub login: String,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct GhComment {
-    pub body: String,
-    pub author: Option<GhAuthor>,
-    #[serde(rename = "createdAt")]
-    pub created_at: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct GhReviewItem {
-    pub state: String,
-    pub author: Option<GhAuthor>,
-    pub body: Option<String>,
-    #[serde(rename = "submittedAt")]
-    pub submitted_at: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GhCheckItem {
-    name: String,
-    state: Option<String>,
-    bucket: Option<String>,
-}
-
-/// Determines if a comment is a structured review verdict, preventing casual comments and
-/// implementer responses from triggering a verdict.
-pub fn is_structured_review_comment(body: &str) -> bool {
-    // 1. Explicitly reject implementer review responses
-    if body.lines().any(|line| {
-        let trimmed = line.trim();
-        trimmed.starts_with("## Review Response") || trimmed.starts_with("# Review Response")
-    }) {
-        return false;
-    }
-
-    // 2. Must contain an anchored review header line
-    let has_review_header = body.lines().any(|line| {
-        let trimmed = line.trim();
-        trimmed.starts_with("## Code Review:")
-            || trimmed.starts_with("### Verdict")
-            || trimmed.starts_with("<<<VERDICT")
-            || trimmed.starts_with("## Operator ruling")
-            || trimmed.starts_with("Verdict as of the ruling:")
-            || trimmed.starts_with("**Verdict as of the ruling:")
-    });
-
-    if !has_review_header {
-        return false;
-    }
-
-    // 3. Must contain an explicit verdict indicator line
-    body.lines().any(|line| {
-        let trimmed = line.trim();
-        trimmed.starts_with("### Verdict")
-            || trimmed.starts_with("Verdict as of the ruling:")
-            || trimmed.starts_with("**Verdict as of the ruling:")
-            || trimmed.starts_with("- verdict:")
-            || trimmed.starts_with("**Verdict:")
-            || trimmed.starts_with("Verdict:")
-            || trimmed.starts_with("LGTM (")
-            || trimmed.starts_with("**LGTM")
-            || trimmed.starts_with("Changes Requested,")
-            || trimmed.starts_with("**Changes Requested")
-    })
-}
-
-fn parse_count(line: &str, prefix: &str) -> Option<usize> {
-    let idx = line.find(prefix)?;
-    let rest = line[idx + prefix.len()..].trim_start_matches([':', '=', ' ']);
-    let num_str: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
-    num_str.parse::<usize>().ok()
-}
-
-/// Extract verdict info (verdict, verdict_sha, p0, p1) from comment or review body text
-pub fn parse_verdict_text(text: &str) -> (Option<String>, Option<String>, usize, usize) {
-    let mut verdict = None;
-    let mut verdict_sha = None;
-    let mut p0 = 0;
-    let mut p1 = 0;
-
-    // Look for SHA in header line first: "## Code Review: ... @ <SHA>"
-    for line in text.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with("## Code Review:") || trimmed.starts_with("## Review:") {
-            if let Some(at_idx) = trimmed.rfind('@') {
-                let after = trimmed[at_idx + 1..].trim();
-                let clean =
-                    after.trim_matches(['*', '`', '(', ')', '.', ',', ':', '"', '\'', '[', ']']);
-                let sha_candidate: String = clean
-                    .chars()
-                    .take_while(|c| c.is_ascii_hexdigit())
-                    .collect();
-                if sha_candidate.len() == 40 {
-                    verdict_sha = Some(sha_candidate);
-                    break;
-                }
-            }
-        }
-    }
-
-    // Focus parsing on the final verdict section if present (using rfind to avoid matching earlier quotes)
-    let target_section = if let Some(idx) = text.rfind("\n### Verdict") {
-        &text[idx..]
-    } else if let Some(idx) = text.rfind("\n<<<VERDICT") {
-        &text[idx..]
-    } else if let Some(idx) = text.rfind("Verdict as of the ruling:") {
-        &text[idx..]
-    } else if let Some(idx) = text.rfind("### Verdict") {
-        &text[idx..]
-    } else {
-        text
-    };
-
-    for line in target_section.lines() {
-        let trimmed = line.trim().trim_matches('*').trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with("<<<") {
-            continue;
-        }
-        let clean = if let Some(idx) = trimmed.find("Verdict as of the ruling:") {
-            trimmed[idx + "Verdict as of the ruling:".len()..]
-                .trim()
-                .trim_matches('*')
-                .trim()
-        } else if let Some(idx) = trimmed.find("Verdict:") {
-            trimmed[idx + "Verdict:".len()..]
-                .trim()
-                .trim_matches('*')
-                .trim()
-        } else {
-            trimmed
-        };
-
-        if clean.starts_with("LGTM") || clean.starts_with("Approved") {
-            verdict = Some("LGTM".to_string());
-            break;
-        } else if clean.starts_with("Changes Requested") || clean.starts_with("changes_requested") {
-            verdict = Some("Changes Requested".to_string());
-            break;
-        }
-    }
-
-    if verdict.is_none() {
-        let has_changes_requested = target_section.contains("Changes Requested")
-            || target_section.contains("changes_requested");
-        let has_lgtm = target_section.contains("LGTM") || target_section.contains("lgtm");
-
-        if has_changes_requested {
-            verdict = Some("Changes Requested".to_string());
-        } else if has_lgtm {
-            verdict = Some("LGTM".to_string());
-        }
-    }
-
-    for line in target_section.lines() {
-        if let Some(val) = parse_count(line, "P0") {
-            p0 = p0.max(val);
-        } else if let Some(val) = parse_count(line, "p0") {
-            p0 = p0.max(val);
-        }
-
-        if let Some(val) = parse_count(line, "P1") {
-            p1 = p1.max(val);
-        } else if let Some(val) = parse_count(line, "p1") {
-            p1 = p1.max(val);
-        }
-    }
-
-    if verdict_sha.is_none() {
-        for word in target_section.split_whitespace() {
-            let clean = word.trim_matches(['*', '`', '(', ')', '.', ',', ':', '"', '\'', '[', ']']);
-            if clean.len() == 40 && clean.chars().all(|c| c.is_ascii_hexdigit()) {
-                verdict_sha = Some(clean.to_string());
-                break;
-            }
-        }
-    }
-
-    (verdict, verdict_sha, p0, p1)
-}
-
-#[derive(Debug, Clone)]
-struct ReviewTimelineEvent {
-    timestamp: String,
-    author: Option<String>,
-    verdict: String,
-    verdict_sha: Option<String>,
-    p0_count: usize,
-    p1_count: usize,
-}
-
-/// Pure timeline extractor: processes reviews and structured comments into the final verdict.
-pub fn extract_timeline_verdict(
-    gh_view: &GhViewPr,
-    allowed_reviewers: Option<&[String]>,
-) -> (Option<String>, Option<String>, Option<String>, usize, usize) {
-    let mut timeline: Vec<ReviewTimelineEvent> = Vec::new();
-
-    // 1. Process GitHub formal reviews (APPROVED / CHANGES_REQUESTED)
-    for r in &gh_view.reviews {
-        if let Some(allowed) = allowed_reviewers {
-            match &r.author {
-                Some(author)
-                    if allowed
-                        .iter()
-                        .any(|u| u.eq_ignore_ascii_case(&author.login)) => {}
-                _ => continue, // Fail closed: unauthenticated/unattributable events are rejected
-            }
-        }
-
-        let verdict_opt = match r.state.as_str() {
-            "APPROVED" => Some("LGTM".to_string()),
-            "CHANGES_REQUESTED" => Some("Changes Requested".to_string()),
-            _ => None,
-        };
-
-        if let Some(formal_verdict) = verdict_opt {
-            let (_, sha, parsed_p0, parsed_p1) = if let Some(body) = &r.body {
-                parse_verdict_text(body)
-            } else {
-                (None, None, 0, 0)
-            };
-
-            let ts = r.submitted_at.clone().unwrap_or_default();
-            let author = r.author.as_ref().map(|a| a.login.clone());
-
-            timeline.push(ReviewTimelineEvent {
-                timestamp: ts,
-                author,
-                verdict: formal_verdict,
-                verdict_sha: sha,
-                p0_count: parsed_p0,
-                p1_count: parsed_p1,
-            });
-        }
-    }
-
-    // 2. Process structured review comments
-    for comment in &gh_view.comments {
-        if let Some(allowed) = allowed_reviewers {
-            match &comment.author {
-                Some(author)
-                    if allowed
-                        .iter()
-                        .any(|u| u.eq_ignore_ascii_case(&author.login)) => {}
-                _ => continue, // Fail closed: unauthenticated/unattributable events are rejected
-            }
-        }
-
-        if !is_structured_review_comment(&comment.body) {
-            continue;
-        }
-
-        let (v, sha, parsed_p0, parsed_p1) = parse_verdict_text(&comment.body);
-        if let Some(found_v) = v {
-            let ts = comment.created_at.clone().unwrap_or_default();
-            let author = comment.author.as_ref().map(|a| a.login.clone());
-
-            timeline.push(ReviewTimelineEvent {
-                timestamp: ts,
-                author,
-                verdict: found_v,
-                verdict_sha: sha,
-                p0_count: parsed_p0,
-                p1_count: parsed_p1,
-            });
-        }
-    }
-
-    // Sort timeline chronologically (oldest to newest) so the newest review event wins
-    timeline.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
-
-    if let Some(latest) = timeline.pop() {
-        (
-            Some(latest.verdict),
-            latest.verdict_sha,
-            latest.author,
-            latest.p0_count,
-            latest.p1_count,
-        )
-    } else {
-        (None, None, None, 0, 0)
-    }
-}
-
-fn fetch_pr_from_gh(
-    pr: u64,
-    allowed_reviewers: Option<&[String]>,
-    repo_root: &Path,
-) -> anyhow::Result<MergeGateInput> {
-    let view_output = Command::new("gh")
-        .args([
-            "pr",
-            "view",
-            &pr.to_string(),
-            "--json",
-            "headRefOid,author,comments,reviews",
-        ])
-        .current_dir(repo_root)
-        .output()
-        .context("execute gh pr view")?;
-
-    if !view_output.status.success() {
-        let stderr = String::from_utf8_lossy(&view_output.stderr);
-        anyhow::bail!("gh pr view {} failed: {}", pr, stderr.trim());
-    }
-
-    let gh_view: GhViewPr =
-        serde_json::from_slice(&view_output.stdout).context("parse gh pr view json output")?;
-
-    let head_sha = gh_view.head_ref_oid.clone();
-    let (verdict, verdict_sha, verdict_author, p0, p1) =
-        extract_timeline_verdict(&gh_view, allowed_reviewers);
-
-    // Fetch PR checks
-    let checks_output = Command::new("gh")
-        .args([
-            "pr",
-            "checks",
-            &pr.to_string(),
-            "--json",
-            "name,state,bucket",
-        ])
-        .current_dir(repo_root)
-        .output()
-        .context("execute gh pr checks")?;
-
-    let mut required_ci_green = true;
-    let mut failed_checks = Vec::new();
-
-    if checks_output.status.success() {
-        let checks: Vec<GhCheckItem> =
-            serde_json::from_slice(&checks_output.stdout).unwrap_or_default();
-
-        let ci_gate_item = checks.iter().find(|c| c.name == "CI Gate");
-
-        if let Some(ci_gate) = ci_gate_item {
-            let pass = ci_gate.bucket.as_deref() == Some("pass")
-                || ci_gate.bucket.as_deref() == Some("skipping")
-                || ci_gate.state.as_deref() == Some("SUCCESS");
-            if !pass {
-                required_ci_green = false;
-                failed_checks.push(format!(
-                    "CI Gate ({})",
-                    ci_gate.bucket.as_deref().unwrap_or("unknown")
-                ));
-            }
-        } else if !checks.is_empty() {
-            for c in &checks {
-                let pass = c.bucket.as_deref() == Some("pass")
-                    || c.bucket.as_deref() == Some("skipping")
-                    || c.state.as_deref() == Some("SUCCESS");
-                if !pass {
-                    required_ci_green = false;
-                    failed_checks.push(format!(
-                        "{} ({})",
-                        c.name,
-                        c.bucket.as_deref().unwrap_or("unknown")
-                    ));
-                }
-            }
-        } else {
-            required_ci_green = false;
-            failed_checks.push("no checks reported".to_string());
-        }
-    } else {
-        required_ci_green = false;
-        failed_checks.push("failed to fetch CI checks via gh".to_string());
-    }
-
-    Ok(MergeGateInput {
-        head_sha,
-        pr: Some(pr),
-        pr_author: gh_view.author.as_ref().map(|a| a.login.clone()),
-        verdict,
-        verdict_sha,
-        verdict_author,
-        p0_count: p0,
-        p1_count: p1,
-        required_ci_green,
-        failed_checks,
-        claimed_by: None,
-        force: false,
-    })
-}
-
-/// Format standard CLI output reports for merge precondition results.
+/// Format the retained advisory compatibility report.
+///
+/// Existing report lines remain for compatibility, with an explicit advisory
+/// line preventing them from being presented as trusted R6 evidence.
 pub fn format_merge_report(result: &MergeGateResult) -> (String, String) {
+    use std::fmt::Write;
+
     let mut stdout_buf = String::new();
     let mut stderr_buf = String::new();
 
     if result.can_merge {
-        use std::fmt::Write;
         let _ = writeln!(stdout_buf, "PASS: Merge preconditions satisfied.");
+        writeln!(stdout_buf, "  Advisory: {ADVISORY_NOTICE}")
+            .expect("writing to String cannot fail");
         let _ = writeln!(stdout_buf, "  PR Head:     {}", result.head_sha);
         if let Some(author) = &result.pr_author {
             let _ = writeln!(stdout_buf, "  PR Author:   {author}");
@@ -642,12 +255,13 @@ pub fn format_merge_report(result: &MergeGateResult) -> (String, String) {
             );
         }
     } else {
-        use std::fmt::Write;
         let _ = writeln!(
             stderr_buf,
             "REFUSED: Merge preconditions not satisfied for head {}:",
             result.head_sha
         );
+        writeln!(stderr_buf, "  Advisory: {ADVISORY_NOTICE}")
+            .expect("writing to String cannot fail");
         if let Some(author) = &result.pr_author {
             let _ = writeln!(stderr_buf, "  PR Author:   {author}");
         }
@@ -661,9 +275,8 @@ pub fn format_merge_report(result: &MergeGateResult) -> (String, String) {
 
 /// Query the coordination board for an active process claim on `pr:<pr_number>`.
 ///
-/// Filters for live sessions and excludes `current_session_id`.
-/// Matches using `subjects_intersect` so glob subjects (e.g. `pr:57*`) are honoured.
-/// Fails closed (returns `Err`) if a claim subject glob cannot be parsed soundly.
+/// This compatibility guard is used only by advisory `--input`/direct-fact
+/// evaluation. Canonical live merge readiness has no claim precondition.
 pub(crate) fn check_active_pr_claim(
     repo_root: &Path,
     pr_number: u64,
@@ -673,49 +286,72 @@ pub(crate) fn check_active_pr_claim(
     let target_subject = format!("pr:{pr_number}");
     let board = edda_bridge_claude::peers::compute_board_state(&project_id);
 
-    // Validate all claim subject globs up front so a corrupted/unparseable glob fails closed
-    for c in &board.claims {
-        if let Some(sub) = c.subject.as_deref() {
-            if crate::cmd_claim::has_wildcard(sub) {
-                globset::GlobBuilder::new(sub)
+    for claim in &board.claims {
+        if let Some(subject) = claim.subject.as_deref() {
+            if crate::cmd_claim::has_wildcard(subject) {
+                globset::GlobBuilder::new(subject)
                     .case_insensitive(true)
                     .build()
-                    .map_err(|e| anyhow::anyhow!("invalid claim subject glob '{sub}': {e}"))?;
+                    .map_err(|e| anyhow::anyhow!("invalid claim subject glob '{subject}': {e}"))?;
             }
         }
     }
 
-    for c in board.claims {
-        let Some(sub) = c.subject.as_deref() else {
+    for claim in board.claims {
+        let Some(subject) = claim.subject.as_deref() else {
             continue;
         };
-        let matches = crate::cmd_claim::subjects_intersect(&target_subject, sub)
+        let matches = crate::cmd_claim::subjects_intersect(&target_subject, subject)
             .map_err(|e| anyhow::anyhow!("failed to parse claim subject: {e}"))?;
         if !matches {
             continue;
         }
         let is_live = matches!(
-            edda_bridge_claude::peers::classify_session_liveness(&project_id, &c.session_id),
+            edda_bridge_claude::peers::classify_session_liveness(&project_id, &claim.session_id),
             edda_bridge_claude::peers::SessionLiveness::Live { .. }
         );
-        if !is_live {
-            continue;
-        }
-        if current_session_id == Some(&c.session_id) {
+        if !is_live || current_session_id == Some(&claim.session_id) {
             continue;
         }
         return Ok(Some(format!(
             "{} (label: '{}', subject: '{}')",
-            c.session_id, c.label, sub
+            claim.session_id, claim.label, subject
         )));
     }
     Ok(None)
 }
 
-/// Execute the merge precondition check CLI entrypoint.
+/// Execute deprecated `edda prs check-merge` compatibility.
+///
+/// A live positional PR goes through the exact `edda review merge` product
+/// entrypoint. Only host-agnostic `--input` and direct facts retain the legacy
+/// advisory evaluator, claim guard, and 0/1 report contract.
 pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result<()> {
-    if args.merge && (args.pr.is_none() || args.input.is_some()) {
-        anyhow::bail!("--merge requires a live PR number and cannot be used with '--input'");
+    if let Some(pr) = args.pr.filter(|_| args.input.is_none()) {
+        if args.allowed_reviewers.is_some() {
+            eprintln!(
+                "edda prs check-merge: --allowed-reviewers is unsupported in live-forward mode; \
+                 canonical `edda review merge` trusts GitHub author_association \
+                 OWNER/MEMBER/COLLABORATOR; refusing"
+            );
+            std::process::exit(2);
+        }
+        if args.force {
+            eprintln!(
+                "edda prs check-merge: --force is unsupported in live-forward mode; process \
+                 claims apply only to deprecated --input/direct-fact advisory diagnostics and \
+                 are not an R6 condition; refusing"
+            );
+            std::process::exit(2);
+        }
+        return crate::cmd_review::run_merge_compat(pr, args.merge, args.json, repo_root);
+    }
+
+    if args.merge {
+        anyhow::bail!(
+            "--merge is forbidden for deprecated --input/direct-fact advisory diagnostics; use \
+             `edda review merge --pr <PR> --merge`"
+        );
     }
 
     let mut input = if let Some(input_source) = &args.input {
@@ -728,8 +364,6 @@ pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result
                 .with_context(|| format!("read input file: {input_source}"))?
         };
         serde_json::from_str::<MergeGateInput>(&raw).context("parse MergeGateInput JSON")?
-    } else if let Some(pr_number) = args.pr {
-        fetch_pr_from_gh(pr_number, args.allowed_reviewers.as_deref(), repo_root)?
     } else if let Some(head_sha) = args.head_sha {
         MergeGateInput {
             head_sha,
@@ -747,7 +381,8 @@ pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result
         }
     } else {
         anyhow::bail!(
-            "Specify either a PR number (e.g. 'edda prs check-merge 580') or '--input <FILE>'"
+            "Specify a live PR number, deprecated '--input <FILE>', or deprecated direct facts \
+             beginning with '--head-sha <SHA>'"
         );
     };
 
@@ -755,8 +390,7 @@ pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result
         input.force = true;
     }
 
-    let target_pr = args.pr.or(input.pr);
-    if let Some(pr_number) = target_pr {
+    if let Some(pr_number) = args.pr.or(input.pr) {
         if input.claimed_by.is_none() {
             let my_sid = std::env::var("EDDA_SESSION_ID").ok();
             input.claimed_by = check_active_pr_claim(repo_root, pr_number, my_sid.as_deref())?;
@@ -766,8 +400,8 @@ pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result
     let result = evaluate_merge_preconditions(&input);
 
     if args.json {
-        let json_out = serde_json::to_string_pretty(&result)?;
-        println!("{json_out}");
+        eprintln!("{ADVISORY_NOTICE}");
+        println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
         let (out, err) = format_merge_report(&result);
         if !out.is_empty() {
@@ -775,27 +409,6 @@ pub fn run_check_merge(args: CheckMergeArgs, repo_root: &Path) -> anyhow::Result
         }
         if !err.is_empty() {
             eprint!("{err}");
-        }
-    }
-
-    if args.merge {
-        if result.can_merge {
-            let pr_number = match args.pr {
-                Some(num) => num,
-                None => anyhow::bail!("--merge requires a PR number positional argument"),
-            };
-            println!("Executing merge: gh pr merge {pr_number} --squash");
-            let status = Command::new("gh")
-                .args(["pr", "merge", &pr_number.to_string(), "--squash"])
-                .current_dir(repo_root)
-                .status()
-                .context("execute gh pr merge")?;
-            if !status.success() {
-                anyhow::bail!("gh pr merge failed with status {}", status);
-            }
-        } else {
-            eprintln!("Error: Cannot merge because preconditions failed.");
-            std::process::exit(1);
         }
     }
 
@@ -831,7 +444,7 @@ mod tests {
     }
 
     #[test]
-    fn test_refuse_when_no_verdict() {
+    fn no_verdict_refuses() {
         let input = MergeGateInput {
             verdict: None,
             verdict_sha: None,
@@ -842,399 +455,170 @@ mod tests {
         assert!(result
             .reasons
             .iter()
-            .any(|r| r.contains("no review verdict")));
+            .any(|reason| reason.contains("no review verdict")));
     }
 
     #[test]
-    fn test_refuse_when_verdict_stale_new_push() {
+    fn only_exact_lgtm_or_approved_is_accepted() {
+        for verdict in ["LGTM", " lgtm ", "APPROVED", " approved "] {
+            let result = evaluate_merge_preconditions(&MergeGateInput {
+                verdict: Some(verdict.into()),
+                ..base_input()
+            });
+            assert!(result.can_merge, "{verdict:?}: {:?}", result.reasons);
+        }
+        for verdict in ["not lgtm", "LGTM later", "unapproved", "changes-requested"] {
+            let result = evaluate_merge_preconditions(&MergeGateInput {
+                verdict: Some(verdict.into()),
+                ..base_input()
+            });
+            assert!(!result.can_merge, "accepted {verdict:?}");
+            assert!(result
+                .reasons
+                .iter()
+                .any(|reason| reason.contains("not LGTM")));
+        }
+    }
+
+    #[test]
+    fn stale_or_invalid_sha_refuses() {
+        for input in [
+            MergeGateInput {
+                head_sha: VALID_SHA_B.into(),
+                verdict_sha: Some(VALID_SHA_A.into()),
+                ..base_input()
+            },
+            MergeGateInput {
+                head_sha: "short".into(),
+                verdict_sha: Some("short".into()),
+                ..base_input()
+            },
+        ] {
+            assert!(!evaluate_merge_preconditions(&input).can_merge);
+        }
+    }
+
+    #[test]
+    fn failed_or_contradictory_ci_refuses() {
+        for input in [
+            MergeGateInput {
+                required_ci_green: false,
+                failed_checks: vec!["CI Gate (fail)".into()],
+                ..base_input()
+            },
+            MergeGateInput {
+                required_ci_green: true,
+                failed_checks: vec!["CI Gate (fail)".into()],
+                ..base_input()
+            },
+        ] {
+            let result = evaluate_merge_preconditions(&input);
+            assert!(!result.can_merge);
+            assert!(result
+                .reasons
+                .iter()
+                .any(|reason| reason.contains("CI Gate (fail)")));
+        }
+    }
+
+    #[test]
+    fn blocking_findings_refuse() {
+        for input in [
+            MergeGateInput {
+                p0_count: 12,
+                ..base_input()
+            },
+            MergeGateInput {
+                p1_count: 2,
+                ..base_input()
+            },
+        ] {
+            let result = evaluate_merge_preconditions(&input);
+            assert!(!result.can_merge);
+            assert!(result
+                .reasons
+                .iter()
+                .any(|reason| reason.contains("blocking findings present")));
+        }
+    }
+
+    #[test]
+    fn all_advisory_scalars_met_approves() {
         let input = MergeGateInput {
-            head_sha: VALID_SHA_B.into(),
-            verdict_sha: Some(VALID_SHA_A.into()),
-            ..base_input()
-        };
-        let result = evaluate_merge_preconditions(&input);
-        assert!(!result.can_merge);
-        assert!(result
-            .reasons
-            .iter()
-            .any(|r| r.contains("SHA window mismatch")));
-    }
-
-    #[test]
-    fn test_refuse_when_sha_is_invalid() {
-        let input = MergeGateInput {
-            head_sha: "short".into(),
-            verdict_sha: Some("short".into()),
-            ..base_input()
-        };
-        let result = evaluate_merge_preconditions(&input);
-        assert!(!result.can_merge);
-        assert!(result
-            .reasons
-            .iter()
-            .any(|r| r.contains("not a valid 40-character hex commit SHA")));
-    }
-
-    #[test]
-    fn test_refuse_when_ci_not_green() {
-        let input = MergeGateInput {
-            required_ci_green: false,
-            failed_checks: vec!["CI Gate (fail)".into()],
-            ..base_input()
-        };
-        let result = evaluate_merge_preconditions(&input);
-        assert!(!result.can_merge);
-        assert!(result.reasons.iter().any(|r| r.contains("CI Gate (fail)")));
-    }
-
-    #[test]
-    fn test_refuse_when_blocking_findings_or_changes_requested() {
-        // Case A: Changes Requested
-        let input_cr = MergeGateInput {
-            verdict: Some("Changes Requested".into()),
-            ..base_input()
-        };
-        let res_cr = evaluate_merge_preconditions(&input_cr);
-        assert!(!res_cr.can_merge);
-        assert!(res_cr.reasons.iter().any(|r| r.contains("not LGTM")));
-
-        // Case B: P0 > 0 (e.g. 12)
-        let input_p0 = MergeGateInput {
-            p0_count: 12,
-            ..base_input()
-        };
-        let res_p0 = evaluate_merge_preconditions(&input_p0);
-        assert!(!res_p0.can_merge);
-        assert!(res_p0.reasons.iter().any(|r| r.contains("12 P0")));
-
-        // Case C: P1 > 0
-        let input_p1 = MergeGateInput {
-            p1_count: 2,
-            ..base_input()
-        };
-        let res_p1 = evaluate_merge_preconditions(&input_p1);
-        assert!(!res_p1.can_merge);
-        assert!(res_p1
-            .reasons
-            .iter()
-            .any(|r| r.contains("blocking findings present")));
-    }
-
-    #[test]
-    fn test_approve_when_all_preconditions_met() {
-        let input = MergeGateInput {
-            verdict_sha: Some(VALID_SHA_A.to_uppercase()), // case-insensitive equality
-            verdict_author: Some("opus-reviewer".into()),
+            verdict_sha: Some(VALID_SHA_A.to_uppercase()),
+            verdict_author: Some("reviewer".into()),
             ..base_input()
         };
         let result = evaluate_merge_preconditions(&input);
         assert!(result.can_merge);
         assert!(result.reasons.is_empty());
-        assert_eq!(result.verdict_author.as_deref(), Some("opus-reviewer"));
     }
 
     #[test]
-    fn test_parse_verdict_text_multi_digits() {
-        let comment = r#"
-### Verdict
-Changes Requested, P0=12, P1=3
-Commit: 1234567890abcdef1234567890abcdef12345678
-"#;
-        let (verdict, sha, p0, p1) = parse_verdict_text(comment);
-        assert_eq!(verdict.as_deref(), Some("Changes Requested"));
-        assert_eq!(
-            sha.as_deref(),
-            Some("1234567890abcdef1234567890abcdef12345678")
-        );
-        assert_eq!(p0, 12);
-        assert_eq!(p1, 3);
+    fn retained_reports_are_explicitly_advisory() {
+        let pass = evaluate_merge_preconditions(&base_input());
+        let (stdout, stderr) = format_merge_report(&pass);
+        assert!(stderr.is_empty());
+        assert!(stdout.contains("PASS: Merge preconditions satisfied."));
+        assert!(stdout.contains(ADVISORY_NOTICE));
+
+        let refused = evaluate_merge_preconditions(&MergeGateInput {
+            verdict: Some("not lgtm".into()),
+            ..base_input()
+        });
+        let (stdout, stderr) = format_merge_report(&refused);
+        assert!(stdout.is_empty());
+        assert!(stderr.contains("REFUSED: Merge preconditions not satisfied"));
+        assert!(stderr.contains(ADVISORY_NOTICE));
     }
 
     #[test]
-    fn test_is_structured_review_comment() {
-        assert!(is_structured_review_comment(
-            "## Code Review: Round 1\n\n### Verdict\nLGTM (P0=0, P1=0) at `1234567890abcdef1234567890abcdef12345678`"
-        ));
-        assert!(is_structured_review_comment(
-            "### Verdict\nChanges Requested"
-        ));
-        assert!(is_structured_review_comment(
-            "<<<VERDICT\n**Verdict:** LGTM\nVERDICT>>>"
-        ));
-        assert!(is_structured_review_comment(
-            "## Operator ruling on #699\n\nVerdict as of the ruling: LGTM"
-        ));
-
-        // Implementer review responses must NEVER match
-        assert!(!is_structured_review_comment(
-            "## Review Response: Round 1 — PR #711\n\n- Requires comments to be structured review verdicts via is_structured_review_comment (e.g. ## Code Review:)"
-        ));
-        assert!(!is_structured_review_comment(
-            "# Review Response: Round 2\n\nLGTM is mentioned here"
-        ));
-
-        // Casual comments must NOT match
-        assert!(!is_structured_review_comment("ready for LGTM review"));
-        assert!(!is_structured_review_comment(
-            "I fixed the bug, please LGTM"
-        ));
-        assert!(!is_structured_review_comment("Not an LGTM yet"));
+    fn input_schema_round_trips_without_compatibility_markers() {
+        let value = serde_json::to_value(base_input()).unwrap();
+        assert_eq!(value["head_sha"], VALID_SHA_A);
+        assert_eq!(value["verdict"], "LGTM");
+        assert_eq!(value["required_ci_green"], true);
+        assert!(value.get("advisory").is_none());
+        assert!(value.get("deprecated").is_none());
     }
 
     #[test]
-    fn test_formal_review_state_not_overridden_by_prose() {
-        let gh_view = GhViewPr {
-            head_ref_oid: VALID_SHA_A.into(),
-            author: Some(GhAuthor {
-                login: "fagemx".into(),
-            }),
-            comments: vec![],
-            reviews: vec![GhReviewItem {
-                state: "CHANGES_REQUESTED".into(),
-                author: Some(GhAuthor {
-                    login: "reviewer".into(),
-                }),
-                body: Some(format!(
-                    "Not an LGTM yet - see inline notes. @ {VALID_SHA_A}"
-                )),
-                submitted_at: Some("2026-09-02T10:00:00Z".into()),
-            }],
-        };
-
-        let (verdict, sha, author, p0, p1) = extract_timeline_verdict(&gh_view, None);
-        assert_eq!(verdict.as_deref(), Some("Changes Requested"));
-        assert_eq!(sha.as_deref(), Some(VALID_SHA_A));
-        assert_eq!(author.as_deref(), Some("reviewer"));
-        assert_eq!(p0, 0);
-        assert_eq!(p1, 0);
-    }
-
-    #[test]
-    fn test_timeline_chronological_order() {
-        let gh_view = GhViewPr {
-            head_ref_oid: VALID_SHA_A.into(),
-            author: Some(GhAuthor {
-                login: "fagemx".into(),
-            }),
-            comments: vec![GhComment {
-                body: format!(
-                    "## Code Review: Round 1\n\n### Verdict\nLGTM (P0=0, P1=0) at `{VALID_SHA_A}`"
-                ),
-                author: Some(GhAuthor {
-                    login: "reviewer-a".into(),
-                }),
-                created_at: Some("2026-09-02T08:00:00Z".into()),
-            }],
-            reviews: vec![GhReviewItem {
-                state: "CHANGES_REQUESTED".into(),
-                author: Some(GhAuthor {
-                    login: "reviewer-b".into(),
-                }),
-                body: Some(format!("blocking findings @ {VALID_SHA_A}")),
-                submitted_at: Some("2026-09-02T09:00:00Z".into()),
-            }],
-        };
-
-        // Newer CHANGES_REQUESTED review (09:00) wins over older LGTM comment (08:00)
-        let (verdict, _, author, _, _) = extract_timeline_verdict(&gh_view, None);
-        assert_eq!(verdict.as_deref(), Some("Changes Requested"));
-        assert_eq!(author.as_deref(), Some("reviewer-b"));
-    }
-
-    #[test]
-    fn test_allowed_reviewers_filter() {
-        let allowed = vec!["authorized-reviewer".to_string()];
-
-        // Case 1: Unauthorized user comment is rejected
-        let gh_view_unauth = GhViewPr {
-            head_ref_oid: VALID_SHA_A.into(),
-            author: Some(GhAuthor {
-                login: "fagemx".into(),
-            }),
-            comments: vec![GhComment {
-                body: format!(
-                    "## Code Review: Round 1\n\n### Verdict\nLGTM (P0=0, P1=0) at `{VALID_SHA_A}`"
-                ),
-                author: Some(GhAuthor {
-                    login: "unauthorized-user".into(),
-                }),
-                created_at: Some("2026-09-02T08:00:00Z".into()),
-            }],
-            reviews: vec![],
-        };
-        let (verdict, _, _, _, _) = extract_timeline_verdict(&gh_view_unauth, Some(&allowed));
-        assert!(verdict.is_none());
-
-        // Case 2: Unattributable (author: None) comment/review is rejected (fail closed)
-        let gh_view_none = GhViewPr {
-            head_ref_oid: VALID_SHA_A.into(),
-            author: Some(GhAuthor {
-                login: "fagemx".into(),
-            }),
-            comments: vec![GhComment {
-                body: format!(
-                    "## Code Review: Round 1\n\n### Verdict\nLGTM (P0=0, P1=0) at `{VALID_SHA_A}`"
-                ),
-                author: None,
-                created_at: Some("2026-09-02T08:00:00Z".into()),
-            }],
-            reviews: vec![GhReviewItem {
-                state: "APPROVED".into(),
-                author: None,
-                body: Some(format!("LGTM @ {VALID_SHA_A}")),
-                submitted_at: Some("2026-09-02T08:30:00Z".into()),
-            }],
-        };
-        let (verdict, _, _, _, _) = extract_timeline_verdict(&gh_view_none, Some(&allowed));
-        assert!(verdict.is_none());
-
-        // Case 3: Authorized reviewer is accepted
-        let gh_view_auth = GhViewPr {
-            head_ref_oid: VALID_SHA_A.into(),
-            author: Some(GhAuthor {
-                login: "fagemx".into(),
-            }),
-            comments: vec![GhComment {
-                body: format!(
-                    "## Code Review: Round 1\n\n### Verdict\nLGTM (P0=0, P1=0) at `{VALID_SHA_A}`"
-                ),
-                author: Some(GhAuthor {
-                    login: "authorized-reviewer".into(),
-                }),
-                created_at: Some("2026-09-02T08:00:00Z".into()),
-            }],
-            reviews: vec![],
-        };
-        let (verdict, _, author, _, _) = extract_timeline_verdict(&gh_view_auth, Some(&allowed));
-        assert_eq!(verdict.as_deref(), Some("LGTM"));
-        assert_eq!(author.as_deref(), Some("authorized-reviewer"));
-    }
-
-    #[test]
-    fn test_run_check_merge_input_file_report_only() {
+    fn input_file_report_only_still_runs() {
         let temp_dir = tempfile::tempdir().unwrap();
         let input_file = temp_dir.path().join("input.json");
-        let valid_input = base_input();
-        fs::write(&input_file, serde_json::to_string(&valid_input).unwrap()).unwrap();
-
+        fs::write(&input_file, serde_json::to_string(&base_input()).unwrap()).unwrap();
         let args = CheckMergeArgs {
-            pr: None,
-            head_sha: None,
-            verdict_sha: None,
-            verdict: None,
-            verdict_author: None,
-            p0: 0,
-            p1: 0,
-            ci_green: false,
-            allowed_reviewers: None,
-            input: Some(input_file.to_str().unwrap().into()),
-            merge: false,
+            input: Some(input_file.to_string_lossy().into_owned()),
             json: true,
             ..Default::default()
         };
-
-        let res = run_check_merge(args, temp_dir.path());
-        assert!(res.is_ok());
+        assert!(run_check_merge(args, temp_dir.path()).is_ok());
     }
 
     #[test]
-    fn test_run_check_merge_rejects_merge_with_input_file() {
+    fn merge_with_input_remains_forbidden() {
         let temp_dir = tempfile::tempdir().unwrap();
         let input_file = temp_dir.path().join("input.json");
         fs::write(&input_file, "{}").unwrap();
-
         let args = CheckMergeArgs {
-            pr: None,
-            head_sha: None,
-            verdict_sha: None,
-            verdict: None,
-            verdict_author: None,
-            p0: 0,
-            p1: 0,
-            ci_green: false,
-            allowed_reviewers: None,
-            input: Some(input_file.to_str().unwrap().into()),
+            input: Some(input_file.to_string_lossy().into_owned()),
             merge: true,
-            json: false,
             ..Default::default()
         };
-
-        let res = run_check_merge(args, temp_dir.path());
-        assert!(res.is_err());
-        assert!(res
-            .unwrap_err()
-            .to_string()
-            .contains("cannot be used with '--input'"));
+        let error = run_check_merge(args, temp_dir.path()).unwrap_err();
+        assert!(error.to_string().contains("--merge is forbidden"));
+        assert!(error.to_string().contains("advisory"));
     }
 
     #[test]
-    fn test_format_merge_report_pass() {
-        let result = MergeGateResult {
-            can_merge: true,
-            head_sha: VALID_SHA_A.into(),
-            pr_author: Some("alice".into()),
-            verdict: Some("LGTM".into()),
-            verdict_sha: Some(VALID_SHA_A.into()),
-            verdict_author: Some("bob".into()),
-            p0_count: 0,
-            p1_count: 0,
-            required_ci_green: true,
-            reasons: vec![],
-            ..Default::default()
-        };
-
-        let (stdout, stderr) = format_merge_report(&result);
-        assert!(stderr.is_empty(), "PASS report must not write to stderr");
-        assert!(stdout.contains("PASS: Merge preconditions satisfied."));
-        assert!(stdout.contains("PR Head:     1234567890abcdef1234567890abcdef12345678"));
-        assert!(stdout.contains("PR Author:   alice"));
-        assert!(stdout.contains("Verdict:     LGTM by bob"));
-        assert!(stdout.contains("Required CI: green"));
-    }
-
-    #[test]
-    fn test_format_merge_report_refused() {
-        let result = MergeGateResult {
-            can_merge: false,
-            head_sha: VALID_SHA_A.into(),
-            pr_author: Some("alice".into()),
-            verdict: Some("Changes Requested".into()),
-            verdict_sha: Some(VALID_SHA_A.into()),
-            verdict_author: Some("bob".into()),
-            p0_count: 1,
-            p1_count: 1,
-            required_ci_green: false,
-            reasons: vec![
-                "review verdict is not LGTM (found 'Changes Requested')".into(),
-                "blocking findings present: 1 P0, 1 P1 (both must be 0)".into(),
-                "required CI check(s) are not green".into(),
-            ],
-            ..Default::default()
-        };
-
-        let (stdout, stderr) = format_merge_report(&result);
-        assert!(stdout.is_empty(), "REFUSED report must not write to stdout");
-        assert!(stderr.contains(
-            "REFUSED: Merge preconditions not satisfied for head 1234567890abcdef1234567890abcdef12345678:"
-        ));
-        assert!(stderr.contains("PR Author:   alice"));
-        assert!(stderr.contains("  - review verdict is not LGTM"));
-        assert!(stderr.contains("  - blocking findings present: 1 P0, 1 P1"));
-        assert!(stderr.contains("  - required CI check(s) are not green"));
-    }
-
-    #[test]
-    fn test_check_active_pr_claim_semantics() {
+    fn active_claim_semantics_remain_available_to_advisory_modes() {
         let repo = tempfile::tempdir().expect("repo");
         std::fs::create_dir_all(repo.path().join(".edda")).expect("edda");
         std::fs::create_dir_all(repo.path().join(".git")).expect("git");
         let project_id = edda_store::project_id(repo.path());
         let _store = crate::test_support::isolated_store();
 
-        // Initially no claims
         assert_eq!(check_active_pr_claim(repo.path(), 570, None).unwrap(), None);
-
-        // Claim with subject pr:570 by session s1 (live)
         edda_bridge_claude::peers::write_heartbeat_minimal(&project_id, "s1", "reviewer", "/tmp");
         edda_bridge_claude::peers::write_claim_with_subject(
             &project_id,
@@ -1243,45 +627,19 @@ Commit: 1234567890abcdef1234567890abcdef12345678
             &[],
             Some("pr:570"),
         );
-
-        // Live claim by s1 is detected for another session
-        let res = check_active_pr_claim(repo.path(), 570, Some("s2")).unwrap();
-        assert!(res.is_some());
-        assert!(res.as_ref().unwrap().contains("s1"));
-        assert!(res.as_ref().unwrap().contains("pr:570"));
-
-        // Same session (s1) is permitted
+        assert!(check_active_pr_claim(repo.path(), 570, Some("s2"))
+            .unwrap()
+            .is_some());
         assert_eq!(
             check_active_pr_claim(repo.path(), 570, Some("s1")).unwrap(),
             None
         );
-
-        // Different PR (571) is clear
         assert_eq!(
             check_active_pr_claim(repo.path(), 571, Some("s2")).unwrap(),
             None
         );
 
-        // Glob matching: a claim on pr:57* matches PR 570 (Round 1 P1-2)
-        edda_bridge_claude::peers::write_heartbeat_minimal(
-            &project_id,
-            "s_glob",
-            "glob_rev",
-            "/tmp",
-        );
-        edda_bridge_claude::peers::write_claim_with_subject(
-            &project_id,
-            "s_glob",
-            "rev-glob",
-            &[],
-            Some("pr:57*"),
-        );
-        let res_glob = check_active_pr_claim(repo.path(), 570, Some("s1")).unwrap(); // s1 is allowed for s1's claim, but s_glob also claims it!
-        assert!(res_glob.is_some());
-        assert!(res_glob.as_ref().unwrap().contains("s_glob"));
-
-        // Unparseable glob (Round 2 P1): fails closed with Err
-        edda_bridge_claude::peers::write_heartbeat_minimal(&project_id, "s_bad", "bad_rev", "/tmp");
+        edda_bridge_claude::peers::write_heartbeat_minimal(&project_id, "s_bad", "bad", "/tmp");
         edda_bridge_claude::peers::write_claim_with_subject(
             &project_id,
             "s_bad",
@@ -1289,7 +647,6 @@ Commit: 1234567890abcdef1234567890abcdef12345678
             &[],
             Some("pr:57[0-"),
         );
-        let res_bad = check_active_pr_claim(repo.path(), 570, Some("s2"));
-        assert!(res_bad.is_err(), "unparseable claim glob must fail closed");
+        assert!(check_active_pr_claim(repo.path(), 570, Some("s2")).is_err());
     }
 }

--- a/crates/edda-cli/src/cmd_prs/merge_gate.rs
+++ b/crates/edda-cli/src/cmd_prs/merge_gate.rs
@@ -224,8 +224,7 @@ pub fn format_merge_report(result: &MergeGateResult) -> (String, String) {
 
     if result.can_merge {
         let _ = writeln!(stdout_buf, "PASS: Merge preconditions satisfied.");
-        writeln!(stdout_buf, "  Advisory: {ADVISORY_NOTICE}")
-            .expect("writing to String cannot fail");
+        stdout_buf.push_str(&format!("  Advisory: {ADVISORY_NOTICE}\n"));
         let _ = writeln!(stdout_buf, "  PR Head:     {}", result.head_sha);
         if let Some(author) = &result.pr_author {
             let _ = writeln!(stdout_buf, "  PR Author:   {author}");
@@ -260,8 +259,7 @@ pub fn format_merge_report(result: &MergeGateResult) -> (String, String) {
             "REFUSED: Merge preconditions not satisfied for head {}:",
             result.head_sha
         );
-        writeln!(stderr_buf, "  Advisory: {ADVISORY_NOTICE}")
-            .expect("writing to String cannot fail");
+        stderr_buf.push_str(&format!("  Advisory: {ADVISORY_NOTICE}\n"));
         if let Some(author) = &result.pr_author {
             let _ = writeln!(stderr_buf, "  PR Author:   {author}");
         }

--- a/crates/edda-cli/src/cmd_review/mod.rs
+++ b/crates/edda-cli/src/cmd_review/mod.rs
@@ -119,6 +119,24 @@ pub fn run_cmd(cmd: ReviewCmd, cwd: &Path) -> Result<()> {
     }
 }
 
+/// Narrow compatibility seam for the deprecated live
+/// `edda prs check-merge <PR>` spelling.
+///
+/// Keep argument construction beside the product command so the compatibility
+/// route cannot acquire its own live verdict, CI, output, exit, or merge logic.
+pub(crate) fn run_merge_compat(pr: u64, execute: bool, json: bool, cwd: &Path) -> Result<()> {
+    merge::run(
+        MergeArgs {
+            pr,
+            merge: execute,
+            check: false,
+            body_file: None,
+            json,
+        },
+        cwd,
+    )
+}
+
 pub fn run(args: ReviewArgs, cwd: &Path) -> Result<()> {
     let result = run_inner(&args, cwd);
     match result {

--- a/crates/edda-cli/tests/process_claim_contract.rs
+++ b/crates/edda-cli/tests/process_claim_contract.rs
@@ -1,12 +1,16 @@
-//! Contract tests for process object claims and merge gate claim protection (GH-581).
+//! Contract tests for process object claims and the deprecated offline
+//! `prs check-merge` advisory compatibility mode (GH-581, GH-1145).
 //!
 //! Verifies:
 //! 1. `edda claim review-pr570 --subject pr:570` records the subject on the board.
 //! 2. `edda claim check pr:570` detects the conflict (exit 1) when session is live.
 //! 3. `edda claim check pr:571` reports clear (exit 0).
-//! 4. `edda prs check-merge` refuses when PR subject is claimed by an active session (exit 1).
-//! 5. `edda prs check-merge --force` overrides the active claim and proceeds with a Claim Notice.
-//! 6. Stale session claims or unrelated subjects do not block merge gate.
+//! 4. `edda prs check-merge --input` refuses an active PR claim (exit 1).
+//! 5. Its offline `--force` overrides the claim and prints a Claim Notice.
+//! 6. Stale claims and unrelated subjects do not block the advisory report.
+//!
+//! Live PR forwarding deliberately has no claim gate; its process-boundary
+//! coverage lives in `prs_check_merge_compat.rs`.
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -188,7 +192,7 @@ fn claim_check_on_stale_session_subject_reports_clear() {
 
 #[test]
 #[allow(clippy::too_many_lines)] // 193 lines at #779; split tracked in none
-fn check_merge_refuses_claimed_pr_unless_force() {
+fn offline_check_merge_refuses_claimed_pr_unless_force() {
     let env = TestEnv::new();
     env.write_heartbeat("active-reviewer", 0); // live session
     let (code, _, _) = env.run_edda(&[
@@ -201,8 +205,8 @@ fn check_merge_refuses_claimed_pr_unless_force() {
     ]);
     assert_eq!(code, 0);
 
-    // Prepare a valid MergeGateInput json file WITHOUT claimed_by.
-    // The gate will resolve the claim live from the coordination board for PR 570.
+    // Prepare a valid advisory MergeGateInput JSON file WITHOUT claimed_by.
+    // Offline compatibility resolves the claim from the board for PR 570.
     let input_json = serde_json::json!({
         "head_sha": "1234567890abcdef1234567890abcdef12345678",
         "pr": 570,
@@ -218,7 +222,7 @@ fn check_merge_refuses_claimed_pr_unless_force() {
     let input_path = env.repo.join("input.json");
     std::fs::write(&input_path, input_json.to_string()).expect("write input.json");
 
-    // Case 1: Same session holding claim is allowed to merge (exit 0)
+    // Case 1: Same session holding claim gets a passing advisory report (exit 0)
     let (code_same, stdout_same, _) = env.run_edda_with_env(
         &[
             "prs",
@@ -234,9 +238,10 @@ fn check_merge_refuses_claimed_pr_unless_force() {
         "same session holding claim should pass: stdout={stdout_same}"
     );
     assert!(stdout_same.contains("PASS: Merge preconditions satisfied"));
+    assert!(stdout_same.contains("Deprecated advisory scalar diagnostics only"));
 
-    // Case 2: Other session trying to merge without --force -> REFUSED (exit 1)
-    // Board claim is detected directly by check-merge
+    // Case 2: Another session requesting the report without --force is refused.
+    // Board claim lookup remains only on the offline compatibility path.
     let (code_refused, _stdout_refused, stderr_refused) = env.run_edda_with_env(
         &[
             "prs",
@@ -254,7 +259,7 @@ fn check_merge_refuses_claimed_pr_unless_force() {
     assert!(stderr_refused.contains("REFUSED"));
     assert!(stderr_refused.contains("PR is claimed by active session 'active-reviewer (label: 'review-pr570', subject: 'pr:570')' — use --force to override"));
 
-    // Case 3: Override with --force -> PASS with Claim Notice (exit 0)
+    // Case 3: Offline --force produces PASS with a Claim Notice (exit 0)
     let (code_force, stdout_force, stderr_force) = env.run_edda_with_env(
         &[
             "prs",
@@ -271,6 +276,7 @@ fn check_merge_refuses_claimed_pr_unless_force() {
         "force should allow merge: stderr={stderr_force} stdout={stdout_force}"
     );
     assert!(stdout_force.contains("PASS: Merge preconditions satisfied"));
+    assert!(stdout_force.contains("Deprecated advisory scalar diagnostics only"));
     assert!(stdout_force.contains("Claim Notice: Overriding process claim held by 'active-reviewer (label: 'review-pr570', subject: 'pr:570')' (--force specified)"));
 
     // Case 4: Another PR (571) is not claimed -> PASS without Claim Notice (exit 0)

--- a/crates/edda-cli/tests/prs_check_merge_compat.rs
+++ b/crates/edda-cli/tests/prs_check_merge_compat.rs
@@ -1,0 +1,463 @@
+//! Process-boundary compatibility contract for GH-1145 d-001.
+//!
+//! A live `edda prs check-merge <PR>` is only another spelling of the
+//! canonical `edda review merge --pr <PR>` product path. Host-agnostic input
+//! and direct facts retain their deprecated advisory 0/1 contract.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+const PR: u64 = 42;
+const HEAD: &str = "aaaaaaaabbbbbbbbccccccccdddddddd11112222";
+
+fn verdict(id: u64, verdict: &str) -> String {
+    let body = format!(
+        "## Code Review: Round {id} — PR #{PR} @ {HEAD}\n\n- escalations: none\n\n### \
+         Verdict\n\n{verdict}\n"
+    );
+    format!(
+        r#"{{"id":{id},"body":{body},"author_association":"OWNER","updated_at":"2026-09-11T10:{id:02}:00Z"}}"#,
+        body = serde_json::to_string(&body).expect("body encodes")
+    )
+}
+
+struct LiveFixture {
+    _dir: tempfile::TempDir,
+    repo: PathBuf,
+    store: PathBuf,
+    gh: PathBuf,
+    fixtures: PathBuf,
+}
+
+impl LiveFixture {
+    fn new(comments: &[String]) -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let repo = dir.path().join("repo");
+        let store = dir.path().join("store");
+        let bin = dir.path().join("bin");
+        let fixtures = dir.path().join("fixtures");
+        for path in [&repo, &store, &bin, &fixtures] {
+            std::fs::create_dir_all(path).expect("create fixture dir");
+        }
+        std::fs::create_dir_all(repo.join(".edda")).expect("create .edda");
+        std::fs::create_dir_all(repo.join(".git")).expect("create .git");
+        std::fs::write(
+            fixtures.join("open.json"),
+            format!(
+                r#"[{{"number":{PR},"headRefOid":"{HEAD}","baseRefName":"main","mergeable":"MERGEABLE"}}]"#
+            ),
+        )
+        .expect("open fixture");
+        std::fs::write(
+            fixtures.join(format!("comments-{PR}.json")),
+            format!("[{}]", comments.join(",")),
+        )
+        .expect("comments fixture");
+        std::fs::write(
+            fixtures.join(format!("pr-{PR}.json")),
+            format!(
+                r#"{{"headRefOid":"{HEAD}","state":"OPEN","title":"fix(edda-cli): converge the compatibility command","mergeable":"MERGEABLE"}}"#
+            ),
+        )
+        .expect("PR fixture");
+        std::fs::write(
+            fixtures.join("check-runs.json"),
+            r#"{"check_runs":[{"name":"CI Gate","html_url":"https://example.invalid/runs/1145"}]}"#,
+        )
+        .expect("check-runs fixture");
+        let gh = write_gh_stub(&bin);
+        Self {
+            _dir: dir,
+            repo,
+            store,
+            gh,
+            fixtures,
+        }
+    }
+
+    fn run_canonical(&self, extra: &[&str]) -> Output {
+        let mut args = vec!["review", "merge", "--pr", "42"];
+        args.extend_from_slice(extra);
+        self.run(&args)
+    }
+
+    fn run_compat(&self, extra: &[&str]) -> Output {
+        let mut args = vec!["prs", "check-merge", "42"];
+        args.extend_from_slice(extra);
+        self.run(&args)
+    }
+
+    fn run(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_edda"))
+            .args(args)
+            .current_dir(&self.repo)
+            .env("EDDA_GH_BIN", &self.gh)
+            .env("GH_FIXTURE_DIR", &self.fixtures)
+            .env("GH_REPO", "fagemx/edda")
+            .env("EDDA_REPO", "fagemx/edda")
+            .env("EDDA_STORE_ROOT", &self.store)
+            .env("EDDA_SESSION_ID", "prs-check-merge-compat")
+            .stdin(Stdio::null())
+            .output()
+            .expect("spawn edda")
+    }
+
+    fn clear_calls(&self) {
+        let _ = std::fs::remove_file(self.fixtures.join("calls.txt"));
+        let _ = std::fs::remove_file(self.fixtures.join("merged.txt"));
+        let _ = std::fs::remove_file(self.fixtures.join("merge-body.txt"));
+    }
+
+    fn calls(&self) -> String {
+        std::fs::read_to_string(self.fixtures.join("calls.txt")).unwrap_or_default()
+    }
+
+    fn set_pr_head(&self, head: &str) {
+        std::fs::write(
+            self.fixtures.join(format!("pr-{PR}.json")),
+            format!(
+                r#"{{"headRefOid":"{head}","state":"OPEN","title":"fix(edda-cli): converge the compatibility command","mergeable":"MERGEABLE"}}"#
+            ),
+        )
+        .expect("replace PR fixture");
+    }
+
+    fn write_live_claim(&self) {
+        let project_id = edda_store::project_id(&self.repo);
+        let state = self.store.join("projects").join(project_id).join("state");
+        std::fs::create_dir_all(&state).expect("claim state dir");
+        let now = chrono::Utc::now().to_rfc3339();
+        let heartbeat = serde_json::json!({
+            "session_id": "other-live-session",
+            "started_at": now,
+            "last_heartbeat": now,
+            "label": "other",
+            "focus_files": [],
+            "active_tasks": [],
+            "files_modified_count": 0,
+            "total_edits": 0,
+            "recent_commits": []
+        });
+        std::fs::write(
+            state.join("session.other-live-session.json"),
+            serde_json::to_vec(&heartbeat).unwrap(),
+        )
+        .expect("heartbeat");
+        let claim = Command::new(env!("CARGO_BIN_EXE_edda"))
+            .args([
+                "claim",
+                "other-review",
+                "--subject",
+                "pr:42",
+                "--session",
+                "other-live-session",
+            ])
+            .current_dir(&self.repo)
+            .env("EDDA_STORE_ROOT", &self.store)
+            .output()
+            .expect("write claim");
+        assert!(claim.status.success(), "stderr={:?}", claim.stderr);
+    }
+}
+
+fn write_gh_stub(bin: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let script = r#"@echo off
+echo %*>>"%GH_FIXTURE_DIR%\calls.txt"
+if not "%GH_REPO%"=="fagemx/edda" ( echo GH_REPO not forwarded 1>&2 & exit /b 9 )
+if "%1 %2"=="pr view" ( type "%GH_FIXTURE_DIR%\pr-%3.json" & exit /b 0 )
+if "%1 %2"=="pr list" ( type "%GH_FIXTURE_DIR%\open.json" & exit /b 0 )
+if "%1 %2"=="pr checks" ( exit /b 0 )
+if "%1 %2"=="pr merge" ( more >"%GH_FIXTURE_DIR%\merge-body.txt" & echo merged>"%GH_FIXTURE_DIR%\merged.txt" & exit /b 0 )
+if "%1 %2"=="api --paginate" goto comments
+if "%1"=="api" ( type "%GH_FIXTURE_DIR%\check-runs.json" & exit /b 0 )
+echo unexpected gh call: %* 1>&2
+exit /b 9
+:comments
+for /f "tokens=5 delims=/" %%A in ("%3") do type "%GH_FIXTURE_DIR%\comments-%%A.json"
+exit /b 0
+"#;
+        let path = bin.join("gh.bat");
+        std::fs::write(&path, script.replace('\n', "\r\n")).expect("write gh stub");
+        path
+    }
+    #[cfg(not(windows))]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let script = r#"#!/bin/sh
+printf '%s\n' "$*" >> "$GH_FIXTURE_DIR/calls.txt"
+[ "$GH_REPO" = 'fagemx/edda' ] || { echo 'GH_REPO not forwarded' >&2; exit 9; }
+case "$1 $2" in
+  'pr view') cat "$GH_FIXTURE_DIR/pr-$3.json" ;;
+  'pr list') cat "$GH_FIXTURE_DIR/open.json" ;;
+  'pr checks') exit 0 ;;
+  'pr merge') cat > "$GH_FIXTURE_DIR/merge-body.txt"; echo merged > "$GH_FIXTURE_DIR/merged.txt" ;;
+  'api --paginate')
+    n=$(printf '%s' "$3" | sed -n 's|.*/issues/\([0-9]*\)/comments$|\1|p')
+    cat "$GH_FIXTURE_DIR/comments-$n.json" ;;
+  'api '*) cat "$GH_FIXTURE_DIR/check-runs.json" ;;
+  *) echo "unexpected gh call: $*" >&2; exit 9 ;;
+esac
+"#;
+        let path = bin.join("gh");
+        std::fs::write(&path, script).expect("write gh stub");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        path
+    }
+}
+
+fn triple(output: &Output) -> (i32, String, String) {
+    (
+        output.status.code().expect("exit code"),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn help_marks_the_two_modes_and_the_advisory_boundary() {
+    let output = Command::new(env!("CARGO_BIN_EXE_edda"))
+        .args(["prs", "check-merge", "--help"])
+        .output()
+        .expect("spawn help");
+    let (code, stdout, stderr) = triple(&output);
+    assert_eq!(code, 0, "stdout={stdout}\nstderr={stderr}");
+    assert!(stdout.contains("Deprecated compatibility"));
+    assert!(stdout.contains("forward to `edda review merge`"));
+    assert!(stdout.contains("not R6 evidence"));
+    assert!(stdout.contains("--allowed-reviewers"));
+    assert!(stdout.contains("Unsupported for live PR forwarding"));
+}
+
+#[test]
+fn live_check_and_json_are_byte_identical_to_canonical_output_and_exit() {
+    let fixture = LiveFixture::new(&[verdict(1, "LGTM (P0=0, P1=0)")]);
+    for extra in [&[][..], &["--json"][..]] {
+        let canonical = triple(&fixture.run_canonical(extra));
+        fixture.clear_calls();
+        let compat = triple(&fixture.run_compat(extra));
+        assert_eq!(compat, canonical, "forwarded output or exit drifted");
+        assert_eq!(compat.0, 0);
+    }
+}
+
+#[test]
+fn live_refusal_and_cannot_judge_exits_match_canonical() {
+    let blocked = LiveFixture::new(&[
+        verdict(1, "Changes Requested, P0=0, P1=1"),
+        verdict(2, "LGTM (P0=0, P1=0)"),
+    ]);
+    let canonical = triple(&blocked.run_canonical(&[]));
+    blocked.clear_calls();
+    let compat = triple(&blocked.run_compat(&[]));
+    assert_eq!(compat, canonical);
+    assert_eq!(compat.0, 1, "standing blocker did not refuse");
+
+    let unreadable = LiveFixture::new(&[verdict(1, "LGTM (P0=0, P1=0)")]);
+    unreadable.set_pr_head("not-a-head");
+    let canonical = triple(&unreadable.run_canonical(&[]));
+    unreadable.clear_calls();
+    let compat = triple(&unreadable.run_compat(&[]));
+    assert_eq!(compat, canonical);
+    assert_eq!(compat.0, 2, "unreadable head was not cannot-judge");
+}
+
+#[test]
+fn legacy_scalar_flags_cannot_bypass_the_canonical_union() {
+    let fixture = LiveFixture::new(&[
+        verdict(1, "Changes Requested, P0=0, P1=1"),
+        verdict(2, "LGTM (P0=0, P1=0)"),
+    ]);
+    let output = fixture.run_compat(&[
+        "--head-sha",
+        HEAD,
+        "--verdict",
+        "LGTM",
+        "--verdict-sha",
+        HEAD,
+        "--ci-green",
+        "--merge",
+    ]);
+    let (code, stdout, stderr) = triple(&output);
+    assert_eq!(code, 1, "stdout={stdout}\nstderr={stderr}");
+    assert!(stderr.contains("union over every §7 verdict comment"));
+    assert!(!fixture.fixtures.join("merged.txt").exists());
+    let calls = fixture.calls().replace('"', "");
+    assert!(
+        calls.contains(&format!(
+            "api --paginate repos/{{owner}}/{{repo}}/issues/{PR}/comments"
+        )),
+        "the canonical trusted-comment reader was bypassed: {calls}"
+    );
+}
+
+#[test]
+fn live_merge_uses_the_canonical_pinned_squash_argv_and_receipt() {
+    let fixture = LiveFixture::new(&[verdict(1, "LGTM (P0=0, P1=0)")]);
+    let (code, stdout, stderr) = triple(&fixture.run_compat(&["--merge"]));
+    assert_eq!(code, 0, "stdout={stdout}\nstderr={stderr}");
+    let calls = fixture.calls().replace('"', "");
+    let expected = format!(
+        "pr merge {PR} --squash --match-head-commit {HEAD} --subject fix(edda-cli): converge the compatibility command (#{PR}) --body-file -"
+    );
+    assert!(calls.lines().any(|line| line == expected), "calls={calls}");
+    let body = std::fs::read_to_string(fixture.fixtures.join("merge-body.txt"))
+        .expect("canonical merge receipt body");
+    assert!(body.contains(HEAD));
+    assert!(body.contains("Round 1"));
+    assert!(body.contains("https://example.invalid/runs/1145"));
+}
+
+#[test]
+fn live_allowed_reviewers_and_force_refuse_instead_of_being_ignored() {
+    let fixture = LiveFixture::new(&[verdict(1, "LGTM (P0=0, P1=0)")]);
+    for (extra, expected) in [
+        (
+            &["--allowed-reviewers", "alice,bob"][..],
+            "--allowed-reviewers is unsupported in live-forward mode",
+        ),
+        (
+            &["--force"][..],
+            "--force is unsupported in live-forward mode",
+        ),
+    ] {
+        fixture.clear_calls();
+        let (code, stdout, stderr) = triple(&fixture.run_compat(extra));
+        assert_eq!(code, 2, "stdout={stdout}\nstderr={stderr}");
+        assert!(stderr.contains(expected));
+        if extra[0] == "--allowed-reviewers" {
+            assert!(stderr.contains("author_association"));
+        }
+        assert!(fixture.calls().is_empty(), "refusal still read GitHub");
+    }
+}
+
+#[test]
+fn a_live_process_claim_does_not_wrap_the_canonical_path() {
+    let fixture = LiveFixture::new(&[verdict(1, "LGTM (P0=0, P1=0)")]);
+    fixture.write_live_claim();
+    fixture.clear_calls();
+    let (code, stdout, stderr) = triple(&fixture.run_compat(&[]));
+    assert_eq!(code, 0, "stdout={stdout}\nstderr={stderr}");
+    assert!(!stdout.contains("Claim Notice"));
+    assert!(!stderr.contains("claimed by active session"));
+}
+
+struct OfflineFixture {
+    _dir: tempfile::TempDir,
+    repo: PathBuf,
+    store: PathBuf,
+}
+
+impl OfflineFixture {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let repo = dir.path().join("repo");
+        let store = dir.path().join("store");
+        std::fs::create_dir_all(repo.join(".edda")).expect("create .edda");
+        std::fs::create_dir_all(repo.join(".git")).expect("create .git");
+        Self {
+            _dir: dir,
+            repo,
+            store,
+        }
+    }
+
+    fn run(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_edda"))
+            .args(args)
+            .current_dir(&self.repo)
+            .env("EDDA_STORE_ROOT", &self.store)
+            .env("EDDA_SESSION_ID", "offline-compat")
+            .stdin(Stdio::null())
+            .output()
+            .expect("spawn edda")
+    }
+}
+
+#[test]
+fn offline_direct_json_keeps_schema_and_zero_one_contract() {
+    let fixture = OfflineFixture::new();
+    let valid = fixture.run(&[
+        "prs",
+        "check-merge",
+        "--head-sha",
+        HEAD,
+        "--verdict",
+        "approved",
+        "--verdict-sha",
+        HEAD,
+        "--ci-green",
+        "--json",
+    ]);
+    let (code, stdout, stderr) = triple(&valid);
+    assert_eq!(code, 0, "stdout={stdout}\nstderr={stderr}");
+    assert!(stderr.contains("Deprecated advisory scalar diagnostics only"));
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("compat JSON");
+    assert_eq!(value["can_merge"], true);
+    assert!(value.get("advisory").is_none());
+    assert!(value.get("deprecated").is_none());
+
+    let not_lgtm = fixture.run(&[
+        "prs",
+        "check-merge",
+        "--head-sha",
+        HEAD,
+        "--verdict",
+        "not lgtm",
+        "--verdict-sha",
+        HEAD,
+        "--ci-green",
+        "--json",
+    ]);
+    let (code, stdout, stderr) = triple(&not_lgtm);
+    assert_eq!(code, 1, "stdout={stdout}\nstderr={stderr}");
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("refusal JSON");
+    assert_eq!(value["can_merge"], false);
+    assert!(value["reasons"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|reason| reason.as_str().unwrap().contains("not LGTM")));
+}
+
+#[test]
+fn offline_input_refuses_contradictory_ci_and_cannot_merge() {
+    let fixture = OfflineFixture::new();
+    let input = fixture.repo.join("input.json");
+    std::fs::write(
+        &input,
+        serde_json::json!({
+            "head_sha": HEAD,
+            "pr": 42,
+            "verdict": "LGTM",
+            "verdict_sha": HEAD,
+            "p0_count": 0,
+            "p1_count": 0,
+            "required_ci_green": true,
+            "failed_checks": ["CI Gate (failure)"]
+        })
+        .to_string(),
+    )
+    .expect("input fixture");
+    let path = input.to_str().unwrap();
+    let (code, stdout, stderr) =
+        triple(&fixture.run(&["prs", "check-merge", "--input", path, "--json"]));
+    assert_eq!(code, 1, "stdout={stdout}\nstderr={stderr}");
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("refusal JSON");
+    assert!(value["reasons"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|reason| reason
+            .as_str()
+            .unwrap()
+            .contains("contradicts nonempty failed_checks")));
+
+    let (code, stdout, stderr) =
+        triple(&fixture.run(&["prs", "check-merge", "--input", path, "--merge"]));
+    assert_eq!(code, 1, "stdout={stdout}\nstderr={stderr}");
+    assert!(stderr.contains("--merge is forbidden"));
+    assert!(stderr.contains("edda review merge --pr <PR> --merge"));
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1018,7 +1018,7 @@ documented surface cannot silently drift from the binary;
 | `export` | Export the ledger as human-readable Markdown (read-only projection; SQLite stays authoritative) | A convenience projection; automation should query the ledger or `edda log`, not parse exports |
 | `hook` | Hook entrypoint (called by supported coding-agent hooks) | Internal: expects a hook payload on stdin; hand-invocation writes events with wrong attribution |
 | `intake` | Task intake — ingest external tasks into the ledger | Experimental ingest surface |
-| `prs` | Scan and record PR events from GitHub | Needs network and a token; normally driven by the scheduler or `edda watch` |
+| `prs` | Scan and record PR events; carries deprecated `check-merge` compatibility | `scan` needs network and a token; live `check-merge` forwards to `edda review merge`, while its offline scalar form is advisory only |
 | `pipeline` | Auto-execution pipeline — skill chain with approval gates | Experimental orchestration layer; prefer `edda plan` / `edda conduct` for reviewed plans |
 | `bundle` | Create and manage review bundles for rapid approval | Deprecated; use `edda review` |
 | `brief` | View task engineering briefs (materialized from ledger events) | Read-only viewer normally consumed via `edda task` workflows |
@@ -1488,7 +1488,7 @@ a `reason`) for each write.
 
 Launching reviews (`edda review`), the trigger policy (`edda review due`,
 GH-763), verdict semantics (`edda review gate`, GH-769), and merging
-(`edda prs check-merge`; GATE-01 — deliver never merges) stay out of scope.
+(`edda review merge`; GATE-01 — deliver never merges) stay out of scope.
 
 #### `edda review drift`
 
@@ -1544,6 +1544,35 @@ merges nothing.
 edda review merge --pr 1105                  # --check is the default
 edda review merge --pr 1105 --merge --body-file .edda/merge-receipt.md
 ```
+
+`edda prs check-merge <PR>` is a deprecated compatibility spelling. With a
+live positional PR and no `--input`, it calls this exact product path: stdout,
+stderr, JSON, and exits 0/1/2 are canonical, and `--merge` therefore uses the
+same `--match-head-commit`, validated squash subject, and receipt. It has no
+live verdict parser, CI classifier, or process-claim gate of its own.
+`--allowed-reviewers` refuses in live-forward mode rather than changing or
+silently bypassing the canonical trust rule: trusted §7 comments are selected
+from GitHub's `author_association` (`OWNER`, `MEMBER`, or `COLLABORATOR`).
+`--force` also refuses there because process claims are not an R6 condition.
+
+Two host-agnostic compatibility forms remain temporarily available:
+
+```bash
+edda prs check-merge --input facts.json --json
+edda prs check-merge --head-sha "$head" --verdict lgtm \
+  --verdict-sha "$head" --ci-green
+```
+
+These forms retain the `MergeGateInput` / `MergeGateResult` JSON shape, human
+report fields, and 0/1 report contract. They are **deprecated advisory scalar
+diagnostics only, not trusted R6 evidence**; output says so explicitly. They
+cannot establish the trusted-comment union or forge-required checks.
+`--merge` remains forbidden. Active-claim refusal and `--force` remain only in
+these offline/direct forms, including a positional PR paired with `--input`
+for claim lookup; they do not wrap live forwarding. The accepted scalar
+verdict is exactly `lgtm` or `approved` (case-insensitive), so prose such as
+`not lgtm` refuses. `required_ci_green: true` together with nonempty
+`failed_checks` also refuses as contradictory.
 
 The conditions run in order. A failed precondition rejects with exit 1;
 an unreadable or malformed answer rejects with exit 2:


### PR DESCRIPTION
## Issue

Issue: #1145

Closes #1145

## Summary

- Forward live `edda prs check-merge <PR>` and `--merge` through the exact `edda review merge` implementation.
- Retain `--input` and direct-fact compatibility as deprecated advisory scalar diagnostics only, with their schema, 0/1 reports, and offline claim/`--force` behavior.
- Remove the duplicate live review parser and CI classifier; explicitly refuse live `--allowed-reviewers` and `--force`.
- Refuse non-exact LGTM/approved scalar verdicts and contradictory green-CI facts.

## Verification

Frozen source: `d4305de0da5100c50cf61cdc7f4e8693ba7d5bfb`

Lane: `C:/Users/fagem/AppData/Local/fleet-workstation/lanes/worker-1`

RAN and passed:

- `cargo fmt --all --check`
- `cargo clippy -p edda --all-targets -- -D warnings`
- `cargo test -p edda`
- `EDDA_BIN=/c/Users/fagem/AppData/Local/fleet-workstation/lanes/worker-1/debug/edda.exe sh scripts/check-cli-docs.sh`
- `sh scripts/lint-markdown-content.sh`
- `sh scripts/lint-file-length.sh --tree`
- `git diff --check`
- focused process tests for `prs_check_merge_compat` and `process_claim_contract`

Round 1 replaced the two production `writeln!(...).expect(...)` calls with direct `String::push_str` and `format!` construction; the advisory output bytes remain unchanged, there is no fallible `fmt::Result` to swallow, and there is no panic path. The first current-head `cargo test -p edda` attempt exposed a stale cross-worktree `edda` build identity (`f8e91dfa27de`) in the shared worker lane. Only the lane's `edda` package artifacts were reclaimed with `cargo clean -p edda`, and the failed crate gate was rerun for that environmental reason before passing. Manual lane clippy is the receipt for the commit's `[skip-clippy]` marker because the hook does not honor `CARGO_TARGET_DIR`.

Default worktree `target/`: absent before build, before commit, and after commit.

Exact-head CI: `CI run 34596024406 @ d4305de0da5100c50cf61cdc7f4e8693ba7d5bfb` — green (Format, Clippy on Linux/macOS/Windows, tests on Linux/macOS/Windows, MSRV, and `CI Gate`). Auxiliary exact-head `contract` run 34596024376 and `Crates publication check` run 34596024410 are also green.

Cost: `$0` external/model spend; existing `worker-1` build lane reused.
