### PR TITLE
feat(agent-manager): add local progress console and direct Pi chat

### DIFF
--- a/.github/workflows/agent-manager.yml
+++ b/.github/workflows/agent-manager.yml
@@ -1,0 +1,28 @@
+name: Agent manager
+on:
+  pull_request:
+    paths: ['integrations/agent-manager/**', 'integrations/pi/**', '.github/workflows/agent-manager.yml']
+  push:
+    branches: [main]
+    paths: ['integrations/agent-manager/**', 'integrations/pi/**', '.github/workflows/agent-manager.yml']
+  workflow_dispatch:
+jobs:
+  manager:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: integrations/agent-manager/package-lock.json
+      - run: npm ci --ignore-scripts
+        working-directory: integrations/agent-manager
+      - run: npm run typecheck
+        working-directory: integrations/agent-manager
+      - run: npm test
+        working-directory: integrations/agent-manager

--- a/docs/superpowers/plans/2026-09-13-agent-manager-console.md
+++ b/docs/superpowers/plans/2026-09-13-agent-manager-console.md
@@ -50,7 +50,8 @@ screens. No fake percentages, theatrical charts, or generated statistics.
 `POST /api/agents/:id/messages`, `GET /api/operations/:id`.
 All API responses require the gateway bearer. A send is an append/steer message,
 not a stale-question approval; basis cursor is provenance only. Expected instance
-and selection revision guard recipient identity. Body max24KiB/message max12KiB.
+and selection revision guard recipient identity. Body max96KiB/message max12KiB
+(shared constants allow JSON escaping without rejecting a valid maximum message).
 Errors use `{error:{code,message}}`, never raw legacy exceptions or credentials.
 
 The independent verifier audited the baseline before implementation. Its proposed

--- a/docs/superpowers/plans/2026-09-13-agent-manager-console.md
+++ b/docs/superpowers/plans/2026-09-13-agent-manager-console.md
@@ -1,0 +1,58 @@
+# Agent manager console implementation plan
+
+**Goal:** Ship a typed local multi-project progress console with direct Pi agent
+conversations, safe operator messages and durable receipts.
+
+**Architecture:** Independent TypeScript package over the existing Pi channel.
+Private SQLite stores operations/events; native HTTP serves a small browser client.
+Edda task truth and Pi runtime ownership stay in their existing systems.
+
+**Tech stack:** Node24, TypeScript5.9.3 strict, native HTTP/SQLite, browser ESM,
+Node test runner. No local Cargo lane; live project tests/DBs are not touched.
+
+## Cohesive bundles
+
+- [ ] Contract/package: `integrations/agent-manager/package.json`, lockfile,
+  `tsconfig.json`, `src/contracts.ts`. Gate: `npm run typecheck`.
+- [ ] Backend: `src/config.ts`, `src/pi-adapter.ts`, `src/store.ts`,
+  `src/manager.ts`, `src/http.ts`, `src/cli.ts`, tests. Contract tests first for
+  unknown JSON, private projections, selected identities and duplicate operations.
+  Required scenarios: send timeout then restart performs zero resend; stale instance
+  performs zero send; one unavailable agent leaves others usable; history omits
+  reasoning/token fields; wrong Origin/Host/auth and oversized requests are rejected.
+- [ ] Browser: `src/web/app.ts`, `src/web/index.html`, `src/web/style.css` in a
+  separate worker worktree on the frozen contract. Show project navigation,
+  status/freshness, public conversation, persistent uncertain draft and operation
+  feed. Use DOM text nodes for all external content. User selects append or priority
+  instruction, with the current recipient always visible. No lifecycle/approval UI.
+- [ ] Integration: build with `tsc`, serve only fixed web assets, read-only import
+  current registration, and add `.github/workflows/agent-manager.yml` for Node24
+  typecheck/tests/build on Windows/Linux/macOS. Existing Pi suite is compatibility
+  evidence, not a reason to run unrelated Rust gates locally.
+- [ ] Verify once after freeze: unit/HTTP tests, real offline Pi end-to-end,
+  browser desktop/mobile behavior and same-root restart. Inspect UI against actual
+  selected live agents without sending work to them. Record ran/read evidence,
+  independent current-head review, CI and R6 landing; preserve running services.
+
+## UI direction
+
+An operations desk for the user's small agent team: a restrained blue/slate palette,
+white work surface, strong project names, clear warm attention color, and an inset
+conversation area. Segoe UI/Microsoft JhengHei for readable Traditional Chinese;
+system monospace only for optional technical identities. Left project/agent list,
+central current work and conversation, compact activity rail; stack on narrow
+screens. No fake percentages, theatrical charts, or generated statistics.
+
+## Frozen API
+
+`src/contracts.ts` is the shared interface. Routes:
+`GET /api/overview`, `GET /api/agents/:id/conversation?after=cursor`,
+`POST /api/agents/:id/messages`, `GET /api/operations/:id`.
+All API responses require the gateway bearer. A send is an append/steer message,
+not a stale-question approval; basis cursor is provenance only. Expected instance
+and selection revision guard recipient identity. Body max24KiB/message max12KiB.
+Errors use `{error:{code,message}}`, never raw legacy exceptions or credentials.
+
+The independent verifier audited the baseline before implementation. Its proposed
+CPU sampler and structured inbox-response UI are intentionally outside this first
+slice; registered resources and ordinary direct messages have explicit semantics.

--- a/docs/superpowers/specs/2026-09-13-agent-manager-console.md
+++ b/docs/superpowers/specs/2026-09-13-agent-manager-console.md
@@ -56,7 +56,9 @@ must use the existing inbox epoch/identity contract.
 
 Every send carries a client-generated UUID, selection revision and freshly viewed
 instance ID. Server rechecks the actual instance, then commits an intent before
-sending through Pi. Same UUID/same payload returns the original operation; changed
+sending through Pi. Adapter-specific encoded-frame limits are checked before
+committing intent (JSON escaping can exceed a channel's frame bound even within
+the text limit). Same UUID/same payload returns the original operation; changed
 payload conflicts. A crash/timeout leaves unknown evidence; restart and refresh
 query receipts but never resend. HTTP success/queued/started/settled are execution
 states, not product acceptance. UI retains uncertain messages and their original

--- a/docs/superpowers/specs/2026-09-13-agent-manager-console.md
+++ b/docs/superpowers/specs/2026-09-13-agent-manager-console.md
@@ -1,0 +1,108 @@
+# Agent manager console — first usable slice
+
+Operator requested research then implementation: regularize the JS/TS management
+layer, show shared progress/intervention, and allow direct conversations with a
+backend agent. This design implements that authorized slice without another
+approval round. Existing Character/Edda work continues independently.
+
+## Findings and choice
+
+Pi 0.7 integration already has authenticated per-session status/conversation/send,
+UUID receipts, managed run status, and private-storage helpers. It has 72 passing
+tests and actual Pi evidence. Cross-project selection, browser access, typed DTOs,
+operator-facing progress and a unified operation journal are missing. Global Pi
+discovery currently aborts on one malformed registry record; explicit selections
+avoid letting unrelated damaged records disable the console.
+
+Options considered: extend the Pi CLI with HTML (fast but couples presentation to
+transport); rewrite everything in Rust/TypeScript (unnecessary replacement of live
+receipt behavior); a typed independent TypeScript service over a Pi adapter
+(chosen). New code is strict TypeScript compiled to ESM, with a lockfile and CI.
+Legacy imports exist only at the Pi adapter boundary. Native Node HTTP/SQLite keep
+runtime dependencies small. Type stripping alone is not type checking, so `tsc`
+is an explicit gate, followed by Node tests.
+
+The package is `integrations/agent-manager`. Responsibilities:
+- contracts/config: versioned DTOs and runtime validation of operator configuration;
+- Pi adapter: selected identity, public projection and existing authenticated APIs;
+- store: SQLite management journal, selected configuration revision, send intents;
+- manager: observations/freshness, operation reconciliation and bounded polling;
+- HTTP/CLI: local authenticated gateway, process ownership and fixed static assets;
+- web: Traditional Chinese overview, agent detail/chat, direct message composer.
+
+This service owns operational records only. It does not invent another Edda task
+rail, infer acceptance from runtime idleness, or decide that an unresponsive owner
+is dead. General automatic delegation, non-Pi adapters, Docker lifecycle operations,
+semantic approval replies and remote/public hosting are subsequent slices.
+
+## Visible behavior
+
+Projects group explicitly selected managers/workers. Each agent shows runtime
+state, observation/heartbeat/progress times, last public response, optional
+manager-written summary and provider-reported usage. Offline/stale/unknown remain
+visible alongside healthy agents. An idle response is execution-unverified, never
+automatically a completed task. Registered shared resources show their source and
+ownership as configuration, not a fabricated live health reading. CPU/RSS sampling
+is not in this slice; provider usage and shared-resource bindings are sufficient.
+
+Select an agent to read its public conversation and target that exact agent in the
+composer. Normal messages append after current work (`followUp`); priority
+instructions use `steer` at Pi's next safe point. Neither action directly kills a
+running tool. These are new operator messages, not atomic approval replies bound to
+an old question. The viewed cursor is recorded for provenance; no conversation-head
+CAS claim is made. Branch-invalid pagination is rejected and the client reloads a
+fresh page without discarding its draft. A later explicit decision-response action
+must use the existing inbox epoch/identity contract.
+
+Every send carries a client-generated UUID, selection revision and freshly viewed
+instance ID. Server rechecks the actual instance, then commits an intent before
+sending through Pi. Same UUID/same payload returns the original operation; changed
+payload conflicts. A crash/timeout leaves unknown evidence; restart and refresh
+query receipts but never resend. HTTP success/queued/started/settled are execution
+states, not product acceptance. UI retains uncertain messages and their original
+IDs and offers receipt inspection instead of blind new-ID retry.
+
+A bounded refresh (roughly three seconds) needs no model calls. Changes in runtime,
+last public response, source error and message receipts populate a durable activity
+feed. An unavailable source or summary file cannot disable other agents. Agent chat
+is read on demand and refreshed while selected; raw reasoning/tool arguments and
+Pi authentication material never enter DTOs.
+
+## Security and storage
+
+Bind IPv4 loopback only. Gateway has its own private random bearer token, distinct
+from Pi tokens. Launcher URL uses a fragment; the web app removes it immediately
+and keeps the gateway credential in origin-scoped browser storage. API requests
+need Authorization; no cookie authentication. Reject nonmatching Host/Origin and
+all CORS preflights. Apply no-store, restrictive CSP, no referrers, fixed assets,
+bounded JSON bodies, message/page limits and selected-agent-only routing. Messages
+render as text, never executable HTML. No arbitrary file path or shell command API.
+
+Configuration and SQLite live in an owner-private service directory, with schema
+version validation and no symlink DB/config targets. Single service ownership is
+exclusive; stale ownership is never replaced by killing a saved PID. SQLite
+transactions protect unique operation IDs and intent-before-effect. Restart opens
+the same records and reconciles nonterminal receipts without replay. Event history
+is bounded when returned, and observation retention may be compacted independently
+of durable operations. Gateway records do not overwrite Pi owner/state files.
+
+## Validation and rollout
+
+Focused tests cover config/DTO privacy, source isolation, stale instance, duplicate
+and conflicting sends, uncertain/crashed delivery recovery, branch cursor failures,
+HTTP authentication/Origin/Host/body bounds, restart and read-only observation.
+Actual offline Pi validates browser -> gateway -> Pi -> receipt -> visible reply.
+Browser verification covers desktop/mobile, keyboard, draft retention, agent target
+selection and reconnect/offline states. Live registration of the existing
+Character/Edda managers is read-only; do not probe them with unsolicited work.
+
+Deploy this slice locally and open the real console after independent review and
+required checks. Import the current delegation index plus explicitly selected worker
+IDs and the Character shared-service record. Existing management can consume the
+same operation/event API later; the console does not claim exclusive control over
+all other clients simply because a conversation is open.
+
+Sources: [Node TypeScript execution](https://nodejs.org/api/typescript.html),
+[TypeScript strict](https://www.typescriptlang.org/tsconfig/strict.html), and the
+checked-in `integrations/pi` APIs/tests. No new transport/model/DB service is
+created merely by opening this console.

--- a/integrations/agent-manager/.gitignore
+++ b/integrations/agent-manager/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.runtime/

--- a/integrations/agent-manager/README.md
+++ b/integrations/agent-manager/README.md
@@ -1,0 +1,119 @@
+# Edda agent manager
+
+A local Traditional Chinese progress and conversation console for explicitly
+selected Pi agents. This is the first typed management-service slice: the browser,
+gateway, operational journal and Pi transport have separate boundaries.
+
+## Run
+
+Requires Node24.14+ (tested on24.14.0), Pi channel0.7, and the sibling
+`integrations/pi` source. New code is TypeScript5.9.3 with strict checks and a
+lockfile; `tsc` emits ESM. Native Node SQLite is experimental in Node24 and emits
+its normal warning. The operational schema is versioned; an unknown schema version
+is refused rather than reset. No Docker, external database or frontend CDN is used.
+
+```powershell
+cd integrations/agent-manager
+npm ci --ignore-scripts
+npm run typecheck
+npm test
+
+# Import the currently selected managers; creates config, never launches agents.
+node dist/src/cli.js init --from-delegation C:/Users/fagem/.edda-pi-sessions/delegations/20260912-acceleration/index.json --root C:/Users/fagem/.edda-agent-manager
+node dist/src/cli.js start --root C:/Users/fagem/.edda-agent-manager
+node dist/src/cli.js status --root C:/Users/fagem/.edda-agent-manager
+node dist/src/cli.js url --root C:/Users/fagem/.edda-agent-manager
+node dist/src/cli.js stop --root C:/Users/fagem/.edda-agent-manager
+```
+
+`start` runs a hidden, owned background service; the launching terminal may exit.
+`serve` runs it in the foreground. Default port4390; choose `--port 0` for an
+available temporary port. The private launch URL includes a gateway credential in
+its fragment; the app removes it immediately and stores it only for that browser
+origin. Do not publish that URL. Pi bearer tokens never leave the backend.
+
+`stop` stops the console only. Pi workers and their work continue. Restart uses the
+same configuration/journal, queries old message receipts, and never replays sends.
+A fresh gateway credential is created per service process; reopen its launch URL
+after a restart. If a service crashed, `recover` clears ownership only when the
+recorded PID is demonstrably absent; it never kills a saved PID. Preserve this
+checkout while the service uses its compiled/static files; stop/rebuild/restart for
+an upgrade rather than editing a running release in place.
+
+## Configuration and actual capabilities
+
+`config.json` in the private root is an explicit operator selection. Add a known
+worker by editing the agents array while the console is stopped, then restart.
+Do not enumerate every directory of an unrelated Pi registry. Each agent has:
+
+```json
+{
+  "id": "character",
+  "name": "Character Sol 負責人",
+  "projectId": "character",
+  "role": "manager",
+  "registryRoot": "C:/path/to/private/pi-registry",
+  "sessionId": "actual-pi-session-id",
+  "runId": "actual-managed-run-uuid-or-null",
+  "workspace": "C:/path/to/actual/worktree",
+  "summaryFile": "C:/path/to/selected/status.md"
+}
+```
+
+The complete file is `{version:1, projects:[...], agents:[...], refreshMs:3000}`.
+Projects contain `id`, `name`, `priority` (lower first) and `resources` (registered
+name/kind/details/owner/source, not live health). `runId` and `summaryFile` accept
+JSON null. The importer handles the current Character/Edda delegation index and
+Character's registered PostgreSQL service.
+
+The overview distinguishes runtime activity, source availability, old heartbeat
+metadata, last public response, manager-written summary and provider-reported
+usage. None implies accepted task completion. Refresh and observation make no model
+calls. Missing summaries and unavailable agents do not suppress healthy peers.
+
+Open an agent to read recent public messages and forward-cursor updates. Send an
+append message (`followUp`) or a priority instruction (`steer`) to the exact viewed
+instance. Priority instructions wait for Pi's next safe point; they do not force
+kill a tool. These are new operator messages, not atomic approval answers to an
+old question. The viewed cursor is recorded as provenance only. No generic
+shell/file/URL proxy or service lifecycle action is exposed to the browser.
+
+Each request has a durable UUID before dispatch. Duplicate identical requests
+return the same operation; changed payloads conflict. Unknown outcomes retain the
+same ID and are queried, never automatically resent. The browser preserves drafts
+per recipient and suspends duplicate sending when another tab changes its pending
+evidence. If a branch cursor becomes invalid, reload the conversation while keeping
+the draft. Completed execution receipts still require product acceptance elsewhere.
+
+Messages are bounded to12KiB UTF-8, with additional adapter encoded-frame validation
+before dispatch. HTTP bodies are bounded to96KiB to accommodate JSON escaping.
+Selections and events are bounded per response. One service owns the private SQLite
+journal; operations retain their original target even if a display agent is later
+bound to a new session. The journal does not replace Edda task/decision truth.
+
+## Architecture and checks
+
+- `contracts.ts` / `config.ts`: DTOs, shared limits, versioned configuration validation.
+- `pi-adapter.ts`: sole production legacy-module boundary, exact identity and private projection.
+- `store.ts`: atomic intent/event records and monotonic receipt evidence in SQLite.
+- `manager.ts`: bounded observations, freshness, summaries and receipt reconciliation.
+- `http.ts` / `cli.ts`: loopback bearer gateway, Host/Origin/body/CSP checks and owned service lifecycle.
+- `web/`: text-safe responsive interface; no external scripts, styles or fonts.
+
+`npm test` covers durable intent/restart, stale identity and branch reset, poisoned
+unselected registry records, duplicate/unknown sends, public projection, actual Pi
+channel HTTP and gateway controls, plus background CLI restart.
+
+Actual installed Pi with an offline provider (no paid model invocation):
+
+```powershell
+node dist/test/offline-smoke.js C:/path/to/pi/dist/bundle/cli.js
+# Keep an isolated browser fixture until POST /api/service/stop:
+node dist/test/offline-smoke.js C:/path/to/pi/dist/bundle/cli.js --serve
+```
+
+The smoke preserves its private receipt/workspace path for inspection. Real agents
+are never used as test recipients. General delegation, non-Pi runtimes, structured
+inbox approvals, automatic Docker operations, CPU/RSS sampling and remote hosting
+remain subsequent slices. Opening a conversation does not claim exclusive control
+over independent clients or the parent's existing monitoring automation.

--- a/integrations/agent-manager/package-lock.json
+++ b/integrations/agent-manager/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "@edda/agent-manager",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@edda/agent-manager",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "24.13.4",
+        "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=24.14.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.4.tgz",
+      "integrity": "sha512-YJ7EqCstVTzIr0fMr7qul/977en+pQHrfmuKIo6Zr9i75Be21dr3MovcfvGtyvi2HAUrRerWps5sMO9I7WaxDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/integrations/agent-manager/package.json
+++ b/integrations/agent-manager/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@edda/agent-manager",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": { "node": ">=24.14.0" },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc",
+    "test": "npm run build && node --test dist/test/*.test.js",
+    "start": "node dist/src/cli.js"
+  },
+  "devDependencies": { "@types/node": "24.13.4", "typescript": "5.9.3" }
+}

--- a/integrations/agent-manager/src/cli.ts
+++ b/integrations/agent-manager/src/cli.ts
@@ -1,0 +1,140 @@
+import { spawn } from 'node:child_process';
+import { randomBytes, randomUUID } from 'node:crypto';
+import { closeSync, existsSync, lstatSync, openSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as delay } from 'node:timers/promises';
+import { AgentManager } from './manager.js';
+import { ManagerStore } from './store.js';
+import { ChannelAdapter, defaultPiRoot, secureRoot } from './pi-adapter.js';
+import { hash, loadConfig, object, parseConfig, text } from './config.js';
+import { serve } from './http.js';
+import type { AgentBinding, ManagerConfig, ProjectView } from './contracts.js';
+
+interface Owner { version: 1; pid: number; instanceId: string; origin: string; token: string; configDigest: string; startedAt: string }
+const [command = 'help', ...args] = process.argv.slice(2), flags = new Map<string, string>();
+for (let i = 0; i < args.length; i += 2) {
+  const name = args[i], value = args[i + 1];
+  if (!name?.startsWith('--') || !value || flags.has(name)) throw new Error('Flags require one unique value each');
+  flags.set(name, value);
+}
+for (const name of flags.keys()) if (!['--root', '--config', '--port', '--pi-root', '--from-delegation', '--instance'].includes(name)) throw new Error(`Unknown option ${name}`);
+const root = resolve(flags.get('--root') || join(homedir(), '.edda-agent-manager'));
+const configFile = resolve(flags.get('--config') || join(root, 'config.json'));
+const piRoot = resolve(flags.get('--pi-root') || defaultPiRoot());
+const port = Number(flags.get('--port') ?? 4390);
+if (!Number.isSafeInteger(port) || port < 0 || port > 65535) throw new Error('Port must be 0..65535');
+const ownerPath = join(root, 'owner.json'), lockPath = join(root, 'service.lock');
+function read(file: string): unknown {
+  const stat = lstatSync(file);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 262144) throw new Error('Invalid bounded configuration record');
+  return JSON.parse(readFileSync(file, 'utf8')) as unknown;
+}
+function owner(): Owner {
+  const value = object(read(ownerPath));
+  if (value.version !== 1 || typeof value.origin !== 'string' || !/^http:\/\/127\.0\.0\.1:[0-9]+$/.test(value.origin) ||
+    typeof value.token !== 'string' || !/^[a-f0-9]{64}$/.test(value.token) || !Number.isSafeInteger(value.pid) || Number(value.pid) <= 0 || typeof value.instanceId !== 'string') throw new Error('Invalid service owner');
+  return value as unknown as Owner;
+}
+function alive(pid: number): boolean { try { process.kill(pid, 0); return true; } catch (e) { if ((e as NodeJS.ErrnoException).code === 'ESRCH') return false; throw e; } }
+async function service(record: Owner): Promise<unknown> {
+  const response = await fetch(`${record.origin}/api/service`, { headers: { authorization: `Bearer ${record.token}` }, signal: AbortSignal.timeout(2000), redirect: 'error' });
+  if (!response.ok) throw new Error('Service authentication failed');
+  const value = object(await response.json() as unknown);
+  if (value.startedAt !== record.startedAt) throw new Error('Service identity changed');
+  return value;
+}
+function fromDelegation(file: string): ManagerConfig {
+  const input = object(read(file)), base = dirname(file), projects: ProjectView[] = [], agents: AgentBinding[] = [];
+  for (const id of ['character', 'edda']) {
+    const source = object(input[id]), name = id === 'character' ? 'Character' : 'Edda';
+    const project: ProjectView = { id, name, priority: id === 'character' ? 0 : 10, resources: [] };
+    if (typeof source.servicesFile === 'string') {
+      const services = object(read(resolve(base, source.servicesFile))), pg = object(services.postgres);
+      if (pg.container && pg.testDatabase) project.resources.push({ id: 'postgres', name: '共用 PostgreSQL', kind: 'database',
+        details: `${text(pg.host)}:${Number(pg.port)} / ${text(pg.testDatabase)}\n容器：${text(pg.container)}\n資料卷：${text(pg.dataVolume)}`,
+        owner: text(pg.lifecycleOwner, 500), source: '交接服務登記；未進行即時健康探測' });
+    }
+    projects.push(project);
+    agents.push({ id, name: `${name} ${id === 'character' ? 'Sol' : 'Flash'} 負責人`, role: 'manager', projectId: id,
+      registryRoot: text(source.registryRoot, 4096), workspace: text(source.worktree, 4096), sessionId: text(source.sessionId),
+      runId: text(source.runId), summaryFile: typeof source.statusFile === 'string' ? resolve(base, source.statusFile) : null });
+  }
+  return parseConfig({ version: 1, projects, agents, refreshMs: 3000 });
+}
+async function main(): Promise<void> {
+  if (command === 'help') {
+    console.log('Agent manager (Node24)\n  init --from-delegation INDEX --root PRIVATE_DIR\n  start|serve --root PRIVATE_DIR [--config FILE] [--port 4390] [--pi-root DIR]\n  status|url|stop|recover --root PRIVATE_DIR\nPrivate launch URL contains the gateway credential. Existing agents are never started or stopped by these commands.'); return;
+  }
+  if (command === 'init') {
+    const input = flags.get('--from-delegation'); if (!input) throw new Error('init requires --from-delegation');
+    await secureRoot(root, piRoot);
+    const config = fromDelegation(resolve(input));
+    writeFileSync(configFile, JSON.stringify(config, null, 2) + '\n', { flag: 'wx', mode: 0o600 });
+    console.log(JSON.stringify({ configFile, selectedAgents: config.agents.map((a) => a.id), agentsStarted: false })); return;
+  }
+  if (command === 'recover') {
+    const lock = object(read(lockPath));
+    if (!Number.isSafeInteger(lock.pid) || Number(lock.pid) <= 0 || alive(Number(lock.pid))) throw new Error('Cannot prove service owner is dead; no recovery performed');
+    if (existsSync(ownerPath) && owner().instanceId !== lock.instanceId) throw new Error('Owner generation mismatch');
+    if (existsSync(ownerPath)) unlinkSync(ownerPath);
+    unlinkSync(lockPath); console.log(JSON.stringify({ recovered: true, agentsChanged: false, operationsReplayed: false })); return;
+  }
+  if (['status', 'url', 'stop'].includes(command)) {
+    const current = owner(), info = await service(current);
+    if (command === 'url') console.log(`${current.origin}/#token=${current.token}`);
+    else if (command === 'status') console.log(JSON.stringify({ ...object(info), origin: current.origin, pid: current.pid, instanceId: current.instanceId }));
+    else {
+      const response = await fetch(`${current.origin}/api/service/stop`, { method: 'POST', headers: { authorization: `Bearer ${current.token}`, 'content-type': 'application/json' }, body: '{}', signal: AbortSignal.timeout(5000) });
+      if (!response.ok) throw new Error('Service stop failed');
+      console.log(JSON.stringify(await response.json()));
+    }
+    return;
+  }
+  if (command !== 'start' && command !== 'serve') throw new Error('Unknown command');
+  const config = loadConfig(configFile), configDigest = hash(JSON.stringify(config));
+  await secureRoot(root, piRoot);
+  if (command === 'start') {
+    if (existsSync(lockPath)) {
+      const current = owner(); await service(current);
+      if (current.configDigest !== configDigest) throw new Error('Service is running with another configuration; stop it before changing selections');
+      console.log(JSON.stringify({ reused: true, origin: current.origin, url: `${current.origin}/#token=${current.token}` })); return;
+    }
+    const instanceId = randomUUID(), fd = openSync(join(root, 'service.log'), 'a', 0o600);
+    const child = spawn(process.execPath, [fileURLToPath(import.meta.url), 'serve', '--root', root, '--config', configFile, '--port', String(port), '--pi-root', piRoot, '--instance', instanceId],
+      { cwd: root, windowsHide: true, detached: true, stdio: ['ignore', fd, fd] });
+    let spawnError: Error | null = null; child.on('error', (e) => { spawnError = e; }); child.unref(); closeSync(fd);
+    for (let i = 0; i < 80; i++) {
+      if (spawnError) throw spawnError;
+      if (child.exitCode !== null || child.signalCode !== null) throw new Error('Service exited before readiness; inspect private service.log');
+      if (existsSync(ownerPath)) {
+        const current = owner();
+        if (current.instanceId !== instanceId) throw new Error('Another start owns this root; inspect status rather than spawning again');
+        await service(current); console.log(JSON.stringify({ started: true, origin: current.origin, url: `${current.origin}/#token=${current.token}`, pid: current.pid })); return;
+      }
+      await delay(250);
+    }
+    throw new Error('Startup is not confirmed; inspect private service.log and status before another start');
+  }
+  const instanceId = flags.get('--instance') || randomUUID();
+  writeFileSync(lockPath, JSON.stringify({ pid: process.pid, instanceId }), { flag: 'wx', mode: 0o600 });
+  let store: ManagerStore | undefined, manager: AgentManager | undefined, gateway: Awaited<ReturnType<typeof serve>> | undefined, closing = false;
+  const shutdown = async (): Promise<void> => {
+    if (closing) return; closing = true;
+    await manager?.stop(); await gateway?.close(); store?.close();
+    if (existsSync(ownerPath) && owner().instanceId === instanceId) unlinkSync(ownerPath);
+    if (object(read(lockPath)).instanceId === instanceId) unlinkSync(lockPath);
+  };
+  try {
+    store = new ManagerStore(root); manager = new AgentManager(config, store, await ChannelAdapter.create(piRoot));
+    await manager.start();
+    const token = randomBytes(32).toString('hex');
+    gateway = await serve(manager, token, { port, onStop: () => { void shutdown(); } });
+    const record: Owner = { version: 1, pid: process.pid, instanceId, origin: gateway.origin, token, configDigest, startedAt: manager.startedAt };
+    writeFileSync(ownerPath, JSON.stringify(record), { flag: 'wx', mode: 0o600 });
+    process.once('SIGINT', () => { void shutdown(); }); process.once('SIGTERM', () => { void shutdown(); });
+    console.log(`Agent manager: ${gateway.origin}/#token=${token}`);
+  } catch (error) { await shutdown(); throw error; }
+}
+void main().catch((error: unknown) => { console.error(error instanceof Error ? error.message : 'Manager operation failed'); process.exitCode = 1; });

--- a/integrations/agent-manager/src/config.ts
+++ b/integrations/agent-manager/src/config.ts
@@ -1,0 +1,81 @@
+import { createHash } from 'node:crypto';
+import { isAbsolute, resolve } from 'node:path';
+import { lstatSync, readFileSync } from 'node:fs';
+import { ManagerError, MAX_MESSAGE_BYTES, type AgentBinding, type ManagerConfig, type SendRequest } from './contracts.js';
+
+export function object(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new ManagerError('INVALID_DATA', '資料格式不正確。');
+  return value as Record<string, unknown>;
+}
+export function text(value: unknown, max = 200): string {
+  if (typeof value !== 'string' || !value.trim() || value.length > max) throw new ManagerError('INVALID_DATA', '文字欄位為空或過長。');
+  return value;
+}
+export function slug(value: unknown): string {
+  const result = text(value, 64);
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/.test(result)) throw new ManagerError('INVALID_ID', '識別碼格式不正確。');
+  return result;
+}
+export function uuid(value: unknown): string {
+  const result = text(value, 36).toLowerCase();
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(result)) throw new ManagerError('INVALID_ID', '操作識別碼格式不正確。');
+  return result;
+}
+function path(value: unknown): string {
+  const result = text(value, 4096);
+  if (!isAbsolute(result)) throw new ManagerError('INVALID_CONFIG', '設定中的路徑必須是絕對路徑。');
+  return resolve(result);
+}
+function array(value: unknown, max: number): unknown[] {
+  if (!Array.isArray(value) || value.length > max) throw new ManagerError('INVALID_CONFIG', '設定清單格式或大小不正確。');
+  return value;
+}
+function unique(values: string[]): void {
+  if (new Set(values).size !== values.length) throw new ManagerError('INVALID_CONFIG', '設定中有重複的識別碼或代理。');
+}
+export const hash = (value: string): string => createHash('sha256').update(value).digest('hex');
+export const selectionRevision = (binding: AgentBinding): string => hash(JSON.stringify(binding));
+export function parseConfig(input: unknown): ManagerConfig {
+  const c = object(input);
+  if (c.version !== 1) throw new ManagerError('INVALID_CONFIG', '不支援的設定版本。');
+  const projects = array(c.projects, 16).map((value) => {
+    const p = object(value), priority = p.priority ?? 10;
+    if (!Number.isSafeInteger(priority) || Number(priority) < 0 || Number(priority) > 100) throw new ManagerError('INVALID_CONFIG', '優先順序必須是 0 到 100。');
+    const resources = array(p.resources ?? [], 16).map((value) => {
+      const r = object(value);
+      return { id: slug(r.id), name: text(r.name), kind: text(r.kind), details: text(r.details, 2000), owner: text(r.owner, 500), source: text(r.source, 500) };
+    });
+    unique(resources.map((r) => r.id));
+    return { id: slug(p.id), name: text(p.name), priority: Number(priority), resources };
+  });
+  const agents = array(c.agents, 32).map((value): AgentBinding => {
+    const a = object(value), role = a.role;
+    if (role !== 'manager' && role !== 'worker') throw new ManagerError('INVALID_CONFIG', '代理角色不正確。');
+    const sessionId = text(a.sessionId, 200);
+    if (!/^[a-zA-Z0-9][a-zA-Z0-9_.:-]*$/.test(sessionId)) throw new ManagerError('INVALID_CONFIG', 'Session 識別碼不正確。');
+    const projectId = slug(a.projectId);
+    if (!projects.some((p) => p.id === projectId)) throw new ManagerError('INVALID_CONFIG', '代理所屬專案未登記。');
+    return { id: slug(a.id), name: text(a.name), role, projectId, registryRoot: path(a.registryRoot), sessionId,
+      runId: a.runId == null ? null : uuid(a.runId), workspace: path(a.workspace), summaryFile: a.summaryFile == null ? null : path(a.summaryFile) };
+  });
+  unique(projects.map((p) => p.id)); unique(agents.map((a) => a.id));
+  unique(agents.map((a) => `${a.registryRoot}\0${a.sessionId}`));
+  const refreshMs = c.refreshMs ?? 3000;
+  if (!Number.isSafeInteger(refreshMs) || Number(refreshMs) < 1000 || Number(refreshMs) > 60000) throw new ManagerError('INVALID_CONFIG', '更新間隔必須是 1 到 60 秒。');
+  return { version: 1, projects: projects.sort((a, b) => a.priority - b.priority), agents, refreshMs: Number(refreshMs) };
+}
+export function loadConfig(file: string): ManagerConfig {
+  const stat = lstatSync(file);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 262144) throw new ManagerError('INVALID_CONFIG', '設定必須是小於 256 KiB 的一般檔案。');
+  try { return parseConfig(JSON.parse(readFileSync(file, 'utf8')) as unknown); }
+  catch (error) { if (error instanceof ManagerError) throw error; throw new ManagerError('INVALID_CONFIG', '無法解析管理設定。'); }
+}
+export function parseSend(input: unknown): SendRequest {
+  const r = object(input), mode = r.mode;
+  if (mode !== 'followUp' && mode !== 'steer') throw new ManagerError('INVALID_REQUEST', '請選擇追加訊息或優先指令。');
+  if (typeof r.message !== 'string' || !r.message.trim()) throw new ManagerError('INVALID_REQUEST', '訊息不可空白。');
+  const message = r.message;
+  if (Buffer.byteLength(message) > MAX_MESSAGE_BYTES) throw new ManagerError('TOO_LARGE', '訊息超過 12 KiB。', 413);
+  return { operationId: uuid(r.operationId), selectionRevision: text(r.selectionRevision, 64), instanceId: uuid(r.instanceId),
+    basisCursor: r.basisCursor == null ? null : text(r.basisCursor, 200), mode, message };
+}

--- a/integrations/agent-manager/src/contracts.ts
+++ b/integrations/agent-manager/src/contracts.ts
@@ -1,0 +1,60 @@
+export type RuntimeState = 'running' | 'executing_tool' | 'idle' | 'waiting_user' | 'stopped' | 'unavailable' | 'unknown';
+export type MessageMode = 'followUp' | 'steer';
+export type OperationStatus = 'prepared' | 'unconfirmed' | 'accepted' | 'queued' | 'started' | 'settled' | 'failed' | 'unknown';
+export interface ResourceView { id: string; name: string; kind: string; details: string; owner: string; source: string }
+export interface ProjectView { id: string; name: string; priority: number; resources: ResourceView[] }
+export interface AgentBinding {
+  id: string; name: string; projectId: string; role: 'manager' | 'worker';
+  registryRoot: string; sessionId: string; runId: string | null; workspace: string;
+  summaryFile: string | null;
+}
+export interface ManagerConfig { version: 1; projects: ProjectView[]; agents: AgentBinding[]; refreshMs: number }
+export interface ModelView { provider: string; id: string }
+export interface UsageView { tokens: number | null; reportedCost: number | null }
+export interface PublicEntry {
+  id: string; timestamp: string | null; kind: 'message' | 'tool_result';
+  role: 'user' | 'assistant' | null; text: string; truncated: boolean;
+  toolName: string | null; toolError: boolean;
+}
+export interface AgentObservation {
+  state: RuntimeState; instanceId: string | null; observedAt: string;
+  heartbeatAt: string | null; lastProgressAt: string | null; lastEvent: string | null;
+  source: 'live' | 'unavailable'; stale: boolean; reason: string | null;
+  model: ModelView | null; usage: UsageView | null;
+  capabilities: { conversation: boolean; send: boolean };
+  latestMessage: PublicEntry | null;
+}
+export interface AgentView extends AgentObservation {
+  id: string; name: string; role: 'manager' | 'worker'; projectId: string;
+  workspace: string; transport: 'pi'; selectionRevision: string;
+  summary: string | null; summaryUpdatedAt: string | null; summaryError: string | null;
+}
+export interface ConversationView {
+  agentId: string; selectionRevision: string; instanceId: string | null;
+  entries: PublicEntry[]; cursor: string | null; headCursor: string | null;
+  hasMore: boolean; observedAt: string; source: 'live' | 'unavailable';
+}
+export interface SendRequest {
+  operationId: string; selectionRevision: string; instanceId: string;
+  basisCursor: string | null; mode: MessageMode; message: string;
+}
+export interface OperationView {
+  id: string; agentId: string; instanceId: string; basisCursor: string | null;
+  mode: MessageMode; message: string; status: OperationStatus;
+  createdAt: string; updatedAt: string; notice: string;
+}
+export interface ManagerEvent { id: number; at: string; agentId: string; kind: 'observation' | 'message'; summary: string; operationId: string | null }
+export interface Overview {
+  version: 1; generatedAt: string; startedAt: string; refreshMs: number;
+  projects: ProjectView[]; agents: AgentView[]; events: ManagerEvent[]; operations: OperationView[];
+}
+export interface AdapterReceipt { status: OperationStatus; instanceId: string; sessionId: string; id: string }
+export interface PiAdapter {
+  observe(binding: AgentBinding): Promise<AgentObservation>;
+  conversation(binding: AgentBinding, after?: string): Promise<Omit<ConversationView, 'agentId' | 'selectionRevision'>>;
+  send(binding: AgentBinding, request: SendRequest): Promise<AdapterReceipt>;
+  receipt(binding: AgentBinding, operation: OperationView): Promise<AdapterReceipt | null>;
+}
+export class ManagerError extends Error {
+  constructor(public code: string, message: string, public status = 400) { super(message); }
+}

--- a/integrations/agent-manager/src/contracts.ts
+++ b/integrations/agent-manager/src/contracts.ts
@@ -1,3 +1,6 @@
+export const MAX_MESSAGE_BYTES = 12 * 1024;
+// JSON escaping can expand each control character to six ASCII bytes.
+export const MAX_BODY_BYTES = 96 * 1024;
 export type RuntimeState = 'running' | 'executing_tool' | 'idle' | 'waiting_user' | 'stopped' | 'unavailable' | 'unknown';
 export type MessageMode = 'followUp' | 'steer';
 export type OperationStatus = 'prepared' | 'unconfirmed' | 'accepted' | 'queued' | 'started' | 'settled' | 'failed' | 'unknown';
@@ -50,6 +53,7 @@ export interface Overview {
 }
 export interface AdapterReceipt { status: OperationStatus; instanceId: string; sessionId: string; id: string }
 export interface PiAdapter {
+  validateMessage?(request: SendRequest): void;
   observe(binding: AgentBinding): Promise<AgentObservation>;
   conversation(binding: AgentBinding, after?: string): Promise<Omit<ConversationView, 'agentId' | 'selectionRevision'>>;
   send(binding: AgentBinding, request: SendRequest): Promise<AdapterReceipt>;

--- a/integrations/agent-manager/src/http.ts
+++ b/integrations/agent-manager/src/http.ts
@@ -1,0 +1,85 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { timingSafeEqual } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+import { AgentManager } from './manager.js';
+import { ManagerError, MAX_BODY_BYTES } from './contracts.js';
+import { parseSend, uuid } from './config.js';
+
+function authorized(header: string | undefined, token: string): boolean {
+  const expected = Buffer.from(`Bearer ${token}`), value = Buffer.from(header || '');
+  return expected.length === value.length && timingSafeEqual(expected, value);
+}
+async function body(req: IncomingMessage): Promise<unknown> {
+  if (Number(req.headers['content-length'] || 0) > MAX_BODY_BYTES) throw new ManagerError('TOO_LARGE', '請縮短訊息後再傳送。', 413);
+  if (!req.headers['content-type']?.toLowerCase().startsWith('application/json')) throw new ManagerError('INVALID_REQUEST', '請使用 JSON 格式。', 400);
+  const buffer = await new Promise<Buffer>((resolve, reject) => {
+    const chunks: Buffer[] = []; let length = 0, overflow = false;
+    req.on('data', (chunk: Buffer) => {
+      if (overflow) return;
+      length += chunk.length;
+      if (length > MAX_BODY_BYTES) { overflow = true; chunks.length = 0; reject(new ManagerError('TOO_LARGE', '請縮短訊息後再傳送。', 413)); }
+      else chunks.push(chunk);
+    });
+    req.once('end', () => { if (!overflow) resolve(Buffer.concat(chunks)); });
+    req.once('error', reject);
+    req.once('aborted', () => reject(new ManagerError('INVALID_REQUEST', '請求已中斷。')));
+  });
+  try { return JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(buffer)) as unknown; }
+  catch { throw new ManagerError('INVALID_REQUEST', '無法解析這則請求。'); }
+}
+export async function serve(manager: AgentManager, token: string, options: { port?: number; assetsRoot?: string; onStop?: () => void } = {}) {
+  if (!/^[a-f0-9]{64}$/.test(token)) throw new Error('Invalid gateway token');
+  const root = options.assetsRoot || fileURLToPath(new URL('../../', import.meta.url));
+  const assets = new Map([
+    ['/', { file: join(root, 'src/web/index.html'), type: 'text/html; charset=utf-8' }],
+    ['/app.js', { file: join(root, 'dist/src/web/app.js'), type: 'text/javascript; charset=utf-8' }],
+    ['/contracts.js', { file: join(root, 'dist/src/contracts.js'), type: 'text/javascript; charset=utf-8' }],
+    ['/style.css', { file: join(root, 'src/web/style.css'), type: 'text/css; charset=utf-8' }],
+  ]);
+  let origin = '';
+  const server = createServer({ maxHeaderSize: 8192 }, (req, res) => { void handle(req, res); });
+  server.requestTimeout = 15000; server.headersTimeout = 10000; server.keepAliveTimeout = 5000;
+  async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    res.setHeader('Cache-Control', 'no-store'); res.setHeader('Referrer-Policy', 'no-referrer');
+    res.setHeader('X-Content-Type-Options', 'nosniff'); res.setHeader('X-Frame-Options', 'DENY');
+    res.setHeader('Content-Security-Policy', "default-src 'none'; script-src 'self'; style-src 'self'; connect-src 'self'; img-src 'self'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'");
+    const json = (status: number, value: unknown): void => { res.writeHead(status, { 'content-type': 'application/json; charset=utf-8' }); res.end(JSON.stringify(value)); };
+    try {
+      if (req.headers.host !== origin.slice(7) || (req.headers.origin && req.headers.origin !== origin) || req.method === 'OPTIONS') throw new ManagerError('FORBIDDEN', '請從本機管理台開啟。', 403);
+      if (!req.url || req.url.length > 2048) throw new ManagerError('INVALID_REQUEST', '請求網址過長。');
+      const url = new URL(req.url, origin);
+      if (url.searchParams.has('token')) throw new ManagerError('INVALID_REQUEST', '登入憑證不能放在網址查詢參數。');
+      const asset = assets.get(url.pathname);
+      if (req.method === 'GET' && asset) { res.writeHead(200, { 'content-type': asset.type }); res.end(readFileSync(asset.file)); return; }
+      if (!authorized(req.headers.authorization, token)) throw new ManagerError('UNAUTHORIZED', '請使用啟動時提供的管理台連結。', 401);
+      if (req.method === 'GET' && url.pathname === '/api/overview') { json(200, manager.overview()); return; }
+      if (req.method === 'GET' && url.pathname === '/api/service') { json(200, { version: 1, startedAt: manager.startedAt, agents: manager.config.agents.length }); return; }
+      const agent = /^\/api\/agents\/([a-zA-Z0-9][a-zA-Z0-9_-]{0,63})\/(conversation|messages)$/.exec(url.pathname);
+      if (agent?.[1] && agent[2] === 'conversation' && req.method === 'GET') {
+        const after = url.searchParams.get('after');
+        if (after && after.length > 200) throw new ManagerError('INVALID_REQUEST', '對話游標過長。');
+        json(200, await manager.conversation(agent[1], after || undefined)); return;
+      }
+      if (agent?.[1] && agent[2] === 'messages' && req.method === 'POST') {
+        const request = parseSend(await body(req)); json(202, await manager.send(agent[1], request)); return;
+      }
+      const operation = /^\/api\/operations\/([a-fA-F0-9-]{36})$/.exec(url.pathname);
+      if (req.method === 'GET' && operation?.[1]) { json(200, await manager.operation(uuid(operation[1]))); return; }
+      if (req.method === 'POST' && url.pathname === '/api/service/stop' && options.onStop) {
+        await body(req); json(200, { status: 'stopping', agentsStopped: false }); setImmediate(options.onStop); return;
+      }
+      throw new ManagerError('NOT_FOUND', '找不到這個管理項目。', 404);
+    } catch (error) {
+      if (res.headersSent || res.destroyed) { res.end(); return; }
+      const known = error instanceof ManagerError;
+      res.setHeader('Connection', 'close'); req.resume();
+      json(known ? error.status : 500, { error: { code: known ? error.code : 'INTERNAL', message: known ? error.message : '管理服務暫時無法完成請求；不會自動重送訊息。' } });
+    }
+  }
+  await new Promise<void>((resolve, reject) => { server.once('error', reject); server.listen(options.port ?? 0, '127.0.0.1', resolve); });
+  const address = server.address(); if (!address || typeof address === 'string') throw new Error('Missing local address');
+  origin = `http://127.0.0.1:${address.port}`;
+  return { origin, port: address.port, close: async () => { await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve())); } };
+}

--- a/integrations/agent-manager/src/manager.ts
+++ b/integrations/agent-manager/src/manager.ts
@@ -1,0 +1,115 @@
+import { lstatSync, readFileSync } from 'node:fs';
+import { ManagerError, type AgentBinding, type AgentView, type ConversationView, type ManagerConfig, type OperationStatus, type OperationView, type Overview, type PiAdapter, type SendRequest } from './contracts.js';
+import { hash, selectionRevision } from './config.js';
+import { unavailable } from './pi-adapter.js';
+import { ManagerStore } from './store.js';
+
+const notices: Record<OperationStatus, string> = {
+  prepared: '操作已記錄，傳送結果尚未確認。', unconfirmed: '通道已收件，尚未確認代理開始處理。',
+  accepted: '通道已接受，尚未確認代理開始處理。', queued: '訊息已排入佇列，等待代理處理。',
+  started: '代理已開始處理這則訊息。', settled: '本輪回覆已結束；工作結果仍需驗收。',
+  failed: '這次訊息未能執行，請查看原因。', unknown: '結果尚待確認；保留原編號，不會自動重送。',
+};
+const labels: Record<AgentView['state'], string> = { running: '執行中', executing_tool: '正在使用工具', idle: '本輪回覆已結束，結果待確認', waiting_user: '等待原介面的選項', stopped: '已停止', unavailable: '暫時無法取得狀態', unknown: '狀態尚待確認' };
+function summary(binding: AgentBinding): Pick<AgentView, 'summary' | 'summaryUpdatedAt' | 'summaryError'> {
+  if (!binding.summaryFile) return { summary: null, summaryUpdatedAt: null, summaryError: null };
+  try {
+    const stat = lstatSync(binding.summaryFile);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 65536) throw new Error('Invalid summary');
+    const value = new TextDecoder('utf-8', { fatal: true }).decode(readFileSync(binding.summaryFile));
+    return { summary: value.slice(0, 12000), summaryUpdatedAt: stat.mtime.toISOString(), summaryError: value.length > 12000 ? '摘要過長，只顯示前段。' : null };
+  } catch { return { summary: null, summaryUpdatedAt: null, summaryError: '目前沒有可讀取的主管摘要。' }; }
+}
+export class AgentManager {
+  readonly startedAt = new Date().toISOString();
+  private views = new Map<string, AgentView>();
+  private refreshing: Promise<void> | null = null;
+  private checking = new Map<string, Promise<OperationView>>();
+  private timer: ReturnType<typeof setInterval> | undefined;
+  constructor(readonly config: ManagerConfig, readonly store: ManagerStore, private adapter: PiAdapter) {
+    store.putSetting('config', JSON.stringify(config));
+  }
+  binding(id: string): AgentBinding {
+    const binding = this.config.agents.find((a) => a.id === id);
+    if (!binding) throw new ManagerError('NOT_FOUND', '此代理未加入管理清單。', 404);
+    return binding;
+  }
+  private view(binding: AgentBinding, observation = unavailable()): AgentView {
+    return { ...observation, id: binding.id, name: binding.name, role: binding.role, projectId: binding.projectId,
+      workspace: binding.workspace, transport: 'pi', selectionRevision: selectionRevision(binding), ...summary(binding) };
+  }
+  overview(): Overview {
+    const selected = new Set(this.config.agents.map((a) => a.id));
+    return { version: 1, generatedAt: new Date().toISOString(), startedAt: this.startedAt, refreshMs: this.config.refreshMs,
+      projects: this.config.projects, agents: this.config.agents.map((a) => this.views.get(a.id) || this.view(a)),
+      events: this.store.events().filter((e) => selected.has(e.agentId)), operations: this.store.operations().filter((op) => selected.has(op.agentId)) };
+  }
+  async refresh(): Promise<void> {
+    if (this.refreshing) return this.refreshing;
+    this.refreshing = this.doRefresh().finally(() => { this.refreshing = null; });
+    return this.refreshing;
+  }
+  private async doRefresh(): Promise<void> {
+    await Promise.all(this.config.agents.map(async (binding) => {
+      let observation;
+      try { observation = await this.adapter.observe(binding); } catch { observation = unavailable(); }
+      const prior = this.views.get(binding.id);
+      if (observation.source === 'unavailable' && prior) observation = { ...observation, latestMessage: observation.latestMessage ?? prior.latestMessage, model: observation.model ?? prior.model,
+        usage: observation.usage ?? prior.usage, lastProgressAt: observation.lastProgressAt ?? prior.lastProgressAt, heartbeatAt: observation.heartbeatAt ?? prior.heartbeatAt };
+      const view = this.view(binding, observation);
+      this.views.set(binding.id, view);
+      const fingerprint = hash(JSON.stringify([view.instanceId, view.state, view.source, view.stale, view.reason, view.latestMessage?.id]));
+      this.store.observation(binding.id, fingerprint, `${binding.name}：${labels[view.state]}`);
+    }));
+    await Promise.all(this.store.operations(100).filter((op) => this.config.agents.some((a) => a.id === op.agentId) && !['settled', 'failed'].includes(op.status))
+      .map((op) => this.reconcile(op).catch(() => op)));
+  }
+  async start(): Promise<void> { await this.refresh(); this.timer = setInterval(() => { void this.refresh().catch(() => {}); }, this.config.refreshMs); }
+  async stop(): Promise<void> { clearInterval(this.timer); if (this.refreshing) await this.refreshing; await Promise.allSettled(this.checking.values()); }
+  async conversation(id: string, after?: string): Promise<ConversationView> {
+    const binding = this.binding(id), result = await this.adapter.conversation(binding, after);
+    return { ...result, agentId: id, selectionRevision: selectionRevision(binding) };
+  }
+  async send(id: string, request: SendRequest): Promise<OperationView> {
+    const binding = this.binding(id);
+    const existing = this.store.existing(id, request);
+    if (existing) return existing; // Never replay a duplicate, including an uncertain intent.
+    this.adapter.validateMessage?.(request);
+    if (request.selectionRevision !== selectionRevision(binding)) throw new ManagerError('STALE_SELECTION', '代理綁定已變更，請更新畫面後再傳送。', 409);
+    const state = await this.adapter.observe(binding);
+    if (state.source !== 'live' || !state.capabilities.send) throw new ManagerError('UNAVAILABLE', '代理目前無法接收訊息，尚未傳送。', 503);
+    if (state.instanceId !== request.instanceId) throw new ManagerError('INSTANCE_CHANGED', '代理已更換執行實例，請先更新畫面。', 409);
+    if (state.state === 'waiting_user') throw new ManagerError('WAITING_USER', '請先處理代理原介面上的結構化選項，這次尚未傳送。', 409);
+    const concurrent = this.store.existing(id, request);
+    if (concurrent) return concurrent;
+    const operation = this.store.begin(binding, request);
+    try {
+      const receipt = await this.adapter.send(binding, request);
+      if (receipt.id !== operation.id || receipt.sessionId !== binding.sessionId || receipt.instanceId !== operation.instanceId) return this.store.update(operation.id, 'unknown', notices.unknown);
+      return this.store.update(operation.id, receipt.status, notices[receipt.status]);
+    } catch (error) {
+      const definite = error instanceof ManagerError && ['UNAVAILABLE', 'INSTANCE_CHANGED', 'WAITING_USER'].includes(error.code);
+      return this.store.update(operation.id, definite ? 'failed' : 'unknown', definite ? error.message : notices.unknown);
+    }
+  }
+  async operation(id: string): Promise<OperationView> {
+    const operation = this.store.operation(id);
+    if (!operation) throw new ManagerError('NOT_FOUND', '尚未找到這次傳送的紀錄；請保留原編號。', 404);
+    this.binding(operation.agentId);
+    return this.reconcile(operation);
+  }
+  private async reconcile(operation: OperationView): Promise<OperationView> {
+    if (['settled', 'failed'].includes(operation.status)) return operation;
+    const checking = this.checking.get(operation.id); if (checking) return checking;
+    const promise = (async () => {
+      // Receipt identity belongs to the immutable original binding, even if the
+      // operator later assigns the display agent to a new Pi session.
+      const target = this.store.target(operation.id);
+      if (!target) return operation;
+      const r = await this.adapter.receipt(target, operation);
+      if (!r || r.id !== operation.id || r.sessionId !== target.sessionId || r.instanceId !== operation.instanceId) return this.store.operation(operation.id) || operation;
+      return this.store.update(operation.id, r.status, notices[r.status]);
+    })().finally(() => { this.checking.delete(operation.id); });
+    this.checking.set(operation.id, promise); return promise;
+  }
+}

--- a/integrations/agent-manager/src/pi-adapter.ts
+++ b/integrations/agent-manager/src/pi-adapter.ts
@@ -1,0 +1,145 @@
+import { realpathSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { ManagerError, type AdapterReceipt, type AgentBinding, type AgentObservation, type ConversationView, type OperationStatus, type OperationView, type PiAdapter, type PublicEntry, type RuntimeState, type SendRequest } from './contracts.js';
+
+// This is the only legacy-module boundary. All values crossing back are projected
+// from unknown JSON into explicit DTO fields; no Pi owner/runner object is returned.
+interface LegacyClient {
+  requestSession(root: string, id: string, path: string, body?: unknown, timeout?: number, instance?: string): Promise<unknown>;
+  getReceipt(root: string, id: string, operationId: string): Promise<unknown>;
+}
+interface LegacyManaged { managedStatus(root: string, id: string): Promise<unknown> }
+interface LegacyStore { privateRoot(root: string): string }
+export const defaultPiRoot = (): string => fileURLToPath(new URL('../../../pi/', import.meta.url));
+export async function secureRoot(root: string, piRoot = defaultPiRoot()): Promise<string> {
+  const legacy = await import(pathToFileURL(resolve(piRoot, 'store.mjs')).href) as LegacyStore;
+  return legacy.privateRoot(root);
+}
+const record = (value: unknown): Record<string, unknown> => value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+const str = (value: unknown, max = 1000): string | null => typeof value === 'string' ? value.slice(0, max) : null;
+const date = (value: unknown): string | null => typeof value === 'string' && Number.isFinite(Date.parse(value)) ? value : null;
+const number = (value: unknown): number | null => typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
+const states: RuntimeState[] = ['running', 'executing_tool', 'idle', 'waiting_user', 'stopped', 'unknown'];
+const statuses: OperationStatus[] = ['prepared', 'unconfirmed', 'accepted', 'queued', 'started', 'settled', 'failed', 'unknown'];
+function canonical(path: string): string { try { return realpathSync(path); } catch { return resolve(path); } }
+function assertState(binding: AgentBinding, value: unknown, instance?: string): Record<string, unknown> {
+  const state = record(value);
+  if (state.live !== true || state.sessionId !== binding.sessionId || typeof state.instanceId !== 'string' ||
+    typeof state.cwd !== 'string' || canonical(state.cwd) !== canonical(binding.workspace)) throw new ManagerError('UNAVAILABLE', '代理身分或工作目錄無法確認。', 409);
+  if (instance && state.instanceId !== instance) throw new ManagerError('INSTANCE_CHANGED', '代理已換成新的執行實例，請更新畫面後再傳送。', 409);
+  return state;
+}
+export function publicEntries(value: unknown): PublicEntry[] {
+  if (!Array.isArray(value)) throw new ManagerError('INVALID_SOURCE', '代理對話格式不正確。', 502);
+  return value.slice(0, 50).flatMap((raw): PublicEntry[] => {
+    const e = record(raw), id = str(e.id, 200);
+    if (!id) return [];
+    if (e.kind === 'tool_result') return [{ id, timestamp: date(e.timestamp), kind: 'tool_result', role: null,
+      text: '', truncated: false, toolName: str(e.toolName, 100), toolError: e.isError === true }];
+    if (e.kind !== 'message' || (e.role !== 'assistant' && e.role !== 'user')) return [];
+    return [{ id, timestamp: date(e.timestamp), kind: 'message', role: e.role, text: str(e.text, 16000) || '',
+      truncated: e.truncated === true || (typeof e.text === 'string' && e.text.length > 16000), toolName: null, toolError: false }];
+  });
+}
+function receipt(value: unknown, binding: AgentBinding, id: string, instance: string): AdapterReceipt {
+  const r = record(value);
+  if (r.id !== id || r.sessionId !== binding.sessionId || r.instanceId !== instance) throw new ManagerError('UNKNOWN_RECEIPT', '回執身分不一致，結果尚待確認。', 502);
+  return { id, sessionId: binding.sessionId, instanceId: instance,
+    status: statuses.includes(r.status as OperationStatus) ? r.status as OperationStatus : 'unknown' };
+}
+export const unavailable = (): AgentObservation => ({ state: 'unavailable', instanceId: null, observedAt: new Date().toISOString(),
+  heartbeatAt: null, lastProgressAt: null, lastEvent: null, source: 'unavailable', stale: true, reason: '目前無法讀取代理；不代表工作已完成。',
+  model: null, usage: null, capabilities: { conversation: false, send: false }, latestMessage: null });
+
+export class ChannelAdapter implements PiAdapter {
+  private cache = new Map<string, { instance: string; progress: string | null; latest: PublicEntry | null }>();
+  private constructor(private client: LegacyClient, private managed: LegacyManaged) {}
+  static async create(piRoot = defaultPiRoot()): Promise<ChannelAdapter> {
+    const client = await import(pathToFileURL(resolve(piRoot, 'client.mjs')).href) as LegacyClient;
+    const managed = await import(pathToFileURL(resolve(piRoot, 'managed-client.mjs')).href) as LegacyManaged;
+    if (typeof client.requestSession !== 'function' || typeof client.getReceipt !== 'function' || typeof managed.managedStatus !== 'function') throw new Error('Unsupported Pi adapter library');
+    return new ChannelAdapter(client, managed);
+  }
+  validateMessage(request: SendRequest): void {
+    const envelope = { id: request.operationId, message: request.message, sender: 'operator-console', mode: request.mode };
+    if (Buffer.byteLength(JSON.stringify(envelope)) > 24576) throw new ManagerError('TOO_LARGE', '訊息包含較多跳脫字元，超過代理通道的容量；請縮短內容。', 413);
+  }
+  async observe(binding: AgentBinding): Promise<AgentObservation> {
+    let managed: Record<string, unknown> = {};
+    try {
+      if (binding.runId) {
+        try {
+          const value = record(await this.managed.managedStatus(binding.registryRoot, binding.runId));
+          if (value.runId === binding.runId && (!value.sessionId || value.sessionId === binding.sessionId)) managed = value;
+        } catch { /* direct selected session still may be reachable */ }
+      }
+      const state = assertState(binding, await this.client.requestSession(binding.registryRoot, binding.sessionId, '/status'));
+      const instance = String(state.instanceId), progress = date(state.lastProgressAt);
+      const capabilities = Array.isArray(state.capabilities) ? state.capabilities : [];
+      let latest = this.cache.get(binding.id)?.instance === instance ? this.cache.get(binding.id)?.latest || null : null;
+      if (capabilities.includes('conversation') && (this.cache.get(binding.id)?.instance !== instance || this.cache.get(binding.id)?.progress !== progress)) {
+        try {
+          const page = record(await this.client.requestSession(binding.registryRoot, binding.sessionId, '/conversation?limit=12', undefined, 2500, instance));
+          const recent = publicEntries(page.entries).filter((e) => e.role === 'assistant' && e.text.trim()).at(-1);
+          if (recent) latest = { ...recent, text: recent.text.slice(0, 700), truncated: recent.truncated || recent.text.length > 700 };
+          this.cache.set(binding.id, { instance, progress, latest });
+        } catch { /* conversation failure must not suppress live process evidence */ }
+      }
+      const heartbeatAt = date(state.heartbeatAt), age = heartbeatAt ? Date.now() - Date.parse(heartbeatAt) : Infinity;
+      const model = record(managed.model), usage = record(managed.usage), modelError = record(managed.modelError);
+      return { state: states.includes(state.state as RuntimeState) ? state.state as RuntimeState : 'unknown', instanceId: instance,
+        observedAt: new Date().toISOString(), heartbeatAt, lastProgressAt: progress, lastEvent: str(state.lastEvent, 100),
+        source: 'live', stale: age > 15000 || age < -5000, reason: modelError.category ? `模型回報：${str(modelError.category, 100)}` : null,
+        model: typeof model.provider === 'string' && typeof model.id === 'string' ? { provider: model.provider, id: model.id } : null,
+        usage: managed.usage ? { tokens: number(usage.tokens), reportedCost: number(usage.reportedCost) } : null,
+        capabilities: { conversation: capabilities.includes('conversation'), send: capabilities.includes('send') }, latestMessage: latest };
+    } catch {
+      const model = record(managed.model), usage = record(managed.usage), stopped = managed.lastRecordedPhase === 'stopped';
+      return { ...unavailable(), state: stopped ? 'stopped' : 'unavailable',
+        reason: stopped ? '上次管理紀錄為已停止；目前沒有即時連線。' : '目前無法讀取代理；不代表工作已完成。',
+        lastProgressAt: date(managed.lastProgressAt),
+        model: typeof model.provider === 'string' && typeof model.id === 'string' ? { provider: model.provider, id: model.id } : null,
+        usage: managed.usage ? { tokens: number(usage.tokens), reportedCost: number(usage.reportedCost) } : null };
+    }
+  }
+  async conversation(binding: AgentBinding, after?: string): Promise<Omit<ConversationView, 'agentId' | 'selectionRevision'>> {
+    let instance: string | null = null;
+    try {
+      const state = assertState(binding, await this.client.requestSession(binding.registryRoot, binding.sessionId, '/status'));
+      instance = String(state.instanceId);
+      const params = new URLSearchParams({ limit: '30' }); if (after) params.set('after', after);
+      const r = record(await this.client.requestSession(binding.registryRoot, binding.sessionId, `/conversation?${params}`, undefined, 2500, String(state.instanceId)));
+      return { instanceId: String(state.instanceId), entries: publicEntries(r.entries), cursor: str(r.cursor, 200), headCursor: str(r.headCursor, 200),
+        hasMore: r.hasMore === true, observedAt: new Date().toISOString(), source: 'live' };
+    } catch (error) {
+      // Pi0.7 deliberately sanitizes plain cursor exceptions. A successful fresh
+      // page on the SAME instance proves that a reset is available; it does not
+      // require exposing the legacy exception or changing a live Pi extension.
+      let resetAvailable = false;
+      if (after && instance) {
+        try { await this.client.requestSession(binding.registryRoot, binding.sessionId, '/conversation?limit=30', undefined, 2500, instance); resetAvailable = true; }
+        catch { /* unavailable/replaced source remains unavailable */ }
+      }
+      if (resetAvailable) throw new ManagerError('STALE_CURSOR', '原對話游標無法接續，請重新讀取目前分支。', 409);
+      if (error instanceof ManagerError) throw error;
+      throw new ManagerError('UNAVAILABLE', '目前無法讀取這個代理的公開對話。', 503);
+    }
+  }
+  async send(binding: AgentBinding, request: SendRequest): Promise<AdapterReceipt> {
+    this.validateMessage(request);
+    let state: Record<string, unknown>;
+    try { state = assertState(binding, await this.client.requestSession(binding.registryRoot, binding.sessionId, '/status'), request.instanceId); }
+    catch (error) { if (error instanceof ManagerError) throw error; throw new ManagerError('UNAVAILABLE', '代理目前無法確認，尚未傳送。', 409); }
+    if (state.state === 'waiting_user') throw new ManagerError('WAITING_USER', '代理正在等待原介面的結構化選項；一般訊息無法取代它。', 409);
+    // New append/steer message, not an atomic answer to a prior question. Pi owns
+    // the exact-instance check and message UUID deduplication at the destination.
+    const r = await this.client.requestSession(binding.registryRoot, binding.sessionId, '/messages',
+      { id: request.operationId, message: request.message, sender: 'operator-console', mode: request.mode }, 2500, request.instanceId);
+    return receipt(r, binding, request.operationId, request.instanceId);
+  }
+  async receipt(binding: AgentBinding, operation: OperationView): Promise<AdapterReceipt | null> {
+    try { return receipt(await this.client.getReceipt(binding.registryRoot, binding.sessionId, operation.id), binding, operation.id, operation.instanceId); }
+    catch { return null; }
+  }
+}

--- a/integrations/agent-manager/src/store.ts
+++ b/integrations/agent-manager/src/store.ts
@@ -1,0 +1,94 @@
+import { DatabaseSync } from 'node:sqlite';
+import { existsSync, lstatSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { ManagerError, type AgentBinding, type ManagerEvent, type OperationStatus, type OperationView, type SendRequest } from './contracts.js';
+import { hash } from './config.js';
+
+export class ManagerStore {
+  private db: DatabaseSync;
+  constructor(root: string) {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+    const file = join(root, 'manager.sqlite');
+    if (lstatSync(root).isSymbolicLink() || (existsSync(file) && (lstatSync(file).isSymbolicLink() || !lstatSync(file).isFile()))) throw new Error('Manager storage must not be a link');
+    for (const suffix of ['-wal', '-shm', '-journal']) if (existsSync(file + suffix) && lstatSync(file + suffix).isSymbolicLink()) throw new Error('Manager sidecar must not be a link');
+    this.db = new DatabaseSync(file);
+    const version = this.db.prepare('PRAGMA user_version').get()?.user_version;
+    if (version !== 0 && version !== 1) { this.db.close(); throw new Error('Unsupported manager storage version'); }
+    this.db.exec(`PRAGMA journal_mode=WAL; PRAGMA busy_timeout=3000;
+      CREATE TABLE IF NOT EXISTS operations(id TEXT PRIMARY KEY, fingerprint TEXT NOT NULL, agent_id TEXT NOT NULL, target TEXT NOT NULL, proof_rank INTEGER NOT NULL DEFAULT 0, data TEXT NOT NULL);
+      CREATE TABLE IF NOT EXISTS events(id INTEGER PRIMARY KEY AUTOINCREMENT, at TEXT NOT NULL, agent_id TEXT NOT NULL, kind TEXT NOT NULL, summary TEXT NOT NULL, operation_id TEXT);
+      CREATE TABLE IF NOT EXISTS observations(agent_id TEXT PRIMARY KEY, fingerprint TEXT NOT NULL);
+      CREATE TABLE IF NOT EXISTS settings(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+      PRAGMA user_version=1;`);
+    // A committed intent followed by a crash is never evidence that no send occurred.
+    for (const row of this.db.prepare("SELECT data FROM operations WHERE json_extract(data,'$.status')='prepared'").all()) {
+      const operation = JSON.parse(String(row.data)) as OperationView;
+      this.update(operation.id, 'unknown', '服務重啟後結果待確認；不會自動重送。');
+    }
+  }
+  close(): void { this.db.close(); }
+  setting(key: string): string | null { const row = this.db.prepare('SELECT value FROM settings WHERE key=?').get(key); return typeof row?.value === 'string' ? row.value : null; }
+  putSetting(key: string, value: string): void { this.db.prepare('INSERT INTO settings(key,value) VALUES(?,?) ON CONFLICT(key) DO UPDATE SET value=excluded.value').run(key, value); }
+  operation(id: string): OperationView | null {
+    const row = this.db.prepare('SELECT data FROM operations WHERE id=?').get(id);
+    return typeof row?.data === 'string' ? JSON.parse(row.data) as OperationView : null;
+  }
+  operations(limit = 40): OperationView[] {
+    return this.db.prepare('SELECT data FROM operations ORDER BY rowid DESC LIMIT ?').all(limit).map((r) => JSON.parse(String(r.data)) as OperationView);
+  }
+  existing(agentId: string, request: SendRequest): OperationView | null {
+    const row = this.db.prepare('SELECT fingerprint,data FROM operations WHERE id=?').get(request.operationId);
+    if (!row) return null;
+    if (row.fingerprint !== hash(JSON.stringify({ agentId, ...request }))) throw new ManagerError('CONFLICT', '這個操作編號已有不同的內容，未再次傳送。', 409);
+    return JSON.parse(String(row.data)) as OperationView;
+  }
+  target(id: string): AgentBinding | null {
+    const row = this.db.prepare('SELECT target FROM operations WHERE id=?').get(id);
+    return typeof row?.target === 'string' ? JSON.parse(row.target) as AgentBinding : null;
+  }
+  begin(binding: AgentBinding, request: SendRequest): OperationView {
+    const agentId = binding.id;
+    const now = new Date().toISOString();
+    const result: OperationView = { id: request.operationId, agentId, instanceId: request.instanceId, basisCursor: request.basisCursor,
+      message: request.message, mode: request.mode, status: 'prepared', createdAt: now, updatedAt: now, notice: '操作已記錄，傳送結果尚未確認。' };
+    this.db.exec('BEGIN IMMEDIATE');
+    try {
+      this.db.prepare('INSERT INTO operations(id,fingerprint,agent_id,target,data) VALUES(?,?,?,?,?)').run(result.id, hash(JSON.stringify({ agentId, ...request })), agentId, JSON.stringify(binding), JSON.stringify(result));
+      this.addEvent(agentId, 'message', '已記錄傳送意圖', result.id);
+      this.db.exec('COMMIT');
+    } catch (error) { this.db.exec('ROLLBACK'); throw error; }
+    return result;
+  }
+  update(id: string, status: OperationStatus, notice: string): OperationView {
+    const current = this.operation(id);
+    if (!current) throw new ManagerError('NOT_FOUND', '找不到這次操作。', 404);
+    if (['settled', 'failed'].includes(current.status) || (current.status === status && current.notice === notice)) return current;
+    const ranks: Record<OperationStatus, number> = { prepared: 0, unconfirmed: 0, accepted: 1, queued: 2, started: 3, settled: 4, failed: 4, unknown: -1 };
+    const previousRank = Number(this.db.prepare('SELECT proof_rank FROM operations WHERE id=?').get(id)?.proof_rank || 0);
+    if (ranks[status] >= 0 && ranks[status] < previousRank) return current;
+    const result = { ...current, status, notice, updatedAt: new Date().toISOString() };
+    this.db.exec('BEGIN IMMEDIATE');
+    try {
+      this.db.prepare('UPDATE operations SET data=?,proof_rank=? WHERE id=?').run(JSON.stringify(result), Math.max(previousRank, ranks[status]), id);
+      if (current.status !== status) this.addEvent(current.agentId, 'message', notice, id);
+      this.db.exec('COMMIT');
+    } catch (error) { this.db.exec('ROLLBACK'); throw error; }
+    return result;
+  }
+  observation(agentId: string, fingerprint: string, summary: string): void {
+    if (this.db.prepare('SELECT fingerprint FROM observations WHERE agent_id=?').get(agentId)?.fingerprint === fingerprint) return;
+    this.db.exec('BEGIN IMMEDIATE');
+    try {
+      this.db.prepare('INSERT INTO observations(agent_id,fingerprint) VALUES(?,?) ON CONFLICT(agent_id) DO UPDATE SET fingerprint=excluded.fingerprint').run(agentId, fingerprint);
+      this.addEvent(agentId, 'observation', summary, null);
+      this.db.exec('COMMIT');
+    } catch (error) { this.db.exec('ROLLBACK'); throw error; }
+  }
+  private addEvent(agentId: string, kind: ManagerEvent['kind'], summary: string, operationId: string | null): void {
+    this.db.prepare('INSERT INTO events(at,agent_id,kind,summary,operation_id) VALUES(?,?,?,?,?)').run(new Date().toISOString(), agentId, kind, summary.slice(0, 500), operationId);
+  }
+  events(limit = 60): ManagerEvent[] {
+    return this.db.prepare('SELECT * FROM events ORDER BY id DESC LIMIT ?').all(limit).map((r) => ({ id: Number(r.id), at: String(r.at),
+      agentId: String(r.agent_id), kind: r.kind as ManagerEvent['kind'], summary: String(r.summary), operationId: r.operation_id == null ? null : String(r.operation_id) }));
+  }
+}

--- a/integrations/agent-manager/src/web/app.ts
+++ b/integrations/agent-manager/src/web/app.ts
@@ -1,4 +1,5 @@
 import type { AgentView, ConversationView, MessageMode, OperationStatus, OperationView, Overview, PublicEntry, RuntimeState, SendRequest } from '../contracts.js';
+import { MAX_MESSAGE_BYTES } from '../contracts.js';
 
 // Everything from the gateway and browser storage is rendered as text, never HTML.
 function element<K extends keyof HTMLElementTagNameMap>(tag: K, text = '', className = ''): HTMLElementTagNameMap[K] {
@@ -205,14 +206,24 @@ function renderConversation(): void {
   const signature = JSON.stringify([...entries.values()]);
   if (signature !== conversationSignature) {
     const pane = get('conversation'); const atEnd = pane.scrollHeight - pane.scrollTop - pane.clientHeight < 70; const oldScroll = pane.scrollTop;
-    pane.replaceChildren(...(entries.size ? [...entries.values()].map(entry => {
-      const tool = entry.kind === 'tool_result'; const item = element(tool ? 'details' : 'article', '', `entry ${tool ? 'tool' : entry.role === 'user' ? 'user' : 'assistant'}`);
-      const label = tool ? `工具結果：${entry.toolName ?? '未命名'}${entry.toolError ? '（錯誤）' : ''}` : entry.role === 'user' ? '操作訊息' : '代理回覆';
-      const meta = element(tool ? 'summary' : 'div', '', 'entry-meta'); meta.append(element('span', label, 'entry-role'), element('time', time(entry.timestamp)));
+    const opened = new Set([...pane.querySelectorAll<HTMLDetailsElement>('details[data-tool-group][open]')].map(item => item.dataset.toolGroup));
+    const nodes: HTMLElement[] = []; let group: HTMLDetailsElement | null = null; let count = 0;
+    for (const entry of entries.values()) {
+      if (entry.kind === 'tool_result') {
+        if (!group) { group = element('details', '', 'entry tool'); group.dataset.toolGroup = entry.id; group.open = opened.has(entry.id); group.append(element('summary', '', 'entry-meta')); nodes.push(group); count = 0; }
+        count++; group.querySelector('summary')!.textContent = `工具活動（${count} 筆）`;
+        group.append(element('p', `${entry.toolName ?? '工具'}${entry.toolError ? '：回報錯誤' : '：已返回'} · ${time(entry.timestamp)}`, 'muted'));
+        continue;
+      }
+      if (!entry.text.trim()) continue;
+      group = null;
+      const item = element('article', '', `entry ${entry.role === 'user' ? 'user' : 'assistant'}`);
+      const meta = element('div', '', 'entry-meta'); meta.append(element('span', entry.role === 'user' ? '操作訊息' : '代理回覆', 'entry-role'), element('time', time(entry.timestamp)));
       item.append(meta, element('div', entry.text, 'entry-body'));
       if (entry.truncated) item.append(element('p', '此則內容已截短。', 'entry-truncated'));
-      return item;
-    }) : [element('p', '尚無公開對話。可在下方開始新訊息。', 'empty')]));
+      nodes.push(item);
+    }
+    pane.replaceChildren(...(nodes.length ? nodes : [element('p', '尚無公開對話。可在下方開始新訊息。', 'empty')]));
     pane.scrollTop = atEnd ? pane.scrollHeight : oldScroll; conversationSignature = signature;
   }
   get('conversation-meta').textContent = conversation ? `觀測 ${time(conversation.observedAt)}` : '讀取中';
@@ -223,14 +234,16 @@ function renderCompose(): void {
   const agent = selectedAgent(); if (!agent) return;
   const draft = draftFor(agent.id); const pending = draft.pending; const message = get<HTMLTextAreaElement>('message');
   const viewMatches = conversation?.agentId === agent.id && conversation.instanceId === agent.instanceId && conversation.selectionRevision === agent.selectionRevision;
-  const canSend = connected && storageWorks && !!token && agent.capabilities.send && !agent.stale && agent.source === 'live' && !!agent.instanceId && viewMatches && conversation?.source === 'live';
-  const tooLong = new TextEncoder().encode(draft.message).length > 12 * 1024;
+  // Old heartbeat metadata is advisory when an authenticated current conversation
+  // confirms the same instance; the server checks that instance again on send.
+  const canSend = connected && storageWorks && !!token && agent.capabilities.send && agent.source === 'live' && !!agent.instanceId && viewMatches && conversation?.source === 'live';
+  const tooLong = new TextEncoder().encode(draft.message).length > MAX_MESSAGE_BYTES;
   message.disabled = !!pending;
   get<HTMLSelectElement>('mode').disabled = !!pending;
   get<HTMLButtonElement>('send').disabled = !canSend || !!pending || sending.has(agent.id) || !draft.message.trim() || tooLong;
   get('mode-help').textContent = draft.mode === 'steer' ? '在下一個安全處理點優先讀取這則指示；不會強制終止正在執行的工具。' : '目前工作結束後，再處理這則訊息。';
   get('draft-status').textContent = pending ? '原始訊息與收據識別碼已保留' : !storageWorks ? '草稿僅暫存於本頁' : draft.message ? '草稿已保存在此瀏覽器' : '草稿依收件人自動保存';
-  get('message-size').textContent = tooLong ? '訊息超過 12 KiB，請縮短內容' : `${new TextEncoder().encode(draft.message).length.toLocaleString('zh-TW')} / 12,288 bytes`;
+  get('message-size').textContent = tooLong ? '訊息超過 12 KiB，請縮短內容' : `${new TextEncoder().encode(draft.message).length.toLocaleString('zh-TW')} / ${MAX_MESSAGE_BYTES.toLocaleString('zh-TW')} bytes`;
   if (!pending && !canSend) notice('send-notice', !storageWorks ? '請先恢復瀏覽器儲存功能。' : !connected ? '工作台連線中斷，草稿已保留。' : '等待此代理的最新對話與可傳送狀態。');
   else notice('send-notice', '');
   get('pending').hidden = !pending;
@@ -279,6 +292,10 @@ async function refreshOverview(): Promise<void> {
     if (selectedId && after && (!before || before.instanceId !== after.instanceId || before.selectionRevision !== after.selectionRevision)) selectAgentAfterIdentityChange();
     if (selectedId && !after) { generation++; conversation = null; entries.clear(); notice('global-notice', '原收件人已移出選取清單；其草稿與待確認請求仍保留。請選擇其他代理。'); }
     renderProjects(); renderAgent(); renderRail();
+    if (!selectedId && result.agents.length) {
+      const first = result.agents.find(a => a.projectId === result.projects[0]?.id && a.role === 'manager') ?? result.agents[0];
+      if (first) selectAgent(first.id);
+    }
   } catch (error) {
     connected = false; get('connection-status').textContent = '連線中斷';
     notice('global-notice', `${errorText(error)} 現有畫面為上次觀測，草稿與原始送出請求已保留。`);

--- a/integrations/agent-manager/src/web/app.ts
+++ b/integrations/agent-manager/src/web/app.ts
@@ -1,0 +1,369 @@
+import type { AgentView, ConversationView, MessageMode, OperationStatus, OperationView, Overview, PublicEntry, RuntimeState, SendRequest } from '../contracts.js';
+
+// Everything from the gateway and browser storage is rendered as text, never HTML.
+function element<K extends keyof HTMLElementTagNameMap>(tag: K, text = '', className = ''): HTMLElementTagNameMap[K] {
+  const result = document.createElement(tag);
+  result.textContent = text;
+  result.className = className;
+  return result;
+}
+function get<K extends HTMLElement = HTMLElement>(id: string): K {
+  const result = document.getElementById(id);
+  if (!result) throw new Error(`Missing interface element: ${id}`);
+  return result as K;
+}
+function notice(id: string, text: string): void { get(id).textContent = text; get(id).hidden = !text; }
+const tokenKey = 'edda-manager-token';
+const stateKey = 'edda-manager-drafts-v1';
+let storageWorks = true;
+function stored(key: string): string | null {
+  try { return localStorage.getItem(key); } catch { storageWorks = false; return null; }
+}
+function save(key: string, value: string): boolean {
+  try { localStorage.setItem(key, value); return true; }
+  catch { storageWorks = false; notice('global-notice', '瀏覽器無法保存資料。草稿暫存於本頁；請先恢復儲存空間或權限，再傳送訊息。'); return false; }
+}
+const fragmentToken = new URLSearchParams(location.hash.slice(1)).get('token');
+// Remove the launcher credential before any request or further initialization.
+if (location.hash) history.replaceState(null, '', location.pathname + location.search);
+let token = fragmentToken ?? stored(tokenKey) ?? '';
+if (fragmentToken) save(tokenKey, fragmentToken);
+
+interface Pending { request: SendRequest; targetName: string; rejected: boolean; notice: string }
+interface Draft { agentId: string; message: string; mode: MessageMode; pending: Pending | null }
+const drafts = new Map<string, Draft>();
+let selectedId = '';
+function record(value: unknown): value is Record<string, unknown> { return typeof value === 'object' && value !== null; }
+function isRequest(value: unknown): value is SendRequest {
+  return record(value) && typeof value.operationId === 'string' && typeof value.selectionRevision === 'string' && typeof value.instanceId === 'string'
+    && (value.basisCursor === null || typeof value.basisCursor === 'string') && (value.mode === 'followUp' || value.mode === 'steer') && typeof value.message === 'string';
+}
+function restore(): void {
+  const raw = stored(stateKey);
+  if (!raw) return;
+  try {
+    const state: unknown = JSON.parse(raw);
+    if (!record(state) || !Array.isArray(state.drafts)) throw new Error('Invalid saved drafts');
+    if (typeof state.selectedId === 'string') selectedId = state.selectedId;
+    for (const value of state.drafts) {
+      if (!record(value) || typeof value.agentId !== 'string' || typeof value.message !== 'string' || (value.mode !== 'followUp' && value.mode !== 'steer')) throw new Error('Invalid saved draft');
+      let pending: Pending | null = null;
+      if (value.pending !== null) {
+        if (!record(value.pending) || !isRequest(value.pending.request) || typeof value.pending.targetName !== 'string' || typeof value.pending.rejected !== 'boolean' || typeof value.pending.notice !== 'string') throw new Error('Invalid pending request');
+        pending = { request: value.pending.request, targetName: value.pending.targetName, rejected: value.pending.rejected, notice: value.pending.notice };
+      }
+      drafts.set(value.agentId, { agentId: value.agentId, message: value.message, mode: value.mode, pending });
+    }
+  } catch {
+    // Do not overwrite unreadable pending-operation evidence with a new request.
+    storageWorks = false;
+    notice('global-notice', '已保存的草稿無法讀取。原始資料已保留，傳送功能暫停；請先檢查瀏覽器儲存資料。');
+  }
+}
+restore();
+function persist(): boolean {
+  if (!storageWorks) return false;
+  return save(stateKey, JSON.stringify({ selectedId, drafts: [...drafts.values()] }));
+}
+function draftFor(id: string): Draft {
+  let draft = drafts.get(id);
+  if (!draft) { draft = { agentId: id, message: '', mode: 'followUp', pending: null }; drafts.set(id, draft); }
+  return draft;
+}
+let overview: Overview | null = null;
+let conversation: ConversationView | null = null;
+let generation = 0;
+let overviewBusy = false;
+let conversationBusy: number | null = null;
+let connected = false;
+const sending = new Set<string>();
+const checking = new Set<string>();
+const entries = new Map<string, PublicEntry>();
+let conversationSignature = '';
+let projectSignature = '';
+const agentAges = new Map<string, HTMLElement>();
+const railSignatures = new Map<string, string>();
+function selectedAgent(): AgentView | undefined { return overview?.agents.find(agent => agent.id === selectedId); }
+function time(value: string | null): string {
+  if (!value) return '未提供';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? '時間未知' : date.toLocaleString('zh-TW', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
+}
+function age(value: string): string {
+  const seconds = Math.max(0, Math.floor((Date.now() - Date.parse(value)) / 1000));
+  return Number.isNaN(seconds) ? '時間未知' : seconds < 60 ? `${seconds} 秒前` : `${Math.floor(seconds / 60)} 分鐘前`;
+}
+const runtimeLabels: Record<RuntimeState, string> = { running: '執行中', executing_tool: '工具執行中', idle: '閒置・待確認', waiting_user: '等待回覆', stopped: '已停止', unavailable: '無法連線', unknown: '狀態未知' };
+const operationLabels: Record<OperationStatus, string> = { prepared: '已記錄送出意圖', unconfirmed: '尚未確認送達', accepted: '已接收訊息', queued: '已排入佇列', started: '已開始處理', settled: '執行已結束', failed: '執行失敗', unknown: '結果不明' };
+function badge(text: string, tone = ''): HTMLElement { return element('span', text, `badge ${tone}`); }
+function runtimeBadge(agent: AgentView): HTMLElement {
+  const tone = agent.stale || ['waiting_user', 'unknown', 'unavailable'].includes(agent.state) ? 'attention' : ['running', 'executing_tool'].includes(agent.state) ? 'active' : '';
+  return badge(runtimeLabels[agent.state] ?? '狀態未知', tone);
+}
+function operationBadge(operation: OperationView): HTMLElement {
+  return badge(operationLabels[operation.status] ?? '結果不明', operation.status === 'failed' ? 'danger' : ['prepared', 'unknown', 'unconfirmed'].includes(operation.status) ? 'attention' : 'active');
+}
+class ApiError extends Error { constructor(public code: string, message: string, public status: number) { super(message); } }
+async function api<T>(path: string, body?: SendRequest): Promise<T> {
+  const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
+  if (body) headers['Content-Type'] = 'application/json';
+  const response = await fetch(path, { method: body ? 'POST' : 'GET', headers, ...(body ? { body: JSON.stringify(body) } : {}), cache: 'no-store', credentials: 'omit', signal: AbortSignal.timeout(15000) });
+  if (!response.ok) {
+    let code = 'http_error'; let message = `工作台回應錯誤（${response.status}）`;
+    try { const data: unknown = await response.json(); if (record(data) && record(data.error)) { if (typeof data.error.code === 'string') code = data.error.code; if (typeof data.error.message === 'string') message = data.error.message; } } catch { /* Keep the bounded status message. */ }
+    throw new ApiError(code, message, response.status);
+  }
+  return await response.json() as T;
+}
+function errorText(error: unknown): string { return error instanceof ApiError ? error.message : '連線中斷或回應逾時。'; }
+function renderProjects(): void {
+  if (!overview) return;
+  for (const agent of overview.agents) { const stamp = agentAges.get(agent.id); if (stamp) stamp.textContent = agent.stale ? '資料已過期' : age(agent.observedAt); }
+  const signature = JSON.stringify([overview.projects.map(project => [project.id, project.name, project.priority]), overview.agents.map(agent => [agent.id, agent.name, agent.projectId, agent.role, agent.state, agent.stale, agent.latestMessage?.text, !!drafts.get(agent.id)?.pending]), selectedId]);
+  if (signature === projectSignature) return;
+  projectSignature = signature;
+  const focusedId = document.activeElement instanceof HTMLElement ? document.activeElement.dataset.agentId : undefined;
+  agentAges.clear();
+  get('project-count').textContent = `${overview.projects.length} 個`;
+  const nodes: HTMLElement[] = [];
+  for (const project of [...overview.projects].sort((a, b) => a.priority - b.priority)) {
+    const group = element('section', '', 'project-group');
+    group.append(element('h2', project.name, 'project-name'));
+    const agents = overview.agents.filter(agent => agent.projectId === project.id);
+    for (const agent of agents) {
+      const button = element('button', '', 'agent-option'); button.type = 'button'; button.dataset.agentId = agent.id; button.setAttribute('aria-current', String(agent.id === selectedId));
+      const top = element('span', '', 'agent-option-top'); top.append(element('span', agent.name, 'agent-option-name'), element('span', agent.role === 'manager' ? '管理者' : '工作者', 'agent-role'));
+      const stamp = element('span', agent.stale ? '資料已過期' : age(agent.observedAt)); agentAges.set(agent.id, stamp);
+      const bottom = element('span', '', 'agent-option-bottom'); bottom.append(runtimeBadge(agent), stamp);
+      const pending = drafts.get(agent.id)?.pending;
+      button.append(top, element('div', agent.latestMessage?.text || '尚無公開回覆', 'agent-preview'), bottom);
+      if (pending) button.append(element('div', '有待確認的訊息收據', 'agent-preview'));
+      button.addEventListener('click', () => selectAgent(agent.id)); group.append(button);
+    }
+    if (!agents.length) group.append(element('p', '此專案尚未選入代理。', 'empty'));
+    nodes.push(group);
+  }
+  get('projects').replaceChildren(...(nodes.length ? nodes : [element('p', '尚未登錄專案。請在工作台設定中選入專案與代理。', 'empty')]));
+  if (focusedId) for (const button of get('projects').querySelectorAll<HTMLButtonElement>('button')) { if (button.dataset.agentId === focusedId) button.focus({ preventScroll: true }); }
+}
+function replaceRail(id: string, nodes: HTMLElement[]): void {
+  const signature = nodes.map(node => node.textContent).join('\n');
+  if (railSignatures.get(id) === signature) return;
+  railSignatures.set(id, signature);
+  const open = new Set([...get(id).querySelectorAll<HTMLDetailsElement>('details[open]')].map(item => item.dataset.operationId));
+  for (const node of nodes) for (const detail of node.querySelectorAll<HTMLDetailsElement>('details')) { if (open.has(detail.dataset.operationId)) detail.open = true; }
+  get(id).replaceChildren(...nodes);
+}
+function renderAgent(): void {
+  const agent = selectedAgent();
+  get('welcome').hidden = !!agent; get('agent-panel').hidden = !agent;
+  if (!agent) return;
+  get('agent-project').textContent = overview?.projects.find(project => project.id === agent.projectId)?.name ?? agent.projectId;
+  get('agent-name').textContent = agent.name;
+  get('agent-identity').textContent = `${agent.id} / ${agent.workspace}`;
+  get('agent-status').replaceChildren(runtimeBadge(agent));
+  get('agent-freshness').replaceChildren(...[
+    `觀測 ${time(agent.observedAt)}`, `心跳 ${time(agent.heartbeatAt)}`, `進度 ${time(agent.lastProgressAt)}`,
+    ...(agent.model ? [`模型 ${agent.model.provider} / ${agent.model.id}`] : []),
+    ...(agent.usage?.tokens !== null && agent.usage?.tokens !== undefined ? [`已回報用量 ${agent.usage.tokens.toLocaleString('zh-TW')} tokens`] : []),
+    ...(agent.usage?.reportedCost !== null && agent.usage?.reportedCost !== undefined ? [`已回報成本 ${agent.usage.reportedCost}（供應商單位）`] : []),
+  ].map(value => element('span', value)));
+  notice('agent-warning', agent.stale || agent.source === 'unavailable' ? `目前資料${agent.stale ? '已過期' : '無法更新'}。${agent.reason ?? '等待來源恢復；其他代理仍可使用。'}` : agent.reason ?? '');
+  get('latest-response').textContent = agent.latestMessage?.text || '尚無公開回覆。';
+  get('recipient').textContent = `${agent.name} (${agent.id})`;
+  renderCompose();
+}
+function renderRail(): void {
+  if (!overview) return;
+  const agent = selectedAgent(); const project = overview.projects.find(item => item.id === agent?.projectId);
+  const managers = overview.agents.filter(item => item.projectId === project?.id && item.role === 'manager');
+  replaceRail('summaries', (managers.length ? managers.map(manager => {
+    const item = element('article', '', 'summary-item'); item.append(element('h3', manager.name), element('p', manager.summary || '尚未提供管理摘要。', 'public-text'), element('p', `更新 ${time(manager.summaryUpdatedAt)}`, 'muted'));
+    if (manager.summaryError) item.append(element('p', manager.summaryError, 'notice'));
+    return item;
+  }) : [element('p', project ? '此專案尚未選入管理者。' : '選擇代理後顯示專案摘要。', 'empty')]));
+  replaceRail('resources', (project?.resources.length ? project.resources.map(resource => {
+    const item = element('article', '', 'resource'); item.append(element('h3', resource.name), element('p', resource.details, 'public-text'), element('p', `${resource.kind} / 歸屬：${resource.owner}`, 'muted'), element('p', `來源：${resource.source}`, 'muted')); return item;
+  }) : [element('p', project ? '尚未登錄共用資源。' : '選擇代理後顯示登錄資源。', 'empty')]));
+  const relevant = (id: string): boolean => !project || overview!.agents.some(item => item.id === id && item.projectId === project.id);
+  const operations = overview.operations.filter(item => relevant(item.agentId)).slice(0, 12);
+  replaceRail('operations', (operations.length ? operations.map(operation => {
+    const item = element('article', '', 'operation'); const heading = element('div', '', 'operation-heading');
+    heading.append(element('span', overview!.agents.find(item => item.id === operation.agentId)?.name ?? operation.agentId, 'operation-name'), operationBadge(operation));
+    const detail = element('details'); detail.dataset.operationId = operation.id; detail.append(element('summary', operation.mode === 'steer' ? '優先指示' : '接續目前工作'), element('p', operation.message, 'public-text'), element('p', operation.id, 'identity'));
+    item.append(heading, element('p', operation.notice), element('p', time(operation.updatedAt), 'muted'), detail);
+    if (operation.status === 'settled') item.append(element('p', '此為執行收據，工作仍需驗收。', 'muted'));
+    return item;
+  }) : [element('p', '尚無訊息收據。', 'empty')]));
+  const events = overview.events.filter(item => relevant(item.agentId)).slice(0, 15);
+  replaceRail('events', (events.length ? events.map(event => {
+    const item = element('article', '', 'event'); const stamp = element('time', time(event.at)); stamp.dateTime = event.at;
+    item.append(element('p', overview!.agents.find(item => item.id === event.agentId)?.name ?? event.agentId, 'muted'), element('p', event.summary), stamp); return item;
+  }) : [element('p', '尚無持久活動紀錄。', 'empty')]));
+}
+function renderConversation(): void {
+  const signature = JSON.stringify([...entries.values()]);
+  if (signature !== conversationSignature) {
+    const pane = get('conversation'); const atEnd = pane.scrollHeight - pane.scrollTop - pane.clientHeight < 70; const oldScroll = pane.scrollTop;
+    pane.replaceChildren(...(entries.size ? [...entries.values()].map(entry => {
+      const tool = entry.kind === 'tool_result'; const item = element(tool ? 'details' : 'article', '', `entry ${tool ? 'tool' : entry.role === 'user' ? 'user' : 'assistant'}`);
+      const label = tool ? `工具結果：${entry.toolName ?? '未命名'}${entry.toolError ? '（錯誤）' : ''}` : entry.role === 'user' ? '操作訊息' : '代理回覆';
+      const meta = element(tool ? 'summary' : 'div', '', 'entry-meta'); meta.append(element('span', label, 'entry-role'), element('time', time(entry.timestamp)));
+      item.append(meta, element('div', entry.text, 'entry-body'));
+      if (entry.truncated) item.append(element('p', '此則內容已截短。', 'entry-truncated'));
+      return item;
+    }) : [element('p', '尚無公開對話。可在下方開始新訊息。', 'empty')]));
+    pane.scrollTop = atEnd ? pane.scrollHeight : oldScroll; conversationSignature = signature;
+  }
+  get('conversation-meta').textContent = conversation ? `觀測 ${time(conversation.observedAt)}` : '讀取中';
+  get('load-more').hidden = !conversation?.hasMore;
+  renderCompose();
+}
+function renderCompose(): void {
+  const agent = selectedAgent(); if (!agent) return;
+  const draft = draftFor(agent.id); const pending = draft.pending; const message = get<HTMLTextAreaElement>('message');
+  const viewMatches = conversation?.agentId === agent.id && conversation.instanceId === agent.instanceId && conversation.selectionRevision === agent.selectionRevision;
+  const canSend = connected && storageWorks && !!token && agent.capabilities.send && !agent.stale && agent.source === 'live' && !!agent.instanceId && viewMatches && conversation?.source === 'live';
+  const tooLong = new TextEncoder().encode(draft.message).length > 12 * 1024;
+  message.disabled = !!pending;
+  get<HTMLSelectElement>('mode').disabled = !!pending;
+  get<HTMLButtonElement>('send').disabled = !canSend || !!pending || sending.has(agent.id) || !draft.message.trim() || tooLong;
+  get('mode-help').textContent = draft.mode === 'steer' ? '在下一個安全處理點優先讀取這則指示；不會強制終止正在執行的工具。' : '目前工作結束後，再處理這則訊息。';
+  get('draft-status').textContent = pending ? '原始訊息與收據識別碼已保留' : !storageWorks ? '草稿僅暫存於本頁' : draft.message ? '草稿已保存在此瀏覽器' : '草稿依收件人自動保存';
+  get('message-size').textContent = tooLong ? '訊息超過 12 KiB，請縮短內容' : `${new TextEncoder().encode(draft.message).length.toLocaleString('zh-TW')} / 12,288 bytes`;
+  if (!pending && !canSend) notice('send-notice', !storageWorks ? '請先恢復瀏覽器儲存功能。' : !connected ? '工作台連線中斷，草稿已保留。' : '等待此代理的最新對話與可傳送狀態。');
+  else notice('send-notice', '');
+  get('pending').hidden = !pending;
+  if (pending) {
+    get('pending-title').textContent = pending.rejected ? '請檢查這則訊息的結果' : '送出結果尚待確認';
+    get('pending-notice').textContent = `${pending.targetName}：${pending.notice} ${pending.rejected ? '可保留草稿，編輯後另送新訊息。' : '請查詢原始收據，確認前不會再次送出。'}`;
+    get('pending-id').textContent = pending.request.operationId;
+    get('pending-message').textContent = pending.request.message;
+    get<HTMLButtonElement>('check-receipt').disabled = checking.has(agent.id) || sending.has(agent.id) || !connected;
+    get('release-rejected').hidden = !pending.rejected;
+  }
+}
+function selectAgent(id: string): void {
+  if (id === selectedId && conversation) return;
+  selectedId = id; generation++; conversation = null; entries.clear(); conversationSignature = 'reset'; persist();
+  const draft = draftFor(id); get<HTMLTextAreaElement>('message').value = draft.message; get<HTMLSelectElement>('mode').value = draft.mode;
+  notice('conversation-notice', ''); renderProjects(); renderAgent(); renderRail(); renderConversation();
+  void refreshConversation();
+}
+function applyOperation(operation: OperationView): void {
+  const draft = drafts.get(operation.agentId); const pending = draft?.pending;
+  if (!draft || !pending || pending.request.operationId !== operation.id) return;
+  // A receipt must belong to the persisted recipient and immutable request.
+  const request = pending.request;
+  if (operation.instanceId !== request.instanceId || operation.mode !== request.mode || operation.message !== request.message || operation.basisCursor !== request.basisCursor) {
+    pending.rejected = false; pending.notice = '收據內容與原始請求不一致，請保留資料並檢查工作台。'; persist(); return;
+  }
+  if (['accepted', 'queued', 'started', 'settled'].includes(operation.status)) {
+    if (draft.message === request.message && draft.mode === request.mode) draft.message = '';
+    draft.pending = null;
+    if (selectedId === operation.agentId) get<HTMLTextAreaElement>('message').value = draft.message;
+  } else { pending.notice = `${operationLabels[operation.status]}。${operation.notice}`; pending.rejected = operation.status === 'failed'; }
+  persist();
+}
+async function refreshOverview(): Promise<void> {
+  if (overviewBusy || !token) return;
+  overviewBusy = true;
+  try {
+    const result = await api<Overview>('/api/overview');
+    const before = selectedAgent(); overview = result; connected = true;
+    get('auth').hidden = true; get('desk').hidden = false;
+    get('connection-status').textContent = `已連線 · 更新 ${time(result.generatedAt)}`;
+    if (storageWorks) notice('global-notice', '');
+    for (const operation of result.operations) applyOperation(operation);
+    const after = selectedAgent();
+    if (selectedId && after && (!before || before.instanceId !== after.instanceId || before.selectionRevision !== after.selectionRevision)) selectAgentAfterIdentityChange();
+    if (selectedId && !after) { generation++; conversation = null; entries.clear(); notice('global-notice', '原收件人已移出選取清單；其草稿與待確認請求仍保留。請選擇其他代理。'); }
+    renderProjects(); renderAgent(); renderRail();
+  } catch (error) {
+    connected = false; get('connection-status').textContent = '連線中斷';
+    notice('global-notice', `${errorText(error)} 現有畫面為上次觀測，草稿與原始送出請求已保留。`);
+    if (error instanceof ApiError && error.status === 401) { get('auth').hidden = false; get('desk').hidden = true; }
+    renderCompose();
+  } finally { overviewBusy = false; }
+}
+function selectAgentAfterIdentityChange(): void {
+  generation++; conversation = null; entries.clear(); conversationSignature = 'reset';
+  const draft = draftFor(selectedId); get<HTMLTextAreaElement>('message').value = draft.message; get<HTMLSelectElement>('mode').value = draft.mode;
+  notice('conversation-notice', '正在讀取目前代理實例的對話；草稿已保留。'); renderConversation();
+}
+async function refreshConversation(reset = false): Promise<void> {
+  const agent = selectedAgent(); const epoch = generation;
+  if (!agent || !connected || !agent.capabilities.conversation || conversationBusy === epoch) return;
+  conversationBusy = epoch;
+  const cursor = reset ? null : conversation?.cursor;
+  try {
+    const result = await api<ConversationView>(`/api/agents/${encodeURIComponent(agent.id)}/conversation${cursor ? `?after=${encodeURIComponent(cursor)}` : ''}`);
+    if (epoch !== generation || selectedId !== agent.id) return;
+    const current = selectedAgent();
+    if (result.agentId !== agent.id || result.selectionRevision !== current?.selectionRevision || result.instanceId !== current.instanceId) {
+      conversation = null; notice('conversation-notice', '代理實例已更新，等待重新讀取對話。'); renderCompose(); return;
+    }
+    if (reset || !conversation) entries.clear();
+    for (const entry of result.entries) entries.set(entry.id, entry);
+    conversation = result;
+    notice('conversation-notice', result.source === 'unavailable' ? '目前無法讀取對話；保留上次觀測與草稿。' : '');
+    renderConversation();
+  } catch (error) {
+    if (epoch !== generation) return;
+    if (cursor && error instanceof ApiError && (error.status === 409 || /cursor|branch/i.test(error.code))) {
+      conversation = null; conversationBusy = null; notice('conversation-notice', '對話分支已改變，重新讀取目前對話；草稿已保留。');
+      await refreshConversation(true); return;
+    }
+    conversation = null; notice('conversation-notice', `${errorText(error)} 草稿已保留，可更新對話後再試。`); renderCompose();
+  } finally { if (conversationBusy === epoch) conversationBusy = null; }
+}
+async function sendMessage(event: SubmitEvent): Promise<void> {
+  event.preventDefault();
+  const agent = selectedAgent(); if (!agent || get<HTMLButtonElement>('send').disabled || sending.has(agent.id)) return;
+  const draft = draftFor(agent.id); const view = conversation;
+  if (draft.pending || !view?.instanceId || view.agentId !== agent.id || view.instanceId !== agent.instanceId || view.selectionRevision !== agent.selectionRevision) return;
+  const request: SendRequest = { operationId: crypto.randomUUID(), selectionRevision: view.selectionRevision, instanceId: view.instanceId, basisCursor: view.headCursor ?? view.cursor, mode: draft.mode, message: draft.message };
+  draft.pending = { request, targetName: `${agent.name} (${agent.id})`, rejected: false, notice: '請求已保存，正在等待工作台收據。' };
+  // No side effect is allowed until the complete request is durable in this browser.
+  if (!persist()) { draft.pending = null; renderCompose(); return; }
+  sending.add(agent.id); renderCompose();
+  try {
+    const operation = await api<OperationView>(`/api/agents/${encodeURIComponent(agent.id)}/messages`, request);
+    applyOperation(operation);
+  } catch (error) {
+    if (draft.pending?.request.operationId === request.operationId) {
+      draft.pending.notice = errorText(error);
+      // A conflict may refer to an existing effect; never release its UUID blindly.
+      draft.pending.rejected = error instanceof ApiError && ([400, 401, 403, 404, 413, 422].includes(error.status)
+        || (error.status === 409 && ['INSTANCE_CHANGED', 'STALE_SELECTION', 'WAITING_USER'].includes(error.code)));
+      persist();
+    }
+  } finally { sending.delete(agent.id); renderCompose(); renderProjects(); void refreshOverview(); }
+}
+async function checkReceipt(): Promise<void> {
+  const id = selectedId; const pending = drafts.get(id)?.pending;
+  if (!pending || checking.has(id)) return;
+  checking.add(id); renderCompose();
+  try { applyOperation(await api<OperationView>(`/api/operations/${encodeURIComponent(pending.request.operationId)}`)); }
+  catch (error) { pending.notice = error instanceof ApiError && error.status === 404 ? '工作台目前找不到原始收據。送出結果仍不明，原始請求已保留。' : errorText(error); persist(); }
+  finally { checking.delete(id); renderCompose(); renderProjects(); void refreshOverview(); }
+}
+get('compose').addEventListener('submit', event => { void sendMessage(event as SubmitEvent); });
+get('message').addEventListener('input', () => { const draft = draftFor(selectedId); if (draft.pending) return; draft.message = get<HTMLTextAreaElement>('message').value; persist(); renderCompose(); });
+get('mode').addEventListener('change', () => { const draft = draftFor(selectedId); if (draft.pending) return; draft.mode = get<HTMLSelectElement>('mode').value === 'steer' ? 'steer' : 'followUp'; persist(); renderCompose(); });
+get('check-receipt').addEventListener('click', () => { void checkReceipt(); });
+get('release-rejected').addEventListener('click', () => { const draft = draftFor(selectedId); if (!draft.pending?.rejected) return; draft.pending = null; persist(); renderCompose(); get('message').focus(); });
+get('conversation-refresh').addEventListener('click', () => { void refreshConversation(); });
+get('load-more').addEventListener('click', () => { void refreshConversation(); });
+async function refresh(): Promise<void> { await refreshOverview(); await refreshConversation(); }
+get('refresh').addEventListener('click', () => { void refresh(); });
+get('auth-form').addEventListener('submit', event => { event.preventDefault(); token = get<HTMLInputElement>('token').value.trim(); if (!token) return; save(tokenKey, token); get<HTMLInputElement>('token').value = ''; void refresh(); });
+window.addEventListener('online', () => { void refresh(); });
+window.addEventListener('offline', () => { connected = false; get('connection-status').textContent = '離線'; renderCompose(); });
+// Another tab changing persistent evidence cannot safely share this tab's drafts.
+window.addEventListener('storage', event => { if (event.key === stateKey) { storageWorks = false; notice('global-notice', '另一個分頁已更新草稿或送出紀錄。本頁暫停傳送，請重新載入以讀取最新紀錄。'); renderCompose(); } });
+if (!token) { get('auth').hidden = false; get('desk').hidden = true; get('connection-status').textContent = '尚未連接'; }
+if (!storageWorks) notice('global-notice', '瀏覽器儲存資料目前無法使用；傳送功能暫停，既有資料不會被覆寫。');
+void refresh();
+window.setInterval(() => { if (!document.hidden) void refresh(); }, 3000);
+document.addEventListener('visibilitychange', () => { if (!document.hidden) void refresh(); });

--- a/integrations/agent-manager/src/web/index.html
+++ b/integrations/agent-manager/src/web/index.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="referrer" content="no-referrer">
+  <title>Edda · 代理工作台</title>
+  <link rel="stylesheet" href="/style.css">
+  <script type="module" src="/app.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#conversation-title">跳至對話</a>
+  <header class="topbar">
+    <a class="brand" href="/" aria-label="Edda 代理工作台"><span class="brand-mark" aria-hidden="true">e</span><span>Edda <span class="brand-caption">代理工作台</span></span></a>
+    <div class="connection"><span id="connection-status" role="status">正在連線</span><button id="refresh" class="quiet" type="button">重新整理</button></div>
+  </header>
+  <div id="global-notice" class="global-notice" role="status" hidden></div>
+  <section id="auth" class="auth" hidden aria-labelledby="auth-title">
+    <h1 id="auth-title">連接本機工作台</h1>
+    <p>從啟動器開啟連結，或貼上工作台存取權杖。</p>
+    <form id="auth-form"><label for="token">工作台存取權杖</label><input id="token" type="password" autocomplete="off" required><button class="primary" type="submit">連接工作台</button></form>
+  </section>
+  <div id="desk" class="desk">
+    <nav class="sidebar" aria-label="專案與代理">
+      <div class="sidebar-heading"><h1>專案</h1><span id="project-count" class="muted"></span></div>
+      <p class="sidebar-note">僅顯示已選入工作台的代理</p>
+      <div id="projects"><p class="empty">正在讀取專案…</p></div>
+      <p class="sidebar-footnote">執行狀態供協作參考。閒置或執行結束，不代表工作已驗收。</p>
+    </nav>
+    <main id="workspace" class="workspace">
+      <div id="welcome" class="welcome"><span class="welcome-symbol" aria-hidden="true">↗</span><h2>選擇一位代理，接續工作</h2><p>查看公開對話與最近進度，再向明確的收件人傳送新訊息。</p></div>
+      <section id="agent-panel" hidden aria-labelledby="agent-name">
+        <header class="agent-header"><div><p id="agent-project" class="muted"></p><h2 id="agent-name"></h2><p id="agent-identity" class="identity"></p></div><div id="agent-status"></div></header>
+        <div id="agent-freshness" class="freshness"></div>
+        <div id="agent-warning" class="notice" hidden></div>
+        <details class="latest"><summary>最近公開回覆</summary><p id="latest-response" class="public-text"></p></details>
+        <section class="conversation-section" aria-labelledby="conversation-title">
+          <div class="section-heading"><h3 id="conversation-title" tabindex="-1">對話</h3><span id="conversation-meta" class="muted"></span><button id="conversation-refresh" class="quiet" type="button">更新對話</button></div>
+          <p id="conversation-notice" class="notice" role="status" hidden></p>
+          <div id="conversation" class="conversation" aria-label="公開對話紀錄" tabindex="0"></div>
+          <button id="load-more" class="load-more" type="button" hidden>繼續載入對話</button>
+        </section>
+        <form id="compose" class="compose">
+          <div class="recipient"><label for="message">新訊息</label><span>收件人：<strong id="recipient"></strong></span></div>
+          <textarea id="message" rows="4" placeholder="補充方向、提出問題，或交付下一步工作…" aria-describedby="mode-help draft-status" required></textarea>
+          <div class="compose-controls"><label class="mode-label" for="mode">送出方式<select id="mode"><option value="followUp">接續目前工作</option><option value="steer">優先指示</option></select></label><button id="send" class="primary" type="submit">傳送新訊息</button></div>
+          <p id="mode-help" class="muted">目前工作結束後，再處理這則訊息。</p>
+          <div class="compose-footer"><span id="draft-status" class="muted"></span><span id="message-size" class="muted"></span></div>
+          <p id="send-notice" class="notice" role="status" hidden></p>
+        </form>
+        <section id="pending" class="pending" hidden aria-labelledby="pending-title"><h3 id="pending-title">正在確認送出結果</h3><p id="pending-notice"></p><p id="pending-id" class="identity"></p><details><summary>檢視原始訊息</summary><p id="pending-message" class="public-text"></p></details><div class="pending-actions"><button id="check-receipt" type="button">查詢收據</button><button id="release-rejected" type="button" hidden>保留草稿，編輯為新訊息</button></div></section>
+      </section>
+    </main>
+    <aside class="activity-rail" aria-label="專案脈絡與活動">
+      <section><h2>管理摘要</h2><div id="summaries"><p class="empty">選擇代理後顯示專案摘要。</p></div></section>
+      <section><h2>共用資源</h2><p class="rail-note">登錄的歸屬與來源，並非即時健康狀態。</p><div id="resources"></div></section>
+      <section><h2>訊息收據</h2><div id="operations"><p class="empty">尚無訊息收據。</p></div></section>
+      <section><h2>最近活動</h2><div id="events"><p class="empty">正在讀取持久紀錄…</p></div></section>
+    </aside>
+  </div>
+  <noscript>工作台需要 JavaScript 才能讀取代理狀態與對話。</noscript>
+</body>
+</html>

--- a/integrations/agent-manager/src/web/style.css
+++ b/integrations/agent-manager/src/web/style.css
@@ -101,6 +101,9 @@ h3 {
   padding:12px 0
 }
 .topbar {
+  position:sticky;
+  top:0;
+  z-index:5;
   height:76px;
   border-bottom:1px solid var(--line);
   background:var(--paper);
@@ -152,6 +155,11 @@ h3 {
   min-height:calc(100vh - 76px)
 }
 .sidebar {
+  position:sticky;
+  top:76px;
+  align-self:start;
+  max-height:calc(100dvh - 76px);
+  overflow:auto;
   padding:26px 18px;
   border-right:1px solid var(--line)
 }
@@ -492,6 +500,9 @@ select {
   border-left:1px solid var(--line);
   min-width:0
 }
+@media(min-width:1151px) {
+  .activity-rail {position:sticky;top:76px;align-self:start;max-height:calc(100dvh - 76px);overflow:auto}
+}
 .activity-rail section+section {
   border-top:1px solid var(--line);
   padding-top:21px;
@@ -685,6 +696,9 @@ select {
 }
 .sidebar {
   border-right:0;
+  position:static;
+  max-height:none;
+  overflow:visible;
   border-bottom:1px solid var(--line);
   padding:15px 12px
 }

--- a/integrations/agent-manager/src/web/style.css
+++ b/integrations/agent-manager/src/web/style.css
@@ -1,0 +1,787 @@
+:root {
+  font-family:"Segoe UI","Microsoft JhengHei",sans-serif;
+  color:#24364b;
+  background:#f3f6fa;
+  font-synthesis:none;
+  --ink:#24364b;
+  --muted:#65758a;
+  --blue:#205fc1;
+  --line:#dde5ef;
+  --attention:#966020;
+  --paper:#fff
+}
+
+* {
+  box-sizing:border-box
+}
+body {
+  margin:0;
+  font-size:14px;
+  line-height:1.6
+}
+button,input,textarea,select {
+  font:inherit
+}
+button {
+  cursor:pointer;
+  border:1px solid #bdcbdc;
+  border-radius:6px;
+  background:#fff;
+  color:var(--ink);
+  padding:8px 13px;
+  min-height:40px
+}
+button:hover {
+  background:#edf3fb;
+  border-color:#7796bc
+}
+button:disabled {
+  cursor:not-allowed;
+  opacity:.55
+}
+button.primary {
+  background:var(--blue);
+  border-color:var(--blue);
+  color:#fff;
+  font-weight:600;
+  padding-inline:22px
+}
+button.primary:hover {
+  background:#174c9e
+}
+button.quiet {
+  border-color:transparent;
+  background:transparent;
+  color:var(--blue);
+  padding:6px 8px
+}
+button.quiet:hover {
+  background:#eaf1fb
+}
+a {
+  color:var(--blue)
+}
+:focus-visible {
+  outline:3px solid #387dde;
+  outline-offset:3px
+}
+[hidden] {
+  display:none!important
+}
+h1,h2,h3,p {
+  margin:0
+}
+h1,h2 {
+  font-size:19px;
+  font-weight:650;
+  letter-spacing:.01em
+}
+h3 {
+  font-size:15px;
+  font-weight:650
+}
+.muted,.rail-note {
+  color:var(--muted);
+  font-size:12px
+}
+.public-text {
+  white-space:pre-wrap;
+  overflow-wrap:anywhere;
+  line-height:1.85
+}
+.identity {
+  font-family:Consolas,monospace;
+  font-size:11px;
+  overflow-wrap:anywhere;
+  color:var(--muted)
+}
+.empty {
+  color:var(--muted);
+  font-size:13px;
+  padding:12px 0
+}
+.topbar {
+  height:76px;
+  border-bottom:1px solid var(--line);
+  background:var(--paper);
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  padding:0 30px;
+  gap:15px
+}
+.brand {
+  display:flex;
+  align-items:center;
+  gap:12px;
+  text-decoration:none;
+  color:var(--ink);
+  font-size:22px;
+  font-weight:700
+}
+.brand-mark {
+  display:grid;
+  place-items:center;
+  width:34px;
+  height:36px;
+  border-radius:8px 8px 8px 2px;
+  background:var(--blue);
+  color:white;
+  font-size:30px;
+  font-weight:500;
+  line-height:1
+}
+.brand-caption {
+  font-size:14px;
+  font-weight:500;
+  margin-left:12px;
+  color:var(--muted)
+}
+.connection {
+  display:flex;
+  align-items:center;
+  gap:15px;
+  font-size:12px;
+  color:var(--muted)
+}
+.desk {
+  display:grid;
+  grid-template-columns:248px minmax(420px,1fr) 294px;
+  max-width:1800px;
+  margin:auto;
+  min-height:calc(100vh - 76px)
+}
+.sidebar {
+  padding:26px 18px;
+  border-right:1px solid var(--line)
+}
+.sidebar-heading {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  padding:0 10px
+}
+.sidebar-note {
+  font-size:11px;
+  color:var(--muted);
+  padding:3px 10px 20px
+}
+.project-group {
+  margin-bottom:22px
+}
+.project-name {
+  font-size:13px;
+  margin:0 10px 7px;
+  font-weight:700
+}
+.agent-option {
+  display:block;
+  width:100%;
+  text-align:left;
+  border:1px solid transparent;
+  background:transparent;
+  padding:11px 12px;
+  margin:3px 0;
+  border-radius:7px
+}
+.agent-option[aria-current=true] {
+  border-color:#bacfed;
+  background:#e6effc;
+  box-shadow:inset 3px 0 var(--blue)
+}
+.agent-option-top {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px
+}
+.agent-option-name {
+  font-weight:600;
+  overflow-wrap:anywhere
+}
+.agent-role {
+  color:var(--muted);
+  font-size:11px
+}
+.agent-preview {
+  overflow:hidden;
+  white-space:nowrap;
+  text-overflow:ellipsis;
+  color:var(--muted);
+  font-size:12px;
+  margin-top:4px
+}
+.agent-option-bottom {
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  gap:5px;
+  margin-top:7px;
+  font-size:11px;
+  color:var(--muted)
+}
+.sidebar-footnote {
+  font-size:11px;
+  color:var(--muted);
+  padding:20px 10px;
+  border-top:1px solid var(--line);
+  margin-top:30px
+}
+.workspace {
+  background:#fff;
+  min-width:0;
+  padding:27px 30px 36px
+}
+.welcome {
+  padding:100px 25px;
+  max-width:500px;
+  margin:auto
+}
+.welcome-symbol {
+  font-size:38px;
+  color:var(--blue);
+  display:block;
+  margin-bottom:20px
+}
+.welcome p {
+  margin-top:14px;
+  color:var(--muted)
+}
+.agent-header {
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-start;
+  gap:16px
+}
+.agent-header h2 {
+  font-size:28px;
+  line-height:1.4;
+  margin:2px 0 5px
+}
+.badge {
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  font-size:11px;
+  padding:3px 8px;
+  border-radius:4px;
+  background:#edf1f5;
+  color:#536478;
+  white-space:nowrap
+}
+.badge::before {
+  content:"";
+  width:6px;
+  height:6px;
+  border-radius:50%;
+  background:currentColor
+}
+.badge.active {
+  background:#eaf2ff;
+  color:#245fab
+}
+.badge.attention {
+  background:#fff0d8;
+  color:#885214
+}
+.badge.danger {
+  background:#fbeaea;
+  color:#a83939
+}
+.freshness {
+  display:flex;
+  flex-wrap:wrap;
+  gap:5px 20px;
+  padding:16px 0 14px;
+  color:var(--muted);
+  font-size:11px
+}
+.notice {
+  padding:10px 13px;
+  background:#fff5e3;
+  border-left:3px solid #c48932;
+  color:#81531d;
+  font-size:12px;
+  overflow-wrap:anywhere
+}
+.latest {
+  border-top:1px solid var(--line);
+  border-bottom:1px solid var(--line);
+  padding:12px 0;
+  margin-bottom:22px
+}
+.latest summary {
+  font-size:12px;
+  color:var(--muted)
+}
+summary {
+  cursor:pointer;
+  min-height:24px
+}
+.latest p {
+  font-size:13px;
+  max-height:190px;
+  overflow:auto;
+  margin-top:12px
+}
+.section-heading {
+  display:flex;
+  align-items:center;
+  gap:12px;
+  margin-bottom:9px
+}
+.section-heading h3 {
+  margin-right:auto
+}
+.conversation {
+  background:#f5f7fb;
+  border:1px solid #e2e8f0;
+  border-radius:8px;
+  min-height:240px;
+  max-height:510px;
+  overflow:auto;
+  padding:20px;
+  scrollbar-gutter:stable
+}
+.conversation>.empty {
+  text-align:center;
+  padding:70px 10px
+}
+.entry {
+  margin-bottom:24px;
+  max-width:80ch
+}
+.entry:last-child {
+  margin-bottom:0
+}
+.entry-meta {
+  display:flex;
+  gap:12px;
+  align-items:center;
+  color:var(--muted);
+  font-size:11px;
+  margin-bottom:5px
+}
+.entry-role {
+  font-size:12px;
+  font-weight:650;
+  color:var(--ink)
+}
+.entry-body {
+  font-size:13px;
+  line-height:1.8;
+  white-space:pre-wrap;
+  overflow-wrap:anywhere
+}
+.entry.user {
+  margin-left:24px;
+  border-left:2px solid #87a9db;
+  padding-left:13px
+}
+.entry.tool {
+  padding:10px 12px;
+  background:#ebeff5;
+  border-radius:4px;
+  font-size:12px
+}
+.entry.tool summary {
+  color:#566980
+}
+.entry.tool .entry-body {
+  margin-top:10px
+}
+.entry-truncated {
+  font-size:11px;
+  color:var(--attention);
+  margin-top:4px
+}
+.load-more {
+  width:100%;
+  margin-top:8px
+}
+.compose {
+  margin-top:22px
+}
+.recipient {
+  display:flex;
+  flex-wrap:wrap;
+  justify-content:space-between;
+  gap:5px;
+  margin-bottom:8px
+}
+.recipient label {
+  font-weight:650
+}
+.recipient span {
+  color:var(--muted);
+  font-size:12px
+}
+.recipient strong {
+  color:var(--blue);
+  overflow-wrap:anywhere
+}
+textarea {
+  width:100%;
+  padding:12px 14px;
+  border:1px solid #b7c8df;
+  border-radius:7px;
+  background:#fff;
+  color:var(--ink);
+  resize:vertical;
+  min-height:108px;
+  max-height:420px;
+  line-height:1.7
+}
+textarea::placeholder {
+  color:#7b8b9e
+}
+.compose-controls {
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  gap:10px;
+  margin-top:10px
+}
+.mode-label {
+  font-size:12px;
+  color:var(--muted);
+  display:flex;
+  align-items:center;
+  gap:8px
+}
+select {
+  border:1px solid var(--line);
+  color:var(--ink);
+  border-radius:5px;
+  padding:8px;
+  background:white;
+  max-width:100%
+}
+#mode-help {
+  margin-top:8px
+}
+.compose-footer {
+  display:flex;
+  justify-content:space-between;
+  gap:10px;
+  margin:10px 0
+}
+.pending {
+  background:#fff7e9;
+  border:1px solid #e8c992;
+  border-radius:7px;
+  padding:15px;
+  margin-top:16px
+}
+.pending p {
+  font-size:12px;
+  margin-top:6px
+}
+.pending details {
+  margin-top:10px;
+  font-size:12px
+}
+.pending-actions {
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  margin-top:12px
+}
+.activity-rail {
+  padding:28px 22px;
+  border-left:1px solid var(--line);
+  min-width:0
+}
+.activity-rail section+section {
+  border-top:1px solid var(--line);
+  padding-top:21px;
+  margin-top:23px
+}
+.activity-rail h2 {
+  font-size:14px;
+  margin-bottom:10px
+}
+.rail-note {
+  font-size:11px;
+  margin-bottom:13px
+}
+.summary-item+.summary-item {
+  margin-top:15px
+}
+.summary-item h3 {
+  font-size:12px;
+  margin-bottom:6px
+}
+.summary-item .public-text {
+  font-size:12px;
+  max-height:220px;
+  overflow:auto
+}
+.summary-item .muted {
+  font-size:11px;
+  margin-top:7px
+}
+.resource {
+  padding:10px 0;
+  border-bottom:1px solid var(--line)
+}
+.resource:last-child {
+  border-bottom:0
+}
+.resource h3 {
+  font-size:12px
+}
+.resource p {
+  font-size:11px;
+  margin-top:4px;
+  overflow-wrap:anywhere
+}
+.operation {
+  padding:12px 0;
+  border-bottom:1px solid var(--line)
+}
+.operation:last-child {
+  border-bottom:0
+}
+.operation-heading {
+  display:flex;
+  flex-wrap:wrap;
+  align-items:center;
+  gap:6px;
+  justify-content:space-between
+}
+.operation-name {
+  font-size:12px;
+  font-weight:600
+}
+.operation p,.operation summary {
+  font-size:11px;
+  margin-top:5px;
+  overflow-wrap:anywhere
+}
+.event {
+  padding:0 0 15px 13px;
+  border-left:2px solid #d6e1ef;
+  position:relative
+}
+.event::before {
+  content:"";
+  position:absolute;
+  left:-4px;
+  top:7px;
+  width:6px;
+  height:6px;
+  background:#91a7c2;
+  border-radius:50%
+}
+.event p {
+  font-size:12px;
+  overflow-wrap:anywhere
+}
+.event time {
+  font-size:11px;
+  color:var(--muted)
+}
+.global-notice {
+  padding:10px 30px;
+  background:#fff0d8;
+  color:#81531d;
+  font-size:12px;
+  border-bottom:1px solid #e8d2ab
+}
+.auth {
+  max-width:460px;
+  margin:70px auto;
+  padding:24px
+}
+.auth p {
+  color:var(--muted);
+  margin:14px 0 24px
+}
+.auth label {
+  display:block;
+  font-size:12px
+}
+.auth input {
+  display:block;
+  width:100%;
+  padding:10px;
+  border:1px solid #b7c8df;
+  border-radius:6px;
+  margin:6px 0 16px
+}
+.skip-link {
+  position:fixed;
+  top:-80px;
+  left:15px;
+  background:white;
+  padding:10px;
+  z-index:5
+}
+.skip-link:focus {
+  top:10px
+}
+
+@media(min-width:1500px) {
+  .workspace {
+  padding-inline:44px
+}
+.desk {
+  grid-template-columns:270px minmax(420px,1fr) 320px
+}
+.conversation {
+  max-height:580px
+}
+
+}
+
+@media(max-width:1150px) {
+  .desk {
+  grid-template-columns:220px minmax(0,1fr)
+}
+.activity-rail {
+  grid-column:2;
+  display:grid;
+  grid-template-columns:1fr 1fr;
+  gap:24px;
+  border-top:1px solid var(--line);
+  border-left:0
+}
+.activity-rail section+section {
+  margin:0;
+  padding:0;
+  border-top:0
+}
+.workspace {
+  padding:24px
+}
+.sidebar {
+  grid-row:1/3
+}
+.brand-caption {
+  margin-left:6px
+}
+
+}
+
+@media(max-width:700px) {
+  .topbar {
+  height:66px;
+  padding:0 16px
+}
+.brand {
+  font-size:20px
+}
+.brand-caption {
+  display:none
+}
+.connection {
+  gap:7px;
+  font-size:11px
+}
+.desk {
+  display:block;
+  min-height:calc(100vh - 66px)
+}
+.sidebar {
+  border-right:0;
+  border-bottom:1px solid var(--line);
+  padding:15px 12px
+}
+.sidebar-heading h1 {
+  font-size:15px
+}
+.sidebar-note {
+  padding-bottom:9px
+}
+.sidebar-footnote {
+  display:none
+}
+#projects {
+  display:flex;
+  gap:15px;
+  overflow-x:auto;
+  align-items:flex-start;
+  padding-bottom:3px
+}
+.project-group {
+  min-width:210px;
+  margin:0
+}
+.project-name {
+  font-size:12px
+}
+.agent-option {
+  padding:8px 10px
+}
+.agent-preview {
+  max-width:205px
+}
+.workspace {
+  padding:22px 16px
+}
+.agent-header h2 {
+  font-size:24px
+}
+.freshness {
+  gap:4px 12px
+}
+.conversation {
+  padding:15px;
+  max-height:440px;
+  min-height:230px
+}
+.section-heading {
+  gap:6px
+}
+.section-heading .muted {
+  font-size:10px
+}
+.recipient {
+  display:block
+}
+.recipient span {
+  display:block;
+  margin-top:3px
+}
+.compose-controls {
+  align-items:flex-end
+}
+.mode-label {
+  display:block
+}
+.mode-label select {
+  display:block;
+  margin-top:3px;
+  font-size:12px
+}
+.compose-controls button {
+  font-size:13px;
+  padding-inline:14px
+}
+.activity-rail {
+  display:block;
+  padding:24px 20px
+}
+.activity-rail section+section {
+  border-top:1px solid var(--line);
+  margin-top:22px;
+  padding-top:20px
+}
+.welcome {
+  padding:50px 8px
+}
+.global-notice {
+  padding-inline:16px
+}
+
+}
+
+@media(prefers-reduced-motion:reduce) {
+  *,*::before,*::after {
+  scroll-behavior:auto!important;
+  animation:none!important;
+  transition:none!important
+}
+
+}

--- a/integrations/agent-manager/test/cli.test.ts
+++ b/integrations/agent-manager/test/cli.test.ts
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as delay } from 'node:timers/promises';
+const exec = promisify(execFile), cli = fileURLToPath(new URL('../src/cli.js', import.meta.url));
+
+test('CLI process survives launcher, reconnects, stops without touching agents and restarts same store', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'manager-cli-'));
+  writeFileSync(join(root, 'config.json'), JSON.stringify({ version: 1, projects: [], agents: [] }));
+  const run = async (command: string) => JSON.parse((await exec(process.execPath, [cli, command, '--root', root, '--port', '0'], { windowsHide: true, timeout: 30000 })).stdout.trim()) as { origin?: string; reused?: boolean; agentsStopped?: boolean };
+  let active = false;
+  try {
+    const first = await run('start'); active = true;
+    assert.ok(first.origin?.startsWith('http://127.0.0.1:'));
+    assert.equal((await run('start')).reused, true);
+    assert.equal((await run('stop')).agentsStopped, false); active = false;
+    for (let i = 0; i < 30 && (await import('node:fs')).existsSync(join(root, 'service.lock')); i++) await delay(100);
+    const second = await run('start'); active = true; assert.ok(second.origin);
+    await run('stop'); active = false;
+    for (let i = 0; i < 30 && (await import('node:fs')).existsSync(join(root, 'service.lock')); i++) await delay(100);
+  } finally {
+    if (active) { await run('stop'); await delay(500); }
+    rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  }
+});

--- a/integrations/agent-manager/test/http.test.ts
+++ b/integrations/agent-manager/test/http.test.ts
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { randomBytes, randomUUID } from 'node:crypto';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { request as httpRequest } from 'node:http';
+import { serve } from '../src/http.js';
+import { ManagerStore } from '../src/store.js';
+import { AgentManager } from '../src/manager.js';
+import { parseConfig, selectionRevision } from '../src/config.js';
+import type { PiAdapter, SendRequest } from '../src/contracts.js';
+
+test('loopback gateway rejects foreign/auth/body/target misuse and preserves message identity', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'manager-http-')), token = randomBytes(32).toString('hex'), instanceId = randomUUID(); let effects = 0;
+  const config = parseConfig({ version: 1, projects: [{ id: 'p', name: 'Project' }], agents: [
+    { id: 'a', name: 'Agent', role: 'worker', projectId: 'p', registryRoot: root, workspace: root, sessionId: 'selected' }] });
+  const adapter: PiAdapter = { observe: async () => ({ state: 'running', instanceId, observedAt: new Date().toISOString(), heartbeatAt: null, lastProgressAt: null, lastEvent: null,
+    source: 'live', stale: false, reason: null, model: null, usage: null, capabilities: { send: true, conversation: true }, latestMessage: null }),
+    conversation: async () => ({ instanceId, entries: [], cursor: null, headCursor: null, hasMore: false, observedAt: new Date().toISOString(), source: 'live' }),
+    send: async (b, r) => { effects++; return { id: r.operationId, sessionId: b.sessionId, instanceId, status: 'started' }; }, receipt: async () => null };
+  const store = new ManagerStore(root), manager = new AgentManager(config, store, adapter);
+  const gateway = await serve(manager, token); const auth = { authorization: `Bearer ${token}` };
+  try {
+    await manager.refresh();
+    assert.equal((await fetch(`${gateway.origin}/api/overview`)).status, 401);
+    assert.equal((await fetch(`${gateway.origin}/api/overview`, { headers: { ...auth, origin: 'https://evil.invalid' } })).status, 403);
+    assert.equal((await fetch(`${gateway.origin}/api/overview`, { method: 'OPTIONS', headers: auth })).status, 403);
+    const badHost = await new Promise<number>((resolve, reject) => {
+      const req = httpRequest(`${gateway.origin}/api/overview`, { headers: { ...auth, host: 'evil.invalid' } }, (res) => { res.resume(); resolve(res.statusCode || 0); }); req.on('error', reject); req.end();
+    });
+    assert.equal(badHost, 403);
+    const overview = await fetch(`${gateway.origin}/api/overview`, { headers: auth });
+    assert.equal(overview.headers.get('cache-control'), 'no-store');
+    const data = await overview.text(); assert.ok(!data.includes('registryRoot')); assert.ok(!data.includes(token));
+    const request: SendRequest = { operationId: randomUUID(), selectionRevision: selectionRevision(config.agents[0]!), instanceId, basisCursor: null, mode: 'followUp', message: '<script>operator text</script>' };
+    const send = (payload: unknown, target = 'a') => fetch(`${gateway.origin}/api/agents/${target}/messages`, { method: 'POST', headers: { ...auth, 'content-type': 'application/json' }, body: JSON.stringify(payload) });
+    assert.equal((await send(request, 'unknown')).status, 404);
+    assert.equal((await send({ ...request, message: 'x'.repeat(30000) })).status, 413);
+    assert.equal((await send(request)).status, 202);
+    assert.equal((await send(request)).status, 202); assert.equal(effects, 1);
+    assert.equal((await send({ ...request, message: 'different' })).status, 409);
+    assert.equal((await send({ ...request, operationId: randomUUID(), message: '文'.repeat(4096) })).status, 202);
+    assert.equal((await send({ ...request, operationId: randomUUID(), message: '文'.repeat(4096) + 'x' })).status, 413);
+    assert.equal((await fetch(`${gateway.origin}/api/operations/${request.operationId}`, { headers: auth })).status, 200);
+    assert.equal((await fetch(`${gateway.origin}/../config.json`, { headers: auth })).status, 404);
+  } finally { await manager.stop(); await gateway.close(); store.close(); rmSync(root, { recursive: true, force: true }); }
+});

--- a/integrations/agent-manager/test/manager.test.ts
+++ b/integrations/agent-manager/test/manager.test.ts
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AgentManager } from '../src/manager.js';
+import { ManagerStore } from '../src/store.js';
+import { parseConfig, selectionRevision } from '../src/config.js';
+import { publicEntries } from '../src/pi-adapter.js';
+import type { AgentObservation, PiAdapter, SendRequest } from '../src/contracts.js';
+
+test('two simultaneous sends create one effect; unknown survives restart and uses original binding', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'manager-effect-')), instanceId = randomUUID(); let effects = 0, settled = false;
+  const config = parseConfig({ version: 1, projects: [{ id: 'p', name: 'Project' }], agents: [
+    { id: 'a', name: 'Agent', projectId: 'p', role: 'worker', registryRoot: root, workspace: root, sessionId: 'original' }] });
+  const binding = config.agents[0]!;
+  const observation: AgentObservation = { state: 'running', instanceId, observedAt: new Date().toISOString(), heartbeatAt: null, lastProgressAt: null, lastEvent: null,
+    source: 'live', stale: false, reason: null, model: null, usage: null, capabilities: { send: true, conversation: true }, latestMessage: null };
+  const adapter: PiAdapter = { observe: async () => observation,
+    conversation: async () => ({ entries: [], instanceId, cursor: null, headCursor: null, hasMore: false, observedAt: new Date().toISOString(), source: 'live' }),
+    send: async () => { effects++; throw new Error('Simulate a timeout after delivery'); },
+    receipt: async (target, op) => { assert.equal(target.sessionId, 'original'); return settled ? { id: op.id, sessionId: target.sessionId, instanceId, status: 'settled' } : null; } };
+  let store = new ManagerStore(root), manager = new AgentManager(config, store, adapter);
+  const request: SendRequest = { operationId: randomUUID(), instanceId, selectionRevision: selectionRevision(binding), basisCursor: 'old-context-is-provenance', mode: 'followUp', message: 'Continue scoped work' };
+  try {
+    await Promise.all([manager.send('a', request), manager.send('a', request)]);
+    assert.equal(effects, 1); assert.equal((await manager.operation(request.operationId)).status, 'unknown');
+    await assert.rejects(() => manager.send('a', { ...request, message: 'different' }), /不同/);
+    store.close(); store = new ManagerStore(root);
+    const replaced = { ...config, agents: [{ ...binding, sessionId: 'replacement' }] };
+    manager = new AgentManager(replaced, store, adapter); settled = true;
+    assert.equal((await manager.operation(request.operationId)).status, 'settled');
+    assert.equal(effects, 1);
+    assert.ok(!JSON.stringify(manager.overview()).includes('registryRoot'));
+  } finally { await manager.stop(); store.close(); rmSync(root, { recursive: true, force: true }); }
+});
+
+test('stale identity is definitive before intent and a failed source does not hide other agents', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'manager-partial-')), instanceId = randomUUID(); let effects = 0;
+  const config = parseConfig({ version: 1, projects: [{ id: 'p', name: 'Project' }], agents: ['a', 'b'].map((id) => (
+    { id, name: id, projectId: 'p', role: 'worker', registryRoot: root, workspace: root, sessionId: id })) });
+  const adapter: PiAdapter = { observe: async (b) => {
+    if (b.id === 'b') throw new Error('poisoned registry');
+    return { state: 'idle', instanceId, observedAt: new Date().toISOString(), heartbeatAt: null, lastProgressAt: null, lastEvent: null, source: 'live', stale: false,
+      reason: null, model: null, usage: null, capabilities: { send: true, conversation: true }, latestMessage: null };
+  }, conversation: async () => { throw new Error('unused'); }, send: async () => { effects++; throw new Error('unused'); }, receipt: async () => null };
+  const store = new ManagerStore(root), manager = new AgentManager(config, store, adapter);
+  try {
+    await manager.refresh();
+    assert.deepEqual(manager.overview().agents.map((a) => a.state), ['idle', 'unavailable']);
+    const request: SendRequest = { operationId: randomUUID(), instanceId: randomUUID(), selectionRevision: selectionRevision(config.agents[0]!), basisCursor: null, mode: 'steer', message: 'new message' };
+    await assert.rejects(() => manager.send('a', request), /更換/);
+    assert.equal(store.operations().length, 0); assert.equal(effects, 0);
+    await manager.refresh(); assert.equal(store.events().length, 2);
+  } finally { await manager.stop(); store.close(); rmSync(root, { recursive: true, force: true }); }
+});
+
+test('public projection omits reasoning, tool arguments and credentials, even on malformed entries', () => {
+  const result = publicEntries([{ id: '1', kind: 'message', role: 'assistant', text: '<script>hello</script>', thinking: 'SECRET_THOUGHT', token: 'SECRET_TOKEN', toolCalls: [{ arguments: 'SECRET_ARGS' }] },
+    { id: '2', kind: 'tool_result', toolName: 'bash', content: 'SECRET_RESULT', isError: true }, { id: '3', kind: 'message', role: 'system', text: 'SECRET_SYSTEM' }]);
+  assert.equal(result.length, 2); assert.equal(result[0]?.text, '<script>hello</script>');
+  assert.ok(!JSON.stringify(result).includes('SECRET')); assert.equal(result[1]?.toolError, true);
+});

--- a/integrations/agent-manager/test/offline-smoke.ts
+++ b/integrations/agent-manager/test/offline-smoke.ts
@@ -1,0 +1,77 @@
+// Explicit actual-Pi integration/browser fixture. Never runs in the default suite.
+import assert from 'node:assert/strict';
+import { randomBytes, randomUUID } from 'node:crypto';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { setTimeout as delay } from 'node:timers/promises';
+import { ChannelAdapter, defaultPiRoot, secureRoot } from '../src/pi-adapter.js';
+import { parseConfig, selectionRevision, object } from '../src/config.js';
+import { ManagerStore } from '../src/store.js';
+import { AgentManager } from '../src/manager.js';
+import { serve } from '../src/http.js';
+import type { ConversationView, OperationView, SendRequest } from '../src/contracts.js';
+
+const entry = process.argv[2], keep = process.argv.includes('--serve');
+if (!entry) throw new Error('Supply installed Pi entry; optional --serve keeps the browser fixture running');
+interface Managed {
+  launchManaged(root: string, input: unknown): Promise<unknown>;
+  managedStatus(root: string, id: string): Promise<unknown>;
+  stopManaged(root: string, id: string, options: { abort: boolean }): Promise<unknown>;
+}
+const api = await import(pathToFileURL(join(defaultPiRoot(), 'managed-client.mjs')).href) as Managed;
+const root = mkdtempSync(join(tmpdir(), 'edda-manager-smoke-')), registry = join(root, 'registry'), workspace = join(root, 'fixture'), agentDir = join(root, 'agent');
+mkdirSync(workspace); mkdirSync(agentDir); await secureRoot(root);
+let runId: string | null = null, manager: AgentManager | null = null, store: ManagerStore | null = null;
+let gateway: Awaited<ReturnType<typeof serve>> | null = null, closed = false;
+async function close(): Promise<void> {
+  if (closed) return; closed = true;
+  await manager?.stop(); await gateway?.close(); store?.close();
+  if (runId) await api.stopManaged(registry, runId, { abort: true });
+}
+try {
+  const launched = object(await api.launchManaged(registry, { project: workspace, piEntry: entry, provider: 'edda-offline-test', model: 'echo',
+    thinking: 'off', noTools: true, noSkills: true, agentDir, extensions: [join(defaultPiRoot(), 'fixtures/offline-provider.mjs')], prompt: 'MANAGER_SMOKE_READY' }));
+  runId = String(launched.runId); const sessionId = String(launched.sessionId);
+  for (let i = 0; i < 100; i++) {
+    const state = object(await api.managedStatus(registry, runId));
+    if (object(state.initialReceipt).status === 'settled') break;
+    if (state.modelError) throw new Error('Offline provider failed');
+    if (i === 99) throw new Error('Offline fixture did not settle');
+    await delay(100);
+  }
+  const config = parseConfig({ version: 1, refreshMs: 1000, projects: [{ id: 'fixture', name: '隔離驗證', priority: 0, resources: [] }], agents: [
+    { id: 'pi-fixture', name: 'Pi 收發驗證', projectId: 'fixture', role: 'worker', registryRoot: registry, workspace, sessionId, runId },
+    { id: 'offline-fixture', name: '離線狀態驗證', projectId: 'fixture', role: 'manager', registryRoot: registry, workspace, sessionId: randomUUID() }] });
+  store = new ManagerStore(join(root, 'manager')); manager = new AgentManager(config, store, await ChannelAdapter.create());
+  await manager.start(); const token = randomBytes(32).toString('hex');
+  gateway = await serve(manager, token, { onStop: () => { void close(); } });
+  const origin = gateway.origin, headers = { authorization: `Bearer ${token}`, 'content-type': 'application/json' };
+  const view = manager.overview().agents[0]!; assert.equal(view.source, 'live');
+  assert.equal(manager.overview().agents[1]?.source, 'unavailable');
+  const request: SendRequest = { operationId: randomUUID(), instanceId: view.instanceId!, selectionRevision: selectionRevision(config.agents[0]!), basisCursor: null, mode: 'followUp', message: 'MANAGER_ACTUAL_PI_ONCE' };
+  for (let i = 0; i < 2; i++) {
+    const response = await fetch(`${origin}/api/agents/pi-fixture/messages`, { method: 'POST', headers, body: JSON.stringify(request) });
+    assert.equal(response.status, 202);
+  }
+  let operation: OperationView | null = null;
+  for (let i = 0; i < 100; i++) {
+    operation = await (await fetch(`${origin}/api/operations/${request.operationId}`, { headers })).json() as OperationView;
+    if (operation.status === 'settled') break;
+    await delay(100);
+  }
+  assert.equal(operation?.status, 'settled');
+  const conversation = await (await fetch(`${origin}/api/agents/pi-fixture/conversation`, { headers })).json() as ConversationView;
+  assert.equal(conversation.entries.filter((e) => e.role === 'user' && e.text.includes(request.message)).length, 1);
+  assert.ok(conversation.entries.some((e) => e.role === 'assistant' && e.text.includes('OFFLINE_ACK') && e.text.includes(request.message)));
+  const summary = { passed: true, actualPi: true, liveModel: false, messageDeliveredOnce: true, publicReplyVisible: true, receiptSettled: true, partialSourceFailureIsolated: true,
+    root, origin, sessionId, runId, operationId: request.operationId };
+  writeFileSync(join(root, 'receipt.json'), JSON.stringify(summary, null, 2));
+  writeFileSync(join(root, 'browser.json'), JSON.stringify({ url: `${origin}/#token=${token}`, origin, token }, null, 2), { mode: 0o600 });
+  console.log(JSON.stringify(summary));
+  if (keep) {
+    process.once('SIGINT', () => { void close(); }); process.once('SIGTERM', () => { void close(); });
+    console.log('Browser fixture remains available; POST /api/service/stop closes only this fixture.');
+  } else await close();
+} catch (error) { await close(); throw error; }

--- a/integrations/agent-manager/test/pi-adapter.test.ts
+++ b/integrations/agent-manager/test/pi-adapter.test.ts
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
+import { setTimeout as delay } from 'node:timers/promises';
+import { ChannelAdapter, defaultPiRoot } from '../src/pi-adapter.js';
+import { AgentManager } from '../src/manager.js';
+import { ManagerStore } from '../src/store.js';
+import { parseConfig, selectionRevision } from '../src/config.js';
+import type { SendRequest } from '../src/contracts.js';
+
+interface Channel { snapshot(): { instanceId: string }; messageStarted(message: string): void; settled(): void; close(): Promise<void> }
+interface ChannelModule { startChannel(options: { root: string; sessionId: string; cwd: string; deliver: (message: string) => void; getConversation: (query: { after?: string }) => unknown }): Promise<Channel> }
+
+test('real Pi HTTP channel adapter isolates poison records, preserves receipts and rejects replacement', async () => {
+  const api = await import(pathToFileURL(join(defaultPiRoot(), 'channel.mjs')).href) as ChannelModule;
+  const root = mkdtempSync(join(tmpdir(), 'manager-pi-')), registry = join(root, 'pi'), workspace = join(root, 'project'), sessionId = randomUUID();
+  mkdirSync(workspace); let deliveries = 0, channel: Channel;
+  const page = (query: { after?: string }) => {
+    if (query.after && query.after !== 'one') throw new Error('Conversation cursor is not on this branch');
+    return { entries: [{ id: 'one', timestamp: new Date().toISOString(), kind: 'message', role: 'assistant', text: 'Public reply', thinking: 'PRIVATE_THOUGHT', toolCalls: [{ arguments: 'PRIVATE_ARGS' }] }], cursor: 'one', headCursor: 'one', hasMore: false };
+  };
+  channel = await api.startChannel({ root: registry, sessionId, cwd: workspace, getConversation: page, deliver: (message) => {
+    deliveries++; setTimeout(() => { channel.messageStarted(message); channel.settled(); }, 10);
+  } });
+  const config = parseConfig({ version: 1, projects: [{ id: 'p', name: 'Project' }], agents: [{ id: 'a', name: 'Selected', projectId: 'p', role: 'worker', registryRoot: registry, workspace, sessionId }] });
+  const store = new ManagerStore(join(root, 'manager')), manager = new AgentManager(config, store, await ChannelAdapter.create());
+  try {
+    const poison = join(registry, 'a'.repeat(64)); mkdirSync(poison); writeFileSync(join(poison, 'state.json'), Buffer.alloc(16));
+    await manager.refresh(); const view = manager.overview().agents[0]!;
+    assert.equal(view.source, 'live'); assert.equal(view.latestMessage?.text, 'Public reply');
+    const conversation = await manager.conversation('a');
+    assert.ok(!JSON.stringify(conversation).includes('PRIVATE'));
+    const ownerFiles = (await import('node:fs')).readdirSync(registry).filter((p) => /^[a-f0-9]{64}$/.test(p) && p !== 'a'.repeat(64));
+    const owner = JSON.parse(readFileSync(join(registry, ownerFiles[0]!, 'owner.json'), 'utf8')) as { token: string };
+    assert.ok(!JSON.stringify(manager.overview()).includes(owner.token));
+    await assert.rejects(() => manager.conversation('a', 'abandoned'), /分支/);
+    const request: SendRequest = { operationId: randomUUID(), selectionRevision: selectionRevision(config.agents[0]!), instanceId: view.instanceId!, basisCursor: 'one', mode: 'followUp', message: 'Visible operator message' };
+    await assert.rejects(() => manager.send('a', { ...request, message: '"'.repeat(12288) }), /容量/);
+    assert.equal(store.operations().length, 0);
+    await manager.send('a', request); await manager.send('a', request); await delay(50);
+    assert.equal((await manager.operation(request.operationId)).status, 'settled'); assert.equal(deliveries, 1);
+    await channel.close(); channel = await api.startChannel({ root: registry, sessionId, cwd: workspace, getConversation: page, deliver: () => { deliveries++; } });
+    await assert.rejects(() => manager.send('a', { ...request, operationId: randomUUID() }), /更換/);
+    assert.equal(deliveries, 1);
+  } finally { await manager.stop(); await channel.close(); store.close(); rmSync(root, { recursive: true, force: true }); }
+});

--- a/integrations/agent-manager/test/store.test.ts
+++ b/integrations/agent-manager/test/store.test.ts
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { ManagerStore } from '../src/store.js';
+import { parseConfig, parseSend } from '../src/config.js';
+import type { SendRequest } from '../src/contracts.js';
+
+test('durable intent rejects changed duplicate and restart never invents no-send', () => {
+  const root = mkdtempSync(join(tmpdir(), 'manager-store-'));
+  let store = new ManagerStore(root);
+  try {
+    const request: SendRequest = { operationId: randomUUID(), selectionRevision: 'a'.repeat(64), instanceId: randomUUID(), basisCursor: null, mode: 'followUp', message: '保留既有修改，請回報進度。' };
+    const op = store.begin({ id: 'character', name: 'Character', role: 'manager', projectId: 'p', registryRoot: root, sessionId: 'original-session', runId: null, workspace: root, summaryFile: null }, request);
+    assert.equal(store.existing('character', request)?.id, op.id);
+    assert.throws(() => store.existing('edda', request), /不同/);
+    assert.throws(() => store.existing('character', { ...request, message: 'different' }), /不同/);
+    store.close(); store = new ManagerStore(root);
+    assert.equal(store.operation(op.id)?.status, 'unknown');
+    assert.equal(store.target(op.id)?.sessionId, 'original-session');
+    assert.ok(!JSON.stringify(store.operations()).includes('registryRoot'));
+    store.update(op.id, 'started', 'Started');
+    assert.equal(store.update(op.id, 'queued', 'late old response').status, 'started');
+    store.update(op.id, 'settled', '回覆已結束，結果待驗收。');
+    assert.equal(store.update(op.id, 'unknown', 'stale').status, 'settled');
+    assert.equal(store.operations().length, 1);
+    assert.equal(store.events().length, 4);
+  } finally { store.close(); rmSync(root, { recursive: true, force: true }); }
+});
+
+test('configuration binds exact selected agents, validates projects and byte limits', () => {
+  const workspace = tmpdir();
+  const input = { version: 1, projects: [{ id: 'p', name: 'Project', priority: 0 }], agents: [
+    { id: 'a', name: 'Agent', role: 'worker', projectId: 'p', workspace, registryRoot: workspace, sessionId: 'session-a' }] };
+  const config = parseConfig(input);
+  assert.equal(config.agents[0]?.runId, null);
+  assert.throws(() => parseConfig({ ...input, agents: [input.agents[0], { ...input.agents[0], id: 'b' }] }), /重複/);
+  assert.throws(() => parseConfig({ ...input, agents: [{ ...input.agents[0], projectId: 'missing' }] }), /未登記/);
+  assert.throws(() => parseConfig({ ...input, agents: [{ ...input.agents[0], registryRoot: '../escape' }] }), /絕對/);
+  assert.throws(() => parseSend({ operationId: randomUUID(), instanceId: randomUUID(), selectionRevision: 'x', basisCursor: null, mode: 'followUp', message: '文'.repeat(5000) }), /12 KiB/);
+});

--- a/integrations/agent-manager/tsconfig.json
+++ b/integrations/agent-manager/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    "verbatimModuleSyntax": true,
+    "rootDir": ".",
+    "outDir": "dist",
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
Issue: #1165

Adds a strict-TypeScript local agent-management service and Traditional Chinese browser console. Operators can see selected agents grouped by project, distinguish live/idle/stopped/unavailable evidence, read public conversations and send new append/priority instructions to a specific Pi instance. Manager summaries, registered shared services and durable message/activity receipts share the same view.

The existing Pi transport remains behind one adapter. A private SQLite journal records intent before dispatch, preserves original targets across rebinding and prevents duplicate/replayed sends after timeout or restart. The gateway is loopback-only with its own bearer credential, Host/Origin/body/CSP checks and fixed text-safe assets; Pi credentials/reasoning/tool arguments never enter browser DTOs. New-message semantics are explicit: this is not an atomic approval reply, force-kill control, or general automatic dispatcher.

Architecture and migration boundary are documented in `docs/superpowers/specs/2026-09-13-agent-manager-console.md`; startup/configuration/recovery instructions are in `integrations/agent-manager/README.md`. No Rust or existing Pi implementation is rewritten. Node24 SQLite remains experimental and is documented/tested as such.

Validation: strict typecheck/build; eight Node tests covering actual Pi HTTP adapter, poisoned unrelated registry, identity/branch/size boundaries, duplicate/unknown/restart/receipt behavior, gateway controls and CLI background lifecycle. Actual offline Pi HTTP and browser round-trip proved one delivery with a visible public reply/settled receipt; responsive390px layout and desktop checked. Real Character/Edda registration was read-only, with no test messages to their active sessions or DB changes. Independent review and exact-head CI follow.

Closes #1165.
