### PR TITLE
feat(integrations): adopt Pi sessions with task dependencies

### DIFF
--- a/docs/superpowers/plans/2026-09-12-pi-adoption.md
+++ b/docs/superpowers/plans/2026-09-12-pi-adoption.md
@@ -1,0 +1,51 @@
+# Pi session adoption implementation plan
+
+**Goal:** One CLI operation connects an existing Pi session to declared task context
+and explicit dependency observation, with usable preflight and failure reporting.
+
+**Architecture:** Reuse compose, enrollment, handoff and dependency endpoints.
+Resolve exact IDs or unique prefixes of at least eight characters across the whole
+registry, including offline entries. Read the chosen task and transitive `after`
+dependencies; optional extra roots cover review/correction tasks with explicit
+links. No name-based or receipt-text inference. Node.js 24; no new dependency.
+
+## Contract
+
+`adopt SESSION --task ID [--project PATH] [--include ID,ID] [--context FILE]
+[--scope TEXT] [--notify] [--max-notifications 10] [--preview] [--expected REVISION]`
+
+- Project defaults to the live session cwd. Exact IDs beat prefix matching;
+  ambiguity, missing session, offline, reload-required and busy have distinct results.
+- Discovery visits root plus explicit include roots and transitive prerequisites,
+  rejects cycles, missing tasks and more than eight unique tasks without silently
+  truncating. Return provenance edges and coverage `explicit_after_snapshot`.
+- Preview performs source reads/cache only. Validate complete context, enrollment
+  scope, cap and all dependency sources before managed mutations. Missing role,
+  doneWhen or authority references remains `needs_context` with source details.
+- Apply uses the same frozen instance throughout. Prepare an idle handoff, enroll
+  if needed, configure observation. Each completed step is reported. Failure after
+  a write is partial/unknown, not rolled back or automatically retried.
+- Reuse an existing current handoff if run identity, goal, role, doneWhen and scope
+  match; its immutable source snapshot remains visible. Task status changes alone
+  must not replace the manifest or reset the observer notification cap. A different
+  handoff or stale instance binding requires its explicit expected revision.
+- Adopt does not imply work started. It reports observed runtime and notification
+  receipt separately; observe-only sends no messages. Repeat configuration preserves
+  existing observer cap/uncertainty behavior.
+- Dependencies are a snapshot at adoption; new review tasks and graph edits require
+  another adoption. No reload/hot-update mechanism, remote transport, authority
+  resolver, runtime replacement or standalone package distribution in this slice.
+
+## Implementation and validation
+
+- [ ] Add `adoption.mjs`: selector, bounded graph discovery, preflight and apply.
+- [ ] Extend `enroll` with optional instance binding; add CLI adopt route and help.
+- [ ] Add `adoption.test.mjs` with actual loopback channel and external task-reader
+  fixture: ambiguity/offline collisions, root/diamond/cycle/overflow/missing tasks,
+  preview and missing metadata without enrollment/handoff, successful adopt,
+  busy/stale CAS, repeated status change preserving notification cap, partial errors.
+- [ ] Add README start-here adoption examples and honest remaining boundaries.
+- [ ] Run focused Node adoption tests; then full npm suite once at frozen code.
+- [ ] Run actual Pi offline-provider smoke through adoption; no user tasks/paid calls.
+- [ ] Obtain independent PR-visible SHA-pinned review, exact-head CI and R6 window;
+  merge under standing operator authorization. Preserve installed source worktree.

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -31,7 +31,54 @@ idle point. Loading the extension does not resume work. It cannot silently attac
 to arbitrary existing terminals. New sessions load installed packages normally.
 Use `/edda-session` inside Pi to see its exact identity and status.
 
-## Start here: check, follow, inspect, pause
+## Start here: adopt an existing session
+
+When the task has a structured management brief, one command prepares its context,
+enrolls the session and follows the task plus its transitive `after` prerequisites:
+
+```powershell
+node integrations/pi/cli.mjs doctor
+node integrations/pi/cli.mjs adopt SESSION_PREFIX --task 17 --scope "Observe the assigned task within existing authority; no new spending." --preview
+node integrations/pi/cli.mjs adopt SESSION_PREFIX --task 17 --scope "Observe the assigned task within existing authority; no new spending." --notify
+```
+
+Use an exact ID or a unique prefix of at least eight characters; offline collisions
+also count. Project defaults to that live session's working directory. Add
+`--project PATH` for another task project, `--include 18,19` for explicit review/fix
+roots, or `--context FILE` for structured metadata when the task brief is prose.
+The metadata format is documented under task-to-handoff composition below.
+
+Adoption reads all prerequisites before applying setup, with an eight-task maximum.
+Cycles, missing tasks and overflow fail visibly; use `follow --tasks` to deliberately
+select a smaller observation set. Coverage is an `explicit_after_snapshot`: new
+review/fix tasks and changed graph edges need another adoption. Names, receipts and
+`done` status are not used to infer acceptance, ownership or missing edges.
+
+`--preview` reads/caches source snapshots but makes no enrollment, handoff, follow
+or message changes. Missing metadata reports exactly what to supply. Busy sessions
+and old extensions report idle/reload steps. Replacing an existing handoff or
+rebinding after reload needs `--expected REVISION`, obtained from `brief`; this is
+an explicit compare-and-set against the existing context, not new work authority.
+
+Repeated adoption reuses a semantically unchanged current manifest and its original
+immutable source snapshot. A task-status-only update does not reset notification
+caps. A changed task graph or explicit configuration is a new subscription; its
+initial alert may consume a normal model turn when `--notify` is present.
+
+Apply is a sequence of existing operations, not a transaction: `adoption_incomplete`
+lists confirmed steps and the possibly-applied last request. Inspect `doctor`,
+`brief` and `dependencies` before retrying. No rollback or blind resend occurs.
+Existing observation stays active until its configuration is changed. `adopted`
+means setup succeeded, not work started; notify mode reports `workStarted: null`
+until its separate message receipt is inspected. Without `--notify`, adoption
+configures observation only. Use an explicit `send` for an authorized work instruction.
+
+The receiver does not yet push decision requests into a manager inbox or wake an
+idle Codex thread. `conversation` reads replies on demand; `brief` reads structured
+reports when prepared. Dependency alerts wake the receiving Pi only. Manager inbox
+delivery and reverse wake routing remain a separate, necessary follow-up.
+
+## Select dependencies directly: follow, inspect, pause
 
 ```powershell
 node integrations/pi/cli.mjs doctor

--- a/integrations/pi/adoption.mjs
+++ b/integrations/pi/adoption.mjs
@@ -1,0 +1,118 @@
+import { digest } from './store.mjs';
+import { listSessions, requestSession } from './client.mjs';
+import { readTask, taskId } from './compose-sources.mjs';
+import { composeHandoff } from './compose.mjs';
+import { readEnrollment, enroll, validateScope } from './supervision.mjs';
+import { dependencyConfiguration, dependencyFact } from './dependency-observer.mjs';
+
+export function selectSession(rows, selector) {
+  const exact = rows.find((row) => row.sessionId === selector);
+  if (exact) return { status: 'selected', state: exact };
+  if (typeof selector !== 'string' || selector.length < 8 || selector.length > 200 || !/^[a-zA-Z0-9_.:-]+$/.test(selector)) {
+    return { status: 'invalid_selector', nextAction: 'Use an exact session ID or at least eight characters of its unique prefix.' };
+  }
+  const matches = rows.filter((row) => row.sessionId.startsWith(selector));
+  if (matches.length === 1) return { status: 'selected', state: matches[0] };
+  return { status: matches.length ? 'ambiguous_session' : 'not_registered',
+    candidates: matches.slice(0, 20).map(({ sessionId, cwd, live }) => ({ sessionId, cwd, live })),
+    nextAction: 'Run list and choose the exact session ID; offline matches also count.' };
+}
+
+export async function discoverDependencies(project, roots, command) {
+  if (!Array.isArray(roots) || !roots.length || roots.length > 8) throw new Error('Select one to eight task roots');
+  roots = [...new Set(roots.map(taskId))];
+  const sources = new Map(), visiting = new Set(), edges = [];
+  async function visit(id) {
+    if (visiting.has(id)) throw new Error(`Dependency cycle at task ${id}; inspect the task rail`);
+    if (sources.has(id)) return;
+    if (sources.size >= 8) throw new Error('Dependency graph exceeds eight tasks; select a smaller explicit scope with follow');
+    let source;
+    try { source = await readTask(project, id, command); dependencyFact(source.task); }
+    catch { throw new Error(`Cannot read task ${id}; no adoption applied`); }
+    sources.set(id, source);
+    visiting.add(id);
+    for (const parent of new Set(source.task.after.map(String))) {
+      edges.push({ taskId: id, after: parent });
+      await visit(parent);
+    }
+    visiting.delete(id);
+  }
+  for (const id of roots) await visit(id);
+  const taskIds = [...sources.keys()].sort((a, b) => Number(a) - Number(b));
+  return { taskIds, edges, roots, coverage: 'explicit_after_snapshot',
+    sourceRevisions: Object.fromEntries([...sources].map(([id, value]) => [id, digest(value.raw)])),
+    notice: 'Includes selected roots and transitive prerequisites only. New review/fix tasks or graph edits require another adoption; done is not acceptance.' };
+}
+
+function semanticManifest(manifest) {
+  const { planRef, ...rest } = manifest;
+  return digest(JSON.stringify(rest));
+}
+
+export async function adoptSession(root, selector, { id, project, include = [], contextFile, scope,
+  notify = false, maxNotifications = 10, preview = false, expectedRevision, eddaCommand } = {}) {
+  taskId(id);
+  if (!Array.isArray(include)) throw new Error('include must be a list of task IDs');
+  include.forEach(taskId);
+  const selected = selectSession(await listSessions(root), selector);
+  if (selected.status !== 'selected') return selected;
+  const { state } = selected;
+  const sessionId = state.sessionId, instanceId = state.instanceId;
+  const base = { sessionId, instanceId, managedTaskId: id, workStarted: null };
+  if (!state.live) return { ...base, status: 'offline', nextAction: 'Inspect the original Pi process; adoption does not restart it.' };
+  if (!['handoff', 'dependencies'].every((cap) => state.capabilities?.includes(cap))) {
+    return { ...base, status: 'needs_reload', nextAction: 'Run /reload in this Pi when idle, then repeat adopt. No terminal automation is performed.' };
+  }
+  if (state.state !== 'idle') return { ...base, status: 'busy', runtimeState: state.state, nextAction: 'Repeat adopt when this instance is idle.' };
+  project ||= state.cwd;
+  const previous = readEnrollment(root, sessionId);
+  const chosenScope = scope ?? (previous?.enabled ? previous.scope : undefined);
+  if (chosenScope === undefined) return { ...base, status: 'needs_enrollment', nextAction: 'Supply --scope with the existing delegated limits.' };
+  validateScope(chosenScope);
+  // Resolve and validate all sources before changing enrollment, handoff or follow.
+  const dependencies = await discoverDependencies(project, [id, ...include], eddaCommand);
+  const config = await dependencyConfiguration({ project, taskIds: dependencies.taskIds, notify, maxNotifications });
+  const composition = await composeHandoff({ project: config.project, id, contextFile, root, eddaCommand });
+  if (composition.status !== 'ready') return { ...base, status: 'needs_context', missing: composition.missing,
+    contextError: composition.contextError, source: composition.source,
+    nextAction: 'Provide declared role/doneWhen/scope metadata via --context, then repeat adopt. No managed changes were made.' };
+  if (composition.source.taskSource.revision !== `sha256:${dependencies.sourceRevisions[id]}`) {
+    return { ...base, status: 'source_changed', nextAction: 'Task changed during preflight; inspect and repeat adopt.' };
+  }
+  const handoff = await requestSession(root, sessionId, '/handoff?budget=32768', undefined, 2500, instanceId);
+  if (!['ready', 'not_prepared', 'stale_binding'].includes(handoff.status)) {
+    return { ...base, status: 'needs_context', nextAction: 'Inspect brief before adoption; existing handoff is unavailable or over budget.' };
+  }
+  const manifestReused = handoff.status === 'ready' && semanticManifest(handoff.manifest) === semanticManifest(composition.manifest);
+  const revision = handoff.manifestRevision || null;
+  if ((expectedRevision !== undefined && expectedRevision !== revision) ||
+    (revision && !manifestReused && expectedRevision !== revision)) {
+    return { ...base, status: 'needs_expected_revision', currentRevision: revision,
+      nextAction: 'Inspect brief, then supply --expected with this exact revision to replace or rebind the handoff.' };
+  }
+  const manifest = manifestReused ? handoff.manifest : composition.manifest;
+  const detail = { ...base, project: config.project, dependencies, manifestReused,
+    manifestRevision: digest(JSON.stringify(manifest)), planRef: manifest.planRef,
+    notify, maxNotifications, scope: chosenScope, workStarted: notify ? null : false };
+  if (preview) return { ...detail, status: 'preview', nextAction: 'Repeat without --preview to apply this declared scope. No managed changes or messages were made.' };
+  const steps = [];
+  let attemptedStep;
+  try {
+    attemptedStep = 'prepare';
+    const prepared = await requestSession(root, sessionId, '/handoff/manifest', { manifest, expectedRevision: revision }, 2500, instanceId);
+    steps.push({ step: attemptedStep, status: prepared.status });
+    attemptedStep = 'enroll';
+    if (!previous?.enabled || previous.scope !== chosenScope) await enroll(root, sessionId, chosenScope, instanceId);
+    else await requestSession(root, sessionId, '/status', undefined, 2500, instanceId);
+    steps.push({ step: attemptedStep, status: 'enabled' });
+    attemptedStep = 'follow';
+    const observer = await requestSession(root, sessionId, '/dependencies', config, 5000, instanceId);
+    steps.push({ step: attemptedStep, status: observer.phase });
+    return { ...detail, status: 'adopted', steps, observer,
+      nextAction: notify ? 'Inspect dependencies for the notification receipt; configured does not mean work started.' :
+        'Observation is configured. Use send for an explicitly authorized work instruction; unfollow pauses observation.' };
+  } catch (error) {
+    return { ...detail, status: 'adoption_incomplete', steps, attemptedStep, error: error.message,
+      nextAction: 'Inspect doctor, brief and dependencies before repeating. Earlier steps or the last request may have applied; no rollback or automatic retry.' };
+  }
+}

--- a/integrations/pi/adoption.test.mjs
+++ b/integrations/pi/adoption.test.mjs
@@ -1,0 +1,133 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile, rm, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { randomUUID } from 'node:crypto';
+import { startChannel } from './channel.mjs';
+import { adoptSession, selectSession, discoverDependencies } from './adoption.mjs';
+import { readEnrollment } from './supervision.mjs';
+import { digest } from './store.mjs';
+
+const metadata = { role: 'controller', doneWhen: ['Synthetic checks pass'], scope: {
+  allowed: ['Observe synthetic fixtures'], excluded: ['Production changes'], reserved: ['New spend'],
+  authorityRefs: [{ uri: 'fixture://operator', revision: 'v1' }],
+} };
+async function fixture(t) {
+  const project = await mkdtemp(join(tmpdir(), 'edda-adoption-test-'));
+  const root = join(project, 'private');
+  const command = { file: process.execPath, args: [fileURLToPath(new URL('./fixtures/edda-task-graph-reader.mjs', import.meta.url))] };
+  const put = (id, after = [], patch = {}) => writeFile(join(project, `task-${id}.json`), JSON.stringify({
+    task_id: id, title: `Synthetic task ${id}`, created_event_id: `evt-${id}`, status: 'ready', after,
+    scope_paths: ['fixture/**'], attempts: 0, receipt: null, brief_ref: 'brief.json', ...patch,
+  }));
+  await put(1, [2]); await put(2);
+  await writeFile(join(project, 'brief.json'), JSON.stringify(metadata));
+  const messages = [];
+  let channel;
+  channel = await startChannel({ root, sessionId: randomUUID(), cwd: project, dependencyCommand: command,
+    deliver: (text) => { messages.push(text); channel.messageStarted(text); channel.settled(); } });
+  t.after(async () => { await channel.close(); await rm(project, { recursive: true, force: true }); });
+  const options = { id: '1', eddaCommand: command, scope: 'Only synthetic fixture observation; no spend.' };
+  const adopt = (extra = {}) => adoptSession(root, channel.sessionId.slice(0, 8), { ...options, ...extra });
+  return { project, root, command, put, channel, messages, options, adopt };
+}
+
+test('unique prefix includes offline collisions and exact identity wins', () => {
+  const rows = [{ sessionId: '12345678-aa', live: true }, { sessionId: '12345678-bb', live: false }];
+  assert.equal(selectSession(rows, '12345678').status, 'ambiguous_session');
+  assert.equal(selectSession(rows, '12345678-aa').state, rows[0]);
+  assert.equal(selectSession(rows, '123').status, 'invalid_selector');
+  assert.equal(selectSession(rows, 'notfound').status, 'not_registered');
+});
+
+test('discover bounded transitive diamond plus explicit review root; cycles/missing/overflow fail', async (t) => {
+  const f = await fixture(t);
+  await f.put(1, [2, 3]); await f.put(2, [4]); await f.put(3, [4]); await f.put(4); await f.put(5, [1]);
+  const graph = await discoverDependencies(f.project, ['1', '5'], f.command);
+  assert.deepEqual(graph.taskIds, ['1', '2', '3', '4', '5']);
+  assert.equal(graph.edges.length, 5);
+  await f.put(4, [1]);
+  await assert.rejects(discoverDependencies(f.project, ['1'], f.command), /cycle/i);
+  await f.put(4, [99]);
+  await assert.rejects(discoverDependencies(f.project, ['1'], f.command), /Cannot read task 99/);
+  for (let i = 1; i <= 9; i++) await f.put(i, i < 9 ? [i + 1] : []);
+  await assert.rejects(discoverDependencies(f.project, ['1'], f.command), /eight/i);
+});
+
+test('preview, missing context, invalid cap and busy session make no managed changes', async (t) => {
+  const f = await fixture(t);
+  const preview = await f.adopt({ preview: true });
+  assert.equal(preview.status, 'preview');
+  assert.deepEqual(preview.dependencies.taskIds, ['1', '2']);
+  assert.equal(readEnrollment(f.root, f.channel.sessionId), null);
+  assert.equal(f.channel.handoffContext().status, 'not_prepared');
+  await assert.rejects(f.adopt({ maxNotifications: 0 }), /cap/);
+  await writeFile(join(f.project, 'brief.json'), 'ordinary prose');
+  assert.equal((await f.adopt()).status, 'needs_context');
+  assert.equal(readEnrollment(f.root, f.channel.sessionId), null);
+  f.channel.event('agent_start');
+  assert.equal((await f.adopt()).status, 'busy');
+  assert.equal(f.messages.length, 0);
+});
+
+test('adopt prepares/enrolls/follows without starting work; repeat status changes preserve cap', async (t) => {
+  const f = await fixture(t);
+  const result = await f.adopt();
+  assert.equal(result.status, 'adopted');
+  assert.equal(result.workStarted, false);
+  assert.equal(f.channel.handoffContext().status, 'ready');
+  await f.channel.dependencies.check();
+  assert.equal(f.messages.length, 0);
+  await f.adopt({ notify: true, maxNotifications: 1 });
+  await f.channel.dependencies.check();
+  assert.equal(f.messages.length, 1);
+  const original = f.channel.dependencies.status();
+  await f.put(1, [2], { status: 'done', receipt: 'Changes Requested' });
+  const again = await f.adopt({ notify: true, maxNotifications: 1 });
+  await f.channel.dependencies.check();
+  assert.equal(again.manifestReused, true);
+  assert.equal(f.channel.dependencies.status().phase, 'notification_limit');
+  assert.equal(f.channel.dependencies.status().lastAlert.id, original.lastAlert.id);
+  assert.equal(f.messages.length, 1);
+});
+
+test('changing managed task needs explicit expected revision, with no enrollment overwrite', async (t) => {
+  const f = await fixture(t);
+  await f.adopt();
+  const revision = f.channel.handoffContext().manifestRevision;
+  const blocked = await f.adopt({ id: '2', scope: 'Different scope' });
+  assert.equal(blocked.status, 'needs_expected_revision');
+  assert.equal(readEnrollment(f.root, f.channel.sessionId).scope, f.options.scope);
+  assert.equal((await f.adopt({ id: '2', expectedRevision: revision })).status, 'adopted');
+});
+
+test('enrollment contention reports partial preparation without configuring observation', async (t) => {
+  const f = await fixture(t);
+  await mkdir(join(f.root, 'supervision'), { recursive: true });
+  await writeFile(join(f.root, 'supervision', `${digest(f.channel.sessionId)}.json.lock`), '');
+  const result = await f.adopt();
+  assert.equal(result.status, 'adoption_incomplete');
+  assert.equal(result.attemptedStep, 'enroll');
+  assert.equal(result.steps.length, 1);
+  assert.equal(f.channel.handoffContext().status, 'ready');
+  assert.equal(f.channel.dependencies.status().configured, false);
+  assert.equal(f.messages.length, 0);
+});
+
+test('reloaded instance requires explicit handoff rebind and remains quiet', async (t) => {
+  const f = await fixture(t);
+  await f.adopt();
+  const revision = f.channel.handoffContext().manifestRevision;
+  await f.channel.close();
+  assert.equal((await f.adopt()).status, 'offline');
+  const replacement = await startChannel({ root: f.root, sessionId: f.channel.sessionId, cwd: f.project,
+    dependencyCommand: f.command, deliver: (text) => f.messages.push(text) });
+  try {
+    assert.equal((await f.adopt()).status, 'needs_expected_revision');
+    assert.equal(replacement.dependencies.status().phase, 'needs_refollow');
+    assert.equal((await f.adopt({ expectedRevision: revision })).status, 'adopted');
+    assert.equal(f.messages.length, 0);
+  } finally { await replacement.close(); }
+});

--- a/integrations/pi/cli.mjs
+++ b/integrations/pi/cli.mjs
@@ -6,6 +6,7 @@ import { listSessions, requestSession, getReceipt, inspectSession, prepareHandof
 import { enroll, watch, checkpoint, reply, managementBrief } from './supervision.mjs';
 import { composeHandoff } from './compose.mjs';
 import { followDependencies, dependencyStatus, unfollowDependencies, doctor } from './dependency-client.mjs';
+import { adoptSession } from './adoption.mjs';
 
 const help = `Edda Pi session channel (same-user, same-machine)
   node integrations/pi/cli.mjs list
@@ -25,6 +26,7 @@ const help = `Edda Pi session channel (same-user, same-machine)
   node integrations/pi/cli.mjs checkpoint SESSION_ID --cursor CURSOR --action observed|working|waiting_user|complete|paused --note TEXT
   node integrations/pi/cli.mjs checkpoint SESSION_ID --action paused --note TEXT
   node integrations/pi/cli.mjs doctor [SESSION_ID]
+  node integrations/pi/cli.mjs adopt SESSION_ID_OR_PREFIX --task ID [--project PATH] [--include ID,ID] [--context FILE] [--scope TEXT] [--notify] [--max-notifications 10] [--preview] [--expected REVISION]
   node integrations/pi/cli.mjs follow SESSION_ID --project PATH --tasks ID,ID [--scope TEXT] [--notify] [--max-notifications 10]
   node integrations/pi/cli.mjs dependencies SESSION_ID
   node integrations/pi/cli.mjs check-dependencies SESSION_ID
@@ -44,7 +46,7 @@ async function main(args) {
   const options = {};
   for (let i = 0; i < rest.length; i++) {
     const arg = rest[i];
-    if (['--conversation', '--notify'].includes(arg) && options[arg] === undefined) { options[arg] = true; continue; }
+    if (['--conversation', '--notify', '--preview'].includes(arg) && options[arg] === undefined) { options[arg] = true; continue; }
     if (!arg.startsWith('--')) { positional.push(arg); continue; }
     if (options[arg] !== undefined || rest[i + 1] === undefined || rest[i + 1].startsWith('--')) throw new Error(`Missing or duplicate option ${arg}`);
     options[arg] = rest[++i];
@@ -56,6 +58,7 @@ async function main(args) {
     prepare: ['--manifest', '--expected'], brief: ['--budget-bytes'],
     compose: ['--project', '--task', '--context', '--output', '--edda-bin'],
     doctor: [], follow: ['--project', '--tasks', '--scope', '--notify', '--max-notifications'],
+    adopt: ['--task', '--project', '--include', '--context', '--scope', '--notify', '--max-notifications', '--preview', '--expected'],
     dependencies: [], 'check-dependencies': [], unfollow: [],
     reply: ['--to', '--message', '--message-file'], checkpoint: ['--cursor', '--action', '--note'],
   }[command];
@@ -65,6 +68,10 @@ async function main(args) {
   const sessionId = positional[0];
   let result;
   if (command === 'doctor') result = await doctor(root, sessionId);
+  if (command === 'adopt') result = await adoptSession(root, sessionId, { id: options['--task'], project: options['--project'],
+    include: options['--include']?.split(',').map((s) => s.trim()), contextFile: options['--context'], scope: options['--scope'],
+    notify: options['--notify'] === true, maxNotifications: Number(options['--max-notifications'] ?? 10),
+    preview: options['--preview'] === true, expectedRevision: options['--expected'] });
   if (command === 'follow') result = await followDependencies(root, sessionId, { project: options['--project'],
     taskIds: options['--tasks']?.split(',').map((s) => s.trim()), scope: options['--scope'],
     notify: options['--notify'] === true, maxNotifications: Number(options['--max-notifications'] || 10) });
@@ -100,7 +107,8 @@ async function main(args) {
       sender: options['--sender'] || 'codex', mode: options['--mode'] || 'followUp' });
   }
   process.stdout.write(JSON.stringify(result, null, 2) + '\n');
-  if (['unknown', 'failed', 'needs_context', 'not_prepared', 'stale_binding', 'unavailable', 'needs_reload', 'needs_enrollment', 'not_registered'].includes(result?.status)) process.exitCode = 2;
+  if (['unknown', 'failed', 'needs_context', 'not_prepared', 'stale_binding', 'unavailable', 'needs_reload', 'needs_enrollment', 'not_registered',
+    'ambiguous_session', 'invalid_selector', 'offline', 'busy', 'source_changed', 'needs_expected_revision', 'adoption_incomplete'].includes(result?.status)) process.exitCode = 2;
 }
 
 main(process.argv.slice(2)).catch((error) => {

--- a/integrations/pi/dependency-observer.mjs
+++ b/integrations/pi/dependency-observer.mjs
@@ -11,7 +11,7 @@ function clip(text, maxBytes) {
   while (end > 0 && end < bytes.length && (bytes[end] & 0xc0) === 0x80) end--;
   return { text: bytes.subarray(0, end).toString('utf8'), truncated: end < bytes.length };
 }
-function fact(task) {
+export function dependencyFact(task) {
   if (!Number.isSafeInteger(task.attempts) || task.attempts < 0 ||
     (task.receipt !== null && task.receipt !== undefined && typeof task.receipt !== 'string') ||
     (task.failure_reason !== null && task.failure_reason !== undefined && typeof task.failure_reason !== 'string') ||
@@ -87,7 +87,7 @@ export function createDependencyObserver({ dir, sessionId, instanceId, policy, r
     if (allowed()) return status();
     let facts;
     try {
-      facts = await Promise.all(data.taskIds.map(async (id) => fact((await readTask(data.project, id, command, signal)).task)));
+      facts = await Promise.all(data.taskIds.map(async (id) => dependencyFact((await readTask(data.project, id, command, signal)).task)));
     } catch {
       const cancelled = signal.aborted;
       abort.abort();

--- a/integrations/pi/dependency-smoke.mjs
+++ b/integrations/pi/dependency-smoke.mjs
@@ -3,7 +3,7 @@
 import assert from 'node:assert/strict';
 import { spawn, execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { mkdtemp, mkdir, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -12,8 +12,10 @@ import { randomUUID } from 'node:crypto';
 import { setTimeout as delay } from 'node:timers/promises';
 import { listSessions, getReceipt, requestSession } from './client.mjs';
 import { followDependencies, dependencyStatus, unfollowDependencies } from './dependency-client.mjs';
+import { adoptSession } from './adoption.mjs';
 
-const [piEntry, eddaBin] = process.argv.slice(2);
+const [piEntry, eddaBin, mode] = process.argv.slice(2);
+if (mode && mode !== '--adopt') throw new Error('Unknown smoke mode');
 if (!piEntry || !eddaBin) throw new Error('Supply Pi JavaScript CLI entry and native Edda executable');
 const root = await mkdtemp(join(tmpdir(), 'edda-dependency-smoke-'));
 const project = join(root, 'project'), registry = join(root, 'channel');
@@ -32,6 +34,17 @@ try {
   const tasks = JSON.parse((await edda('task', 'list', '--json')).stdout);
   assert.equal(tasks.length, 1);
   const id = String(tasks[0].task_id);
+  let managedId;
+  if (mode === '--adopt') {
+    await writeFile(join(project, 'brief.json'), JSON.stringify({ role: 'controller', doneWhen: ['Acknowledge synthetic notifications'],
+      scope: { allowed: ['Offline fixture only'], excluded: ['User tasks'], reserved: ['Paid model calls'],
+        authorityRefs: [{ uri: 'fixture://smoke', revision: 'v1' }] } }));
+    await edda('task', 'new', 'Synthetic managed controller', '--after', id, '--brief', 'brief.json');
+    managedId = String(JSON.parse((await edda('task', 'list', '--json')).stdout).find((task) => String(task.task_id) !== id).task_id);
+    // This standalone smoke process must read from the same isolated Edda store.
+    for (const key of Object.keys(process.env)) if (key.startsWith('EDDA_')) delete process.env[key];
+    for (const [key, value] of Object.entries(env)) if (key.startsWith('EDDA_')) process.env[key] = value;
+  }
   child = spawn(process.execPath, [resolve(piEntry), '--mode', 'rpc', '--no-session', '--no-extensions',
     '-e', fileURLToPath(new URL('./extension.mjs', import.meta.url)),
     '-e', fileURLToPath(new URL('./fixtures/offline-provider.mjs', import.meta.url)),
@@ -52,8 +65,13 @@ try {
     throw new Error(`Timed out: ${label}; ${stderr}`);
   }
   session = await until(async () => (await listSessions(registry)).find((row) => row.live), 'Pi registration');
-  await followDependencies(registry, session.sessionId, { project, taskIds: [id], notify: true, maxNotifications: 3,
-    scope: 'Only observe the isolated synthetic task and acknowledge notifications with the offline fixture. No real work or spending.' });
+  const scope = 'Only observe the isolated synthetic task and acknowledge notifications with the offline fixture. No real work or spending.';
+  if (mode === '--adopt') {
+    const adopted = await adoptSession(registry, session.sessionId.slice(0, 8), { id: managedId, scope, notify: true, maxNotifications: 3 });
+    assert.equal(adopted.status, 'adopted');
+    assert.ok(adopted.dependencies.taskIds.includes(id));
+    assert.equal(adopted.workStarted, null);
+  } else await followDependencies(registry, session.sessionId, { project, taskIds: [id], notify: true, maxNotifications: 3, scope });
   await until(async () => {
     const state = await dependencyStatus(registry, session.sessionId);
     return state.lastAlert && (await getReceipt(registry, session.sessionId, state.lastAlert.id)).status === 'settled';
@@ -69,14 +87,14 @@ try {
       (await getReceipt(registry, session.sessionId, state.lastAlert.id)).status === 'settled';
   }, 'automatic dependency notification', 80000);
   const final = await dependencyStatus(registry, session.sessionId);
-  assert.equal(final.facts[0].status, 'done');
-  assert.ok(final.facts[0].receipt.includes('Changes Requested'));
+  assert.equal(final.facts.find((fact) => fact.taskId === id).status, 'done');
+  assert.ok(final.facts.find((fact) => fact.taskId === id).receipt.includes('Changes Requested'));
   assert.ok(output.includes('OFFLINE_ACK:'));
   assert.equal((await requestSession(registry, session.sessionId, '/status')).state, 'idle');
   await unfollowDependencies(registry, session.sessionId);
   assert.equal((await dependencyStatus(registry, session.sessionId)).phase, 'paused');
   console.log(JSON.stringify({ passed: true, actualPi: true, actualEdda: true, periodicTrigger: true,
-    sameSession: true, notifications: final.notifications, reviewRejectionPreserved: true, paused: true, paidCalls: 0 }, null, 2));
+    sameSession: true, adoption: mode === '--adopt', notifications: final.notifications, reviewRejectionPreserved: true, paused: true, paidCalls: 0 }, null, 2));
 } finally {
   if (session && child?.exitCode === null) await unfollowDependencies(registry, session.sessionId);
   if (child && child.exitCode === null && child.signalCode === null) {

--- a/integrations/pi/fixtures/edda-task-graph-reader.mjs
+++ b/integrations/pi/fixtures/edda-task-graph-reader.mjs
@@ -1,0 +1,6 @@
+// Process-boundary fixture: reads only the selected synthetic task file.
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+const [command, verb, id, format] = process.argv.slice(2);
+if (command !== 'task' || verb !== 'show' || format !== '--json' || !/^[0-9]+$/.test(id)) process.exit(71);
+process.stdout.write(readFileSync(join(process.cwd(), `task-${id}.json`), 'utf8'));

--- a/integrations/pi/package.json
+++ b/integrations/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edda/pi-session-channel",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "engines": { "node": ">=24" },

--- a/integrations/pi/supervision.mjs
+++ b/integrations/pi/supervision.mjs
@@ -22,9 +22,12 @@ async function locked(root, id, action) {
   writeFileSync(path, '', { flag: 'wx', mode: 0o600 });
   try { return await action(); } finally { unlinkSync(path); }
 }
-export async function enroll(root, id, scope) {
+export function validateScope(scope) {
   if (typeof scope !== 'string' || !scope.trim() || scope.length > 8000) throw new Error('An explicit bounded supervision scope is required');
-  const state = await requestSession(root, id, '/status');
+}
+export async function enroll(root, id, scope, expectedInstance) {
+  validateScope(scope);
+  const state = await requestSession(root, id, '/status', undefined, 2500, expectedInstance);
   privateRoot(root);
   mkdirSync(folder(root), { recursive: true, mode: 0o700 });
   return locked(root, id, async () => {


### PR DESCRIPTION
Issue: #1152
Closes #1152
Decision: session.adoption

Pi adoption previously required separate composition, enrollment, manifest preparation and dependency selection. `adopt` now performs a complete preflight and connects those existing operations, accepting exact session IDs or unique prefixes and defaulting to the live session project.

It discovers bounded transitive `after` dependencies plus explicitly selected review/fix roots, shows missing context before setup, and reports partial operations honestly. Repeated status-only adoption retains the existing immutable handoff and notification cap; replacing context or rebinding after reload requires an expected revision. Setup does not claim work started.

Validation at f63a48d0174fa7eedb67da245f63bd4479431f47:

- RAN Windows Node24.14 adoption suite: 7/7, covering graph limits/cycles, prefix ambiguity, side-effect-free preflight, cap preservation, partial setup and reload binding.
- RAN actual Pi0.85.1 + native Edda isolated smoke with `--adopt`: unique prefix, automatic prerequisite inclusion, real60s timer, two notifications/same-session replies, rejected review evidence preserved and pause verified; paidCalls=0.
- RAN full npm regression suite: 49/49 passing on Windows Node24.14 (94 seconds). Exact-head CI dispatched. No Rust changes or local Cargo builds.
- RAN diff check and commit hooks; clean frozen worktree.

Limits: explicit graph snapshot only; no automatic graph refresh, manager inbox/reverse Codex wake, authorization resolver, hot reload, remote transport or standalone package distribution. Existing subscriptions remain active until changed; apply is a visible sequence rather than a transaction. Source worktree stays installed and must be preserved.
