### PR TITLE
feat(integrations): add non-blocking Pi manager inbox

### DIFF
--- a/docs/superpowers/plans/2026-09-12-pi-manager-inbox.md
+++ b/docs/superpowers/plans/2026-09-12-pi-manager-inbox.md
@@ -32,7 +32,7 @@ message through the existing exact-instance channel and durable receipt path.
   A missing/mismatched/revoked optional record produces a warning and omits its
   citation; it does not block the manager's otherwise valid explicit response.
 - `inbox-respond` explicitly chooses a message and optional authorization record.
-  Revalidate enabled enrollment, exact idle instance, current report/work identity
+  Revalidate any existing enrollment scope/pause, exact idle instance, current report/work identity
   and manifest/scope before a write-ahead response intent. One event has one
   deterministic message ID; uncertain attempts query receipts and never resend.
   Read acknowledgement, response intent, accepted/started/settled receipt and task

--- a/docs/superpowers/plans/2026-09-12-pi-manager-inbox.md
+++ b/docs/superpowers/plans/2026-09-12-pi-manager-inbox.md
@@ -1,0 +1,69 @@
+# Pi manager inbox and response loop
+
+**Goal:** Pi stopping/decision events become durable, bounded manager work items,
+with explicit authorization evidence reuse and receipt-linked responses.
+
+**Architecture:** Keep the existing same-user private channel store. Pi is the
+event producer; `local-manager` is the inbox recipient. A caller-supplied consumer
+ID distinguishes manager read acknowledgements; it is a label, not authentication.
+Events never grant authority. Only an explicitly invoked manager response sends a
+message through the existing exact-instance channel and durable receipt path.
+
+## Contract
+
+- An immutable event carries session/instance/report or work identity, run and
+  manifest revision, enrollment-scope digest, timestamp, report and evidence refs.
+  Structured waiting_decision reports become decision requests. Reportless
+  settlement becomes unread activity/missing report with a UTF-8 bounded public
+  assistant excerpt. Do not infer requested authority from prose or expose reasoning.
+- Attempt publication after a structured report is recorded. Reconcile pending
+  publication and the last durable handoff report at startup and on heartbeat.
+  Telemetry failure never rejects a valid report, handoff update, channel startup
+  or task execution. Events are create-only and
+  deduplicated by stable identity. Retain event/ack/response/authorization files;
+  no automatic pruning of unread or unanswered requests.
+- `inbox` returns a bounded index. `inbox-read` fetches one complete event with
+  its authorization candidates and response evidence. `inbox-ack` acknowledges
+  reading only. An acknowledged unanswered decision stays pending.
+- Authorization records are manager-authored declarations with exact requested
+  action/resource, run/manifest/scope binding, and an explicit source URI/revision.
+  Worker reports cannot create records. Matching is exact and returns evidence to
+  the manager, never an automatic approval. Revocation removes reuse candidates.
+  A missing/mismatched/revoked optional record produces a warning and omits its
+  citation; it does not block the manager's otherwise valid explicit response.
+- `inbox-respond` explicitly chooses a message and optional authorization record.
+  Revalidate enabled enrollment, exact idle instance, current report/work identity
+  and manifest/scope before a write-ahead response intent. One event has one
+  deterministic message ID; uncertain attempts query receipts and never resend.
+  Read acknowledgement, response intent, accepted/started/settled receipt and task
+  acceptance remain separate. A response receipt is never task acceptance.
+- Current host wake capability is `unsupported`: no desktop adapter is configured.
+  `inbox-wake` returns that status and performs no process/model call. An active
+  manager can poll/read/respond; there is no claim that an idle Codex is notified.
+  The [official App Server documentation](https://learn.chatgpt.com/docs/app-server)
+  describes transports and turn/start, but this integration has no configured
+  connection to the existing desktop host. Do not spawn a second runtime to fake it.
+
+**Operator clarification:** This is side-channel observation, not a new execution
+gate. Structured reports, acknowledgements and authorization records are optional;
+missing metadata must never make the worker stop to fill forms or seek approval.
+Only wrong/stale destination, explicit pause/scope changes and duplicate delivery
+checks constrain the managed response. Ordinary authorized send remains available.
+Storage errors are visible and may leave unpersisted observations unavailable after
+a crash; already-persisted events and pending publication are never silently erased.
+
+## Implementation and tests
+
+- Add small storage, producer and manager-response modules under integrations/pi.
+- Wire report/settlement producer into channel and capture only assistant text from
+  message_end. Surface producer errors/capability in status; preserve pending source.
+- Add CLI index/read/ack/authorization-record/revoke/respond/wake and README workflow.
+- Test exact duplicate events, missing report excerpt, no reasoning, per-consumer
+  acknowledgement, restart recovery, unacknowledged requests, stale epoch/instance/
+  scope, revoked or mismatched authorization, response dedupe/unknown receipts and
+  unsupported wake. Use real private files and authenticated loopback transport.
+- Actual Pi offline-provider scenario: request -> outbound event -> manager reads
+  and records fixture authorization -> response -> same-session execution; a repeated
+  request under the same binding finds the existing declaration. No paid calls.
+- Full Node suite and exact-head CI; independent PR-visible review; R6 controller
+  merge under standing operator approval. No Rust/Cargo build or live auto-subscription.

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -73,10 +73,85 @@ means setup succeeded, not work started; notify mode reports `workStarted: null`
 until its separate message receipt is inspected. Without `--notify`, adoption
 configures observation only. Use an explicit `send` for an authorized work instruction.
 
-The receiver does not yet push decision requests into a manager inbox or wake an
-idle Codex thread. `conversation` reads replies on demand; `brief` reads structured
-reports when prepared. Dependency alerts wake the receiving Pi only. Manager inbox
-delivery and reverse wake routing remain a separate, necessary follow-up.
+The receiver now persists stopping/decision events in a local manager inbox (below).
+It does not wake an idle Codex thread. `conversation` still reads replies on demand;
+`brief` reads structured reports when prepared. Dependency alerts wake Pi only.
+
+## Manager inbox: observe, read and respond
+
+Pi publishes a decision event when it records `waiting_decision`; other structured
+stopping reports are also retained. Without a structured report, settlement saves
+an unread-activity event with at most 2400 UTF-8 bytes of the final public assistant
+text. No approval is inferred from prose and no private reasoning is captured.
+Workers do not need to fill metadata or stop for another approval to continue work.
+
+```powershell
+node integrations/pi/cli.mjs inbox
+node integrations/pi/cli.mjs inbox-read EVENT_ID
+node integrations/pi/cli.mjs inbox-ack EVENT_ID
+node integrations/pi/cli.mjs inbox-respond EVENT_ID --message "The existing task scope is approved; proceed with the specified next step."
+```
+
+The index is bounded (`--limit 1..50`, default 20); use `--after EVENT_ID` for the
+next page. Pages are observation snapshots, not a streaming delivery cursor; start
+from the beginning when polling again. `--consumer NAME` separates each manager's
+read acknowledgements. All local consumers share the same inbox; names are labels,
+not authentication or assignment. Ack means read, not approval or resolution;
+unanswered questions and historical responses remain available across restarts.
+`inbox-read --budget-bytes 32768` can expand one event without replaying a transcript.
+
+An explicit response uses one deterministic message ID per event. It checks the
+original idle instance and current work/scope before sending; old questions cannot
+silently send into a new run. Its intent precedes delivery and uncertainty never
+causes a blind resend. Inspect `inbox-read` for the actual message receipt. A
+started/settled message proves processing began, never independent task acceptance.
+The ordinary `send` command remains available for a fresh authorized instruction.
+
+### Optional reuse of an existing authorization
+
+This is manager evidence, not an additional permission gate. A manager can save a
+reference to an already-approved exact action/resource using a JSON file:
+
+```json
+{
+  "requestedAction": "fixture_continue",
+  "resource": "offline-only",
+  "source": { "uri": "fixture://operator", "revision": "approved-v1" },
+  "note": "This action is already approved within the existing scope."
+}
+```
+
+```powershell
+node integrations/pi/cli.mjs authorization-record EVENT_ID --record approval-reference.json
+node integrations/pi/cli.mjs inbox-respond EVENT_ID --authorization RECORD_ID --message "Proceed with the already-approved step."
+node integrations/pi/cli.mjs authorization-revoke RECORD_ID
+```
+
+Replace fixture values with the request's exact action/resource and actual evidence
+reference. A later matching request under the same session/run/manifest/scope shows
+the saved reference as a candidate. The receiver cannot create it through its report
+tool, and matching never sends a response automatically. References are manager
+declarations, not independently verified grants; their contents are not fetched or
+executed. Missing/mismatched/revoked optional evidence produces a warning and is
+omitted from the explicit response, not a new request for permission.
+
+### Delivery limits and failures
+
+`inbox-wake` currently returns `unsupported` with `notified: false`: this package
+has no configured adapter to the existing Codex desktop host. It starts no process,
+model or schedule. An active manager can read the durable inbox; persistence is not
+proof that an idle manager was notified. Host wake routing is still required for
+unattended supervision.
+
+Inbox telemetry is a side channel. Storage/notification errors appear in session
+status but do not reject valid handoff reports, handoff updates or ordinary channel
+messages. Persisted events, read acknowledgements, response intents and authorization
+records live in the private registry and are not automatically deleted. A pending
+publication is replayed idempotently on startup/heartbeat; the latest durable report
+can also be recovered. If storage failed before anything was persisted, an observation
+may be unavailable after a crash; no successful delivery is claimed. Hard-link atomic
+publication requires a filesystem supporting hard links; unsupported storage reports
+an error and original work continues.
 
 ## Select dependencies directly: follow, inspect, pause
 
@@ -435,6 +510,7 @@ node integrations/pi/pi-smoke.mjs C:/nvm4w/nodejs/node_modules/@earendil-works/p
 node integrations/pi/pi-smoke.mjs C:/nvm4w/nodejs/node_modules/@earendil-works/pi-coding-agent/dist/bundle/cli.js --supervise
 node integrations/pi/pi-smoke.mjs C:/nvm4w/nodejs/node_modules/@earendil-works/pi-coding-agent/dist/bundle/cli.js --handoff
 node integrations/pi/pi-smoke.mjs C:/nvm4w/nodejs/node_modules/@earendil-works/pi-coding-agent/dist/bundle/cli.js --handoff-budget
+node integrations/pi/pi-smoke.mjs C:/nvm4w/nodejs/node_modules/@earendil-works/pi-coding-agent/dist/bundle/cli.js --inbox
 node integrations/pi/dependency-smoke.mjs C:/nvm4w/nodejs/node_modules/@earendil-works/pi-coding-agent/dist/bundle/cli.js C:/Users/fagem/.cargo/bin/edda.exe
 ```
 

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -105,7 +105,10 @@ original idle instance and current work/scope before sending; old questions cann
 silently send into a new run. Its intent precedes delivery and uncertainty never
 causes a blind resend. Inspect `inbox-read` for the actual message receipt. A
 started/settled message proves processing began, never independent task acceptance.
-The ordinary `send` command remains available for a fresh authorized instruction.
+Enrollment and a prepared manifest are not prerequisites for responding to a
+reportless event. Missing setup is not a denial; an explicit pause or change to an
+existing bound scope still protects against stale responses. The ordinary `send`
+command remains available for a fresh authorized instruction.
 
 ### Optional reuse of an existing authorization
 

--- a/integrations/pi/channel.mjs
+++ b/integrations/pi/channel.mjs
@@ -4,6 +4,9 @@ import { openStore, digest, validateSession, validateId } from './store.mjs';
 import { createHandoff } from './handoff.mjs';
 import { createDependencyObserver } from './dependency-observer.mjs';
 import { readEnrollment } from './supervision.mjs';
+import { createInboxProducer } from './inbox-producer.mjs';
+import { inboxStore, inboxId, messageId } from './inbox-store.mjs';
+import { assertCurrentEvent } from './inbox-binding.mjs';
 
 const terminal = new Set(['settled', 'failed', 'unknown']);
 const now = () => new Date().toISOString();
@@ -39,6 +42,7 @@ export async function startChannel({ root, sessionId, cwd, label = '', deliver, 
   const store = openStore(root, sessionId, owner);
   let handoff;
   let dependencies;
+  let inbox;
   try { handoff = createHandoff(store.dir, sessionId, instanceId); }
   catch (error) { store.release(); throw error; }
   let closed = false;
@@ -82,21 +86,26 @@ export async function startChannel({ root, sessionId, cwd, label = '', deliver, 
   const channel = {
     sessionId, instanceId,
     snapshot: () => ({ ...state, toolNames: [...state.toolNames], live: !closed,
-      capabilities: ['send', 'receipts', 'handoff', 'dependencies', ...(getConversation ? ['conversation'] : [])] }),
+      capabilities: ['send', 'receipts', 'handoff', 'dependencies', 'inbox', ...(getConversation ? ['conversation'] : [])],
+      inbox: inbox?.status() }),
     get dependencies() { return dependencies; },
     handoffContext: (budget) => handoff.context(channel.snapshot(), budget),
     reportHandoff(id, value) {
       if (closed || storageError) throw fail('Channel unavailable', 503);
-      return handoff.report(id, value);
+      inbox.reconcile();
+      const p = readEnrollment(root, sessionId);
+      const receipt = handoff.report(id, value, p?.enabled && typeof p.scope === 'string' ? digest(p.scope) : null);
+      inbox.reconcile();
+      return receipt;
     },
     event(name, data = {}) {
       if (closed) return;
-      if (name === 'agent_start') { busy = true; lastStopReason = null; }
+      if (name === 'agent_start') { busy = true; lastStopReason = null; inbox.begin(); }
       if (name === 'ui_prompt_start') waiting = true;
       if (name === 'ui_prompt_end') waiting = false;
       if (name === 'tool_execution_start') tools.set(data.toolCallId, data.toolName);
       if (name === 'tool_execution_end') tools.delete(data.toolCallId);
-      if (name === 'assistant_end') lastStopReason = data.stopReason;
+      if (name === 'assistant_end') { lastStopReason = data.stopReason; inbox.assistant(data.text); }
       state.lastEvent = name;
       state.lastProgressAt = now();
       recompute();
@@ -117,6 +126,7 @@ export async function startChannel({ root, sessionId, cwd, label = '', deliver, 
         if (r.instanceId === instanceId && r.status === 'started') update(r, ['error', 'aborted'].includes(lastStopReason) ? 'failed' : 'settled');
       }
       channel.event('agent_settled');
+      inbox.settled();
     },
     async close() {
       if (closed) return;
@@ -174,6 +184,15 @@ export async function startChannel({ root, sessionId, cwd, label = '', deliver, 
       if (req.headers.origin || Buffer.byteLength(auth) !== Buffer.byteLength(expected) || !timingSafeEqual(Buffer.from(auth), Buffer.from(expected))) throw fail('Unauthorized', 401);
       if (req.headers['x-edda-instance'] !== instanceId) throw fail('Wrong session instance', 409);
       if (req.method === 'GET' && req.url === '/status') return reply(200, channel.snapshot());
+      if (req.method === 'POST' && req.url === '/inbox/respond') {
+        if (req.headers['content-type'] !== 'application/json') throw fail('Expected application/json', 415);
+        const body = await jsonBody(req), records = inboxStore(root);
+        const event = records.read('events', inboxId(body.eventId));
+        if (!event) throw fail('Inbox event not found', 404);
+        if (validateId(body.id) !== messageId(body.eventId)) throw fail('Inbox response must use its event message identity', 409);
+        assertCurrentEvent(event.data, channel.snapshot(), channel.handoffContext(32768), readEnrollment(root, sessionId));
+        return reply(200, submitMessage(body, true));
+      }
       if (req.method === 'GET' && req.url === '/dependencies') return reply(200, dependencies.status());
       if (req.method === 'POST' && req.url?.startsWith('/dependencies')) {
         if (closed || storageError) throw fail('Channel unavailable', 503);
@@ -192,6 +211,7 @@ export async function startChannel({ root, sessionId, cwd, label = '', deliver, 
         if (closed || storageError) throw fail('Channel unavailable', 503);
         if (req.headers['content-type'] !== 'application/json') throw fail('Expected application/json', 415);
         const body = await jsonBody(req);
+        inbox.reconcile();
         handoff.prepare(body.manifest, body.expectedRevision, channel.snapshot());
         return reply(200, channel.handoffContext());
       }
@@ -217,6 +237,14 @@ export async function startChannel({ root, sessionId, cwd, label = '', deliver, 
   server.timeout = 5000;
   let heartbeat;
   try {
+    try {
+      inbox = createInboxProducer({ root, sessionId, instanceId, evidence: () => handoff.outboundEvidence(),
+        context: () => channel.handoffContext(32768), policy: () => readEnrollment(root, sessionId) });
+    } catch (error) {
+      // Telemetry setup never disables the original channel or task execution.
+      inbox = { status: () => ({ status: 'storage_error', error: error.message, wake: { status: 'unsupported', notified: false } }),
+        begin() {}, assistant() {}, settled() {}, reconcile() {} };
+    }
     dependencies = createDependencyObserver({ dir: store.dir, sessionId, instanceId,
       policy: () => readEnrollment(root, sessionId), runtime: () => channel.snapshot(),
       manifestRevision: () => handoff.currentRevision(), send: (body) => submitMessage(body, true),
@@ -229,7 +257,7 @@ export async function startChannel({ root, sessionId, cwd, label = '', deliver, 
     store.owner(owner);
     save();
     heartbeat = setInterval(() => {
-      try { save(); }
+      try { save(); inbox.reconcile(); }
       catch { storageError = true; recompute(); }
     }, heartbeatMs);
     heartbeat.unref();

--- a/integrations/pi/cli.mjs
+++ b/integrations/pi/cli.mjs
@@ -7,6 +7,9 @@ import { enroll, watch, checkpoint, reply, managementBrief } from './supervision
 import { composeHandoff } from './compose.mjs';
 import { followDependencies, dependencyStatus, unfollowDependencies, doctor } from './dependency-client.mjs';
 import { adoptSession } from './adoption.mjs';
+import { listInbox, readInbox, acknowledgeInbox, recordAuthorization, revokeAuthorization, respondInbox } from './inbox-manager.mjs';
+import { wakeCapability } from './inbox-store.mjs';
+import { readBoundedFile } from './compose-sources.mjs';
 
 const help = `Edda Pi session channel (same-user, same-machine)
   node integrations/pi/cli.mjs list
@@ -31,6 +34,14 @@ const help = `Edda Pi session channel (same-user, same-machine)
   node integrations/pi/cli.mjs dependencies SESSION_ID
   node integrations/pi/cli.mjs check-dependencies SESSION_ID
   node integrations/pi/cli.mjs unfollow SESSION_ID
+  node integrations/pi/cli.mjs inbox [--consumer codex] [--limit 20] [--after EVENT_ID]
+  node integrations/pi/cli.mjs inbox-read EVENT_ID [--consumer codex] [--budget-bytes 16384]
+  node integrations/pi/cli.mjs inbox-ack EVENT_ID [--consumer codex]
+  node integrations/pi/cli.mjs authorization-record EVENT_ID --record FILE [--consumer codex]
+  node integrations/pi/cli.mjs authorization-revoke RECORD_ID [--consumer codex]
+  node integrations/pi/cli.mjs inbox-respond EVENT_ID --message TEXT [--authorization RECORD_ID] [--consumer codex]
+  node integrations/pi/cli.mjs inbox-respond EVENT_ID --message-file PATH [--authorization RECORD_ID]
+  node integrations/pi/cli.mjs inbox-wake
 
 JSON stdout; diagnostics stderr. EDDA_PI_CHANNEL_DIR overrides the private root.
 Supervision commands are tools for an authorized controller, not a decision engine.
@@ -60,13 +71,28 @@ async function main(args) {
     doctor: [], follow: ['--project', '--tasks', '--scope', '--notify', '--max-notifications'],
     adopt: ['--task', '--project', '--include', '--context', '--scope', '--notify', '--max-notifications', '--preview', '--expected'],
     dependencies: [], 'check-dependencies': [], unfollow: [],
+    inbox: ['--consumer', '--limit', '--after'], 'inbox-read': ['--consumer', '--budget-bytes'], 'inbox-ack': ['--consumer'],
+    'authorization-record': ['--record', '--consumer'], 'authorization-revoke': ['--consumer'],
+    'inbox-respond': ['--message', '--message-file', '--authorization', '--consumer'], 'inbox-wake': [],
     reply: ['--to', '--message', '--message-file'], checkpoint: ['--cursor', '--action', '--note'],
   }[command];
   if (!allowed || Object.keys(options).some((key) => !allowed.includes(key))) throw new Error('Unknown command or option; use --help');
-  const counts = command === 'doctor' ? [0, 1] : [['list', 'watch', 'compose'].includes(command) ? 0 : 1];
+  const counts = command === 'doctor' ? [0, 1] : [['list', 'watch', 'compose', 'inbox', 'inbox-wake'].includes(command) ? 0 : 1];
   if (!counts.includes(positional.length)) throw new Error('Use the exact session ID; see --help');
   const sessionId = positional[0];
   let result;
+  if (command === 'inbox') result = listInbox(root, { consumer: options['--consumer'], limit: options['--limit'], after: options['--after'] });
+  if (command === 'inbox-read') result = await readInbox(root, sessionId, { consumer: options['--consumer'], budget: options['--budget-bytes'] });
+  if (command === 'inbox-ack') result = acknowledgeInbox(root, sessionId, options['--consumer']);
+  if (command === 'inbox-wake') result = wakeCapability();
+  if (command === 'authorization-record') result = await recordAuthorization(root, sessionId,
+    JSON.parse((await readBoundedFile(options['--record'])).text), options['--consumer']);
+  if (command === 'authorization-revoke') result = revokeAuthorization(root, sessionId, options['--consumer']);
+  if (command === 'inbox-respond') {
+    if (Boolean(options['--message']) === Boolean(options['--message-file'])) throw new Error('Supply exactly one of --message or --message-file');
+    result = await respondInbox(root, sessionId, { message: options['--message'] || (await readBoundedFile(options['--message-file'])).text,
+      authorizationId: options['--authorization'], consumer: options['--consumer'] });
+  }
   if (command === 'doctor') result = await doctor(root, sessionId);
   if (command === 'adopt') result = await adoptSession(root, sessionId, { id: options['--task'], project: options['--project'],
     include: options['--include']?.split(',').map((s) => s.trim()), contextFile: options['--context'], scope: options['--scope'],
@@ -108,7 +134,7 @@ async function main(args) {
   }
   process.stdout.write(JSON.stringify(result, null, 2) + '\n');
   if (['unknown', 'failed', 'needs_context', 'not_prepared', 'stale_binding', 'unavailable', 'needs_reload', 'needs_enrollment', 'not_registered',
-    'ambiguous_session', 'invalid_selector', 'offline', 'busy', 'source_changed', 'needs_expected_revision', 'adoption_incomplete'].includes(result?.status)) process.exitCode = 2;
+    'ambiguous_session', 'invalid_selector', 'offline', 'busy', 'source_changed', 'needs_expected_revision', 'adoption_incomplete', 'unsupported'].includes(result?.status)) process.exitCode = 2;
 }
 
 main(process.argv.slice(2)).catch((error) => {

--- a/integrations/pi/extension.mjs
+++ b/integrations/pi/extension.mjs
@@ -83,7 +83,11 @@ export default function eddaSessionChannel(pi) {
     c.messageStarted(text);
   }));
   pi.on('message_end', (event, ctx) => guard(ctx, (c) => {
-    if (event.message.role === 'assistant') c.event('assistant_end', { stopReason: event.message.stopReason });
+    if (event.message.role === 'assistant') {
+      const content = event.message.content;
+      const text = typeof content === 'string' ? content : (content || []).filter((p) => p.type === 'text').map((p) => p.text).join('\n');
+      c.event('assistant_end', { stopReason: event.message.stopReason, text });
+    }
   }));
   pi.on('agent_settled', (_event, ctx) => guard(ctx, (c) => c.settled()));
   pi.registerCommand('edda-session', {

--- a/integrations/pi/extension.test.mjs
+++ b/integrations/pi/extension.test.mjs
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import extension from './extension.mjs';
 import { listSessions, requestSession, getReceipt } from './client.mjs';
+import { listInbox, readInbox } from './inbox-manager.mjs';
 
 test('Pi lifecycle, tool spans, queued messages, UI waits, settlement and session replacement', async (t) => {
   const root = await mkdtemp(join(tmpdir(), 'edda-extension-test-'));
@@ -50,8 +51,14 @@ test('Pi lifecycle, tool spans, queued messages, UI waits, settlement and sessio
   assert.equal((await getReceipt(root, sid, id)).status, 'unconfirmed');
   await emit('agent_start');
   await emit('message_start', { message: { role: 'user', content: [{ type: 'text', text: delivered[0].text }] } });
-  await emit('message_end', { message: { role: 'assistant', stopReason: 'stop' } });
+  await emit('message_end', { message: { role: 'assistant', stopReason: 'stop', content: [
+    { type: 'thinking', thinking: 'PRIVATE_REASONING_MUST_NOT_LEAK' }, { type: 'text', text: 'Public stopping reason' },
+  ] } });
   await emit('agent_settled');
+  const inbox = listInbox(root);
+  const detail = await readInbox(root, inbox.events.at(-1).eventId);
+  assert.equal(detail.event.excerpt.text, 'Public stopping reason');
+  assert.ok(!JSON.stringify(detail).includes('PRIVATE_REASONING_MUST_NOT_LEAK'));
   assert.equal((await getReceipt(root, sid, id)).status, 'settled');
   const prior = sid;
   await emit('session_shutdown');

--- a/integrations/pi/handoff.mjs
+++ b/integrations/pi/handoff.mjs
@@ -18,7 +18,7 @@ export function createHandoff(dir, sessionId, instanceId) {
       !Number.isSafeInteger(data.settledEpoch) || data.settledEpoch < 0 || data.settledEpoch > data.workEpoch ||
       !data.reportIds || typeof data.reportIds !== 'object' || Array.isArray(data.reportIds)) throw problem('Invalid persisted handoff state');
     if (data.latestReport) {
-      const { reportId, instanceId: reportInstance, workEpoch, recordedAt, ...value } = data.latestReport;
+      const { reportId, instanceId: reportInstance, workEpoch, recordedAt, supervisorScopeDigest, ...value } = data.latestReport;
       normalizeReport(value);
       if (reportInstance !== data.instanceId || value.manifestRevision !== data.manifestRevision || workEpoch > data.workEpoch) throw problem('Invalid persisted handoff report binding');
     }
@@ -27,6 +27,8 @@ export function createHandoff(dir, sessionId, instanceId) {
   const commit = (next) => { writeJson(path, next); data = next; };
   return {
     currentRevision: () => current() ? data.manifestRevision : null,
+    outboundEvidence: () => data?.latestReport ? { report: data.latestReport,
+      runId: data.manifest.runId, planRef: data.manifest.planRef } : null,
     prepare(value, expectedRevision, runtime) {
       if (runtime.state !== 'idle') throw problem('Handoff preparation requires an idle instance', 409);
       const manifest = normalizeManifest(value);
@@ -44,7 +46,7 @@ export function createHandoff(dir, sessionId, instanceId) {
       if (name === 'agent_start') commit({ ...data, workEpoch: data.workEpoch + 1 });
       if (name === 'agent_settled') commit({ ...data, settledEpoch: data.workEpoch });
     },
-    report(id, value) {
+    report(id, value, supervisorScopeDigest = null) {
       id = validateId(id);
       const report = normalizeReport(value);
       if (!current()) throw problem('No handoff bound to this instance; prepare or explicitly rebind first', 409);
@@ -61,7 +63,7 @@ export function createHandoff(dir, sessionId, instanceId) {
       const recordedAt = now();
       const receipt = { reportId: id, sessionId, instanceId, manifestRevision: data.manifestRevision,
         workEpoch: data.workEpoch, recordedAt, status: 'recorded', acceptance: 'unverified' };
-      commit({ ...data, latestReport: { ...report, reportId: id, instanceId, workEpoch: data.workEpoch, recordedAt },
+      commit({ ...data, latestReport: { ...report, reportId: id, instanceId, workEpoch: data.workEpoch, recordedAt, supervisorScopeDigest },
         reportIds: { ...data.reportIds, [id]: { fingerprint, receipt } } });
       return receipt;
     },

--- a/integrations/pi/inbox-binding.mjs
+++ b/integrations/pi/inbox-binding.mjs
@@ -4,7 +4,8 @@ export function assertCurrentEvent(event, state, handoff, policy) {
   if (!state.live || state.state !== 'idle' || event.sessionId !== state.sessionId || event.instanceId !== state.instanceId) {
     throw new Error('Inbox response requires the original live idle instance');
   }
-  if (!policy?.enabled || typeof policy.scope !== 'string' || digest(policy.scope) !== event.binding.scopeDigest) {
+  if (policy?.enabled === false || (event.binding.scopeDigest !== null &&
+    (!policy?.enabled || typeof policy.scope !== 'string' || digest(policy.scope) !== event.binding.scopeDigest))) {
     throw new Error('Inbox scope changed or supervision paused');
   }
   if ((handoff.manifestRevision ?? null) !== event.binding.manifestRevision ||
@@ -15,7 +16,7 @@ export function assertCurrentEvent(event, state, handoff, policy) {
   } else if (state.inbox?.localEpoch !== event.localEpoch) throw new Error('Inbox work epoch changed');
 }
 export function authorizationMatches(event, record) {
-  return event.kind === 'decision_request' && event.binding.scopeDigest &&
+  return event.kind === 'decision_request' && event.binding.runId && event.binding.manifestRevision &&
     digest(JSON.stringify(record.binding)) === digest(JSON.stringify(event.binding)) &&
     record.sessionId === event.sessionId && record.requestedAction === event.report.decision.requestedAction &&
     record.resource === event.report.decision.resource;

--- a/integrations/pi/inbox-binding.mjs
+++ b/integrations/pi/inbox-binding.mjs
@@ -1,0 +1,29 @@
+import { digest } from './store.mjs';
+
+export function assertCurrentEvent(event, state, handoff, policy) {
+  if (!state.live || state.state !== 'idle' || event.sessionId !== state.sessionId || event.instanceId !== state.instanceId) {
+    throw new Error('Inbox response requires the original live idle instance');
+  }
+  if (!policy?.enabled || typeof policy.scope !== 'string' || digest(policy.scope) !== event.binding.scopeDigest) {
+    throw new Error('Inbox scope changed or supervision paused');
+  }
+  if ((handoff.manifestRevision ?? null) !== event.binding.manifestRevision ||
+    (handoff.manifest?.runId ?? null) !== event.binding.runId) throw new Error('Inbox manifest binding changed');
+  if (event.report) {
+    if (handoff.status !== 'ready' || handoff.report?.reportId !== event.report.reportId ||
+      handoff.workEpoch !== event.report.workEpoch) throw new Error('Inbox report is no longer current');
+  } else if (state.inbox?.localEpoch !== event.localEpoch) throw new Error('Inbox work epoch changed');
+}
+export function authorizationMatches(event, record) {
+  return event.kind === 'decision_request' && event.binding.scopeDigest &&
+    digest(JSON.stringify(record.binding)) === digest(JSON.stringify(event.binding)) &&
+    record.sessionId === event.sessionId && record.requestedAction === event.report.decision.requestedAction &&
+    record.resource === event.report.decision.resource;
+}
+export function checkAuthorization(store, event, id) {
+  const record = store.read('authorizations', id);
+  if (!record || store.read('revocations', id) || !authorizationMatches(event, record.data)) {
+    throw new Error('Authorization is missing, revoked or does not match this exact request/scope');
+  }
+  return record;
+}

--- a/integrations/pi/inbox-manager.mjs
+++ b/integrations/pi/inbox-manager.mjs
@@ -1,0 +1,114 @@
+import { randomUUID } from 'node:crypto';
+import { digest, validateSession } from './store.mjs';
+import { requestSession, getReceipt } from './client.mjs';
+import { readEnrollment } from './supervision.mjs';
+import { fitContext } from './handoff-schema.mjs';
+import { inboxStore, inboxId, messageId, wakeCapability } from './inbox-store.mjs';
+import { assertCurrentEvent, authorizationMatches, checkAuthorization } from './inbox-binding.mjs';
+
+const consumerId = (value = 'codex') => validateSession(value);
+function requiredEvent(store, id) {
+  const record = store.read('events', inboxId(id));
+  if (!record) throw new Error('Inbox event not found');
+  return record;
+}
+const ackId = (eventId, consumer) => digest(`${consumerId(consumer)}:${eventId}`);
+
+export function listInbox(root, { consumer = 'codex', limit = 20, after } = {}) {
+  consumerId(consumer);
+  limit = Number(limit);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 50) throw new Error('Inbox limit must be 1..50');
+  const store = inboxStore(root);
+  const rows = store.list('events').sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
+  const offset = after ? rows.findIndex((row) => row.id === inboxId(after)) : -1;
+  if (after && offset < 0) throw new Error('Unknown inbox cursor');
+  const selected = rows.slice(offset + 1, offset + 1 + limit);
+  return fitContext({ status: 'inbox', consumer, wake: wakeCapability(), events: selected.map(({ id, createdAt, data }) => ({
+    eventId: id, createdAt, sessionId: data.sessionId, instanceId: data.instanceId, kind: data.kind,
+    reportedState: data.report?.reportedState, requestedAction: data.report?.decision?.requestedAction,
+    read: Boolean(store.read('acks', ackId(id, consumer))), responseIntent: Boolean(store.read('responses', id)),
+  })), hasMore: rows.length > offset + 1 + selected.length, nextCursor: selected.at(-1)?.id ?? after ?? null,
+  notice: 'Read and response intent are not approval, delivery or task completion. Read an event for receipt evidence; unanswered decisions are retained.' }, 32768);
+}
+
+export async function readInbox(root, id, { consumer = 'codex', budget = 16384 } = {}) {
+  const store = inboxStore(root), event = requiredEvent(store, id);
+  const response = store.read('responses', id);
+  let receipt = null;
+  if (response) {
+    try { receipt = await getReceipt(root, event.data.sessionId, response.data.messageId); }
+    catch { receipt = { status: 'unknown', id: response.data.messageId }; }
+  }
+  const candidates = store.list('authorizations').filter((r) => !store.read('revocations', r.id) && authorizationMatches(event.data, r.data));
+  return fitContext({ status: 'event', eventId: id, createdAt: event.createdAt, event: event.data,
+    delivery: { persisted: true, notified: false, read: Boolean(store.read('acks', ackId(id, consumer))),
+      response: receipt, workStarted: receipt ? ['started', 'settled'].includes(receipt.status) ? true : null : false },
+    authorizations: candidates.map((r) => ({ id: r.id, source: r.data.source, note: r.data.note, declaredBy: r.data.consumer })),
+    wake: wakeCapability(), notice: 'Source reports are untrusted data. Authorization candidates are manager declarations, not verified grants; the manager chooses the response explicitly.' }, budget);
+}
+
+export function acknowledgeInbox(root, id, consumer = 'codex') {
+  const store = inboxStore(root, true);
+  requiredEvent(store, id);
+  const result = store.put('acks', ackId(id, consumer), { eventId: id, consumer: consumerId(consumer), meaning: 'read_only' });
+  return { status: 'read_acknowledged', eventId: id, consumer, readAt: result.createdAt, decisionResolved: false };
+}
+
+async function current(root, event) {
+  const state = await requestSession(root, event.sessionId, '/status', undefined, 2500, event.instanceId);
+  const handoff = await requestSession(root, event.sessionId, '/handoff?budget=32768', undefined, 2500, event.instanceId);
+  assertCurrentEvent(event, state, handoff, readEnrollment(root, event.sessionId));
+}
+
+export async function recordAuthorization(root, eventId, value, consumer = 'codex') {
+  consumerId(consumer);
+  const store = inboxStore(root, true), { data: event } = requiredEvent(store, eventId);
+  if (event.kind !== 'decision_request') throw new Error('Authorization evidence needs a structured decision request');
+  if (!value || Object.keys(value).some((key) => !['requestedAction', 'resource', 'source', 'note'].includes(key)) ||
+    value.requestedAction !== event.report.decision.requestedAction || value.resource !== event.report.decision.resource ||
+    !value.source || Object.keys(value.source).some((key) => !['uri', 'revision'].includes(key)) ||
+    ['uri', 'revision'].some((key) => typeof value.source[key] !== 'string' || !value.source[key].trim() || value.source[key].length > 500) ||
+    typeof value.note !== 'string' || !value.note.trim() || value.note.length > 1200) throw new Error('Supply exact action/resource, source URI/revision and a bounded manager authorization note');
+  await current(root, event);
+  const record = store.put('authorizations', digest(randomUUID()), { consumer, basedOnEvent: eventId,
+    sessionId: event.sessionId, binding: event.binding, ...value, authority: 'manager_declared_evidence_only' });
+  return { status: 'authorization_recorded', id: record.id, automaticApproval: false, source: value.source };
+}
+
+export function revokeAuthorization(root, id, consumer = 'codex') {
+  const store = inboxStore(root, true);
+  if (!store.read('authorizations', id)) throw new Error('Authorization record not found');
+  store.put('revocations', id, { consumer: consumerId(consumer), revoked: true });
+  return { status: 'revoked', id };
+}
+
+export async function respondInbox(root, eventId, { message, authorizationId, consumer = 'codex' }) {
+  consumerId(consumer);
+  if (typeof message !== 'string' || !message.trim() || Buffer.byteLength(message) > 12000) throw new Error('Response must contain 1..12000 UTF-8 bytes');
+  const store = inboxStore(root, true), { data: event } = requiredEvent(store, eventId);
+  const intent = { messageId: messageId(eventId), messageHash: digest(message), authorizationId: authorizationId || null, consumer };
+  const previous = store.read('responses', eventId);
+  if (previous) {
+    if (previous.fingerprint !== digest(JSON.stringify(intent))) throw new Error('Event already has a different manager response');
+    try { return await getReceipt(root, event.sessionId, intent.messageId); }
+    catch { return { sessionId: event.sessionId, id: intent.messageId, status: 'unknown', nextAction: 'Prior intent exists; no automatic resend.' }; }
+  }
+  await current(root, event);
+  let authorization = null, authorizationWarning;
+  if (authorizationId) {
+    try { authorization = checkAuthorization(store, event, authorizationId); }
+    catch { authorizationWarning = 'Authorization evidence is unavailable, revoked or mismatched; omitted from the explicit manager response. No new permission gate was added.'; }
+  }
+  const text = `Manager response to inbox event ${eventId}.\n` +
+    (authorization ? `Existing manager-declared authorization evidence (not a new grant): ${JSON.stringify({ id: authorization.id,
+      action: authorization.data.requestedAction, resource: authorization.data.resource, source: authorization.data.source })}\n` : '') + message;
+  store.put('responses', eventId, intent);
+  try {
+    const receipt = await requestSession(root, event.sessionId, '/inbox/respond', { id: intent.messageId, message: text,
+      sender: 'inbox-manager', mode: 'followUp', eventId }, 2500, event.instanceId);
+    return { ...receipt, ...(authorizationWarning ? { authorizationWarning } : {}) };
+  } catch (error) {
+    return { sessionId: event.sessionId, id: intent.messageId, status: 'unknown', error: error.message,
+      nextAction: 'Response intent persisted; inspect its receipt and current event before deciding. No automatic resend.' };
+  }
+}

--- a/integrations/pi/inbox-producer.mjs
+++ b/integrations/pi/inbox-producer.mjs
@@ -1,0 +1,53 @@
+import { digest } from './store.mjs';
+import { inboxStore, wakeCapability } from './inbox-store.mjs';
+
+export function publicExcerpt(text, maxBytes = 2400) {
+  const bytes = Buffer.from(typeof text === 'string' ? text : '');
+  let end = Math.min(bytes.length, maxBytes);
+  while (end > 0 && end < bytes.length && (bytes[end] & 0xc0) === 0x80) end--;
+  return { text: bytes.subarray(0, end).toString('utf8'), truncated: end < bytes.length };
+}
+export function createInboxProducer({ root, sessionId, instanceId, evidence, context, policy }) {
+  const store = inboxStore(root, true);
+  let epoch = 0, excerpt = publicExcerpt(''), error = null, lastEventId = null;
+  const write = (key, data) => {
+    store.recover();
+    const id = digest(key);
+    store.publish(id, { sessionId, recipient: 'local-manager', ...data });
+    lastEventId = id; error = null;
+    return id;
+  };
+  function report() {
+    const value = evidence();
+    if (!value || value.report.reportedState === 'working') return null;
+    return write(`${sessionId}:${value.report.instanceId}:report:${value.report.reportId}`, {
+      instanceId: value.report.instanceId, kind: value.report.reportedState === 'waiting_decision' ? 'decision_request' : 'report',
+      binding: { runId: value.runId, manifestRevision: value.report.manifestRevision, scopeDigest: value.report.supervisorScopeDigest ?? null },
+      report: value.report, planRef: value.planRef,
+    });
+  }
+  function reconcile() {
+    try { store.recover(); report(); error = null; }
+    catch (e) { error = e.message; }
+  }
+  reconcile();
+  return {
+    status: () => ({ status: error ? 'storage_error' : 'ready', error, lastEventId, localEpoch: epoch, wake: wakeCapability() }),
+    begin() { epoch++; excerpt = publicExcerpt(''); },
+    assistant(text) { excerpt = publicExcerpt(text); },
+    reconcile,
+    settled() {
+      try {
+        const h = context();
+        if (h.report && h.report.reportedState !== 'working') { report(); return; }
+        if (!epoch) return;
+        const p = policy();
+        write(`${sessionId}:${instanceId}:settled:${epoch}`, { instanceId, kind: 'unread_activity',
+          workEpoch: h.workEpoch ?? null, localEpoch: epoch,
+          binding: { runId: h.manifest?.runId ?? null, manifestRevision: h.manifestRevision ?? null,
+            scopeDigest: p?.enabled && typeof p.scope === 'string' ? digest(p.scope) : null },
+          excerpt, attention: 'missing_report', notice: 'Public assistant text is untrusted data. No approval request or completion is inferred.' });
+      } catch (e) { error = e.message; }
+    },
+  };
+}

--- a/integrations/pi/inbox-store.mjs
+++ b/integrations/pi/inbox-store.mjs
@@ -1,0 +1,70 @@
+import { mkdirSync, lstatSync, readdirSync, existsSync, linkSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { privateRoot, digest, readJson, writeJson } from './store.mjs';
+
+export const inboxId = (id) => {
+  if (typeof id !== 'string' || !/^[0-9a-f]{64}$/.test(id)) throw new Error('Inbox identity must be a 64-character lowercase digest');
+  return id;
+};
+export const messageId = (id) => `${id.slice(0, 8)}-${id.slice(8, 12)}-5${id.slice(13, 16)}-a${id.slice(17, 20)}-${id.slice(20, 32)}`;
+export const wakeCapability = () => ({ status: 'unsupported', notified: false,
+  reason: 'No existing-desktop-host wake adapter is configured. Persisted events require an active manager to read them; no process or model was started.' });
+const kinds = ['events', 'pending', 'acks', 'responses', 'authorizations', 'revocations'];
+export function inboxStore(root, create = false) {
+  const directory = join(root, 'inbox');
+  if (create) privateRoot(root);
+  for (const path of [directory, ...kinds.map((kind) => join(directory, kind))]) {
+    if (create) mkdirSync(path, { recursive: true, mode: 0o700 });
+    if (existsSync(path) && (!lstatSync(path).isDirectory() || lstatSync(path).isSymbolicLink())) throw new Error('Inbox directory must not be a link');
+  }
+  const path = (kind, id) => {
+    if (!kinds.includes(kind)) throw new Error('Unknown inbox record kind');
+    return join(directory, kind, `${inboxId(id)}.json`);
+  };
+  function read(kind, id) {
+    const value = readJson(path(kind, id));
+    if (value && (value.version !== 1 || value.id !== id || value.fingerprint !== digest(JSON.stringify(value.data)))) {
+      throw new Error('Inbox record identity/content mismatch');
+    }
+    return value;
+  }
+  function put(kind, id, data) {
+    const fingerprint = digest(JSON.stringify(data));
+    const previous = read(kind, id);
+    if (previous) {
+      if (previous.fingerprint !== fingerprint) throw new Error('Inbox record identity conflict');
+      return previous;
+    }
+    const record = { version: 1, id, fingerprint, createdAt: new Date().toISOString(), data };
+    if (Buffer.byteLength(JSON.stringify(record)) > 32768) throw new Error('Inbox record exceeds 32 KiB');
+    const target = path(kind, id), temp = `${target}.${randomUUID()}.tmp`;
+    try {
+      writeJson(temp, record, true);
+      try { linkSync(temp, target); }
+      catch (error) {
+        if (error.code !== 'EEXIST') throw error;
+        if (read(kind, id).fingerprint !== fingerprint) throw new Error('Concurrent inbox record conflict');
+      }
+      return read(kind, id);
+    } finally { if (existsSync(temp)) unlinkSync(temp); }
+  }
+  const list = (kind) => existsSync(join(directory, kind)) ? readdirSync(join(directory, kind))
+    .filter((name) => /^[0-9a-f]{64}\.json$/.test(name)).map((name) => read(kind, name.slice(0, -5))) : [];
+  return { read, put, list,
+    publish(id, data) {
+      const previous = read('events', id);
+      if (previous) return put('events', id, data);
+      put('pending', id, data);
+      const result = put('events', id, data);
+      unlinkSync(path('pending', id));
+      return result;
+    },
+    recover() {
+      for (const pending of list('pending')) {
+        put('events', pending.id, pending.data);
+        unlinkSync(path('pending', pending.id));
+      }
+    },
+  };
+}

--- a/integrations/pi/inbox.test.mjs
+++ b/integrations/pi/inbox.test.mjs
@@ -149,3 +149,17 @@ test('pending publication recovers and malformed inbox setup does not block orig
     channel.settled();
   } finally { await channel.close(); }
 });
+
+test('reportless session can receive an explicit inbox response without enrollment or a manifest', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'edda-inbox-unmanaged-'));
+  const messages = [];
+  const channel = await startChannel({ root, sessionId: randomUUID(), cwd: root, deliver: (text) => messages.push(text) });
+  t.after(async () => { await channel.close(); await rm(root, { recursive: true, force: true }); });
+  channel.event('agent_start');
+  channel.event('assistant_end', { stopReason: 'stop', text: 'Waiting for a concrete instruction' });
+  channel.settled();
+  const id = listInbox(root).events[0].eventId;
+  assert.equal((await respondInbox(root, id, { message: 'Continue the already-authorized task.' })).status, 'unconfirmed');
+  assert.equal(messages.length, 1);
+  assert.equal(channel.handoffContext().status, 'not_prepared');
+});

--- a/integrations/pi/inbox.test.mjs
+++ b/integrations/pi/inbox.test.mjs
@@ -1,0 +1,151 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { startChannel } from './channel.mjs';
+import { prepareHandoff, requestSession } from './client.mjs';
+import { enroll } from './supervision.mjs';
+import { digest } from './store.mjs';
+import { inboxStore, wakeCapability } from './inbox-store.mjs';
+import { publicExcerpt } from './inbox-producer.mjs';
+import { listInbox, readInbox, acknowledgeInbox, recordAuthorization, revokeAuthorization, respondInbox } from './inbox-manager.mjs';
+
+const manifest = { version: 1, runId: 'fixture-run', role: 'controller', goal: 'Offline fixture',
+  planRef: { uri: 'fixture://plan', revision: 'v1' }, doneWhen: ['Synthetic check'],
+  scope: { allowed: ['Synthetic task'], excluded: ['Real work'], reserved: ['Spending'],
+    authorityRefs: [{ uri: 'fixture://operator', revision: 'v1' }] } };
+async function fixture(t, delivery) {
+  const root = await mkdtemp(join(tmpdir(), 'edda-inbox-test-'));
+  let channel;
+  const messages = [];
+  const deliver = delivery || ((text) => {
+    messages.push(text); channel.event('agent_start'); channel.messageStarted(text);
+    channel.event('assistant_end', { stopReason: 'stop', text: 'Synthetic response completed' }); channel.settled();
+  });
+  channel = await startChannel({ root, sessionId: randomUUID(), cwd: root, deliver });
+  await enroll(root, channel.sessionId, 'Synthetic fixture; no new spend.');
+  await prepareHandoff(root, channel.sessionId, manifest);
+  t.after(async () => { await channel.close(); await rm(root, { recursive: true, force: true }); });
+  const report = () => {
+    channel.event('agent_start');
+    const id = randomUUID();
+    const value = { manifestRevision: channel.handoffContext().manifestRevision, reportedState: 'waiting_decision',
+      stage: 'fixture', summary: 'Need fixture continuation', nextStep: 'Read existing operator reference', evidence: [], dependencies: [],
+      decision: { question: 'May fixture continue?', requestedAction: 'fixture_continue', resource: 'offline-only', recommendation: 'Use existing authorization' } };
+    channel.reportHandoff(id, value); channel.settled();
+    return listInbox(root, { limit: 50 }).events.filter((e) => e.kind === 'decision_request').at(-1).eventId;
+  };
+  const authorization = { requestedAction: 'fixture_continue', resource: 'offline-only',
+    source: { uri: 'fixture://operator-approved', revision: 'v1' }, note: 'Operator already authorized this synthetic operation.' };
+  return { root, channel, messages, report, authorization };
+}
+
+test('decision events are durable/deduplicated; read acknowledgement never clears unanswered decisions', async (t) => {
+  const f = await fixture(t), id = f.report();
+  f.channel.settled();
+  assert.equal(listInbox(f.root).events.length, 1);
+  acknowledgeInbox(f.root, id, 'manager-one');
+  assert.equal(listInbox(f.root, { consumer: 'manager-one' }).events[0].read, true);
+  assert.equal(listInbox(f.root, { consumer: 'manager-two' }).events[0].read, false);
+  const detail = await readInbox(f.root, id);
+  assert.equal(detail.event.kind, 'decision_request');
+  assert.equal(detail.delivery.notified, false);
+  assert.equal(detail.delivery.response, null);
+  assert.equal(wakeCapability().status, 'unsupported');
+});
+
+test('same scoped authorization is a reuse candidate; explicit response executes once', async (t) => {
+  const f = await fixture(t), first = f.report();
+  const grant = await recordAuthorization(f.root, first, f.authorization);
+  const response = await respondInbox(f.root, first, { message: 'Continue the synthetic operation.', authorizationId: grant.id });
+  assert.equal(response.status, 'settled');
+  assert.equal((await respondInbox(f.root, first, { message: 'Continue the synthetic operation.', authorizationId: grant.id })).status, 'settled');
+  assert.equal(f.messages.length, 1);
+  const second = f.report();
+  assert.deepEqual((await readInbox(f.root, second)).authorizations.map((r) => r.id), [grant.id]);
+  assert.equal(f.messages.length, 1, 'candidate matching never auto-sends');
+  await assert.rejects(respondInbox(f.root, first, { message: 'Different instruction' }), /different manager response/);
+});
+
+test('authorization records are optional; revoked or mismatched evidence warns but does not block explicit response', async (t) => {
+  const f = await fixture(t), first = f.report();
+  const grant = await recordAuthorization(f.root, first, f.authorization);
+  revokeAuthorization(f.root, grant.id);
+  assert.equal((await readInbox(f.root, first)).authorizations.length, 0);
+  const result = await respondInbox(f.root, first, { message: 'Proceed within the existing fixture scope.', authorizationId: grant.id });
+  assert.equal(result.status, 'settled');
+  assert.ok(result.authorizationWarning);
+  assert.ok(!f.messages[0].includes('Existing manager-declared'));
+});
+
+test('new work, scope change and receiver replacement reject stale automatic replies', async (t) => {
+  const f = await fixture(t), first = f.report();
+  f.channel.event('agent_start'); f.channel.settled();
+  await assert.rejects(respondInbox(f.root, first, { message: 'Stale' }), /no longer current/);
+  const second = f.report();
+  await enroll(f.root, f.channel.sessionId, 'Changed scope');
+  await assert.rejects(respondInbox(f.root, second, { message: 'Stale scope' }), /scope changed/);
+  await f.channel.close();
+  const replacement = await startChannel({ root: f.root, sessionId: f.channel.sessionId, cwd: f.root, deliver() {} });
+  try {
+    assert.ok(listInbox(f.root, { limit: 50 }).events.some((r) => r.eventId === second));
+    await assert.rejects(respondInbox(f.root, second, { message: 'Wrong instance' }), /instance changed/);
+  } finally { await replacement.close(); }
+});
+
+test('unknown response is not retried and remains inspectable after read acknowledgement', async (t) => {
+  let calls = 0;
+  const f = await fixture(t, () => { calls++; throw new Error('uncertain runtime acceptance'); });
+  const id = f.report();
+  assert.equal((await respondInbox(f.root, id, { message: 'Fixture' })).status, 'unknown');
+  acknowledgeInbox(f.root, id);
+  assert.equal((await respondInbox(f.root, id, { message: 'Fixture' })).status, 'unknown');
+  assert.equal(calls, 1);
+  assert.equal((await readInbox(f.root, id)).delivery.response.status, 'unknown');
+  assert.equal(listInbox(f.root).events.length, 1);
+});
+
+test('reportless settlement produces bounded public activity without inferring approval', async (t) => {
+  const f = await fixture(t);
+  f.channel.event('agent_start');
+  f.channel.event('assistant_end', { stopReason: 'stop', text: '請批准'.repeat(1000) });
+  f.channel.settled();
+  const id = listInbox(f.root).events[0].eventId;
+  const event = (await readInbox(f.root, id)).event;
+  assert.equal(event.kind, 'unread_activity');
+  assert.equal(event.report, undefined);
+  assert.ok(event.excerpt.truncated);
+  assert.ok(Buffer.byteLength(event.excerpt.text) <= 2400);
+  assert.ok(!publicExcerpt('你', 2).text.includes('\uFFFD'));
+  assert.equal((await respondInbox(f.root, id, { message: 'Already authorized; continue.' })).status, 'settled');
+});
+
+test('pending publication recovers and malformed inbox setup does not block original channel', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'edda-inbox-error-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const store = inboxStore(root, true), id = digest('pending-fixture');
+  store.put('pending', id, { sessionId: 'fixture', recipient: 'local-manager', kind: 'unread_activity' });
+  store.recover();
+  assert.ok(store.read('events', id));
+  assert.equal(store.list('pending').length, 0);
+  const badRoot = join(root, 'bad');
+  await mkdir(join(badRoot, 'inbox'), { recursive: true });
+  await writeFile(join(badRoot, 'inbox', 'events'), 'cannot create event directory');
+  let calls = 0;
+  const channel = await startChannel({ root: badRoot, sessionId: randomUUID(), cwd: root, deliver: () => { calls++; } });
+  try {
+    assert.equal(channel.snapshot().inbox.status, 'storage_error');
+    const result = await requestSession(badRoot, channel.sessionId, '/messages', { id: randomUUID(), message: 'Continue', sender: 'manager', mode: 'followUp' });
+    assert.equal(result.status, 'unconfirmed');
+    assert.equal(calls, 1);
+    await prepareHandoff(badRoot, channel.sessionId, manifest);
+    assert.equal(channel.handoffContext().status, 'ready');
+    channel.event('agent_start');
+    assert.equal(channel.reportHandoff(randomUUID(), { manifestRevision: channel.handoffContext().manifestRevision,
+      reportedState: 'paused', stage: 'fixture', summary: 'Valid report despite broken telemetry', nextStep: 'Original work can continue',
+      evidence: [], dependencies: [] }).status, 'recorded');
+    channel.settled();
+  } finally { await channel.close(); }
+});

--- a/integrations/pi/package.json
+++ b/integrations/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edda/pi-session-channel",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "engines": { "node": ">=24" },

--- a/integrations/pi/pi-smoke.mjs
+++ b/integrations/pi/pi-smoke.mjs
@@ -11,12 +11,14 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { listSessions, requestSession, getReceipt, prepareHandoff, managementContext } from './client.mjs';
 import { enroll, watch, reply } from './supervision.mjs';
 import { largeManifest } from './fixtures/large-handoff.mjs';
+import { listInbox, readInbox, acknowledgeInbox, recordAuthorization, respondInbox } from './inbox-manager.mjs';
 
 const entry = process.argv[2];
 const reject = process.argv.includes('--reject');
 const supervise = process.argv.includes('--supervise');
 const large = process.argv.includes('--handoff-budget');
-const handoff = process.argv.includes('--handoff') || large;
+const inboxMode = process.argv.includes('--inbox');
+const handoff = process.argv.includes('--handoff') || large || inboxMode;
 if (handoff && (supervise || reject)) throw new Error('Run --handoff separately from the other smoke modes');
 if (!entry) throw new Error('Supply the installed Pi JavaScript CLI entry path');
 const root = await mkdtemp(join(tmpdir(), 'edda-pi-smoke-'));
@@ -64,6 +66,7 @@ try {
   child.stdin.write(JSON.stringify({ id: 'initial', type: 'get_state' }) + '\n');
   const session = await until(async () => (await listSessions(registry)).find((row) => row.live), 'registration');
   if (handoff) {
+    if (inboxMode) await enroll(registry, session.sessionId, 'The synthetic offline operation is already authorized. No real work or paid calls.');
     const manifest = large ? largeManifest() : JSON.parse(await readFile(new URL('./fixtures/management-manifest.json', import.meta.url), 'utf8'));
     await prepareHandoff(registry, session.sessionId, manifest);
   }
@@ -91,7 +94,20 @@ try {
     assert.equal(view.handoff.report.decision.question, large ? 'q'.repeat(1000) : 'May the synthetic fixture continue?');
   }
   let secondId = randomUUID();
-  if (supervise) {
+  let authorization;
+  if (inboxMode) {
+    const eventId = listInbox(registry).events.find((event) => event.kind === 'decision_request').eventId;
+    const request = await readInbox(registry, eventId);
+    assert.equal(request.event.report.decision.requestedAction, 'fixture_continue');
+    assert.equal(request.delivery.notified, false);
+    assert.equal(request.wake.status, 'unsupported');
+    acknowledgeInbox(registry, eventId);
+    assert.ok(listInbox(registry).events.some((event) => event.eventId === eventId));
+    authorization = await recordAuthorization(registry, eventId, { requestedAction: 'fixture_continue', resource: 'offline-only',
+      source: { uri: 'fixture://operator', revision: 'already-approved-v1' }, note: 'Reuse the fixture operator authorization; no new scope.' });
+    const response = await respondInbox(registry, eventId, { message: 'CHANNEL_SMOKE_TWO', authorizationId: authorization.id });
+    secondId = response.id;
+  } else if (supervise) {
     await enroll(registry, session.sessionId, 'Approve only the synthetic offline fixture operation; no external side effects.');
     const [view] = await watch(registry, { withConversation: true });
     assert.ok(view.conversation.entries.some((e) => e.text === 'Please explicitly reply APPROVE_OFFLINE_TASK.'));
@@ -124,10 +140,23 @@ try {
       assert.ok(view.handoff.serializedBytes > 16384 && view.handoff.serializedBytes <= 32768);
     }
   }
+  if (inboxMode) {
+    const thirdId = randomUUID();
+    await requestSession(registry, session.sessionId, '/messages', { id: thirdId, message: 'CHANNEL_SMOKE_ONE', sender: 'codex-smoke', mode: 'followUp' });
+    await until(async () => (await getReceipt(registry, session.sessionId, thirdId)).status === 'settled', 'repeated question');
+    const question = listInbox(registry).events.filter((event) => event.kind === 'decision_request').at(-1);
+    const detail = await readInbox(registry, question.eventId);
+    assert.ok(detail.authorizations.some((record) => record.id === authorization.id));
+    const response = await respondInbox(registry, question.eventId, { message: 'CHANNEL_SMOKE_TWO', authorizationId: authorization.id });
+    await until(async () => (await getReceipt(registry, session.sessionId, response.id)).status === 'settled', 'reused authorization response');
+    assert.equal((await readInbox(registry, question.eventId)).delivery.workStarted, true);
+    assert.equal((await respondInbox(registry, question.eventId, { message: 'CHANNEL_SMOKE_TWO', authorizationId: authorization.id })).id, response.id);
+  }
   const conversation = await requestSession(registry, session.sessionId, '/conversation?limit=20');
   assert.ok(conversation.entries.some((e) => e.role === 'assistant' && e.text.includes(supervise ? 'OFFLINE_TASK_STARTED' : 'CHANNEL_SMOKE_TWO')));
   console.log(JSON.stringify({ passed: true, actualPi: true, sessionId: session.sessionId,
-    messagesSettled: 2, sameSession: true, bidirectional: true, supervisedQuestionAnswer: supervise,
+    messagesSettled: inboxMode ? 4 : 2, sameSession: true, bidirectional: true, supervisedQuestionAnswer: supervise,
+    durableInbox: inboxMode, authorizationReused: inboxMode, hostWake: 'not_configured',
     structuredHandoff: handoff, explicitBudgetRecovery: large, provider: 'offline fixture', paidCalls: 0 }, null, 2));
   }
 } finally {


### PR DESCRIPTION
Issue: #1154
Closes #1154
Decision: session.inbox, session.inbox-gating

Pi stopping or decision reports previously remained invisible until a manager replayed conversation. The extension now publishes bounded durable inbox events; reportless settlement captures only the final public assistant excerpt. Managers can inspect/read-ack/respond and cite an existing scoped authorization declaration, with one message identity and observable receipt per event.

This is an advisory side channel, not a new execution gate. Broken inbox storage does not block original messages, valid reports or handoff updates. Structured metadata, enrollment and a prepared manifest are not prerequisites for responding to reportless events. A revoked/mismatched optional authorization warns and is omitted, while the explicit manager response remains available. Only stale destination/work/scope, explicit pause and duplicate delivery protection constrain the managed response.

The host wake capability is explicitly unsupported/not configured: persisted events do not claim an idle Codex was notified. No new runtime, schedule or paid model is started. This satisfies the issue's explicit unsupported-capability route; a desktop wake adapter remains separate work.

Validation at final head 3a5a8cabdf5f6f28a837daa7f2c9dded8e915037:

- Exact-head Node CI34687017478 green on Windows/Linux/macOS; main CI34687017474 Format/CI Gate green, Cargo jobs path-filter skipped.
- RAN Windows Node24.14 inbox8/8 for the final optional-enrollment correction. READ previous full56/56 (~99s) and focused extension/inbox8/8 for unchanged behavior, including private-reasoning exclusion.
- Actual Pi0.85.1 offline-provider `--inbox` smoke: four settled messages in one session; decision persisted/read/acknowledged, referenced manager authorization reused on a repeated request, exact response returned and execution observed; paidCalls=0, hostWake=not_configured.
- Focused report/extension/inbox suite 16/16; pending-publication recovery, malformed telemetry setup without message/handoff/report blockage, stale epoch/instance/scope, optional revoked evidence warning and unknown receipt dedupe.
- Diff check and commit hooks; clean frozen worktree. No Rust/Cargo/toolchain changes or local Cargo build.

Scope: integrations/pi and the stage plan. Events/acks/response intents/declarations remain private and retained; consumers are labels within the same-user trust boundary. Storage failure before persistence can lose an unpersisted observation on crash; durable pending publication and published events recover without blind resend. Preserve the installed local package source worktree.
