### PR TITLE
feat(integrations): launch and recover owned Pi sessions

### DIFF
--- a/docs/superpowers/plans/2026-09-12-pi-managed-launch.md
+++ b/docs/superpowers/plans/2026-09-12-pi-managed-launch.md
@@ -1,0 +1,50 @@
+# Managed Pi launch and recovery
+
+**Goal:** Create a usable managed Pi from one command, own its lifecycle, and keep
+session/event evidence available when the calling client exits or reconnects.
+
+**Architecture:** Snapshot flat integration runtime modules, package metadata and
+the Windows ACL helper to a digest-addressed private release. A hidden detached
+Node runner launches one Pi RPC child with `--no-extensions` plus the pinned Edda
+extension. It owns stdin/stdout and an authenticated loopback status/idle-stop
+endpoint. The existing Pi channel owns work messages and inbox publication.
+
+## Interfaces and boundaries
+
+- `runtime-install`: canonical release path, version and file digest manifest.
+- `launch --project PATH [--pi-entry FILE] [--provider NAME --model NAME]
+  [--prompt-file FILE] [--run-id UUID]`: create-only run configuration and printed
+  run ID before start; launch existing matching ID returns existing evidence.
+- `run-status RUN_ID`: challenge runner instance; show Pi/session/version, current
+  channel state, initial receipt and inbox event pointer. Never equate PID existence
+  with authenticated ownership. No transcript/tool-argument dump.
+- `run-stop RUN_ID [--abort]`: verify runner token/instance and live idle Pi, then end only its
+  owned child (bounded stdin close with owned-child termination fallback). Preserve
+  session files and inbox. Busy work requires explicit --abort and is reported as
+  interrupted, never completed. No arbitrary saved-PID kill.
+- `run-resume RUN_ID`: explicit recovery only after both runner and Pi owners are
+  absent/dead; conservative refusal on ambiguous liveness. Reuse the exact checked
+  session file and identity. No original-prompt replay and no automatic task resume.
+- LF-only JSONL parser with bounded frames; tolerate Pi diagnostics separately and
+  consume get_state responses for session identity/file. Do not retain reasoning,
+  tool arguments or raw stdout; existing extension publishes bounded public inbox.
+- Durable startup/initial-message intent handles duplicate invocation and uncertain
+  delivery. Crashed launch locks are visible and never blindly stolen.
+- Ordinary user credentials/settings remain usable, while extension selection is
+  explicit for this new process. Additional trusted extensions may be passed for
+  fixtures/custom providers. No mutation of already-running user sessions/settings.
+- This runner is the lifecycle/event entry point, not an autonomous decision maker
+  or a Codex desktop wake adapter. No model polling or new reporting prerequisites.
+
+## Work and validation
+
+- Implement release snapshot/config/record helpers and bounded LF RPC parser.
+- Implement owned background runner, authenticated status/stop and launch/resume CLI.
+- Test immutable-release verification, framing, duplicate identity, wrong endpoint
+  identity and failure outcomes with temporary process-boundary fixtures.
+- Actual Pi offline provider: client disconnect/reconnect, question/response, idle
+  stop/resume same session, retained inbox, no duplicate initial message.
+- Bounded configured-model dogfood writes only an explicitly assigned temporary
+  fixture and stops. Report tool/model/token evidence separately; no trial retries.
+- Focused Node tests then full suite once; frozen independent PR review, exact-head
+  CI and R6 merge under existing operator authorization. No local Cargo build.

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -31,6 +31,64 @@ idle point. Loading the extension does not resume work. It cannot silently attac
 to arbitrary existing terminals. New sessions load installed packages normally.
 Use `/edda-session` inside Pi to see its exact identity and status.
 
+## Start a managed Pi
+
+For new sessions, managed launch owns the process and fixes the integration version
+from the beginning. It automatically snapshots the runtime outside the checkout:
+
+```powershell
+node integrations/pi/cli.mjs launch --project C:/my-project --provider openrouter --model deepseek/deepseek-v4.1-flash --thinking low --prompt-file task.txt
+node integrations/pi/cli.mjs run-status RUN_ID
+node integrations/pi/cli.mjs run-stop RUN_ID
+node integrations/pi/cli.mjs run-resume RUN_ID
+```
+
+The run ID is printed before launch. The result contains a separate Pi session ID,
+runner instance, loaded integration version/release/module path, selected model,
+session file and initial-message receipt. Use the Pi session ID with `send`,
+`conversation`, `adopt` and other session commands. Use the run ID for lifecycle
+commands. The calling CLI may exit; the hidden runner and its owned Pi remain alive.
+
+`--provider`, `--model`, `--thinking` and the initial prompt are optional; normal Pi
+model configuration applies when omitted. Pi is discovered in a local/global Node
+installation, or supply `--pi-entry /path/to/pi/dist/bundle/cli.js` (also configurable
+through `EDDA_PI_ENTRY`). A missing installation gives an explicit setup error.
+`--agent-dir` can select an existing isolated Pi configuration directory. Extra
+trusted extensions can be loaded with `--extension FILE`; `--no-tools` is useful
+for isolated protocol tests. This process uses `--no-extensions` plus the fixed
+Edda integration and explicitly requested extensions, avoiding duplicate legacy
+channels. Other Pi configuration and standard resource discovery still apply.
+
+Runtime files live under the private registry's `releases/<digest>/`. A release
+manifest verifies their bytes before launch and recovery. Source edits cannot change
+an already-installed release. `runtime-install` creates/verifies a release without
+starting Pi or changing global settings; `<release.path>/cli.mjs` is a stable CLI
+entry independent of this development worktree. Pi itself remains an installed
+dependency: its version is reported, while the integration is digest-pinned.
+
+`run-status` authenticates the actual runner and queries its Pi channel. Readiness
+is not proof of work starting: inspect `initialReceipt` and current Pi state. Progress
+and provider-reported token/cost totals are bounded metadata, not raw RPC logs.
+Model errors expose a category/status code without credential or response-body dumps.
+
+Idle stop closes only the runner's owned Pi child. `run-stop RUN_ID --abort` explicitly
+interrupts busy owned work; ordinary stop refuses to interrupt it. Neither command
+kills arbitrary saved PIDs. Stop retains session history, inbox and receipts.
+`run-resume` restores the same validated session file and observed model/thinking
+settings; it does not resend the original task. Send a fresh explicit instruction
+when you want work to continue. Retrying `launch` with the same run ID and identical
+inputs reconnects instead of starting a duplicate; different inputs conflict.
+
+If the runner crashes, status reports unavailable rather than inferring ownership
+from a PID. Recovery refuses when a previous runner/Pi may still be alive, the
+session file is missing/mismatched, or a launch/resume lock is ambiguous. Inspect
+that evidence rather than creating another run ID on a timeout. A crash before
+the initial prompt is sent can leave an unknown initial intent; recovery never
+blindly replays it. Newly created empty sessions may not yet have a persisted file.
+
+This is the process/event entry point for management. It does not autonomously
+approve work, poll a manager model, or wake the Codex desktop conversation.
+
 ## Start here: adopt an existing session
 
 When the task has a structured management brief, one command prepares its context,
@@ -514,6 +572,7 @@ node integrations/pi/pi-smoke.mjs C:/nvm4w/nodejs/node_modules/@earendil-works/p
 node integrations/pi/pi-smoke.mjs C:/nvm4w/nodejs/node_modules/@earendil-works/pi-coding-agent/dist/bundle/cli.js --handoff
 node integrations/pi/pi-smoke.mjs C:/nvm4w/nodejs/node_modules/@earendil-works/pi-coding-agent/dist/bundle/cli.js --handoff-budget
 node integrations/pi/pi-smoke.mjs C:/nvm4w/nodejs/node_modules/@earendil-works/pi-coding-agent/dist/bundle/cli.js --inbox
+node integrations/pi/managed-smoke.mjs C:/nvm4w/nodejs/node_modules/@earendil-works/pi-coding-agent/dist/bundle/cli.js
 node integrations/pi/dependency-smoke.mjs C:/nvm4w/nodejs/node_modules/@earendil-works/pi-coding-agent/dist/bundle/cli.js C:/Users/fagem/.cargo/bin/edda.exe
 ```
 
@@ -527,6 +586,14 @@ using the offline provider, changes only its synthetic task, waits for the actua
 60-second timer to notify, verifies the same-session reply, then pauses and cleans
 only that test's processes/directories.
 
+The managed smoke checks client reconnection, same-session stop/resume, inbox
+retention and no initial-prompt replay. Its default provider is offline. An explicitly
+authorized real-model fixture can run with `--live PROVIDER MODEL`; it writes and
+verifies one file only in its temporary project, records observed usage, and cleans
+up owned processes. Failed smoke evidence is preserved in its printed temporary
+directory. The real model test is separate from deterministic CI and is not a model
+quality benchmark.
+
 ## Remaining usability/product work
 
 - Automatic selection of newly created review/fix tasks and structured acceptance joins.
@@ -535,7 +602,8 @@ only that test's processes/directories.
 - Full authority resolution and manager/strong-model escalation policy; no natural
   language permission guessing is implemented.
 - Proactive Pi-to-Codex wake routing, Claude/Hermes recipient adapters and remote hosts.
-- Packaged distribution and a stable installer path independent of a development worktree.
+- Published package distribution and upgrade management for the Pi dependency itself;
+  managed integration releases already have a stable path outside the worktree.
 
 These are separate stages. Current dependency alerts are usable with explicit
 selected tasks and limits; they do not claim those broader capabilities.

--- a/integrations/pi/channel.mjs
+++ b/integrations/pi/channel.mjs
@@ -7,6 +7,10 @@ import { readEnrollment } from './supervision.mjs';
 import { createInboxProducer } from './inbox-producer.mjs';
 import { inboxStore, inboxId, messageId } from './inbox-store.mjs';
 import { assertCurrentEvent } from './inbox-binding.mjs';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const integrationVersion = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')).version;
 
 const terminal = new Set(['settled', 'failed', 'unknown']);
 const now = () => new Date().toISOString();
@@ -86,6 +90,7 @@ export async function startChannel({ root, sessionId, cwd, label = '', deliver, 
   const channel = {
     sessionId, instanceId,
     snapshot: () => ({ ...state, toolNames: [...state.toolNames], live: !closed,
+      integration: { version: integrationVersion, modulePath: fileURLToPath(import.meta.url), releaseId: process.env.EDDA_PI_RELEASE_ID || null },
       capabilities: ['send', 'receipts', 'handoff', 'dependencies', 'inbox', ...(getConversation ? ['conversation'] : [])],
       inbox: inbox?.status() }),
     get dependencies() { return dependencies; },

--- a/integrations/pi/cli.mjs
+++ b/integrations/pi/cli.mjs
@@ -10,6 +10,8 @@ import { adoptSession } from './adoption.mjs';
 import { listInbox, readInbox, acknowledgeInbox, recordAuthorization, revokeAuthorization, respondInbox } from './inbox-manager.mjs';
 import { wakeCapability } from './inbox-store.mjs';
 import { readBoundedFile } from './compose-sources.mjs';
+import { installRuntime } from './managed-store.mjs';
+import { launchManaged, managedStatus, stopManaged, resumeManaged } from './managed-client.mjs';
 
 const help = `Edda Pi session channel (same-user, same-machine)
   node integrations/pi/cli.mjs list
@@ -42,6 +44,11 @@ const help = `Edda Pi session channel (same-user, same-machine)
   node integrations/pi/cli.mjs inbox-respond EVENT_ID --message TEXT [--authorization RECORD_ID] [--consumer codex]
   node integrations/pi/cli.mjs inbox-respond EVENT_ID --message-file PATH [--authorization RECORD_ID]
   node integrations/pi/cli.mjs inbox-wake
+  node integrations/pi/cli.mjs runtime-install
+  node integrations/pi/cli.mjs launch --project PATH [--pi-entry FILE] [--provider NAME] [--model NAME] [--thinking LEVEL] [--prompt-file FILE] [--run-id UUID] [--extension FILE] [--agent-dir PATH] [--no-tools]
+  node integrations/pi/cli.mjs run-status RUN_ID
+  node integrations/pi/cli.mjs run-stop RUN_ID [--abort]
+  node integrations/pi/cli.mjs run-resume RUN_ID
 
 JSON stdout; diagnostics stderr. EDDA_PI_CHANNEL_DIR overrides the private root.
 Supervision commands are tools for an authorized controller, not a decision engine.
@@ -57,7 +64,7 @@ async function main(args) {
   const options = {};
   for (let i = 0; i < rest.length; i++) {
     const arg = rest[i];
-    if (['--conversation', '--notify', '--preview'].includes(arg) && options[arg] === undefined) { options[arg] = true; continue; }
+    if (['--conversation', '--notify', '--preview', '--no-tools', '--abort'].includes(arg) && options[arg] === undefined) { options[arg] = true; continue; }
     if (!arg.startsWith('--')) { positional.push(arg); continue; }
     if (options[arg] !== undefined || rest[i + 1] === undefined || rest[i + 1].startsWith('--')) throw new Error(`Missing or duplicate option ${arg}`);
     options[arg] = rest[++i];
@@ -74,13 +81,26 @@ async function main(args) {
     inbox: ['--consumer', '--limit', '--after'], 'inbox-read': ['--consumer', '--budget-bytes'], 'inbox-ack': ['--consumer'],
     'authorization-record': ['--record', '--consumer'], 'authorization-revoke': ['--consumer'],
     'inbox-respond': ['--message', '--message-file', '--authorization', '--consumer'], 'inbox-wake': [],
+    'runtime-install': [], launch: ['--project', '--pi-entry', '--provider', '--model', '--thinking', '--prompt-file', '--run-id', '--extension', '--agent-dir', '--no-tools'],
+    'run-status': [], 'run-stop': ['--abort'], 'run-resume': [],
     reply: ['--to', '--message', '--message-file'], checkpoint: ['--cursor', '--action', '--note'],
   }[command];
   if (!allowed || Object.keys(options).some((key) => !allowed.includes(key))) throw new Error('Unknown command or option; use --help');
-  const counts = command === 'doctor' ? [0, 1] : [['list', 'watch', 'compose', 'inbox', 'inbox-wake'].includes(command) ? 0 : 1];
+  const counts = command === 'doctor' ? [0, 1] : [['list', 'watch', 'compose', 'inbox', 'inbox-wake', 'runtime-install', 'launch'].includes(command) ? 0 : 1];
   if (!counts.includes(positional.length)) throw new Error('Use the exact session ID; see --help');
   const sessionId = positional[0];
   let result;
+  if (command === 'runtime-install') result = { status: 'installed', release: installRuntime(root), settingsChanged: false };
+  if (command === 'launch') {
+    const runId = validateId(options['--run-id'] || randomUUID());
+    process.stderr.write(`Run ID: ${runId}\n`);
+    result = await launchManaged(root, { runId, project: options['--project'], piEntry: options['--pi-entry'],
+      provider: options['--provider'], model: options['--model'], prompt: options['--prompt-file'] ? (await readBoundedFile(options['--prompt-file'])).text : undefined,
+      extensions: options['--extension'] ? [options['--extension']] : [], agentDir: options['--agent-dir'], noTools: options['--no-tools'] === true, thinking: options['--thinking'] });
+  }
+  if (command === 'run-status') result = await managedStatus(root, sessionId);
+  if (command === 'run-stop') result = await stopManaged(root, sessionId, { abort: options['--abort'] === true });
+  if (command === 'run-resume') result = await resumeManaged(root, sessionId);
   if (command === 'inbox') result = listInbox(root, { consumer: options['--consumer'], limit: options['--limit'], after: options['--after'] });
   if (command === 'inbox-read') result = await readInbox(root, sessionId, { consumer: options['--consumer'], budget: options['--budget-bytes'] });
   if (command === 'inbox-ack') result = acknowledgeInbox(root, sessionId, options['--consumer']);
@@ -134,7 +154,8 @@ async function main(args) {
   }
   process.stdout.write(JSON.stringify(result, null, 2) + '\n');
   if (['unknown', 'failed', 'needs_context', 'not_prepared', 'stale_binding', 'unavailable', 'needs_reload', 'needs_enrollment', 'not_registered',
-    'ambiguous_session', 'invalid_selector', 'offline', 'busy', 'source_changed', 'needs_expected_revision', 'adoption_incomplete', 'unsupported'].includes(result?.status)) process.exitCode = 2;
+    'ambiguous_session', 'invalid_selector', 'offline', 'busy', 'source_changed', 'needs_expected_revision', 'adoption_incomplete', 'unsupported',
+    'runner_unreachable', 'launch_pending', 'stop_pending', 'exited'].includes(result?.status)) process.exitCode = 2;
 }
 
 main(process.argv.slice(2)).catch((error) => {

--- a/integrations/pi/fixtures/managed-pi.mjs
+++ b/integrations/pi/fixtures/managed-pi.mjs
@@ -1,0 +1,44 @@
+// Synthetic RPC subprocess for lifecycle boundary tests; actual-Pi smoke is separate.
+import { appendFileSync, readFileSync, existsSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { randomUUID } from 'node:crypto';
+const args = process.argv.slice(2), option = (key) => args[args.indexOf(key) + 1];
+const root = process.env.EDDA_PI_CHANNEL_DIR;
+const release = join(root, 'releases', process.env.EDDA_PI_RELEASE_ID);
+const { startChannel } = await import(pathToFileURL(join(release, 'channel.mjs')));
+const { pageConversation, projectEntry } = await import(pathToFileURL(join(release, 'conversation.mjs')));
+const resumed = args.includes('--session') ? option('--session') : null;
+const id = resumed ? JSON.parse(readFileSync(resumed, 'utf8').split('\n')[0]).id : randomUUID();
+const file = resumed || join(option('--session-dir'), `${id}.jsonl`);
+if (!existsSync(file)) writeFileSync(file, JSON.stringify({ type: 'session', id, version: 3, cwd: process.cwd(), timestamp: new Date().toISOString() }) + '\n');
+const entries = readFileSync(file, 'utf8').trim().split('\n').map(JSON.parse).slice(1);
+const output = (value) => process.stdout.write(JSON.stringify(value) + '\n');
+function message(role, text) {
+  const row = { type: 'message', id: randomUUID(), parentId: entries.at(-1)?.id || null,
+    timestamp: new Date().toISOString(), message: { role, content: [{ type: 'text', text }], stopReason: 'stop' } };
+  entries.push(row); appendFileSync(file, JSON.stringify(row) + '\n');
+}
+let channel;
+channel = await startChannel({ root, sessionId: id, cwd: process.cwd(),
+  getConversation: (options) => pageConversation(entries.map(projectEntry), options),
+  deliver: (text) => {
+    channel.event('agent_start'); channel.messageStarted(text); message('user', text);
+    output({ type: 'agent_start' });
+    if (text.endsWith('BUSY')) return;
+    message('assistant', 'FIXTURE_REPLY');
+    channel.event('assistant_end', { stopReason: 'stop', text: 'FIXTURE_REPLY' }); channel.settled();
+    output({ type: 'agent_settled' });
+  } });
+let buffer = '';
+process.stdin.on('data', (chunk) => {
+  buffer += chunk.toString();
+  let end;
+  while ((end = buffer.indexOf('\n')) >= 0) {
+    const request = JSON.parse(buffer.slice(0, end)); buffer = buffer.slice(end + 1);
+    if (option('--provider') === 'bad-rpc') { process.stdout.write('NOT JSON\n'); continue; }
+    if (request.type === 'get_state') output({ type: 'response', command: 'get_state', id: request.id, success: true,
+      data: { sessionId: id, sessionFile: file, model: { provider: 'fixture', id: 'echo' }, isStreaming: channel.snapshot().state !== 'idle' } });
+  }
+});
+process.stdin.on('end', async () => { await channel.close(); process.exit(0); });

--- a/integrations/pi/managed-client.mjs
+++ b/integrations/pi/managed-client.mjs
@@ -113,7 +113,7 @@ export async function resumeManaged(root, id) {
     if (!state?.sessionId || !state.sessionFile || !inside(join(dir, 'sessions'), state.sessionFile)) throw new Error('No owned persisted session to resume');
     if (lstatSync(join(dir, 'sessions')).isSymbolicLink()) throw new Error('Managed session directory must not be a link');
     const file = realpathSync(state.sessionFile);
-    if (!inside(join(dir, 'sessions'), file) || !lstatSync(file).isFile()) throw new Error('Session file escaped managed storage');
+    if (!inside(realpathSync(join(dir, 'sessions')), file) || !lstatSync(file).isFile()) throw new Error('Session file escaped managed storage');
     const headerFd = openSync(file, 'r'), buffer = Buffer.alloc(16384);
     let size;
     try { size = readSync(headerFd, buffer, 0, buffer.length, 0); } finally { closeSync(headerFd); }

--- a/integrations/pi/managed-client.mjs
+++ b/integrations/pi/managed-client.mjs
@@ -1,0 +1,135 @@
+import { spawn } from 'node:child_process';
+import { mkdirSync, openSync, closeSync, unlinkSync, realpathSync, lstatSync, readSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { setTimeout as delay } from 'node:timers/promises';
+import { managedDir, installRuntime, verifyRelease, findPiEntry, alive, inside } from './managed-store.mjs';
+import { readJson, writeJson, validateId, digest, sessionDir, recover } from './store.mjs';
+import { requestSession } from './client.mjs';
+
+function runConfig(root, id) {
+  const dir = managedDir(root, id), config = readJson(join(dir, 'config.json'));
+  if (!config || config.runId !== id || config.root !== resolve(root)) throw new Error('Managed run configuration not found or identity mismatch');
+  return { dir, config };
+}
+async function runnerRequest(root, id, operation, abort = false) {
+  const { dir } = runConfig(root, id), owner = readJson(join(dir, 'owner.json'));
+  if (!owner || owner.runId !== id || !/^[0-9a-f]{64}$/.test(owner.token) || !Number.isInteger(owner.port) || owner.port < 1 || owner.port > 65535) throw new Error('Managed runner unavailable');
+  validateId(owner.serviceId);
+  const response = await fetch(`http://127.0.0.1:${owner.port}/${operation}`, { method: operation === 'stop' ? 'POST' : 'GET',
+    headers: { authorization: `Bearer ${owner.token}`, 'x-edda-instance': owner.serviceId, ...(abort ? { 'x-edda-abort': 'true' } : {}) }, redirect: 'error', signal: AbortSignal.timeout(operation === 'stop' ? 10000 : 3000) });
+  const result = await response.json();
+  if (!response.ok) throw new Error(result.error || 'Managed request failed');
+  if (result.runId !== id || result.serviceId !== owner.serviceId) throw new Error('Managed runner response identity mismatch');
+  return result;
+}
+export async function managedStatus(root, id) {
+  id = validateId(id);
+  const { dir, config } = runConfig(root, id);
+  try { return await runnerRequest(root, id, 'status'); }
+  catch {
+    const state = readJson(join(dir, 'state.json'));
+    return { ...(state || {}), runId: id, live: false, status: 'runner_unreachable', lastRecordedPhase: state?.phase,
+      release: config.release, nextAction: state?.sessionFile ? 'Inspect and explicitly run-resume; initial work is not replayed.' : 'Inspect the launch evidence; do not create a duplicate on a timeout.' };
+  }
+}
+export async function stopManaged(root, id, { abort = false } = {}) {
+  id = validateId(id);
+  const { dir } = runConfig(root, id), owner = readJson(join(dir, 'owner.json'));
+  const result = await runnerRequest(root, id, 'stop', abort);
+  const deadline = Date.now() + 5000;
+  while (alive(owner?.pid) && Date.now() < deadline) await delay(50);
+  return alive(owner?.pid) ? { ...result, status: 'stop_pending', nextAction: 'Query run-status before resume; the runner is still exiting.' } : result;
+}
+
+function startRunner(root, dir, config, resume) {
+  const serviceId = randomUUID();
+  const previous = readJson(join(dir, 'state.json'));
+  writeJson(join(dir, 'state.json'), { ...previous, runId: config.runId, serviceId, phase: 'launch_requested', updatedAt: new Date().toISOString() });
+  const fd = openSync(join(dir, 'runner.log'), 'a', 0o600);
+  let child;
+  try {
+    child = spawn(process.execPath, [join(config.release.path, 'managed-runner.mjs'), resolve(root), config.runId, serviceId, ...(resume ? ['--resume'] : [])],
+      { cwd: config.project, detached: true, windowsHide: true, stdio: ['ignore', fd, fd] });
+    child.on('error', (error) => { writeJson(join(dir, 'state.json'), { ...previous, runId: config.runId, serviceId, phase: 'failed', error: error.message }); });
+    child.unref();
+  } finally { closeSync(fd); }
+  return serviceId;
+}
+async function awaitLaunch(root, id, serviceId) {
+  const deadline = Date.now() + 30000;
+  let result;
+  while (Date.now() < deadline) {
+    result = await managedStatus(root, id);
+    if (result.serviceId === serviceId && (result.live || ['failed', 'exited', 'stopped'].includes(result.lastRecordedPhase))) return result;
+    await delay(150);
+  }
+  return { ...result, status: 'launch_pending', nextAction: 'Query run-status with this run ID; do not launch a new ID merely because startup is slow.' };
+}
+
+export async function launchManaged(root, { runId = randomUUID(), project, piEntry, provider, model, prompt,
+  extensions = [], agentDir, noTools = false, thinking } = {}) {
+  runId = validateId(runId); root = resolve(root);
+  if (!project) throw new Error('launch requires --project');
+  project = realpathSync(resolve(project));
+  if (!lstatSync(project).isDirectory()) throw new Error('Project must be a directory');
+  if (prompt !== undefined && (typeof prompt !== 'string' || !prompt.trim() || Buffer.byteLength(prompt) > 16384)) throw new Error('Initial prompt must contain 1..16384 UTF-8 bytes');
+  for (const value of [provider, model]) if (value !== undefined && (typeof value !== 'string' || !value.trim() || value.length > 300)) throw new Error('Invalid provider/model');
+  if (thinking !== undefined && !['off', 'minimal', 'low', 'medium', 'high', 'xhigh'].includes(thinking)) throw new Error('Invalid thinking level');
+  if (!Array.isArray(extensions) || extensions.length > 8) throw new Error('Select at most eight trusted extra extensions');
+  extensions = extensions.map((path) => {
+    const file = realpathSync(resolve(path));
+    if (!lstatSync(file).isFile()) throw new Error('Extra extension must be a file');
+    return file;
+  });
+  if (agentDir) agentDir = realpathSync(resolve(agentDir));
+  const pi = findPiEntry(piEntry);
+  const inputs = { project, pi, provider: provider || null, model: model || null, prompt: prompt ?? null,
+    extensions, agentDir: agentDir || null, noTools: Boolean(noTools), thinking: thinking || null };
+  const dir = managedDir(root, runId, true), previous = readJson(join(dir, 'config.json'));
+  if (previous) {
+    if (previous.inputsDigest !== digest(JSON.stringify(inputs))) throw new Error('Run ID already has different launch inputs');
+    return managedStatus(root, runId);
+  }
+  const release = installRuntime(root);
+  const config = { version: 1, runId, root, ...inputs, inputsDigest: digest(JSON.stringify(inputs)), release };
+  writeJson(join(dir, 'config.json'), config, true);
+  mkdirSync(join(dir, 'sessions'), { mode: 0o700 });
+  const serviceId = startRunner(root, dir, config, false);
+  return awaitLaunch(root, runId, serviceId);
+}
+
+export async function resumeManaged(root, id) {
+  id = validateId(id);
+  const { dir, config } = runConfig(root, id);
+  const lock = join(dir, 'resume.lock');
+  const fd = openSync(lock, 'wx', 0o600);
+  try {
+    const existing = await managedStatus(root, id);
+    if (existing.live) return existing;
+    const state = readJson(join(dir, 'state.json'));
+    const owner = readJson(join(dir, 'owner.json'));
+    if (alive(owner?.pid) || alive(state?.runnerPid)) throw new Error('Previous runner may still be alive; no duplicate launch');
+    if (!state?.sessionId || !state.sessionFile || !inside(join(dir, 'sessions'), state.sessionFile)) throw new Error('No owned persisted session to resume');
+    if (lstatSync(join(dir, 'sessions')).isSymbolicLink()) throw new Error('Managed session directory must not be a link');
+    const file = realpathSync(state.sessionFile);
+    if (!inside(join(dir, 'sessions'), file) || !lstatSync(file).isFile()) throw new Error('Session file escaped managed storage');
+    const headerFd = openSync(file, 'r'), buffer = Buffer.alloc(16384);
+    let size;
+    try { size = readSync(headerFd, buffer, 0, buffer.length, 0); } finally { closeSync(headerFd); }
+    const newline = buffer.subarray(0, size).indexOf(10);
+    if (newline < 0) throw new Error('Session header exceeds bounded read');
+    const header = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(buffer.subarray(0, newline)));
+    if (header.type !== 'session' || header.id !== state.sessionId || realpathSync(header.cwd) !== config.project) throw new Error('Session file identity/project mismatch');
+    try {
+      const live = await requestSession(root, state.sessionId, '/status');
+      if (live.live) throw Object.assign(new Error('Pi is still running; reconnect instead of launching another process'), { live: true });
+    } catch (error) { if (error.live) throw error; }
+    const piOwner = readJson(join(sessionDir(root, state.sessionId), 'owner.json'));
+    if (alive(state.childPid) || alive(piOwner?.pid)) throw new Error('Previous Pi may still be alive; recovery refused');
+    if (piOwner) recover(root, state.sessionId, piOwner.instanceId);
+    verifyRelease(config.release);
+    const serviceId = startRunner(root, dir, config, true);
+    return await awaitLaunch(root, id, serviceId);
+  } finally { closeSync(fd); unlinkSync(lock); }
+}

--- a/integrations/pi/managed-runner.mjs
+++ b/integrations/pi/managed-runner.mjs
@@ -1,0 +1,158 @@
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+import { existsSync, unlinkSync, realpathSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { managedDir, verifyRelease, rpcFrames, inside } from './managed-store.mjs';
+import { readJson, writeJson, validateId, digest } from './store.mjs';
+import { requestSession, getReceipt } from './client.mjs';
+import { messageId } from './inbox-store.mjs';
+
+const [rootArg, runArg, serviceArg, mode] = process.argv.slice(2);
+const root = resolve(rootArg), runId = validateId(runArg), serviceId = validateId(serviceArg);
+const dir = managedDir(root, runId), config = readJson(join(dir, 'config.json'));
+if (!config || config.version !== 1 || config.runId !== runId || config.root !== root) throw new Error('Invalid managed run configuration');
+verifyRelease(config.release);
+const prior = readJson(join(dir, 'state.json'));
+if (prior?.serviceId !== serviceId || prior.phase !== 'launch_requested') throw new Error('Launch generation is no longer current');
+const resume = mode === '--resume';
+if (mode && !resume) throw new Error('Unknown runner mode');
+const token = randomBytes(32).toString('hex');
+let state = { ...prior, runId, serviceId, runnerPid: process.pid, phase: 'starting',
+  release: config.release, piVersion: config.pi.version, updatedAt: new Date().toISOString() };
+let child, stopped = false, server, heartbeat, rpcError, observed, stateSequence = 0;
+const save = () => { state.updatedAt = new Date().toISOString(); writeJson(join(dir, 'state.json'), state); };
+const initialId = messageId(digest(`${runId}:initial`));
+save();
+
+async function childExit() {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
+  child.stdin.end();
+  const deadline = Date.now() + 2000;
+  while (child.exitCode === null && child.signalCode === null && Date.now() < deadline) await delay(50);
+  if (child.exitCode === null && child.signalCode === null) {
+    // This is the actual ChildProcess owned by this runner, never a saved PID.
+    child.kill();
+    const killedDeadline = Date.now() + 5000;
+    while (child.exitCode === null && child.signalCode === null && Date.now() < killedDeadline) await delay(50);
+    if (child.exitCode === null && child.signalCode === null) throw new Error('Owned Pi did not exit; preserve run for inspection');
+  }
+}
+async function cleanup() {
+  clearInterval(heartbeat);
+  await childExit();
+  const ownerPath = join(dir, 'owner.json'), owner = readJson(ownerPath);
+  if (owner?.serviceId === serviceId) unlinkSync(ownerPath);
+  if (server?.listening) await new Promise((resolveClose) => server.close(resolveClose));
+}
+async function snapshot() {
+  let piState = null, receipt = state.initialReceipt || null;
+  if (state.sessionId) {
+    try { piState = await requestSession(root, state.sessionId, '/status', undefined, 2000, state.instanceId); } catch { /* stale/offline stays visible */ }
+    if (state.initialAttemptedAt) {
+      try { receipt = await getReceipt(root, state.sessionId, initialId); } catch { receipt = { id: initialId, status: 'unknown' }; }
+    }
+  }
+  return { ...state, live: true, status: state.phase, pi: piState,
+    sessionPersisted: Boolean(state.sessionFile && existsSync(state.sessionFile)), initialReceipt: receipt,
+    notice: 'Runner readiness is not work completion. Resume never replays the initial prompt; inbox delivery does not imply a manager decision.' };
+}
+
+try {
+  const env = { ...process.env, EDDA_PI_CHANNEL_DIR: root, EDDA_PI_RELEASE_ID: config.release.id,
+    EDDA_SESSION_ID: runId, EDDA_SESSION_LABEL: `managed-pi-${runId.slice(0, 8)}` };
+  delete env.EDDA_PROJECT_ID;
+  if (config.agentDir) env.PI_CODING_AGENT_DIR = config.agentDir;
+  const model = resume && prior.model ? prior.model : { provider: config.provider, id: config.model };
+  const args = [config.pi.entry, '--mode', 'rpc', '--no-extensions', '-e', join(config.release.path, 'extension.mjs'),
+    '--session-dir', join(dir, 'sessions'), ...(resume ? ['--session', prior.sessionFile] : []),
+    ...(model.provider ? ['--provider', model.provider] : []), ...(model.id ? ['--model', model.id] : []),
+    ...((resume ? prior.thinkingLevel : config.thinking) ? ['--thinking', resume ? prior.thinkingLevel : config.thinking] : []),
+    ...(config.noTools ? ['--no-tools'] : []), ...config.extensions.flatMap((path) => ['-e', path])];
+  child = spawn(process.execPath, args, { cwd: config.project, env, windowsHide: true, stdio: ['pipe', 'pipe', 'pipe'] });
+  state.childPid = child.pid; save();
+  child.on('error', (error) => { rpcError = error; });
+  child.stdin.on('error', (error) => { rpcError = error; });
+  child.stderr.on('data', () => { state.stderrObserved = true; });
+  child.stdout.on('data', rpcFrames((event) => {
+    if (event.type === 'response' && event.command === 'get_state') {
+      if (!event.success || !event.data?.sessionId || !event.data?.sessionFile) throw new Error('Pi did not supply persisted session identity');
+      observed = event.data;
+      if (state.sessionId && observed.sessionId !== state.sessionId) throw new Error('Managed Pi changed session identity');
+      if (!inside(join(dir, 'sessions'), observed.sessionFile)) throw new Error('Pi session file is outside owned storage');
+      state.sessionId = observed.sessionId; state.sessionFile = observed.sessionFile;
+      state.model = observed.model ? { provider: observed.model.provider, id: observed.model.id } : null;
+      state.thinkingLevel = observed.thinkingLevel || null;
+    }
+    if (['agent_start', 'agent_settled', 'tool_execution_start', 'tool_execution_end', 'extension_error'].includes(event.type)) {
+      state.lastEvent = event.type; state.lastProgressAt = new Date().toISOString();
+    }
+    if (event.type === 'message_end' && event.message?.role === 'assistant' && event.message.usage) {
+      // Aggregate observable accounting only; no raw messages or reasoning logs.
+      const usage = event.message.usage;
+      state.usage = { tokens: (state.usage?.tokens || 0) + (Number(usage.totalTokens) || 0),
+        reportedCost: (state.usage?.reportedCost || 0) + (Number(usage.cost?.total) || 0) };
+    }
+    if (event.type === 'message_end' && event.message?.role === 'assistant') {
+      state.lastModelStopReason = event.message.stopReason;
+      const error = event.message.errorMessage;
+      if (typeof error === 'string' && error) {
+        state.modelError = { category: /credit|balance|funds/i.test(error) ? 'credit_or_quota' :
+          /auth|api.?key|401|403/i.test(error) ? 'authentication' : /timeout|timed.out/i.test(error) ? 'timeout' : 'provider_error',
+          httpStatus: error.match(/\b[45][0-9]{2}\b/)?.[0] || null };
+      }
+    }
+  }, (error) => { rpcError = error; }));
+  const queryState = () => child.stdin.write(JSON.stringify({ type: 'get_state', id: `managed-state-${++stateSequence}` }) + '\n');
+  queryState();
+  const deadline = Date.now() + 25000;
+  let piState;
+  while (Date.now() < deadline) {
+    if (rpcError) throw rpcError;
+    if (child.exitCode !== null || child.signalCode !== null) throw new Error('Pi exited during startup; inspect installation/provider configuration');
+    if (observed) {
+      try { piState = await requestSession(root, observed.sessionId, '/status'); } catch { /* registration in progress */ }
+      if (piState?.live) break;
+    }
+    await delay(100);
+  }
+  if (!piState?.live || !['inbox', 'handoff', 'receipts'].every((cap) => piState.capabilities?.includes(cap)) ||
+    piState.integration?.releaseId !== config.release.id || piState.integration?.version !== config.release.version ||
+    realpathSync(piState.integration.modulePath) !== realpathSync(join(config.release.path, 'channel.mjs'))) {
+    throw new Error('Pi registration/version handshake failed; no initial task was sent');
+  }
+  state.instanceId = piState.instanceId; state.integration = piState.integration; state.phase = 'ready'; save();
+  server = createServer(async (req, res) => {
+    const reply = (code, body) => { res.writeHead(code, { 'content-type': 'application/json', 'cache-control': 'no-store' }); res.end(JSON.stringify(body)); };
+    try {
+      const supplied = req.headers.authorization || '', expected = `Bearer ${token}`;
+      if (req.headers.origin || Buffer.byteLength(supplied) !== Buffer.byteLength(expected) ||
+        !timingSafeEqual(Buffer.from(supplied), Buffer.from(expected)) || req.headers['x-edda-instance'] !== serviceId) throw new Error('Unauthorized managed request');
+      if (req.method === 'GET' && req.url === '/status') return reply(200, await snapshot());
+      if (req.method !== 'POST' || req.url !== '/stop') return reply(404, { error: 'Unknown managed operation' });
+      if (stopped) throw new Error('Stop already in progress');
+      const current = await requestSession(root, state.sessionId, '/status', undefined, 2000, state.instanceId);
+      const abort = req.headers['x-edda-abort'] === 'true';
+      if (current.state !== 'idle' && !abort) throw new Error('Pi is working; idle stop refused without interrupting it. Use explicit --abort to stop owned work.');
+      stopped = true; state.phase = 'stopping'; save();
+      await childExit();
+      state.phase = 'stopped'; state.stopMode = abort ? 'explicit_abort' : 'idle'; save();
+      reply(200, { runId, serviceId, status: 'stopped', sessionId: state.sessionId, sessionFile: state.sessionFile, interrupted: abort, initialReplayed: false });
+    } catch (error) { reply(409, { error: error.message }); }
+  });
+  server.requestTimeout = 5000; server.headersTimeout = 5000;
+  await new Promise((resolveListen, reject) => { server.once('error', reject); server.listen(0, '127.0.0.1', resolveListen); });
+  writeJson(join(dir, 'owner.json'), { runId, serviceId, pid: process.pid, port: server.address().port, token });
+  if (!resume && config.prompt !== null && !state.initialAttemptedAt) {
+    state.initialAttemptedAt = new Date().toISOString(); state.initialReceipt = { id: initialId, status: 'unknown' }; save();
+    try { state.initialReceipt = await requestSession(root, state.sessionId, '/messages', { id: initialId, message: config.prompt, sender: 'managed-launch', mode: 'followUp' }, 2500, state.instanceId); }
+    catch { /* intent remains unknown; never replay */ }
+    save();
+  }
+  heartbeat = setInterval(() => { if (!stopped) { queryState(); save(); } }, 2000);
+  while (!stopped && child.exitCode === null && child.signalCode === null && !rpcError) await delay(200);
+  if (!stopped) { state.phase = rpcError ? 'failed' : 'exited'; state.error = rpcError?.message || 'Pi process exited'; save(); }
+} catch (error) {
+  state.phase = 'failed'; state.error = error.message; save();
+} finally { await cleanup(); }

--- a/integrations/pi/managed-runner.mjs
+++ b/integrations/pi/managed-runner.mjs
@@ -4,7 +4,7 @@ import { randomBytes, timingSafeEqual } from 'node:crypto';
 import { existsSync, unlinkSync, realpathSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
-import { managedDir, verifyRelease, rpcFrames, inside } from './managed-store.mjs';
+import { managedDir, verifyRelease, rpcFrames, inside, findPiEntry } from './managed-store.mjs';
 import { readJson, writeJson, validateId, digest } from './store.mjs';
 import { requestSession, getReceipt } from './client.mjs';
 import { messageId } from './inbox-store.mjs';
@@ -20,7 +20,7 @@ const resume = mode === '--resume';
 if (mode && !resume) throw new Error('Unknown runner mode');
 const token = randomBytes(32).toString('hex');
 let state = { ...prior, runId, serviceId, runnerPid: process.pid, phase: 'starting',
-  release: config.release, piVersion: config.pi.version, updatedAt: new Date().toISOString() };
+  release: config.release, piVersion: null, expectedPiVersion: config.pi.version, updatedAt: new Date().toISOString() };
 let child, stopped = false, server, heartbeat, rpcError, observed, stateSequence = 0;
 const save = () => { state.updatedAt = new Date().toISOString(); writeJson(join(dir, 'state.json'), state); };
 const initialId = messageId(digest(`${runId}:initial`));
@@ -60,6 +60,8 @@ async function snapshot() {
 }
 
 try {
+  state.piVersion = findPiEntry(config.pi.entry).version;
+  save();
   const env = { ...process.env, EDDA_PI_CHANNEL_DIR: root, EDDA_PI_RELEASE_ID: config.release.id,
     EDDA_SESSION_ID: runId, EDDA_SESSION_LABEL: `managed-pi-${runId.slice(0, 8)}` };
   delete env.EDDA_PROJECT_ID;

--- a/integrations/pi/managed-smoke.mjs
+++ b/integrations/pi/managed-smoke.mjs
@@ -1,0 +1,88 @@
+// Real Pi lifecycle dogfood. Default offline; --live uses explicit configured provider/model.
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { randomUUID } from 'node:crypto';
+import { setTimeout as delay } from 'node:timers/promises';
+import { launchManaged, managedStatus, stopManaged, resumeManaged } from './managed-client.mjs';
+import { requestSession, getReceipt } from './client.mjs';
+import { listInbox, readInbox, respondInbox } from './inbox-manager.mjs';
+import { alive } from './managed-store.mjs';
+
+const [entry, mode, provider, model] = process.argv.slice(2);
+if (mode && mode !== '--live') throw new Error('Unknown smoke mode');
+if (mode === '--live' && (!provider || !model)) throw new Error('--live requires explicit provider and model');
+const root = await mkdtemp(join(tmpdir(), 'edda-managed-smoke-'));
+const registry = join(root, 'registry'), project = join(root, 'project'), agentDir = join(root, 'agent');
+await mkdir(project); await mkdir(agentDir);
+let runId, sessionId, passed = false;
+const prompt = mode === '--live' ? 'This is one bounded acceptance fixture for Edda issue #1157. Work only in the current temporary directory. Create smoke-result.txt containing exactly MANAGED_PI_OK followed by a newline, verify its contents, then reply MANAGED_PI_DONE and stop. Do not touch other directories, start subagents, access the network, install dependencies, or ask for another approval. The operator explicitly authorized this fixture.' : 'ASK_OFFLINE_PERMISSION';
+async function until(fn, label, timeout = 30000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const value = await fn(); if (value) return value;
+    await delay(200);
+  }
+  throw new Error(`Timed out: ${label}`);
+}
+try {
+  const launch = await launchManaged(registry, { runId: randomUUID(), project, piEntry: entry, prompt,
+    provider: mode === '--live' ? provider : 'edda-offline-test', model: mode === '--live' ? model : 'echo', thinking: mode === '--live' ? 'low' : undefined,
+    ...(mode === '--live' ? {} : { agentDir, noTools: true, extensions: [fileURLToPath(new URL('./fixtures/offline-provider.mjs', import.meta.url))] }) });
+  runId = launch.runId; sessionId = launch.sessionId;
+  assert.equal(launch.live, true);
+  assert.equal(launch.pi.integration.releaseId, launch.release.id);
+  assert.ok(launch.pi.capabilities.includes('inbox'));
+  await until(async () => {
+    const status = await managedStatus(registry, runId);
+    if (status.initialReceipt?.status === 'failed' || status.modelError ||
+      (status.lastEvent === 'extension_error' && status.initialReceipt?.status === 'unconfirmed')) throw new Error(`Model invocation failed: ${JSON.stringify(status.modelError || { status: status.lastEvent || 'failed' })}`);
+    return status.initialReceipt?.status === 'settled';
+  }, 'initial task settlement', mode === '--live' ? 120000 : 30000);
+  const afterWork = await managedStatus(registry, runId);
+  assert.equal(afterWork.sessionPersisted, true);
+  const inbox = listInbox(registry), eventId = inbox.events.at(-1).eventId;
+  const item = await readInbox(registry, eventId);
+  if (mode === '--live') {
+    assert.equal(await readFile(join(project, 'smoke-result.txt'), 'utf8'), 'MANAGED_PI_OK\n');
+    assert.ok(item.event.excerpt.text.includes('MANAGED_PI_DONE'));
+  } else {
+    assert.ok(item.event.excerpt.text.includes('APPROVE_OFFLINE_TASK'));
+    const reply = await respondInbox(registry, eventId, { message: 'APPROVE_OFFLINE_TASK' });
+    await until(async () => (await getReceipt(registry, sessionId, reply.id)).status === 'settled', 'same-session response');
+  }
+  const beforeStop = await requestSession(registry, sessionId, '/conversation?limit=50');
+  assert.equal((await stopManaged(registry, runId)).status, 'stopped');
+  const resumed = await resumeManaged(registry, runId);
+  assert.equal(resumed.live, true);
+  assert.equal(resumed.sessionId, sessionId);
+  assert.deepEqual(resumed.model, afterWork.model);
+  assert.equal(resumed.thinkingLevel, afterWork.thinkingLevel);
+  assert.notEqual(resumed.serviceId, launch.serviceId);
+  assert.notEqual(resumed.instanceId, launch.instanceId);
+  const afterResume = await requestSession(registry, sessionId, '/conversation?limit=50');
+  assert.equal(afterResume.headCursor, beforeStop.headCursor);
+  assert.equal(afterResume.entries.filter((e) => e.role === 'user' && e.text?.includes(prompt)).length, 1);
+  assert.ok(listInbox(registry).events.some((e) => e.eventId === eventId));
+  passed = true;
+  console.log(JSON.stringify({ passed: true, actualPi: true, liveModel: mode === '--live', sessionId,
+    pinnedRuntime: true, reconnect: true, sameSessionRecovery: true, initialReplayed: false,
+    inboxPreserved: true, model: afterWork.model, usage: afterWork.usage || null }, null, 2));
+} finally {
+  if (runId) {
+    const state = await managedStatus(registry, runId);
+    if (!passed) {
+      const evidence = { runId, phase: state.phase, runnerLive: state.live, piState: state.pi?.state,
+        lastEvent: state.lastEvent, model: state.model, modelError: state.modelError, initialReceipt: state.initialReceipt,
+        usage: state.usage, error: state.error };
+      await writeFile(join(root, 'failure-evidence.json'), JSON.stringify(evidence, null, 2));
+      console.log(JSON.stringify({ failed: true, evidenceRoot: root, ...evidence }));
+    }
+    if (state.live) await stopManaged(registry, runId, { abort: state.pi?.state !== 'idle' });
+    const final = await managedStatus(registry, runId);
+    if (alive(final.runnerPid) || alive(final.childPid)) throw new Error(`Owned fixture still active; preserve ${root} and run ${runId} for inspection`);
+  }
+  if (passed) await rm(root, { recursive: true, force: true });
+}

--- a/integrations/pi/managed-store.mjs
+++ b/integrations/pi/managed-store.mjs
@@ -1,0 +1,102 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, lstatSync, writeFileSync, renameSync, rmSync } from 'node:fs';
+import { dirname, join, resolve, relative, isAbsolute } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+import { randomUUID } from 'node:crypto';
+import { digest, privateRoot, readJson, validateId } from './store.mjs';
+
+export function inside(parent, child) {
+  const path = relative(resolve(parent), resolve(child));
+  return path !== '..' && !path.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`) && !isAbsolute(path);
+}
+export function managedDir(root, id, create = false) {
+  id = validateId(id);
+  const base = join(resolve(root), 'managed'), dir = join(base, id);
+  if (create) privateRoot(root);
+  for (const path of [base, dir]) {
+    if (create) mkdirSync(path, { recursive: true, mode: 0o700 });
+    if (existsSync(path) && (!lstatSync(path).isDirectory() || lstatSync(path).isSymbolicLink())) throw new Error('Managed directory must not be a link');
+  }
+  return dir;
+}
+export function verifyRelease(release) {
+  if (!release || !/^[0-9a-f]{64}$/.test(release.id) || !isAbsolute(release.path)) throw new Error('Invalid runtime release');
+  const manifest = readJson(join(release.path, 'release.json'));
+  if (!manifest || manifest.id !== release.id || digest(JSON.stringify(manifest.files)) !== release.id) throw new Error('Runtime release manifest mismatch');
+  for (const [name, hash] of Object.entries(manifest.files)) {
+    if (!/^[a-z0-9.-]+$/.test(name)) throw new Error('Invalid runtime filename');
+    const path = join(release.path, name), stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 1024 * 1024 || digest(readFileSync(path)) !== hash) throw new Error(`Runtime file mismatch: ${name}`);
+  }
+  return manifest;
+}
+export function installRuntime(root, source = dirname(fileURLToPath(import.meta.url))) {
+  privateRoot(root);
+  const releases = join(resolve(root), 'releases');
+  mkdirSync(releases, { recursive: true, mode: 0o700 });
+  if (lstatSync(releases).isSymbolicLink()) throw new Error('Release directory must not be a link');
+  const names = readdirSync(source).filter((name) => name === 'package.json' || name.endsWith('.ps1') ||
+    (name.endsWith('.mjs') && !name.endsWith('.test.mjs') && !name.includes('smoke'))).sort();
+  const files = {}, bytes = new Map();
+  for (const name of names) {
+    const path = join(source, name), stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 1024 * 1024) throw new Error('Invalid runtime source file');
+    const content = readFileSync(path); files[name] = digest(content); bytes.set(name, content);
+  }
+  if (!files['managed-runner.mjs'] || !files['extension.mjs'] || !files['package.json']) throw new Error('Incomplete runtime source');
+  const id = digest(JSON.stringify(files)), target = join(releases, id);
+  const release = { id, path: target, version: JSON.parse(bytes.get('package.json').toString()).version };
+  if (!existsSync(target)) {
+    const stage = join(releases, `.staging-${randomUUID()}`);
+    mkdirSync(stage, { mode: 0o700 });
+    try {
+      for (const [name, content] of bytes) writeFileSync(join(stage, name), content, { flag: 'wx', mode: 0o600 });
+      writeFileSync(join(stage, 'release.json'), JSON.stringify({ version: 1, id, files }, null, 2), { flag: 'wx', mode: 0o600 });
+      try { renameSync(stage, target); }
+      catch (error) { if (!existsSync(target)) throw error; }
+    } finally {
+      if (existsSync(stage) && inside(releases, stage)) rmSync(stage, { recursive: true, force: true });
+    }
+  }
+  verifyRelease(release);
+  return release;
+}
+export function findPiEntry(explicit) {
+  const packagePath = '@earendil-works/pi-coding-agent';
+  const candidates = explicit ? [resolve(explicit)] : process.env.EDDA_PI_ENTRY ? [resolve(process.env.EDDA_PI_ENTRY)] : [
+    join(dirname(process.execPath), 'node_modules', packagePath, 'dist/bundle/cli.js'),
+    join(dirname(process.execPath), '../lib/node_modules', packagePath, 'dist/bundle/cli.js'),
+  ];
+  if (!explicit && !process.env.EDDA_PI_ENTRY) {
+    try { candidates.unshift(join(dirname(createRequire(import.meta.url).resolve(packagePath)), 'bundle/cli.js')); } catch { /* optional local package */ }
+  }
+  for (const entry of candidates) {
+    if (!existsSync(entry) || !lstatSync(entry).isFile()) continue;
+    const metadata = readJson(join(dirname(dirname(dirname(entry))), 'package.json'));
+    if (metadata?.name === packagePath) return { entry: resolve(entry), version: metadata.version };
+  }
+  throw new Error('Pi installation not found; supply --pi-entry with its installed dist/bundle/cli.js');
+}
+export function alive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try { process.kill(pid, 0); return true; }
+  catch (error) { return error.code !== 'ESRCH'; }
+}
+
+// Pi RPC is LF-only JSONL: Unicode U+2028/U+2029 inside strings are not delimiters.
+export function rpcFrames(onMessage, onError, maxBytes = 4 * 1024 * 1024) {
+  let buffer = Buffer.alloc(0), failed = false;
+  return (chunk) => {
+    if (failed) return;
+    buffer = Buffer.concat([buffer, chunk]);
+    let end;
+    while ((end = buffer.indexOf(10)) >= 0) {
+      const line = buffer.subarray(0, end); buffer = buffer.subarray(end + 1);
+      if (line.length > maxBytes) { failed = true; onError(new Error('Pi RPC frame exceeds limit')); return; }
+      if (!line.length) continue;
+      try { onMessage(JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(line))); }
+      catch (error) { failed = true; onError(new Error(`Invalid Pi RPC frame: ${error.name}`)); return; }
+    }
+    if (buffer.length > maxBytes) { failed = true; onError(new Error('Pi RPC frame exceeds limit')); }
+  };
+}

--- a/integrations/pi/managed.test.mjs
+++ b/integrations/pi/managed.test.mjs
@@ -81,8 +81,11 @@ test('CLI launch survives client exit; duplicate identity, authenticated stop an
   assert.equal((await managedStatus(f.registry, f.runId)).live, true);
   const before = await requestSession(f.registry, state.sessionId, '/conversation?limit=20');
   assert.equal((await stopManaged(f.registry, f.runId)).status, 'stopped');
+  await writeFile(join(f.root, 'pi/package.json'), JSON.stringify({ type: 'module', name: '@earendil-works/pi-coding-agent', version: 'fixture-updated' }));
   const resumed = await resumeManaged(f.registry, f.runId);
   assert.equal(resumed.sessionId, state.sessionId);
+  assert.equal(resumed.piVersion, 'fixture-updated');
+  assert.equal(resumed.expectedPiVersion, 'fixture');
   assert.notEqual(resumed.instanceId, state.instanceId);
   assert.equal((await requestSession(f.registry, state.sessionId, '/conversation?limit=20')).headCursor, before.headCursor);
   assert.ok(listInbox(f.registry).events.length);

--- a/integrations/pi/managed.test.mjs
+++ b/integrations/pi/managed.test.mjs
@@ -1,0 +1,116 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile, readFile, copyFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { randomUUID } from 'node:crypto';
+import { setTimeout as delay } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+import { installRuntime, verifyRelease, rpcFrames, managedDir, alive } from './managed-store.mjs';
+import { launchManaged, managedStatus, stopManaged, resumeManaged } from './managed-client.mjs';
+import { requestSession } from './client.mjs';
+import { readJson } from './store.mjs';
+import { listInbox } from './inbox-manager.mjs';
+
+const exec = promisify(execFile);
+async function until(fn) {
+  const deadline = Date.now() + 10000;
+  while (Date.now() < deadline) { if (await fn()) return; await delay(100); }
+  throw new Error('Timed out waiting for owned fixture');
+}
+async function fixture(t) {
+  const root = await mkdtemp(join(tmpdir(), 'edda-managed-test-'));
+  const project = join(root, 'project'), registry = join(root, 'registry'), pkg = join(root, 'pi');
+  await mkdir(project); await mkdir(join(pkg, 'dist/bundle'), { recursive: true });
+  await writeFile(join(pkg, 'package.json'), JSON.stringify({ type: 'module', name: '@earendil-works/pi-coding-agent', version: 'fixture' }));
+  const entry = join(pkg, 'dist/bundle/cli.js');
+  await copyFile(new URL('./fixtures/managed-pi.mjs', import.meta.url), entry);
+  const runId = randomUUID();
+  t.after(async () => {
+    if (readJson(join(managedDir(registry, runId), 'config.json'))) {
+      const state = await managedStatus(registry, runId);
+      if (state.live) await stopManaged(registry, runId, { abort: true });
+      await until(async () => { const current = await managedStatus(registry, runId); return !alive(current.runnerPid) && !alive(current.childPid); });
+    }
+    await rm(root, { recursive: true, force: true });
+  });
+  return { root, project, registry, entry, runId };
+}
+
+test('runtime install is repeatable and verifies actual file bytes', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'edda-release-test-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const first = installRuntime(root), second = installRuntime(root);
+  assert.deepEqual(first, second);
+  assert.equal(verifyRelease(first).id, first.id);
+  await writeFile(join(first.path, 'extension.mjs'), 'changed');
+  assert.throws(() => verifyRelease(first), /mismatch/);
+});
+
+test('RPC parser honors LF only across UTF-8 chunks and refuses malformed/oversized frames', () => {
+  const messages = [], errors = [];
+  const parse = rpcFrames((m) => messages.push(m), (e) => errors.push(e.message));
+  for (const byte of Buffer.from(JSON.stringify({ text: '你\u2028我\u2029' }) + '\r\n')) parse(Buffer.from([byte]));
+  assert.equal(messages[0].text, '你\u2028我\u2029');
+  assert.deepEqual(errors, []);
+  parse(Buffer.from('bad\n'));
+  assert.equal(errors.length, 1);
+  const large = rpcFrames(() => {}, (e) => errors.push(e.message), 4);
+  large(Buffer.from('12345'));
+  assert.match(errors.at(-1), /limit/);
+});
+
+test('CLI launch survives client exit; duplicate identity, authenticated stop and same-session resume', async (t) => {
+  const f = await fixture(t);
+  const promptFile = join(f.root, 'prompt.txt'); await writeFile(promptFile, 'HELLO');
+  const cli = fileURLToPath(new URL('./cli.mjs', import.meta.url));
+  const launched = await exec(process.execPath, [cli, 'launch', '--project', f.project, '--pi-entry', f.entry,
+    '--run-id', f.runId, '--prompt-file', promptFile, '--provider', 'fixture', '--model', 'echo'],
+  { env: { ...process.env, EDDA_PI_CHANNEL_DIR: f.registry }, windowsHide: true, timeout: 45000 });
+  const state = JSON.parse(launched.stdout);
+  assert.equal(state.live, true);
+  await until(async () => (await managedStatus(f.registry, f.runId)).initialReceipt?.status === 'settled');
+  const duplicate = await launchManaged(f.registry, { runId: f.runId, project: f.project, piEntry: f.entry, prompt: 'HELLO', provider: 'fixture', model: 'echo' });
+  assert.equal(duplicate.serviceId, state.serviceId);
+  await assert.rejects(launchManaged(f.registry, { runId: f.runId, project: f.project, piEntry: f.entry, prompt: 'DIFFERENT' }), /different launch inputs/);
+  const owner = readJson(join(managedDir(f.registry, f.runId), 'owner.json'));
+  const rejected = await fetch(`http://127.0.0.1:${owner.port}/stop`, { method: 'POST', headers: { authorization: `Bearer ${owner.token}`, 'x-edda-instance': randomUUID() } });
+  assert.equal(rejected.status, 409);
+  assert.equal((await managedStatus(f.registry, f.runId)).live, true);
+  const before = await requestSession(f.registry, state.sessionId, '/conversation?limit=20');
+  assert.equal((await stopManaged(f.registry, f.runId)).status, 'stopped');
+  const resumed = await resumeManaged(f.registry, f.runId);
+  assert.equal(resumed.sessionId, state.sessionId);
+  assert.notEqual(resumed.instanceId, state.instanceId);
+  assert.equal((await requestSession(f.registry, state.sessionId, '/conversation?limit=20')).headCursor, before.headCursor);
+  assert.ok(listInbox(f.registry).events.length);
+});
+
+test('busy stop refuses; explicit abort only stops the owned child', async (t) => {
+  const f = await fixture(t);
+  await launchManaged(f.registry, { runId: f.runId, project: f.project, piEntry: f.entry, prompt: 'BUSY' });
+  await until(async () => (await managedStatus(f.registry, f.runId)).pi?.state === 'running');
+  await assert.rejects(stopManaged(f.registry, f.runId), /working/);
+  const result = await stopManaged(f.registry, f.runId, { abort: true });
+  assert.equal(result.status, 'stopped'); assert.equal(result.interrupted, true);
+});
+
+test('malformed RPC fails without an initial prompt being sent', async (t) => {
+  const f = await fixture(t);
+  const result = await launchManaged(f.registry, { runId: f.runId, project: f.project, piEntry: f.entry, prompt: 'MUST_NOT_SEND', provider: 'bad-rpc' });
+  assert.equal(result.lastRecordedPhase, 'failed');
+  assert.match(result.error, /RPC frame/);
+  assert.equal(result.initialAttemptedAt, undefined);
+});
+
+test('missing session file prevents recovery without spawning a replacement', async (t) => {
+  const f = await fixture(t);
+  const launched = await launchManaged(f.registry, { runId: f.runId, project: f.project, piEntry: f.entry });
+  await stopManaged(f.registry, f.runId);
+  const source = await readFile(launched.sessionFile, 'utf8');
+  await rm(launched.sessionFile);
+  await assert.rejects(resumeManaged(f.registry, f.runId), /ENOENT/);
+  await writeFile(launched.sessionFile, source);
+});

--- a/integrations/pi/managed.test.mjs
+++ b/integrations/pi/managed.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, rm, writeFile, readFile, copyFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, writeFile, readFile, copyFile, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFile } from 'node:child_process';
@@ -113,4 +113,27 @@ test('missing session file prevents recovery without spawning a replacement', as
   await rm(launched.sessionFile);
   await assert.rejects(resumeManaged(f.registry, f.runId), /ENOENT/);
   await writeFile(launched.sessionFile, source);
+});
+
+test('system-style ancestor aliases do not reject an owned session during resume', async (t) => {
+  const f = await fixture(t);
+  const alias = join(f.root, 'ancestor-alias');
+  const target = join(f.root, 'real-ancestor');
+  await mkdir(target);
+  await symlink(target, alias, process.platform === 'win32' ? 'junction' : 'dir');
+  const registry = join(alias, 'registry');
+  let launched;
+  try {
+    launched = await launchManaged(registry, { project: f.project, piEntry: f.entry, prompt: 'HELLO' });
+    await until(async () => (await managedStatus(registry, launched.runId)).initialReceipt?.status === 'settled');
+    await stopManaged(registry, launched.runId);
+    const resumed = await resumeManaged(registry, launched.runId);
+    assert.equal(resumed.sessionId, launched.sessionId);
+    assert.equal(resumed.live, true);
+  } finally {
+    if (launched) {
+      const status = await managedStatus(registry, launched.runId);
+      if (status.live) await stopManaged(registry, launched.runId, { abort: true });
+    }
+  }
 });

--- a/integrations/pi/package.json
+++ b/integrations/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edda/pi-session-channel",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "engines": { "node": ">=24" },


### PR DESCRIPTION
Issue: #1157
Closes #1157
Decision: session.managed-runtime

New Pi sessions can now be launched and recovered through an owned background runner instead of being manually opened and later attached. Launch snapshots the integration into a verified digest-addressed private release, explicitly loads that extension, and checks actual Pi session/version/capability identity before sending the optional initial task.

`runtime-install`, `launch`, `run-status`, `run-stop` and `run-resume` expose lifecycle and bounded event/receipt evidence. The caller can exit while the runner remains. Duplicate run IDs reconnect, idle stop affects only the actual owned child, explicit `--abort` can interrupt it, and recovery validates/reuses the same session file without replaying the initial prompt. Model and thinking settings survive recovery. No new worker reporting/approval gate or autonomous manager-model polling is added.

Validation at final reviewed head 02d542895fdeecddbfb997f1e07d964c6fdc13d7:

- Exact-head Node CI34689623672:64/64 on Windows/Linux/macOS. MainCI34689623711 Format/CI Gate green, Cargo jobs path-filter skipped. RAN managed7/7 for canonical ancestor aliases and focused1/1 for actual-versus-expected installed Pi version after recovery; READ previous full63/63 (~102s) for unchanged surfaces.
- RAN real Pi0.85.1 offline-provider lifecycle smoke: question -> inbox -> concrete response -> continuation; fixed release handshake, client reconnection, stop/resume, same session/history, retained inbox and no initial replay. Final-head rerun includes model/thinking preservation assertions.
- RAN one user-requested real-model fixture with OpenRouter `deepseek/deepseek-v4.1-flash`: wrote and verified only the assigned temporary file, then stopped/resumed the same session with inbox/history preserved. Reported usage31,772 tokens, reported costUSD0.004878918. This proves this bounded workflow, not a general model benchmark. Normal-path receipt remains applicable after the later session-directory containment check.
- Earlier GLM5.3Flash fixture exceeded120s without settlement and was stopped, not retried. Diagnostic attribution was insufficient; it is not treated as evidence against model quality. Failure evidence retention and categorized model errors were added before the DeepSeek trial.
- Diff check and commit hooks; clean frozen worktree. No Rust/Cargo/toolchain changes or local Cargo build.

Scope: integrations/pi and stage plan. Existing user Pi processes/settings are preserved. Integration release bytes are pinned; installed Pi itself remains a separately versioned dependency. An ambiguous prior owner or launch/resume lock is reported, never stolen; restart does not imply resumed task execution. A desktop wake adapter/autonomous decision manager remains outside this lifecycle slice.
